### PR TITLE
Improve Resque Performance

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -33,6 +33,7 @@ EOS
   spec.require_paths = ['lib']
 
   spec.add_dependency 'msgpack'
+  spec.add_dependency 'concurrent-ruby'
 
   spec.add_development_dependency 'rake', '~> 10.5'
   spec.add_development_dependency('rubocop', '= 0.49.1') if RUBY_VERSION >= '2.1.0'

--- a/lib/ddtrace/buffer.rb
+++ b/lib/ddtrace/buffer.rb
@@ -58,7 +58,7 @@ module Datadog
     end
 
     def closed?
-      @mutex.synchronise do
+      @mutex.synchronize do
         return @closed
       end
     end

--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -86,13 +86,13 @@ module Datadog
               trace_call = Concurrent::Promise.new { callback_traces }.execute
               callback_services
 
-              # Increase @flush_interval callback_traces returns immediately with nil
+              # Increase @flush_interval if callback_traces returns immediately with nil
               if trace_call.state == :fulfilled && trace_call.value.nil?
                 @flush_interval = [@flush_interval * BACK_OFF_RATIO, BACK_OFF_MAX].min
 
               # Block on callback_traces if buffer is closed
               elsif @trace_buffer.closed? && trace_call.state == :pending
-                trace_call.wait
+                trace_call.wait(DEFAULT_TIMEOUT)
               end
             end
 

--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -83,17 +83,18 @@ module Datadog
 
             # Flush when buffer is closed or every @flush_interval
             if @trace_buffer.closed? || (Time.now - start_time >= @flush_interval)
-              trace_call = Concurrent::Promise.new { callback_traces }.execute
+              #trace_call = Concurrent::Promise.new { callback_traces }.execute
+              trace_call = callback_traces
               callback_services
 
               # Increase @flush_interval if callback_traces returns immediately with nil
-              if trace_call.state == :fulfilled && trace_call.value.nil?
-                @flush_interval = [@flush_interval * BACK_OFF_RATIO, BACK_OFF_MAX].min
+            #  if trace_call.state == :fulfilled && trace_call.value.nil?
+            #    @flush_interval = [@flush_interval * BACK_OFF_RATIO, BACK_OFF_MAX].min
 
-              # Block on callback_traces if buffer is closed
-              elsif @trace_buffer.closed? && trace_call.state == :pending
-                trace_call.wait(DEFAULT_TIMEOUT)
-              end
+            #  # Block on callback_traces if buffer is closed
+            #  elsif @trace_buffer.closed? && trace_call.state == :pending
+            #    trace_call.wait(DEFAULT_TIMEOUT)
+            #  end
             end
 
             break unless run

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -2,6 +2,7 @@ require 'helper'
 require 'ddtrace'
 require 'ddtrace/tracer'
 require 'thread'
+require 'concurrent'
 
 class TracerIntegrationTest < Minitest::Test
   def agent_receives_span_step1(tracer)

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -85,40 +85,6 @@ class TracerIntegrationTest < Minitest::Test
     assert_equal(0, stats[:transport][:internal_error])
   end
 
-  def shutdown_exec_only_once(tracer)
-    tracer.set_service_info('my.service', 'rails', 'web')
-    span = tracer.start_span('my.short.op')
-    span.service = 'my.service'
-    span.finish()
-    first_shutdown = nil
-    second_shutdown = nil
-    worker = Thread.new() do
-      first_shutdown = tracer.shutdown!
-    end
-
-    100.times do
-      break if tracer.writer.worker.shutting_down # wait until first shutdown is halfway through execution
-      sleep(0.01)
-    end
-
-    second_worker = Thread.new() do
-      second_shutdown = tracer.shutdown!
-    end
-
-    worker.join(2)
-    second_worker.join(2)
-
-    stats = tracer.writer.stats
-    assert(first_shutdown, 'should have run through the shutdown method')
-    assert_equal(false, second_shutdown, 'should not have executed shutdown')
-    assert_equal(true, span.finished?, 'span did not finish')
-    assert_equal(1, stats[:traces_flushed], 'wrong number of traces flushed')
-    assert_equal(1, stats[:services_flushed], 'wrong number of services flushed')
-    assert_equal(0, stats[:transport][:client_error])
-    assert_equal(0, stats[:transport][:server_error])
-    assert_equal(0, stats[:transport][:internal_error])
-  end
-
   def test_agent_receives_span
     # test that the agent really receives the spans
     # this test can be long since it waits internal buffers flush
@@ -140,15 +106,5 @@ class TracerIntegrationTest < Minitest::Test
     tracer.configure(enabled: true, hostname: '127.0.0.1', port: '8126')
 
     agent_receives_short_span(tracer)
-  end
-
-  def test_shutdown_exec_once
-    skip unless ENV['TEST_DATADOG_INTEGRATION'] || RUBY_PLATFORM != 'java'
-    # requires a running agent, and test does not apply to Java threading model
-
-    tracer = Datadog::Tracer.new
-    tracer.configure(enabled: true, hostname: '127.0.0.1', port: '8126')
-
-    shutdown_exec_only_once(tracer)
   end
 end


### PR DESCRIPTION
- Adds mutexes for safe checking of `@run` (pedro/shutdown-improvements)
- Improves performances of `worker` thread and `shutdown!` method by reducing number of checks/polls and the duration of these
  - worker checks more frequently if the buffer is closed, instead of checking for every `flush_interval` 
  - worker blocks on `callback_traces` instead of sleeping when buffer closed