### PR TITLE
[core] add metrics testing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,7 +34,7 @@ Style/NumericLiterals:
   Enabled: false
 
 Metrics/ClassLength:
-  Max: 120
+  Max: 140
 
 Metrics/BlockLength:
   Max: 42

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -236,12 +236,15 @@ to trace requests to the home page:
         # set some span metadata
         span.service = 'my-web-site'
         span.resource = '/'
-        span.set_tag('http.method', request.request_method)
 
         # trace the activerecord call
         tracer.trace('posts.fetch') do
           @posts = Posts.order(created_at: :desc).limit(10)
         end
+
+        # add some attributes and metrics
+        span.set_tag('http.method', request.request_method)
+        span.set_metric('posts.count', len(@posts))
 
         # trace the template rendering
         tracer.trace('template.render') do

--- a/lib/ddtrace/sampler.rb
+++ b/lib/ddtrace/sampler.rb
@@ -1,4 +1,3 @@
-
 module Datadog
   # \Sampler performs client-side trace sampling.
   class Sampler

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -57,7 +57,7 @@ module Datadog
     def set_tag(key, value)
       @meta[key] = value.to_s
     rescue StandardError => e
-      Datadog::Tracer.log.error("Unable to set the tag #{key}, ignoring it. Caused by: #{e}")
+      Datadog::Tracer.log.debug("Unable to set the tag #{key}, ignoring it. Caused by: #{e}")
     end
 
     # Return the tag with the given key, nil if it doesn't exist.
@@ -68,7 +68,11 @@ module Datadog
     # Set the given key / value metric pair on the span. Keys must be string.
     # Values must be floating point numbers.
     def set_metric(key, value)
+      # enforce that the value is a floating point number
+      value = Float(value)
       @metrics[key] = value
+    rescue StandardError => e
+      Datadog::Tracer.log.debug("Unable to set the metric #{key}, ignoring it. Caused by: #{e}")
     end
 
     # Return the metric with the given key, nil if it doesn't exist.

--- a/test/contrib/sinatra/tracer_test.rb
+++ b/test/contrib/sinatra/tracer_test.rb
@@ -1,7 +1,5 @@
-
 require 'contrib/sinatra/tracer_test_base'
 
-# rubocop:disable Metrics/ClassLength
 class TracerTest < TracerTestBase
   class TracerTestApp < Sinatra::Application
     configure do

--- a/test/sampler_test.rb
+++ b/test/sampler_test.rb
@@ -3,6 +3,14 @@ require 'helper'
 require 'ddtrace/sampler'
 
 class SamplerTest < Minitest::Test
+  def setup
+    Datadog::Tracer.log.level = Logger::FATAL
+  end
+
+  def teardown
+    Datadog::Tracer.log.level = Logger::WARN
+  end
+
   def test_all_sampler
     spans = [Datadog::Span.new(nil, '', trace_id: 1),
              Datadog::Span.new(nil, '', trace_id: 2),

--- a/test/span_test.rb
+++ b/test/span_test.rb
@@ -69,4 +69,41 @@ class SpanTest < Minitest::Test
     assert_equal(child.parent_id, 0)
     assert_equal(child.service, 'defaultdb')
   end
+
+  def test_get_valid_metric
+    span = Datadog::Span.new(nil, 'test.span')
+    span.set_metric('a', 10)
+    assert_equal(10.0, span.get_metric('a'))
+  end
+
+  def test_set_valid_metrics
+    # metrics must be converted to float values
+    span = Datadog::Span.new(nil, 'test.span')
+    span.set_metric('a', 0)
+    span.set_metric('b', -12)
+    span.set_metric('c', 12.134)
+    span.set_metric('d', 1231543543265475686787869123)
+    span.set_metric('e', '12.34')
+    h = span.to_hash
+    expected = {
+      'a' => 0.0,
+      'b' => -12.0,
+      'c' => 12.134,
+      'd' => 1231543543265475686787869123.0,
+      'e' => 12.34,
+    }
+    assert_equal(expected, h[:metrics])
+  end
+
+  def test_invalid_metrics
+    # invalid values must be discarded
+    span = Datadog::Span.new(nil, 'test.span')
+    span.set_metric('a', nil)
+    span.set_metric('b', {})
+    span.set_metric('c', [])
+    span.set_metric('d', span)
+    span.set_metric('e', 'a_string')
+    h = span.to_hash
+    assert_equal({}, h[:metrics])
+  end
 end

--- a/test/span_test.rb
+++ b/test/span_test.rb
@@ -90,7 +90,7 @@ class SpanTest < Minitest::Test
       'b' => -12.0,
       'c' => 12.134,
       'd' => 1231543543265475686787869123.0,
-      'e' => 12.34,
+      'e' => 12.34
     }
     assert_equal(expected, h[:metrics])
   end

--- a/test/transport_test.rb
+++ b/test/transport_test.rb
@@ -45,6 +45,26 @@ class UtilsTest < Minitest::Test
     assert_equal true, @transport_msgpack.success?(code), "transport.send failed, code: #{code}"
   end
 
+  def test_agent_decodes_float_metrics
+    # test that the agent can decoder properly our metrics
+    skip unless ENV['TEST_DATADOG_INTEGRATION'] # requires a running agent
+
+	# one trace with two spans
+    traces = get_test_traces(2)
+
+    # set some metrics to the trace
+    traces[0][0].set_metric('a', 10.0)
+    traces[0][1].set_metric('b', 1231543543265475686787869123.0)
+
+    # JSON encoding
+    code = @transport_json.send(:traces, traces)
+    assert_equal true, @transport_json.success?(code), "transport.send failed, code: #{code}"
+
+    # Msgpack encoding
+    code = @transport_msgpack.send(:traces, traces)
+    assert_equal true, @transport_msgpack.success?(code), "transport.send failed, code: #{code}"
+  end
+
   def test_send_services
     skip unless ENV['TEST_DATADOG_INTEGRATION'] # requires a runnning agent
     services = get_test_services()

--- a/test/transport_test.rb
+++ b/test/transport_test.rb
@@ -49,7 +49,7 @@ class UtilsTest < Minitest::Test
     # test that the agent can decoder properly our metrics
     skip unless ENV['TEST_DATADOG_INTEGRATION'] # requires a running agent
 
-	# one trace with two spans
+    # one trace with two spans
     traces = get_test_traces(2)
 
     # set some metrics to the trace


### PR DESCRIPTION
### What it does

* tests `set_metric` for valid and invalid values
* enforces that the `value` used in `set_metric` is stored as `float`
* invalid values can be safely discarded before sending the trace