### PR TITLE
[core] add `SyncWriter`

### DIFF
--- a/lib/ddtrace/contrib/resque/patcher.rb
+++ b/lib/ddtrace/contrib/resque/patcher.rb
@@ -1,7 +1,13 @@
 module Datadog
   module Contrib
+    # Namespace for `resque` integration
     module Resque
       SERVICE = 'resque'.freeze
+
+      class << self
+        # Globally-acccesible reference for pre-forking optimization
+        attr_accessor :sync_writer
+      end
 
       # Patcher for Resque integration - sets up the pin for the integration
       module Patcher

--- a/lib/ddtrace/contrib/resque/resque_job.rb
+++ b/lib/ddtrace/contrib/resque/resque_job.rb
@@ -29,7 +29,7 @@ Resque.before_first_fork do
 
   # Create SyncWriter instance before forking
   sync_writer = Datadog::SyncWriter.new(transport: pin.tracer.writer.transport)
-  Datadog::SyncWriter::CACHED_INSTANCE = sync_writer
+  Datadog::Contrib::Resque.sync_writer = sync_writer
 end
 
 Resque.after_fork do
@@ -38,5 +38,5 @@ Resque.after_fork do
   next unless pin && pin.tracer
   # clean the state so no CoW happens
   pin.tracer.provider.context = nil
-  pin.tracer.writer = Datadog::SyncWriter::CACHED_INSTANCE
+  pin.tracer.writer = Datadog::Contrib::Resque.sync_writer
 end

--- a/lib/ddtrace/sync_writer.rb
+++ b/lib/ddtrace/sync_writer.rb
@@ -1,0 +1,36 @@
+module Datadog
+  # SyncWriter flushes both services and traces synchronously
+  class SyncWriter
+    attr_reader :transport
+
+    def initialize(options = {})
+      @transport = options.fetch(:transport) do
+        HTTPTransport.new(Writer::HOSTNAME, Writer::PORT)
+      end
+    end
+
+    def write(trace, services)
+      perform_concurrently(
+        proc { flush_services(services) },
+        proc { flush_trace(trace) }
+      )
+    rescue => e
+      Tracer.log.error(e)
+    end
+
+    private
+
+    def perform_concurrently(*tasks)
+      tasks.map { |task| Thread.new(&task) }.each(&:join)
+    end
+
+    def flush_services(services)
+      transport.send(:services, services)
+    end
+
+    def flush_trace(trace)
+      processed_traces = Pipeline.process!([trace])
+      transport.send(:traces, processed_traces)
+    end
+  end
+end

--- a/lib/ddtrace/sync_writer.rb
+++ b/lib/ddtrace/sync_writer.rb
@@ -15,7 +15,7 @@ module Datadog
         proc { flush_trace(trace) }
       )
     rescue => e
-      Tracer.log.error(e)
+      Tracer.log.debug(e)
     end
 
     private

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -18,8 +18,8 @@ module Datadog
   # of these function calls and sub-requests would be encapsulated within a single trace.
   # rubocop:disable Metrics/ClassLength
   class Tracer
-    attr_reader :writer, :sampler, :services, :tags, :provider
-    attr_accessor :enabled
+    attr_reader :sampler, :services, :tags, :provider
+    attr_accessor :enabled, :writer
     attr_writer :default_service
 
     # Global, memoized, lazy initialized instance of a logger that is used within the the Datadog

--- a/lib/ddtrace/transport.rb
+++ b/lib/ddtrace/transport.rb
@@ -100,11 +100,13 @@ module Datadog
     # this method should target a stable API that works whatever is the agent
     # or the tracing client versions.
     def downgrade!
-      fallback_version = @api.fetch(:fallback)
+      @mutex.synchronize do
+        fallback_version = @api.fetch(:fallback)
 
-      @api = API.fetch(fallback_version)
-      @encoder = @api[:encoder].new
-      @headers['Content-Type'] = @encoder.content_type
+        @api = API.fetch(fallback_version)
+        @encoder = @api[:encoder].new
+        @headers['Content-Type'] = @encoder.content_type
+      end
     end
 
     def informational?(code)

--- a/test/contrib/resque/hooks_test.rb
+++ b/test/contrib/resque/hooks_test.rb
@@ -13,7 +13,6 @@ module Datadog
         def setup
           redis_url = "redis://#{REDIS_HOST}:#{REDIS_PORT}"
           ::Resque.redis = redis_url
-          Monkey.patch_module(:resque)
           @tracer = enable_test_tracer!
           ::Resque::Failure.clear
         end

--- a/test/contrib/resque/test_helper.rb
+++ b/test/contrib/resque/test_helper.rb
@@ -28,3 +28,7 @@ module TestCleanStateJob
     raise StandardError if spans != 1
   end
 end
+
+Datadog::Monkey.patch_module(:resque)
+Resque.after_fork { Datadog::Pin.get_from(Resque).tracer.writer = FauxWriter.new }
+Resque.before_first_fork.each(&:call)

--- a/test/sync_writer_test.rb
+++ b/test/sync_writer_test.rb
@@ -1,0 +1,63 @@
+require 'minitest'
+require 'ddtrace'
+require 'helper'
+require 'ddtrace/sync_writer'
+
+module Datadog
+  class SyncWriterTest < Minitest::Test
+    def setup
+      @transport = SpyTransport.new
+      @sync_writer = SyncWriter.new(transport: @transport)
+    end
+
+    def test_sync_write
+      trace = get_test_traces(1).first
+      services = get_test_services
+
+      @sync_writer.write(trace, services)
+      assert_includes(@transport.calls, [:traces, [trace]])
+      assert_includes(@transport.calls, [:services, services])
+    end
+
+    def test_sync_write_filtering
+      trace1 = [Span.new(nil, 'span_1')]
+      trace2 = [Span.new(nil, 'span_2')]
+
+      Pipeline.before_flush(
+        Pipeline::SpanFilter.new { |span| span.name == 'span_1' }
+      )
+
+      @sync_writer.write(trace1, {})
+      @sync_writer.write(trace2, {})
+
+      refute_includes(@transport.calls, [:traces, [trace1]])
+      assert_includes(@transport.calls, [:traces, [trace2]])
+    end
+
+    def test_itegration_with_tracer
+      tracer = Tracer.new(writer: @sync_writer)
+      span = tracer.start_span('foo.bar')
+      span.finish
+
+      assert_includes(@transport.calls, [:traces, [[span]]])
+    end
+
+    def teardown
+      Pipeline.processors = []
+    end
+
+    class SpyTransport
+      def initialize
+        @mutex = Mutex.new
+      end
+
+      def send(*call_arguments)
+        @mutex.synchronize { calls << call_arguments }
+      end
+
+      def calls
+        @calls ||= []
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Overview

Adds a sync writer so that no threads are used to flush data. This means that when the `Tracer` finishes a trace (calling the `write()` method under the hood), the call is blocking. It's not meant to be used as a default tracer, but instead a good replacement in processes that forks and dies at the end (i.e. Resque).

It reduces a lot the overhead since no signals / timeouts must be waited.