### PR TITLE
bumping version 0.1.5 => 0.2.0

### DIFF
--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -1,8 +1,8 @@
 module Datadog
   module VERSION
     MAJOR = 0
-    MINOR = 1
-    PATCH = 5
+    MINOR = 2
+    PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
Just a bumping for master release. The use of a single thread has been not included in the ``0.2.0``