### PR TITLE
[rails] improve instrumentation stability for Template/Partial rendering

### DIFF
--- a/lib/ddtrace/contrib/rails/action_view.rb
+++ b/lib/ddtrace/contrib/rails/action_view.rb
@@ -25,13 +25,9 @@ module Datadog
           end
 
           # subscribe when the partial rendering has been processed
-          ::ActiveSupport::Notifications.subscribe('render_partial.action_view') do |*args|
-            render_partial(*args)
+          ::ActiveSupport::Notifications.subscribe('finish_render_partial.action_view') do |*args|
+            finish_render_partial(*args)
           end
-        end
-
-        def self.get_key(f)
-          'datadog_actionview_' + f
         end
 
         def self.start_render_template(_name, _start, _finish, _id, payload)
@@ -68,36 +64,32 @@ module Datadog
           Datadog::Tracer.log.error(e.message)
         end
 
-        def self.start_render_partial(*)
-          key = get_key('render_partial')
-          return if Thread.current[key]
+        def self.start_render_partial(_name, _start, _finish, _id, payload)
+          # retrieve the tracing context
+          tracing_context = payload.fetch(:tracing_context)
 
           tracer = ::Rails.configuration.datadog_trace.fetch(:tracer)
-          type = Datadog::Ext::HTTP::TEMPLATE
-          tracer.trace('rails.render_partial', span_type: type)
-
-          Thread.current[key] = true
+          span = tracer.trace('rails.render_partial', span_type: Datadog::Ext::HTTP::TEMPLATE)
+          tracing_context[:dd_rails_partial_span] = span
         rescue StandardError => e
           Datadog::Tracer.log.error(e.message)
         end
 
-        def self.render_partial(_name, start, finish, _id, payload)
-          key = get_key('render_partial')
-          return unless Thread.current[key]
-          Thread.current[key] = false
+        def self.finish_render_partial(_name, start, finish, _id, payload)
+          # retrieve the tracing context and the latest active span
+          tracing_context = payload.fetch(:tracing_context)
+          span = tracing_context[:dd_rails_partial_span]
+          return unless span && !span.finished?
 
           # finish the tracing and update the execution time
-          tracer = ::Rails.configuration.datadog_trace.fetch(:tracer)
-          span = tracer.active_span()
-          return unless span
-
           begin
-            template_name = Datadog::Contrib::Rails::Utils.normalize_template_name(payload.fetch(:identifier))
-            span.set_tag('rails.template_name', template_name)
-            span.set_error(payload[:exception]) if payload[:exception]
+            template_name = tracing_context[:template_name]
+            exception = tracing_context[:exception]
+
+            span.set_tag('rails.template_name', template_name) if template_name
+            span.set_error(exception) if exception
           ensure
-            span.start_time = start
-            span.finish(finish)
+            span.finish()
           end
         rescue StandardError => e
           Datadog::Tracer.log.error(e.message)

--- a/lib/ddtrace/contrib/rails/action_view.rb
+++ b/lib/ddtrace/contrib/rails/action_view.rb
@@ -14,14 +14,14 @@ module Datadog
             start_render_template(*args)
           end
 
+          # subscribe when the template rendering has been processed
+          ::ActiveSupport::Notifications.subscribe('finish_render_template.action_view') do |*args|
+            finish_render_template(*args)
+          end
+
           # subscribe when the partial rendering starts
           ::ActiveSupport::Notifications.subscribe('start_render_partial.action_view') do |*args|
             start_render_partial(*args)
-          end
-
-          # subscribe when the template rendering has been processed
-          ::ActiveSupport::Notifications.subscribe('render_template.action_view') do |*args|
-            render_template(*args)
           end
 
           # subscribe when the partial rendering has been processed
@@ -34,15 +34,36 @@ module Datadog
           'datadog_actionview_' + f
         end
 
-        def self.start_render_template(*)
-          key = get_key('render_template')
-          return if Thread.current[key]
+        def self.start_render_template(_name, _start, _finish, _id, payload)
+          # retrieve the tracing context
+          tracing_context = payload.fetch(:tracing_context)
 
+          # create a new Span and add it to the tracing context
           tracer = ::Rails.configuration.datadog_trace.fetch(:tracer)
