### PR TITLE
Add `Configuration` API

### DIFF
--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -3,6 +3,7 @@ require 'ddtrace/pin'
 require 'ddtrace/tracer'
 require 'ddtrace/error'
 require 'ddtrace/pipeline'
+require 'ddtrace/configuration'
 
 # \Datadog global namespace that includes all tracing functionality for Tracer and Span classes.
 module Datadog
@@ -29,6 +30,18 @@ module Datadog
 
   def self.registry
     @registry
+  end
+
+  class << self
+    attr_writer :configuration
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configure
+      yield(configuration)
+    end
   end
 end
 

--- a/lib/ddtrace/configurable.rb
+++ b/lib/ddtrace/configurable.rb
@@ -1,0 +1,63 @@
+module Datadog
+  InvalidOptionError = Class.new(StandardError)
+  # Configurable provides configuration methods for a given class/module
+  module Configurable
+    IDENTITY = ->(x) { x }
+
+    def self.included(base)
+      base.singleton_class.send(:include, ClassMethods)
+    end
+
+    # ClassMethods
+    module ClassMethods
+      def set_option(name, value)
+        assert_valid!(name)
+
+        options[name][:value] = options[name][:setter].call(value)
+      end
+
+      def get_option(name)
+        assert_valid!(name)
+
+        options[name][:value] || options[name][:default]
+      end
+
+      def to_h
+        options.each_with_object({}) do |(key, meta), hash|
+          hash[key] = meta[:value]
+        end
+      end
+
+      def reset_options!
+        options.each do |name, meta|
+          set_option(name, meta[:default])
+        end
+      end
+
+      private
+
+      def option(name, meta = {})
+        name = name.to_sym
+        meta[:setter] ||= IDENTITY
+        options[name] = meta
+      end
+
+      def options
+        @options ||= {}
+      end
+
+      def assert_valid!(name)
+        return if options.key?(name)
+        raise(InvalidOptionError, "#{pretty_name} doesn't have the option: #{name}")
+      end
+
+      def pretty_name
+        entry = Datadog.registry.find { |el| el.klass == self }
+
+        return entry.name if entry
+
+        to_s
+      end
+    end
+  end
+end

--- a/lib/ddtrace/configurable.rb
+++ b/lib/ddtrace/configurable.rb
@@ -41,11 +41,16 @@ module Datadog
         end
       end
 
+      def sorted_options
+        Configuration::Resolver.new(__dependency_graph).call
+      end
+
       private
 
-      def option(name, meta = {})
+      def option(name, meta = {}, &block)
         name = name.to_sym
-        meta[:setter] ||= IDENTITY
+        meta[:setter] ||= (block || IDENTITY)
+        meta[:depends_on] ||= []
         __options[name] = meta
       end
 
@@ -64,6 +69,12 @@ module Datadog
         return entry.name if entry
 
         to_s
+      end
+
+      def __dependency_graph
+        __options.each_with_object({}) do |(name, meta), graph|
+          graph[name] = meta[:depends_on]
+        end
       end
     end
   end

--- a/lib/ddtrace/configurable.rb
+++ b/lib/ddtrace/configurable.rb
@@ -18,12 +18,15 @@ module Datadog
         __assert_valid!(name)
 
         __options[name][:value] = __options[name][:setter].call(value)
+        __options[name][:set_flag] = true
       end
 
       def get_option(name)
         __assert_valid!(name)
 
-        __options[name][:value] || __options[name][:default]
+        return __options[name][:default] unless __options[name][:set_flag]
+
+        __options[name][:value]
       end
 
       def to_h

--- a/lib/ddtrace/configurable.rb
+++ b/lib/ddtrace/configurable.rb
@@ -8,10 +8,6 @@ module Datadog
       base.singleton_class.send(:include, ClassMethods)
     end
 
-    def merge_configuration(options, defaults = self.class)
-      defaults.to_h.merge(options)
-    end
-
     # ClassMethods
     module ClassMethods
       def set_option(name, value)

--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -1,0 +1,34 @@
+require_relative 'configuration/proxy'
+
+module Datadog
+  # Configuration provides a unique access point for configurations
+  class Configuration
+    InvalidIntegrationError = Class.new(StandardError)
+
+    def initialize(options = {})
+      @registry = options.fetch(:registry, Datadog.registry)
+    end
+
+    def [](integration_name)
+      integration = fetch_integration(integration_name)
+      Proxy.new(integration)
+    end
+
+    def use(integration_name, options = {})
+      integration = fetch_integration(integration_name)
+
+      options.each_with_object(Proxy.new(integration)) do |(name, value), proxy|
+        proxy[name] = value
+      end
+
+      integration.patch if integration.respond_to?(:patch)
+    end
+
+    private
+
+    def fetch_integration(name)
+      @registry[name] ||
+        raise(InvalidIntegrationError, "'#{name}' is not a valid integration.")
+    end
+  end
+end

