### PR TITLE
Add `faraday` integration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,7 @@ namespace :test do
     t.test_files = FileList['test/contrib/rails/**/*disable_env*_test.rb']
   end
 
-  [:elasticsearch, :http, :redis, :sinatra, :sidekiq, :rack, :grape].each do |contrib|
+  [:elasticsearch, :http, :redis, :sinatra, :sidekiq, :rack, :faraday, :grape].each do |contrib|
     Rake::TestTask.new(contrib) do |t|
       t.libs << %w[test lib]
       t.test_files = FileList["test/contrib/#{contrib}/*_test.rb"]
@@ -140,12 +140,14 @@ task :ci do
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:sidekiq'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:rack'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:grape'
+    sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:faraday'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:monkey'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:elasticsearch'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:http'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:redis'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:sinatra'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:rack'
+    sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:faraday'
     sh 'rvm $SIDEKIQ_OLD_VERSIONS --verbose do appraisal contrib-old rake test:sidekiq'
   when 2
     sh 'rvm $RAILS3_VERSIONS --verbose do appraisal rails30-postgres rake test:rails'

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -387,6 +387,39 @@ giving precedence to the middleware settings. Inherited configurations are:
 * ``trace_agent_hostname``
 * ``trace_agent_port``
 
+### Faraday
+
+The `faraday` integration is available through the `ddtrace` middleware:
+
+    require 'faraday'
+    require 'ddtrace'
+
+    Datadog::Monkey.patch_module(:faraday) # registers the tracing middleware
+
+    connection = Faraday.new('https://example.com') do |builder|
+      builder.use(:ddtrace, options)
+      builder.adapter Faraday.default_adapter
+    end
+
+    connection.get('/foo')
+
+Where `options` is an optional `Hash` that accepts the following parameters:
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `split_by_domain` | Boolean | `false` | Uses the request domain as the service name when set to `true`. |
+| `distributed_tracing` | Boolean | `false` | Propagates tracing context along the HTTP request when set to `true`. |
+| `error_handler` | Callable | [Click Here](https://github.com/DataDog/dd-trace-rb/blob/4fe3bc9df032eac3cd294b0bebcc866080dbe04f/lib/ddtrace/contrib/faraday/middleware.rb#L11-L13) | A callable object that receives a single argument – the request environment. If it evaluates to a *truthy* value, the trace span is marked as an error. By default, only server-side errors (e.g. `5xx`) are flagged as errors. |
+
+It's worth mentioning that `ddtrace` also supports instrumentation for the
+`net/http` library, so if you're using it as farady's backend you might see
+instrumentation both on `faraday` and `net/http` levels. If you want to avoid
+multiple levels of instrumentation for your HTTP requests, remember that you can
+always fine tune witch libraries are patched by calling:
+
+    Datadog::Monkey.patch([:foo, :bar])
+    # instead of Datadog::Monkey.patch_all
+
 ## Advanced usage
 
 ### Manual Instrumentation

--- a/lib/ddtrace/contrib/faraday/middleware.rb
+++ b/lib/ddtrace/contrib/faraday/middleware.rb
@@ -1,0 +1,75 @@
+require 'faraday'
+require 'ddtrace/ext/http'
+require 'ddtrace/ext/net'
+require 'ddtrace/ext/distributed'
+
+module Datadog
+  module Contrib
+    module Faraday
+      # Middleware implements a faraday-middleware for ddtrace instrumentation
+      class Middleware < ::Faraday::Middleware
+        DEFAULT_ERROR_HANDLER = lambda do |env|
+          Ext::HTTP::ERROR_RANGE.cover?(env[:status])
+        end
+
+        DEFAULT_OPTIONS = {
+          distributed_tracing: false,
+          split_by_domain: false,
+          error_handler: DEFAULT_ERROR_HANDLER
+        }.freeze
+
+        def initialize(app, options = {})
+          super(app)
+          @options = DEFAULT_OPTIONS.merge(options)
+        end
+
+        def call(env)
+          dd_pin.tracer.trace(SERVICE) do |span|
+            annotate!(span, env)
+            propagate!(span, env) if options[:distributed_tracing]
+            app.call(env).on_complete { |resp| handle_response(span, resp) }
+          end
+        end
+
+        private
+
+        attr_reader :app, :options
+
+        def annotate!(span, env)
+          span.resource = env[:method].to_s.upcase
+          span.service = service_name(env)
+          span.span_type = Ext::HTTP::TYPE
+          span.set_tag(Ext::HTTP::URL, env[:url].path)
+          span.set_tag(Ext::HTTP::METHOD, env[:method].to_s.upcase)
+          span.set_tag(Ext::NET::TARGET_HOST, env[:url].host)
+          span.set_tag(Ext::NET::TARGET_PORT, env[:url].port)
+        end
+
+        def handle_response(span, env)
+          if options.fetch(:error_handler).call(env)
+            span.set_error(["Error #{env[:status]}", env[:body]])
+          end
+
+          span.set_tag(Ext::HTTP::STATUS_CODE, env[:status])
+        end
+
+        def propagate!(span, env)
+          env[:request_headers].merge!(
+            Ext::DistributedTracing::HTTP_HEADER_TRACE_ID => span.trace_id,
+            Ext::DistributedTracing::HTTP_HEADER_PARENT_ID => span.parent_id
+          )
+        end
+
+        def dd_pin
+          Pin.get_from(::Faraday)
+        end
+
+        def service_name(env)
+          return env[:url].host if options[:split_by_domain]
+
+          dd_pin.service
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/faraday/patcher.rb
+++ b/lib/ddtrace/contrib/faraday/patcher.rb
@@ -1,0 +1,52 @@
+module Datadog
+  module Contrib
+    module Faraday
+      COMPATIBLE_UNTIL = Gem::Version.new('1.0.0')
+      SERVICE = 'faraday-request'.freeze
+
+      # Responsible for hooking the instrumentation into faraday
+      module Patcher
+        @patched = false
+
+        class << self
+          def patch
+            return @patched if patched? || !compatible?
+
+            require 'ddtrace/ext/app_types'
+            require 'ddtrace/contrib/faraday/middleware'
+
+            add_pin
+            add_middleware
+
+            @patched = true
+          rescue => e
+            Tracer.log.error("Unable to apply Faraday integration: #{e}")
+            @patched
+          end
+
+          def patched?
+            @patched
+          end
+
+          private
+
+          def compatible?
+            return unless defined?(::Faraday::VERSION)
+
+            Gem::Version.new(::Faraday::VERSION) < COMPATIBLE_UNTIL
+          end
+
+          def add_pin
+            Pin.new(SERVICE, app_type: Ext::AppTypes::WEB).tap do |pin|
+              pin.onto(::Faraday)
+            end
+          end
+
+          def add_middleware
+            ::Faraday::Middleware.register_middleware(ddtrace: Middleware)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/ext/http.rb
+++ b/lib/ddtrace/ext/http.rb
@@ -6,6 +6,7 @@ module Datadog
       URL = 'http.url'.freeze
       METHOD = 'http.method'.freeze
       STATUS_CODE = 'http.status_code'.freeze
+      ERROR_RANGE = 500...600
     end
   end
 end

--- a/lib/ddtrace/monkey.rb
+++ b/lib/ddtrace/monkey.rb
@@ -8,6 +8,7 @@ require 'ddtrace/contrib/elasticsearch/patcher'
 require 'ddtrace/contrib/grape/patcher'
 require 'ddtrace/contrib/redis/patcher'
 require 'ddtrace/contrib/http/patcher'
+require 'ddtrace/contrib/faraday/patcher'
 
 module Datadog
   # Monkey is used for monkey-patching 3rd party libs.
@@ -18,6 +19,7 @@ module Datadog
       http: true,
       redis: true,
       grape: true,
+      faraday: true,
       active_record: false
     }
     # Patchers should expose 2 methods:
