### PR TITLE
Trace exceptions through Rack middleware

### DIFF
--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -29,11 +29,14 @@ end
 if defined?(Rails::VERSION)
   if Rails::VERSION::MAJOR.to_i >= 3
     require 'ddtrace/contrib/rails/framework'
+    require 'ddtrace/contrib/rails/middleware'
 
     module Datadog
       # Run the auto instrumentation directly after initializers in
       # `config/initializers` are executed
       class Railtie < Rails::Railtie
+        config.app_middleware.use(Datadog::Contrib::Rails::Middleware)
+
         config.after_initialize do |app|
           Datadog::Contrib::Rails::Framework.configure(config: app.config)
           Datadog::Contrib::Rails::Framework.auto_instrument()

--- a/lib/ddtrace/contrib/rails/action_controller.rb
+++ b/lib/ddtrace/contrib/rails/action_controller.rb
@@ -6,71 +6,35 @@ module Datadog
     module Rails
       # TODO[manu]: write docs
       module ActionController
-        KEY = 'datadog_actioncontroller'.freeze
-
         def self.instrument
-          # subscribe when the request processing starts
-          ::ActiveSupport::Notifications.subscribe('start_processing.action_controller') do |*args|
-            start_processing(*args)
-          end
-
           # subscribe when the request processing has been completed
           ::ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*args|
             process_action(*args)
           end
         end
 
-        def self.start_processing(*)
-          return if Thread.current[KEY]
-
-          tracer = ::Rails.configuration.datadog_trace.fetch(:tracer)
-          service = ::Rails.configuration.datadog_trace.fetch(:default_service)
-          type = Datadog::Ext::HTTP::TYPE
-          tracer.trace('rails.request', service: service, span_type: type)
-
-          Thread.current[KEY] = true
-        rescue StandardError => e
-          Datadog::Tracer.log.error(e.message)
-        end
-
-        def self.process_action(_name, start, finish, _id, payload)
-          return unless Thread.current[KEY]
-          Thread.current[KEY] = false
-
+        def self.process_action(_name, _start, _finish, _id, payload)
           tracer = ::Rails.configuration.datadog_trace.fetch(:tracer)
           span = tracer.active_span()
           return unless span
 
-          begin
-            span.resource = "#{payload.fetch(:controller)}##{payload.fetch(:action)}"
-            span.set_tag(Datadog::Ext::HTTP::URL, payload.fetch(:path))
-            span.set_tag(Datadog::Ext::HTTP::METHOD, payload.fetch(:method))
-            span.set_tag('rails.route.action', payload.fetch(:action))
-            span.set_tag('rails.route.controller', payload.fetch(:controller))
+          span.resource = "#{payload.fetch(:controller)}##{payload.fetch(:action)}"
+          span.set_tag(Datadog::Ext::HTTP::URL, payload.fetch(:path))
+          span.set_tag(Datadog::Ext::HTTP::METHOD, payload.fetch(:method))
+          span.set_tag('rails.route.action', payload.fetch(:action))
+          span.set_tag('rails.route.controller', payload.fetch(:controller))
 
-            if payload[:exception].nil?
-              # [christian] in some cases :status is not defined,
-              # rather than firing an error, simply acknowledge we don't know it.
-              status = payload.fetch(:status, '?').to_s
-              if status.starts_with?('5')
-                span.status = 1
-                span.set_tag(Datadog::Ext::Errors::STACK, caller().join('\n'))
-              end
-              span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, status)
-            else
-              error = payload[:exception]
-              span.status = 1
-              span.set_tag(Datadog::Ext::Errors::TYPE, error[0])
-              span.set_tag(Datadog::Ext::Errors::MSG, error[1])
-              span.set_tag(Datadog::Ext::Errors::STACK, caller().join("\n"))
-              # [manu,christian]: it's right to have a 500? there are cases in Rails that let
-              # user to recover the error after this point?
-              span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, payload.fetch(:status, '500').to_s)
-            end
-          ensure
-            span.start_time = start
-            span.finish_at(finish)
+          if payload[:exception].nil?
+            # [christian] in some cases :status is not defined,
+            # rather than firing an error, simply acknowledge we don't know it.
+            status = payload.fetch(:status, '?').to_s
+            span.status = 1 if status.starts_with?('5')
+          else
+            status = payload.fetch(:status, '500').to_s
+            span.status = 1
           end
