### PR TITLE
Experimental auto tracing (not working).

### DIFF
--- a/lib/ddtrace/contrib/http/patcher.rb
+++ b/lib/ddtrace/contrib/http/patcher.rb
@@ -101,6 +101,11 @@ module Datadog
                 # a possibly infinite number of resources.
                 span.set_tag(Datadog::Ext::HTTP::URL, req.path)
                 span.set_tag(Datadog::Ext::HTTP::METHOD, req.method)
+
+                # Experimental auto tracing
+                req['x-ddtrace-parent_trace_id'] = span.trace_id.to_s
+                req['x-ddtrace-parent_span_id'] = span.span_id.to_s
+
                 response = request_without_datadog(req, body, &block)
                 span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, response.code)
                 if req.respond_to?(:uri) && req.uri

--- a/lib/ddtrace/contrib/sinatra/tracer.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer.rb
@@ -152,6 +152,14 @@ module Datadog
               span.set_tag('sinatra.route.path', @datadog_route)
               span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, response.status)
 
+              # Adding tags just because this was supposed to be working already
+              span.set_tag('span.trace_id', request.env['HTTP_X_DDTRACE_PARENT_TRACE_ID'])
+              span.set_tag('span.parent_id', request.env['HTTP_X_DDTRACE_PARENT_SPAN_ID'])
+
+              # Experimental auto tracing
+              span.trace_id = request.env['HTTP_X_DDTRACE_PARENT_TRACE_ID'].to_i  if request.env['HTTP_X_DDTRACE_PARENT_TRACE_ID']
+              span.parent_id = request.env['HTTP_X_DDTRACE_PARENT_SPAN_ID'].to_i  if request.env['HTTP_X_DDTRACE_PARENT_SPAN_ID']
+
               if response.server_error?
                 span.status = 1
 


### PR DESCRIPTION
Related to my previous feature request https://github.com/DataDog/dd-trace-rb/issues/89

Inspired by the [documentation](http://www.rubydoc.info/gems/ddtrace#Other_libraries), I am trying to automate the distributed tracing, but I can't make it work. ;(

The first part is adding the trace_id and span_id to outgoing requests on `net/http`.

I checked logs and I am getting both IDs on the other side of the equation (the receiving server).

The other part, the Sinatra tracer (I have a Rails app is hitting a Sinatra app), I can't get to work, I even tried to set tags but they are empty. When I manually added some `puts` and used Postman I was able to see the headers on this exact spot. So I am not sure what's going on.

The traces remain disconnected on the APM interface.

Thoughts?