### PR TITLE
Provide better defaults for `rails` service names

### DIFF
--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -33,23 +33,26 @@ module Datadog
         # default configurations for the Rails integration; by default
         # the Datadog.tracer is enabled, while the Rails auto instrumentation
         # is kept disabled.
-        DEFAULT_CONFIG = {
-          enabled: true,
-          auto_instrument: false,
-          auto_instrument_redis: false,
-          auto_instrument_grape: false,
-          default_service: 'rails-app',
-          default_controller_service: 'rails-controller',
-          default_cache_service: 'rails-cache',
-          default_grape_service: 'grape',
-          template_base_path: 'views/',
-          tracer: Datadog.tracer,
-          debug: false,
-          trace_agent_hostname: Datadog::Writer::HOSTNAME,
-          trace_agent_port: Datadog::Writer::PORT,
-          env: nil,
-          tags: {}
-        }.freeze
+
+        def self.default_config
+          {
+            enabled: true,
+            auto_instrument: false,
+            auto_instrument_redis: false,
+            auto_instrument_grape: false,
+            default_service: "#{Utils.app_name}-rack",
+            default_controller_service: "#{Utils.app_name}-rails-controller",
+            default_cache_service: "#{Utils.app_name}-rails-cache",
+            default_grape_service: "#{Utils.app_name}-grape",
+            template_base_path: 'views/',
+            tracer: Datadog.tracer,
+            debug: false,
+            trace_agent_hostname: Datadog::Writer::HOSTNAME,
+            trace_agent_port: Datadog::Writer::PORT,
+            env: nil,
+            tags: {}
+          }
+        end
 
         # configure Datadog settings
         # rubocop:disable Metrics/MethodLength
@@ -57,7 +60,7 @@ module Datadog
           # tracer defaults
           # merge default configurations with users settings
           user_config = config[:config].datadog_trace rescue {}
-          datadog_config = DEFAULT_CONFIG.merge(user_config)
+          datadog_config = default_config.merge(user_config)
           datadog_config[:tracer].enabled = datadog_config[:enabled]
 
           # set debug logging

--- a/lib/ddtrace/contrib/rails/utils.rb
+++ b/lib/ddtrace/contrib/rails/utils.rb
@@ -37,6 +37,14 @@ module Datadog
             vendor
           end
         end
+
+        def self.app_name
+          if ::Rails::VERSION::MAJOR >= 4
+            ::Rails.application.class.parent_name.underscore
+          else
+            ::Rails.application.class.to_s.underscore
+          end
+        end
       end
     end
   end

--- a/test/contrib/rails/cache_test.rb
+++ b/test/contrib/rails/cache_test.rb
@@ -24,7 +24,7 @@ class CacheTracingTest < ActionController::TestCase
     assert_equal(get.name, 'rails.cache')
     assert_equal(get.span_type, 'cache')
     assert_equal(get.resource, 'GET')
-    assert_equal(get.service, 'rails-cache')
+    assert_equal(get.service, "#{app_name}-rails-cache")
     assert_equal(get.get_tag('rails.cache.backend').to_s, 'file_store')
     assert_equal(get.get_tag('rails.cache.key'), 'custom-key')
     assert_equal(set.name, 'rails.cache')
@@ -39,7 +39,7 @@ class CacheTracingTest < ActionController::TestCase
     assert_equal(span.name, 'rails.cache')
     assert_equal(span.span_type, 'cache')
     assert_equal(span.resource, 'SET')
-    assert_equal(span.service, 'rails-cache')
+    assert_equal(span.service, "#{app_name}-rails-cache")
     assert_equal(span.get_tag('rails.cache.backend').to_s, 'file_store')
     assert_equal(span.get_tag('rails.cache.key'), 'custom-key')
   end
@@ -53,7 +53,7 @@ class CacheTracingTest < ActionController::TestCase
     assert_equal(span.name, 'rails.cache')
     assert_equal(span.span_type, 'cache')
     assert_equal(span.resource, 'DELETE')
