### PR TITLE
[core] drop legacy port 7777

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,8 +28,6 @@ dependencies:
     # configure Ruby interpreters
     - rvm get head
     - rvm install $MRI_VERSIONS
-    # run the agent
-    - docker run -d -e DD_API_KEY=invalid_key_but_this_is_fine -e DD_BIND_HOST=0.0.0.0 -e DD_APM_ENABLED=true -p 127.0.0.1:8126:8126 -p 127.0.0.1:7777:7777 datadog/docker-dd-agent
   override:
     - rvm $MRI_VERSIONS --verbose do gem update --system
     - rvm $MRI_VERSIONS --verbose do gem install bundler

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,3 +31,12 @@ redis:
     image: redis:3.0
     ports:
         - "127.0.0.1:${TEST_REDIS_PORT}:6379"
+
+ddagent:
+    image: datadog/docker-dd-agent
+    environment:
+        - DD_APM_ENABLED=true
+        - DD_BIND_HOST=0.0.0.0
+        - DD_API_KEY=invalid_key_but_this_is_fine
+    ports:
+        - "127.0.0.1:8126:8126"

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -64,7 +64,7 @@ of the Datadog tracer, you can override the following defaults:
       tracer: Datadog.tracer,
       debug: false,
       trace_agent_hostname: 'localhost',
-      trace_agent_port: 7777
+      trace_agent_port: 8126
     }
 
 Available settings are:

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -9,7 +9,7 @@ module Datadog
     attr_reader :transport
 
     HOSTNAME = 'localhost'.freeze
-    PORT = '7777'.freeze
+    PORT = '8126'.freeze
 
     def initialize(options = {})
       # writer and transport parameters

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -72,7 +72,7 @@ class TracerIntegrationTest < Minitest::Test
     skip unless ENV['TEST_DATADOG_INTEGRATION'] # requires a running agent
 
     tracer = Datadog::Tracer.new
-    tracer.configure(enabled: true, hostname: '127.0.0.1', port: '7777')
+    tracer.configure(enabled: true, hostname: '127.0.0.1', port: '8126')
 
     agent_receives_span_step1(tracer)
     success = agent_receives_span_step2(tracer)

--- a/test/transport_test.rb
+++ b/test/transport_test.rb
@@ -7,9 +7,9 @@ class UtilsTest < Minitest::Test
   def setup
     # set the transport and temporary disable the logger to prevent
     # spam in the tests output
-    @default_transport = Datadog::HTTPTransport.new('localhost', '7777')
-    @transport_json = Datadog::HTTPTransport.new('localhost', '7777', encoder: Datadog::Encoding::JSONEncoder.new())
-    @transport_msgpack = Datadog::HTTPTransport.new('localhost', '7777', encoder: Datadog::Encoding::MsgpackEncoder.new())
+    @default_transport = Datadog::HTTPTransport.new('localhost', '8126')
+    @transport_json = Datadog::HTTPTransport.new('localhost', '8126', encoder: Datadog::Encoding::JSONEncoder.new())
+    @transport_msgpack = Datadog::HTTPTransport.new('localhost', '8126', encoder: Datadog::Encoding::MsgpackEncoder.new())
     @original_level = Datadog::Tracer.log.level
     Datadog::Tracer.log.level = Logger::FATAL
   end


### PR DESCRIPTION
### What it does

**Breaking change**

*drop legacy port `7777` in favor of `8126`
* the `datadog/docker-dd-agent ` container is launched via `docker-compose`