### PR TITLE
Ensure traces sent before process ends 

### DIFF
--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -7,8 +7,7 @@ require 'ddtrace/error'
 module Datadog
   DEFAULT_TIMEOUT = 5
 
-  attr_accessor :shutdown_called
-
+  @shutdown_called = false
   @tracer = Datadog::Tracer.new()
 
   # Default tracer that can be used as soon as +ddtrace+ is required:
@@ -29,6 +28,10 @@ module Datadog
     @tracer
   end
 
+  def self.shutdown_called
+    @shutdown_called
+  end
+
   def self.shutdown(tracer = Datadog.tracer)
     return if @shutdown_called || !tracer.enabled || tracer.writer.worker.nil?
     @shutdown_called = true
@@ -39,6 +42,7 @@ module Datadog
       sleep(0.05)
       Datadog::Tracer.log.debug('Waiting for the buffers to clear before exiting')
     end
+    @shutdown_called = false
   end
 end
 

--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -24,6 +24,18 @@ module Datadog
   def self.tracer
     @tracer
   end
+
+  def self.shutdown(tracer = @tracer)
+    Datadog::Tracer.log.debug("////// SHUTDOWN METHOD")
+    return if !tracer.enabled || tracer.writer.worker.nil?
+    Datadog::Tracer.log.debug("////// tracer enabled, worker not nil")
+    loop do
+      sleep (0.1)
+      Datadog::Tracer.log.debug("////// slept")
+      break if tracer.writer.worker.trace_buffer.empty? && tracer.writer.worker.service_buffer.empty?
+    end
+    Datadog::Tracer.log.debug("///// exiting")
+  end
 end
 
 # Datadog auto instrumentation for frameworks

--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -5,9 +5,6 @@ require 'ddtrace/error'
 
 # \Datadog global namespace that includes all tracing functionality for Tracer and Span classes.
 module Datadog
-  DEFAULT_TIMEOUT = 5
-
-  @shutdown_called = false
   @tracer = Datadog::Tracer.new()
 
   # Default tracer that can be used as soon as +ddtrace+ is required:
@@ -26,23 +23,6 @@ module Datadog
 
   def self.tracer
     @tracer
-  end
-
-  def self.shutdown_called
-    @shutdown_called
-  end
-
-  def self.shutdown(tracer = Datadog.tracer)
-    return if @shutdown_called || !tracer.enabled || tracer.writer.worker.nil?
-    @shutdown_called = true
-    sleep(0.1)
-    timeout_time = Time.now + DEFAULT_TIMEOUT
-    worker = tracer.writer.worker
-    while (!worker.trace_buffer.empty? || !worker.service_buffer.empty?) && Time.now <= timeout_time
-      sleep(0.05)
-      Datadog::Tracer.log.debug('Waiting for the buffers to clear before exiting')
-    end
-    @shutdown_called = false
   end
 end
 

--- a/lib/ddtrace/buffer.rb
+++ b/lib/ddtrace/buffer.rb
@@ -10,11 +10,13 @@ module Datadog
 
       @mutex = Mutex.new()
       @traces = []
+      @closed = false
     end
 
     # Add a new ``trace`` in the local queue. This method doesn't block the execution
     # even if the buffer is full. In that case, a random trace is discarded.
     def push(trace)
+      return if @closed
       @mutex.synchronize do
         len = @traces.length
         if len < @max_size || @max_size <= 0
@@ -46,6 +48,18 @@ module Datadog
         traces = @traces
         @traces = []
         return traces
+      end
+    end
+
+    def close
+      @mutex.synchronize do
+        @closed = true
+      end
+    end
+
+    def closed?
+      @mutex.synchronise do
+        return @closed
       end
     end
   end

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -18,8 +18,6 @@ module Datadog
   # of these function calls and sub-requests would be encapsulated within a single trace.
   # rubocop:disable Metrics/ClassLength
   class Tracer
-    DEFAULT_TIMEOUT = 5
-
     attr_reader :writer, :sampler, :services, :tags, :provider
     attr_accessor :enabled
     attr_writer :default_service
@@ -59,8 +57,8 @@ module Datadog
       log.level == Logger::DEBUG
     end
 
-    def self.shutdown!
-      return if !@enabled? || @writer.worker.nil?
+    def shutdown!
+      return if !@enabled || @writer.worker.nil?
       @writer.worker.shutdown!
     end
 

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -57,6 +57,18 @@ module Datadog
       log.level == Logger::DEBUG
     end
 
+    # Shorthand that calls the `shutdown!` method of a registered worker.
+    # It's useful to ensure that the Trace Buffer is properly flushed before
+    # shutting down the application.
+    #
+    # For instance:
+    #
+    #   tracer.trace('operation_name', service='rake_tasks') do |span|
+    #     span.set_tag('task.name', 'script')
+    #   end
+    #
+    #   tracer.shutdown!
+    #
     def shutdown!
       return if !@enabled || @writer.worker.nil?
       @writer.worker.shutdown!

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -18,6 +18,8 @@ module Datadog
   # of these function calls and sub-requests would be encapsulated within a single trace.
   # rubocop:disable Metrics/ClassLength
   class Tracer
