### PR TITLE
Enable priority sampling

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -39,5 +39,8 @@ EOS
   spec.add_development_dependency 'minitest', '= 5.10.1'
   spec.add_development_dependency 'appraisal', '~> 2.2'
   spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'webmock', '~> 2.0'
+  # locking transitive dependency of webmock
+  spec.add_development_dependency 'addressable',  '~> 2.4.0'
   spec.add_development_dependency 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
 end

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -719,6 +719,32 @@ overhead.
     sampler = Datadog::RateSampler.new(0.5) # sample 50% of the traces
     Datadog.tracer.configure(sampler: sampler)
 
+#### Priority sampling
+
+Priority sampling consists in deciding if a trace will be kept by using a priority attribute that will be propagated for distributed traces. Its value gives indication to the Agent and to the backend on how important the trace is.
+
+* 0: Don’t keep the trace.
+* 1: The sampler automatically decided to keep the trace.
+* 2: The user asked the keep the trace.
+
+For now, priority sampling is disabled by default. Enabling it ensures that your sampled distributed traces will be complete. To enable the priorty sampling:
+
+```rb
+Datadog.tracer.configure(priority_sampling: true)
+```
+
+Once enabled, the sampler will automatically assign a priority of 0 or 1 to traces, depending on their service and volume.
+
+You can also set this priority manually to either drop a non-interesting trace or to keep an important one. For that, set the `context#sampling_priority` to 0 or 2. It has to be done before any context propagation (fork, RPC calls) to be effective:
+
+```rb
+# Indicate to not keep the trace
+span.context.sampling_priority = 0
+
+# Indicate to keep the trace
+span.context.sampling_priority = 2
+```
+
 ### Distributed Tracing
 
 To trace requests across hosts, the spans on the secondary hosts must be linked together by setting ``trace_id`` and ``parent_id``:

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -727,7 +727,7 @@ Priority sampling consists in deciding if a trace will be kept by using a priori
 * 1: The sampler automatically decided to keep the trace.
 * 2: The user asked the keep the trace.
 
