### PR TITLE
Create priority sampler feedback loop

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -39,5 +39,8 @@ EOS
   spec.add_development_dependency 'minitest', '= 5.10.1'
   spec.add_development_dependency 'appraisal', '~> 2.2'
   spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'webmock', '~> 2.0'
+  # locking transitive dependency of webmock
+  spec.add_development_dependency 'addressable',  '~> 2.4.0'
   spec.add_development_dependency 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
 end

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -44,6 +44,7 @@ module Datadog
           default_grape_service: 'grape',
           template_base_path: 'views/',
           tracer: Datadog.tracer,
+          priority_sampling: false,
           debug: false,
           trace_agent_hostname: Datadog::Writer::HOSTNAME,
           trace_agent_port: Datadog::Writer::PORT,
@@ -66,7 +67,8 @@ module Datadog
           # set the address of the trace agent
           datadog_config[:tracer].configure(
             hostname: datadog_config[:trace_agent_hostname],
-            port: datadog_config[:trace_agent_port]
+            port: datadog_config[:trace_agent_port],
+            priority_sampling: datadog_config[:priority_sampling]
           )
 
           # set default tracer tags

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -122,13 +122,15 @@ module Datadog
 
       @priority_sampling = priority_sampling unless priority_sampling.nil?
       @enabled = enabled unless enabled.nil?
-      @writer.transport.hostname = hostname unless hostname.nil?
-      @writer.transport.port = port unless port.nil?
       @sampler = sampler unless sampler.nil?
 
       if priority_sampling
         @sampler = PrioritySampler.new(base_sampler: @sampler)
+        @writer = Writer.new(priority_sampler: @sampler)
       end
+
+      @writer.transport.hostname = hostname unless hostname.nil?
+      @writer.transport.port = port unless port.nil?
     end
 
     # Set the information about the given service. A valid example is:

--- a/lib/ddtrace/transport.rb
+++ b/lib/ddtrace/transport.rb
@@ -20,30 +20,35 @@ module Datadog
     RUBY_INTERPRETER = RUBY_VERSION > '1.9' ? RUBY_ENGINE + '-' + RUBY_PLATFORM : 'ruby-' + RUBY_PLATFORM
 
     API = {
-      'v0.3' => {
+      V4 = 'v0.4'.freeze => {
+        traces_endpoint: '/v0.4/traces'.freeze,
+        services_endpoint: '/v0.4/services'.freeze,
+        encoder: Encoding::MsgpackEncoder,
+        fallback: 'v0.3'.freeze
+      }.freeze,
+      V3 = 'v0.3'.freeze => {
         traces_endpoint: '/v0.3/traces'.freeze,
         services_endpoint: '/v0.3/services'.freeze,
         encoder: Encoding::MsgpackEncoder,
         fallback: 'v0.2'.freeze
       }.freeze,
-      'v0.2' => {
+      V2 = 'v0.2'.freeze => {
         traces_endpoint: '/v0.2/traces'.freeze,
         services_endpoint: '/v0.2/services'.freeze,
         encoder: Encoding::JSONEncoder
       }.freeze
     }.freeze
 
-    DEFAULT_API = 'v0.3'.freeze
-
-    private_constant :API, :DEFAULT_API
+    private_constant :API
 
     def initialize(hostname, port, options = {})
-      api_version = options.fetch(:api_version, DEFAULT_API)
+      api_version = options.fetch(:api_version, V3)
 
       @hostname = hostname
       @port = port
       @api = API.fetch(api_version)
       @encoder = options[:encoder] || @api[:encoder].new
+      @response_callback = options[:response_callback]
 
       # overwrite the Content-type with the one chosen in the Encoder
       @headers = options.fetch(:headers, {})
@@ -159,6 +164,8 @@ module Datadog
         @mutex.synchronize { @count_server_error += 1 }
       end
 
+      process_callback(response)
+
       status_code
     rescue StandardError => e
       Datadog::Tracer.log.error(e.message)
@@ -175,6 +182,16 @@ module Datadog
           internal_error: @count_internal_error
         }
       end
+    end
+
+    private
+
+    def process_callback(response)
+      return unless @response_callback && @response_callback.respond_to?(:call)
+
+      @response_callback.call(response)
+    rescue => e
+      Tracer.log.debug("Error processing callback: #{e}")
     end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,10 +1,14 @@
 require 'minitest'
 require 'minitest/autorun'
+require 'webmock/minitest'
 
 require 'ddtrace/encoding'
 require 'ddtrace/transport'
 require 'ddtrace/tracer'
 require 'ddtrace/span'
+
+WebMock.allow_net_connect!
+WebMock.disable!
 
 # Give access to otherwise private members
 module Datadog

--- a/test/writer_test.rb
+++ b/test/writer_test.rb
@@ -1,0 +1,47 @@
+require 'helper'
+require 'ddtrace/transport'
+require 'ddtrace/writer'
+require 'json'
+
+module Datadog
+  class WriterTest < Minitest::Test
+    def setup
+      WebMock.enable!
+    end
+
+    def teardown
+      WebMock.reset!
+      WebMock.disable!
+    end
+
+    def test_sampling_feedback_loop
+      sampler = Minitest::Mock.new
+      writer = Writer.new(priority_sampler: sampler)
+      response_body = { 'service:a,env:test' => 0.1, 'service:b,env:test' => 0.5 }.to_json
+      v4_endpoint = stub_request(:post, traces_endpoint).to_return(body: response_body)
+
+      sampler.expect(:update, true, [{ 'service:a,env:test' => 0.1, 'service:b,env:test' => 0.5 }])
+      writer.send_spans(get_test_traces(1), writer.transport)
+      assert_requested(v4_endpoint)
+      sampler.verify
+    end
+
+    def test_outdated_agent
+      sampler = Minitest::Mock.new
+      writer = Writer.new(priority_sampler: sampler)
+      v4_endpoint = stub_request(:post, traces_endpoint).to_return(status: 404)
+      v3_endpoint = stub_request(:post, traces_endpoint(HTTPTransport::V3))
+
+      writer.send_spans(get_test_traces(1), writer.transport)
+
+      assert_requested(v4_endpoint)
+      assert_requested(v3_endpoint)
+    end
+
+    private
+
+    def traces_endpoint(api_version = HTTPTransport::V4)
+      "#{Writer::HOSTNAME}:#{Writer::PORT}/#{api_version}/traces"
+    end
+  end
+end


### PR DESCRIPTION
This PR provides the feedback loop between the `datadog-trace-agent` and the `PrioritySampler`. The purpose of it is to adjust dynamically the sampling rates of each service after each flush.