### PR TITLE
[ci] updating testing matrix

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,60 +1,62 @@
-appraise "rails3-postgres" do
-  gem "test-unit"
-  gem "rails", "3.2.22.5"
-  gem "pg", platform: :ruby
-  gem 'activerecord-jdbcpostgresql-adapter', platform: :jruby
-end
-
-appraise "rails4-postgres" do
-  gem "rails", "4.2.7.1"
-  gem "pg", platform: :ruby
-  gem 'activerecord-jdbcpostgresql-adapter', platform: :jruby
-end
-
-appraise "rails3-mysql2" do
-  gem "test-unit"
-  gem "rails", "3.2.22.5"
-  gem "mysql2", "0.3.21", platform: :ruby
-  gem "activerecord-mysql-adapter", platform: :ruby
-  gem 'activerecord-jdbcmysql-adapter', platform: :jruby
-end
-
-appraise "rails4-mysql2" do
-  gem "rails", "4.2.7.1"
-  gem "mysql2", platform: :ruby
-  gem 'activerecord-jdbcmysql-adapter', platform: :jruby
-end
-
-appraise "rails3-postgres-redis" do
-  gem "test-unit"
-  gem "rails", "3.2.22.5"
-  gem "pg", platform: :ruby
-  gem 'activerecord-jdbcpostgresql-adapter', platform: :jruby
-  gem "redis-rails"
-end
-
-appraise "rails4-postgres-redis" do
-  gem "rails", "4.2.7.1"
-  gem "pg", platform: :ruby
-  gem 'activerecord-jdbcpostgresql-adapter', platform: :jruby
-  gem "redis-rails"
-end
-
-if RUBY_VERSION >= "2.2.2" && RUBY_PLATFORM != "java"
-  appraise "rails5-postgres" do
-    gem "rails", "5.0.0.1"
+if RUBY_VERSION < "2.4.0"
+  appraise "rails3-postgres" do
+    gem "test-unit"
+    gem "rails", "3.2.22.5"
     gem "pg", platform: :ruby
+    gem 'activerecord-jdbcpostgresql-adapter', platform: :jruby
   end
 
-  appraise "rails5-mysql2" do
-    gem "rails", "5.0.0.1"
+  appraise "rails4-postgres" do
+    gem "rails", "4.2.7.1"
+    gem "pg", platform: :ruby
+    gem 'activerecord-jdbcpostgresql-adapter', platform: :jruby
+  end
+
+  appraise "rails3-mysql2" do
+    gem "test-unit"
+    gem "rails", "3.2.22.5"
+    gem "mysql2", "0.3.21", platform: :ruby
+    gem "activerecord-mysql-adapter", platform: :ruby
+    gem 'activerecord-jdbcmysql-adapter', platform: :jruby
+  end
+
+  appraise "rails4-mysql2" do
+    gem "rails", "4.2.7.1"
     gem "mysql2", platform: :ruby
+    gem 'activerecord-jdbcmysql-adapter', platform: :jruby
   end
 
-  appraise "rails5-postgres-redis" do
-    gem "rails", "5.0.0.1"
+  appraise "rails3-postgres-redis" do
+    gem "test-unit"
+    gem "rails", "3.2.22.5"
     gem "pg", platform: :ruby
+    gem 'activerecord-jdbcpostgresql-adapter', platform: :jruby
     gem "redis-rails"
+  end
+
+  appraise "rails4-postgres-redis" do
+    gem "rails", "4.2.7.1"
+    gem "pg", platform: :ruby
+    gem 'activerecord-jdbcpostgresql-adapter', platform: :jruby
+    gem "redis-rails"
+  end
+
+  if RUBY_VERSION >= "2.2.2" && RUBY_PLATFORM != "java"
+    appraise "rails5-postgres" do
+      gem "rails", "5.0.1"
+      gem "pg", platform: :ruby
+    end
+
+    appraise "rails5-mysql2" do
+      gem "rails", "5.0.1"
+      gem "mysql2", platform: :ruby
+    end
+
+    appraise "rails5-postgres-redis" do
+      gem "rails", "5.0.1"
+      gem "pg", platform: :ruby
+      gem "redis-rails"
+    end
   end
 end
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,8 +2,11 @@ machine:
   services:
     - docker
   environment:
-    MRI_VERSIONS: 2.3.1,2.2.5,2.1.10
-    RAILS5_VERSIONS: 2.3.1,2.2.5
+    LAST_STABLE: 2.4.0
+    EARLY_STABLE: 2.1.10
+    MRI_VERSIONS: 2.4.0,2.3.3,2.2.6,2.1.10
+    RAILS_VERSIONS: 2.3.3,2.2.6,2.1.10
+    RAILS5_VERSIONS: 2.3.3,2.2.6
     AGENT_BUILD_PATH: "/home/ubuntu/agent"
     TEST_DATADOG_INTEGRATION: 1
 
@@ -27,28 +30,29 @@ dependencies:
     - cd $AGENT_BUILD_PATH && docker build -t datadog/trace-agent .
     - docker run -d -e DD_API_KEY=invalid_key_but_this_is_fine -e DD_BIND_HOST=0.0.0.0 -p 127.0.0.1:7777:7777 datadog/trace-agent
   override:
