### PR TITLE
Use return value of block

### DIFF
--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -124,16 +124,18 @@ module Datadog
       # call the finish only if a block is given; this ensures
       # that a call to tracer.trace() without a block, returns
       # a span that should be manually finished.
-      begin
-        yield(span) if block_given?
-      rescue StandardError => e
-        span.set_error(e)
-        raise
-      ensure
-        span.finish() if block_given?
+      if block_given?
+        begin
+          yield(span)
+        rescue StandardError => e
+          span.set_error(e)
+          raise
+        ensure
+          span.finish()
+        end
+      else
+        span
       end
-
-      span
     end
 
     # Record the given finished span in the +spans+ list. When a +span+ is recorded, it will be sent

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -5,11 +5,14 @@ class TracerTest < Minitest::Test
   def test_trace
     tracer = get_test_tracer
 
-    tracer.trace('something') do |s|
+    ret = tracer.trace('something') do |s|
       assert_equal(s.name, 'something')
       assert_nil(s.end_time)
       sleep(0.001)
+      :return_val
     end
+
+    assert_equal(ret, :return_val)
 
     spans = tracer.writer.spans()
     assert_equal(spans.length, 1)


### PR DESCRIPTION
Fixes https://github.com/DataDog/dd-trace-rb/issues/41

When calling Datadog::Tracer#trace with a block, the return value of the
block will be used as the return value.