### PR TITLE
[rails] disabling Rails by default if the application environment is not production

### DIFF
--- a/docs/GettingStarted
+++ b/docs/GettingStarted
@@ -132,9 +132,9 @@ of the Datadog tracer, you can override the following defaults:
     # config/initializers/datadog-tracer.rb
 
     Rails.configuration.datadog_trace = {
-      enabled: true,
-      auto_instrument: true,
-      auto_instrument_redis: true,
+      enabled: Rails.env.production?,
+      auto_instrument: Rails.env.production?,
+      auto_instrument_redis: Rails.env.production?,
       default_service: 'rails-app',
       default_cache_service: 'rails-cache',
       template_base_path: 'views/',
@@ -164,6 +164,21 @@ The available settings are:
 * +debug+: set to true to enable debug logging.
 * +trace_agent_hostname+: set the hostname of the trace agent.
 * +trace_agent_port+: set the port the trace agent is listening on.
+
+By default, the tracer is enabled only if Rails is executed with +RAILS_ENV=production+. If the tracer should
+be enabled in different configurations, you may need to change your initializer to:
+
+    # config/initializers/datadog-tracer.rb
+
+    # enable/disable the tracer with a condition
+    tracing_state = Rails.env.production? || Rails.env.staging?
+
+    Rails.configuration.datadog_trace = {
+      enabled: tracing_state,
+      auto_instrument: tracing_state,
+      auto_instrument_redis: tracing_state,
+      # ... other settings if you may have
+    }
 
 === Redis
 

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -14,11 +14,16 @@ module Datadog
     module Rails
       # TODO[manu]: write docs
       module Framework
+        # get Rails operation mode; Rails ships with 'production' as a default
+        # environment to set the entire application in production mode. This should
+        # be a reasonable default to disable the tracer in other environments.
+        PRODUCTION_MODE = ::Rails.env.production?
+
         # the default configuration
         DEFAULT_CONFIG = {
-          enabled: true,
-          auto_instrument: true,
-          auto_instrument_redis: true,
+          enabled: PRODUCTION_MODE,
+          auto_instrument: PRODUCTION_MODE,
+          auto_instrument_redis: PRODUCTION_MODE,
           default_service: 'rails-app',
           default_cache_service: 'rails-cache',
           template_base_path: 'views/',

--- a/test/contrib/rails/apps/application.rb
+++ b/test/contrib/rails/apps/application.rb
@@ -16,6 +16,15 @@ module RailsTrace
     # initializes the application and runs all migrations;
     # the require order is important
     def test_config
+      # Enables the auto-instrumentation
+      Rails.configuration.datadog_trace = {
+        enabled: true,
+        auto_instrument: true,
+        auto_instrument_redis: true
+      }
+      require 'ddtrace'
+
+      # Initialize the Rails application
       require 'contrib/rails/apps/controllers'
       initialize!
       require 'contrib/rails/apps/models'

--- a/test/contrib/rails/apps/rails3.rb
+++ b/test/contrib/rails/apps/rails3.rb
@@ -2,8 +2,6 @@ require 'rails/all'
 require 'rails/test_help'
 require 'contrib/rails/apps/cache'
 
-require 'ddtrace'
-
 class Rails3 < Rails::Application
   config.cache_store = get_cache
   config.secret_key_base = 'not_so_secret'

--- a/test/contrib/rails/apps/rails3.rb
+++ b/test/contrib/rails/apps/rails3.rb
@@ -9,6 +9,15 @@ class Rails3 < Rails::Application
   config.active_support.deprecation = :stderr
 end
 
+# Enables the auto-instrumentation
+Rails.configuration.datadog_trace = {
+  enabled: true,
+  auto_instrument: true,
+  auto_instrument_redis: true
+}
+require 'ddtrace'
+
+# Initialize the Rails application
 require 'contrib/rails/apps/controllers'
 Rails3.initialize!
 require 'contrib/rails/apps/models'

--- a/test/contrib/rails/apps/rails4.rb
+++ b/test/contrib/rails/apps/rails4.rb
@@ -1,7 +1,5 @@
 require 'contrib/rails/apps/application'
 
-require 'ddtrace'
-
 module Rails4
   class Application < RailsTrace::TestApplication
     config.active_support.test_order = :random

--- a/test/contrib/rails/apps/rails5.rb
+++ b/test/contrib/rails/apps/rails5.rb
@@ -1,7 +1,5 @@
 require 'contrib/rails/apps/application'
 
-require 'ddtrace'
-
 module Rails5
   class Application < RailsTrace::TestApplication
   end

--- a/test/contrib/rails/redis_cache_test.rb
+++ b/test/contrib/rails/redis_cache_test.rb
@@ -12,7 +12,7 @@ require 'contrib/rails/test_helper'
 class RedisCacheTracingTest < ActionController::TestCase
   setup do
     @original_tracer = Rails.configuration.datadog_trace[:tracer]
-    @tracer = get_test_tracer
+    @tracer = get_test_tracer()
     Rails.configuration.datadog_trace[:tracer] = @tracer
     assert_equal(true, Rails.cache.respond_to?(:data), "cache '#{Rails.cache}' has no data")
     pin = Datadog::Pin.get_from(Rails.cache.data)

--- a/test/contrib/rails/test_helper.rb
+++ b/test/contrib/rails/test_helper.rb
@@ -57,12 +57,3 @@ when '3.2.22.5'
 else
   logger.error 'A Rails app for this version is not found!'
 end
-
-# Enables the auto-instrumentation
-Rails.configuration.datadog_trace = {
-  enabled: true,
-  auto_instrument: true,
-  auto_instrument_redis: true
-}
-
-require 'ddtrace'

--- a/test/contrib/rails/test_helper.rb
+++ b/test/contrib/rails/test_helper.rb
@@ -57,3 +57,12 @@ when '3.2.22.5'
 else
   logger.error 'A Rails app for this version is not found!'
 end
+
+# Enables the auto-instrumentation
+Rails.configuration.datadog_trace = {
+  enabled: true,
+  auto_instrument: true,
+  auto_instrument_redis: true
+}
+
+require 'ddtrace'

--- a/test/contrib/redis/redis_test.rb
+++ b/test/contrib/redis/redis_test.rb
@@ -6,7 +6,7 @@ class RedisSetGetTest < Minitest::Test
   REDIS_HOST = '127.0.0.1'.freeze
   REDIS_PORT = 46379
   def setup
-    @tracer = get_test_tracer
+    @tracer = get_test_tracer()
 
     @drivers = {}
     [:ruby, :hiredis].each do |d|

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -154,6 +154,12 @@ end
 # reset default configuration and replace any dummy tracer
 # with the global one
 def reset_config
-  ::Rails.configuration.datadog_trace = {}
-  Datadog::Contrib::Rails::Framework.configure({})
+  ::Rails.configuration.datadog_trace = {
+    enabled: true,
+    auto_instrument: true,
+    auto_instrument_redis: true
+  }
+
+  config = { config: ::Rails.application.config }
+  Datadog::Contrib::Rails::Framework.configure(config)
 end


### PR DESCRIPTION
### What it does
Related to #53 

It disables the Rails automatic instrumentation (and the ``Datadog.tracer``) by default if the Rails environment is not set to ``production``. The global instance of ``Datadog.tracer`` is not affected if used outside Rails.

Usually, Rails provides [a set of default environments][1] such as:
* ``production``
* ``test``
* ``development``

If users don't use this convention, they can disable/enable the tracer as usual using a Rails initializer:
```ruby
# config/initializers/datadog-tracer.rb (or whatever)

# this is just an example and you can change it with a func or anything else
tracing_state = Rails.env.production? || Rails.env.staging?

Rails.configuration.datadog_trace = {
  enabled: tracing_state,
  auto_instrument: tracing_state,
  auto_instrument_redis: tracing_state,
  # ... other settings
}
```

#### Opened questions

@LotharSee doing that means the Rails instrumentation is disabled by default in any environment that is not ``production``. Users with ``staging`` environment will not have the tracer activated. We may change the condition to:
```ruby
# enables the tracing by default in any env except for 'test' and 'development'
PRODUCTION_MODE = !::Rails.env.test? && !::Rails.env.development?
```

[1]: http://guides.rubyonrails.org/configuring.html#creating-rails-environments