### PR TITLE
Correct use of Datadog;:Pin object in doc example

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -440,7 +440,7 @@ You can use this object to instrument your own code:
     class MyWebSite
       def initialize
         pin = Datadog::Pin.new('my-web-site', app_type: Datadog::Ext::AppTypes::WEB)
-        Datadog::Pin.onto(self)
+        pin.onto(self)
       end
 
       def serve(something)


### PR DESCRIPTION
There is no class level `onto` method - it appears from my troubleshooting that one uses `pin#onto` instead (which makes sense, since the method assigns the `pin` variable).