-    assert_equal(span.service, 'rails-cache')
+    assert_equal(span.service, "#{app_name}-rails-cache")
     assert_equal(span.get_tag('rails.cache.backend').to_s, 'file_store')
     assert_equal(span.get_tag('rails.cache.key'), 'custom-key')
   end

--- a/test/contrib/rails/default_service_test.rb
+++ b/test/contrib/rails/default_service_test.rb
@@ -26,6 +26,6 @@ class TracingDefaultServiceTest < ActionController::TestCase
     span = spans[0]
     assert_equal('web.request', span.name)
     assert_equal('/index', span.resource, '/index')
-    assert_equal('rails-app', span.service, 'service name should reflect this is a Rails application')
+    assert_equal("#{app_name}-rack", span.service, 'service name should reflect this is a Rails application')
   end
 end

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -68,7 +68,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_equal(cache_span.name, 'rails.cache')
     assert_equal(cache_span.span_type, 'cache')
     assert_equal(cache_span.resource, 'SET')
-    assert_equal(cache_span.service, 'rails-cache')
+    assert_equal("#{app_name}-rails-cache", cache_span.service)
     assert_equal(cache_span.get_tag('rails.cache.backend').to_s, 'file_store')
     assert_equal(cache_span.get_tag('rails.cache.key'), 'empty-key')
   end

