### PR TITLE
Remove `auto_instrument` options

### DIFF
--- a/lib/ddtrace/contrib/aws/patcher.rb
+++ b/lib/ddtrace/contrib/aws/patcher.rb
@@ -1,7 +1,6 @@
 module Datadog
   module Contrib
     module Aws
-      SERVICE = 'aws'.freeze
       AGENT = 'aws-sdk-ruby'.freeze
       RESOURCE = 'aws.command'.freeze
 
@@ -9,6 +8,7 @@ module Datadog
       module Patcher
         include Base
         register_as :aws, auto_patch: true
+        option :service_name, default: 'aws'
 
         @patched = false
 
@@ -37,7 +37,7 @@ module Datadog
           private
 
           def add_pin
-            Pin.new(SERVICE, app_type: Ext::AppTypes::WEB).tap do |pin|
+            Pin.new(get_option(:service_name), app_type: Ext::AppTypes::WEB).tap do |pin|
               pin.onto(::Aws)
             end
           end

--- a/lib/ddtrace/contrib/dalli/patcher.rb
+++ b/lib/ddtrace/contrib/dalli/patcher.rb
@@ -2,7 +2,6 @@ module Datadog
   module Contrib
     module Dalli
       COMPATIBLE_WITH = Gem::Version.new('2.0.0')
-      SERVICE = 'memcached'.freeze
       NAME = 'memcached.command'.freeze
       CMD_TAG = 'memcached.command'.freeze
 
@@ -10,6 +9,7 @@ module Datadog
       module Patcher
         include Base
         register_as :dalli, auto_patch: true
+        option :service_name, default: 'memcached'
 
         @patched = false
 
@@ -42,7 +42,7 @@ module Datadog
           end
 
           def add_pin!
-            Pin.new(SERVICE, app_type: Ext::AppTypes::DB).tap do |pin|
+            Pin.new(get_option(:service_name), app_type: Ext::AppTypes::DB).tap do |pin|
               pin.onto(::Dalli)
             end
           end

--- a/lib/ddtrace/contrib/elasticsearch/patcher.rb
+++ b/lib/ddtrace/contrib/elasticsearch/patcher.rb
@@ -16,6 +16,7 @@ module Datadog
       module Patcher
         include Base
         register_as :elasticsearch, auto_patch: true
+        option :service_name, default: SERVICE
 
         @patched = false
 
@@ -45,6 +46,7 @@ module Datadog
 
         # rubocop:disable Metrics/MethodLength
         def patch_elasticsearch_transport_client
+          # rubocop:disable Metrics/BlockLength
           ::Elasticsearch::Transport::Client.class_eval do
             alias_method :initialize_without_datadog, :initialize
             Datadog::Monkey.without_warnings do
@@ -52,7 +54,8 @@ module Datadog
             end
 
             def initialize(*args)
-              pin = Datadog::Pin.new(SERVICE, app: 'elasticsearch', app_type: Datadog::Ext::AppTypes::DB)
+              service = Datadog.configuration[:elasticsearch][:service_name]
+              pin = Datadog::Pin.new(service, app: 'elasticsearch', app_type: Datadog::Ext::AppTypes::DB)
               pin.onto(self)
               initialize_without_datadog(*args)
             end

--- a/lib/ddtrace/contrib/faraday/patcher.rb
+++ b/lib/ddtrace/contrib/faraday/patcher.rb
@@ -8,6 +8,7 @@ module Datadog
       module Patcher
         include Base
         register_as :faraday, auto_patch: true
+        option :service_name, default: SERVICE
 
         @patched = false
 
@@ -42,6 +43,7 @@ module Datadog
           def add_pin
             Pin.new(SERVICE, app_type: Ext::AppTypes::WEB).tap do |pin|
               pin.onto(::Faraday)
+              pin.service = Datadog.configuration[:faraday][:service_name]
             end
           end
 

--- a/lib/ddtrace/contrib/grape/patcher.rb
+++ b/lib/ddtrace/contrib/grape/patcher.rb
@@ -8,6 +8,7 @@ module Datadog
       module Patcher
         include Base
         register_as :grape, auto_patch: true
+        option :service_name, default: SERVICE
 
         @patched = false
 
@@ -31,7 +32,8 @@ module Datadog
               patch_endpoint_render()
 
               # attach a PIN object globally and set the service once
