### PR TITLE
Rubocop fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,7 +24,7 @@ Metrics/MethodLength:
 Style/AccessorMethodName:
   Enabled: false
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Enabled: false
 
 Style/RescueModifier:

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -129,6 +129,7 @@ class SpyTransport < Datadog::HTTPTransport
   # - then arrays contain, as a FIFO, all the data passed to send(endpoint, data)
   def helper_dump
     @helper_mutex.synchronize do
+      # rubocop:disable Security/MarshalLoad
       return Marshal.load(Marshal.dump(@helper_sent))
     end
   end


### PR DESCRIPTION
Tests which used to pass on CI now fail due to rubocop update. This patch should fix it.