+
+          span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, status)
         rescue StandardError => e
           Datadog::Tracer.log.error(e.message)
         end

--- a/lib/ddtrace/contrib/rails/middleware.rb
+++ b/lib/ddtrace/contrib/rails/middleware.rb
@@ -1,3 +1,5 @@
+require 'ddtrace/ext/http'
+
 module Datadog
   module Contrib
     module Rails
@@ -8,7 +10,23 @@ module Datadog
         end
 
         def call(env)
+          span = tracer.trace('rails.request', service: service, span_type: Datadog::Ext::HTTP::TYPE)
           @app.call(env)
+        rescue Exception => e
+          span.set_error(e)
+          raise e
+        ensure
+          span.finish
+        end
+
+        private
+
+        def tracer
+          ::Rails.configuration.datadog_trace.fetch(:tracer)
+        end
+
+        def service
+          ::Rails.configuration.datadog_trace.fetch(:default_service)
         end
       end
     end

--- a/lib/ddtrace/contrib/rails/middleware.rb
+++ b/lib/ddtrace/contrib/rails/middleware.rb
@@ -1,0 +1,16 @@
+module Datadog
+  module Contrib
+    module Rails
+      class Middleware
+
+        def initialize(app)
+          @app = app
+        end
+
+        def call(env)
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/test/contrib/rails/controller_test.rb
+++ b/test/contrib/rails/controller_test.rb
@@ -126,7 +126,7 @@ class TracingControllerTest < ActionDispatch::IntegrationTest
     assert_equal(1, span.status, 'span should be flagged as an error')
     assert_nil(span.get_tag('error.type'), 'type should be undefined')
     assert_nil(span.get_tag('error.msg'), 'msg should be empty')
-    assert_match(/ddtrace/, span.get_tag('error.stack'), 'stack should contain the call stack when error was raised')
+    assert_nil(span.get_tag('error.stack'), 'stack should be empty')
     assert_equal('520', span.get_tag('http.status_code'), 'status should be 520 Web server is returning an unknown error')
   end
 end

--- a/test/contrib/rails/controller_test.rb
+++ b/test/contrib/rails/controller_test.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 require 'contrib/rails/test_helper'
 
-class TracingControllerTest < ActionController::TestCase
+class TracingControllerTest < ActionDispatch::IntegrationTest
   setup do
     @original_tracer = Rails.configuration.datadog_trace[:tracer]
     @tracer = get_test_tracer
@@ -15,7 +15,7 @@ class TracingControllerTest < ActionController::TestCase
 
   test 'request is properly traced' do
     # make the request and assert the proper span
-    get :index
+    get '/'
     assert_response :success
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 2)
@@ -33,7 +33,7 @@ class TracingControllerTest < ActionController::TestCase
 
   test 'template rendering is properly traced' do
     # render the template and assert the proper span
-    get :index
+    get '/'
     assert_response :success
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 2)
@@ -47,7 +47,7 @@ class TracingControllerTest < ActionController::TestCase
 
   test 'template partial rendering is properly traced' do
     # render the template and assert the proper span
-    get :partial
+    get '/partial'
     assert_response :success
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 3)
@@ -63,7 +63,7 @@ class TracingControllerTest < ActionController::TestCase
 
   test 'a full request with database access on the template' do
     # render the endpoint
-    get :full
+    get '/full'
     assert_response :success
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 4)
@@ -87,23 +87,19 @@ class TracingControllerTest < ActionController::TestCase
   end
 
   test 'multiple calls should not leave an unfinished span in the local thread buffer' do
-    get :full
+    get '/full'
     assert_response :success
     assert_nil(Thread.current[:datadog_span])
 
-    get :full
+    get '/full'
     assert_response :success
     assert_nil(Thread.current[:datadog_span])
   end
 
   test 'error should be trapped and reported as such' do