-          type = Datadog::Ext::HTTP::TEMPLATE
-          tracer.trace('rails.render_template', span_type: type)
+          span = tracer.trace('rails.render_template', span_type: Datadog::Ext::HTTP::TEMPLATE)
+          tracing_context[:dd_rails_template_span] = span
+        rescue StandardError => e
+          Datadog::Tracer.log.debug(e.message)
+        end
 
-          Thread.current[key] = true
+        def self.finish_render_template(_name, _start, _finish, _id, payload)
+          # retrieve the tracing context and the latest active span
+          tracing_context = payload.fetch(:tracing_context)
+          span = tracing_context[:dd_rails_template_span]
+          return unless span && !span.finished?
+
+          # finish the tracing and update the execution time
+          begin
+            template_name = tracing_context[:template_name]
+            layout = tracing_context[:layout]
+            exception = tracing_context[:exception]
+
+            span.set_tag('rails.template_name', template_name) if template_name
+            span.set_tag('rails.layout', layout) if layout
+            span.set_error(exception) if exception
+          ensure
+            span.finish()
+          end
         rescue StandardError => e
           Datadog::Tracer.log.error(e.message)
         end
@@ -56,29 +77,6 @@ module Datadog
           tracer.trace('rails.render_partial', span_type: type)
 
           Thread.current[key] = true
-        rescue StandardError => e
-          Datadog::Tracer.log.error(e.message)
-        end
-
-        def self.render_template(_name, start, finish, _id, payload)
-          key = get_key('render_template')
-          return unless Thread.current[key]
-          Thread.current[key] = false
-
-          # finish the tracing and update the execution time
-          tracer = ::Rails.configuration.datadog_trace.fetch(:tracer)
-          span = tracer.active_span()
-          return unless span
-
-          begin
-            template_name = Datadog::Contrib::Rails::Utils.normalize_template_name(payload.fetch(:identifier))
-            span.set_tag('rails.template_name', template_name)
-            span.set_tag('rails.layout', payload.fetch(:layout))
-            span.set_error(payload[:exception]) if payload[:exception]
-          ensure
-            span.start_time = start
-            span.finish(finish)
-          end
         rescue StandardError => e
           Datadog::Tracer.log.error(e.message)
         end

--- a/lib/ddtrace/contrib/rails/action_view.rb
+++ b/lib/ddtrace/contrib/rails/action_view.rb
@@ -10,22 +10,22 @@ module Datadog
           Datadog::RailsRendererPatcher.patch_renderer()
 
           # subscribe when the template rendering starts
-          ::ActiveSupport::Notifications.subscribe('start_render_template.action_view') do |*args|
+          ::ActiveSupport::Notifications.subscribe('!datadog.start_render_template.action_view') do |*args|
             start_render_template(*args)
           end
 
           # subscribe when the template rendering has been processed
-          ::ActiveSupport::Notifications.subscribe('finish_render_template.action_view') do |*args|
+          ::ActiveSupport::Notifications.subscribe('!datadog.finish_render_template.action_view') do |*args|
             finish_render_template(*args)
           end
 
           # subscribe when the partial rendering starts
-          ::ActiveSupport::Notifications.subscribe('start_render_partial.action_view') do |*args|
+          ::ActiveSupport::Notifications.subscribe('!datadog.start_render_partial.action_view') do |*args|
             start_render_partial(*args)
           end
 
           # subscribe when the partial rendering has been processed
-          ::ActiveSupport::Notifications.subscribe('finish_render_partial.action_view') do |*args|
+          ::ActiveSupport::Notifications.subscribe('!datadog.finish_render_partial.action_view') do |*args|
             finish_render_partial(*args)
           end
         end

--- a/lib/ddtrace/contrib/rails/action_view.rb
+++ b/lib/ddtrace/contrib/rails/action_view.rb
@@ -46,7 +46,7 @@ module Datadog
           # retrieve the tracing context and the latest active span
           tracing_context = payload.fetch(:tracing_context)
           span = tracing_context[:dd_rails_template_span]
-          return if span.try(:finished?)
+          return if !span || span.finished?
 
           # finish the tracing and update the execution time
           begin
@@ -61,7 +61,7 @@ module Datadog
             span.finish()
           end
         rescue StandardError => e
