### PR TITLE
add global tags to the Tracer class

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -64,7 +64,8 @@ of the Datadog tracer, you can override the following defaults:
       tracer: Datadog.tracer,
       debug: false,
       trace_agent_hostname: 'localhost',
-      trace_agent_port: 8126
+      trace_agent_port: 8126,
+      env: Rails.env
     }
 
 Available settings are:
@@ -86,6 +87,7 @@ Available settings are:
 * ``debug``: set to true to enable debug logging.
 * ``trace_agent_hostname``: set the hostname of the trace agent.
 * ``trace_agent_port``: set the port the trace agent is listening on.
+* ``env``: set the environment. Defaults to the Rails environment
 
 ### Sinatra
 

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -60,7 +60,7 @@ module Datadog
             Datadog::Ext::AppTypes::CACHE
           )
 
-          datadog_config[:tracer].set_tag('env', datadog_config[:env])
+          datadog_config[:tracer].set_tags('env' => datadog_config[:env])
 
           if defined?(::ActiveRecord)
             begin

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -26,7 +26,8 @@ module Datadog
           tracer: Datadog.tracer,
           debug: false,
           trace_agent_hostname: Datadog::Writer::HOSTNAME,
-          trace_agent_port: Datadog::Writer::PORT
+          trace_agent_port: Datadog::Writer::PORT,
+          env: Rails.env
         }.freeze
 
         # configure Datadog settings
@@ -52,11 +53,14 @@ module Datadog
             'rails',
             Datadog::Ext::AppTypes::WEB
           )
+
           datadog_config[:tracer].set_service_info(
             datadog_config[:default_cache_service],
             'rails',
             Datadog::Ext::AppTypes::CACHE
           )
+
+          datadog_config[:tracer].set_tag('env', datadog_config[:env])
 
           if defined?(::ActiveRecord)
             begin

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -27,7 +27,7 @@ module Datadog
           debug: false,
           trace_agent_hostname: Datadog::Writer::HOSTNAME,
           trace_agent_port: Datadog::Writer::PORT,
-          env: Rails.env
+          env: ::Rails.env
         }.freeze
 
         # configure Datadog settings

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -138,9 +138,7 @@ module Datadog
       span.set_parent(parent)
       @buffer.set(span)
 
-      unless @tags.empty?
-        @tags.each { |k, v| span.set_tag(k, v) }
-      end
+      @tags.each { |k, v| span.set_tag(k, v) } unless @tags.empty?
 
       # sampling
       if parent.nil?

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -95,11 +95,9 @@ module Datadog
     # appended to each span created by the tracer. Keys and values must be strings.
     # A valid example is:
     #
-    #   tracer.set_tag('env', 'prod')
-    def set_tag(key, value)
-      @tags[key] = value.to_s
-    rescue StandardError => e
-      Datadog::Tracer.log.debug("Unable to set the tag #{key}, ignoring it. Caused by: #{e}")
+    #   tracer.set_tags('env' => 'prod', 'component' => 'core')
+    def set_tags(tags)
+      @tags.update(tags)
     end
 
     # Return a +span+ that will trace an operation called +name+. You could trace your code

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -52,6 +52,7 @@ module Datadog
       @mutex = Mutex.new
       @spans = []
       @services = {}
+      @tags = {}
     end
 
     # Updates the current \Tracer instance, so that the tracer can be configured after the
@@ -88,6 +89,17 @@ module Datadog
 
       return unless Datadog::Tracer.debug_logging
       Datadog::Tracer.log.debug("set_service_info: service: #{service} app: #{app} type: #{app_type}")
+    end
+
+    # Set the given key / value tag pair at the tracer level. These tags will be
+    # appended to each span created by the tracer. Keys and values must be strings.
+    # A valid example is:
+    #
+    #   tracer.set_tag('env', 'prod')
+    def set_tag(key, value)
+      @tags[key] = value.to_s
+    rescue StandardError => e
+      Datadog::Tracer.log.debug("Unable to set the tag #{key}, ignoring it. Caused by: #{e}")
     end
 
     # Return a +span+ that will trace an operation called +name+. You could trace your code

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -138,6 +138,10 @@ module Datadog
       span.set_parent(parent)
       @buffer.set(span)
 
