### PR TITLE
[rails] avoid conditional require for active_record contrib module

### DIFF
--- a/lib/ddtrace/contrib/rails/active_record.rb
+++ b/lib/ddtrace/contrib/rails/active_record.rb
@@ -8,6 +8,9 @@ module Datadog
       # TODO[manu]: write docs
       module ActiveRecord
         def self.instrument
+          # ActiveRecord is instrumented only if it's available
+          return unless defined?(::ActiveRecord)
+
           # subscribe when the active record query has been processed
           ::ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
             sql(*args)

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -4,7 +4,7 @@ require 'ddtrace/ext/app_types'
 require 'ddtrace/contrib/rails/core_extensions'
 require 'ddtrace/contrib/rails/action_controller'
 require 'ddtrace/contrib/rails/action_view'
-require 'ddtrace/contrib/rails/active_record' if defined?(::ActiveRecord)
+require 'ddtrace/contrib/rails/active_record'
 require 'ddtrace/contrib/rails/active_support'
 require 'ddtrace/contrib/rails/utils'
 
@@ -102,7 +102,7 @@ module Datadog
           # instrumenting Rails framework
           Datadog::Contrib::Rails::ActionController.instrument()
           Datadog::Contrib::Rails::ActionView.instrument()
-          Datadog::Contrib::Rails::ActiveRecord.instrument() if defined?(::ActiveRecord)
+          Datadog::Contrib::Rails::ActiveRecord.instrument()
           Datadog::Contrib::Rails::ActiveSupport.instrument()
 
           # by default, Rails 3 doesn't instrument the cache system


### PR DESCRIPTION
### What it does

Related to: #40 

Avoids conditional require for ``ddtrace/contrib/rails/active_record`` module. In some configuration (and/or for order import), it's possible that the constant ``Datadog::Contrib::Rails::ActiveRecord`` is not initialized:
```
Detected Rails >= 3.x. Enabling auto-instrumentation for core components.
  .../dd-trace-rb-1b724b8af03c/lib/ddtrace/contrib/rails/framework.rb:97:in `auto_instrument': uninitialized constant Datadog::Contrib::Rails::ActiveRecord (NameError)
```

The loading / auto instrumentation behavior is not changed and everything behaves like before.