+    - rvm $MRI_VERSIONS --verbose do gem update --system
     - rvm $MRI_VERSIONS --verbose do gem install bundler
     - rvm $MRI_VERSIONS --verbose do bundle install
     - rvm $MRI_VERSIONS --verbose do appraisal install
 
 test:
   override:
-    - rvm 2.1.10 --verbose do rake rubocop
+    - rvm $EARLY_STABLE --verbose do rake rubocop
 # Disabled because of a Java incompatibility
 # TODO: integration tests should run with the master branch of the agent
     - rvm $MRI_VERSIONS --verbose do rake test
-    - rvm $MRI_VERSIONS --verbose do appraisal rails3-postgres rake rails
-    - rvm $MRI_VERSIONS --verbose do appraisal rails3-mysql2 rake rails
-    - rvm $MRI_VERSIONS --verbose do appraisal rails4-postgres rake rails
-    - rvm $MRI_VERSIONS --verbose do appraisal rails4-mysql2 rake rails
-    - rvm $RAILS5_VERSIONS --verbose do appraisal rails5-postgres rake rails
-    - rvm $RAILS5_VERSIONS --verbose do appraisal rails5-mysql2 rake rails
-    - rvm $MRI_VERSIONS --verbose do appraisal rails3-postgres-redis rake railsredis
-    - rvm $MRI_VERSIONS --verbose do appraisal rails4-postgres-redis rake railsredis
-    - rvm $RAILS5_VERSIONS --verbose do appraisal rails5-postgres-redis rake railsredis
     - rvm $MRI_VERSIONS --verbose do appraisal contrib rake contrib
     - rvm $MRI_VERSIONS --verbose do appraisal contrib rake monkey
-    - rvm 2.3.1 --verbose do rake benchmark
+    - rvm $RAILS_VERSIONS --verbose do appraisal rails3-mysql2 rake rails
+    - rvm $RAILS_VERSIONS --verbose do appraisal rails3-postgres rake rails
+    - rvm $RAILS_VERSIONS --verbose do appraisal rails3-postgres-redis rake railsredis
+    - rvm $RAILS_VERSIONS --verbose do appraisal rails4-mysql2 rake rails
+    - rvm $RAILS_VERSIONS --verbose do appraisal rails4-postgres rake rails
+    - rvm $RAILS_VERSIONS --verbose do appraisal rails4-postgres-redis rake railsredis
+    - rvm $RAILS5_VERSIONS --verbose do appraisal rails5-mysql2 rake rails
+    - rvm $RAILS5_VERSIONS --verbose do appraisal rails5-postgres rake rails
+    - rvm $RAILS5_VERSIONS --verbose do appraisal rails5-postgres-redis rake railsredis
+    - rvm $LAST_STABLE --verbose do rake benchmark
 
 deployment:
   develop:

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -34,9 +34,8 @@ EOS
 
   spec.add_dependency "msgpack"
 
-  spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rubocop", "~> 0.43"
-  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "rubocop", "~> 0.47"
+  spec.add_development_dependency "minitest", "~> 5.10"
   spec.add_development_dependency "appraisal", "~> 2.1"
 end

--- a/docs/GettingStarted
+++ b/docs/GettingStarted
@@ -349,6 +349,7 @@ The \Datadog Trace Client has been tested with the following Ruby versions:
 * Ruby MRI 2.1
 * Ruby MRI 2.2
 * Ruby MRI 2.3
+* Ruby MRI 2.4
 * JRuby 9.1.5 (experimental)
 
 Other versions aren't yet officially supported.

--- a/gemfiles/rails5_mysql2.gemfile
+++ b/gemfiles/rails5_mysql2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "5.0.0.1"
+gem "rails", "5.0.1"
 gem "mysql2", :platform => :ruby
 
 gemspec :path => "../"

--- a/gemfiles/rails5_postgres.gemfile
+++ b/gemfiles/rails5_postgres.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "5.0.0.1"
+gem "rails", "5.0.1"
 gem "pg", :platform => :ruby
 
 gemspec :path => "../"

--- a/gemfiles/rails5_postgres_redis.gemfile
+++ b/gemfiles/rails5_postgres_redis.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "5.0.0.1"
+gem "rails", "5.0.1"
 gem "pg", :platform => :ruby
 gem "redis-rails"
 

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -1,4 +1,3 @@
-require 'ddtrace'
 require 'ddtrace/ext/app_types'
 
 require 'ddtrace/contrib/rails/core_extensions'

--- a/test/contrib/rails/test_helper.rb
+++ b/test/contrib/rails/test_helper.rb
@@ -46,7 +46,7 @@ ENV['DATABASE_URL'] = connector
 logger.info "Testing against Rails #{Rails.version} with connector '#{connector}'"
 
 case Rails.version
-when '5.0.0.1'
+when '5.0.1'
   require 'contrib/rails/apps/rails5'
 when '4.2.7.1'
   require 'contrib/rails/apps/rails4'


### PR DESCRIPTION
### What it does

* Ruby ``2.4.0`` is officially supported
* updates the test matrix to support Rails ``5.0.1``
* Rails tests are not launched for Ruby 2.4.0 until new versions are released
* updates development dependencies