+    DEFAULT_TIMEOUT = 5
+
     attr_reader :writer, :sampler, :services, :tags, :provider
     attr_accessor :enabled
     attr_writer :default_service
@@ -55,6 +57,11 @@ module Datadog
     # Return if the debug mode is activated or not
     def self.debug_logging
       log.level == Logger::DEBUG
+    end
+
+    def self.shutdown!
+      return if !@enabled? || @writer.worker.nil?
+      @writer.worker.shutdown!
     end
 
     # Return the current active \Context for this traced execution. This method is

--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -88,6 +88,8 @@ module Datadog
           sleep(0.05)
           Datadog::Tracer.log.debug('Waiting for the buffers to clear before exiting')
         end
+        stop
+        join
         @shutting_down = false
       end
 

--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -9,6 +9,8 @@ module Datadog
     # will perform a task at regular intervals. The thread can be stopped
     # with the +stop()+ method and can start with the +start()+ method.
     class AsyncTransport
+      attr_reader :trace_buffer, :service_buffer
+
       def initialize(transport, buff_size, trace_task, service_task, interval)
         @trace_task = trace_task
         @service_task = service_task

--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -76,6 +76,7 @@ module Datadog
         @run = false
       end
 
+      # Closes all available queues and waits for the trace and service buffer to flush
       def shutdown!
         return if @shutting_down || (@trace_buffer.empty? && @service_buffer.empty?)
         @shutting_down = true

--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -78,7 +78,7 @@ module Datadog
 
       # Closes all available queues and waits for the trace and service buffer to flush
       def shutdown!
-        return if @shutting_down || (@trace_buffer.empty? && @service_buffer.empty?)
+        return false if @shutting_down
         @shutting_down = true
         @trace_buffer.close
         @service_buffer.close
@@ -91,6 +91,7 @@ module Datadog
         stop
         join
         @shutting_down = false
+        true
       end
 
       # Block until executor shutdown is complete or until timeout seconds have passed.

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -5,7 +5,7 @@ require 'ddtrace/workers'
 module Datadog
   # Traces and services writer that periodically sends data to the trace-agent
   class Writer
-    attr_reader :transport
+    attr_reader :transport, :worker
 
     HOSTNAME = 'localhost'.freeze
     PORT = '8126'.freeze

--- a/test/buffer_test.rb
+++ b/test/buffer_test.rb
@@ -69,4 +69,20 @@ class TraceBufferTest < Minitest::Test
     assert_includes(output_traces, input_traces[0])
     assert_includes(output_traces, input_traces[1])
   end
+
+  def test_closed_trace_buffer
+    # the trace buffer should not accept anymore traces when closed
+    buffer = Datadog::TraceBuffer.new(4)
+    buffer.push(1)
+    buffer.push(2)
+    buffer.push(3)
+    buffer.push(4)
+    buffer.close
+    buffer.push(5)
+    buffer.push(6)
+    out = buffer.pop
+    assert_equal(out.length, 4)
+    assert(!out.include?(5))
+    assert(!out.include?(6))
+  end
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -123,7 +123,8 @@ class TracerIntegrationTest < Minitest::Test
   end
 
   def test_short_span
-    skip unless ENV['TEST_DATADOG_INTEGRATION'] # requires a running agent
+    skip unless ENV['TEST_DATADOG_INTEGRATION'] || RUBY_PLATFORM != 'java'
+    # requires a running agent, and test does not apply to Java threading model
 
     tracer = Datadog::Tracer.new
     tracer.configure(enabled: true, hostname: '127.0.0.1', port: '8126')
@@ -132,7 +133,8 @@ class TracerIntegrationTest < Minitest::Test
   end
 
   def test_shutdown_exec_once
-    skip unless ENV['TEST_DATADOG_INTEGRATION'] # requires a running agent
+    skip unless ENV['TEST_DATADOG_INTEGRATION'] || RUBY_PLATFORM != 'java'
+    # requires a running agent, and test does not apply to Java threading model
 
     tracer = Datadog::Tracer.new
     tracer.configure(enabled: true, hostname: '127.0.0.1', port: '8126')


### PR DESCRIPTION
### Overview
Fix for a problem found when implementing the Resque integration - the Resque process would end before the thread could finish sending the traces. This PR is to implement a shutdown method similar to that of the Python client: https://github.com/DataDog/dd-trace-py/blob/master/ddtrace/writer.py#L104-L121 

### Major changes 
To ensure trace sending is completed before a process exits, call the `shutdown` method after the span should be `finished`.
```
Datadog.tracer.trace('web.request', service: 'my-web-site') do |span|
  do_something
end
Datadog.shutdown
```
You can pass it in a tracer or the method will just use the default `Datadog.tracer`: 
`def self.shutdown(tracer = Datadog.tracer)`

### User impact 
Trace sending completion is ensured for short-running processes 