+      unless @tags.empty?
+        @tags.each { |k, v| span.set_tag(k, v) }
+      end
+
       # sampling
       if parent.nil?
         @sampler.sample(span)

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -14,7 +14,7 @@ module Datadog
   # Even though the request may require multiple resources and machines to handle the request, all
   # of these function calls and sub-requests would be encapsulated within a single trace.
   class Tracer
-    attr_reader :writer, :sampler, :services
+    attr_reader :writer, :sampler, :services, :tags
     attr_accessor :enabled
 
     # Global, memoized, lazy initialized instance of a logger that is used within the the Datadog

--- a/test/contrib/rails/tracer_test.rb
+++ b/test/contrib/rails/tracer_test.rb
@@ -22,6 +22,7 @@ class TracerTest < ActionController::TestCase
     assert !Rails.configuration.datadog_trace[:debug]
     assert_equal(Rails.configuration.datadog_trace[:trace_agent_hostname], Datadog::Writer::HOSTNAME)
     assert_equal(Rails.configuration.datadog_trace[:trace_agent_port], Datadog::Writer::PORT)
+    assert_equal(Rails.configuration.datadog_trace[:env], 'test')
   end
 
   test 'a default service and database should be properly set' do
@@ -112,5 +113,13 @@ class TracerTest < ActionController::TestCase
 
     assert_equal(tracer.writer.transport.hostname, 'example.com')
     assert_equal(tracer.writer.transport.port, 42)
+  end
+
+  test 'tracer environment can be changed by the user' do
+    update_config(:env, 'dev')
+
+    tracer = Rails.configuration.datadog_trace[:tracer]
+
+    assert_equal(tracer.tags['env'], 'dev')
   end
 end

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -102,6 +102,19 @@ class TracerTest < Minitest::Test
     assert_equal(tracer.services['rest-api'], 'app' => 'rails', 'app_type' => 'web')
   end
 
+  def test_set_tag
+    tracer = get_test_tracer
+    tracer.set_tag('env', 'test')
+    assert_equal(tracer.tags['env'], 'test')
+  end
+
+  def test_trace_global_tags
+    tracer = get_test_tracer
+    tracer.set_tag('env', 'test')
+    span = tracer.trace('something')
+    assert_equal(span.get_tag('env'), 'test')
+  end
+
   def test_disabled_tracer
     tracer = get_test_tracer
     tracer.enabled = false

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -102,17 +102,19 @@ class TracerTest < Minitest::Test
     assert_equal(tracer.services['rest-api'], 'app' => 'rails', 'app_type' => 'web')
   end
 
-  def test_set_tag
+  def test_set_tags
     tracer = get_test_tracer
-    tracer.set_tag('env', 'test')
+    tracer.set_tags('env' => 'test', 'component' => 'core')
     assert_equal(tracer.tags['env'], 'test')
+    assert_equal(tracer.tags['component'], 'core')
   end
 
   def test_trace_global_tags
     tracer = get_test_tracer
-    tracer.set_tag('env', 'test')
+    tracer.set_tags('env' => 'test', 'component' => 'core')
     span = tracer.trace('something')
     assert_equal(span.get_tag('env'), 'test')
+    assert_equal(span.get_tag('component'), 'core')
   end
 
   def test_disabled_tracer


### PR DESCRIPTION
### What it does

Rebase of contribution #92 (thanks @intelekshual!).

This PR adds the ability to set global tags on a `Tracer` instance. These tags are applied to every `Span` created by the Tracer. This is useful when instrumenting applications in different environments (ex. staging and production), which is why the Rails contrib app has been updated to set the env tag to the Rails environment.