--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -1,4 +1,5 @@
 require_relative 'configuration/proxy'
+require_relative 'configuration/resolver'
 
 module Datadog
   # Configuration provides a unique access point for configurations
@@ -17,8 +18,8 @@ module Datadog
     def use(integration_name, options = {})
       integration = fetch_integration(integration_name)
 
-      options.each_with_object(Proxy.new(integration)) do |(name, value), proxy|
-        proxy[name] = value
+      integration.sorted_options.each do |name|
+        integration.set_option(name, options[name]) if options.key?(name)
       end
 
       integration.patch if integration.respond_to?(:patch)

--- a/lib/ddtrace/configuration/proxy.rb
+++ b/lib/ddtrace/configuration/proxy.rb
@@ -7,7 +7,11 @@ module Datadog
       end
 
       def [](param)
-        @integration.get_option(param)
+        value = @integration.get_option(param)
+
+        return value.call if value.respond_to?(:call)
+
+        value
       end
 
       def []=(param, value)

--- a/lib/ddtrace/configuration/proxy.rb
+++ b/lib/ddtrace/configuration/proxy.rb
@@ -1,7 +1,11 @@
+require 'forwardable'
+
 module Datadog
   class Configuration
     # Proxy provides a hash-like interface for fetching/setting configurations
     class Proxy
+      extend Forwardable
+
       def initialize(integration)
         @integration = integration
       end
@@ -18,15 +22,8 @@ module Datadog
         @integration.set_option(param, value)
       end
 
-      def to_h
-        @integration.to_h
-      end
-
-      alias to_hash to_h
-
-      def reset!
-        @integration.reset_options!
-      end
+      def_delegators :@integration, :to_h, :reset_options!
+      def_delegators :to_h, :to_hash, :merge
     end
   end
 end

--- a/lib/ddtrace/configuration/proxy.rb
+++ b/lib/ddtrace/configuration/proxy.rb
@@ -1,0 +1,28 @@
+module Datadog
+  class Configuration
+    # Proxy provides a hash-like interface for fetching/setting configurations
+    class Proxy
+      def initialize(integration)
+        @integration = integration
+      end
+
+      def [](param)
+        @integration.get_option(param)
+      end
+
+      def []=(param, value)
+        @integration.set_option(param, value)
+      end
+
+      def to_h
+        @integration.to_h
+      end
+
+      alias to_hash to_h
+
+      def reset!
+        @integration.reset_options!
+      end
+    end
+  end
+end

--- a/lib/ddtrace/configuration/resolver.rb
+++ b/lib/ddtrace/configuration/resolver.rb
@@ -1,0 +1,24 @@
+require 'tsort'
+
+module Datadog
+  class Configuration
+    # Resolver performs a topological sort over the dependency graph
+    class Resolver
+      include TSort
+
+      def initialize(dependency_graph = {})
+        @dependency_graph = dependency_graph
+      end
+
+      def tsort_each_node(&blk)
+        @dependency_graph.each_key(&blk)
+      end
+
+      def tsort_each_child(node, &blk)
+        @dependency_graph.fetch(node).each(&blk)
+      end
+
+      alias call tsort
+    end
+  end
+end

--- a/lib/ddtrace/contrib/base.rb
+++ b/lib/ddtrace/contrib/base.rb
@@ -1,4 +1,5 @@
 require 'ddtrace/registry'
+require 'ddtrace/configurable'
 
 module Datadog
   module Contrib
@@ -6,6 +7,7 @@ module Datadog
     module Base
       def self.included(base)
         base.send(:include, Registry::Registerable)
+        base.send(:include, Configurable)
       end
     end
   end

--- a/test/configurable_test.rb
+++ b/test/configurable_test.rb
@@ -56,26 +56,6 @@ module Datadog
       end
     end
 
-    def test_merge_configuration
-      klass = Class.new do
-        include Configurable
-        option :x, default: :default_x
-        option :y, default: :default_y
-
-        attr_reader :options
-
-        def initialize(options = {})
-          @options = merge_configuration(options)
-        end
-      end
-
-      instance = klass.new(x: :custom_x, z: :custom_z)
-
-      assert_equal(:custom_x, instance.options[:x])
-      assert_equal(:default_y, instance.options[:y])
-      assert_equal(:custom_z, instance.options[:z])
-    end
-
     def test_to_h
       @module.class_eval do
         option :x, default: 1

