### PR TITLE
Service flushing improvements

### DIFF
--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -303,6 +303,7 @@ module Datadog
       end
 
       @writer.write(trace, @services)
+      @services = {}
     end
 
     private :write, :guess_context_and_parent

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -13,8 +13,7 @@ module Datadog
     def initialize(options = {})
       # writer and transport parameters
       @buff_size = options.fetch(:buffer_size, 100)
-      @span_interval = options.fetch(:spans_interval, 1)
-      @service_interval = options.fetch(:services_interval, 120)
+      @flush_interval = options.fetch(:flush_interval, 1)
 
       # transport and buffers
       @transport = options.fetch(:transport, Datadog::HTTPTransport.new(HOSTNAME, PORT))
@@ -36,12 +35,11 @@ module Datadog
     def start
       @trace_handler = ->(items, transport) { send_spans(items, transport) }
       @service_handler = ->(items, transport) { send_services(items, transport) }
-      @worker = Datadog::Workers::AsyncTransport.new(@span_interval,
-                                                     @service_interval,
-                                                     @transport,
+      @worker = Datadog::Workers::AsyncTransport.new(@transport,
                                                      @buff_size,
                                                      @trace_handler,
-                                                     @service_handler)
+                                                     @service_handler,
+                                                     @flush_interval)
 
       @worker.start()
     end

--- a/test/contrib/rails/tracer_test.rb
+++ b/test/contrib/rails/tracer_test.rb
@@ -32,10 +32,11 @@ class TracerTest < ActionDispatch::IntegrationTest
   end
 
   test 'a default service and database should be properly set' do
-    tracer = Datadog.tracer
+    reset_config()
+    services = Datadog.tracer.services
     adapter_name = get_adapter_name()
     assert_equal(
-      tracer.services,
+      services,
       'rails-app' => {
         'app' => 'rack', 'app_type' => 'web'
       },

--- a/test/contrib/sidekiq/tracer_configure_test.rb
+++ b/test/contrib/sidekiq/tracer_configure_test.rb
@@ -16,7 +16,7 @@ class TracerTest < TracerTestBase
 
     assert_equal(true, @tracer.enabled)
     assert_equal(
-      @tracer.services,
+      @writer.services,
       'sidekiq' => {
         'app' => 'sidekiq', 'app_type' => 'worker'
       }

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -80,7 +80,7 @@ class FauxWriter < Datadog::Writer
     @mutex.synchronize do
       super(trace, services)
       @spans << trace
-      @services = services
+      @services = @services.merge(services) if !services.empty?
     end
   end
 
@@ -121,7 +121,7 @@ class FauxWriter < Datadog::Writer
   def services
     @mutex.synchronize do
       services = @services
-      @services = []
+      @services = {} 
       services
     end
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -80,7 +80,7 @@ class FauxWriter < Datadog::Writer
     @mutex.synchronize do
       super(trace, services)
       @spans << trace
-      @services = @services.merge(services) if !services.empty?
+      @services = @services.merge(services) unless services.empty?
     end
   end
 
@@ -121,7 +121,7 @@ class FauxWriter < Datadog::Writer
   def services
     @mutex.synchronize do
       services = @services
-      @services = {} 
+      @services = {}
       services
     end
   end


### PR DESCRIPTION
### Overview
The current implementation involves saving the previously sent services in order to compare with the new batch to ensure that old services are not sent again. In addition to this, the interval for sending services is much longer than that for sending traces - running the risk of not sending a service at all. Improvements made in this PR include not saving services in memory for comparison, but instead sending services along with the first trace. One single `flush_interval` of 1 second replaces the two different `span_interval` and `service_interval`

### Major changes 