@@ -29,6 +31,7 @@ module Datadog
                   http: Datadog::Contrib::HTTP::Patcher,
                   redis: Datadog::Contrib::Redis::Patcher,
                   grape: Datadog::Contrib::Grape::Patcher,
+                  faraday: Datadog::Contrib::Faraday::Patcher,
                   active_record: Datadog::Contrib::ActiveRecord::Patcher }
     @mutex = Mutex.new
 

--- a/test/contrib/faraday/middleware_test.rb
+++ b/test/contrib/faraday/middleware_test.rb
@@ -1,0 +1,124 @@
+require 'helper'
+require 'ddtrace'
+require 'faraday'
+require 'ddtrace/ext/distributed'
+
+module Datadog
+  module Contrib
+    module Faraday
+      class MiddlewareTest < Minitest::Test
+        Monkey.patch_module(:faraday)
+
+        def setup
+          ::Faraday.datadog_pin.tracer = get_test_tracer
+        end
+
+        def test_no_interference
+          response = client.get('/success')
+
+          assert_kind_of(::Faraday::Response, response)
+          assert_equal(response.body, 'OK')
+          assert_equal(response.status, 200)
+        end
+
+        def test_successful_request
+          client.get('/success')
+          span = request_span
+
+          assert_equal(SERVICE, span.service)
+          assert_equal(SERVICE, span.name)
+          assert_equal('GET', span.resource)
+          assert_equal('GET', span.get_tag(Ext::HTTP::METHOD))
+          assert_equal('200', span.get_tag(Ext::HTTP::STATUS_CODE))
+          assert_equal('/success', span.get_tag(Ext::HTTP::URL))
+          assert_equal('example.com', span.get_tag(Ext::NET::TARGET_HOST))
+          assert_equal('80', span.get_tag(Ext::NET::TARGET_PORT))
+          assert_equal(Ext::HTTP::TYPE, span.span_type)
+          refute_equal(Ext::Errors::STATUS, span.status)
+        end
+
+        def test_error_response
+          client.post('/failure')
+          span = request_span
+
+          assert_equal(SERVICE, span.service)
+          assert_equal(SERVICE, span.name)
+          assert_equal('POST', span.resource)
+          assert_equal('POST', span.get_tag(Ext::HTTP::METHOD))
+          assert_equal('/failure', span.get_tag(Ext::HTTP::URL))
+          assert_equal('500', span.get_tag(Ext::HTTP::STATUS_CODE))
+          assert_equal('example.com', span.get_tag(Ext::NET::TARGET_HOST))
+          assert_equal('80', span.get_tag(Ext::NET::TARGET_PORT))
+          assert_equal(Ext::HTTP::TYPE, span.span_type)
+          assert_equal(Ext::Errors::STATUS, span.status)
+          assert_equal('Error 500', span.get_tag(Ext::Errors::TYPE))
+          assert_equal('Boom!', span.get_tag(Ext::Errors::MSG))
+        end
+
+        def test_client_error
+          client.get('/not_found')
+          span = request_span
+
+          refute_equal(Ext::Errors::STATUS, span.status)
+        end
+
+        def test_custom_error_handling
+          custom_handler = ->(env) { (400...600).cover?(env[:status]) }
+          client(error_handler: custom_handler).get('not_found')
+          span = request_span
+
+          assert_equal(Ext::Errors::STATUS, span.status)
+        end
+
+        def test_split_by_domain_option
+          client(split_by_domain: true).get('/success')
+          span = request_span
+
+          assert_equal(span.name, SERVICE)
+          assert_equal(span.service, 'example.com')
+          assert_equal(span.resource, 'GET')
+        end
+
+        def test_default_tracing_headers
+          response = client.get('/success')
+          headers = response.env.request_headers
+
+          refute_includes(headers, Ext::DistributedTracing::HTTP_HEADER_TRACE_ID)
+          refute_includes(headers, Ext::DistributedTracing::HTTP_HEADER_PARENT_ID)
+        end
+
+        def test_distributed_tracing
+          response = client(distributed_tracing: true).get('/success')
+          headers = response.env.request_headers
+          span = request_span
+
+          assert_equal(headers[Ext::DistributedTracing::HTTP_HEADER_TRACE_ID], span.trace_id)
+          assert_equal(headers[Ext::DistributedTracing::HTTP_HEADER_PARENT_ID], span.parent_id)
+        end
+
+        private
+
+        attr_reader :client
+
+        def client(options = {})
+          ::Faraday.new('http://example.com') do |builder|
+            builder.use(:ddtrace, options)
+            builder.adapter(:test) do |stub|
+              stub.get('/success') { |_| [200, {}, 'OK'] }
+              stub.post('/failure') { |_| [500, {}, 'Boom!'] }
+              stub.get('/not_found') { |_| [404, {}, 'Not Found.'] }
+            end
+          end
+        end
+
+        def request_span
+          tracer.writer.spans.find { |span| span.name == SERVICE }
+        end
+
+        def tracer
+          ::Faraday.datadog_pin.tracer
+        end
+      end
+    end
+  end
+end

