### PR TITLE
[rails] remove sql.query tag from the SQL span

### DIFF
--- a/lib/ddtrace/contrib/rails/active_record.rb
+++ b/lib/ddtrace/contrib/rails/active_record.rb
@@ -28,8 +28,10 @@ module Datadog
             span_type: span_type
           )
 
+          # the span should have the query ONLY in the Resource attribute,
+          # so that the ``sql.query`` tag will be set in the agent with an
+          # obfuscated version
           span.span_type = Datadog::Ext::SQL::TYPE
-          span.set_tag(Datadog::Ext::SQL::QUERY, payload.fetch(:sql))
           span.set_tag('rails.db.vendor', adapter_name)
           span.start_time = start
           span.finish_at(finish)

--- a/test/contrib/rails/database_test.rb
+++ b/test/contrib/rails/database_test.rb
@@ -25,7 +25,8 @@ class DatabaseTracingTest < ActiveSupport::TestCase
     assert_equal(span.service, adapter_name)
     assert_equal(span.get_tag('rails.db.vendor'), adapter_name)
     assert_includes(span.resource, 'SELECT COUNT(*) FROM')
-    assert_includes(span.get_tag('sql.query'), 'SELECT COUNT(*) FROM')
+    # ensure that the sql.query tag is not set
+    assert_equal(span.get_tag('sql.query'), nil)
     assert span.to_hash[:duration] > 0
   end
 


### PR DESCRIPTION
### What it does

Removes the ``sql.query`` tag so that it can be set in the agent with an obfuscated version