### PR TITLE
[Resque] Cleanup after fork

### DIFF
--- a/lib/ddtrace/contrib/resque/resque_job.rb
+++ b/lib/ddtrace/contrib/resque/resque_job.rb
@@ -31,7 +31,9 @@ Resque.before_first_fork do
 end
 
 Resque.after_fork do
-  Thread.current[:datadog_context] = nil
+  # get the current tracer
   pin = Datadog::Pin.get_from(Resque)
+  # clean the state so no CoW happens
+  pin.tracer.provider.context = nil
   pin.tracer.writer.start
 end

--- a/lib/ddtrace/contrib/resque/resque_job.rb
+++ b/lib/ddtrace/contrib/resque/resque_job.rb
@@ -29,3 +29,9 @@ Resque.before_first_fork do
   pin = Datadog::Pin.get_from(Resque)
   pin.tracer.set_service_info(pin.service, 'resque', Datadog::Ext::AppTypes::WORKER)
 end
+
+Resque.after_fork do
+  Thread.current[:datadog_context] = nil
+  pin = Datadog::Pin.get_from(Resque)
+  pin.tracer.writer.start
+end

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -33,6 +33,7 @@ module Datadog
     # spawns two different workers for spans and services;
     # they share the same transport which is thread-safe
     def start
+      @pid = Process.pid
       @trace_handler = ->(items, transport) { send_spans(items, transport) }
       @service_handler = ->(items, transport) { send_services(items, transport) }
       @worker = Datadog::Workers::AsyncTransport.new(@transport,
@@ -94,7 +95,6 @@ module Datadog
       pid = Process.pid
       @mutex_after_fork.synchronize do
         if pid != @pid
-          @pid = pid
           # we should start threads because the worker doesn't own this
           start()
         end


### PR DESCRIPTION
## Overview
The child process created when Resque forks to work on a new job receives a copy of the parent process's buffers and `writer`. This clears it out after the fork to ensure a clean slate and may help with performance. For example, if a span is not finished and a `worker` thread not created, the buffers will never be cleared and the process will sleep in the `shutdown!` method until it times out at 5 seconds. 

## Breaking Changes
No breaking changes