### PR TITLE
Customize service names

### DIFF
--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -2,8 +2,22 @@
 
 module Datadog
   module Contrib
+    # Redis contains the patcher and a method for determining the service name
     module Redis
-      SERVICE = 'redis'.freeze
+      DEFAULT_SERVICE_NAME = 'redis'.freeze
+
+      def self.service_name
+        @service_name ||= \
+          if defined?(::Sinatra)
+            ::Sinatra::Application.settings.datadog_tracer.cfg
+                                  .fetch(:default_redis_service, DEFAULT_SERVICE_NAME)
+          elsif defined?(::Rails)
+            ::Rails.configuration.datadog_trace
+                   .fetch(:default_redis_service, DEFAULT_SERVICE_NAME)
+          else
+            DEFAULT_SERVICE_NAME
+          end
+      end
 
       # Patcher enables patching of 'redis' module.
       # This is used in monkey.rb to automatically apply patches
@@ -58,7 +72,7 @@ module Datadog
             end
 
             def initialize(*args)
-              pin = Datadog::Pin.new(SERVICE, app: 'redis', app_type: Datadog::Ext::AppTypes::DB)
+              pin = Datadog::Pin.new(Redis.service_name, app: 'redis', app_type: Datadog::Ext::AppTypes::DB)
               pin.onto(self)
               if pin.tracer && pin.service
                 pin.tracer.set_service_info(pin.service, pin.app, pin.app_type)

--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -4,7 +4,6 @@ module Datadog
   module Contrib
     module Redis
       SERVICE = 'redis'.freeze
-      DRIVER = 'redis.driver'.freeze
 
       # Patcher enables patching of 'redis' module.
       # This is used in monkey.rb to automatically apply patches


### PR DESCRIPTION
## Background

DataDog does not provide a good mechanism of isolating APM services by tags, and so we prefer to namespace service names. Whilst there is some limited support for customization for the Rails patch, it's not present in the HTTP or Redis patchers.

## What's this PR do?

- Remove `Datadog::Contrib::Redis::DRIVER`
- Add `.service_name` methods to HTTP and Redis patchers that can look up configuration for Rails / Sinatra in order to plug in the customized service name

## Discussion

- Should tests be added? Where?
- Could config be inverted so that it's set in a `Datadog.configure` block rather than each tracer having to work out how to access configuration?
- Is this a desirable thing, or is our use case somehow divergent from the general case?