### PR TITLE
[rails] Rails action_controller is part of the rack request

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -64,8 +64,9 @@ of the Datadog tracer, you can override the following defaults:
       auto_instrument: false,
       auto_instrument_redis: false,
       default_service: 'rails-app',
-      default_database_service: 'postgresql',
+      default_controller_service: 'rails-controller',
       default_cache_service: 'rails-cache',
+      default_database_service: 'postgresql',
       template_base_path: 'views/',
       tracer: Datadog.tracer,
       debug: false,
@@ -84,9 +85,10 @@ Available settings are:
 * ``auto_instrument_redis``: if set to ``true`` Redis calls will be traced as such. Calls to Redis cache may be
   still instrumented but you will not have the detail of low-level Redis calls.
 * ``default_service``: set the service name used when tracing application requests. Defaults to ``rails-app``
+* ``default_controller_service``: set the service name used when tracing a Rails action controller. Defaults to ``rails-controller``
+* ``default_cache_service``: set the cache service name used when tracing cache activity. Defaults to ``rails-cache``
 * ``default_database_service``: set the database service name used when tracing database activity. Defaults to the
   current adapter name, so if you're using PostgreSQL it will be ``postgres``.
-* ``default_cache_service``: set the cache service name used when tracing cache activity. Defaults to ``rails-cache``
 * ``template_base_path``: used when the template name is parsed in the auto instrumented code. If you don't store
   your templates in the ``views/`` folder, you may need to change this value
 * ``tracer``: is the global tracer used by the tracing application. Usually you don't need to change that value

--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -31,15 +31,30 @@ if defined?(Rails::VERSION)
     require 'ddtrace/contrib/rails/framework'
 
     module Datadog
-      # Run the auto instrumentation directly after initializers in
-      # `config/initializers` are executed
+      # Railtie class initializes
       class Railtie < Rails::Railtie
-        config.app_middleware.insert_before 0, Datadog::Contrib::Rack::TraceMiddleware
-
-        config.after_initialize do |app|
-          Datadog::Contrib::Rails::Framework.configure(config: app.config)
+        # auto instrument Rails and third party components after
+        # the framework initialization
+        config.after_initialize do
           Datadog::Contrib::Rails::Framework.auto_instrument()
           Datadog::Contrib::Rails::Framework.auto_instrument_redis()
+        end
+
+        # Configure datadog settings before building the middleware stack.
+        # This is required because the middleware stack is frozen after
+        # the initialization and so it's too late to add our tracing
+        # functionalities. The body of this block is always executed after
+        # users code but before the last `Finisher`.
+        initializer :datadog_config, before: :build_middleware_stack do |app|
+          Datadog::Contrib::Rails::Framework.configure(config: app.config)
+
+          # add the Rack middleware if auto instrumentation is enabled
+          tracer = ::Rails.configuration.datadog_trace[:tracer]
+          service = ::Rails.configuration.datadog_trace[:default_service]
+          app.config.middleware.insert_before(
+            0, Datadog::Contrib::Rack::TraceMiddleware,
+            tracer: tracer, default_service: service
+          )
         end
       end
     end

--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -34,20 +34,12 @@ if defined?(Rails::VERSION)
       # Run the auto instrumentation directly after initializers in
       # `config/initializers` are executed
       class Railtie < Rails::Railtie
-        # TODO[manu]: with the current configuration this is the only way to
-        # "disable" auto instrumentation by bypassing the tracing middleware
-        # code; this part must be updated because it still change users
-        # applications
-        options = {}
-        config.app_middleware.insert_before 0, Datadog::Contrib::Rack::TraceMiddleware, options
+        config.app_middleware.insert_before 0, Datadog::Contrib::Rack::TraceMiddleware
 
         config.after_initialize do |app|
           Datadog::Contrib::Rails::Framework.configure(config: app.config)
           Datadog::Contrib::Rails::Framework.auto_instrument()
           Datadog::Contrib::Rails::Framework.auto_instrument_redis()
