### PR TITLE
[rails] Rack middleware configuration is delayed

### DIFF
--- a/test/contrib/rack/middleware_test.rb
+++ b/test/contrib/rack/middleware_test.rb
@@ -256,8 +256,8 @@ class RackBaseTest < Minitest::Test
     # by default it should have a Tracer and a service
     middleware = Datadog::Contrib::Rack::TraceMiddleware.new(proc {})
     refute_nil(middleware)
-    assert_equal(middleware.instance_eval { @tracer }, Datadog.tracer)
-    assert_equal(middleware.instance_eval { @service }, 'rack')
+    assert_equal(middleware.instance_eval { @options[:tracer] }, Datadog.tracer)
+    assert_equal(middleware.instance_eval { @options[:default_service] }, 'rack')
   end
 
   def test_middleware_builder
@@ -265,7 +265,7 @@ class RackBaseTest < Minitest::Test
     tracer = get_test_tracer()
     middleware = Datadog::Contrib::Rack::TraceMiddleware.new(proc {}, tracer: tracer, default_service: 'custom-rack')
     refute_nil(middleware)
-    assert_equal(middleware.instance_eval { @tracer }, tracer)
-    assert_equal(middleware.instance_eval { @service }, 'custom-rack')
+    assert_equal(middleware.instance_eval { @options[:tracer] }, tracer)
+    assert_equal(middleware.instance_eval { @options[:default_service] }, 'custom-rack')
   end
 end

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -5,6 +5,7 @@ require 'contrib/rails/test_helper'
 class FullStackTest < ActionDispatch::IntegrationTest
   setup do
     # store original tracers
+    Rails.application.app.configure()
     @rails_tracer = Rails.configuration.datadog_trace[:tracer]
     @rack_tracer = Rails.application.app.instance_variable_get :@tracer
 


### PR DESCRIPTION
### What it does

Rack middleware cannot be initialized before `:build_middleware_stack` because at that time we don't have users' initializers (and so the settings). We're initializing the configuration later, after the first call.