### PR TITLE
[tracer:stacktrace] fix error stack traces

### DIFF
--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -29,10 +29,13 @@ end
 if defined?(Rails::VERSION)
   if Rails::VERSION::MAJOR.to_i >= 3
     require 'ddtrace/contrib/rails/framework'
+    require 'ddtrace/contrib/rails/middlewares'
 
     module Datadog
       # Railtie class initializes
       class Railtie < Rails::Railtie
+        config.app_middleware.use(Datadog::Contrib::Rails::TraceMiddleware)
+
         # auto instrument Rails and third party components after
         # the framework initialization
         options = {}

--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -34,7 +34,7 @@ if defined?(Rails::VERSION)
     module Datadog
       # Railtie class initializes
       class Railtie < Rails::Railtie
-        config.app_middleware.use(Datadog::Contrib::Rails::TraceMiddleware)
+        config.app_middleware.use(Datadog::Contrib::Rails::ExceptionMiddleware)
 
         # auto instrument Rails and third party components after
         # the framework initialization

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -130,6 +130,7 @@ module Datadog
             request_span.status = 1
             # in any case we don't touch the stacktrace if it has been set
             if request_span.get_tag(Datadog::Ext::Errors::STACK).nil?
+              # [TODO:christian] this is the one to change
               request_span.set_tag(Datadog::Ext::Errors::STACK, caller().join("\n"))
             end
           end

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -87,7 +87,7 @@ module Datadog
 
           # call the rest of the stack
           status, headers, response = @app.call(env)
-          return status, headers, response
+
         # rubocop:disable Lint/RescueException
         # Here we really want to catch *any* exception, not only StandardError,
         # as we really have no clue of what is in the block,

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -87,6 +87,7 @@ module Datadog
 
           # call the rest of the stack
           status, headers, response = @app.call(env)
+          return status, headers, response
         # rubocop:disable Lint/RescueException
         # Here we really want to catch *any* exception, not only StandardError,
         # as we really have no clue of what is in the block,
@@ -96,7 +97,7 @@ module Datadog
         rescue Exception => e
           # catch exceptions that may be raised in the middleware chain
           # Note: if a middleware catches an Exception without re raising,
-          # the Exception cannot be recorded here
+          # the Exception cannot be recorded here.
           request_span.set_error(e)
           raise e
         ensure
@@ -128,11 +129,6 @@ module Datadog
           # unless it has been already set by the underlying framework
           if status.to_s.start_with?('5') && request_span.status.zero?
             request_span.status = 1
-            # in any case we don't touch the stacktrace if it has been set
-            if request_span.get_tag(Datadog::Ext::Errors::STACK).nil?
-              # [TODO:christian] this is the one to change
-              request_span.set_tag(Datadog::Ext::Errors::STACK, caller().join("\n"))
-            end
           end
 
           request_span.finish()

--- a/lib/ddtrace/contrib/rails/action_controller.rb
+++ b/lib/ddtrace/contrib/rails/action_controller.rb
@@ -33,7 +33,6 @@ module Datadog
           Datadog::Tracer.log.error(e.message)
         end
 
-        # rubocop:disable Metrics/MethodLength
         def self.process_action(_name, start, finish, _id, payload)
           return unless Thread.current[KEY]
           Thread.current[KEY] = false
@@ -58,10 +57,7 @@ module Datadog
               # [christian] in some cases :status is not defined,
               # rather than firing an error, simply acknowledge we don't know it.
               status = payload.fetch(:status, '?').to_s
-              if status.starts_with?('5')
-                span.status = 1
-                span.set_tag(Datadog::Ext::Errors::STACK, caller().join("\n"))
-              end
+              span.status = 1 if status.starts_with?('5')
             else
               error = payload[:exception]
               if defined?(::ActionDispatch::ExceptionWrapper)
