### PR TITLE
[rails] provide tags setting to include global tags from Rails settings

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -65,7 +65,8 @@ of the Datadog tracer, you can override the following defaults:
       debug: false,
       trace_agent_hostname: 'localhost',
       trace_agent_port: 8126,
-      env: Rails.env
+      env: Rails.env,
+      tags: {}
     }
 
 Available settings are:
@@ -88,6 +89,7 @@ Available settings are:
 * ``trace_agent_hostname``: set the hostname of the trace agent.
 * ``trace_agent_port``: set the port the trace agent is listening on.
 * ``env``: set the environment. Defaults to the Rails environment
+* ``tags``: set global tags that should be applied to all spans. Defaults to an empty hash
 
 ### Sinatra
 

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -50,7 +50,7 @@ module Datadog
 
           # set default tracer tags
           datadog_config[:tracer].set_tags(datadog_config[:tags])
-          datadog_config[:tracer].set_tags('env' => datadog_config[:env])
+          datadog_config[:tracer].set_tags('env' => datadog_config[:env]) if datadog_config[:env]
 
           # set default service details
           datadog_config[:tracer].set_service_info(

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -49,8 +49,8 @@ module Datadog
           )
 
           # set default tracer tags
-          datadog_config[:tracer].set_tags('env' => datadog_config[:env])
           datadog_config[:tracer].set_tags(datadog_config[:tags])
+          datadog_config[:tracer].set_tags('env' => datadog_config[:env])
 
           # set default service details
           datadog_config[:tracer].set_service_info(

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -27,7 +27,8 @@ module Datadog
           debug: false,
           trace_agent_hostname: Datadog::Writer::HOSTNAME,
           trace_agent_port: Datadog::Writer::PORT,
-          env: ::Rails.env
+          env: ::Rails.env,
+          tags: {}
         }.freeze
 
         # configure Datadog settings
@@ -47,6 +48,10 @@ module Datadog
             port: datadog_config[:trace_agent_port]
           )
 
+          # set default tracer tags
+          datadog_config[:tracer].set_tags('env' => datadog_config[:env])
+          datadog_config[:tracer].set_tags(datadog_config[:tags])
+
           # set default service details
           datadog_config[:tracer].set_service_info(
             datadog_config[:default_service],
@@ -59,8 +64,6 @@ module Datadog
             'rails',
             Datadog::Ext::AppTypes::CACHE
           )
-
-          datadog_config[:tracer].set_tags('env' => datadog_config[:env])
 
           if defined?(::ActiveRecord)
             begin

--- a/test/contrib/rails/tracer_test.rb
+++ b/test/contrib/rails/tracer_test.rb
@@ -144,5 +144,11 @@ class TracerTest < ActionController::TestCase
     update_config(:tags, 'env' => 'bar')
     tracer = Rails.configuration.datadog_trace[:tracer]
     assert_equal(tracer.tags['env'], 'dev')
+
+    # env is not valid but tags is set
+    update_config(:env, nil)
+    update_config(:tags, 'env' => 'bar')
+    tracer = Rails.configuration.datadog_trace[:tracer]
+    assert_equal(tracer.tags['env'], 'bar')
   end
 end

--- a/test/contrib/rails/tracer_test.rb
+++ b/test/contrib/rails/tracer_test.rb
@@ -132,4 +132,17 @@ class TracerTest < ActionController::TestCase
     assert_equal(tracer.tags['component'], 'api')
     assert_equal(tracer.tags['section'], 'users')
   end
+
+  test 'tracer env setting has precedence over tags setting' do
+    # default case
+    update_config(:tags, 'env' => 'foo')
+    tracer = Rails.configuration.datadog_trace[:tracer]
+    assert_equal(tracer.tags['env'], 'test')
+
+    # explicit set
+    update_config(:env, 'dev')
+    update_config(:tags, 'env' => 'bar')
+    tracer = Rails.configuration.datadog_trace[:tracer]
+    assert_equal(tracer.tags['env'], 'dev')
+  end
 end

--- a/test/contrib/rails/tracer_test.rb
+++ b/test/contrib/rails/tracer_test.rb
@@ -23,6 +23,7 @@ class TracerTest < ActionController::TestCase
     assert_equal(Rails.configuration.datadog_trace[:trace_agent_hostname], Datadog::Writer::HOSTNAME)
     assert_equal(Rails.configuration.datadog_trace[:trace_agent_port], Datadog::Writer::PORT)
     assert_equal(Rails.configuration.datadog_trace[:env], 'test')
+    assert_equal(Rails.configuration.datadog_trace[:tags], {})
   end
 
   test 'a default service and database should be properly set' do
@@ -121,5 +122,14 @@ class TracerTest < ActionController::TestCase
     tracer = Rails.configuration.datadog_trace[:tracer]
 
     assert_equal(tracer.tags['env'], 'dev')
+  end
+
+  test 'tracer global tags can be changed by the user' do
+    update_config(:tags, 'component' => 'api', 'section' => 'users')
+
+    tracer = Rails.configuration.datadog_trace[:tracer]
+
+    assert_equal(tracer.tags['component'], 'api')
+    assert_equal(tracer.tags['section'], 'users')
   end
 end


### PR DESCRIPTION
### What it does

Users can set tracer global tags using Rails settings like:
```ruby
Rails.configuration.datadog_trace = {
      enabled: true,
      auto_instrument: true,
      auto_instrument_redis: true,
      tags: { 'component' => 'API', 'another' => 'with_value' }
}
```
All created spans will have both `component` and `another` tags.

Follow-up of #100.