### PR TITLE
Fix ID collision for forked processes

### DIFF
--- a/lib/ddtrace/utils.rb
+++ b/lib/ddtrace/utils.rb
@@ -1,16 +1,28 @@
-require 'thread'
-
 module Datadog
   # Utils contains low-level utilities, typically to provide pseudo-random trace IDs.
   module Utils
     # We use a custom random number generator because we want no interference
     # with the default one. Using the default prng, we could break code that
     # would rely on srand/rand sequences.
-    @rnd = Random.new
 
     # Return a span id
     def self.next_id
+      reset! if was_forked?
+
       @rnd.rand(Datadog::Span::MAX_ID)
     end
+
+    def self.reset!
+      @pid = Process.pid
+      @rnd = Random.new
+    end
+
+    def self.was_forked?
+      Process.pid != @pid
+    end
+
+    private_class_method :reset!, :was_forked?
+
+    reset!
   end
 end

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -41,4 +41,21 @@ class UtilsTest < Minitest::Test
       assert_equal(0.6221087710398319, r2, '2nd randomly generated number should not be altered by tracing')
     end
   end
+
+  def test_forked_process_id_collision
+    skip if RUBY_PLATFORM == 'java'
+
+    r, w = IO.pipe
+
+    fork do
+      r.close
+      w.write(Datadog::Utils.next_id)
+      w.close
+    end
+
+    w.close
+    Process.wait
+    refute_equal(Datadog::Utils.next_id, r.read.chomp.to_i)
+    r.close
+  end
 end


### PR DESCRIPTION
This PR fixes ID collisions that might arise in applications that make use of process forking (`unicorn`, `resque` etc.).
Here we basically ensure that `parent` and `children` processes don't share the same `seed` for the random number generator.