### PR TITLE
[core] use the new agent API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ Metrics/LineLength:
 # so periodic disabling and re-running to inspect values is suggested.
 
 Metrics/AbcSize:
-  Max: 40
+  Max: 50
 
 # TODO: As refactors continue, this should drop. However, the goal of
 # 10 lines in a method may be a little lofty.

--- a/lib/ddtrace/encoding.rb
+++ b/lib/ddtrace/encoding.rb
@@ -3,11 +3,14 @@ require 'json'
 module Datadog
   # Encoding module that encodes data for the AgentTransport
   module Encoding
-    # Encode the given set of spans in JSON format
+    # Encode the given set of spans in the right JSON format
+    # so that the agent can parse the list of traces
     def self.encode_spans(traces)
-      spans = traces.flatten
-      hashes = spans.map(&:to_hash)
-      JSON.dump(hashes)
+      to_send = []
+      traces.each do |trace|
+        to_send << trace.map(&:to_hash)
+      end
+      JSON.dump(to_send)
     end
 
     def self.encode_services(services)

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -10,8 +10,8 @@ module Datadog
 
     HOSTNAME = 'localhost'.freeze
     PORT = '7777'.freeze
-    SPANS_ENDPOINT = '/spans'.freeze
-    SERVICES_ENDPOINT = '/services'.freeze
+    SPANS_ENDPOINT = '/v0.2/traces'.freeze
+    SERVICES_ENDPOINT = '/v0.2/services'.freeze
 
     def initialize(options = {})
       # writer and transport parameters

--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -9,25 +9,27 @@ class TracerTest < Minitest::Test
     defaults = {
       service: 'test-app',
       resource: '/traces',
-      span_type: 'web',
+      span_type: 'web'
     }
     traces << [
-        Datadog::Span.new(nil, 'client.testing', **defaults).finish(),
-        Datadog::Span.new(nil, 'client.testing', **defaults).finish()
+      Datadog::Span.new(nil, 'client.testing', **defaults).finish(),
+      Datadog::Span.new(nil, 'client.testing', **defaults).finish()
     ]
     traces << [
-        Datadog::Span.new(nil, 'client.testing', **defaults).finish(),
-        Datadog::Span.new(nil, 'client.testing', **defaults).finish()
+      Datadog::Span.new(nil, 'client.testing', **defaults).finish(),
+      Datadog::Span.new(nil, 'client.testing', **defaults).finish()
     ]
 
     to_send = Datadog::Encoding.encode_spans(traces)
 
     assert to_send.is_a? String
-    # the spans list must be flatten
-    items = JSON.load(to_send)
-    assert_equal(items.length, 4)
+    # the spans list must be a list of traces
+    items = JSON.parse(to_send)
+    assert_equal(items.length, 2)
+    assert_equal(items[0].length, 2)
+    assert_equal(items[1].length, 2)
     # each span must be properly formatted
-    span = items[0]
+    span = items[0][0]
     assert span['span_id']
     assert span['parent_id']
     assert span['trace_id']


### PR DESCRIPTION
### What it does?

Uses the new agent API `v0.2` that expects a list of traces instead of a list of spans.
