### PR TITLE
[rails] use direct instrumentation instead of Rails instrumentation

### DIFF
--- a/lib/ddtrace/contrib/rails/action_view.rb
+++ b/lib/ddtrace/contrib/rails/action_view.rb
@@ -7,30 +7,10 @@ module Datadog
       module ActionView
         def self.instrument
           # patch Rails core components
-          Datadog::RailsRendererPatcher.patch_renderer()
-
-          # subscribe when the template rendering starts
-          ::ActiveSupport::Notifications.subscribe('!datadog.start_render_template.action_view') do |*args|
-            start_render_template(*args)
-          end
-
-          # subscribe when the template rendering has been processed
-          ::ActiveSupport::Notifications.subscribe('!datadog.finish_render_template.action_view') do |*args|
-            finish_render_template(*args)
-          end
-
-          # subscribe when the partial rendering starts
-          ::ActiveSupport::Notifications.subscribe('!datadog.start_render_partial.action_view') do |*args|
-            start_render_partial(*args)
-          end
-
-          # subscribe when the partial rendering has been processed
-          ::ActiveSupport::Notifications.subscribe('!datadog.finish_render_partial.action_view') do |*args|
-            finish_render_partial(*args)
-          end
+          Datadog::RailsRendererPatcher.patch_renderer
         end
 
-        def self.start_render_template(_name, _start, _finish, _id, payload)
+        def self.start_render_template(payload)
           # retrieve the tracing context
           tracing_context = payload.fetch(:tracing_context)
 
@@ -42,7 +22,7 @@ module Datadog
           Datadog::Tracer.log.debug(e.message)
         end
 
-        def self.finish_render_template(_name, _start, _finish, _id, payload)
+        def self.finish_render_template(payload)
           # retrieve the tracing context and the latest active span
           tracing_context = payload.fetch(:tracing_context)
           span = tracing_context[:dd_rails_template_span]
@@ -64,7 +44,7 @@ module Datadog
           Datadog::Tracer.log.debug(e.message)
         end
 
-        def self.start_render_partial(_name, _start, _finish, _id, payload)
+        def self.start_render_partial(payload)
           # retrieve the tracing context
           tracing_context = payload.fetch(:tracing_context)
 
@@ -75,7 +55,7 @@ module Datadog
           Datadog::Tracer.log.debug(e.message)
         end
 
-        def self.finish_render_partial(_name, start, finish, _id, payload)
+        def self.finish_render_partial(payload)
           # retrieve the tracing context and the latest active span
           tracing_context = payload.fetch(:tracing_context)
           span = tracing_context[:dd_rails_partial_span]

--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -196,11 +196,17 @@ module Datadog
             tracing_context: {}
           }
 
-          ActiveSupport::Notifications.instrument('!datadog.start_cache_tracing.active_support', raw_payload)
-
-          ActiveSupport::Notifications.instrument('!datadog.finish_cache_tracing.active_support', raw_payload) do
+          begin
+            # process and catch cache exceptions
+            Datadog::Contrib::Rails::ActiveSupport.start_trace_cache(raw_payload)
             read_without_datadog(*args, &block)
+          rescue Exception => e
+            payload[:exception] = [e.class.name, e.message]
+            payload[:exception_object] = e
+            raise e
           end
+        ensure
+          Datadog::Contrib::Rails::ActiveSupport.finish_trace_cache(raw_payload)
         end
       end
     end
@@ -215,11 +221,17 @@ module Datadog
             tracing_context: {}
           }
 
-          ActiveSupport::Notifications.instrument('!datadog.start_cache_tracing.active_support', raw_payload)
-
-          ActiveSupport::Notifications.instrument('!datadog.finish_cache_tracing.active_support', raw_payload) do
+          begin
+            # process and catch cache exceptions
+            Datadog::Contrib::Rails::ActiveSupport.start_trace_cache(raw_payload)
             fetch_without_datadog(*args, &block)
+          rescue Exception => e
+            payload[:exception] = [e.class.name, e.message]
+            payload[:exception_object] = e
+            raise e
           end
+        ensure
+          Datadog::Contrib::Rails::ActiveSupport.finish_trace_cache(raw_payload)
         end
       end
     end
@@ -234,11 +246,17 @@ module Datadog
             tracing_context: {}
           }
 
