### PR TITLE
Replace calls to `Time.now` by `POSIX#clock_gettime`

### DIFF
--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -193,7 +193,7 @@ module Datadog
     # * +start_time+: when the span actually starts (defaults to \now)
     # * +tags+: extra tags which should be added to the span.
     def start_span(name, options = {})
-      start_time = options.fetch(:start_time, Time.now.utc)
+      start_time = options.fetch(:start_time, Utils.current_time)
       tags = options.fetch(:tags, {})
 
       opts = options.select do |k, _v|

--- a/lib/ddtrace/utils.rb
+++ b/lib/ddtrace/utils.rb
@@ -1,3 +1,5 @@
+require 'rbconfig'
+
 module Datadog
   # Utils contains low-level utilities, typically to provide pseudo-random trace IDs.
   module Utils
@@ -27,6 +29,20 @@ module Datadog
       return string if string.size <= size
 
       string.slice(0, size - omission.size) + omission
+    end
+
+    def self.windows_platform?
+      RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+    end
+
+    if defined?(Process::CLOCK_REALTIME) && !windows_platform?
+      def self.current_time
+        Process.clock_gettime(Process::CLOCK_REALTIME)
+      end
+    else
+      def self.current_time
+        Time.now.to_f
+      end
     end
 
     private_class_method :reset!, :was_forked?

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -45,8 +45,8 @@ def get_test_traces(n)
   }
 
   n.times do
-    span1 = Datadog::Span.new(nil, 'client.testing', defaults).finish()
-    span2 = Datadog::Span.new(nil, 'client.testing', defaults).finish()
+    span1 = generate_span(nil, 'client.testing', defaults).finish
+    span2 = generate_span(nil, 'client.testing', defaults).finish
     span2.set_parent(span1)
     traces << [span1, span2]
   end
@@ -229,5 +229,11 @@ def try_wait_until(options = {})
     break if attempts <= 0 || yield
     sleep(backoff)
     attempts -= 1
+  end
+end
+
+def generate_span(*args)
+  Datadog::Span.new(*args).tap do |span|
+    span.start_time = Datadog::Utils.current_time
   end
 end

--- a/test/span_test.rb
+++ b/test/span_test.rb
@@ -4,14 +4,13 @@ require 'ddtrace/span'
 class SpanTest < Minitest::Test
   def test_span_finish
     tracer = nil
-    span = Datadog::Span.new(tracer, 'my.op')
+    span = generate_span(tracer, 'my.op')
     # the start_time is not set, calling start_span with Tracer would set it
-    assert_nil(span.start_time)
     assert_nil(span.end_time)
     span.finish
     # the end_time must be set
     sleep(0.001)
-    assert span.end_time < Time.now.utc
+    assert span.end_time < Datadog::Utils.current_time
     assert span.start_time <= span.end_time
     assert span.to_hash[:duration] >= 0
   end
@@ -31,7 +30,7 @@ class SpanTest < Minitest::Test
   def test_span_finish_at
     # finish_at must set the right time
     span = Datadog::Span.new(nil, 'span.test')
-    now = Time.now.utc
+    now = Datadog::Utils.current_time
     # wait 0.01s but set the end time before the wait
     sleep(0.01)
     span.finish(now)
@@ -43,7 +42,7 @@ class SpanTest < Minitest::Test
   def test_span_finish_at_once
     # calling finish_at() multiple times doesn't have any effect
     span = Datadog::Span.new(nil, 'span.test')
-    now = Time.now.utc
+    now = Datadog::Utils.current_time
     # wait 0.01s but set the end time before the wait
     sleep(0.01)
     span.finish(now)

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -218,7 +218,7 @@ class TracerTest < Minitest::Test
     assert_equal('special-service', span.service)
     assert_equal('extra-resource', span.resource)
     assert_equal('my-type', span.span_type)
-    assert_equal(yesterday, span.start_time)
+    assert_equal(yesterday.to_f, span.start_time)
     assert_equal('test', span.get_tag('env'))
     assert_equal('cool', span.get_tag('temp'))
     assert_equal('value1', span.get_tag('tag1'))


### PR DESCRIPTION
```rb
require 'benchmark'

Benchmark.bm do |x|
  x.report { 100_000.times { Time.now.utc.to_f } }
  x.report { 100_000.times { Process.clock_gettime(Process::CLOCK_REALTIME) } }
end
```

```
       user     system      total        real
   0.110000   0.000000   0.110000 (  0.117189)
   0.010000   0.000000   0.010000 (  0.012614)
```

The POSIX wrapper `#clock_gettime` is considerably faster.
Besides that, `Time` objects have no use for us, so we can avoid their allocation as well.