@@ -74,7 +70,6 @@ module Datadog
                 span.status = 1
                 span.set_tag(Datadog::Ext::Errors::TYPE, error[0])
                 span.set_tag(Datadog::Ext::Errors::MSG, error[1])
-                span.set_tag(Datadog::Ext::Errors::STACK, caller().join("\n"))
               end
             end
           ensure

--- a/lib/ddtrace/contrib/rails/middlewares.rb
+++ b/lib/ddtrace/contrib/rails/middlewares.rb
@@ -7,7 +7,7 @@ module Datadog
       # This is only here to catch errors, the Rack module does something very similar, however,
       # since it's not in the same place in the stack, when the Rack middleware is called,
       # error is already swallowed and handled by Rails so we miss the call stack, for instance.
-      class TraceMiddleware
+      class ExceptionMiddleware
         def initialize(app)
           @app = app
         end

--- a/lib/ddtrace/contrib/rails/middlewares.rb
+++ b/lib/ddtrace/contrib/rails/middlewares.rb
@@ -1,0 +1,32 @@
+require 'ddtrace/ext/http'
+
+module Datadog
+  module Contrib
+    # Rails module includes middlewares that are required for Rails to be properly instrumented.
+    module Rails
+      # This is only here to catch errors, the Rack module does something very similar, however,
+      # since it's not in the same place in the stack, when the Rack middleware is called,
+      # error is already swallowed and handled by Rails so we miss the call stack, for instance.
+      class TraceMiddleware
+        def initialize(app)
+          @app = app
+        end
+
+        def call(env)
+          @app.call(env)
+        # rubocop:disable Lint/RescueException
+        # Here we really want to catch *any* exception, not only StandardError,
+        # as we really have no clue of what is in the block,
+        # and it is user code which should be executed no matter what.
+        # It's not a problem since we re-raise it afterwards so for example a
+        # SignalException::Interrupt would still bubble up.
+        rescue Exception => e
+          tracer = ::Rails.configuration.datadog_trace.fetch(:tracer)
+          span = tracer.active_span()
+          span.set_error(e) unless span.nil?
+          raise e
+        end
+      end
+    end
+  end
+end

--- a/test/contrib/rack/middleware_test.rb
+++ b/test/contrib/rack/middleware_test.rb
@@ -165,7 +165,7 @@ class TracerTest < RackBaseTest
     assert_equal('GET', span.get_tag('http.method'))
     assert_equal('500', span.get_tag('http.status_code'))
     assert_equal('/500/', span.get_tag('http.url'))
-    refute_nil(span.get_tag('error.stack'))
+    assert_nil(span.get_tag('error.stack'))
     assert_equal(1, span.status)
     assert_nil(span.parent)
   end

--- a/test/contrib/rails/apps/controllers.rb
+++ b/test/contrib/rails/apps/controllers.rb
@@ -12,6 +12,7 @@ class TracingController < ActionController::Base
       'views/tracing/partial.html.erb' => 'Hello from <%= render "views/tracing/body.html.erb" %>',
       'views/tracing/full.html.erb' => '<% Article.all.each do |article| %><% end %>',
       'views/tracing/error.html.erb' => '<%= 1/0 %>',
+      'views/tracing/sub_error.html.erb' => '<%= 1/0 %>',
       'views/tracing/soft_error.html.erb' => 'nothing',
       'views/tracing/not_found.html.erb' => 'nothing',
       'views/tracing/error_partial.html.erb' => 'Hello from <%= render "views/tracing/inner_error.html.erb" %>',
@@ -38,6 +39,18 @@ class TracingController < ActionController::Base
     else
       render nothing: true, status: 520
     end
+  end
+
+  def sub_error
+    a_nested_error_call
+  end
+
+  def a_nested_error_call
+    another_nested_error_call
+  end
+
+  def another_nested_error_call
+    error
   end
 
   def not_found
