### PR TITLE
Fix trace leak across multiple requests

### DIFF
--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -40,7 +40,7 @@ module Datadog
 
         def configure
           # ensure that the configuration is executed only once
-          return if @tracer && @service
+          return clean_context if @tracer && @service
 
           # retrieve the current tracer and service
           @tracer = @options.fetch(:tracer)
@@ -134,6 +134,15 @@ module Datadog
           request_span.finish()
 
           [status, headers, response]
+        end
+
+        private
+
+        # TODO: Remove this once we change how context propagation works. This
+        # ensures we clean thread-local variables on each HTTP request avoiding
+        # memory leaks.
+        def clean_context
+          @tracer.provider.context = Datadog::Context.new
         end
       end
     end

--- a/test/contrib/rack/middleware_test.rb
+++ b/test/contrib/rack/middleware_test.rb
@@ -239,6 +239,14 @@ class TracerTest < RackBaseTest
     assert_equal(1, span.status)
     assert_nil(span.parent)
   end
+
+  def test_middleware_context_cleaning
+    get '/leak'
+    get '/success'
+
+    assert_equal(0, @tracer.provider.context.trace.length)
+    assert_equal(1, @tracer.writer.spans.length)
+  end
 end
 
 class CustomTracerTest < RackBaseTest


### PR DESCRIPTION
Depends on #183 

This PR provides a temporary fix to a memory leak associated with unfinished spans, which are retained in the context object instead of being flushed. This issue is happening because we currently rely on thread local variables for context propagation across multiple spans, and these variables are not necessarily garbage collected at the end of each request – they might return to a thread pool instead and be reused in following the requests.

This PR ensures that each HTTP request has a clean context object.