-              pin = Datadog::Pin.new(SERVICE, app: 'grape', app_type: Datadog::Ext::AppTypes::WEB)
+              service = get_option(:service_name)
+              pin = Datadog::Pin.new(service, app: 'grape', app_type: Datadog::Ext::AppTypes::WEB)
               pin.onto(::Grape)
               if pin.tracer && pin.service
                 pin.tracer.set_service_info(pin.service, 'grape', pin.app_type)

--- a/lib/ddtrace/contrib/mongodb/patcher.rb
+++ b/lib/ddtrace/contrib/mongodb/patcher.rb
@@ -13,6 +13,7 @@ module Datadog
       module Patcher
         include Base
         register_as :mongo, auto_patch: true
+        option :service_name, default: SERVICE
 
         @patched = false
 
@@ -63,7 +64,8 @@ module Datadog
             def initialize(*args, &blk)
               # attach the Pin instance
               initialize_without_datadog(*args, &blk)
-              pin = Datadog::Pin.new(SERVICE, app: APP, app_type: Datadog::Ext::AppTypes::DB)
+              service = Datadog.configuration[:mongo][:service_name]
+              pin = Datadog::Pin.new(service, app: APP, app_type: Datadog::Ext::AppTypes::DB)
               pin.onto(self)
               if pin.tracer && pin.service
                 pin.tracer.set_service_info(pin.service, 'mongodb', pin.app_type)

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -17,12 +17,12 @@ module Datadog
         register_as :rack
 
         option :tracer, default: Datadog.tracer
-        option :default_service, default: 'rack'
+        option :service_name, default: 'rack'
         option :distributed_tracing_enabled, default: false
 
         def initialize(app, options = {})
           # update options with our configuration, unless it's already available
-          [:tracer, :default_service, :distributed_tracing_enabled].each do |k|
+          [:tracer, :service_name, :distributed_tracing_enabled].each do |k|
             Datadog.configuration[:rack][k] = options[k] unless options[k].nil?
           end
 
@@ -35,7 +35,7 @@ module Datadog
 
           # retrieve the current tracer and service
           @tracer = Datadog.configuration[:rack][:tracer]
-          @service = Datadog.configuration[:rack][:default_service]
+          @service = Datadog.configuration[:rack][:service_name]
           @distributed_tracing_enabled = Datadog.configuration[:rack][:distributed_tracing_enabled]
 
           # configure the Rack service

--- a/lib/ddtrace/contrib/rails/action_controller.rb
+++ b/lib/ddtrace/contrib/rails/action_controller.rb
@@ -14,7 +14,7 @@ module Datadog
         def self.start_processing(payload)
           # trace the execution
           tracer = Datadog.configuration[:rails][:tracer]
-          service = Datadog.configuration[:rails][:default_controller_service]
+          service = Datadog.configuration[:rails][:controller_service]
           type = Datadog::Ext::HTTP::TYPE
           span = tracer.trace('rails.action_controller', service: service, span_type: type)
 

--- a/lib/ddtrace/contrib/rails/active_record.rb
+++ b/lib/ddtrace/contrib/rails/active_record.rb
@@ -19,7 +19,7 @@ module Datadog
 
         def self.sql(_name, start, finish, _id, payload)
           tracer = Datadog.configuration[:rails][:tracer]
-          database_service = Datadog.configuration[:rails][:default_database_service]
+          database_service = Datadog.configuration[:rails][:database_service]
           adapter_name = ::ActiveRecord::Base.connection_config[:adapter]
           adapter_name = Datadog::Contrib::Rails::Utils.normalize_vendor(adapter_name)
           span_type = Datadog::Ext::SQL::TYPE

--- a/lib/ddtrace/contrib/rails/active_support.rb
+++ b/lib/ddtrace/contrib/rails/active_support.rb
@@ -26,7 +26,7 @@ module Datadog
                     payload[:action] == 'GET'
 
           # create a new ``Span`` and add it to the tracing context
-          service = Datadog.configuration[:rails][:default_cache_service]
+          service = Datadog.configuration[:rails][:cache_service]
           type = Datadog::Ext::CACHE::TYPE
           span = tracer.trace('rails.cache', service: service, span_type: type)
           span.resource = payload.fetch(:action)

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -129,7 +129,6 @@ module Datadog
           pin = Datadog::Pin.get_from(::Grape)
           return unless pin && pin.enabled?
           pin.tracer = Datadog.configuration[:rails][:tracer]
