### PR TITLE
[core] provide support for trace-agent API v0.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
 # 80 characters is a nice goal, but not worth currently changing in existing
 # code for the sake of changing it to conform to a length set in 1928 (IBM).
 Metrics/LineLength:
-  Max: 120
+  Max: 124
 
 # These exceptions are good goals to attain, and probably will over time,
 # so periodic disabling and re-running to inspect values is suggested.

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -32,6 +32,8 @@ EOS
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "msgpack"
+
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rubocop", "~> 0.43"

--- a/lib/ddtrace/encoding.rb
+++ b/lib/ddtrace/encoding.rb
@@ -61,12 +61,5 @@ module Datadog
         MessagePack.pack(obj)
       end
     end
-
-    # Switching logic that choose the best encoder for the API transport.
-    # The default behavior is to use Msgpack, falling back to the Ruby
-    # built-in JSON encoder.
-    def self.get_encoder
-      JSONEncoder.new()
-    end
   end
 end

--- a/lib/ddtrace/encoding.rb
+++ b/lib/ddtrace/encoding.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'msgpack'
 
 module Datadog
   # Encoding module that encodes data for the AgentTransport
@@ -46,6 +47,18 @@ module Datadog
 
       def encode(obj)
         JSON.dump(obj)
+      end
+    end
+
+    # Encoder for the Msgpack format
+    class MsgpackEncoder < Encoder
+      def initialize
+        Datadog::Tracer.log.debug('using Msgpack encoder')
+        @content_type = 'application/msgpack'
+      end
+
+      def encode(obj)
+        MessagePack.pack(obj)
       end
     end
 

--- a/lib/ddtrace/encoding.rb
+++ b/lib/ddtrace/encoding.rb
@@ -3,18 +3,57 @@ require 'json'
 module Datadog
   # Encoding module that encodes data for the AgentTransport
   module Encoding
-    # Encode the given set of spans in the right JSON format
-    # so that the agent can parse the list of traces
-    def self.encode_spans(traces)
-      to_send = []
-      traces.each do |trace|
-        to_send << trace.map(&:to_hash)
+    # Encoder interface that provides the logic to encode traces and service
+    class Encoder
+      attr_reader :content_type
+
+      # When extending the ``Encoder`` class, ``content_type`` must be set because
+      # they're used by the HTTPTransport so that it should not need to know what is
+      # the right header to suggest the decoding format to the agent
+      def initialize
+        @content_type = ''
       end
-      JSON.dump(to_send)
+
+      # Encodes a list of traces, expecting a list of items where each items
+      # is a list of spans. Before dump the string in a serialized format all
+      # traces are normalized. The traces nesting is not changed.
+      def encode_traces(traces)
+        to_send = []
+        traces.each do |trace|
+          to_send << trace.map(&:to_hash)
+        end
+        encode(to_send)
+      end
+
+      # Encodes services hash
+      def encode_services(services)
+        encode(services)
+      end
+
+      # Defines the underlying format used during traces or services encoding.
+      # This method must be implemented and should only be used by the internal functions.
+      def encode(_)
+        raise NotImplementedError
+      end
     end
 
-    def self.encode_services(services)
-      JSON.dump(services)
+    # Encoder for the JSON format
+    class JSONEncoder < Encoder
+      def initialize
+        Datadog::Tracer.log.debug('using JSON encoder; application performance may be degraded')
+        @content_type = 'application/json'
+      end
+
+      def encode(obj)
+        JSON.dump(obj)
+      end
+    end
+
+    # Switching logic that choose the best encoder for the API transport.
+    # The default behavior is to use Msgpack, falling back to the Ruby
+    # built-in JSON encoder.
+    def self.get_encoder
+      JSONEncoder.new()
     end
   end
 end

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -74,7 +74,7 @@ module Datadog
       services = services[0]
       @service_worker.enqueue(services)
 
-      transport.send(:traces, services)
+      transport.send(:services, services)
     end
 
     # enqueue the trace for submission to the API

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -10,8 +10,6 @@ module Datadog
 
     HOSTNAME = 'localhost'.freeze
     PORT = '7777'.freeze
