### PR TITLE
[exception] catch Exception and not StandardError

### DIFF
--- a/lib/ddtrace/contrib/active_record/patcher.rb
+++ b/lib/ddtrace/contrib/active_record/patcher.rb
@@ -23,7 +23,7 @@ module Datadog
               patch_active_record()
 
               @patched = true
-            rescue => e
+            rescue StandardError => e
               Datadog::Tracer.log.error("Unable to apply Active Record integration: #{e}")
             end
           end

--- a/lib/ddtrace/contrib/elasticsearch/patcher.rb
+++ b/lib/ddtrace/contrib/elasticsearch/patcher.rb
@@ -33,7 +33,7 @@ module Datadog
               patch_elasticsearch_transport_client()
 
               @patched = true
-            rescue StandardError => e
+            rescue StandartError => e
               Datadog::Tracer.log.error("Unable to apply Elastic Search integration: #{e}")
             end
           end

--- a/lib/ddtrace/contrib/grape/endpoint.rb
+++ b/lib/ddtrace/contrib/grape/endpoint.rb
@@ -79,7 +79,7 @@ module Datadog
             # catch thrown exceptions
             span.set_error(payload[:exception_object]) unless payload[:exception_object].nil?
 
-            # ovverride the current span with this notification values
+            # override the current span with this notification values
             span.set_tag('grape.route.endpoint', api_view)
             span.set_tag('grape.route.path', path)
           ensure

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -58,7 +58,13 @@ module Datadog
 
           # call the rest of the stack
           status, headers, response = @app.call(env)
-        rescue StandardError => e
+        # rubocop:disable Lint/RescueException
+        # Here we really want to catch *any* exception, not only StandardError,
+        # as we really have no clue of what is in the block,
+        # and it is user code which should be executed no matter what.
+        # It's not a problem since we re-raise it afterwards so for example a
+        # SignalException::Interrupt would still bubble up.
+        rescue Exception => e
           # catch exceptions that may be raised in the middleware chain
           # Note: if a middleware catches an Exception without re raising,
           # the Exception cannot be recorded here

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -128,7 +128,7 @@ module Datadog
       return @default_service if instance_variable_defined?(:@default_service) && @default_service
       begin
         @default_service = File.basename($PROGRAM_NAME, '.*')
-      rescue => e
+      rescue StandardError => e
         Datadog::Tracer.log.error("unable to guess default service: #{e}")
         @default_service = 'ruby'.freeze
       end
@@ -232,9 +232,15 @@ module Datadog
       if block_given?
         begin
           yield(span)
-        rescue StandardError => e
+        # rubocop:disable Lint/RescueException
+        # Here we really want to catch *any* exception, not only StandardError,
+        # as we really have no clue of what is in the block,
+        # and it is user code which should be executed no matter what.
+        # It's not a problem since we re-raise it afterwards so for example a
+        # SignalException::Interrupt would still bubble up.
+        rescue Exception => e
           span.set_error(e)
-          raise
+          raise e
         ensure
           span.finish()
         end

--- a/test/contrib/rack/helpers.rb
+++ b/test/contrib/rack/helpers.rb
@@ -30,6 +30,10 @@ class RackBaseTest < Minitest::Test
         run(proc { |_env| [500, { 'Content-Type' => 'text/html' }, 'KO'] })
       end
 
+      map '/nomemory/' do
+        run(proc { |_env| raise NoMemoryError, 'Non-standard error' })
+      end
+
       map '/app/' do
         run(proc do |env|
           # this should be considered a web framework that can alter


### PR DESCRIPTION
Small patch inspired by #120 to catch Exception and not StandardError in case we run user code and re-raise the exception afterwards (pass-through mode, just annotating the span with the error without really swallowing the error).