--- a/test/monkey_test.rb
+++ b/test/monkey_test.rb
@@ -4,11 +4,12 @@ require 'ddtrace'
 require 'active_record'
 require 'elasticsearch/transport'
 require 'redis'
+require 'faraday'
 
 class MonkeyTest < Minitest::Test
   def test_autopatch_modules
     assert_equal(
-      { elasticsearch: true, http: true, redis: true, grape: true, active_record: false },
+      { elasticsearch: true, http: true, redis: true, grape: true, faraday: true, active_record: false },
       Datadog::Monkey.autopatch_modules
     )
   end
@@ -23,16 +24,18 @@ class MonkeyTest < Minitest::Test
     assert_equal(false, Datadog::Contrib::HTTP::Patcher.patched?)
     assert_equal(false, Datadog::Contrib::Redis::Patcher.patched?)
     assert_equal(false, Datadog::Contrib::Grape::Patcher.patched?)
+    refute(Datadog::Contrib::Faraday::Patcher.patched?)
     assert_equal(false, Datadog::Contrib::ActiveRecord::Patcher.patched?)
-    assert_equal({ elasticsearch: false, http: false, redis: false, grape: false, active_record: false }, Datadog::Monkey.get_patched_modules())
+    assert_equal({ elasticsearch: false, http: false, redis: false, grape: false, faraday: false, active_record: false }, Datadog::Monkey.get_patched_modules())
 
     Datadog::Monkey.patch_module(:redis)
     assert_equal(false, Datadog::Contrib::Elasticsearch::Patcher.patched?)
     assert_equal(false, Datadog::Contrib::HTTP::Patcher.patched?)
     assert_equal(true, Datadog::Contrib::Redis::Patcher.patched?)
     assert_equal(false, Datadog::Contrib::Grape::Patcher.patched?)
