### PR TITLE
Provide tracer configuration

### DIFF
--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -26,6 +26,15 @@ module Datadog
       integration.patch if integration.respond_to?(:patch)
     end
 
+    def tracer(options = {})
+      instance = options.fetch(:instance, Datadog.tracer)
+
+      instance.configure(options)
+      instance.set_tags(options[:tags]) if options[:tags]
+      instance.set_tags(env: options[:env]) if options[:env]
+      instance.class.debug_logging = options.fetch(:debug, false)
+    end
+
     private
 
     def fetch_integration(name)

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -38,18 +38,6 @@ module Datadog
           Datadog.configuration.use(:rails, user_config)
           tracer = Datadog.configuration[:rails][:tracer]
 
-          tracer.enabled = Datadog.configuration[:rails][:enabled]
-          tracer.class.debug_logging = Datadog.configuration[:rails][:debug]
-
-          tracer.configure(
-            hostname: Datadog.configuration[:rails][:trace_agent_hostname],
-            port: Datadog.configuration[:rails][:trace_agent_port],
-            priority_sampling: Datadog.configuration[:rails][:priority_sampling]
-          )
-
-          tracer.set_tags(Datadog.configuration[:rails][:tags])
-          tracer.set_tags('env' => Datadog.configuration[:rails][:env]) if Datadog.configuration[:rails][:env]
-
           tracer.set_service_info(
             Datadog.configuration[:rails][:service_name],
             'rack',

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -12,14 +12,8 @@ module Datadog
         option :cache_service, default: 'rails-cache'
         option :database_service
         option :distributed_tracing_enabled, default: false
-        option :priority_sampling, default: false
         option :template_base_path, default: 'views/'
         option :tracer, default: Datadog.tracer
-        option :debug, default: false
-        option :trace_agent_hostname, default: Datadog::Writer::HOSTNAME
-        option :trace_agent_port, default: Datadog::Writer::PORT
-        option :env, default: nil
-        option :tags, default: {}
 
         @patched = false
 

--- a/lib/ddtrace/contrib/sidekiq/tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/tracer.rb
@@ -18,33 +18,13 @@ module Datadog
       class Tracer
         include Base
         register_as :sidekiq
-
-        option :enabled, default: true
         option :service_name, default: 'sidekiq'
         option :tracer, default: Datadog.tracer
-        option :debug, default: false
-        option :trace_agent_hostname, default: Writer::HOSTNAME
-        option :trace_agent_port, default: Writer::PORT
 
         def initialize(options = {})
-          # check if Rails configuration is available and use it to override
-          # Sidekiq defaults
-          rails_config = Datadog.configuration[:rails].to_h
-          rails_config.delete(:service_name)
-          base_config = Datadog.configuration[:sidekiq].merge(rails_config)
-          user_config = base_config.merge(options)
-          @tracer = user_config[:tracer]
-          @sidekiq_service = user_config[:service_name]
-
-          # set Tracer status
-          @tracer.enabled = user_config[:enabled]
-          Datadog::Tracer.debug_logging = user_config[:debug]
-
-          # configure the Tracer instance
-          @tracer.configure(
-            hostname: user_config[:trace_agent_hostname],
-            port: user_config[:trace_agent_port]
-          )
+          config = Datadog.configuration[:sidekiq].merge(options)
+          @tracer = config[:tracer]
+          @sidekiq_service = config[:service_name]
         end
 
         def call(worker, job, queue)

--- a/lib/ddtrace/contrib/sinatra/tracer.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer.rb
@@ -23,26 +23,12 @@ module Datadog
         include Base
         register_as :sinatra
 
-        option :enabled, default: true, depends_on: [:tracer] do |value|
-          get_option(:tracer).enabled = value
-        end
-
         option :service_name, default: 'sinatra', depends_on: [:tracer] do |value|
           get_option(:tracer).set_service_info(value, 'sinatra', Ext::AppTypes::WEB)
           value
         end
 
         option :tracer, default: Datadog.tracer
-
-        option(:debug, default: false) { |value| Datadog::Tracer.debug_logging = value }
-
-        option :trace_agent_hostname, default: Writer::HOSTNAME, depends_on: [:tracer] do |value|
-          get_option(:tracer).configure(hostname: value)
-        end
-
-        option :trace_agent_port, default: Writer::PORT, depends_on: [:tracer] do |value|
-          get_option(:tracer).configure(port: value)
-        end
 
         def route(verb, action, *)
           # Keep track of the route name when the app is instantiated for an

--- a/test/contrib/rails/rails_sidekiq_test.rb
+++ b/test/contrib/rails/rails_sidekiq_test.rb
@@ -37,11 +37,8 @@ class RailsSidekiqTest < ActionController::TestCase
   end
 
   test 'Sidekiq middleware uses Rails configuration if available' do
-    # configure Rails
-    update_config(:enabled, false)
-    update_config(:debug, true)
-    update_config(:trace_agent_hostname, 'agent1.example.com')
-    update_config(:trace_agent_port, '7777')
+    @tracer.configure(enabled: false, debug: true, host: 'tracer.example.com', port: 7777)
+    Datadog::Contrib::Rails::Framework.configure({})
     db_adapter = get_adapter_name()
 
     # add Sidekiq middleware
@@ -52,7 +49,6 @@ class RailsSidekiqTest < ActionController::TestCase
     # do something to force middleware execution
     EmptyWorker.perform_async()
 
-    assert_equal(false, @tracer.enabled)
     assert_equal(
       @tracer.services,
       'rails-app' => {
@@ -71,8 +67,5 @@ class RailsSidekiqTest < ActionController::TestCase
         'app' => 'sidekiq', 'app_type' => 'worker'
       }
     )
-    assert_equal(true, Datadog::Tracer.debug_logging)
-    assert_equal('agent1.example.com', @tracer.writer.transport.hostname)
-    assert_equal('7777', @tracer.writer.transport.port)
   end
 end

--- a/test/contrib/rails/tracer_test.rb
+++ b/test/contrib/rails/tracer_test.rb
@@ -2,7 +2,6 @@ require 'helper'
 
 require 'contrib/rails/test_helper'
 
-# rubocop:disable Metrics/ClassLength
 class TracerTest < ActionDispatch::IntegrationTest
   setup do
     # don't pollute the global tracer
@@ -24,11 +23,6 @@ class TracerTest < ActionDispatch::IntegrationTest
     refute_nil(Datadog.configuration[:rails][:database_service])
     assert_equal(Datadog.configuration[:rails][:template_base_path], 'views/')
     assert Datadog.configuration[:rails][:tracer]
-    assert !Datadog.configuration[:rails][:debug]
-    assert_equal(Datadog.configuration[:rails][:trace_agent_hostname], Datadog::Writer::HOSTNAME)
-    assert_equal(Datadog.configuration[:rails][:trace_agent_port], Datadog::Writer::PORT)
-    assert_nil(Datadog.configuration[:rails][:env], 'no env should be set by default')
-    assert_equal(Datadog.configuration[:rails][:tags], {}, 'no tags should be set by default')
   end
 
   test 'a default service and database should be properly set' do
@@ -117,62 +111,5 @@ class TracerTest < ActionDispatch::IntegrationTest
         'app' => 'rails', 'app_type' => 'cache'
       }
     )
