### PR TITLE
[redis/rails] passing block when calling fetch

### DIFF
--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -30,9 +30,9 @@ module Datadog
     # It might seem redundant to instrument both read and fetch since
     # fetch very often calls read. But there's no garantee of this, in
     # some cases fetch can call directly read_entry without calling read.
-    def fetch(*args)
+    def fetch(*args, &block)
       ActiveSupport::Notifications.instrument('start_cache_fetch.active_support')
-      super(*args)
+      super(*args, &block)
     end
   end
 

--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -30,9 +30,9 @@ module Datadog
     # It might seem redundant to instrument both read and fetch since
     # fetch very often calls read. But there's no garantee of this, in
     # some cases fetch can call directly read_entry without calling read.
-    def fetch(*args, &block)
+    def fetch(*args)
       ActiveSupport::Notifications.instrument('start_cache_fetch.active_support')
-      super(*args, &block)
+      super(*args)
     end
   end
 


### PR DESCRIPTION
The bug did not show up yet, but technically, `fetch` should forward a block to `super()` when monkey-patched. See https://github.com/rails/rails/blob/master/activesupport/lib/active_support/cache.rb#L283