### PR TITLE
Merge rack and rails services

### DIFF
--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -17,7 +17,10 @@ module Datadog
         register_as :rack
 
         option :tracer, default: Datadog.tracer
-        option :service_name, default: 'rack'
+        option :service_name, default: 'rack', depends_on: [:tracer] do |value|
+          get_option(:tracer).set_service_info(value, 'rack', Ext::AppTypes::WEB)
+          value
+        end
         option :distributed_tracing_enabled, default: false
 
         def initialize(app, options = {})
@@ -39,11 +42,6 @@ module Datadog
           @distributed_tracing_enabled = Datadog.configuration[:rack][:distributed_tracing_enabled]
 
           # configure the Rack service
-          @tracer.set_service_info(
-            @service,
-            'rack',
-            Datadog::Ext::AppTypes::WEB
-          )
         end
 
         # rubocop:disable Metrics/MethodLength

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -6,9 +6,8 @@ module Datadog
         include Base
         register_as :rails, auto_patch: true
 
-        option :enabled, default: true
         option :service_name, default: 'rails-app'
-        option :controller_service, default: 'rails-controller'
+        option :controller_service
         option :cache_service, default: 'rails-cache'
         option :database_service
         option :distributed_tracing_enabled, default: false

--- a/test/contrib/rails/rails_sidekiq_test.rb
+++ b/test/contrib/rails/rails_sidekiq_test.rb
@@ -52,9 +52,6 @@ class RailsSidekiqTest < ActionController::TestCase
     assert_equal(
       @tracer.services,
       'rails-app' => {
-        'app' => 'rack', 'app_type' => 'web'
-      },
-      'rails-controller' => {
         'app' => 'rails', 'app_type' => 'web'
       },
       db_adapter => {

--- a/test/contrib/rails/tracer_test.rb
+++ b/test/contrib/rails/tracer_test.rb
@@ -16,9 +16,8 @@ class TracerTest < ActionDispatch::IntegrationTest
   end
 
   test 'the configuration is correctly called' do
-    assert Datadog.configuration[:rails][:enabled]
     assert_equal(Datadog.configuration[:rails][:service_name], 'rails-app')
-    assert_equal(Datadog.configuration[:rails][:controller_service], 'rails-controller')
+    assert_nil(Datadog.configuration[:rails][:controller_service])
     assert_equal(Datadog.configuration[:rails][:cache_service], 'rails-cache')
     refute_nil(Datadog.configuration[:rails][:database_service])
     assert_equal(Datadog.configuration[:rails][:template_base_path], 'views/')
@@ -31,19 +30,18 @@ class TracerTest < ActionDispatch::IntegrationTest
     services = Datadog.configuration[:rails][:tracer].services
     adapter_name = get_adapter_name()
     assert_equal(
-      services,
-      'rails-app' => {
-        'app' => 'rack', 'app_type' => 'web'
+      {
+        'rails-app' => {
+          'app' => 'rails', 'app_type' => 'web'
+        },
+        adapter_name => {
+          'app' => adapter_name, 'app_type' => 'db'
+        },
+        'rails-cache' => {
+          'app' => 'rails', 'app_type' => 'cache'
+        }
       },
-      'rails-controller' => {
-        'app' => 'rails', 'app_type' => 'web'
-      },
-      adapter_name => {
-        'app' => adapter_name, 'app_type' => 'db'
-      },
-      'rails-cache' => {
-        'app' => 'rails', 'app_type' => 'cache'
-      }
+      services
     )
   end
 
@@ -53,41 +51,42 @@ class TracerTest < ActionDispatch::IntegrationTest
     adapter_name = get_adapter_name()
 
     assert_equal(
-      tracer.services,
-      'rails-app' => {
-        'app' => 'rack', 'app_type' => 'web'
+      {
+        'rails-app' => {
+          'app' => 'rails', 'app_type' => 'web'
+        },
+        'customer-db' => {
+          'app' => adapter_name, 'app_type' => 'db'
+        },
+        'rails-cache' => {
+          'app' => 'rails', 'app_type' => 'cache'
+        }
       },
-      'rails-controller' => {
-        'app' => 'rails', 'app_type' => 'web'
-      },
-      'customer-db' => {
-        'app' => adapter_name, 'app_type' => 'db'
-      },
-      'rails-cache' => {
-        'app' => 'rails', 'app_type' => 'cache'
-      }
+      tracer.services
     )
   end
 
   test 'application service can be changed by user' do
-    update_config(:controller_service, 'my-custom-app')
     tracer = Datadog.configuration[:rails][:tracer]
+    update_config(:controller_service, 'my-custom-app')
     adapter_name = get_adapter_name()
 
     assert_equal(
-      tracer.services,
-      'rails-app' => {
-        'app' => 'rack', 'app_type' => 'web'
+      {
+        'rails-app' => {
+          'app' => 'rack', 'app_type' => 'web'
+        },
+        'my-custom-app' => {
+          'app' => 'rails', 'app_type' => 'web'
+        },
+        adapter_name => {
+          'app' => adapter_name, 'app_type' => 'db'
+        },
+        'rails-cache' => {
+          'app' => 'rails', 'app_type' => 'cache'
+        }
       },
-      'my-custom-app' => {
-        'app' => 'rails', 'app_type' => 'web'
-      },
-      adapter_name => {
-        'app' => adapter_name, 'app_type' => 'db'
-      },
-      'rails-cache' => {
-        'app' => 'rails', 'app_type' => 'cache'
-      }
+      tracer.services
     )
   end
 
@@ -97,19 +96,18 @@ class TracerTest < ActionDispatch::IntegrationTest
     adapter_name = get_adapter_name()
 
     assert_equal(
-      tracer.services,
-      'rails-app' => {
-        'app' => 'rack', 'app_type' => 'web'
+      {
+        'rails-app' => {
+          'app' => 'rails', 'app_type' => 'web'
+        },
+        adapter_name => {
+          'app' => adapter_name, 'app_type' => 'db'
+        },
+        'service-cache' => {
+          'app' => 'rails', 'app_type' => 'cache'
+        }
       },
-      'rails-controller' => {
-        'app' => 'rails', 'app_type' => 'web'
-      },
-      adapter_name => {
-        'app' => adapter_name, 'app_type' => 'db'
-      },
-      'service-cache' => {
-        'app' => 'rails', 'app_type' => 'cache'
-      }
+      tracer.services
     )
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -202,9 +202,7 @@ end
 # * +value+: the value of the key
 def update_config(key, value)
   Datadog.configuration[:rails][key] = value
-  ::Rails.configuration.datadog_trace.merge!(Datadog.registry[:rails].to_h)
-  config = { config: ::Rails.application.config }
-  Datadog::Contrib::Rails::Framework.configure(config)
+  Datadog::Contrib::Rails::Framework.configure({})
 end
 
 # reset default configuration and replace any dummy tracer


### PR DESCRIPTION
This PR puts `rack` and `rails-controller` spans under the same service name by default. For distinct service names, use the `controller_service` option as it follows:
```rb
Datadog.configure do |c|
  c.use :rails, service_name: 'rack-handler', controller_service: 'rails-controller'
end
```
**Breaking change**

It's worth mentioning this is a breaking change since it will affect metrics associated with rails controllers and rack middleware, so make sure to update any monitors that rely on these services, or use the `controller_service` option to have the same name you're using now.