-          Datadog::Tracer.log.error(e.message)
+          Datadog::Tracer.log.debug(e.message)
         end
 
         def self.start_render_partial(_name, _start, _finish, _id, payload)
@@ -72,14 +72,14 @@ module Datadog
           span = tracer.trace('rails.render_partial', span_type: Datadog::Ext::HTTP::TEMPLATE)
           tracing_context[:dd_rails_partial_span] = span
         rescue StandardError => e
-          Datadog::Tracer.log.error(e.message)
+          Datadog::Tracer.log.debug(e.message)
         end
 
         def self.finish_render_partial(_name, start, finish, _id, payload)
           # retrieve the tracing context and the latest active span
           tracing_context = payload.fetch(:tracing_context)
           span = tracing_context[:dd_rails_partial_span]
-          return if span.try(:finished?)
+          return if !span || span.finished?
 
           # finish the tracing and update the execution time
           begin
@@ -92,7 +92,7 @@ module Datadog
             span.finish()
           end
         rescue StandardError => e
-          Datadog::Tracer.log.error(e.message)
+          Datadog::Tracer.log.debug(e.message)
         end
       end
     end

--- a/lib/ddtrace/contrib/rails/action_view.rb
+++ b/lib/ddtrace/contrib/rails/action_view.rb
@@ -46,7 +46,7 @@ module Datadog
           # retrieve the tracing context and the latest active span
           tracing_context = payload.fetch(:tracing_context)
           span = tracing_context[:dd_rails_template_span]
-          return unless span && !span.finished?
+          return if span.try(:finished?)
 
           # finish the tracing and update the execution time
           begin
@@ -79,7 +79,7 @@ module Datadog
           # retrieve the tracing context and the latest active span
           tracing_context = payload.fetch(:tracing_context)
           span = tracing_context[:dd_rails_partial_span]
-          return unless span && !span.finished?
+          return if span.try(:finished?)
 
           # finish the tracing and update the execution time
           begin

--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -35,7 +35,7 @@ module Datadog
           layout = layout_name.try(:[], 'virtual_path')
           @tracing_context[:template_name] = template_name
           @tracing_context[:layout] = layout
-		rescue StandardError => e
+        rescue StandardError => e
           Datadog::Tracer.log.error(e.message)
         ensure
           render_template_without_datadog(*args)
@@ -44,15 +44,8 @@ module Datadog
         # method aliasing to patch the class
         alias_method :render_without_datadog, :render
         alias_method :render, :render_with_datadog
-
-        if klass.private_method_defined? :render_template
-          alias_method :render_template_without_datadog, :render_template
-          alias_method :render_template, :render_template_with_datadog
-        else
-          # Rails < 3.1 compatibility
-          alias_method :render_template_without_datadog, :_render_template
-          alias_method :_render_template, :render_template_with_datadog
-        end
+        alias_method :render_template_without_datadog, :render_template
+        alias_method :render_template, :render_template_with_datadog
       end
     end
 
@@ -68,11 +61,35 @@ module Datadog
     def patch_renderer_render_partial
       if defined?(::ActionView::PartialRenderer)
         ::ActionView::PartialRenderer.class_eval do
-          alias_method :render_partial_without_datadog, :render_partial
-          def render_partial(*args, &block)
-            ActiveSupport::Notifications.instrument('start_render_partial.action_view')
-            render_partial_without_datadog(*args, &block)
+          def render_with_datadog(*args, &block)
+            # create a tracing context and start the rendering span
+            @tracing_context = {}
+            ::ActiveSupport::Notifications.instrument('start_render_partial.action_view', tracing_context: @tracing_context)
+            render_without_datadog(*args)
+          rescue Exception => e
+            # attach the exception to the tracing context if any
+            @tracing_context[:exception] = e
+            raise e
+          ensure
+            # ensure that the template `Span` is finished even during exceptions
+            ::ActiveSupport::Notifications.instrument('finish_render_partial.action_view', tracing_context: @tracing_context)
           end
