### PR TITLE
[elasticsearch] safe-guard when the body is already encoded

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,3 +41,9 @@ Metrics/BlockLength:
 
 Metrics/ParameterLists:
   Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Max: 15
+
+Metrics/PerceivedComplexity:
+  Max: 15

--- a/lib/ddtrace/contrib/http/patcher.rb
+++ b/lib/ddtrace/contrib/http/patcher.rb
@@ -14,8 +14,6 @@ module Datadog
 
       module_function
 
-      # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/PerceivedComplexity
       def should_skip_tracing?(req, address, port, transport, pin)
         # we don't want to trace our own call to the API (they use net/http)
         # when we know the host & port (from the URI) we use it, else (most-likely

--- a/lib/ddtrace/contrib/sinatra/tracer.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer.rb
@@ -85,9 +85,7 @@ module Datadog
         end
 
         # rubocop:disable Metrics/AbcSize
-        # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/MethodLength
-        # rubocop:disable Metrics/PerceivedComplexity
         def self.registered(app)
           ::Sinatra::Base.module_eval do
             def render(engine, data, *)


### PR DESCRIPTION
### What it does

* if the Elasticsearch `perform_request` fails for our instrumentation, `ensure` the original method is called
* handles the case where the `body` is already encoded as a string; in that case the `JSON.generate()` will fail so we use it as is

#### Note
Third party libraries encode the `body` as a String (i.e. [Chewy][1]) so we should handle that case

[1]: https://github.com/toptal/chewy