### PR TITLE
[tool] add .ruby-version to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,9 +45,8 @@ build-iPhoneSimulator/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
-# .ruby-version
-# .ruby-gemset
+.ruby-version
+.ruby-gemset
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc


### PR DESCRIPTION
### Overview

Since it's a library, `.ruby-version` is not required.