-    SPANS_ENDPOINT = '/v0.2/traces'.freeze
-    SERVICES_ENDPOINT = '/v0.2/services'.freeze
 
     def initialize(options = {})
       # writer and transport parameters
@@ -62,8 +60,7 @@ module Datadog
       # FIXME[matt]: if there's an error, requeue; the new Transport can
       # behave differently if it's a server or a client error. Don't requeue
       # if we have a client error?
-      spans = Datadog::Encoding.encode_spans(traces)
-      transport.send(SPANS_ENDPOINT, spans)
+      transport.send(:traces, traces)
 
       # TODO[all]: is it really required? it's a number that will grow indefinitely
       @traces_flushed += traces.length()
@@ -77,8 +74,7 @@ module Datadog
       services = services[0]
       @service_worker.enqueue(services)
 
-      services = Datadog::Encoding.encode_services(services)
-      transport.send(SERVICES_ENDPOINT, services)
+      transport.send(:traces, services)
     end
 
     # enqueue the trace for submission to the API

--- a/test/benchmark_test.rb
+++ b/test/benchmark_test.rb
@@ -4,6 +4,7 @@ require 'benchmark'
 
 require 'helper'
 require 'ddtrace'
+require 'ddtrace/encoding'
 
 include Benchmark
 
@@ -22,5 +23,33 @@ class TraceBufferTest < Minitest::Test
     end
 
     assert_equal(tracer.writer.spans.length, N)
+  end
+end
+
+class EncoderTest < Minitest::Test
+  N = 10000
+
+  def test_benchmark_json_encoder
+    # create and finish a huge number of spans with a single thread
+    traces = get_test_traces(50)
+    json_encoder = Datadog::Encoding::JSONEncoder.new()
+
+    Benchmark.benchmark(CAPTION, 7, FORMAT, '>total:', '>avg:') do |x|
+      x.report("Encoding #{traces.length} traces with JSON:") do
+        N.times { json_encoder.encode_traces(traces) }
+      end
+    end
+  end
+
+  def test_benchmark_msgpack_encoder
+    # create and finish a huge number of spans with a single thread
+    traces = get_test_traces(50)
+    msgpack_encoder = Datadog::Encoding::MsgpackEncoder.new()
+
+    Benchmark.benchmark(CAPTION, 7, FORMAT, '>total:', '>avg:') do |x|
+      x.report("Encoding #{traces.length} traces with Msgpack:") do
+        N.times { msgpack_encoder.encode_traces(traces) }
+      end
+    end
   end
 end

--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -3,10 +3,11 @@ require 'ddtrace/span'
 require 'ddtrace/encoding'
 
 class TracerTest < Minitest::Test
-  def test_traces_encoding
+  def test_traces_encoding_json
     # test encoding for JSON format
+    encoder = Datadog::Encoding::JSONEncoder.new()
     traces = get_test_traces(2)
-    to_send = Datadog::Encoding.encode_spans(traces)
+    to_send = encoder.encode_traces(traces)
 
     assert to_send.is_a? String
     # the spans list must be a list of traces

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -73,6 +73,13 @@ class FauxTransport < Datadog::HTTPTransport
   end
 end
 
+# Add class accessors for testing purposes
+module Datadog
+  class HTTPTransport
+    attr_accessor :traces_endpoint, :services_endpoint, :encoder, :headers
+  end
+end
+
 # update Datadog user configuration; you should pass:
 #
 # * +key+: the key that should be updated

--- a/test/transport_test.rb
+++ b/test/transport_test.rb
@@ -75,4 +75,29 @@ class UtilsTest < Minitest::Test
     assert_equal nil, code,
                  "transport.send did not return 'nil'; code: #{code}"
   end
