### PR TITLE
[rails] active_record keeps track of the :cached key if it's available

### DIFF
--- a/lib/ddtrace/contrib/rails/active_record.rb
+++ b/lib/ddtrace/contrib/rails/active_record.rb
@@ -31,11 +31,20 @@ module Datadog
             span_type: span_type
           )
 
+          # find out if the SQL query has been cached in this request. This meta is really
+          # helpful to users because some spans may have 0ns of duration because the query
+          # is simply cached from memory, so the notification is fired with start == finish.
+          # TODO[manu]: this feature has been merged into master but has not yet released.
+          # We're supporting this action as a best effort, but we should add a test after
+          # a new version of Rails is out.
+          cached = payload[:cached]
+
           # the span should have the query ONLY in the Resource attribute,
           # so that the ``sql.query`` tag will be set in the agent with an
           # obfuscated version
           span.span_type = Datadog::Ext::SQL::TYPE
           span.set_tag('rails.db.vendor', adapter_name)
+          span.set_tag('rails.db.cached', cached) if cached
           span.start_time = start
           span.finish_at(finish)
         rescue StandardError => e

--- a/test/contrib/rails/database_test.rb
+++ b/test/contrib/rails/database_test.rb
@@ -24,6 +24,7 @@ class DatabaseTracingTest < ActiveSupport::TestCase
     assert_equal(span.span_type, 'sql')
     assert_equal(span.service, adapter_name)
     assert_equal(span.get_tag('rails.db.vendor'), adapter_name)
+    assert_equal(span.get_tag('rails.db.cached'), nil)
     assert_includes(span.resource, 'SELECT COUNT(*) FROM')
     # ensure that the sql.query tag is not set
     assert_nil(span.get_tag('sql.query'))


### PR DESCRIPTION
### What it does

Keeps track of the ``:cached`` attribute in the ``active_record`` instrumentation payload. This is a best effort support for the moment, since this change [has been deployed][1] in the Rails master but it has not been released.

Having ``rails.db.cached`` meta is useful to explain users why some SQL queries has 0ns of duration.

[1]: https://github.com/rails/rails/blob/ff9999babf00dce6491a9bbf830abf4bc4ff9f9d/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb#L101-L117