### PR TITLE
Fix constant-lookup for ruby-1.9.3

### DIFF
--- a/lib/ddtrace/contrib/aws/patcher.rb
+++ b/lib/ddtrace/contrib/aws/patcher.rb
@@ -46,7 +46,7 @@ module Datadog
           def loaded_constants
             SERVICES.each_with_object([]) do |service, constants|
               next if ::Aws.autoload?(service)
-              constants << ::Aws.const_get("#{service}::Client") rescue next
+              constants << ::Aws.const_get(service).const_get(:Client) rescue next
             end
           end
         end


### PR DESCRIPTION
In ruby-1.9.3 `Module#constant_get` doesn't support nested constants (e.g., `const_get(A::B::C)`).
This was causing `Datadog::Contrib::Aws::Patcher` to misbehave in certain cases in which the `Patcher` runs *after* a service client is auto-loaded:

```rb
Aws::S3::Client.new
Datadog::Monkey.patch_module(:aws)
```
