### PR TITLE
[ci] pin Rubocop version to avoid code style changes

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -35,7 +35,7 @@ EOS
   spec.add_dependency 'msgpack'
 
   spec.add_development_dependency 'rake', '~> 10.5'
-  spec.add_development_dependency('rubocop', '~> 0.47') if RUBY_VERSION >= '2.1.0'
+  spec.add_development_dependency('rubocop', '= 0.49.1') if RUBY_VERSION >= '2.1.0'
   spec.add_development_dependency 'minitest', '= 5.10.1'
   spec.add_development_dependency 'appraisal', '~> 2.1'
   spec.add_development_dependency 'yard', '~> 0.9'


### PR DESCRIPTION
### Overview

With the latest version >= 0.50, we have a lot of complains from Rubocop. This pins the version to the latest accepted style. We'll update Rubocop (and our style) as soon as we release the 0.9.0.