### PR TITLE
[rack] improve safety of the middleware

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -72,6 +72,7 @@ of the Datadog tracer, you can override the following defaults:
       default_controller_service: 'rails-controller',
       default_cache_service: 'rails-cache',
       default_database_service: 'postgresql',
+      distributed_tracing_enabled: false,
       template_base_path: 'views/',
       tracer: Datadog.tracer,
       debug: false,
@@ -96,6 +97,8 @@ Available settings are:
 * ``default_cache_service``: set the cache service name used when tracing cache activity. Defaults to ``rails-cache``
 * ``default_database_service``: set the database service name used when tracing database activity. Defaults to the
   current adapter name, so if you're using PostgreSQL it will be ``postgres``.
+* ``distributed_tracing_enabled``: enable [distributed tracing](#Distributed_Tracing) so that this service trace is
+  connected with a trace of another service if tracing headers are sent
 * ``default_grape_service``: set the service name used when tracing a Grape application mounted in your Rails router.
   Defaults to ``grape``
 * ``template_base_path``: used when the template name is parsed in the auto instrumented code. If you don't store

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -38,9 +38,9 @@ module Datadog
           @options = options
         end
 
-        def configure
+        def configure(reload = false)
           # ensure that the configuration is executed only once
-          return clean_context if @tracer && @service
+          return unless reload || !@tracer || !@service
 
           # retrieve the current tracer and service
           @tracer = @options.fetch(:tracer)
@@ -58,7 +58,8 @@ module Datadog
         # rubocop:disable Metrics/MethodLength
         def call(env)
           # configure the Rack middleware once
-          configure()
+          configure
+          clean_context
 
           trace_options = {
             service: @service,

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -2,12 +2,14 @@ require 'helper'
 
 require 'contrib/rails/test_helper'
 
+# rubocop:disable Metrics/ClassLength
 class FullStackTest < ActionDispatch::IntegrationTest
   setup do
-    # store original tracers
+    # store original tracers and options
     Rails.application.app.configure()
     @rails_tracer = Rails.configuration.datadog_trace[:tracer]
     @rack_tracer = Rails.application.app.instance_variable_get :@tracer
+    @rack_options = Rails.application.app.instance_variable_get :@options
 
     # replace the Rails and the Rack tracer with a dummy one;
     # this prevents the overhead to reinitialize the Rails application
@@ -15,12 +17,15 @@ class FullStackTest < ActionDispatch::IntegrationTest
     @tracer = get_test_tracer
     Rails.configuration.datadog_trace[:tracer] = @tracer
     Rails.application.app.instance_variable_set(:@tracer, @tracer)
+    Rails.application.app.instance_variable_set(:@options, @rack_options.dup)
   end
 
   teardown do
     # restore original tracers
     Rails.configuration.datadog_trace[:tracer] = @rails_tracer
     Rails.application.app.instance_variable_set(:@tracer, @rack_tracer)
+    Rails.application.app.instance_variable_set(:@options, @rack_options)
+    Rails.application.app.configure(reload: true)
   end
 
   test 'a full request is properly traced' do
@@ -177,5 +182,23 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_equal(request_span.get_tag('http.method'), 'GET')
     assert_equal(request_span.get_tag('http.status_code'), '404')
     assert_equal(request_span.status, 0)
+  end
+
+  test 'rails configuration enables distributed tracing' do
+    # enable distributed tracing
+    update_config(:distributed_tracing_enabled, true)
+
+    # make a request that doesn't have a route
+    get '/', headers: { 'x-datadog-trace-id' => '42', 'x-datadog-parent-id' => '100' }
+    assert_response 200
+
+    # get spans
+    spans = @tracer.writer.spans()
+    assert_operator(spans.length, :>=, 1, 'there should be at least 1 span')
+    request_span = spans[0]
+
+    assert_equal('rack.request', request_span.name)
+    assert_equal(42, request_span.trace_id)
+    assert_equal(100, request_span.parent_id)
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -194,9 +194,15 @@ end
 # * +key+: the key that should be updated
 # * +value+: the value of the key
 def update_config(key, value)
+  # update Rails configuration
   ::Rails.configuration.datadog_trace[key] = value
   config = { config: ::Rails.application.config }
   Datadog::Contrib::Rails::Framework.configure(config)
+
+  # update Rack configuration
+  options = Rails.application.app.instance_variable_get :@options
+  options.update(::Rails.configuration.datadog_trace)
+  Rails.application.app.configure(reload: true)
 end
 
 # reset default configuration and replace any dummy tracer


### PR DESCRIPTION
### Overview

While it should never happen, it's possible that a wrong configuration or an unexpected behavior crashes the Rack middleware. Though it's a remote case, this PR leverage `begin-rescue-ensure` statements to be sure that `@app.call(env)` is always call whatever happens, and that the `request_span.finish()` is called at the end before returning `[status, headers, response]`.

### Users impact

No one, since it's expected to work the same. Because we never raise an exception unless we introduce a bug, the overhead of this code path is minimal.