### PR TITLE
Fix typo in HTTPTransport#send

### DIFF
--- a/lib/ddtrace/transport.rb
+++ b/lib/ddtrace/transport.rb
@@ -25,7 +25,7 @@ module Datadog
 
       response = Net::HTTP.start(@hostname, @port, read_timeout: TIMEOUT) { |http| http.request(request) }
       handle_response(response)
-    rescue StandarError => e
+    rescue StandardError => e
       Datadog::Tracer.log.error(e.message)
     end
 


### PR DESCRIPTION
I noticed this via this log message:

```
Error during the flush: dropped 1 items. Cause: uninitialized constant Datadog::HTTPTransport::StandarError
```

Would you like a test for this?