-
-          # override Rack Middleware configurations with Rails
-          options.update(::Rails.configuration.datadog_trace)
         end
       end
     end

--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -34,10 +34,20 @@ if defined?(Rails::VERSION)
       # Run the auto instrumentation directly after initializers in
       # `config/initializers` are executed
       class Railtie < Rails::Railtie
+        # TODO[manu]: with the current configuration this is the only way to
+        # "disable" auto instrumentation by bypassing the tracing middleware
+        # code; this part must be updated because it still change users
+        # applications
+        options = {}
+        config.app_middleware.insert_before 0, Datadog::Contrib::Rack::TraceMiddleware, options
+
         config.after_initialize do |app|
           Datadog::Contrib::Rails::Framework.configure(config: app.config)
           Datadog::Contrib::Rails::Framework.auto_instrument()
           Datadog::Contrib::Rails::Framework.auto_instrument_redis()
+
+          # override Rack Middleware configurations with Rails
+          options.update(::Rails.configuration.datadog_trace)
         end
       end
     end

--- a/lib/ddtrace/contrib/rails/action_controller.rb
+++ b/lib/ddtrace/contrib/rails/action_controller.rb
@@ -24,9 +24,9 @@ module Datadog
           return if Thread.current[KEY]
 
           tracer = ::Rails.configuration.datadog_trace.fetch(:tracer)
-          service = ::Rails.configuration.datadog_trace.fetch(:default_service)
+          service = ::Rails.configuration.datadog_trace.fetch(:default_controller_service)
           type = Datadog::Ext::HTTP::TYPE
-          tracer.trace('rails.request', service: service, span_type: type)
+          tracer.trace('rails.action_controller', service: service, span_type: type)
 
           Thread.current[KEY] = true
         rescue StandardError => e
@@ -42,9 +42,14 @@ module Datadog
           return unless span
 
           begin
-            span.resource = "#{payload.fetch(:controller)}##{payload.fetch(:action)}"
-            span.set_tag(Datadog::Ext::HTTP::URL, payload.fetch(:path))
-            span.set_tag(Datadog::Ext::HTTP::METHOD, payload.fetch(:method))
+            # set the parent resource if it's a `rack.request`
+            # TODO[manu]: it is possible that the direct parent is another layer
+            # of manual instrumentation; in that case we may choose to do this
+            # check with the root span using the `span` buffer directly
+            resource = "#{payload.fetch(:controller)}##{payload.fetch(:action)}"
+            span.parent.resource = resource if span.parent.resource == 'rack.request'
+            span.resource = resource
+
             span.set_tag('rails.route.action', payload.fetch(:action))
             span.set_tag('rails.route.controller', payload.fetch(:controller))
 
@@ -56,16 +61,12 @@ module Datadog
                 span.status = 1
                 span.set_tag(Datadog::Ext::Errors::STACK, caller().join("\n"))
               end
-              span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, status)
             else
               error = payload[:exception]
               span.status = 1
               span.set_tag(Datadog::Ext::Errors::TYPE, error[0])
               span.set_tag(Datadog::Ext::Errors::MSG, error[1])
               span.set_tag(Datadog::Ext::Errors::STACK, caller().join("\n"))
-              # [manu,christian]: it's right to have a 500? there are cases in Rails that let
-              # user to recover the error after this point?
-              span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, payload.fetch(:status, '500').to_s)
             end
           ensure
             span.start_time = start

--- a/lib/ddtrace/contrib/rails/action_controller.rb
+++ b/lib/ddtrace/contrib/rails/action_controller.rb
@@ -42,13 +42,13 @@ module Datadog
           return unless span
 
           begin
-            # set the parent resource if it's a `rack.request`
-            # TODO[manu]: it is possible that the direct parent is another layer
-            # of manual instrumentation; in that case we may choose to do this
-            # check with the root span using the `span` buffer directly
             resource = "#{payload.fetch(:controller)}##{payload.fetch(:action)}"
-            span.parent.resource = resource if span.parent.resource == 'rack.request'
             span.resource = resource