-  end
-
-  test 'debug logging can be changed by the user' do
-    update_config(:debug, true)
-
-    assert_equal(Datadog::Tracer.debug_logging, true)
-  end
-
-  test 'tracer agent address can be changed by the user' do
-    update_config(:trace_agent_hostname, 'example.com')
-    update_config(:trace_agent_port, 42)
-
-    tracer = Datadog.configuration[:rails][:tracer]
-
-    assert_equal(tracer.writer.transport.hostname, 'example.com')
-    assert_equal(tracer.writer.transport.port, 42)
-  end
-
-  test 'tracer environment can be changed by the user' do
-    update_config(:env, 'dev')
-
-    tracer = Datadog.configuration[:rails][:tracer]
-
-    assert_equal(tracer.tags['env'], 'dev')
-  end
-
-  test 'tracer global tags can be changed by the user' do
-    update_config(:tags, 'component' => 'api', 'section' => 'users')
-
-    tracer = Datadog.configuration[:rails][:tracer]
-
-    assert_equal(tracer.tags['component'], 'api')
-    assert_equal(tracer.tags['section'], 'users')
-  end
-
-  test 'tracer env and env tag setting precedence' do
-    # default case
-    tracer = Datadog.configuration[:rails][:tracer]
-    assert_nil(tracer.tags['env'])
-
-    # use the Rails value
-    update_config(:env, ::Rails.env)
-    update_config(:tags, 'env' => 'foo')
-    tracer = Datadog.configuration[:rails][:tracer]
-    assert_equal(tracer.tags['env'], 'test')
-
-    # explicit set
-    update_config(:env, 'dev')
-    update_config(:tags, 'env' => 'bar')
-    tracer = Datadog.configuration[:rails][:tracer]
-    assert_equal(tracer.tags['env'], 'dev')
-
-    # env is not valid but tags is set
-    update_config(:env, nil)
-    update_config(:tags, 'env' => 'bar')
-    tracer = Datadog.configuration[:rails][:tracer]
-    assert_equal(tracer.tags['env'], 'bar')
   end
 end

