### PR TITLE
Patch ActiveRecord only when it's available.

### DIFF
--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -12,7 +12,7 @@ require 'ddtrace/contrib/rails/active_support'
 require 'ddtrace/contrib/rails/utils'
 
 # Rails < 3.1
-unless defined?(ActiveRecord::Base.connection_config)
+if defined?(::ActiveRecord) && !defined?(::ActiveRecord::Base.connection_config)
   ActiveRecord::Base.class_eval do
     class << self
       def connection_config


### PR DESCRIPTION
It crashes when using rails without active record. Also currently there are at least 3 places where we apply stuff to active record:

- `contrib/rails/framework`
- `contrib/rails/active_record`
- `contrib/active_record`

It would be probably best to have one place for this eval, or just use some kind of wrapper method around `connection_config` that would handle this instead of patching AR