+
+            # set the parent resource if it's a `rack.request` span
+            if !span.parent.nil? && span.parent.name == 'rack.request'
+              span.parent.resource = resource
+            end
 
             span.set_tag('rails.route.action', payload.fetch(:action))
             span.set_tag('rails.route.controller', payload.fetch(:controller))

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/ext/app_types'
 
+require 'ddtrace/contrib/rack/middlewares'
 require 'ddtrace/contrib/rails/core_extensions'
 require 'ddtrace/contrib/rails/action_controller'
 require 'ddtrace/contrib/rails/action_view'

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -59,7 +59,7 @@ module Datadog
           # set default service details
           datadog_config[:tracer].set_service_info(
             datadog_config[:default_service],
-            'rails',
+            'rack',
             Datadog::Ext::AppTypes::WEB
           )
 

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -22,6 +22,7 @@ module Datadog
           auto_instrument: false,
           auto_instrument_redis: false,
           default_service: 'rails-app',
+          default_controller_service: 'rails-controller',
           default_cache_service: 'rails-cache',
           template_base_path: 'views/',
           tracer: Datadog.tracer,
@@ -58,6 +59,12 @@ module Datadog
           # set default service details
           datadog_config[:tracer].set_service_info(
             datadog_config[:default_service],
+            'rails',
+            Datadog::Ext::AppTypes::WEB
+          )
+
+          datadog_config[:tracer].set_service_info(
+            datadog_config[:default_controller_service],
             'rails',
             Datadog::Ext::AppTypes::WEB
           )

--- a/test/contrib/rails/apps/application.rb
+++ b/test/contrib/rails/apps/application.rb
@@ -13,7 +13,13 @@ module RailsTrace
       super(*args)
       redis_cache = [:redis_store, { url: ENV['REDIS_URL'] }]
       file_cache = [:file_store, '/tmp/ddtrace-rb/cache/']
+
+      config.secret_key_base = 'f624861242e4ccf20eacb6bb48a886da'
       config.cache_store = ENV['REDIS_URL'] ? redis_cache : file_cache
+      config.eager_load = false
+      config.consider_all_requests_local = true
+      config.middleware.delete ActionDispatch::DebugExceptions
+
       if ENV['USE_SIDEKIQ']
         config.active_job.queue_adapter = :sidekiq
         # add Sidekiq middleware
@@ -23,8 +29,6 @@ module RailsTrace
           )
         end
       end
-      config.eager_load = false
-      config.secret_key_base = 'not_so_secret'
     end
 
     # configure the application: it loads common controllers,

--- a/test/contrib/rails/apps/rails3.rb
+++ b/test/contrib/rails/apps/rails3.rb
@@ -6,10 +6,13 @@ require 'ddtrace'
 class Rails3 < Rails::Application
   redis_cache = [:redis_store, { url: ENV['REDIS_URL'] }]
   file_cache = [:file_store, '/tmp/ddtrace-rb/cache/']
+
+  config.secret_token = 'f624861242e4ccf20eacb6bb48a886da'
   config.cache_store = ENV['REDIS_URL'] ? redis_cache : file_cache
-  config.secret_key_base = 'not_so_secret'
   config.active_support.test_order = :random
   config.active_support.deprecation = :stderr
+  config.consider_all_requests_local = true
+  config.middleware.delete ActionDispatch::DebugExceptions
 end
 
 # Enables the auto-instrumentation for the testing application

--- a/test/contrib/rails/controller_test.rb
+++ b/test/contrib/rails/controller_test.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 require 'contrib/rails/test_helper'
 
-class TracingControllerTest < ActionController::TestCase
+class TracingControllerTest < ActionDispatch::IntegrationTest
   setup do
     @original_tracer = Rails.configuration.datadog_trace[:tracer]
     @tracer = get_test_tracer
@@ -15,7 +15,7 @@ class TracingControllerTest < ActionController::TestCase
 
   test 'request is properly traced' do
     # make the request and assert the proper span