@@ -67,6 +80,7 @@ routes = {
   '/full' => 'tracing#full',
   '/error' => 'tracing#error',
   '/soft_error' => 'tracing#soft_error',
+  '/sub_error' => 'tracing#sub_error',
   '/not_found' => 'tracing#not_found',
   '/error_template' => 'tracing#error_template',
   '/error_partial' => 'tracing#error_partial'

--- a/test/contrib/rails/controller_test.rb
+++ b/test/contrib/rails/controller_test.rb
@@ -108,8 +108,7 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(1, span.status, 'span should be flagged as an error')
     assert_equal('ZeroDivisionError', span.get_tag('error.type'), 'type should contain the class name of the error')
     assert_equal('divided by 0', span.get_tag('error.msg'), 'msg should state we tried to divided by 0')
-    assert_match(/ddtrace/, span.get_tag('error.stack'), 'stack should contain the call stack when error was raised')
-    assert_match(/\n/, span.get_tag('error.stack'), 'stack should have multiple lines')
+    assert_nil(span.get_tag('error.stack'))
   end
 
   test 'http error code should be trapped and reported as such, even with no exception' do
@@ -127,6 +126,6 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(1, span.status, 'span should be flagged as an error')
     assert_nil(span.get_tag('error.type'), 'type should be undefined')
     assert_nil(span.get_tag('error.msg'), 'msg should be empty')
-    assert_match(/ddtrace/, span.get_tag('error.stack'), 'stack should contain the call stack when error was raised')
+    assert_nil(span.get_tag('error.stack'), 'no error stack')
   end
 end

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -97,7 +97,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_equal(request_span.get_tag('http.status_code'), '500')
     assert_equal(request_span.status, 1, 'span should be flagged as an error')
     assert_not_nil(request_span.get_tag('error.stack')) # error stack is in rack span
-    # [TODO:christian] audit for actual content of the stack
+    assert_match(/controllers\.rb.*error/, request_span.get_tag('error.stack'))
   end
 
   test 'the rack.request span has the Rails exception, soft error version' do
@@ -114,7 +114,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_equal(controller_span.status, 1)
     assert_nil(controller_span.get_tag('error.type'))
     assert_nil(controller_span.get_tag('error.msg'))
-    assert_nil(controller_span.get_tag('error.stack')) # error stack is in rack span
+    assert_nil(controller_span.get_tag('error.stack'))
 
     assert_equal('rack.request', request_span.name)
     assert_equal(request_span.span_type, 'http')
@@ -123,8 +123,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_equal(request_span.get_tag('http.method'), 'GET')
     assert_equal(request_span.get_tag('http.status_code'), '520')
     assert_equal(request_span.status, 1, 'span should be flagged as an error')
-    assert_not_nil(request_span.get_tag('error.stack')) # error stack is in rack span
-    # [TODO:christian] audit for actual content of the stack
+    assert_nil(request_span.get_tag('error.stack'))
   end
 
   test 'the rack.request span has the Rails exception and call stack is correct' do
@@ -151,8 +150,10 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_equal(request_span.get_tag('http.status_code'), '500')
     assert_equal(request_span.status, 1, 'span should be flagged as an error')
     assert_not_nil(request_span.get_tag('error.stack')) # error stack is in rack span
-    puts request_span.get_tag('error.stack')
-    # [TODO:christian] audit for actual content of the stack
+    assert_match(/controllers\.rb.*error/, request_span.get_tag('error.stack'))
+    assert_match(/controllers\.rb.*another_nested_error_call/, request_span.get_tag('error.stack'))
+    assert_match(/controllers\.rb.*a_nested_error_call/, request_span.get_tag('error.stack'))
+    assert_match(/controllers\.rb.*sub_error/, request_span.get_tag('error.stack'))
   end
 
   test 'the status code is properly set if Rails controller is bypassed' do

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -98,6 +98,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_equal(request_span.status, 1, 'span should be flagged as an error')
     assert_not_nil(request_span.get_tag('error.stack')) # error stack is in rack span
     assert_match(/controllers\.rb.*error/, request_span.get_tag('error.stack'))
+    assert_match(/\n/, request_span.get_tag('error.stack'))
   end
 
   test 'the rack.request span has the Rails exception, soft error version' do
@@ -149,11 +150,14 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_equal(request_span.get_tag('http.method'), 'GET')
     assert_equal(request_span.get_tag('http.status_code'), '500')
     assert_equal(request_span.status, 1, 'span should be flagged as an error')
+    assert_equal(controller_span.get_tag('error.type'), 'ZeroDivisionError')
+    assert_equal(controller_span.get_tag('error.msg'), 'divided by 0')
     assert_not_nil(request_span.get_tag('error.stack')) # error stack is in rack span
     assert_match(/controllers\.rb.*error/, request_span.get_tag('error.stack'))
     assert_match(/controllers\.rb.*another_nested_error_call/, request_span.get_tag('error.stack'))
     assert_match(/controllers\.rb.*a_nested_error_call/, request_span.get_tag('error.stack'))
     assert_match(/controllers\.rb.*sub_error/, request_span.get_tag('error.stack'))
+    assert_match(/\n/, request_span.get_tag('error.stack'))
   end
 
   test 'the status code is properly set if Rails controller is bypassed' do

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -87,8 +87,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_equal(controller_span.status, 1)
     assert_equal(controller_span.get_tag('error.type'), 'ZeroDivisionError')
     assert_equal(controller_span.get_tag('error.msg'), 'divided by 0')
-    assert_match(/ddtrace/, controller_span.get_tag('error.stack'))
-    assert_match(/\n/, controller_span.get_tag('error.stack'))
+    assert_nil(controller_span.get_tag('error.stack')) # error stack is in rack span
 
     assert_equal('rack.request', request_span.name)
     assert_equal(request_span.span_type, 'http')
@@ -97,6 +96,35 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_equal(request_span.get_tag('http.method'), 'GET')
     assert_equal(request_span.get_tag('http.status_code'), '500')
     assert_equal(request_span.status, 1, 'span should be flagged as an error')
+    assert_not_nil(request_span.get_tag('error.stack')) # error stack is in rack span
+    # [TODO:christian] audit for actual content of the stack
+  end
+
+  test 'the rack.request span has the Rails exception, soft error version' do
+    # make a request that fails
+    get '/soft_error'
+    # assert_response 520
+
+    # get spans
+    spans = @tracer.writer.spans()
+    assert_operator(spans.length, :>=, 2, 'there should be at least 2 spans')
+    request_span, controller_span = spans
+
+    assert_equal(controller_span.name, 'rails.action_controller')
+    assert_equal(controller_span.status, 1)
+    assert_nil(controller_span.get_tag('error.type'))
+    assert_nil(controller_span.get_tag('error.msg'))
+    assert_nil(controller_span.get_tag('error.stack')) # error stack is in rack span
+
+    assert_equal('rack.request', request_span.name)
+    assert_equal(request_span.span_type, 'http')
+    assert_equal(request_span.resource, 'TracingController#soft_error')
+    assert_equal(request_span.get_tag('http.url'), '/soft_error')
+    assert_equal(request_span.get_tag('http.method'), 'GET')
+    assert_equal(request_span.get_tag('http.status_code'), '520')
+    assert_equal(request_span.status, 1, 'span should be flagged as an error')
+    assert_not_nil(request_span.get_tag('error.stack')) # error stack is in rack span
+    # [TODO:christian] audit for actual content of the stack
   end
 
   test 'the status code is properly set if Rails controller is bypassed' do


### PR DESCRIPTION
Rails instrumentation does not report correct stack traces (see #110 which also referred to this point). This patch introduces a new way to populate this stack trace (heavily inspired by @Ferdy89 work), not relying on `caller` any more which, indeed, is not want we want.