### PR TITLE
[distributed tracing] disabling tracer disables distributed headers

### DIFF
--- a/lib/ddtrace/contrib/faraday/middleware.rb
+++ b/lib/ddtrace/contrib/faraday/middleware.rb
@@ -28,7 +28,7 @@ module Datadog
         def call(env)
           dd_pin.tracer.trace(SERVICE) do |span|
             annotate!(span, env)
-            propagate!(span, env) if options[:distributed_tracing]
+            propagate!(span, env) if options[:distributed_tracing] && dd_pin.tracer.enabled
             app.call(env).on_complete { |resp| handle_response(span, resp) }
           end
         end

--- a/lib/ddtrace/contrib/http/patcher.rb
+++ b/lib/ddtrace/contrib/http/patcher.rb
@@ -129,7 +129,7 @@ module Datadog
                   span.set_tag(Datadog::Ext::HTTP::URL, req.path)
                   span.set_tag(Datadog::Ext::HTTP::METHOD, req.method)
 
-                  unless Datadog::Contrib::HTTP.should_skip_distributed_tracing?(pin)
+                  if pin.tracer.enabled && !Datadog::Contrib::HTTP.should_skip_distributed_tracing?(pin)
                     req.add_field(Datadog::Ext::DistributedTracing::HTTP_HEADER_TRACE_ID, span.trace_id)
                     req.add_field(Datadog::Ext::DistributedTracing::HTTP_HEADER_PARENT_ID, span.span_id)
                     if span.sampling_priority

--- a/lib/ddtrace/contrib/http/patcher.rb
+++ b/lib/ddtrace/contrib/http/patcher.rb
@@ -132,8 +132,11 @@ module Datadog
                   if pin.tracer.enabled && !Datadog::Contrib::HTTP.should_skip_distributed_tracing?(pin)
                     req.add_field(Datadog::Ext::DistributedTracing::HTTP_HEADER_TRACE_ID, span.trace_id)
                     req.add_field(Datadog::Ext::DistributedTracing::HTTP_HEADER_PARENT_ID, span.span_id)
-                    if span.sampling_priority
-                      req.add_field(Datadog::Ext::DistributedTracing::HTTP_HEADER_SAMPLING_PRIORITY, span.sampling_priority)
+                    if span.context.sampling_priority
+                      req.add_field(
+                        Datadog::Ext::DistributedTracing::HTTP_HEADER_SAMPLING_PRIORITY,
+                        span.context.sampling_priority
+                      )
                     end
                   end
                 rescue StandardError => e

--- a/test/contrib/faraday/middleware_test.rb
+++ b/test/contrib/faraday/middleware_test.rb
@@ -96,6 +96,22 @@ module Datadog
           assert_equal(headers[Ext::DistributedTracing::HTTP_HEADER_PARENT_ID], span.span_id.to_s)
         end
 
+        def test_distributed_tracing_disabled
+          tracer.enabled = false
+
+          response = client(distributed_tracing: true).get('/success')
+          headers = response.env.request_headers
+          span = request_span
+
+          # headers should not be set when the tracer is disabled: we do not want the callee
+          # to refer to spans which will never be sent to the agent.
+          assert_nil(headers[Ext::DistributedTracing::HTTP_HEADER_TRACE_ID])
+          assert_nil(headers[Ext::DistributedTracing::HTTP_HEADER_PARENT_ID])
+          assert_nil(span, 'disabled tracer, no spans should reach the writer')
+
+          tracer.enabled = true
+        end
+
         private
 
         attr_reader :client

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -179,7 +179,7 @@ class TracerIntegrationTest < Minitest::Test
       span_b.finish
       span_a.finish
 
-      try_wait_until { tracer.writer.stats[:traces_flushed] >= 2 }
+      try_wait_until { tracer.writer.stats[:traces_flushed] >= 1 }
       stats = tracer.writer.stats
 
       assert_equal(1, stats[:traces_flushed], 'wrong number of traces flushed')


### PR DESCRIPTION
When the tracer is disabled, the traces/spans are not sent, so we
should not set the distributed tracing headers, else children called
with these would refer to non-existing (never sent) parent traces.