### PR TITLE
Migrate `sinatra` to new configuration API

### DIFF
--- a/lib/ddtrace/contrib/active_record/patcher.rb
+++ b/lib/ddtrace/contrib/active_record/patcher.rb
@@ -44,7 +44,7 @@ module Datadog
         def self.datadog_trace
           # TODO: Consider using patcher for Rails as well.
           # @tracer ||= defined?(::Rails) && ::Rails.configuration.datadog_trace
-          @datadog_trace ||= defined?(::Sinatra) && ::Sinatra::Application.settings.datadog_tracer.cfg
+          @datadog_trace ||= defined?(::Sinatra) && Datadog.configuration[:sinatra].to_h
         end
 
         def self.adapter_name

--- a/test/contrib/sinatra/tracer_activerecord_test.rb
+++ b/test/contrib/sinatra/tracer_activerecord_test.rb
@@ -21,13 +21,13 @@ class TracerActiveRecordTest < TracerTestBase
     app().set :datadog_test_writer, @writer
 
     tracer = Datadog::Tracer.new(writer: @writer)
-    app().settings.datadog_tracer.configure(tracer: tracer, enabled: true)
+    Datadog.configuration.use(:sinatra, tracer: tracer, enabled: true)
 
     conn = ActiveRecord::Base.establish_connection(adapter: 'sqlite3',
                                                    database: ':memory:')
     app().set :datadog_test_conn, conn
 
-    Datadog::Monkey.patch_module(:active_record)
+    Datadog.configuration.use(:active_record)
 
     super
   end

--- a/test/contrib/sinatra/tracer_disabled_test.rb
+++ b/test/contrib/sinatra/tracer_disabled_test.rb
@@ -17,7 +17,7 @@ class DisabledTracerTest < ::TracerTestBase
     app().set :datadog_test_writer, @writer
 
     tracer = Datadog::Tracer.new(writer: @writer)
-    app().settings.datadog_tracer.configure(tracer: tracer, enabled: false)
+    Datadog.configuration.use(:sinatra, tracer: tracer, enabled: false)
 
     super
   end

--- a/test/contrib/sinatra/tracer_test.rb
+++ b/test/contrib/sinatra/tracer_test.rb
@@ -40,7 +40,7 @@ class TracerTest < TracerTestBase
     app().set :datadog_test_writer, @writer
 
     tracer = Datadog::Tracer.new(writer: @writer)
-    app().settings.datadog_tracer.configure(tracer: tracer, enabled: true)
+    Datadog.configuration.use(:sinatra, tracer: tracer, enabled: true)
 
     super
   end


### PR DESCRIPTION
### Overview

This PR migrates the `sinatra` integration to the new configuration API.

### Usage Example

```rb
require 'sinatra'
require 'ddtrace'
require 'ddtrace/contrib/sinatra/tracer'

Datadog.configure do |c|
  c.use :sinatra, default_service: 'my-sinatra-app'
end

get '/' do
  'Hello, World!'
end
```