+    refute(Datadog::Contrib::Faraday::Patcher.patched?)
     assert_equal(false, Datadog::Contrib::ActiveRecord::Patcher.patched?)
-    assert_equal({ elasticsearch: false, http: false, redis: true, grape: false, active_record: false }, Datadog::Monkey.get_patched_modules())
+    assert_equal({ elasticsearch: false, http: false, redis: true, grape: false, faraday: false, active_record: false }, Datadog::Monkey.get_patched_modules())
 
     # now do it again to check it's idempotent
     Datadog::Monkey.patch_module(:redis)
@@ -40,16 +43,18 @@ class MonkeyTest < Minitest::Test
     assert_equal(false, Datadog::Contrib::HTTP::Patcher.patched?)
     assert_equal(true, Datadog::Contrib::Redis::Patcher.patched?)
     assert_equal(false, Datadog::Contrib::Grape::Patcher.patched?)
+    refute(Datadog::Contrib::Faraday::Patcher.patched?)
     assert_equal(false, Datadog::Contrib::ActiveRecord::Patcher.patched?)
-    assert_equal({ elasticsearch: false, http: false, redis: true, grape: false, active_record: false }, Datadog::Monkey.get_patched_modules())
+    assert_equal({ elasticsearch: false, http: false, redis: true, grape: false, faraday: false, active_record: false }, Datadog::Monkey.get_patched_modules())
 
     Datadog::Monkey.patch(elasticsearch: true, redis: true)
     assert_equal(true, Datadog::Contrib::Elasticsearch::Patcher.patched?)
     assert_equal(false, Datadog::Contrib::HTTP::Patcher.patched?)
     assert_equal(true, Datadog::Contrib::Redis::Patcher.patched?)
     assert_equal(false, Datadog::Contrib::Grape::Patcher.patched?)