+
+          def render_partial_with_datadog(*args)
+            # update the tracing context with computed values before the rendering
+            template_name = Datadog::Contrib::Rails::Utils.normalize_template_name(@template.try('identifier'))
+            @tracing_context[:template_name] = template_name
+          rescue StandardError => e
+            Datadog::Tracer.log.error(e.message)
+          ensure
+            render_partial_without_datadog(*args)
+          end
+
+          # method aliasing to patch the class
+          alias_method :render_without_datadog, :render
+          alias_method :render, :render_with_datadog
+          alias_method :render_partial_without_datadog, :render_partial
+          alias_method :render_partial, :render_partial_with_datadog
         end
       else # Rails < 3.1
         ::ActionView::Partials::PartialRenderer.class_eval do

--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -71,7 +71,7 @@ module Datadog
         alias_method :render_without_datadog, :render
         alias_method :render, :render_with_datadog
 
-        if klass.private_method_defined? :render_template
+        if klass.private_method_defined?(:render_template) || klass.method_defined?(:render_template)
           alias_method :render_template_without_datadog, :render_template
           alias_method :render_template, :render_template_with_datadog
         else

--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -63,7 +63,7 @@ module Datadog
             @tracing_context[:template_name] = template_name
             @tracing_context[:layout] = layout
           rescue StandardError => e
-            Datadog::Tracer.log.error(e.message)
+            Datadog::Tracer.log.debug(e.message)
           end
 
           # execute the original function anyway
@@ -113,7 +113,7 @@ module Datadog
             template_name = Datadog::Contrib::Rails::Utils.normalize_template_name(@template.try('identifier'))
             @tracing_context[:template_name] = template_name
           rescue StandardError => e
-            Datadog::Tracer.log.error(e.message)
+            Datadog::Tracer.log.debug(e.message)
           end
 
           # execute the original function anyway

--- a/test/contrib/rails/apps/controllers.rb
+++ b/test/contrib/rails/apps/controllers.rb
@@ -64,6 +64,10 @@ class TracingController < ActionController::Base
     render 'views/tracing/error.html.erb'
   end
 
+  def missing_template
+    render 'views/tracing/ouch.not.here'
+  end
+
   def error_partial
     render 'views/tracing/error_partial.html.erb'
   end
@@ -83,7 +87,8 @@ routes = {
   '/sub_error' => 'tracing#sub_error',
   '/not_found' => 'tracing#not_found',
   '/error_template' => 'tracing#error_template',
-  '/error_partial' => 'tracing#error_partial'
+  '/error_partial' => 'tracing#error_partial',
+  '/missing_template' => 'tracing#missing_template'
 }
 
 if Rails.version >= '3.2.22.5'

--- a/test/contrib/rails/apps/controllers.rb
+++ b/test/contrib/rails/apps/controllers.rb
@@ -12,6 +12,7 @@ class TracingController < ActionController::Base
       'views/tracing/partial.html.erb' => 'Hello from <%= render "views/tracing/body.html.erb" %>',
       'views/tracing/full.html.erb' => '<% Article.all.each do |article| %><% end %>',
       'views/tracing/error.html.erb' => '<%= 1/0 %>',
+      'views/tracing/missing_partial.html.erb' => '<%= render "ouch.html.erb" %>',
       'views/tracing/sub_error.html.erb' => '<%= 1/0 %>',
       'views/tracing/soft_error.html.erb' => 'nothing',
       'views/tracing/not_found.html.erb' => 'nothing',
@@ -68,6 +69,10 @@ class TracingController < ActionController::Base
     render 'views/tracing/ouch.not.here'
   end
 
+  def missing_partial
+    render 'views/tracing/missing_partial.html.erb'
+  end
+
   def error_partial
     render 'views/tracing/error_partial.html.erb'
   end
@@ -88,7 +93,8 @@ routes = {
   '/not_found' => 'tracing#not_found',
   '/error_template' => 'tracing#error_template',
   '/error_partial' => 'tracing#error_partial',
-  '/missing_template' => 'tracing#missing_template'
+  '/missing_template' => 'tracing#missing_template',
+  '/missing_partial' => 'tracing#missing_partial'
 }
 
 if Rails.version >= '3.2.22.5'

--- a/test/contrib/rails/controller_test.rb
+++ b/test/contrib/rails/controller_test.rb
@@ -28,6 +28,20 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span.get_tag('rails.route.controller'), 'TracingController')
   end
 
