### PR TITLE
Ensure all setters are triggered when calling `Configuration#use`

### DIFF
--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -17,9 +17,10 @@ module Datadog
 
     def use(integration_name, options = {})
       integration = fetch_integration(integration_name)
+      settings = Proxy.new(integration)
 
       integration.sorted_options.each do |name|
-        integration.set_option(name, options[name]) if options.key?(name)
+        settings[name] = options.fetch(name, settings[name])
       end
 
       integration.patch if integration.respond_to?(:patch)

--- a/lib/ddtrace/contrib/sinatra/tracer.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer.rb
@@ -34,7 +34,7 @@ module Datadog
 
         option :tracer, default: Datadog.tracer
 
-        option(:debug, default: false) { |value| Tracer.debug_logging = value }
+        option(:debug, default: false) { |value| Datadog::Tracer.debug_logging = value }
 
         option :trace_agent_hostname, default: Writer::HOSTNAME, depends_on: [:tracer] do |value|
           get_option(:tracer).configure(hostname: value)

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -88,5 +88,25 @@ module Datadog
       assert_equal(5, @configuration[:example][:number])
       assert_equal(25, @configuration[:example][:multiply_by])
     end
+
+    def test_default_also_passes_through_setter
+      array = []
+
+      integration = Module.new do
+        include Contrib::Base
+        option :option1
+        option :option2, default: 10 do |value|
+          array << value
+          value
+        end
+      end
+
+      @registry.add(:example, integration)
+      @configuration.use(:example, option1: :foo!)
+
+      assert_equal(:foo!, @configuration[:example][:option1])
+      assert_equal(10, @configuration[:example][:option2])
+      assert_includes(array, 10)
+    end
   end
 end


### PR DESCRIPTION
This PR ensures that custom option setters are triggered even for default values. For more information about custom option setters, see https://github.com/DataDog/dd-trace-rb/pull/203