### PR TITLE
[tracer:idmismatch] ensuring submitted spans belong to the same trace.

### DIFF
--- a/test/concurrent_test.rb
+++ b/test/concurrent_test.rb
@@ -1,0 +1,50 @@
+require 'helper'
+require 'ddtrace/tracer'
+
+class ConcurrentTest < Minitest::Test
+  def traced_task
+    @tracer.trace('a-root-task') do |_root_span|
+      delay = rand()
+      @tracer.trace('a-sub-task') do |sub_span|
+        sub_span.set_tag('delay', delay)
+      end
+      # the delay *must* be between the instant the sub-span finishes
+      # and the instant the root span is done.
+      sleep delay
+    end
+    @tracer.writer.spans()
+  end
+
+  def test_parallel_tasks
+    @tracer = get_test_tracer
+
+    semaphore = Mutex.new
+    threads = []
+    traces = []
+
+    3.times do |_i|
+      100.times do
+        thr = Thread.new do
+          trace = traced_task
+          semaphore.synchronize do
+            traces << trace
+          end
+        end
+        threads << thr
+      end
+      threads.each(&:join)
+    end
+
+    assert_equal(300, traces.length)
+    traces.each do |trace|
+      assert_equal(2, trace.length)
+      sub = trace[0]
+      root = trace[1]
+      assert_equal('a-root-task', root.name)
+      assert_equal('a-sub-task', sub.name)
+      assert_equal(root.trace_id, root.span_id)
+      assert_equal(root.trace_id, sub.trace_id, 'root span and sub span must have the same trace id')
+      assert_equal(root.trace_id, sub.parent_id)
+    end
+  end
+end


### PR DESCRIPTION
Some real-world examples clearly show different traces packed together in payloads. While this never happens within our test suites and, generally speaking, linear, sequential mono-thread-process environments, it happens. I did not really see where, elsewhere in the code, we ensure this never happens (two different traces concurrently sharing the same tracer instance).