-          pin.service = Datadog.configuration[:rails][:default_grape_service]
         end
 
         # automatically instrument all Rails component

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -51,28 +51,28 @@ module Datadog
           tracer.set_tags('env' => Datadog.configuration[:rails][:env]) if Datadog.configuration[:rails][:env]
 
           tracer.set_service_info(
-            Datadog.configuration[:rails][:default_service],
+            Datadog.configuration[:rails][:service_name],
             'rack',
             Datadog::Ext::AppTypes::WEB
           )
 
           tracer.set_service_info(
-            Datadog.configuration[:rails][:default_controller_service],
+            Datadog.configuration[:rails][:controller_service],
             'rails',
             Datadog::Ext::AppTypes::WEB
           )
           tracer.set_service_info(
-            Datadog.configuration[:rails][:default_cache_service],
+            Datadog.configuration[:rails][:cache_service],
             'rails',
             Datadog::Ext::AppTypes::CACHE
           )
 
           # By default, default service would be guessed from the script
           # being executed, but here we know better, get it from Rails config.
-          tracer.default_service = Datadog.configuration[:rails][:default_service]
+          tracer.default_service = Datadog.configuration[:rails][:service_name]
 
           Datadog.configuration[:rack][:tracer] = tracer
-          Datadog.configuration[:rack][:default_service] = Datadog.configuration[:rails][:default_service]
+          Datadog.configuration[:rack][:service_name] = Datadog.configuration[:rails][:service_name]
           Datadog.configuration[:rack][:distributed_tracing_enabled] = \
             Datadog.configuration[:rails][:distributed_tracing_enabled]
 
@@ -81,9 +81,9 @@ module Datadog
               # set default database service details and store it in the configuration
               conn_cfg = ::ActiveRecord::Base.connection_config()
               adapter_name = Datadog::Contrib::Rails::Utils.normalize_vendor(conn_cfg[:adapter])
-              Datadog.configuration[:rails][:default_database_service] ||= adapter_name
+              Datadog.configuration[:rails][:database_service] ||= adapter_name
               tracer.set_service_info(
-                Datadog.configuration[:rails][:default_database_service],
+                Datadog.configuration[:rails][:database_service],
                 adapter_name,
                 Datadog::Ext::AppTypes::DB
               )

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -10,11 +10,11 @@ module Datadog
         option :auto_instrument, default: false
         option :auto_instrument_redis, default: false
         option :auto_instrument_grape, default: false
-        option :default_service, default: 'rails-app'
-        option :default_controller_service, default: 'rails-controller'
-        option :default_cache_service, default: 'rails-cache'
+        option :service_name, default: 'rails-app'
+        option :controller_service, default: 'rails-controller'
+        option :cache_service, default: 'rails-cache'
         option :default_grape_service, default: 'grape'
-        option :default_database_service
+        option :database_service
         option :distributed_tracing_enabled, default: false
         option :priority_sampling, default: false
         option :template_base_path, default: 'views/'

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -24,7 +24,6 @@ module Datadog
         option :trace_agent_port, default: Datadog::Writer::PORT
         option :env, default: nil
         option :tags, default: {}
-        option :sidekiq_service, default: 'sidekiq'
 
         @patched = false
 

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -7,9 +7,6 @@ module Datadog
         register_as :rails, auto_patch: true
 
         option :enabled, default: true
-        option :auto_instrument, default: false
-        option :auto_instrument_redis, default: false
-        option :auto_instrument_grape, default: false
         option :service_name, default: 'rails-app'
         option :controller_service, default: 'rails-controller'
         option :cache_service, default: 'rails-cache'

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -13,7 +13,6 @@ module Datadog
         option :service_name, default: 'rails-app'
         option :controller_service, default: 'rails-controller'
         option :cache_service, default: 'rails-cache'
-        option :default_grape_service, default: 'grape'
         option :database_service
         option :distributed_tracing_enabled, default: false
         option :priority_sampling, default: false

--- a/lib/ddtrace/contrib/rails/railtie.rb
+++ b/lib/ddtrace/contrib/rails/railtie.rb
@@ -10,9 +10,10 @@ module Datadog
 
     config.after_initialize do |app|
       Datadog::Contrib::Rails::Framework.configure(config: app.config)
