### PR TITLE
[docs] add missing Faraday link

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -32,6 +32,7 @@ provides auto instrumentation for the following web frameworks and libraries:
 * [Elastic Search](#Elastic_Search)
 * [MongoDB](#MongoDB)
 * [Dalli](#Dalli)
+* [Faraday](#Faraday)
 * [Net/HTTP](#Net_HTTP)
 * [Redis](#Redis)
 
@@ -344,6 +345,22 @@ Or, by enabling distributed tracing for all HTTP calls:
 
 See [distributed tracing](#Distributed_Tracing) for details.
 
+### Faraday
+
+The `faraday` integration is available through the `ddtrace` middleware:
+
+    require 'faraday'
+    require 'ddtrace'
+
+    Datadog::Monkey.patch_module(:faraday) # registers the tracing middleware
+
+    connection = Faraday.new('https://example.com') do |builder|
+      builder.use(:ddtrace, options)
+      builder.adapter Faraday.default_adapter
+    end
+
+    connection.get('/foo')
+
 ### AWS
 
 The AWS integration will trace every interaction (e.g. API calls) with AWS
@@ -438,22 +455,6 @@ giving precedence to the middleware settings. Inherited configurations are:
 * ``debug``
 * ``trace_agent_hostname``
 * ``trace_agent_port``
-
-### Faraday
-
-The `faraday` integration is available through the `ddtrace` middleware:
-
-    require 'faraday'
-    require 'ddtrace'
-
-    Datadog::Monkey.patch_module(:faraday) # registers the tracing middleware
-
-    connection = Faraday.new('https://example.com') do |builder|
-      builder.use(:ddtrace, options)
-      builder.adapter Faraday.default_adapter
-    end
-
-    connection.get('/foo')
 
 Where `options` is an optional `Hash` that accepts the following parameters:
 


### PR DESCRIPTION
### Overview

Add link in the list. It's helpful to find out immediately supported libraries.