### PR TITLE
[rails] discard parameters from the cache_store configuration

### DIFF
--- a/lib/ddtrace/contrib/rails/active_support.rb
+++ b/lib/ddtrace/contrib/rails/active_support.rb
@@ -93,7 +93,9 @@ module Datadog
           begin
             # finish the tracing and update the execution time
             span.resource = resource
-            span.set_tag('rails.cache.backend', ::Rails.configuration.cache_store)
+            # discard parameters from the cache_store configuration
+            store, = *Array.wrap(::Rails.configuration.cache_store).flatten
+            span.set_tag('rails.cache.backend', store)
             span.set_tag('rails.cache.key', payload.fetch(:key))
 
             if payload[:exception]

--- a/test/contrib/rails/cache_test.rb
+++ b/test/contrib/rails/cache_test.rb
@@ -25,7 +25,7 @@ class CacheTracingTest < ActionController::TestCase
     assert_equal(span.span_type, 'cache')
     assert_equal(span.resource, 'GET')
     assert_equal(span.service, 'rails-cache')
-    assert_equal(span.get_tag('rails.cache.backend').to_s, '[:file_store, "/tmp/ddtrace-rb/cache/"]')
+    assert_equal(span.get_tag('rails.cache.backend').to_s, 'file_store')
     assert_equal(span.get_tag('rails.cache.key'), 'custom-key')
   end
 
@@ -39,7 +39,7 @@ class CacheTracingTest < ActionController::TestCase
     assert_equal(span.span_type, 'cache')
     assert_equal(span.resource, 'SET')
     assert_equal(span.service, 'rails-cache')
-    assert_equal(span.get_tag('rails.cache.backend').to_s, '[:file_store, "/tmp/ddtrace-rb/cache/"]')
+    assert_equal(span.get_tag('rails.cache.backend').to_s, 'file_store')
     assert_equal(span.get_tag('rails.cache.key'), 'custom-key')
   end
 
@@ -53,7 +53,7 @@ class CacheTracingTest < ActionController::TestCase
     assert_equal(span.span_type, 'cache')
     assert_equal(span.resource, 'DELETE')
     assert_equal(span.service, 'rails-cache')
-    assert_equal(span.get_tag('rails.cache.backend').to_s, '[:file_store, "/tmp/ddtrace-rb/cache/"]')
+    assert_equal(span.get_tag('rails.cache.backend').to_s, 'file_store')
     assert_equal(span.get_tag('rails.cache.key'), 'custom-key')
   end
 

--- a/test/contrib/rails/redis_cache_test.rb
+++ b/test/contrib/rails/redis_cache_test.rb
@@ -40,7 +40,7 @@ class RedisCacheTracingTest < ActionController::TestCase
       assert_equal(span.span_type, 'cache')
       assert_equal(span.resource, 'GET')
       assert_equal(span.service, 'rails-cache')
-      assert_equal(span.get_tag('rails.cache.backend').to_s, '[:redis_store, {:url=>"redis://127.0.0.1:46379"}]')
+      assert_equal(span.get_tag('rails.cache.backend').to_s, 'redis_store')
       assert_equal(span.get_tag('rails.cache.key'), 'custom-key')
       span = spans[-2]
       assert_equal(span.name, 'redis.command')
@@ -101,7 +101,7 @@ class RedisCacheTracingTest < ActionController::TestCase
     assert_equal(span.span_type, 'cache')
     assert_equal(span.resource, 'SET')
     assert_equal(span.service, 'rails-cache')
-    assert_equal(span.get_tag('rails.cache.backend').to_s, '[:redis_store, {:url=>"redis://127.0.0.1:46379"}]')
+    assert_equal(span.get_tag('rails.cache.backend').to_s, 'redis_store')
     assert_equal(span.get_tag('rails.cache.key'), 'custom-key')
     span = spans[-2]
     assert_equal(span.name, 'redis.command')
@@ -123,7 +123,7 @@ class RedisCacheTracingTest < ActionController::TestCase
     assert_equal(span.span_type, 'cache')
     assert_equal(span.resource, 'DELETE')
     assert_equal(span.service, 'rails-cache')
-    assert_equal(span.get_tag('rails.cache.backend').to_s, '[:redis_store, {:url=>"redis://127.0.0.1:46379"}]')
+    assert_equal(span.get_tag('rails.cache.backend').to_s, 'redis_store')
     assert_equal(span.get_tag('rails.cache.key'), 'custom-key')
     span = spans[-2]
     assert_equal(span.name, 'redis.command')


### PR DESCRIPTION
### What it does

Discards parameters like:
```
[:redis_store, "redis://localhost:6379/0", {:expires_in=>60 minutes}]
```

The ``rails.cache.backend`` will only contains ``redis_store`` value.