--- a/test/contrib/sidekiq/disabled_tracer_test.rb
+++ b/test/contrib/sidekiq/disabled_tracer_test.rb
@@ -12,8 +12,8 @@ class DisabledTracerTest < TracerTestBase
     super
 
     Sidekiq::Testing.server_middleware do |chain|
-      chain.add(Datadog::Contrib::Sidekiq::Tracer,
-                tracer: @tracer, enabled: false)
+      @tracer.configure(enabled: false)
+      chain.add(Datadog::Contrib::Sidekiq::Tracer, tracer: @tracer)
     end
   end
 

--- a/test/contrib/sidekiq/tracer_configure_test.rb
+++ b/test/contrib/sidekiq/tracer_configure_test.rb
@@ -14,42 +14,31 @@ class TracerTest < TracerTestBase
     end
     EmptyWorker.perform_async()
 
-    assert_equal(true, @tracer.enabled)
     assert_equal(
       @writer.services,
       'sidekiq' => {
         'app' => 'sidekiq', 'app_type' => 'worker'
       }
     )
-    assert_equal(false, Datadog::Tracer.debug_logging)
-    assert_equal('localhost', @tracer.writer.transport.hostname)
-    assert_equal('8126', @tracer.writer.transport.port)
   end
 
   def test_configuration_custom
     # it should configure the tracer with users' settings
+    @tracer.configure(enabled: false)
     Sidekiq::Testing.server_middleware do |chain|
       chain.add(
         Datadog::Contrib::Sidekiq::Tracer,
         tracer: @tracer,
-        enabled: false,
-        service_name: 'my-sidekiq',
-        debug: true,
-        trace_agent_hostname: 'trace.example.com',
-        trace_agent_port: '7777'
+        service_name: 'my-sidekiq'
       )
     end
     EmptyWorker.perform_async()
 
-    assert_equal(false, @tracer.enabled)
     assert_equal(
       @tracer.services,
       'my-sidekiq' => {
         'app' => 'sidekiq', 'app_type' => 'worker'
       }
     )
-    assert_equal(true, Datadog::Tracer.debug_logging)
-    assert_equal('trace.example.com', @tracer.writer.transport.hostname)
-    assert_equal('7777', @tracer.writer.transport.port)
   end
 end

--- a/test/contrib/sinatra/tracer_activerecord_test.rb
+++ b/test/contrib/sinatra/tracer_activerecord_test.rb
@@ -21,7 +21,7 @@ class TracerActiveRecordTest < TracerTestBase
     app().set :datadog_test_writer, @writer
 
     tracer = Datadog::Tracer.new(writer: @writer)
-    Datadog.configuration.use(:sinatra, tracer: tracer, enabled: true)
+    Datadog.configuration.use(:sinatra, tracer: tracer)
 
     conn = ActiveRecord::Base.establish_connection(adapter: 'sqlite3',
                                                    database: ':memory:')

--- a/test/contrib/sinatra/tracer_disabled_test.rb
+++ b/test/contrib/sinatra/tracer_disabled_test.rb
@@ -16,8 +16,8 @@ class DisabledTracerTest < ::TracerTestBase
     @writer = FauxWriter.new()
     app().set :datadog_test_writer, @writer
 
-    tracer = Datadog::Tracer.new(writer: @writer)
-    Datadog.configuration.use(:sinatra, tracer: tracer, enabled: false)
+    tracer = Datadog::Tracer.new(writer: @writer, enabled: false)
+    Datadog.configuration.use(:sinatra, tracer: tracer)
 
     super
   end

--- a/test/contrib/sinatra/tracer_test.rb
+++ b/test/contrib/sinatra/tracer_test.rb
@@ -40,8 +40,8 @@ class TracerTest < TracerTestBase
     @writer = FauxWriter.new()
     app().set :datadog_test_writer, @writer
 
-    tracer = Datadog::Tracer.new(writer: @writer)
-    Datadog.configuration.use(:sinatra, tracer: tracer, enabled: true)
+    tracer = Datadog::Tracer.new(writer: @writer, enabled: true)
+    Datadog.configuration.use(:sinatra, tracer: tracer)
 
     super
   end


### PR DESCRIPTION
This PR let's `Datadog.tracer` be configured through `Datadog.configure` block. Options originally associated to the tracer domain (`hostname`, `port`, `debug` etc.) are no longer part of the contributions. The example below summarizes the changes:

```rb
Rails.initializer.datadog_tracer = {
  enabled: true,
  debug: true,
  trace_agent_hostname: 'localhost',
  trace_agent_port: 7777
}
```

Should now be replaced by:

```rb
Datadog.configure do |c|
  c.tracer enabled: true, debug: true, hostname: 'localhost', port: 7777
  c.use :rails
end
```