--- a/test/configurable_test.rb
+++ b/test/configurable_test.rb
@@ -76,5 +76,14 @@ module Datadog
       @module.set_option(:y, 100)
       assert_equal({ x: 1, y: 100 }, @module.to_h)
     end
+
+    def test_false_options
+      @module.class_eval do
+        option :boolean, default: true
+      end
+
+      @module.set_option(:boolean, false)
+      refute(@module.get_option(:boolean))
+    end
   end
 end

--- a/test/configurable_test.rb
+++ b/test/configurable_test.rb
@@ -1,0 +1,50 @@
+require 'ddtrace/configurable'
+
+module Datadog
+  class ConfigurableTest < Minitest::Test
+    def setup
+      @module = Module.new { include(Configurable) }
+    end
+
+    def test_option_methods
+      assert_respond_to(@module, :set_option)
+      assert_respond_to(@module, :get_option)
+    end
+
+    def test_option_default
+      @module.class_eval do
+        option :foo, default: :bar
+      end
+
+      assert_equal(:bar, @module.get_option(:foo))
+    end
+
+    def test_setting_an_option
+      @module.class_eval do
+        option :foo, default: :bar
+      end
+
+      @module.set_option(:foo, 'baz!')
+      assert_equal('baz!', @module.get_option(:foo))
+    end
+
+    def test_custom_setter
+      @module.class_eval do
+        option :shout, setter: ->(v) { v.upcase }
+      end
+
+      @module.set_option(:shout, 'loud')
+      assert_equal('LOUD', @module.get_option(:shout))
+    end
+
+    def test_invalid_option
+      assert_raises(InvalidOptionError) do
+        @module.set_option(:bad_option, 'foo')
+      end
+
+      assert_raises(InvalidOptionError) do
+        @module.get_option(:bad_option)
+      end
+    end
+  end
+end

--- a/test/configurable_test.rb
+++ b/test/configurable_test.rb
@@ -46,5 +46,35 @@ module Datadog
         @module.get_option(:bad_option)
       end
     end
+
+    def test_merge_configuration
+      klass = Class.new do
+        include Configurable
+        option :x, default: :default_x
+        option :y, default: :default_y
+
+        attr_reader :options
+
+        def initialize(options = {})
+          @options = merge_configuration(options)
+        end
+      end
+
+      instance = klass.new(x: :custom_x, z: :custom_z)
+
+      assert_equal(:custom_x, instance.options[:x])
+      assert_equal(:default_y, instance.options[:y])
+      assert_equal(:custom_z, instance.options[:z])
+    end
+
+    def test_to_h
+      @module.class_eval do
+        option :x, default: 1
+        option :y, default: 2
+      end
+
+      @module.set_option(:y, 100)
+      assert_equal({ x: 1, y: 100 }, @module.to_h)
+    end
   end
 end

--- a/test/configurable_test.rb
+++ b/test/configurable_test.rb
@@ -37,6 +37,15 @@ module Datadog
       assert_equal('LOUD', @module.get_option(:shout))
     end
 
+    def test_custom_setter_block
+      @module.class_eval do
+        option(:shout) { |value| "#{value.upcase}!" }
+      end
+
+      @module.set_option(:shout, 'ouch')
+      assert_equal('OUCH!', @module.get_option(:shout))
+    end
+
     def test_invalid_option
       assert_raises(InvalidOptionError) do
         @module.set_option(:bad_option, 'foo')
@@ -84,6 +93,16 @@ module Datadog
 
       @module.set_option(:boolean, false)
       refute(@module.get_option(:boolean))
+    end
+
+    def test_dependency_solving
+      @module.class_eval do
+        option :foo, depends_on: [:bar]
+        option :bar, depends_on: [:baz]
+        option :baz
+      end
+
+      assert_equal([:baz, :bar, :foo], @module.sorted_options)
     end
   end
 end

--- a/test/configuration/proxy_test.rb
+++ b/test/configuration/proxy_test.rb
@@ -1,0 +1,34 @@
+require 'ddtrace/configurable'
+
+module Datadog
+  class Configuration
+    class ProxyTest < Minitest::Test
+      def setup
+        @module = Module.new do
+          include Configurable
+          option :x, default: :a
+          option :y, default: :b
+        end
+
+        @proxy = Proxy.new(@module)
+      end
+
+      def test_hash_syntax
+        @proxy[:x] = 1
+        @proxy[:y] = 2
+
+        assert_equal(1, @proxy[:x])
+        assert_equal(2, @proxy[:y])
+      end
+
+      def test_hash_coercion
+        assert_equal({ x: :a, y: :b }, @proxy.to_h)
+        assert_equal({ x: :a, y: :b }, @proxy.to_hash)
+      end
+
+      def test_merge
+        assert_equal({ x: :a, y: :b, z: :c }, @proxy.merge(z: :c))
+      end
+    end
+  end
+end

