### PR TITLE
[sinatra] change the name with service_name instead of default_service

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -142,7 +142,7 @@ either ``sinatra`` or ``sinatra/base``:
     require 'ddtrace/contrib/sinatra/tracer'
 
     Datadog.configure do |c|
-      c.use :sinatra, default_service: 'my-app'
+      c.use :sinatra, service_name: 'my-app'
     end
 
     get '/' do
@@ -157,7 +157,7 @@ Available settings are:
 
 * ``enabled``: define if the ``tracer`` is enabled or not. If set to ``false``, the code is still instrumented
   but no spans are sent to the local trace agent.
-* ``default_service``: set the service name used when tracing application requests. Defaults to ``sinatra``
+* ``service_name``: set the service name used when tracing application requests. Defaults to ``sinatra``
 * ``tracer``: set the tracer to use. Usually you don't need to change that value
   unless you're already using a different initialized tracer somewhere else
 * ``debug``: set to ``true`` to enable debug logging.

--- a/lib/ddtrace/contrib/sinatra/tracer.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer.rb
@@ -27,7 +27,7 @@ module Datadog
           get_option(:tracer).enabled = value
         end
 
-        option :default_service, default: 'sinatra', depends_on: [:tracer] do |value|
+        option :service_name, default: 'sinatra', depends_on: [:tracer] do |value|
           get_option(:tracer).set_service_info(value, 'sinatra', Ext::AppTypes::WEB)
           value
         end
@@ -90,7 +90,7 @@ module Datadog
             tracer = Datadog.configuration[:sinatra][:tracer]
 
             span = tracer.trace('sinatra.request',
-                                service: Datadog.configuration[:sinatra][:default_service],
+                                service: Datadog.configuration[:sinatra][:service_name],
                                 span_type: Datadog::Ext::HTTP::TYPE)
             span.set_tag(Datadog::Ext::HTTP::URL, request.path)
             span.set_tag(Datadog::Ext::HTTP::METHOD, request.request_method)


### PR DESCRIPTION
### Overview

We're introducing a breaking change, and so we should change the option value too. In that we we're consistent with the future configuration common to all integrations.

To change the service name we should use `service_name` option instead of the old `default_service`.