### PR TITLE
[jruby] removing flaky tests for JRuby test suite

### DIFF
--- a/test/contrib/rails/cache_test.rb
+++ b/test/contrib/rails/cache_test.rb
@@ -27,7 +27,6 @@ class CacheTracingTest < ActionController::TestCase
     assert_equal(span.service, 'rails-cache')
     assert_equal(span.get_tag('rails.cache.backend').to_s, '[:file_store, "/tmp/ddtrace-rb/cache/"]')
     assert_equal(span.get_tag('rails.cache.key'), 'custom-key')
-    assert span.to_hash[:duration] > 0
   end
 
   test 'cache.write() is properly traced' do
@@ -42,7 +41,6 @@ class CacheTracingTest < ActionController::TestCase
     assert_equal(span.service, 'rails-cache')
     assert_equal(span.get_tag('rails.cache.backend').to_s, '[:file_store, "/tmp/ddtrace-rb/cache/"]')
     assert_equal(span.get_tag('rails.cache.key'), 'custom-key')
-    assert span.to_hash[:duration] > 0
   end
 
   test 'cache.delete() is properly traced' do
@@ -57,7 +55,6 @@ class CacheTracingTest < ActionController::TestCase
     assert_equal(span.service, 'rails-cache')
     assert_equal(span.get_tag('rails.cache.backend').to_s, '[:file_store, "/tmp/ddtrace-rb/cache/"]')
     assert_equal(span.get_tag('rails.cache.key'), 'custom-key')
-    assert span.to_hash[:duration] > 0
   end
 
   test 'doing a cache call uses the proper service name if it is changed' do

--- a/test/contrib/rails/controller_test.rb
+++ b/test/contrib/rails/controller_test.rb
@@ -29,7 +29,6 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span.get_tag('http.status_code'), '200')
     assert_equal(span.get_tag('rails.route.action'), 'index')
     assert_equal(span.get_tag('rails.route.controller'), 'TracingController')
-    assert span.to_hash[:duration] > 0
   end
 
   test 'template rendering is properly traced' do
@@ -44,7 +43,6 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span.resource, 'rails.render_template')
     assert_equal(span.get_tag('rails.template_name'), 'tracing/index.html.erb')
     assert_equal(span.get_tag('rails.layout'), 'layouts/application')
-    assert span.to_hash[:duration] > 0
   end
 
   test 'template partial rendering is properly traced' do
@@ -61,9 +59,6 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_partial.resource, 'rails.render_partial')
     assert_equal(span_partial.get_tag('rails.template_name'), 'tracing/_body.html.erb')
     assert_equal(span_partial.parent, span_template)
-
-    assert span_template.to_hash[:duration] > 0
-    assert span_partial.to_hash[:duration] > 0
   end
 
   test 'a full request with database access on the template' do
@@ -89,12 +84,6 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_template.parent, span_request)
     assert_equal(span_database.parent, span_template)
     assert_equal(span_cache.parent, span_request)
-
-    # assert they're finished
-    assert span_request.to_hash[:duration] > 0
-    assert span_template.to_hash[:duration] > 0
-    assert span_database.to_hash[:duration] > 0
-    assert span_cache.to_hash[:duration] > 0
   end
 
   test 'multiple calls should not leave an unfinished span in the local thread buffer' do

--- a/test/contrib/rails/database_test.rb
+++ b/test/contrib/rails/database_test.rb
@@ -27,7 +27,6 @@ class DatabaseTracingTest < ActiveSupport::TestCase
     assert_includes(span.resource, 'SELECT COUNT(*) FROM')
     # ensure that the sql.query tag is not set
     assert_equal(span.get_tag('sql.query'), nil)
-    assert span.to_hash[:duration] > 0
   end
 
   test 'doing a database call uses the proper service name if it is changed' do

--- a/test/contrib/rails/errors_test.rb
+++ b/test/contrib/rails/errors_test.rb
@@ -32,7 +32,6 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span.get_tag('rails.route.controller'), 'TracingController')
     assert_equal(span.get_tag('error.type'), 'ZeroDivisionError')
     assert_equal(span.get_tag('error.msg'), 'divided by 0')
-    assert span.to_hash[:duration] > 0
   end
 
   test 'error in the template must be traced' do
@@ -51,7 +50,6 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_template.get_tag('rails.layout'), 'layouts/application')
     assert_equal(span_template.get_tag('error.type'), 'ActionView::Template::Error')
     assert_equal(span_template.get_tag('error.msg'), 'divided by 0')
-    assert span_template.to_hash[:duration] > 0
 
     span_request = spans[1]
     assert_equal(span_request.name, 'rails.request')
@@ -65,7 +63,6 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_request.get_tag('rails.route.controller'), 'TracingController')
     assert_equal(span_request.get_tag('error.type'), 'ActionView::Template::Error')
     assert_equal(span_request.get_tag('error.msg'), 'divided by 0')
-    assert span_request.to_hash[:duration] > 0
   end
 
   test 'error in the template partials must be traced' do
@@ -83,7 +80,6 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_partial.get_tag('rails.template_name'), 'tracing/_inner_error.html.erb')
     assert_equal(span_partial.get_tag('error.type'), 'ActionView::Template::Error')
     assert_equal(span_partial.get_tag('error.msg'), 'divided by 0')
-    assert span_partial.to_hash[:duration] > 0
 
     span_template = spans[1]
     assert_equal(span_template.name, 'rails.render_template')
@@ -94,7 +90,6 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_template.get_tag('rails.layout'), 'layouts/application')
     assert_equal(span_template.get_tag('error.type'), 'ActionView::Template::Error')
     assert_equal(span_template.get_tag('error.msg'), 'divided by 0')
-    assert span_template.to_hash[:duration] > 0
 
     span_request = spans[2]
     assert_equal(span_request.name, 'rails.request')
@@ -108,6 +103,5 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_request.get_tag('rails.route.controller'), 'TracingController')
     assert_equal(span_request.get_tag('error.type'), 'ActionView::Template::Error')
     assert_equal(span_request.get_tag('error.msg'), 'divided by 0')
-    assert span_request.to_hash[:duration] > 0
   end
 end

--- a/test/span_test.rb
+++ b/test/span_test.rb
@@ -13,6 +13,7 @@ class SpanTest < Minitest::Test
     # the end_time must be set
     sleep(0.001)
     assert span.end_time < Time.now.utc
+    assert span.to_hash[:duration] > 0
   end
 
   def test_span_ids


### PR DESCRIPTION
### What it does

Removes some useless checks that causes problems in the JRuby test suite.
These checks are not important because if a span is not finished, it will not be published in the tracer ``TraceBuffer``. Furthermore, the ``:duration`` is already checked in the ``span_test.rb``.

If we don't include this PR, we may have many flaky tests because the duration will be ``0`` in some cases (because of optimizations/memory access/rounding?) when using the JVM in CircleCI.