--- a/test/configuration/resolver_test.rb
+++ b/test/configuration/resolver_test.rb
@@ -1,0 +1,22 @@
+require 'ddtrace/configuration'
+
+module Datadog
+  class Configuration
+    class ResolverTest < Minitest::Test
+      def test_dependency_solving
+        graph = { 1 => [2], 2 => [3, 4], 3 => [], 4 => [3], 5 => [1] }
+        tsort = Resolver.new(graph).call
+
+        assert_equal([3, 4, 2, 1, 5], tsort)
+      end
+
+      def test_cyclic_dependecy
+        graph = { 1 => [2], 2 => [1] }
+
+        assert_raises(TSort::Cyclic) do
+          Resolver.new(graph).call
+        end
+      end
+    end
+  end
+end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,0 +1,64 @@
+require 'ddtrace/configuration'
+require 'ddtrace/configurable'
+
+module Datadog
+  class ConfigurationTest < Minitest::Test
+    def setup
+      @registry = Registry.new
+      @configuration = Configuration.new(registry: @registry)
+    end
+
+    def test_use_method
+      contrib = Minitest::Mock.new
+      contrib.expect(:patch, true)
+
+      @registry.add(:example, contrib)
+      @configuration.use(:example)
+
+      assert_mock(contrib)
+    end
+
+    def test_module_configuration
+      integration = Module.new do
+        include Contrib::Base
+        option :option1
+        option :option2
+      end
+
+      @registry.add(:example, integration)
+
+      @configuration.use(:example, option1: :foo!, option2: :bar!)
+
+      assert_equal(:foo!, @configuration[:example][:option1])
+      assert_equal(:bar!, @configuration[:example][:option2])
+    end
+
+    def test_setting_a_configuration_param
+      integration = Module.new do
+        include Contrib::Base
+        option :option1
+      end
+
+      @registry.add(:example, integration)
+      @configuration[:example][:option1] = :foo
+      assert_equal(:foo, @configuration[:example][:option1])
+    end
+
+    def test_invalid_integration
+      assert_raises(Configuration::InvalidIntegrationError) do
+        @configuration[:foobar]
+      end
+    end
+
+    def test_hash_coercion
+      integration = Module.new do
+        include Contrib::Base
+        option :option1, default: :foo
+        option :option2, default: :bar
+      end
+
+      @registry.add(:example, integration)
+      assert_equal({ option1: :foo, option2: :bar }, @configuration[:example].to_h)
+    end
+  end
+end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -50,6 +50,17 @@ module Datadog
       end
     end
 
+    def test_lazy_option
+      integration = Module.new do
+        include Contrib::Base
+        option :option1, default: -> { 1 + 1 }
+      end
+
+      @registry.add(:example, integration)
+
+      assert_equal(2, @configuration[:example][:option1])
+    end
+
     def test_hash_coercion
       integration = Module.new do
         include Contrib::Base


### PR DESCRIPTION
### Overview

This PR provides the core components that will power the new configuration API. All integrations should include the `Base` module which in turn includes the `Registerable` and the `Configurable` modules.

By doing so, the integration will be globally accessible through the name specified in `.register_as` method call and all of its configuration parameters can be exposed through a series of `.option` declarations.

As a result, users will be able to configure everything within a single configuration block such as:

```rb
Datadog.configure do |c|
  c.use :rails, default_service_name: 'foobar'
  c.use :aws
  c.use :http, distributed_tracing_enabled: true
  c.use :dalli
end
```

And the integrations will look like:

```rb
module Datadog
  module Contrib
    module HTTP
      include Base
      register_as :http
      option :distributed_tracing_enabled, default: false

      def patch
        # Instrumentation Code
      end
    end
  end
end
```

These changes should obviate the interaction with `Datadog::Monkey` and `Datadog::Pin` in the future.

### Meta Options! (For Integration Development)

The `.option` method provided by `Configurable` has the following features:

#### Default Values

A default value can be specified as:

```rb
option :foo, default: 'bar'
```
Notice that we also support lazily evaluated defaults, so you can have something like:
```rb
option :foo, default: -> { 1 + 1 }
```
#### Custom Setters

You can specify custom setters for your option param using either the `setter` option or providing a block:

```rb
option :shout, setter: ->(value) { value.upcase }
# alternative syntax
option(:shout) { |value| value.upcase }
```

#### Dependent Options

```rb
module AwesomeIntegration
  include Datadog::Contrib::Base
  option :tracer, default: Datadog.tracer
  option :enabled, depends_on: [:tracer] do |value|
    get_option(:tracer).enabled = value
  end
end
```
