### PR TITLE
Lock `redis` dependency for old ruby versions

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -124,7 +124,7 @@ if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM != 'java'
 else
   appraise 'contrib-old' do
     gem 'elasticsearch-transport'
-    gem 'redis'
+    gem 'redis', '< 4.0.0'
     gem 'hiredis'
     gem 'rack', '1.4.7'
     gem 'rack-test'

--- a/gemfiles/contrib_old.gemfile
+++ b/gemfiles/contrib_old.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "elasticsearch-transport"
-gem "redis"
+gem "redis", "< 4.0.0"
 gem "hiredis"
 gem "rack", "1.4.7"
 gem "rack-test"


### PR DESCRIPTION
`redis 4.0.0` has been released and requires `ruby >= 2.2.2`