+    refute(Datadog::Contrib::Faraday::Patcher.patched?)
     assert_equal(false, Datadog::Contrib::ActiveRecord::Patcher.patched?)
-    assert_equal({ elasticsearch: true, http: false, redis: true, grape: false, active_record: false }, Datadog::Monkey.get_patched_modules())
+    assert_equal({ elasticsearch: true, http: false, redis: true, grape: false, faraday: false, active_record: false }, Datadog::Monkey.get_patched_modules())
 
     # verify that active_record is not auto patched by default
     Datadog::Monkey.patch_all()
@@ -57,15 +62,17 @@ class MonkeyTest < Minitest::Test
     assert_equal(true, Datadog::Contrib::HTTP::Patcher.patched?)
     assert_equal(true, Datadog::Contrib::Redis::Patcher.patched?)
     assert_equal(false, Datadog::Contrib::Grape::Patcher.patched?)
+    assert(Datadog::Contrib::Faraday::Patcher.patched?)
     assert_equal(false, Datadog::Contrib::ActiveRecord::Patcher.patched?)
-    assert_equal({ elasticsearch: true, http: true, redis: true, grape: false, active_record: false }, Datadog::Monkey.get_patched_modules())
+    assert_equal({ elasticsearch: true, http: true, redis: true, grape: false, faraday: true, active_record: false }, Datadog::Monkey.get_patched_modules())
 
     Datadog::Monkey.patch_module(:active_record)
     assert_equal(true, Datadog::Contrib::Elasticsearch::Patcher.patched?)
     assert_equal(true, Datadog::Contrib::HTTP::Patcher.patched?)
     assert_equal(true, Datadog::Contrib::Redis::Patcher.patched?)
     assert_equal(false, Datadog::Contrib::Grape::Patcher.patched?)
+    assert(Datadog::Contrib::Faraday::Patcher.patched?)
     assert_equal(true, Datadog::Contrib::ActiveRecord::Patcher.patched?)
-    assert_equal({ elasticsearch: true, http: true, redis: true, grape: false, active_record: true }, Datadog::Monkey.get_patched_modules())
+    assert_equal({ elasticsearch: true, http: true, redis: true, grape: false, faraday: true, active_record: true }, Datadog::Monkey.get_patched_modules())
   end
 end


### PR DESCRIPTION
This PR enables instrumentation for HTTP requests made through `faraday`.

### Usage
```ruby
connection = Faraday.new('https://example.com') do |builder|
  builder.use(:ddtrace, options)
  builder.adapter Faraday.default_adapter
end

connection.get('/foo')
```
Where `options` is an optional `Hash` that accepts the following parameters:

| Key | Type | Default | Description |
| --- | --- | --- | --- |
| `split_by_domain` | Boolean | `false` | Uses the request domain as the service name when set to `true`. |
| `distributed_tracing` | Boolean | `false` | Propagates tracing context along the HTTP request when set to `true`. |
| `error_handler` | Callable | [Click Here](https://github.com/DataDog/dd-trace-rb/blob/4fe3bc9df032eac3cd294b0bebcc866080dbe04f/lib/ddtrace/contrib/faraday/middleware.rb#L11-L13) | A callable object that receives a single argument – the request environment. If it evaluates to a *truthy* value, the trace span is marked as an error. By default, only server-side errors (e.g. `5xx`) are flagged as errors. |