-    err = false
-    begin
-      get :error
-    rescue
-      err = true
-    end
-    assert_equal(true, err, 'should have raised an error')
+    get '/error'
+    assert_response :error
+
     spans = @tracer.writer.spans()
     assert_equal(1, spans.length)
     span = spans[0]
@@ -117,7 +113,7 @@ class TracingControllerTest < ActionController::TestCase
   end
 
   test 'http error code should be trapped and reported as such, even with no exception' do
-    get :soft_error
+    get '/soft_error'
 
     spans = @tracer.writer.spans()
     if Rails::VERSION::MAJOR.to_i >= 5

--- a/test/contrib/rails/errors_test.rb
+++ b/test/contrib/rails/errors_test.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 require 'contrib/rails/test_helper'
 
-class TracingControllerTest < ActionController::TestCase
+class TracingControllerTest < ActionDispatch::IntegrationTest
   setup do
     @original_tracer = Rails.configuration.datadog_trace[:tracer]
     @tracer = get_test_tracer
@@ -14,9 +14,9 @@ class TracingControllerTest < ActionController::TestCase
   end
 
   test 'error in the controller must be traced' do
-    assert_raises ZeroDivisionError do
-      get :error
-    end
+    get '/error'
+    assert_response :error
+
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 1)
 
@@ -35,9 +35,9 @@ class TracingControllerTest < ActionController::TestCase
   end
 
   test 'error in the template must be traced' do
-    assert_raises ::ActionView::Template::Error do
-      get :error_template
-    end
+    get '/error_template'
+    assert_response :error
+
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 2)
 
@@ -66,9 +66,9 @@ class TracingControllerTest < ActionController::TestCase
   end
 
   test 'error in the template partials must be traced' do
-    assert_raises ::ActionView::Template::Error do
-      get :error_partial
-    end
+    get '/error_partial'
+    assert_response :error
+
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 3)
 


### PR DESCRIPTION
We're currently running the latest version of the gem in our production Rails 4.2.8 application and in all of our errors in DataDog's UI we see the same stacktrace:
```ruby
/app/vendor/bundle/ruby/2.2.0/gems/ddtrace-0.6.1/lib/ddtrace/contrib/rails/action_controller.rb:19:in `block in instrument'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.8/lib/active_support/notifications/fanout.rb:127:in `call'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.8/lib/active_support/notifications/fanout.rb:127:in `finish'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.8/lib/active_support/notifications/fanout.rb:46:in `block in finish'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.8/lib/active_support/notifications/fanout.rb:46:in `each'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.8/lib/active_support/notifications/fanout.rb:46:in `finish'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.8/lib/active_support/notifications/instrumenter.rb:36:in `finish'
```
This is not the stacktrace of any of the errors thrown, but simply the callstack of the code that's reporting the error. The reason is because [the code is using `caller` to populate the stacktrace](https://github.com/DataDog/dd-trace-rb/blob/master/lib/ddtrace/contrib/rails/action_controller.rb#L65) and `caller` doesn't have much to do with exceptions. Even when we manually set the error from somewhere in code, that line overrides it with the same callstack, over and over.

Examining the code a little closer it looks like it's actually hard to get the right stacktrace from the `ActiveSupport`'s instrumentation. Looking at how do other gems get this information ([Honeybadger](https://github.com/honeybadger-io/honeybadger-ruby/blob/master/lib/honeybadger/rack/error_notifier.rb#L36), [NewRelic](https://github.com/newrelic/rpm/blob/master/lib/new_relic/agent/instrumentation/middleware_tracing.rb#L101), [Sentry](https://github.com/getsentry/raven-ruby/blob/master/lib/raven/integrations/rack.rb#L54)), it looks to us like using a custom middleware layer is the way to go.

For us this also means we'll be able to trace errors thrown from our API layer, where we use Grape; Grape reuses the same Rack middleware stack, but does not go through ActiveController so we currently don't have a simple way of tracing those errors.

In order to make this change, we've changed some of the tests from being `ActionController::TestCase` to be `ActionDispatch::IntegrationTest`. The latter are said to be slower, but the former don't go through the middleware stack so the tests were failing.

Let us know your thoughts on this. Thanks!