### PR TITLE
[packaging] RubyGems is used to publish stable versions

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -68,5 +68,4 @@ deployment:
     tag: /v[0-9]+(\.[0-9]+)*/
     commands:
       - S3_DIR=trace rake release:docs
-      - S3_DIR=trace VERSION_SUFFIX= rake release:gem
       - cp -r ./rubygems/* $CIRCLE_ARTIFACTS

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -20,9 +20,8 @@ EOS
   spec.homepage = "https://github.com/DataDog/dd-trace-rb"
   spec.license  = "BSD-3-Clause"
 
-  # TODO[manu]: after GA, change that with rubygems.org
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "http://localhost:8808"
+    spec.metadata['allowed_push_host'] = "https://rubygems.org"
   else
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end

--- a/docs/GettingStarted
+++ b/docs/GettingStarted
@@ -7,21 +7,21 @@ databases and microservices so that developers have great visiblity into bottlen
 
 Install the tracer with the +gem+ command, but point to Datadog's gems repository:
 
-    $ gem install ddtrace --source http://gems.datadoghq.com/trace/
+    $ gem install ddtrace
 
 On the other hand, if you're using +Bundler+, just update your +Gemfile+ as follows:
 
     source 'https://rubygems.org'
 
     # tracing gem
-    gem 'ddtrace', :source => 'http://gems.datadoghq.com/trace/'
+    gem 'ddtrace'
 
 If you're using the Ruby on Rails framework, you need to configure the auto-instrumentation with an {extra step}[#label-Auto+Instrumentation].
 
 == Quickstart (Auto Instrumentation)
 
 If you are on a {supported integration}[#label-Integrations], you should be able to generate traffic and view
-metrics in your {dashboard}[https://app.datadoghq.com/trace].
+metrics listed in your service list.
 
 == Quickstart (Manual Instrumentation)
 


### PR DESCRIPTION
### What it does

* CircleCI **will not** publish a stable version after a new tag is pushed
* to publish a new version use the built-in ``rake release`` command

#### What's missing

* the ``rake release`` command should be launched by our CI