-      Datadog::Contrib::Rails::Framework.auto_instrument
-      Datadog::Contrib::Rails::Framework.auto_instrument_redis
-      Datadog::Contrib::Rails::Framework.auto_instrument_grape
+      Datadog::Contrib::Rails::ActionController.instrument
+      Datadog::Contrib::Rails::ActionView.instrument
+      Datadog::Contrib::Rails::ActiveRecord.instrument
+      Datadog::Contrib::Rails::ActiveSupport.instrument
     end
   end
 end

--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -30,8 +30,8 @@ module Datadog
 
               patch_redis()
               patch_redis_client()
-
               @patched = true
+              RailsCachePatcher.reload_cache_store if Datadog.registry[:rails].patched?
             rescue StandardError => e
               Datadog::Tracer.log.error("Unable to apply Redis integration: #{e}")
             end

--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -11,6 +11,7 @@ module Datadog
       module Patcher
         include Base
         register_as :redis, auto_patch: true
+        option :service_name, default: SERVICE
 
         @patched = false
 
@@ -62,7 +63,8 @@ module Datadog
             end
 
             def initialize(*args)
-              pin = Datadog::Pin.new(SERVICE, app: 'redis', app_type: Datadog::Ext::AppTypes::DB)
+              service = Datadog.configuration[:redis][:service_name]
+              pin = Datadog::Pin.new(service, app: 'redis', app_type: Datadog::Ext::AppTypes::DB)
               pin.onto(self)
               if pin.tracer && pin.service
                 pin.tracer.set_service_info(pin.service, pin.app, pin.app_type)

--- a/lib/ddtrace/contrib/resque/patcher.rb
+++ b/lib/ddtrace/contrib/resque/patcher.rb
@@ -13,6 +13,7 @@ module Datadog
       module Patcher
         include Base
         register_as :resque, auto_patch: true
+        option :service_name, default: SERVICE
 
         @patched = false
 
@@ -36,7 +37,7 @@ module Datadog
           private
 
           def add_pin
-            Pin.new(SERVICE, app_type: Ext::AppTypes::WORKER).tap do |pin|
+            Pin.new(get_option(:service_name), app_type: Ext::AppTypes::WORKER).tap do |pin|
               pin.onto(::Resque)
             end
           end

--- a/lib/ddtrace/contrib/sidekiq/tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/tracer.rb
@@ -20,7 +20,7 @@ module Datadog
         register_as :sidekiq
 
         option :enabled, default: true
-        option :sidekiq_service, default: 'sidekiq'
+        option :service_name, default: 'sidekiq'
         option :tracer, default: Datadog.tracer
         option :debug, default: false
         option :trace_agent_hostname, default: Writer::HOSTNAME
@@ -29,10 +29,12 @@ module Datadog
         def initialize(options = {})
           # check if Rails configuration is available and use it to override
           # Sidekiq defaults
-          base_config = Datadog.configuration[:sidekiq].merge(Datadog.configuration[:rails])
+          rails_config = Datadog.configuration[:rails].to_h
+          rails_config.delete(:service_name)
+          base_config = Datadog.configuration[:sidekiq].merge(rails_config)
           user_config = base_config.merge(options)
           @tracer = user_config[:tracer]
-          @sidekiq_service = user_config[:sidekiq_service]
+          @sidekiq_service = user_config[:service_name]
 
           # set Tracer status
           @tracer.enabled = user_config[:enabled]
@@ -86,7 +88,7 @@ module Datadog
         end
 
         def sidekiq_service(resource)
-          worker_config(resource).fetch(:service, @sidekiq_service)
+          worker_config(resource).fetch(:service_name, @sidekiq_service)
         end
 
         def set_service_info(service)

--- a/lib/ddtrace/contrib/sucker_punch/patcher.rb
+++ b/lib/ddtrace/contrib/sucker_punch/patcher.rb
@@ -8,6 +8,7 @@ module Datadog
       module Patcher
         include Base
         register_as :sucker_punch, auto_patch: true
+        option :service_name, default: SERVICE
 
         @patched = false
 
@@ -41,7 +42,7 @@ module Datadog
         end
 
         def add_pin!
