### PR TITLE
[benchmark] add a simple benchmark for creating many traces

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,13 +7,18 @@ require 'appraisal'
 Rake::TestTask.new(:test) do |t|
   t.libs << %w(test lib)
   t.test_files = FileList['test/**/*_test.rb'].reject do |path|
-    path.include?('rails')
+    path.include?('rails') || path.include?('benchmark')
   end
 end
 
 Rake::TestTask.new(:rails) do |t|
   t.libs << %w(test lib)
   t.test_files = FileList['test/contrib/rails/**/*_test.rb']
+end
+
+Rake::TestTask.new(:benchmark) do |t|
+  t.libs << %w(test lib)
+  t.test_files = FileList['test/benchmark_test.rb']
 end
 
 RuboCop::RakeTask.new(:rubocop) do |t|

--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,7 @@ test:
     - rvm $ALL_VERSIONS --verbose do appraisal rails-3 rake rails
     - rvm $ALL_VERSIONS --verbose do appraisal rails-4 rake rails
     - rvm $RAILS5_VERSIONS --verbose do appraisal rails-5 rake rails
+    - rvm 2.3.1 --verbose do rake benchmark
 
 deployment:
   develop:

--- a/test/benchmark_test.rb
+++ b/test/benchmark_test.rb
@@ -1,0 +1,25 @@
+require 'minitest'
+require 'minitest/autorun'
+require 'benchmark'
+
+require 'helper'
+require 'ddtrace'
+
+include Benchmark
+
+class TraceBufferTest < Minitest::Test
+  N = 100000
+
+  def test_benchmark_create_traces
+    # create and finish a huge number of spans with a single thread
+    tracer = get_test_tracer()
+
+    Benchmark.benchmark(CAPTION, 7, FORMAT, '>total:', '>avg:') do |x|
+      x.report("create #{N} traces:") do
+        N.times { tracer.trace('benchmark.test').finish() }
+      end
+    end
+
+    assert_equal(tracer.writer.spans.length, N)
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -16,7 +16,7 @@ end
 class FauxWriter < Datadog::Writer
   def initialize
     @transport = FauxTransport.new(HOSTNAME, PORT)
-    @trace_buffer = Datadog::TraceBuffer.new(10)
+    @trace_buffer = Datadog::TraceBuffer.new(0)
     @services = {}
   end
 


### PR DESCRIPTION
### What it does

Adds a simple `rake benchmark` commands that runs a set of benchmarks. Currently there is only one benchmark that checks the time spent to create and finish a single trace with just one span.

This benchmark is required for the next refactoring.
#### Output example

```
# Running:

              user     system      total        real
create 100000 traces:  0.720000   0.040000   0.760000 (  0.760682)
.

Finished in 0.786162s, 1.2720 runs/s, 1.2720 assertions/s.

1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```
