### PR TITLE
[docs] use redcarpet provider when building with rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -92,6 +92,8 @@ end
 
 YARD::Rake::YardocTask.new(:docs) do |t|
   t.options += ['--title', "ddtrace #{Datadog::VERSION::STRING} documentation"]
+  t.options += ['--markup', 'markdown']
+  t.options += ['--markup-provider', 'redcarpet']
 end
 
 # Deploy tasks

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -39,4 +39,5 @@ EOS
   spec.add_development_dependency 'minitest', '= 5.10.1'
   spec.add_development_dependency 'appraisal', '~> 2.2'
   spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'redcarpet', '~> 3.4'
 end


### PR DESCRIPTION
### Overview

Without this patch, the `Faraday` table is not correctly rendered when using `rake docs` command.