-          Pin.new(SERVICE, app_type: Ext::AppTypes::WORKER).tap do |pin|
+          Pin.new(get_option(:service_name), app_type: Ext::AppTypes::WORKER).tap do |pin|
             pin.onto(::SuckerPunch)
           end
         end

--- a/test/contrib/rack/helpers.rb
+++ b/test/contrib/rack/helpers.rb
@@ -92,7 +92,7 @@ class RackBaseTest < Minitest::Test
   def setup
     # configure our Middleware with a DummyTracer
     @tracer = get_test_tracer()
-    Datadog.configuration[:rack][:default_service] = 'rack'
+    Datadog.configuration[:rack][:service_name] = 'rack'
     super
   end
 end

--- a/test/contrib/rack/middleware_test.rb
+++ b/test/contrib/rack/middleware_test.rb
@@ -255,7 +255,7 @@ class CustomTracerTest < RackBaseTest
     service = 'custom-rack'
 
     Rack::Builder.new do
-      use Datadog::Contrib::Rack::TraceMiddleware, tracer: tracer, default_service: service
+      use Datadog::Contrib::Rack::TraceMiddleware, tracer: tracer, service_name: service
 
       map '/' do
         run(proc { |_env| [200, { 'Content-Type' => 'text/html' }, 'OK'] })
@@ -292,7 +292,7 @@ class RackBaseTest < Minitest::Test
     middleware = Datadog::Contrib::Rack::TraceMiddleware.new(proc {})
     refute_nil(middleware)
     assert_equal(Datadog.tracer, Datadog.configuration[:rack][:tracer])
-    assert_equal('rack', Datadog.configuration[:rack][:default_service])
+    assert_equal('rack', Datadog.configuration[:rack][:service_name])
 
     Datadog.configuration.use(:rack, previous_configuration)
   end
@@ -302,10 +302,10 @@ class RackBaseTest < Minitest::Test
     previous_configuration = Datadog.registry[:rack].to_h
 
     tracer = get_test_tracer()
-    middleware = Datadog::Contrib::Rack::TraceMiddleware.new(proc {}, tracer: tracer, default_service: 'custom-rack')
+    middleware = Datadog::Contrib::Rack::TraceMiddleware.new(proc {}, tracer: tracer, service_name: 'custom-rack')
     refute_nil(middleware)
     assert_equal(tracer, Datadog.configuration[:rack][:tracer])
-    assert_equal('custom-rack', Datadog.configuration[:rack][:default_service])
+    assert_equal('custom-rack', Datadog.configuration[:rack][:service_name])
 
     Datadog.configuration.use(:rack, previous_configuration)
   end

--- a/test/contrib/rails/apps/application.rb
+++ b/test/contrib/rails/apps/application.rb
@@ -42,7 +42,8 @@ module RailsTrace
     def test_config
       # Enables the auto-instrumentation for the testing application
       Datadog.configure do |c|
-        c.use :rails, auto_instrument: true, auto_instrument_redis: true
+        c.use :rails
+        c.use :redis
       end
       Rails.application.config.active_job.queue_adapter = :sidekiq
 

--- a/test/contrib/rails/apps/rails3.rb
+++ b/test/contrib/rails/apps/rails3.rb
@@ -17,7 +17,8 @@ end
 
 # Enables the auto-instrumentation for the testing application
 Datadog.configure do |c|
-  c.use :rails, auto_instrument: true, auto_instrument_redis: true
+  c.use :rails
+  c.use :redis
 end
 
 # Initialize the Rails application

--- a/test/contrib/rails/cache_test.rb
+++ b/test/contrib/rails/cache_test.rb
@@ -5,7 +5,7 @@ class CacheTracingTest < ActionController::TestCase
   setup do
     @original_tracer = Datadog.configuration[:rails][:tracer]
     @tracer = get_test_tracer
-    Datadog.configuration[:rails][:default_cache_service] = 'rails-cache'
+    Datadog.configuration[:rails][:cache_service] = 'rails-cache'
     Datadog.configuration[:rails][:tracer] = @tracer
   end
 
@@ -81,7 +81,7 @@ class CacheTracingTest < ActionController::TestCase
 
   test 'doing a cache call uses the proper service name if it is changed' do
     # update database configuration
