### PR TITLE
[ci] disable JRuby tests; it should be tested with the agent master branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -37,20 +37,21 @@ dependencies:
 test:
   override:
     - rvm 2.1.10 --verbose do rake rubocop
-    - rvm $MRI_VERSIONS,$JRUBY_VERSIONS --verbose do rake test
-    - rvm $MRI_VERSIONS,$JRUBY_VERSIONS --verbose do appraisal rails3-postgres rake rails
-    - rvm $MRI_VERSIONS,$JRUBY_VERSIONS --verbose do appraisal rails3-mysql2 rake rails
-    - rvm $MRI_VERSIONS,$JRUBY_VERSIONS --verbose do appraisal rails4-postgres rake rails
-    - rvm $MRI_VERSIONS,$JRUBY_VERSIONS --verbose do appraisal rails4-mysql2 rake rails
+# Disabled because of a Java incompatibility
+# TODO: integration tests should run with the master branch of the agent
+    - rvm $MRI_VERSIONS --verbose do rake test
+    - rvm $MRI_VERSIONS --verbose do appraisal rails3-postgres rake rails
+    - rvm $MRI_VERSIONS --verbose do appraisal rails3-mysql2 rake rails
+    - rvm $MRI_VERSIONS --verbose do appraisal rails4-postgres rake rails
+    - rvm $MRI_VERSIONS --verbose do appraisal rails4-mysql2 rake rails
     - rvm $RAILS5_VERSIONS --verbose do appraisal rails5-postgres rake rails
     - rvm $RAILS5_VERSIONS --verbose do appraisal rails5-mysql2 rake rails
-    - rvm $MRI_VERSIONS,$JRUBY_VERSIONS --verbose do appraisal rails3-postgres-redis rake railsredis
-    - rvm $MRI_VERSIONS,$JRUBY_VERSIONS --verbose do appraisal rails4-postgres-redis rake railsredis
+    - rvm $MRI_VERSIONS --verbose do appraisal rails3-postgres-redis rake railsredis
+    - rvm $MRI_VERSIONS --verbose do appraisal rails4-postgres-redis rake railsredis
     - rvm $RAILS5_VERSIONS --verbose do appraisal rails5-postgres-redis rake railsredis
-    - rvm $MRI_VERSIONS,$JRUBY_VERSIONS --verbose do appraisal contrib rake contrib
-    - rvm $MRI_VERSIONS,$JRUBY_VERSIONS --verbose do appraisal contrib rake monkey
+    - rvm $MRI_VERSIONS --verbose do appraisal contrib rake contrib
+    - rvm $MRI_VERSIONS --verbose do appraisal contrib rake monkey
     - rvm 2.3.1 --verbose do rake benchmark
-    - rvm jruby-9.1.5.0 --verbose do rake benchmark
 
 deployment:
   develop:


### PR DESCRIPTION
### What it does

JRuby is currently in the experimental support and an incompatibility issue was fixed but not deployed in the latest version of the agent. Because the current Ruby CI doesn't run our integration tests with the ``trace-agent`` master branch, it will always fail.

#### What we should do later
* enable the JRuby CI before making a new ``dd-trace-rb`` release
* test Ruby integrations with the master branch and the latest released version