--- a/test/contrib/rails/rails_sidekiq_test.rb
+++ b/test/contrib/rails/rails_sidekiq_test.rb
@@ -56,16 +56,16 @@ class RailsSidekiqTest < ActionController::TestCase
     assert_equal(false, @tracer.enabled)
     assert_equal(
       @tracer.services,
-      'rails-app' => {
+      "#{app_name}-rack" => {
         'app' => 'rack', 'app_type' => 'web'
       },
-      'rails-controller' => {
+      "#{app_name}-rails-controller" => {
         'app' => 'rails', 'app_type' => 'web'
       },
       db_adapter => {
         'app' => db_adapter, 'app_type' => 'db'
       },
-      'rails-cache' => {
+      "#{app_name}-rails-cache" => {
         'app' => 'rails', 'app_type' => 'cache'
       },
       'rails-sidekiq' => {

--- a/test/contrib/rails/redis_cache_test.rb
+++ b/test/contrib/rails/redis_cache_test.rb
@@ -42,7 +42,7 @@ class RedisCacheTracingTest < ActionController::TestCase
       assert_equal(cache.name, 'rails.cache')
       assert_equal(cache.span_type, 'cache')
       assert_equal(cache.resource, 'GET')
-      assert_equal(cache.service, 'rails-cache')
+      assert_equal(cache.service, "#{app_name}-rails-cache")
       assert_equal(cache.get_tag('rails.cache.backend').to_s, 'redis_store')
       assert_equal(cache.get_tag('rails.cache.key'), 'custom-key')
 
@@ -107,7 +107,7 @@ class RedisCacheTracingTest < ActionController::TestCase
     assert_equal(cache.name, 'rails.cache')
     assert_equal(cache.span_type, 'cache')
     assert_equal(cache.resource, 'SET')
-    assert_equal(cache.service, 'rails-cache')
+    assert_equal(cache.service, "#{app_name}-rails-cache")
     assert_equal(cache.get_tag('rails.cache.backend').to_s, 'redis_store')
     assert_equal(cache.get_tag('rails.cache.key'), 'custom-key')
 
@@ -130,7 +130,7 @@ class RedisCacheTracingTest < ActionController::TestCase
     assert_equal(cache.name, 'rails.cache')
     assert_equal(cache.span_type, 'cache')
     assert_equal(cache.resource, 'DELETE')
-    assert_equal(cache.service, 'rails-cache')
+    assert_equal(cache.service, "#{app_name}-rails-cache")
     assert_equal(cache.get_tag('rails.cache.backend').to_s, 'redis_store')
     assert_equal(cache.get_tag('rails.cache.key'), 'custom-key')
 

--- a/test/contrib/rails/test_helper.rb
+++ b/test/contrib/rails/test_helper.rb
@@ -83,3 +83,7 @@ when '3.0.20'
 else
   logger.error 'A Rails app for this version is not found!'
 end
+
+def app_name
+  Datadog::Contrib::Rails::Utils.app_name
+end

--- a/test/contrib/rails/tracer_test.rb
+++ b/test/contrib/rails/tracer_test.rb
@@ -18,9 +18,9 @@ class TracerTest < ActionDispatch::IntegrationTest
     assert Rails.configuration.datadog_trace[:enabled]
     assert Rails.configuration.datadog_trace[:auto_instrument]
     assert Rails.configuration.datadog_trace[:auto_instrument_redis]
-    assert_equal(Rails.configuration.datadog_trace[:default_service], 'rails-app')
-    assert_equal(Rails.configuration.datadog_trace[:default_controller_service], 'rails-controller')
-    assert_equal(Rails.configuration.datadog_trace[:default_cache_service], 'rails-cache')
+    assert_equal("#{app_name}-rack", Rails.configuration.datadog_trace[:default_service])
+    assert_equal("#{app_name}-rails-controller", Rails.configuration.datadog_trace[:default_controller_service])
+    assert_equal("#{app_name}-rails-cache", Rails.configuration.datadog_trace[:default_cache_service])
     refute_nil(Rails.configuration.datadog_trace[:default_database_service])
     assert_equal(Rails.configuration.datadog_trace[:template_base_path], 'views/')
     assert Rails.configuration.datadog_trace[:tracer]
@@ -37,16 +37,16 @@ class TracerTest < ActionDispatch::IntegrationTest
     adapter_name = get_adapter_name()
     assert_equal(
       services,
-      'rails-app' => {
+      "#{app_name}-rack" => {
         'app' => 'rack', 'app_type' => 'web'
       },
-      'rails-controller' => {
+      "#{app_name}-rails-controller" => {
         'app' => 'rails', 'app_type' => 'web'
       },
       adapter_name => {
         'app' => adapter_name, 'app_type' => 'db'
       },
-      'rails-cache' => {
+      "#{app_name}-rails-cache" => {
         'app' => 'rails', 'app_type' => 'cache'
       }
     )
@@ -59,16 +59,16 @@ class TracerTest < ActionDispatch::IntegrationTest
 
     assert_equal(
       tracer.services,
-      'rails-app' => {
+      "#{app_name}-rack" => {
         'app' => 'rack', 'app_type' => 'web'
       },
-      'rails-controller' => {
+      "#{app_name}-rails-controller" => {
         'app' => 'rails', 'app_type' => 'web'
       },
       'customer-db' => {
         'app' => adapter_name, 'app_type' => 'db'
       },
-      'rails-cache' => {
+      "#{app_name}-rails-cache" => {
         'app' => 'rails', 'app_type' => 'cache'
       }
     )
@@ -81,7 +81,7 @@ class TracerTest < ActionDispatch::IntegrationTest
 
     assert_equal(
       tracer.services,
-      'rails-app' => {
+      "#{app_name}-rack" => {
         'app' => 'rack', 'app_type' => 'web'
       },
       'my-custom-app' => {
@@ -90,7 +90,7 @@ class TracerTest < ActionDispatch::IntegrationTest
       adapter_name => {
         'app' => adapter_name, 'app_type' => 'db'
       },
-      'rails-cache' => {
+      "#{app_name}-rails-cache" => {
         'app' => 'rails', 'app_type' => 'cache'
       }
     )
@@ -103,10 +103,10 @@ class TracerTest < ActionDispatch::IntegrationTest
 
     assert_equal(
       tracer.services,
-      'rails-app' => {
+      "#{app_name}-rack" => {
         'app' => 'rack', 'app_type' => 'web'
       },
-      'rails-controller' => {
+      "#{app_name}-rails-controller" => {
         'app' => 'rails', 'app_type' => 'web'
       },
       adapter_name => {


### PR DESCRIPTION
Instead of using static defaults (`rails-app`, `rails-controller`), we prepend the Rails app name to that value. The app name is retrieved using `::Rails.application.class`, so you will have:
```
intake-rails-app
intake-rails-controller
...
```