-    update_config(:default_cache_service, 'service-cache')
+    update_config(:cache_service, 'service-cache')
 
     # make the cache write and assert the proper spans
     Rails.cache.write('custom-key', 50)

--- a/test/contrib/rails/database_test.rb
+++ b/test/contrib/rails/database_test.rb
@@ -5,7 +5,7 @@ class DatabaseTracingTest < ActiveSupport::TestCase
   setup do
     @original_tracer = Datadog.configuration[:rails][:tracer]
     @tracer = get_test_tracer
-    Datadog.configuration[:rails][:default_database_service] = get_adapter_name
+    Datadog.configuration[:rails][:database_service] = get_adapter_name
     Datadog.configuration[:rails][:tracer] = @tracer
   end
 
@@ -33,7 +33,7 @@ class DatabaseTracingTest < ActiveSupport::TestCase
 
   test 'doing a database call uses the proper service name if it is changed' do
     # update database configuration
-    update_config(:default_database_service, 'customer-db')
+    update_config(:database_service, 'customer-db')
 
     # make the query and assert the proper spans
     Article.count

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -13,7 +13,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     # and the Rack stack
     @tracer = get_test_tracer
     Datadog.registry[:rails].reset_options!
-    Datadog.configuration[:rails][:default_database_service] = get_adapter_name
+    Datadog.configuration[:rails][:database_service] = get_adapter_name
     Datadog.configuration[:rails][:tracer] = @tracer
     Datadog.configuration[:rack][:tracer] = @tracer
   end

--- a/test/contrib/rails/rails_sidekiq_test.rb
+++ b/test/contrib/rails/rails_sidekiq_test.rb
@@ -39,7 +39,6 @@ class RailsSidekiqTest < ActionController::TestCase
   test 'Sidekiq middleware uses Rails configuration if available' do
     # configure Rails
     update_config(:enabled, false)
-    update_config(:sidekiq_service, 'rails-sidekiq')
     update_config(:debug, true)
     update_config(:trace_agent_hostname, 'agent1.example.com')
     update_config(:trace_agent_port, '7777')
@@ -47,7 +46,7 @@ class RailsSidekiqTest < ActionController::TestCase
 
     # add Sidekiq middleware
     Sidekiq::Testing.server_middleware do |chain|
-      chain.add(Datadog::Contrib::Sidekiq::Tracer, tracer: @tracer)
+      chain.add(Datadog::Contrib::Sidekiq::Tracer, tracer: @tracer, service_name: 'rails-sidekiq')
     end
 
     # do something to force middleware execution

--- a/test/contrib/rails/redis_cache_test.rb
+++ b/test/contrib/rails/redis_cache_test.rb
@@ -15,6 +15,7 @@ class RedisCacheTracingTest < ActionController::TestCase
     @original_tracer = Datadog.configuration[:rails][:tracer]
     @tracer = get_test_tracer()
     Datadog.configuration[:rails][:tracer] = @tracer
+    Datadog.configuration.use(:redis)
 
     # get the Redis pin accessing private methods (only Rails 3.x)
     client = Rails.cache.instance_variable_get(:@data)

--- a/test/contrib/rails/tracer_test.rb
+++ b/test/contrib/rails/tracer_test.rb
@@ -18,8 +18,6 @@ class TracerTest < ActionDispatch::IntegrationTest
 
   test 'the configuration is correctly called' do
     assert Datadog.configuration[:rails][:enabled]
-    refute Datadog.configuration[:rails][:auto_instrument]
-    refute Datadog.configuration[:rails][:auto_instrument_redis]
     assert_equal(Datadog.configuration[:rails][:service_name], 'rails-app')
     assert_equal(Datadog.configuration[:rails][:controller_service], 'rails-controller')
     assert_equal(Datadog.configuration[:rails][:cache_service], 'rails-cache')

--- a/test/contrib/rails/tracer_test.rb
+++ b/test/contrib/rails/tracer_test.rb
@@ -8,7 +8,7 @@ class TracerTest < ActionDispatch::IntegrationTest
     # don't pollute the global tracer
     @tracer = get_test_tracer
     Datadog.registry[:rails].reset_options!
-    Datadog.configuration[:rails][:default_database_service] = get_adapter_name
+    Datadog.configuration[:rails][:database_service] = get_adapter_name
     Datadog.configuration[:rails][:tracer] = @tracer
   end
 