+  test 'template tracing does not break the code' do
+    # render a template and expect the correct result
+    get :index
+    assert_response :success
+    assert_equal('Hello from index.html.erb', response.body)
+  end
+
+  test 'template partial tracing does not break the code' do
+    # render a partial and expect the correct result
+    get :partial
+    assert_response :success
+    assert_equal('Hello from _body.html.erb partial', response.body)
+  end
+
   test 'template rendering is properly traced' do
     # render the template and assert the proper span
     get :index

--- a/test/contrib/rails/errors_test.rb
+++ b/test/contrib/rails/errors_test.rb
@@ -2,6 +2,8 @@ require 'helper'
 
 require 'contrib/rails/test_helper'
 
+# rubocop:disable Metrics/ClassLength
+# rubocop:disable Metrics/BlockLength
 class TracingControllerTest < ActionController::TestCase
   setup do
     @original_tracer = Rails.configuration.datadog_trace[:tracer]

--- a/test/contrib/rails/errors_test.rb
+++ b/test/contrib/rails/errors_test.rb
@@ -100,7 +100,11 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_request.get_tag('rails.route.action'), 'missing_partial')
     assert_equal(span_request.get_tag('rails.route.controller'), 'TracingController')
     assert_equal(span_request.get_tag('error.type'), 'ActionView::Template::Error')
-    assert_includes(span_request.get_tag('error.msg'), 'Missing partial tracing/_ouch.html.erb')
+    if Rails.version >= '3.2.22.5'
+      assert_includes(span_request.get_tag('error.msg'), 'Missing partial tracing/_ouch.html.erb')
+    else
+      assert_includes(span_request.get_tag('error.msg'), 'Missing partial tracing/ouch.html')
+    end
 
     assert_equal(span_partial.name, 'rails.render_partial')
     assert_equal(span_partial.status, 1)
@@ -109,7 +113,11 @@ class TracingControllerTest < ActionController::TestCase
     assert_nil(span_partial.get_tag('rails.template_name'))
     assert_nil(span_partial.get_tag('rails.layout'))
     assert_equal(span_partial.get_tag('error.type'), 'ActionView::MissingTemplate')
-    assert_includes(span_request.get_tag('error.msg'), 'Missing partial tracing/_ouch.html.erb')
+    if Rails.version >= '3.2.22.5'
+      assert_includes(span_partial.get_tag('error.msg'), 'Missing partial tracing/_ouch.html.erb')
+    else
+      assert_includes(span_partial.get_tag('error.msg'), 'Missing partial tracing/ouch.html')
+    end
 
     assert_equal(span_template.name, 'rails.render_template')
     assert_equal(span_template.status, 1)
@@ -117,8 +125,13 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_template.resource, 'rails.render_template')
     assert_equal(span_template.get_tag('rails.template_name'), 'tracing/missing_partial.html.erb')
     assert_equal(span_template.get_tag('rails.layout'), 'layouts/application')
-    assert_equal(span_template.get_tag('error.type'), 'ActionView::Template::Error')
-    assert_includes(span_template.get_tag('error.msg'), 'Missing partial tracing/_ouch.html.erb')
+    if Rails.version >= '3.2.22.5'
+      assert_equal(span_template.get_tag('error.type'), 'ActionView::Template::Error')
+      assert_includes(span_template.get_tag('error.msg'), 'Missing partial tracing/_ouch.html.erb')
+    else
+      assert_equal(span_template.get_tag('error.type'), 'ActionView::MissingTemplate')
+      assert_includes(span_template.get_tag('error.msg'), 'Missing partial tracing/ouch.html')
+    end
   end
 
   test 'error in the template must be traced' do


### PR DESCRIPTION
### Overview

Many code paths around our Rails instrumentation are not very robust, especially if for any reason a `Span` is not properly finished. In that case, we rely in the opening/closing order, keeping the `Trace` opened (so it's not flushed). While wrong manual instrumentation may lead to that case too, we must enforce the stability of our code

### Major changes

* [Template instrumentation]: we patch directly the class `ActionView::TemplateRenderer`, creating a `tracing_context` to carry the template span. Some tags are computed after the rendering so that we don't compute them twice.
* (others are WIP)

### Users impact

The goal of this PR is to improve our internal instrumentation, so **NO IMPACT** must be expected. It should *simply work* without any change.