### PR TITLE
guard against retrieving ::ActiveRecord::Base.connection_config

### DIFF
--- a/lib/ddtrace/contrib/rails/active_record.rb
+++ b/lib/ddtrace/contrib/rails/active_record.rb
@@ -18,6 +18,9 @@ module Datadog
         end
 
         def self.sql(_name, start, finish, _id, payload)
+          return unless ::ActiveRecord::Base.connection_handler.active_connections?
+          Datadog::Tracer.log.info('ActiveRecord connection not present')
+          Datadog::Tracer.log.debug(payload.inspect)
           tracer = ::Rails.configuration.datadog_trace.fetch(:tracer)
           database_service = ::Rails.configuration.datadog_trace.fetch(:default_database_service)
           adapter_name = ::ActiveRecord::Base.connection_config[:adapter]


### PR DESCRIPTION
Our logs are currently being polluted with the following error
```
ddtrace: [ddtrace] (/usr/local/bundle/gems/ddtrace-0.8.2/lib/ddtrace/contrib/rails/active_record.rb:51:in `rescue in sql') ActiveRecord::ConnectionNotEstablished
```

I believe the issue is related to using the [following strategy](https://devcenter.heroku.com/articles/forked-pg-connections#resque-ruby-queuing) to manage connections with resque workers.

When `Resque.after_fork` is called to establish a connection ActiveRecord has already been subscribed to via 

```ruby
 ::ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
  sql(*args)
end
```

This leads to `adapter_name = ::ActiveRecord::Base.connection_config[:adapter]` throwing an exception. 