@@ -20,10 +20,10 @@ class TracerTest < ActionDispatch::IntegrationTest
     assert Datadog.configuration[:rails][:enabled]
     refute Datadog.configuration[:rails][:auto_instrument]
     refute Datadog.configuration[:rails][:auto_instrument_redis]
-    assert_equal(Datadog.configuration[:rails][:default_service], 'rails-app')
-    assert_equal(Datadog.configuration[:rails][:default_controller_service], 'rails-controller')
-    assert_equal(Datadog.configuration[:rails][:default_cache_service], 'rails-cache')
-    refute_nil(Datadog.configuration[:rails][:default_database_service])
+    assert_equal(Datadog.configuration[:rails][:service_name], 'rails-app')
+    assert_equal(Datadog.configuration[:rails][:controller_service], 'rails-controller')
+    assert_equal(Datadog.configuration[:rails][:cache_service], 'rails-cache')
+    refute_nil(Datadog.configuration[:rails][:database_service])
     assert_equal(Datadog.configuration[:rails][:template_base_path], 'views/')
     assert Datadog.configuration[:rails][:tracer]
     assert !Datadog.configuration[:rails][:debug]
@@ -34,7 +34,7 @@ class TracerTest < ActionDispatch::IntegrationTest
   end
 
   test 'a default service and database should be properly set' do
-    update_config(:default_cache_service, 'rails-cache')
+    update_config(:cache_service, 'rails-cache')
     reset_config()
     services = Datadog.configuration[:rails][:tracer].services
     adapter_name = get_adapter_name()
@@ -56,7 +56,7 @@ class TracerTest < ActionDispatch::IntegrationTest
   end
 
   test 'database service can be changed by user' do
-    update_config(:default_database_service, 'customer-db')
+    update_config(:database_service, 'customer-db')
     tracer = Datadog.configuration[:rails][:tracer]
     adapter_name = get_adapter_name()
 
@@ -78,7 +78,7 @@ class TracerTest < ActionDispatch::IntegrationTest
   end
 
   test 'application service can be changed by user' do
-    update_config(:default_controller_service, 'my-custom-app')
+    update_config(:controller_service, 'my-custom-app')
     tracer = Datadog.configuration[:rails][:tracer]
     adapter_name = get_adapter_name()
 
@@ -100,7 +100,7 @@ class TracerTest < ActionDispatch::IntegrationTest
   end
 
   test 'cache service can be changed by user' do
-    update_config(:default_cache_service, 'service-cache')
+    update_config(:cache_service, 'service-cache')
     tracer = Datadog.configuration[:rails][:tracer]
     adapter_name = get_adapter_name()
 

--- a/test/contrib/sidekiq/tracer_configure_test.rb
+++ b/test/contrib/sidekiq/tracer_configure_test.rb
@@ -33,7 +33,7 @@ class TracerTest < TracerTestBase
         Datadog::Contrib::Sidekiq::Tracer,
         tracer: @tracer,
         enabled: false,
-        sidekiq_service: 'my-sidekiq',
+        service_name: 'my-sidekiq',
         debug: true,
         trace_agent_hostname: 'trace.example.com',
         trace_agent_port: '7777'

--- a/test/contrib/sidekiq/tracer_test.rb
+++ b/test/contrib/sidekiq/tracer_test.rb
@@ -22,7 +22,7 @@ class TracerTest < TracerTestBase
     include Sidekiq::Worker
 
     def self.datadog_tracer_config
-      { service: 'sidekiq-slow' }
+      { service_name: 'sidekiq-slow' }
     end
 
     def perform(); end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -211,7 +211,8 @@ end
 # with the global one
 def reset_config
   Datadog.configure do |c|
-    c.use :rails, auto_instrument: true, auto_instrument_redis: true
+    c.use :rails
+    c.use :redis
   end
 
   config = { config: ::Rails.application.config }


### PR DESCRIPTION
This PR removes `auto_instrument` options from `rails` since they're no longer needed.

### New API

```rb
Datadog.configure do |c|
  c.use :rails
  c.use :redis
  c.use :grape
end
```

### Old API

```rb
Rails.configuration.datadog_trace = {
  auto_instrument: true,
  auto_instrument_redis: true,
  auto_instrument_grape: true
}
```