-    get :index
+    get '/'
     assert_response :success
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 2)
@@ -33,7 +33,7 @@ class TracingControllerTest < ActionController::TestCase
 
   test 'template rendering is properly traced' do
     # render the template and assert the proper span
-    get :index
+    get '/'
     assert_response :success
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 2)
@@ -47,7 +47,7 @@ class TracingControllerTest < ActionController::TestCase
 
   test 'template partial rendering is properly traced' do
     # render the template and assert the proper span
-    get :partial
+    get '/partial'
     assert_response :success
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 3)
@@ -63,7 +63,7 @@ class TracingControllerTest < ActionController::TestCase
 
   test 'a full request with database access on the template' do
     # render the endpoint
-    get :full
+    get '/full'
     assert_response :success
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 4)
@@ -87,23 +87,19 @@ class TracingControllerTest < ActionController::TestCase
   end
 
   test 'multiple calls should not leave an unfinished span in the local thread buffer' do
-    get :full
+    get '/full'
     assert_response :success
     assert_nil(Thread.current[:datadog_span])
 
-    get :full
+    get '/full'
     assert_response :success
     assert_nil(Thread.current[:datadog_span])
   end
 
   test 'error should be trapped and reported as such' do
-    err = false
-    begin
-      get :error
-    rescue
-      err = true
-    end
-    assert_equal(true, err, 'should have raised an error')
+    get '/error'
+    assert_response :error
+
     spans = @tracer.writer.spans()
     assert_equal(1, spans.length)
     span = spans[0]
@@ -117,7 +113,7 @@ class TracingControllerTest < ActionController::TestCase
   end
 
   test 'http error code should be trapped and reported as such, even with no exception' do
-    get :soft_error
+    get '/soft_error'
 
     spans = @tracer.writer.spans()
     if Rails::VERSION::MAJOR.to_i >= 5

--- a/test/contrib/rails/controller_test.rb
+++ b/test/contrib/rails/controller_test.rb
@@ -21,12 +21,9 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(spans.length, 2)
 
     span = spans[1]
-    assert_equal(span.name, 'rails.request')
+    assert_equal(span.name, 'rails.action_controller')
     assert_equal(span.span_type, 'http')
     assert_equal(span.resource, 'TracingController#index')
-    assert_equal(span.get_tag('http.url'), '/')
-    assert_equal(span.get_tag('http.method'), 'GET')
-    assert_equal(span.get_tag('http.status_code'), '200')
     assert_equal(span.get_tag('rails.route.action'), 'index')
     assert_equal(span.get_tag('rails.route.controller'), 'TracingController')
   end
@@ -77,7 +74,7 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_cache.name, 'rails.cache')
     assert_equal(span_database.name, "#{adapter_name}.query")
     assert_equal(span_template.name, 'rails.render_template')
-    assert_equal(span_request.name, 'rails.request')
+    assert_equal(span_request.name, 'rails.action_controller')
 
     # assert the parenting
     assert_nil(span_request.parent)
@@ -107,13 +104,12 @@ class TracingControllerTest < ActionController::TestCase
     spans = @tracer.writer.spans()
     assert_equal(1, spans.length)
     span = spans[0]
-    assert_equal('rails.request', span.name)
+    assert_equal('rails.action_controller', span.name)
     assert_equal(1, span.status, 'span should be flagged as an error')
     assert_equal('ZeroDivisionError', span.get_tag('error.type'), 'type should contain the class name of the error')
     assert_equal('divided by 0', span.get_tag('error.msg'), 'msg should state we tried to divided by 0')
     assert_match(/ddtrace/, span.get_tag('error.stack'), 'stack should contain the call stack when error was raised')
     assert_match(/\n/, span.get_tag('error.stack'), 'stack should have multiple lines')
-    assert_equal('500', span.get_tag('http.status_code'), 'status should be 500 error by default')
   end
 
   test 'http error code should be trapped and reported as such, even with no exception' do
@@ -126,11 +122,10 @@ class TracingControllerTest < ActionController::TestCase
       assert_equal(2, spans.length, 'legacy code (rails <= 4) uses render with a status, so there is an extra render span')
     end
     span = spans[spans.length - 1]
