### PR TITLE
[resque] add Pin guard to Resque.after_fork

### DIFF
--- a/lib/ddtrace/contrib/resque/resque_job.rb
+++ b/lib/ddtrace/contrib/resque/resque_job.rb
@@ -35,6 +35,7 @@ end
 Resque.after_fork do
   # get the current tracer
   pin = Datadog::Pin.get_from(Resque)
+  next unless pin && pin.tracer
   # clean the state so no CoW happens
   pin.tracer.provider.context = nil
   pin.tracer.writer.start


### PR DESCRIPTION
### Overview

Ensure the class extension works even if the `Pin` is not available. Follow-up of #223 