### PR TITLE
[rails] adding cache support for Passenger

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,8 +4,6 @@ machine:
   environment:
     MRI_VERSIONS: 2.3.1,2.2.5,2.1.10
     RAILS5_VERSIONS: 2.3.1,2.2.5
-    JRUBY_VERSIONS: jruby-9.1.5.0
-    JRUBY_OPTS: --dev
     AGENT_BUILD_PATH: "/home/ubuntu/agent"
     TEST_DATADOG_INTEGRATION: 1
 
@@ -23,16 +21,15 @@ dependencies:
     - bundle install
     - rvm get head
     - rvm install $MRI_VERSIONS
-    - rvm install $JRUBY_VERSIONS
     # prepare and run the trace agent
     # TODO[manu]: remove this part when everything will be open source
     - git clone git@github.com:DataDog/datadog-trace-agent.git $AGENT_BUILD_PATH
     - cd $AGENT_BUILD_PATH && docker build -t datadog/trace-agent .
     - docker run -d -e DD_API_KEY=invalid_key_but_this_is_fine -e DD_BIND_HOST=0.0.0.0 -p 127.0.0.1:7777:7777 datadog/trace-agent
   override:
-    - rvm $MRI_VERSIONS,$JRUBY_VERSIONS --verbose do gem install bundler
-    - rvm $MRI_VERSIONS,$JRUBY_VERSIONS --verbose do bundle install
-    - rvm $MRI_VERSIONS,$JRUBY_VERSIONS --verbose do appraisal install
+    - rvm $MRI_VERSIONS --verbose do gem install bundler
+    - rvm $MRI_VERSIONS --verbose do bundle install
+    - rvm $MRI_VERSIONS --verbose do appraisal install
 
 test:
   override:

--- a/docs/GettingStarted
+++ b/docs/GettingStarted
@@ -85,7 +85,7 @@ The supported versions are:
 The currently supported web server are:
 * Puma 2.16+ and 3.6+
 * Unicorn 4.8+ and 5.1+
-* Passenger 5.0 (experimental)
+* Passenger 5.0+
 
 ==== Auto Instrumentation
 

--- a/lib/ddtrace/contrib/rails/action_view.rb
+++ b/lib/ddtrace/contrib/rails/action_view.rb
@@ -6,6 +6,9 @@ module Datadog
       # TODO[manu]: write docs
       module ActionView
         def self.instrument
+          # patch Rails core components
+          Datadog::RailsPatcher.patch_renderer()
+
           # subscribe when the template rendering starts
           ::ActiveSupport::Notifications.subscribe('start_render_template.action_view') do |*args|
             start_render_template(*args)

--- a/lib/ddtrace/contrib/rails/active_support.rb
+++ b/lib/ddtrace/contrib/rails/active_support.rb
@@ -44,10 +44,6 @@ module Datadog
           ::ActiveSupport::Notifications.subscribe('cache_delete.active_support') do |*args|
             trace_cache('DELETE', *args)
           end
-
-          # by default, Rails 3 doesn't instrument the cache system
-          return unless ::Rails::VERSION::MAJOR.to_i == 3
-          ::ActiveSupport::Cache::Store.instrument = true
         end
 
         def self.create_span(tracer)

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -95,19 +95,11 @@ module Datadog
           return unless ::Rails.configuration.datadog_trace[:auto_instrument]
           Datadog::Tracer.log.info('Detected Rails >= 3.x. Enabling auto-instrumentation for core components.')
 
-          # patch Rails core components
-          Datadog::RailsPatcher.patch_renderer()
-          Datadog::RailsPatcher.patch_cache_store()
-
           # instrumenting Rails framework
           Datadog::Contrib::Rails::ActionController.instrument()
           Datadog::Contrib::Rails::ActionView.instrument()
           Datadog::Contrib::Rails::ActiveRecord.instrument()
           Datadog::Contrib::Rails::ActiveSupport.instrument()
-
-          # by default, Rails 3 doesn't instrument the cache system
-          return unless ::Rails::VERSION::MAJOR.to_i == 3
-          ::ActiveSupport::Cache::Store.instrument = true
         end
       end
     end


### PR DESCRIPTION
### What it does

Adds cache support to Passenger. Because of an implementation detail related to how Rails 3.x [stores the cache instrumentation][1], Passenger didn't work properly. Spans were correctly created using the ``start_cache_*.active_support`` signals, but they were never closed because ``cache_*.active_support`` were not activated.

This patch ensures that cache instrumentation is activated if the ``auto_instrument`` flag is on.

[1]: https://github.com/rails/rails/blob/v3.2.22.5/activesupport/lib/active_support/cache.rb#L175-L177