-    assert_equal('rails.request', span.name)
+    assert_equal('rails.action_controller', span.name)
     assert_equal(1, span.status, 'span should be flagged as an error')
     assert_nil(span.get_tag('error.type'), 'type should be undefined')
     assert_nil(span.get_tag('error.msg'), 'msg should be empty')
     assert_match(/ddtrace/, span.get_tag('error.stack'), 'stack should contain the call stack when error was raised')
-    assert_equal('520', span.get_tag('http.status_code'), 'status should be 520 Web server is returning an unknown error')
   end
 end

--- a/test/contrib/rails/errors_test.rb
+++ b/test/contrib/rails/errors_test.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 require 'contrib/rails/test_helper'
 
-class TracingControllerTest < ActionController::TestCase
+class TracingControllerTest < ActionDispatch::IntegrationTest
   setup do
     @original_tracer = Rails.configuration.datadog_trace[:tracer]
     @tracer = get_test_tracer
@@ -14,9 +14,9 @@ class TracingControllerTest < ActionController::TestCase
   end
 
   test 'error in the controller must be traced' do
-    assert_raises ZeroDivisionError do
-      get :error
-    end
+    get '/error'
+    assert_response :error
+
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 1)
 
@@ -35,9 +35,9 @@ class TracingControllerTest < ActionController::TestCase
   end
 
   test 'error in the template must be traced' do
-    assert_raises ::ActionView::Template::Error do
-      get :error_template
-    end
+    get '/error_template'
+    assert_response :error
+
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 2)
 
@@ -66,9 +66,9 @@ class TracingControllerTest < ActionController::TestCase
   end
 
   test 'error in the template partials must be traced' do
-    assert_raises ::ActionView::Template::Error do
-      get :error_partial
-    end
+    get '/error_partial'
+    assert_response :error
+
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 3)
 

--- a/test/contrib/rails/errors_test.rb
+++ b/test/contrib/rails/errors_test.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 require 'contrib/rails/test_helper'
 
-class TracingControllerTest < ActionDispatch::IntegrationTest
+class TracingControllerTest < ActionController::TestCase
   setup do
     @original_tracer = Rails.configuration.datadog_trace[:tracer]
     @tracer = get_test_tracer
@@ -14,9 +14,9 @@ class TracingControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'error in the controller must be traced' do
-    get '/error'
-    assert_response :error
-
+    assert_raises ZeroDivisionError do
+      get :error
+    end
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 1)
 
@@ -35,9 +35,9 @@ class TracingControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'error in the template must be traced' do
-    get '/error_template'
-    assert_response :error
-
+    assert_raises ::ActionView::Template::Error do
+      get :error_template
+    end
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 2)
 
@@ -66,9 +66,9 @@ class TracingControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'error in the template partials must be traced' do
-    get '/error_partial'
-    assert_response :error
-
+    assert_raises ::ActionView::Template::Error do
+      get :error_partial
+    end
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 3)
 

--- a/test/contrib/rails/errors_test.rb
+++ b/test/contrib/rails/errors_test.rb
@@ -21,13 +21,10 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(spans.length, 1)
 
     span = spans[0]
-    assert_equal(span.name, 'rails.request')
+    assert_equal(span.name, 'rails.action_controller')
     assert_equal(span.status, 1)
     assert_equal(span.span_type, 'http')
     assert_equal(span.resource, 'TracingController#error')
-    assert_equal(span.get_tag('http.url'), '/error')
-    assert_equal(span.get_tag('http.method'), 'GET')
-    assert_equal(span.get_tag('http.status_code'), '500')
     assert_equal(span.get_tag('rails.route.action'), 'error')
     assert_equal(span.get_tag('rails.route.controller'), 'TracingController')
     assert_equal(span.get_tag('error.type'), 'ZeroDivisionError')
@@ -52,13 +49,10 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_template.get_tag('error.msg'), 'divided by 0')
 
     span_request = spans[1]