-          ActiveSupport::Notifications.instrument('!datadog.start_cache_tracing.active_support', raw_payload)
-
-          ActiveSupport::Notifications.instrument('!datadog.finish_cache_tracing.active_support', raw_payload) do
+          begin
+            # process and catch cache exceptions
+            Datadog::Contrib::Rails::ActiveSupport.start_trace_cache(raw_payload)
             write_without_datadog(*args, &block)
+          rescue Exception => e
+            payload[:exception] = [e.class.name, e.message]
+            payload[:exception_object] = e
+            raise e
           end
+        ensure
+          Datadog::Contrib::Rails::ActiveSupport.finish_trace_cache(raw_payload)
         end
       end
     end
@@ -253,11 +271,17 @@ module Datadog
             tracing_context: {}
           }
 
-          ActiveSupport::Notifications.instrument('!datadog.start_cache_tracing.active_support', raw_payload)
-
-          ActiveSupport::Notifications.instrument('!datadog.finish_cache_tracing.active_support', raw_payload) do
+          begin
+            # process and catch cache exceptions
+            Datadog::Contrib::Rails::ActiveSupport.start_trace_cache(raw_payload)
             delete_without_datadog(*args, &block)
+          rescue Exception => e
+            payload[:exception] = [e.class.name, e.message]
+            payload[:exception_object] = e
+            raise e
           end
+        ensure
+          Datadog::Contrib::Rails::ActiveSupport.finish_trace_cache(raw_payload)
         end
       end
     end

--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -27,11 +27,9 @@ module Datadog
           # context when a partial is rendered
           @tracing_context ||= {}
           if @tracing_context.empty?
-            ::ActiveSupport::Notifications.instrument(
-              '!datadog.start_render_template.action_view',
-              tracing_context: @tracing_context
-            )
+            Datadog::Contrib::Rails::ActionView.start_render_template(tracing_context: @tracing_context)
           end
+
           render_without_datadog(*args)
         rescue Exception => e
           # attach the exception to the tracing context if any
@@ -39,10 +37,7 @@ module Datadog
           raise e
         ensure
           # ensure that the template `Span` is finished even during exceptions
-          ::ActiveSupport::Notifications.instrument(
-            '!datadog.finish_render_template.action_view',
-            tracing_context: @tracing_context
-          )
+          Datadog::Contrib::Rails::ActionView.finish_render_template(tracing_context: @tracing_context)
         end
 
         def render_template_with_datadog(*args)
@@ -90,10 +85,7 @@ module Datadog
         def render_with_datadog(*args, &block)
           # create a tracing context and start the rendering span
           @tracing_context = {}
-          ::ActiveSupport::Notifications.instrument(
-            '!datadog.start_render_partial.action_view',
-            tracing_context: @tracing_context
-          )
+          Datadog::Contrib::Rails::ActionView.start_render_partial(tracing_context: @tracing_context)
           render_without_datadog(*args)
         rescue Exception => e
           # attach the exception to the tracing context if any
@@ -101,10 +93,7 @@ module Datadog
           raise e
         ensure
           # ensure that the template `Span` is finished even during exceptions
-          ::ActiveSupport::Notifications.instrument(
-            '!datadog.finish_render_partial.action_view',
-            tracing_context: @tracing_context
-          )
+          Datadog::Contrib::Rails::ActionView.finish_render_partial(tracing_context: @tracing_context)
         end
 
         def render_partial_with_datadog(*args)

--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -2,7 +2,7 @@ module Datadog
   # RailsRendererPatcher contains function to patch Rails rendering libraries.
   # rubocop:disable Lint/RescueException
   # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/BlockLength
+  # rubocop:disable Metrics/ModuleLength
   module RailsRendererPatcher
     module_function
 


### PR DESCRIPTION
### Overview

Since most of the methods require wrapping Rails internals execution, it's useless relying in Rails instrumentation just to keep the code separated. With this patch, We're not relying in the Rails instrumentation anymore, keeping a subscriber only for ActiveRecord.

### Benchmark

The following benchmark hits the `:index` available in the testing app to see the benefit of this change:
```
# Rails instrumentation:  148.740000   2.710000 151.450000 (152.737155)
# Direct instrumentation: 143.570000   2.530000 146.100000 (146.734710)
```