+
+  def test_traces_api_downgrade
+    skip unless ENV['TEST_DATADOG_INTEGRATION'] # requires a running agent
+    traces = get_test_traces(2)
+
+    # defaults should use the Msgpack encoder
+    assert_equal true, @default_transport.encoder.is_a?(Datadog::Encoding::MsgpackEncoder),
+                 "transport doesn't use Msgpack encoder, found: #{@default_transport.encoder}"
+
+    assert_equal 'application/msgpack', @default_transport.headers['Content-Type'],
+                 "transport content-type is not msgpack, found: #{@default_transport.headers['Content-Type']}"
+
+    # make the call to a not existing endpoint (it will return 404)
+    @default_transport.traces_endpoint = '/v0.0/traces'.freeze
+    code = @default_transport.send(:traces, traces)
+
+    # HTTPTransport should downgrade the encoder and API level
+    assert_equal true, @default_transport.encoder.is_a?(Datadog::Encoding::JSONEncoder),
+                 "transport didn't downgrade the encoder, found: #{@default_transport.encoder}"
+    assert_equal 'application/json', @default_transport.headers['Content-Type'],
+                 "transport content-type is not json, found: #{@default_transport.headers['Content-Type']}"
+
+    # in any cases, the call should end with a success
+    assert_equal true, @default_transport.success?(code), "transport.send failed, code: #{code}"
+  end
 end

--- a/test/transport_test.rb
+++ b/test/transport_test.rb
@@ -33,16 +33,14 @@ class UtilsTest < Minitest::Test
   def test_send_traces
     skip unless ENV['TEST_DATADOG_INTEGRATION'] # requires a runnning agent
     traces = get_test_traces(2)
-    encoded_spans = Datadog::Encoding.encode_spans(traces)
-    code = @transport.send('/v0.2/traces', encoded_spans)
+    code = @transport.send(:traces, traces)
     assert_equal true, @transport.success?(code), "transport.send failed, code: #{code}"
   end
 
   def test_send_services
     skip unless ENV['TEST_DATADOG_INTEGRATION'] # requires a runnning agent
-    services = get_test_services
-    encoded_services = Datadog::Encoding.encode_services(services)
-    code = @transport.send('/v0.2/services', encoded_services)
+    services = get_test_services()
+    code = @transport.send(:services, services)
     assert_equal true, @transport.success?(code), "transport.send failed, code: #{code}"
   end
 
@@ -50,18 +48,16 @@ class UtilsTest < Minitest::Test
     skip unless ENV['TEST_DATADOG_INTEGRATION'] # requires a runnning agent
     bad_transport = Datadog::HTTPTransport.new('localhost', '8888')
     traces = get_test_traces(2)
-    spans = Datadog::Encoding.encode_spans(traces)
-    code = bad_transport.send('/v0.2/traces', spans)
+    code = bad_transport.send(:traces, traces)
     assert_equal true, bad_transport.server_error?(code),
                  "transport.send did not fail (it should have failed) code: #{code}"
   end
 
-  def test_send_404
+  def test_send_router
     skip unless ENV['TEST_DATADOG_INTEGRATION'] # requires a running agent
     traces = get_test_traces(2)
-    spans = Datadog::Encoding.encode_spans(traces)
-    code = @transport.send('/admin.php', spans)
-    assert_equal 404, code,
-                 "transport.send did not return 404 (it should have returned 404) code: #{code}"
+    code = @transport.send(:admin, traces)
+    assert_equal nil, code,
+                 "transport.send did not return 'nil'; code: #{code}"
   end
 end


### PR DESCRIPTION
### What it does

Adds support to the ``trace-agent`` API version ``0.3``. This new API uses msgpack as a new communication format by default. The API also support JSON encoding if users want to send their traces manually.

If a ``404`` is hit, it means that the API is not available and so we have to downgrade the API level to a stable version (``JSONEncoder`` with the ``v0.2`` API at the time of writing).

The flow is:
* use ``MsgpackEncoder`` as default
* at the first call (services or traces are the same), read the status code
* if the response is a ``404`` or a ``415``, downgrade and re-try the call with the stable version
* in any other cases, keep the current encoder and API version (a ``5xx`` or ``4xx`` doesn't mean we should change the encoder because probably we've a different problem)

### Note
I includes also some benchmarks (that should be enhanced in the future):
```
                                      user     system      total        real
Encoding 50 traces with JSON:    10.940000   0.220000  11.160000 ( 11.440404)
Encoding 50 traces with Msgpack:  4.630000   0.280000   4.910000 (  4.974906)
```