### PR TITLE
[ci] pin minitest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ build-iPhoneSimulator/
 # lock files
 Gemfile.lock
 gemfiles/*.lock
+
+# bundle config
+gemfiles/.bundle

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -35,7 +35,7 @@ EOS
 
   spec.add_development_dependency 'rake', '~> 10.5'
   spec.add_development_dependency('rubocop', '~> 0.47') if RUBY_VERSION >= '2.1.0'
-  spec.add_development_dependency 'minitest', '~> 5.10'
+  spec.add_development_dependency 'minitest', '= 5.10.1'
   spec.add_development_dependency 'appraisal', '~> 2.1'
   spec.add_development_dependency 'yard', '~> 0.9'
 end

--- a/gemfiles/contrib.gemfile
+++ b/gemfiles/contrib.gemfile
@@ -13,4 +13,4 @@ gem "sqlite3"
 gem "activerecord"
 gem "sidekiq"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/contrib_old.gemfile
+++ b/gemfiles/contrib_old.gemfile
@@ -12,4 +12,4 @@ gem "sqlite3"
 gem "activerecord", "3.2.22.5"
 gem "sidekiq", "4.0.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails3_mysql2.gemfile
+++ b/gemfiles/rails3_mysql2.gemfile
@@ -4,8 +4,8 @@ source "https://rubygems.org"
 
 gem "test-unit"
 gem "rails", "3.2.22.5"
-gem "mysql2", "0.3.21", :platform => :ruby
-gem "activerecord-mysql-adapter", :platform => :ruby
-gem "activerecord-jdbcmysql-adapter", :platform => :jruby
+gem "mysql2", "0.3.21", platform: :ruby
+gem "activerecord-mysql-adapter", platform: :ruby
+gem "activerecord-jdbcmysql-adapter", platform: :jruby
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails3_postgres.gemfile
+++ b/gemfiles/rails3_postgres.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "test-unit"
 gem "rails", "3.2.22.5"
-gem "pg", "0.15.1", :platform => :ruby
-gem "activerecord-jdbcpostgresql-adapter", :platform => :jruby
+gem "pg", "0.15.1", platform: :ruby
+gem "activerecord-jdbcpostgresql-adapter", platform: :jruby
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails3_postgres_redis.gemfile
+++ b/gemfiles/rails3_postgres_redis.gemfile
@@ -4,8 +4,8 @@ source "https://rubygems.org"
 
 gem "test-unit"
 gem "rails", "3.2.22.5"
-gem "pg", "0.15.1", :platform => :ruby
-gem "activerecord-jdbcpostgresql-adapter", :platform => :jruby
+gem "pg", "0.15.1", platform: :ruby
+gem "activerecord-jdbcpostgresql-adapter", platform: :jruby
 gem "redis-rails"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails3_postgres_sidekiq.gemfile
+++ b/gemfiles/rails3_postgres_sidekiq.gemfile
@@ -4,8 +4,8 @@ source "https://rubygems.org"
 
 gem "test-unit"
 gem "rails", "3.2.22.5"
-gem "pg", "0.15.1", :platform => :ruby
-gem "activerecord-jdbcpostgresql-adapter", :platform => :jruby
+gem "pg", "0.15.1", platform: :ruby
+gem "activerecord-jdbcpostgresql-adapter", platform: :jruby
 gem "sidekiq"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails4_mysql2.gemfile
+++ b/gemfiles/rails4_mysql2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "4.2.7.1"
-gem "mysql2", :platform => :ruby
-gem "activerecord-jdbcmysql-adapter", :platform => :jruby
+gem "mysql2", platform: :ruby
+gem "activerecord-jdbcmysql-adapter", platform: :jruby
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails4_postgres.gemfile
+++ b/gemfiles/rails4_postgres.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "4.2.7.1"
-gem "pg", :platform => :ruby
-gem "activerecord-jdbcpostgresql-adapter", :platform => :jruby
+gem "pg", platform: :ruby
+gem "activerecord-jdbcpostgresql-adapter", platform: :jruby
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails4_postgres_redis.gemfile
+++ b/gemfiles/rails4_postgres_redis.gemfile
@@ -3,8 +3,8 @@
 source "https://rubygems.org"
 
 gem "rails", "4.2.7.1"
-gem "pg", :platform => :ruby
-gem "activerecord-jdbcpostgresql-adapter", :platform => :jruby
+gem "pg", platform: :ruby
+gem "activerecord-jdbcpostgresql-adapter", platform: :jruby
 gem "redis-rails"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails4_postgres_sidekiq.gemfile
+++ b/gemfiles/rails4_postgres_sidekiq.gemfile
@@ -3,9 +3,9 @@
 source "https://rubygems.org"
 
 gem "rails", "4.2.7.1"
-gem "pg", :platform => :ruby
-gem "activerecord-jdbcpostgresql-adapter", :platform => :jruby
+gem "pg", platform: :ruby
+gem "activerecord-jdbcpostgresql-adapter", platform: :jruby
 gem "sidekiq"
 gem "activejob"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails5_mysql2.gemfile
+++ b/gemfiles/rails5_mysql2.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "5.0.1"
-gem "mysql2", :platform => :ruby
+gem "mysql2", platform: :ruby
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails5_postgres.gemfile
+++ b/gemfiles/rails5_postgres.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "5.0.1"
-gem "pg", :platform => :ruby
+gem "pg", platform: :ruby
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails5_postgres_redis.gemfile
+++ b/gemfiles/rails5_postgres_redis.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "5.0.1"
-gem "pg", :platform => :ruby
+gem "pg", platform: :ruby
 gem "redis-rails"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/rails5_postgres_sidekiq.gemfile
@@ -3,8 +3,8 @@
 source "https://rubygems.org"
 
 gem "rails", "5.0.1"
-gem "pg", :platform => :ruby
+gem "pg", platform: :ruby
 gem "sidekiq"
 gem "activejob"
 
-gemspec :path => "../"
+gemspec path: "../"


### PR DESCRIPTION
Recent version of minitest (5.10.2, was released yesterday May 9th) breaks our CI. This pins it to previous version, from December, which works for our usage.