### PR TITLE
[ci] pin rubygems system version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ dependencies:
     - rvm get head
     - rvm install $MRI_VERSIONS
   override:
-    - rvm $MRI_VERSIONS,$MRI_OLD_VERSIONS --verbose do gem update --system
+    - rvm $MRI_VERSIONS,$MRI_OLD_VERSIONS --verbose do gem update --system=2.6.11
     - rvm $MRI_VERSIONS,$MRI_OLD_VERSIONS --verbose do gem install bundler
     - rvm $MRI_VERSIONS,$MRI_OLD_VERSIONS --verbose do bundle install
     - rvm $MRI_VERSIONS,$MRI_OLD_VERSIONS --verbose do appraisal install

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ dependencies:
     - pip install docker-compose==1.7.1
     - docker-compose up -d | cat
     # installing dev dependencies
-    - gem update --system
+    - gem update --system=2.6.11
     - gem install builder
     - gem update bundler
     - bundle install


### PR DESCRIPTION
### What it does

Our builds stop working when using the latest `2.6.12` release of rubygems. The issue is:
```
Updating rubygems-update
ERROR:  While executing gem ... (TypeError)
    no implicit conversion of nil into String
```

Pinning all versions to a previous one, fixes the problem.