-For now, priority sampling is disabled by default. Enabling it ensures that your sampled distributed traces will be complete. To enable the priorty sampling:
+For now, priority sampling is disabled by default. Enabling it ensures that your sampled distributed traces will be complete. To enable the priority sampling:
 
 ```rb
 Datadog.tracer.configure(priority_sampling: true)

--- a/lib/ddtrace/context.rb
+++ b/lib/ddtrace/context.rb
@@ -139,6 +139,8 @@ module Datadog
 
         trace = @trace
         sampled = @sampled
+        attach_sampling_priority if sampled && @sampling_priority
+
         reset
         return trace, sampled
       end
@@ -152,9 +154,17 @@ module Datadog
       end
     end
 
+    def attach_sampling_priority
+      @trace.first.set_metric(
+        Ext::DistributedTracing::SAMPLING_PRIORITY_KEY,
+        @sampling_priority
+      )
+    end
+
     private :reset
     private :check_finished_spans
     private :set_current_span
+    private :attach_sampling_priority
   end
 
   # ThreadLocalContext can be used as a tracer global reference to create

--- a/lib/ddtrace/contrib/faraday/middleware.rb
+++ b/lib/ddtrace/contrib/faraday/middleware.rb
@@ -56,7 +56,7 @@ module Datadog
         end
 
         def propagate!(span, env)
-          Datadog::HTTPPropagator.inject!(span, env[:request_headers])
+          Datadog::HTTPPropagator.inject!(span.context, env[:request_headers])
         end
 
         def dd_pin

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -43,7 +43,8 @@ module Datadog
 
           tracer.configure(
             hostname: Datadog.configuration[:rails][:trace_agent_hostname],
-            port: Datadog.configuration[:rails][:trace_agent_port]
+            port: Datadog.configuration[:rails][:trace_agent_port],
+            priority_sampling: Datadog.configuration[:rails][:priority_sampling]
           )
 
           tracer.set_tags(Datadog.configuration[:rails][:tags])

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -16,6 +16,7 @@ module Datadog
         option :default_grape_service, default: 'grape'
         option :default_database_service
         option :distributed_tracing_enabled, default: false
+        option :priority_sampling, default: false
         option :template_base_path, default: 'views/'
         option :tracer, default: Datadog.tracer
         option :debug, default: false

--- a/lib/ddtrace/ext/distributed.rb
+++ b/lib/ddtrace/ext/distributed.rb
@@ -6,6 +6,7 @@ module Datadog
       HTTP_HEADER_TRACE_ID = 'x-datadog-trace-id'.freeze
       HTTP_HEADER_PARENT_ID = 'x-datadog-parent-id'.freeze
       HTTP_HEADER_SAMPLING_PRIORITY = 'x-datadog-sampling-priority'.freeze
+      SAMPLING_PRIORITY_KEY = '_sampling_priority_v1'.freeze
     end
   end
 end

--- a/lib/ddtrace/propagation/http_propagator.rb
+++ b/lib/ddtrace/propagation/http_propagator.rb
@@ -8,14 +8,11 @@ module Datadog
     include Ext::DistributedTracing
 
     # inject! popolates the env with span ID, trace ID and sampling priority
-    def self.inject!(span, env)
-      headers = { HTTP_HEADER_TRACE_ID => span.trace_id.to_s,
-                  HTTP_HEADER_PARENT_ID => span.span_id.to_s }
-      if span.sampling_priority
-        headers[HTTP_HEADER_SAMPLING_PRIORITY] = span.sampling_priority.to_s
-      end
-      env.merge! headers
-      env.delete(HTTP_HEADER_SAMPLING_PRIORITY) unless span.sampling_priority
+    def self.inject!(context, env)
+      env[HTTP_HEADER_TRACE_ID] = context.trace_id.to_s
+      env[HTTP_HEADER_PARENT_ID] = context.span_id.to_s
+      env[HTTP_HEADER_SAMPLING_PRIORITY] = context.sampling_priority.to_s
+      env.delete(HTTP_HEADER_SAMPLING_PRIORITY) unless context.sampling_priority
     end
 
     # extract returns a context containing the span ID, trace ID and

--- a/lib/ddtrace/sampler.rb
+++ b/lib/ddtrace/sampler.rb
@@ -96,10 +96,10 @@ module Datadog
     end
 
     def sample(span)
-      span.sampling_priority = 0
+      span.context.sampling_priority = 0 if span.context
       return unless @base_sampler.sample(span)
       return unless @post_sampler.sample(span)
-      span.sampling_priority = 1
+      span.context.sampling_priority = 1 if span.context
 
       true
     end

--- a/lib/ddtrace/sampler.rb
+++ b/lib/ddtrace/sampler.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module Datadog
   # \Sampler performs client-side trace sampling.
   class Sampler
@@ -86,6 +88,8 @@ module Datadog
 
   # \PrioritySampler
   class PrioritySampler
+    extend Forwardable
+
     def initialize(opts = {})
       @base_sampler = opts[:base_sampler] || RateSampler.new
       @post_sampler = opts[:post_sampler] || RateByServiceSampler.new
@@ -96,6 +100,10 @@ module Datadog
       return unless @base_sampler.sample(span)
       return unless @post_sampler.sample(span)
       span.sampling_priority = 1
+
+      true
     end
+
+    def_delegators :@post_sampler, :update
   end
 end

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -22,7 +22,7 @@ module Datadog
                   :start_time, :end_time,
                   :span_id, :trace_id, :parent_id,
                   :status, :sampled,
-                  :tracer, :context, :sampling_priority
+                  :tracer, :context
 
     attr_reader :parent
 
@@ -46,7 +46,6 @@ module Datadog
       @span_id = Datadog::Utils.next_id
       @parent_id = options.fetch(:parent_id, 0)
       @trace_id = options.fetch(:trace_id, Datadog::Utils.next_id)
-      @sampling_priority = options[:sampling_priority]
 
       @context = options.fetch(:context, nil)
 
@@ -161,7 +160,6 @@ module Datadog
         @parent_id = parent.span_id
         @service ||= parent.service
         @sampled = parent.sampled
-        @sampling_priority = parent.sampling_priority
       end
     end
 

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -118,11 +118,17 @@ module Datadog
       hostname = options.fetch(:hostname, nil)
       port = options.fetch(:port, nil)
       sampler = options.fetch(:sampler, nil)
+      priority_sampling = options[:priority_sampling]
 
+      @priority_sampling = priority_sampling unless priority_sampling.nil?
       @enabled = enabled unless enabled.nil?
       @writer.transport.hostname = hostname unless hostname.nil?
       @writer.transport.port = port unless port.nil?
       @sampler = sampler unless sampler.nil?
+
+      if priority_sampling
+        @sampler = PrioritySampler.new(base_sampler: @sampler)
+      end
     end
 
     # Set the information about the given service. A valid example is:

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -120,7 +120,6 @@ module Datadog
       sampler = options.fetch(:sampler, nil)
       priority_sampling = options[:priority_sampling]
 
-      @priority_sampling = priority_sampling unless priority_sampling.nil?
       @enabled = enabled unless enabled.nil?
       @sampler = sampler unless sampler.nil?
 
@@ -212,7 +211,6 @@ module Datadog
         if ctx && ctx.trace_id && ctx.span_id
           span.trace_id = ctx.trace_id
           span.parent_id = ctx.span_id
-          span.sampling_priority = ctx.sampling_priority
         end
       else
         # child span

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -122,13 +122,15 @@ module Datadog
 
       @priority_sampling = priority_sampling unless priority_sampling.nil?
       @enabled = enabled unless enabled.nil?
-      @writer.transport.hostname = hostname unless hostname.nil?
-      @writer.transport.port = port unless port.nil?
       @sampler = sampler unless sampler.nil?
 
       if priority_sampling
         @sampler = PrioritySampler.new(base_sampler: @sampler)
+        @writer = Writer.new(priority_sampler: @sampler)
       end
+
+      @writer.transport.hostname = hostname unless hostname.nil?
+      @writer.transport.port = port unless port.nil?
     end
 
     # Set the information about the given service. A valid example is:

--- a/lib/ddtrace/transport.rb
+++ b/lib/ddtrace/transport.rb
@@ -20,30 +20,35 @@ module Datadog
     RUBY_INTERPRETER = RUBY_VERSION > '1.9' ? RUBY_ENGINE + '-' + RUBY_PLATFORM : 'ruby-' + RUBY_PLATFORM
 
     API = {
-      'v0.3' => {
+      V4 = 'v0.4'.freeze => {
+        traces_endpoint: '/v0.4/traces'.freeze,
+        services_endpoint: '/v0.4/services'.freeze,
+        encoder: Encoding::MsgpackEncoder,
+        fallback: 'v0.3'.freeze
+      }.freeze,
+      V3 = 'v0.3'.freeze => {
         traces_endpoint: '/v0.3/traces'.freeze,
         services_endpoint: '/v0.3/services'.freeze,
         encoder: Encoding::MsgpackEncoder,
         fallback: 'v0.2'.freeze
       }.freeze,
-      'v0.2' => {
+      V2 = 'v0.2'.freeze => {
         traces_endpoint: '/v0.2/traces'.freeze,
         services_endpoint: '/v0.2/services'.freeze,
         encoder: Encoding::JSONEncoder
       }.freeze
     }.freeze
 
-    DEFAULT_API = 'v0.3'.freeze
-
-    private_constant :API, :DEFAULT_API
+    private_constant :API
 
     def initialize(hostname, port, options = {})
-      api_version = options.fetch(:api_version, DEFAULT_API)
+      api_version = options.fetch(:api_version, V3)
 
       @hostname = hostname
       @port = port
       @api = API.fetch(api_version)
       @encoder = options[:encoder] || @api[:encoder].new
+      @response_callback = options[:response_callback]
 
       # overwrite the Content-type with the one chosen in the Encoder
       @headers = options.fetch(:headers, {})
@@ -159,6 +164,8 @@ module Datadog
         @mutex.synchronize { @count_server_error += 1 }
       end
 
+      process_callback(response)
+
       status_code
     rescue StandardError => e
       Datadog::Tracer.log.error(e.message)
@@ -175,6 +182,16 @@ module Datadog
           internal_error: @count_internal_error
         }
       end
+    end
+
+    private
+
+    def process_callback(response)
+      return unless @response_callback && @response_callback.respond_to?(:call)
+
+      @response_callback.call(response)
+    rescue => e
+      Tracer.log.debug("Error processing callback: #{e}")
     end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,10 +1,14 @@
 require 'minitest'
 require 'minitest/autorun'
+require 'webmock/minitest'
 
 require 'ddtrace/encoding'
 require 'ddtrace/transport'
 require 'ddtrace/tracer'
 require 'ddtrace/span'
+
+WebMock.allow_net_connect!
+WebMock.disable!
 
 # Give access to otherwise private members
 module Datadog

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -71,8 +71,9 @@ end
 
 # FauxWriter is a dummy writer that buffers spans locally.
 class FauxWriter < Datadog::Writer
-  def initialize
-    super(transport: FauxTransport.new(HOSTNAME, PORT))
+  def initialize(options = {})
+    options[:transport] ||= FauxTransport.new(HOSTNAME, PORT)
+    super
     @mutex = Mutex.new
 
     # easy access to registered components

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -164,24 +164,28 @@ class TracerIntegrationTest < Minitest::Test
   end
 
   def test_priority_sampling_integration
-    tracer = Datadog::Tracer.new
-    tracer.configure(enabled: true, hostname: '127.0.0.1', port: '8126', priority_sampling: true)
+    # Whatever the sampling priority sampling is, all traces are sent to the agent,
+    # the agent then sends it or not depending on the priority, but they are all sent.
+    3.times do |i|
+      tracer = Datadog::Tracer.new
+      tracer.configure(enabled: true, hostname: '127.0.0.1', port: '8126', priority_sampling: true)
 
-    span_a = tracer.start_span('span_a')
-    span_b = tracer.start_span('span_b', child_of: span_a.context)
+      span_a = tracer.start_span('span_a')
+      span_b = tracer.start_span('span_b', child_of: span_a.context)
 
-    # I want to keep the trace to which `span_b` belongs
-    span_b.context.sampling_priority = 10
+      # I want to keep the trace to which `span_b` belongs
+      span_b.context.sampling_priority = i
 
-    span_b.finish
-    span_a.finish
+      span_b.finish
+      span_a.finish
 
-    try_wait_until { tracer.writer.stats[:traces_flushed] >= 2 }
-    stats = tracer.writer.stats
+      try_wait_until { tracer.writer.stats[:traces_flushed] >= 2 }
+      stats = tracer.writer.stats
 
-    assert_equal(1, stats[:traces_flushed], 'wrong number of traces flushed')
-    assert_equal(0, stats[:transport][:client_error])
-    assert_equal(0, stats[:transport][:server_error])
-    assert_equal(0, stats[:transport][:internal_error])
+      assert_equal(1, stats[:traces_flushed], 'wrong number of traces flushed')
+      assert_equal(0, stats[:transport][:client_error])
+      assert_equal(0, stats[:transport][:server_error])
+      assert_equal(0, stats[:transport][:internal_error])
+    end
   end
 end

--- a/test/priority_sampler_test.rb
+++ b/test/priority_sampler_test.rb
@@ -4,7 +4,8 @@ require 'ddtrace/sampler'
 module Datadog
   class PrioritySamplerTest < Minitest::Test
     def setup
-      @span = Span.new(nil, nil, service: 'foobar')
+      @context = Context.new
+      @span = Span.new(nil, nil, service: 'foobar', context: @context)
       @base_sampler = MiniTest::Mock.new
       @post_sampler = MiniTest::Mock.new
 
@@ -22,7 +23,7 @@ module Datadog
       @base_sampler.verify
       @post_sampler.verify
 
-      assert_equal(0, @span.sampling_priority)
+      assert_equal(0, @context.sampling_priority)
     end
 
     def test_sampling_composition_1
@@ -34,7 +35,7 @@ module Datadog
       @base_sampler.verify
       @post_sampler.verify
 
-      assert(1, @span.sampling_priority)
+      assert(1, @context.sampling_priority)
     end
 
     def test_sampling_composition_2
@@ -46,7 +47,7 @@ module Datadog
       @base_sampler.verify
       @post_sampler.verify
 
-      assert(0, @span.sampling_priority)
+      assert(0, @context.sampling_priority)
     end
 
     def test_sampling_update

--- a/test/priority_sampler_test.rb
+++ b/test/priority_sampler_test.rb
@@ -1,0 +1,59 @@
+require 'minitest'
+require 'ddtrace/sampler'
+
+module Datadog
+  class PrioritySamplerTest < Minitest::Test
+    def setup
+      @span = Span.new(nil, nil, service: 'foobar')
+      @base_sampler = MiniTest::Mock.new
+      @post_sampler = MiniTest::Mock.new
+
+      @priority_sampler = PrioritySampler.new(
+        base_sampler: @base_sampler,
+        post_sampler: @post_sampler
+      )
+    end
+
+    def test_sampling_short_circuiting
+      @base_sampler.expect(:sample, false, [@span])
+
+      refute(@priority_sampler.sample(@span))
+
+      @base_sampler.verify
+      @post_sampler.verify
+
+      assert_equal(0, @span.sampling_priority)
+    end
+
+    def test_sampling_composition_1
+      @base_sampler.expect(:sample, true, [@span])
+      @post_sampler.expect(:sample, true, [@span])
+
+      assert(@priority_sampler.sample(@span))
+
+      @base_sampler.verify
+      @post_sampler.verify
+
+      assert(1, @span.sampling_priority)
+    end
+
+    def test_sampling_composition_2
+      @base_sampler.expect(:sample, true, [@span])
+      @post_sampler.expect(:sample, false, [@span])
+
+      refute(@priority_sampler.sample(@span))
+
+      @base_sampler.verify
+      @post_sampler.verify
+
+      assert(0, @span.sampling_priority)
+    end
+
+    def test_sampling_update
+      rates_by_service = { foo: 1, bar: 0 }
+      @post_sampler.expect(:update, nil, [rates_by_service])
+      @priority_sampler.update(rates_by_service)
+      @post_sampler.verify
+    end
+  end
+end

--- a/test/propagation/http_propagator_test.rb
+++ b/test/propagation/http_propagator_test.rb
@@ -8,18 +8,20 @@ class HTTPPropagatorTest < Minitest::Test
 
     tracer.trace('caller') do |span|
       env = { 'something' => 'alien' }
-      Datadog::HTTPPropagator.inject!(span, env)
+      Datadog::HTTPPropagator.inject!(span.context, env)
       assert_equal({ 'something' => 'alien',
                      'x-datadog-trace-id' => span.trace_id.to_s,
                      'x-datadog-parent-id' => span.span_id.to_s }, env)
-      span.sampling_priority = 0
-      Datadog::HTTPPropagator.inject!(span, env)
+
+      span.context.sampling_priority = 0
+      Datadog::HTTPPropagator.inject!(span.context, env)
       assert_equal({ 'something' => 'alien',
                      'x-datadog-trace-id' => span.trace_id.to_s,
                      'x-datadog-parent-id' => span.span_id.to_s,
                      'x-datadog-sampling-priority' => '0' }, env)
-      span.sampling_priority = nil
-      Datadog::HTTPPropagator.inject!(span, env)
+
+      span.context.sampling_priority = nil
+      Datadog::HTTPPropagator.inject!(span.context, env)
       assert_equal({ 'something' => 'alien',
                      'x-datadog-trace-id' => span.trace_id.to_s,
                      'x-datadog-parent-id' => span.span_id.to_s }, env)

--- a/test/rate_by_service_sampler_test.rb
+++ b/test/rate_by_service_sampler_test.rb
@@ -48,6 +48,20 @@ module Datadog
       assert_in_epsilon(counter, DEFAULT_RATE * ITERATIONS_PER_SERVICE, MAX_DEVIATION)
     end
 
+    def test_fallback_update
+      counter = 0
+      rate = 0.2
+      @sampler.update('service:,env:' => rate)
+
+      ITERATIONS_PER_SERVICE.times do
+        span = Span.new(nil, nil, service: 'foo_service')
+        @sampler.sample(span)
+        counter += 1 if span.sampled
+      end
+
+      assert_in_epsilon(counter, rate * ITERATIONS_PER_SERVICE, MAX_DEVIATION)
+    end
+
     private
 
     def span_for(service_key)

--- a/test/rate_by_service_sampler_test.rb
+++ b/test/rate_by_service_sampler_test.rb
@@ -1,0 +1,62 @@
+require 'minitest'
+require 'ddtrace/sampler'
+
+module Datadog
+  class RateByServiceSamplerTest < Minitest::Test
+    MAX_DEVIATION = 0.3
+    ITERATIONS_PER_SERVICE = 1_000
+    DEFAULT_RATE = 0.5
+
+    def setup
+      @rates = {
+        'service:a,env:test' => 1.0,
+        'service:b,env:test' => 0.5,
+        'service:c,env:test' => 0.25,
+        'service:d,env:test' => 0.1
+      }
+
+      @sampler = RateByServiceSampler.new(DEFAULT_RATE, env: :test)
+      @sampler.update(@rates)
+    end
+
+    def test_sampling
+      counter = Hash.new(0)
+
+      @rates.each do |service_key, _|
+        ITERATIONS_PER_SERVICE.times do
+          span = span_for(service_key)
+          @sampler.sample(span)
+          counter[service_key] += 1 if span.sampled
+        end
+      end
+
+      @rates.each do |service_key, sampling_rate|
+        sample_expect = sampling_rate * ITERATIONS_PER_SERVICE
+        assert_in_epsilon(counter[service_key], sample_expect, MAX_DEVIATION)
+      end
+    end
+
+    def test_sampling_fallback
+      counter = 0
+
+      ITERATIONS_PER_SERVICE.times do
+        span = Span.new(nil, nil, service: 'foo_service')
+        @sampler.sample(span)
+        counter += 1 if span.sampled
+      end
+
+      assert_in_epsilon(counter, DEFAULT_RATE * ITERATIONS_PER_SERVICE, MAX_DEVIATION)
+    end
+
+    private
+
+    def span_for(service_key)
+      name = service_name(service_key)
+      Span.new(nil, nil, service: name)
+    end
+
+    def service_name(service_key)
+      service_key.match(/service:(?<name>.)/)[:name]
+    end
+  end
+end

--- a/test/writer_test.rb
+++ b/test/writer_test.rb
@@ -1,0 +1,47 @@
+require 'helper'
+require 'ddtrace/transport'
+require 'ddtrace/writer'
+require 'json'
+
+module Datadog
+  class WriterTest < Minitest::Test
+    def setup
+      WebMock.enable!
+    end
+
+    def teardown
+      WebMock.reset!
+      WebMock.disable!
+    end
+
+    def test_sampling_feedback_loop
+      sampler = Minitest::Mock.new
+      writer = Writer.new(priority_sampler: sampler)
+      response_body = { 'service:a,env:test' => 0.1, 'service:b,env:test' => 0.5 }.to_json
+      v4_endpoint = stub_request(:post, traces_endpoint).to_return(body: response_body)
+
+      sampler.expect(:update, true, [{ 'service:a,env:test' => 0.1, 'service:b,env:test' => 0.5 }])
+      writer.send_spans(get_test_traces(1), writer.transport)
+      assert_requested(v4_endpoint)
+      sampler.verify
+    end
+
+    def test_outdated_agent
+      sampler = Minitest::Mock.new
+      writer = Writer.new(priority_sampler: sampler)
+      v4_endpoint = stub_request(:post, traces_endpoint).to_return(status: 404)
+      v3_endpoint = stub_request(:post, traces_endpoint(HTTPTransport::V3))
+
+      writer.send_spans(get_test_traces(1), writer.transport)
+
+      assert_requested(v4_endpoint)
+      assert_requested(v3_endpoint)
+    end
+
+    private
+
+    def traces_endpoint(api_version = HTTPTransport::V4)
+      "#{Writer::HOSTNAME}:#{Writer::PORT}/#{api_version}/traces"
+    end
+  end
+end


### PR DESCRIPTION
### Overview

Introduces Priority Sampling to force the sampler to keep a trace (or to discard it). This includes Distributed Tracing propagation for the priority sampling attribute.