### PR TITLE
Improving CI testing time

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,9 +19,12 @@ dependencies:
     # only docker-engine==1.9
     - pip install docker-compose==1.7.1
     - docker-compose up -d | cat
-    # configure Ruby interpreters
+    # installing dev dependencies
+    - gem update --system
     - gem install builder
+    - gem update bundler
     - bundle install
+    # configure Ruby interpreters
     - rvm get head
     - rvm install $MRI_VERSIONS
     # prepare and run the trace agent

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@ machine:
   services:
     - docker
   environment:
+    # FIXME: Disabled $JRUBY_VERSIONS tests because of a Java incompatibility
     LAST_STABLE: 2.4.0
     EARLY_STABLE: 2.1.10
     MRI_VERSIONS: 2.4.0,2.3.3,2.2.6,2.1.10
@@ -41,24 +42,9 @@ dependencies:
 test:
   override:
     - rvm $EARLY_STABLE --verbose do rake rubocop
-# Disabled $JRUBY_VERSIONS tests because of a Java incompatibility
-# TODO: integration tests should run with the master branch of the agent
-    - rvm $MRI_VERSIONS --verbose do rake test:main
-    - rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:monkey
-    - rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:elasticsearch
-    - rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:http
-    - rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:redis
-    - rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:sinatra
-    - rvm $RAILS_VERSIONS --verbose do appraisal rails3-postgres rake test:rails
-    - rvm $RAILS_VERSIONS --verbose do appraisal rails3-mysql2 rake test:rails
-    - rvm $RAILS_VERSIONS --verbose do appraisal rails4-postgres rake test:rails
-    - rvm $RAILS_VERSIONS --verbose do appraisal rails4-mysql2 rake test:rails
-    - rvm $RAILS5_VERSIONS --verbose do appraisal rails5-postgres rake test:rails
-    - rvm $RAILS5_VERSIONS --verbose do appraisal rails5-mysql2 rake test:rails
-    - rvm $RAILS_VERSIONS --verbose do appraisal rails3-postgres-redis rake test:railsredis
-    - rvm $RAILS_VERSIONS --verbose do appraisal rails4-postgres-redis rake test:railsredis
-    - rvm $RAILS5_VERSIONS --verbose do appraisal rails5-postgres-redis rake test:railsredis
-    - rvm $LAST_STABLE --verbose do rake benchmark
+    # TODO: integration tests should run with the master branch of the agent
+    - rake ci:
+        parallel: true
 
 deployment:
   develop:


### PR DESCRIPTION
### What it does

* overrides system rubies so that cache should not be invalidated (if a new version of bundler is available, the package will be updated and the right version is used)
* uses x3 parallel execution reducing execution time

[Example execution][1]

[1]: https://circleci.com/gh/DataDog/dd-trace-rb/588

#### What's missing

The workload is manually configured so a better approach is preferred. Anyway it's good enough at this time and it improves tests execution. Further improvement should include caching Docker containers (and maybe using Ruby containers to run tests), but actually CircleCI doesn't support a good docker layers caching. It only provides a workaround. Fair enough for now.