### PR TITLE
[docs] update integrations docs

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -787,8 +787,11 @@ sent upstream.  To achieve that, you can hook custom *processors* into the
 pipeline using the method `Datadog::Pipeline.before_flush`:
 
     Datadog::Pipeline.before_flush(
+      # filter the Span if the given block evaluates true
       Datadog::Pipeline::SpanFilter.new { |span| span.resource =~ /PingController/ },
       Datadog::Pipeline::SpanFilter.new { |span| span.get_tag('host') == 'localhost' }
+
+      # alter the Span updating fields or tags
       Datadog::Pipeline::SpanProcessor.new { |span| span.resource.gsub!(/password=.*/, '') }
     )
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -863,11 +863,6 @@ Currently we are supporting Sinatra >= 1.4.0.
 
 Currently we are supporting Sidekiq >= 4.0.0.
 
-### Glossary
+### Terminology
 
-* ``Service``: The name of a set of processes that do the same job. Some examples are ``datadog-web-app`` or ``datadog-metrics-db``.
-* ``Resource``: A particular query to a service. For a web application, some examples might be a URL stem like ``/user/home`` or a
-handler function like ``web.user.home``. For a SQL database, a resource would be the SQL of the query itself like ``select * from users where id = ?``.
-You can track thousands (not millions or billions) of unique resources per services, so prefer resources like ``/user/home`` rather than ``/user/home?id=123456789``.
-* ``Span``: A span tracks a unit of work in a service, like querying a database or rendering a template. Spans are associated
-with a service and optionally a resource. Spans have names, start times, durations and optional tags.
+If you need more context about the terminology used in the APM, take a look at the [official documentation](https://docs.datadoghq.com/tracing/terminology/).

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -24,17 +24,18 @@ The easiest way to get started with the tracing client is to instrument your web
 provides auto instrumentation for the following web frameworks and libraries:
 
 * [Ruby on Rails](#Ruby_on_Rails)
-* [Sidekiq](#Sidekiq)
 * [Sinatra](#Sinatra)
 * [Rack](#Rack)
 * [Grape](#Grape)
 * [Active Record](#Active_Record)
 * [Elastic Search](#Elastic_Search)
 * [MongoDB](#MongoDB)
-* [Dalli](#Dalli)
-* [Faraday](#Faraday)
+* [Sidekiq](#Sidekiq)
+* [Resque](#Resque)
 * [SuckerPunch](#SuckerPunch)
 * [Net/HTTP](#Net_HTTP)
+* [Faraday](#Faraday)
+* [Dalli](#Dalli)
 * [Redis](#Redis)
 
 ## Web Frameworks
@@ -419,6 +420,21 @@ executions. It can be added as any other Sidekiq middleware:
     Sidekiq.configure_server do |config|
       config.server_middleware do |chain|
         chain.add(Datadog::Contrib::Sidekiq::Tracer)
+      end
+    end
+
+### Resque
+
+The Resque integration uses Resque hooks that wraps the ``perform`` method.
+To add tracing to a Resque job, extend your base class with the provided
+one:
+
+    class MyJob
+      # add tracing to Resque hooks
+      extend Datadog::Contrib::Resque::ResqueJob
+
+      def self.perform(*args)
+        # do_something that is traced
       end
     end
 


### PR DESCRIPTION
### Overview

* adds `Resque` doc
* reorder paragraphs since they were wrong
* removed the _Glossary_ since we have official docs