### PR TITLE
add TestTracer for use in tests

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -33,6 +33,7 @@ EOS
   spec.require_paths = ['lib']
 
   spec.add_dependency 'msgpack'
+  spec.add_dependency 'concurrent-ruby'
 
   spec.add_development_dependency 'rake', '~> 10.5'
   spec.add_development_dependency('rubocop', '~> 0.47') if RUBY_VERSION >= '2.1.0'

--- a/lib/ddtrace/test_tracer.rb
+++ b/lib/ddtrace/test_tracer.rb
@@ -1,0 +1,22 @@
+require 'ddtrace/tracer'
+require 'concurrent'
+
+module Datadog
+  class TestTracer < Tracer
+    attr_reader :traces
+
+    def initialize(options = {})
+      @traces = Concurrent::Array.new
+      super(options.merge(enabled: false))
+    end
+
+    def reset!
+      @traces.clear
+    end
+
+    def write(trace)
+      @traces << trace
+      super
+    end
+  end
+end


### PR DESCRIPTION
I've found this useful when adding tracing to our apps at Square.

E.g. in RSpec:

```ruby
let!(:tracer) { Datadog::TestTracer.new }
after { tracer.reset! }

it "traces" do
  do_my_thing_that_has_custom_tracing
  expect(tracer.traces.size).to eq(3)
end
```

We have added custom RSpec matchers to make these kinds of tests more ergonomic. An example using an RSpec matcher would be:

```ruby
require "datadog/rspec_matcher"

it "traces" do
  expect {
    do_my_thing_that_has_custom_tracing
  }.to trace([{trace_id: 1234, service: "Foo", resource: "boom"}])
```

which would test that `do_my_thing_that_has_custom_tracing` creates a single span that has `trace_id == 1234`, `service == "Foo"`, and `resource == "boom"`.