### PR TITLE
[faraday] update the HTTP_HEADER_PARENT_ID to send the span_id instead of parent_id

### DIFF
--- a/lib/ddtrace/contrib/faraday/middleware.rb
+++ b/lib/ddtrace/contrib/faraday/middleware.rb
@@ -56,7 +56,7 @@ module Datadog
         def propagate!(span, env)
           env[:request_headers].merge!(
             Ext::DistributedTracing::HTTP_HEADER_TRACE_ID => span.trace_id,
-            Ext::DistributedTracing::HTTP_HEADER_PARENT_ID => span.parent_id
+            Ext::DistributedTracing::HTTP_HEADER_PARENT_ID => span.span_id
           )
         end
 

--- a/lib/ddtrace/contrib/faraday/middleware.rb
+++ b/lib/ddtrace/contrib/faraday/middleware.rb
@@ -55,8 +55,8 @@ module Datadog
 
         def propagate!(span, env)
           env[:request_headers].merge!(
-            Ext::DistributedTracing::HTTP_HEADER_TRACE_ID => span.trace_id,
-            Ext::DistributedTracing::HTTP_HEADER_PARENT_ID => span.span_id
+            Ext::DistributedTracing::HTTP_HEADER_TRACE_ID => span.trace_id.to_s,
+            Ext::DistributedTracing::HTTP_HEADER_PARENT_ID => span.span_id.to_s
           )
         end
 

--- a/test/contrib/faraday/middleware_test.rb
+++ b/test/contrib/faraday/middleware_test.rb
@@ -93,7 +93,7 @@ module Datadog
           span = request_span
 
           assert_equal(headers[Ext::DistributedTracing::HTTP_HEADER_TRACE_ID], span.trace_id)
-          assert_equal(headers[Ext::DistributedTracing::HTTP_HEADER_PARENT_ID], span.parent_id)
+          assert_equal(headers[Ext::DistributedTracing::HTTP_HEADER_PARENT_ID], span.span_id)
         end
 
         private

--- a/test/contrib/faraday/middleware_test.rb
+++ b/test/contrib/faraday/middleware_test.rb
@@ -92,8 +92,8 @@ module Datadog
           headers = response.env.request_headers
           span = request_span
 
-          assert_equal(headers[Ext::DistributedTracing::HTTP_HEADER_TRACE_ID], span.trace_id)
-          assert_equal(headers[Ext::DistributedTracing::HTTP_HEADER_PARENT_ID], span.span_id)
+          assert_equal(headers[Ext::DistributedTracing::HTTP_HEADER_TRACE_ID], span.trace_id.to_s)
+          assert_equal(headers[Ext::DistributedTracing::HTTP_HEADER_PARENT_ID], span.span_id.to_s)
         end
 
         private


### PR DESCRIPTION
### Overview

The current version sends the wrong value via headers when doing distributed tracing (`span.parent_id` instead of the `span.span_id`).

Closes #210 

#### What is missing
* [x] add a regression test for the parent_id => span_id
* [x] add a regression test for `to_s` because we need to make a real call