### PR TITLE
[span] adding a default 'ruby' service is none is given

### DIFF
--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -12,6 +12,10 @@ module Datadog
   class Span
     # The max value for a \Span identifier
     MAX_ID = 2**64 - 1
+    # A default value for service. One should really override this one
+    # for non-root spans which have a parent. However, root spans without
+    # a service would be invalid and rejected.
+    DEFAULT_SERVICE = 'ruby'.freeze
 
     attr_accessor :name, :service, :resource, :span_type,
                   :start_time, :end_time,

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -141,6 +141,8 @@ module Datadog
     # Record the given finished span in the +spans+ list. When a +span+ is recorded, it will be sent
     # to the Datadog trace agent as soon as the trace is finished.
     def record(span)
+      span.service ||= Datadog::Span::DEFAULT_SERVICE
+
       spans = []
       @mutex.synchronize do
         @spans << span

--- a/test/workers_test.rb
+++ b/test/workers_test.rb
@@ -120,6 +120,40 @@ class WorkersSpanTest < WorkersTest
     dumped_traces = dump[500][:traces]
     assert_operator(1, :<=, dumped_traces.length, 'there should have been errors on traces endpoint')
   end
+
+  # test that a default service is provided if none has been given at all
+  def test_span_default_service
+    span = Datadog::Span.new(@tracer, 'my.op')
+    sleep(0.001)
+    span.finish()
+
+    (20 * SPAN_INTERVAL).times do
+      break if @writer.stats[:traces_flushed] >= 1
+      sleep(0.1)
+    end
+
+    assert_equal(1, @writer.stats[:traces_flushed], 'wrong number of traces flushed')
+    dump = @transport.helper_dump
+    dumped_traces = dump[200][:traces]
+    refute_nil(dumped_traces, 'no 200 OK data for default traces endpoint')
+    # unmarshalling data
+    assert_equal(1, dumped_traces.length, 'there should be one and only one payload')
+    assert_kind_of(String, dumped_traces[0])
+    payload = JSON.parse(dumped_traces[0])
+    assert_kind_of(Array, payload)
+    assert_equal(1, payload.length, 'there should be one trace in the payload')
+    trace = payload[0]
+    assert_kind_of(Array, trace)
+    assert_equal(1, trace.length, 'there should be one span in the trace')
+    span = trace[0]
+    assert_kind_of(Hash, span)
+    # checking content
+    assert_equal(0, span['parent_id'], 'a root span should have no parent')
+    assert_equal(0, span['error'], 'there should be explicitely no error')
+    assert_equal(span['trace_id'], span['span_id'], 'a root span should have equal trace_id and span_id')
+    # now the whole purpose of this test: check we have a 'ruby' service by default
+    assert_equal('ruby', span['service'], 'wrong service')
+  end
 end
 
 class WorkersServiceTest < WorkersTest


### PR DESCRIPTION
It's technically possible to create a span without a service, and this is valid, it should inherit the service from its parent in that case. However root spans have no parent so it's impossible to infer/guess a valid name. This patch provides a default value (`ruby`) in that case.