### PR TITLE
Lock `redis` version for `rails32_postgres_redis` appraisal

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -40,6 +40,7 @@ if RUBY_VERSION < '2.4.0' && RUBY_PLATFORM != 'java'
       gem 'pg', '0.15.1', platform: :ruby
       gem 'activerecord-jdbcpostgresql-adapter', platform: :jruby
       gem 'redis-rails'
+      gem 'redis', '< 4.0'
     end
 
     if RUBY_VERSION < '2.2.2'

--- a/gemfiles/rails32_postgres_redis.gemfile
+++ b/gemfiles/rails32_postgres_redis.gemfile
@@ -7,5 +7,6 @@ gem "rails", "3.2.22.5"
 gem "pg", "0.15.1", platform: :ruby
 gem "activerecord-jdbcpostgresql-adapter", platform: :jruby
 gem "redis-rails"
+gem "redis", "< 4.0"
 
 gemspec path: "../"


### PR DESCRIPTION
`redis >= 4.0` doesn't support `ruby 1.9.3`.