### PR TITLE
[contrib:rails] only treat 5xx errors as real errors

### DIFF
--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -55,6 +55,7 @@ module Datadog
           )
         end
 
+        # rubocop:disable Metrics/MethodLength
         def call(env)
           # configure the Rack middleware once
           configure()
@@ -113,9 +114,15 @@ module Datadog
           # be set in another level but if they're missing, reasonable defaults
           # are used.
           request_span.resource = "#{env['REQUEST_METHOD']} #{status}".strip unless request_span.resource
-          request_span.set_tag('http.method', env['REQUEST_METHOD']) if request_span.get_tag('http.method').nil?
-          request_span.set_tag('http.url', url) if request_span.get_tag('http.url').nil?
-          request_span.set_tag('http.status_code', status) if request_span.get_tag('http.status_code').nil? && status
+          if request_span.get_tag(Datadog::Ext::HTTP::METHOD).nil?
+            request_span.set_tag(Datadog::Ext::HTTP::METHOD, env['REQUEST_METHOD'])
+          end
+          if request_span.get_tag(Datadog::Ext::HTTP::URL).nil?
+            request_span.set_tag(Datadog::Ext::HTTP::URL, url)
+          end
+          if request_span.get_tag(Datadog::Ext::HTTP::STATUS_CODE).nil? && status
+            request_span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, status)
+          end
 
           # detect if the status code is a 5xx and flag the request span as an error
           # unless it has been already set by the underlying framework

--- a/lib/ddtrace/contrib/rails/action_controller.rb
+++ b/lib/ddtrace/contrib/rails/action_controller.rb
@@ -63,10 +63,14 @@ module Datadog
               end
             else
               error = payload[:exception]
-              span.status = 1
-              span.set_tag(Datadog::Ext::Errors::TYPE, error[0])
-              span.set_tag(Datadog::Ext::Errors::MSG, error[1])
-              span.set_tag(Datadog::Ext::Errors::STACK, caller().join("\n"))
+              status = ActionDispatch::ExceptionWrapper.status_code_for_exception(error[0])
+              status = status ? status.to_s : '?'
+              if status.starts_with?('5')
+                span.status = 1
+                span.set_tag(Datadog::Ext::Errors::TYPE, error[0])
+                span.set_tag(Datadog::Ext::Errors::MSG, error[1])
+                span.set_tag(Datadog::Ext::Errors::STACK, caller().join("\n"))
+              end
             end
           ensure
             span.start_time = start

--- a/lib/ddtrace/contrib/rails/action_controller.rb
+++ b/lib/ddtrace/contrib/rails/action_controller.rb
@@ -33,6 +33,7 @@ module Datadog
           Datadog::Tracer.log.error(e.message)
         end
 
+        # rubocop:disable Metrics/MethodLength
         def self.process_action(_name, start, finish, _id, payload)
           return unless Thread.current[KEY]
           Thread.current[KEY] = false
@@ -63,8 +64,12 @@ module Datadog
               end
             else
               error = payload[:exception]
-              status = ActionDispatch::ExceptionWrapper.status_code_for_exception(error[0])
-              status = status ? status.to_s : '?'
+              if defined?(::ActionDispatch::ExceptionWrapper)
+                status = ::ActionDispatch::ExceptionWrapper.status_code_for_exception(error[0])
+                status = status ? status.to_s : '?'
+              else
+                status = '500'
+              end
               if status.starts_with?('5')
                 span.status = 1
                 span.set_tag(Datadog::Ext::Errors::TYPE, error[0])

--- a/test/contrib/rails/apps/application.rb
+++ b/test/contrib/rails/apps/application.rb
@@ -33,7 +33,6 @@ module RailsTrace
 
     def config.database_configuration
       parsed = super
-      puts '', 'UYOUOUUO', ''
       raise parsed.to_yaml # Replace this line to add custom connections to the hash from database.yml
     end
 

--- a/test/contrib/rails/apps/controllers.rb
+++ b/test/contrib/rails/apps/controllers.rb
@@ -13,6 +13,7 @@ class TracingController < ActionController::Base
       'views/tracing/full.html.erb' => '<% Article.all.each do |article| %><% end %>',
       'views/tracing/error.html.erb' => '<%= 1/0 %>',
       'views/tracing/soft_error.html.erb' => 'nothing',
+      'views/tracing/not_found.html.erb' => 'nothing',
       'views/tracing/error_partial.html.erb' => 'Hello from <%= render "views/tracing/inner_error.html.erb" %>',
       'views/tracing/_body.html.erb' => '_body.html.erb partial',
       'views/tracing/_inner_error.html.erb' => '<%= 1/0 %>'
@@ -39,6 +40,13 @@ class TracingController < ActionController::Base
     end
   end
 
+  def not_found
+    # Here we raise manually a 'Not Found' exception.
+    # The conversion is by default done by Rack::Utils.status_code using
+    # http://www.rubydoc.info/gems/rack/Rack/Utils#HTTP_STATUS_CODES-constant
+    raise ActionController::RoutingError, :not_found
+  end
+
   def error_template
     render 'views/tracing/error.html.erb'
   end
@@ -59,6 +67,7 @@ routes = {
   '/full' => 'tracing#full',
   '/error' => 'tracing#error',
   '/soft_error' => 'tracing#soft_error',
+  '/not_found' => 'tracing#not_found',
   '/error_template' => 'tracing#error_template',
   '/error_partial' => 'tracing#error_partial'
 }

--- a/test/contrib/rails/errors_test.rb
+++ b/test/contrib/rails/errors_test.rb
@@ -41,11 +41,13 @@ class TracingControllerTest < ActionController::TestCase
 
     span = spans[0]
     assert_equal(span.name, 'rails.action_controller')
-    assert_equal(span.status, 0)
     assert_equal(span.span_type, 'http')
     assert_equal(span.resource, 'TracingController#not_found')
     assert_equal(span.get_tag('rails.route.action'), 'not_found')
     assert_equal(span.get_tag('rails.route.controller'), 'TracingController')
+    # Stop here for old Rails versions, which have no ActionDispatch::ExceptionWrapper
+    return if Rails.version < '3.2.22.5'
+    assert_equal(span.status, 0)
     assert_nil(span.get_tag('error.type'))
     assert_nil(span.get_tag('error.msg'))
   end


### PR DESCRIPTION
As mentionned in https://github.com/DataDog/dd-trace-rb/issues/103 -> do not pull the red flag when error is not a `5xx` status code.