-    assert_equal(span_request.name, 'rails.request')
+    assert_equal(span_request.name, 'rails.action_controller')
     assert_equal(span_request.status, 1)
     assert_equal(span_request.span_type, 'http')
     assert_equal(span_request.resource, 'TracingController#error_template')
-    assert_equal(span_request.get_tag('http.url'), '/error_template')
-    assert_equal(span_request.get_tag('http.method'), 'GET')
-    assert_equal(span_request.get_tag('http.status_code'), '500')
     assert_equal(span_request.get_tag('rails.route.action'), 'error_template')
     assert_equal(span_request.get_tag('rails.route.controller'), 'TracingController')
     assert_equal(span_request.get_tag('error.type'), 'ActionView::Template::Error')
@@ -92,13 +86,10 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_template.get_tag('error.msg'), 'divided by 0')
 
     span_request = spans[2]
-    assert_equal(span_request.name, 'rails.request')
+    assert_equal(span_request.name, 'rails.action_controller')
     assert_equal(span_request.status, 1)
     assert_equal(span_request.span_type, 'http')
     assert_equal(span_request.resource, 'TracingController#error_partial')
-    assert_equal(span_request.get_tag('http.url'), '/error_partial')
-    assert_equal(span_request.get_tag('http.method'), 'GET')
-    assert_equal(span_request.get_tag('http.status_code'), '500')
     assert_equal(span_request.get_tag('rails.route.action'), 'error_partial')
     assert_equal(span_request.get_tag('rails.route.controller'), 'TracingController')
     assert_equal(span_request.get_tag('error.type'), 'ActionView::Template::Error')

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -1,0 +1,120 @@
+require 'helper'
+
+require 'contrib/rails/test_helper'
+
+class FullStackTest < ActionDispatch::IntegrationTest
+  setup do
+    # store original tracers
+    @rails_tracer = Rails.configuration.datadog_trace[:tracer]
+    @rack_tracer = Rails.application.app.instance_variable_get :@tracer
+
+    # replace the Rails and the Rack tracer with a dummy one;
+    # this prevents the overhead to reinitialize the Rails application
+    # and the Rack stack
+    @tracer = get_test_tracer
+    Rails.configuration.datadog_trace[:tracer] = @tracer
+    Rails.application.app.instance_variable_set(:@tracer, @tracer)
+  end
+
+  teardown do
+    # restore original tracers
+    Rails.configuration.datadog_trace[:tracer] = @rails_tracer
+    Rails.application.app.instance_variable_set(:@tracer, @rack_tracer)
+  end
+
+  test 'a full request is properly traced' do
+    # make the request and assert the proper span
+    get '/full'
+    assert_response :success
+
+    # get spans
+    spans = @tracer.writer.spans()
+    assert_equal(spans.length, 5)
+    request_span = spans[4]
+    controller_span = spans[3]
+    render_span = spans[2]
+    database_span = spans[1]
+    cache_span = spans[0]
+
+    assert_equal(request_span.name, 'rack.request')
+    assert_equal(request_span.span_type, 'http')
+    assert_equal(request_span.resource, 'TracingController#full')
+    assert_equal(request_span.get_tag('http.url'), '/full')
+    assert_equal(request_span.get_tag('http.method'), 'GET')
+    assert_equal(request_span.get_tag('http.status_code'), '200')
+
+    assert_equal(controller_span.name, 'rails.action_controller')
+    assert_equal(controller_span.span_type, 'http')
+    assert_equal(controller_span.resource, 'TracingController#full')
+    assert_equal(controller_span.get_tag('rails.route.action'), 'full')
+    assert_equal(controller_span.get_tag('rails.route.controller'), 'TracingController')
+
+    assert_equal(render_span.name, 'rails.render_template')
+    assert_equal(render_span.span_type, 'template')
+    assert_equal(render_span.resource, 'rails.render_template')
+    assert_equal(render_span.get_tag('rails.template_name'), 'tracing/full.html.erb')
+
+    adapter_name = get_adapter_name()
+    assert_equal(database_span.name, "#{adapter_name}.query")
+    assert_equal(database_span.span_type, 'sql')
+    assert_equal(database_span.service, adapter_name)
+    assert_equal(database_span.get_tag('rails.db.vendor'), adapter_name)
+    assert_nil(database_span.get_tag('rails.db.cached'))
+    assert_includes(database_span.resource, 'SELECT')
+    assert_includes(database_span.resource, 'FROM')
+    assert_includes(database_span.resource, 'articles')
+
+    assert_equal(cache_span.name, 'rails.cache')
+    assert_equal(cache_span.span_type, 'cache')
+    assert_equal(cache_span.resource, 'SET')
+    assert_equal(cache_span.service, 'rails-cache')
+    assert_equal(cache_span.get_tag('rails.cache.backend').to_s, 'file_store')
+    assert_equal(cache_span.get_tag('rails.cache.key'), 'empty-key')
+  end
+
+  test 'the rack.request span has the Rails exception' do
+    # make a request that fails
+    get '/error'
+    assert_response :error
+
+    # get spans
+    spans = @tracer.writer.spans()
+    assert_equal(2, spans.length)
+    request_span = spans[1]
+    controller_span = spans[0]
+
+    assert_equal(controller_span.name, 'rails.action_controller')
+    assert_equal(controller_span.status, 1)
+    assert_equal(controller_span.get_tag('error.type'), 'ZeroDivisionError')
+    assert_equal(controller_span.get_tag('error.msg'), 'divided by 0')
+    assert_match(/ddtrace/, controller_span.get_tag('error.stack'))
+    assert_match(/\n/, controller_span.get_tag('error.stack'))
+
+    assert_equal('rack.request', request_span.name)
+    assert_equal(request_span.span_type, 'http')
+    assert_equal(request_span.resource, 'TracingController#error')
+    assert_equal(request_span.get_tag('http.url'), '/error')
+    assert_equal(request_span.get_tag('http.method'), 'GET')
+    assert_equal(request_span.get_tag('http.status_code'), '500')
+    assert_equal(request_span.status, 1, 'span should be flagged as an error')
+  end
+
+  test 'the status code is properly set if Rails controller is bypassed' do
+    # make a request that doesn't have a route
+    get '/not_existing'
+    assert_response 404
+
+    # get spans
+    spans = @tracer.writer.spans()
+    assert_equal(1, spans.length)
+    request_span = spans[0]
+
+    assert_equal('rack.request', request_span.name)
+    assert_equal(request_span.span_type, 'http')
+    assert_equal(request_span.resource, 'GET 404')
+    assert_equal(request_span.get_tag('http.url'), '/not_existing')
+    assert_equal(request_span.get_tag('http.method'), 'GET')
+    assert_equal(request_span.get_tag('http.status_code'), '404')
+    assert_equal(request_span.status, 0)
+  end
+end

--- a/test/contrib/rails/rails_sidekiq_test.rb
+++ b/test/contrib/rails/rails_sidekiq_test.rb
@@ -57,6 +57,9 @@ class RailsSidekiqTest < ActionController::TestCase
     assert_equal(
       @tracer.services,
       'rails-app' => {
+        'app' => 'rack', 'app_type' => 'web'
+      },
+      'rails-controller' => {
         'app' => 'rails', 'app_type' => 'web'
       },
       db_adapter => {


### PR DESCRIPTION
### What it does

Major change about how Rails applications are traced. Now the Rack `TraceMiddleware` is used and so an high overview of the whole request is available. Changes include:
* the `TraceMiddleware` is added at initialization time, before the middleware stack is built
* the `rails.request` now becomes `rails.action_controller` and is not the root span anymore
* because the `TraceMiddleware` is used, `rack.request` is the root span for all traces and it includes all http-related tags
* the `rails.request` is now part of the `rails-controller` service (it's user configurable)
* when we're inside a Rails controller, the `process_action.action_controller()` changes the `rack.request` resource so that it has a meaningful name
* if Rails is not hit, the `rack.request` keeps the default resource name like `GET 200` or `GET 404`