### PR TITLE
Make stacktraces be constructed with proper newline characters

### DIFF
--- a/lib/ddtrace/contrib/rails/action_controller.rb
+++ b/lib/ddtrace/contrib/rails/action_controller.rb
@@ -62,7 +62,7 @@ module Datadog
               span.status = 1
               span.set_tag(Datadog::Ext::Errors::TYPE, error[0])
               span.set_tag(Datadog::Ext::Errors::MSG, error[1])
-              span.set_tag(Datadog::Ext::Errors::STACK, caller().join('\n'))
+              span.set_tag(Datadog::Ext::Errors::STACK, caller().join("\n"))
               # [manu,christian]: it's right to have a 500? there are cases in Rails that let
               # user to recover the error after this point?
               span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, payload.fetch(:status, '500').to_s)

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -86,7 +86,7 @@ module Datadog
       @status = 1
       @meta[Datadog::Ext::Errors::MSG] = e.message if e.respond_to?(:message) && e.message
       @meta[Datadog::Ext::Errors::TYPE] = e.class.to_s
-      @meta[Datadog::Ext::Errors::STACK] = e.backtrace.join('\n') if e.respond_to?(:backtrace) && e.backtrace
+      @meta[Datadog::Ext::Errors::STACK] = e.backtrace.join("\n") if e.respond_to?(:backtrace) && e.backtrace
     end
 
     # Mark the span finished at the current time and submit it.

--- a/test/contrib/rails/controller_test.rb
+++ b/test/contrib/rails/controller_test.rb
@@ -112,6 +112,7 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal('ZeroDivisionError', span.get_tag('error.type'), 'type should contain the class name of the error')
     assert_equal('divided by 0', span.get_tag('error.msg'), 'msg should state we tried to divided by 0')
     assert_match(/ddtrace/, span.get_tag('error.stack'), 'stack should contain the call stack when error was raised')
+    assert_match(/\n/, span.get_tag('error.stack'), 'stack should have multiple lines')
     assert_equal('500', span.get_tag('http.status_code'), 'status should be 500 error by default')
   end
 

--- a/test/span_test.rb
+++ b/test/span_test.rb
@@ -106,4 +106,22 @@ class SpanTest < Minitest::Test
     h = span.to_hash
     assert_equal({}, h[:metrics])
   end
+
+  def test_set_error
+    span = Datadog::Span.new(nil, 'test.span')
+    error = RuntimeError.new('Something broke!')
+    error.set_backtrace(['list', 'of', 'calling', 'methods'])
+    displayed_backtrace = <<-BACKTRACE.chomp
+list
+of
+calling
+methods
+BACKTRACE
+
+    span.set_error(error)
+
+    assert_equal('Something broke!', span.get_tag('error.msg'))
+    assert_equal('RuntimeError', span.get_tag('error.type'))
+    assert_equal(displayed_backtrace, span.get_tag('error.stack'))
+  end
 end


### PR DESCRIPTION
There's a bug when joining the stacktrace which makes them be joined with the string '\n' instead of an actual newline character. As a consequence, the Datadog UI shows an awkward long line with a lot of \n displayed, instead of the expetected view of a line per frame in the stacktrace.

Example of stacktrace before the fix:

<img width="905" alt="screen shot 2017-04-12 at 5 18 20 pm" src="https://cloud.githubusercontent.com/assets/1112217/24981833/1b17130e-1fa4-11e7-8b65-f4ba49f4e54d.png">

Example of stacktrace in the UI after this fix:

<img width="877" alt="screen shot 2017-04-12 at 5 19 24 pm" src="https://cloud.githubusercontent.com/assets/1112217/24981865/43aff70e-1fa4-11e7-88b3-da03d49852a7.png">
