### PR TITLE
Provide better default names for `rails` services

### DIFF
--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -36,6 +36,7 @@ module Datadog
           Datadog.configuration.use(:rails, user_config)
           config = Datadog.configuration[:rails]
           tracer = config[:tracer]
+          config[:service_name] ||= Utils.app_name
 
           Datadog.configuration.use(
             :rack,
@@ -45,6 +46,7 @@ module Datadog
           )
 
           config[:controller_service] ||= config[:service_name]
+          config[:cache_service] ||= "#{config[:service_name]}-cache"
 
           tracer.set_service_info(config[:controller_service], 'rails', Ext::AppTypes::WEB)
           tracer.set_service_info(config[:cache_service], 'rails', Ext::AppTypes::CACHE)
@@ -58,7 +60,7 @@ module Datadog
               # set default database service details and store it in the configuration
               conn_cfg = ::ActiveRecord::Base.connection_config()
               adapter_name = Datadog::Contrib::Rails::Utils.normalize_vendor(conn_cfg[:adapter])
-              config[:database_service] ||= adapter_name
+              config[:database_service] ||= "#{config[:service_name]}-#{adapter_name}"
               tracer.set_service_info(config[:database_service], adapter_name, Ext::AppTypes::DB)
             rescue StandardError => e
               Datadog::Tracer.log.warn("Unable to get database config (#{e}), skipping ActiveRecord instrumentation")

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -6,9 +6,9 @@ module Datadog
         include Base
         register_as :rails, auto_patch: true
 
-        option :service_name, default: 'rails-app'
+        option :service_name
         option :controller_service
-        option :cache_service, default: 'rails-cache'
+        option :cache_service
         option :database_service
         option :distributed_tracing_enabled, default: false
         option :template_base_path, default: 'views/'

--- a/lib/ddtrace/contrib/rails/utils.rb
+++ b/lib/ddtrace/contrib/rails/utils.rb
@@ -37,6 +37,14 @@ module Datadog
             vendor
           end
         end
+
+        def self.app_name
+          if ::Rails::VERSION::MAJOR >= 4
+            ::Rails.application.class.parent_name.underscore
+          else
+            ::Rails.application.class.to_s.underscore
+          end
+        end
       end
     end
   end

--- a/test/contrib/rails/default_service_test.rb
+++ b/test/contrib/rails/default_service_test.rb
@@ -26,6 +26,6 @@ class TracingDefaultServiceTest < ActionController::TestCase
     span = spans[0]
     assert_equal('web.request', span.name)
     assert_equal('/index', span.resource, '/index')
-    assert_equal('rails-app', span.service, 'service name should reflect this is a Rails application')
+    assert_equal(app_name, span.service, 'service name should reflect this is a Rails application')
   end
 end

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -13,9 +13,9 @@ class FullStackTest < ActionDispatch::IntegrationTest
     # and the Rack stack
     @tracer = get_test_tracer
     Datadog.registry[:rails].reset_options!
-    Datadog.configuration[:rails][:database_service] = get_adapter_name
     Datadog.configuration[:rails][:tracer] = @tracer
-    Datadog.configuration[:rack][:tracer] = @tracer
+    Datadog.configuration[:rails][:database_service] = get_adapter_name
+    Datadog::Contrib::Rails::Framework.configure({})
   end
 
   teardown do
@@ -69,7 +69,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_equal(cache_span.name, 'rails.cache')
     assert_equal(cache_span.span_type, 'cache')
     assert_equal(cache_span.resource, 'SET')
-    assert_equal(cache_span.service, 'rails-cache')
+    assert_equal(cache_span.service, "#{app_name}-cache")
     assert_equal(cache_span.get_tag('rails.cache.backend').to_s, 'file_store')
     assert_equal(cache_span.get_tag('rails.cache.key'), 'empty-key')
   end

--- a/test/contrib/rails/rails_sidekiq_test.rb
+++ b/test/contrib/rails/rails_sidekiq_test.rb
@@ -51,13 +51,13 @@ class RailsSidekiqTest < ActionController::TestCase
 
     assert_equal(
       @tracer.services,
-      'rails-app' => {
+      app_name => {
         'app' => 'rails', 'app_type' => 'web'
       },
-      db_adapter => {
+      "#{app_name}-#{db_adapter}" => {
         'app' => db_adapter, 'app_type' => 'db'
       },
-      'rails-cache' => {
+      "#{app_name}-cache" => {
         'app' => 'rails', 'app_type' => 'cache'
       },
       'rails-sidekiq' => {

--- a/test/contrib/rails/redis_cache_test.rb
+++ b/test/contrib/rails/redis_cache_test.rb
@@ -43,7 +43,7 @@ class RedisCacheTracingTest < ActionController::TestCase
       assert_equal(cache.name, 'rails.cache')
       assert_equal(cache.span_type, 'cache')
       assert_equal(cache.resource, 'GET')
-      assert_equal(cache.service, 'rails-cache')
+      assert_equal(cache.service, "#{app_name}-cache")
       assert_equal(cache.get_tag('rails.cache.backend').to_s, 'redis_store')
       assert_equal(cache.get_tag('rails.cache.key'), 'custom-key')
 
@@ -109,7 +109,7 @@ class RedisCacheTracingTest < ActionController::TestCase
     assert_equal(cache.name, 'rails.cache')
     assert_equal(cache.span_type, 'cache')
     assert_equal(cache.resource, 'SET')
-    assert_equal(cache.service, 'rails-cache')
+    assert_equal(cache.service, "#{app_name}-cache")
     assert_equal(cache.get_tag('rails.cache.backend').to_s, 'redis_store')
     assert_equal(cache.get_tag('rails.cache.key'), 'custom-key')
 
@@ -133,7 +133,7 @@ class RedisCacheTracingTest < ActionController::TestCase
     assert_equal(cache.name, 'rails.cache')
     assert_equal(cache.span_type, 'cache')
     assert_equal(cache.resource, 'DELETE')
-    assert_equal(cache.service, 'rails-cache')
+    assert_equal(cache.service, "#{app_name}-cache")
     assert_equal(cache.get_tag('rails.cache.backend').to_s, 'redis_store')
     assert_equal(cache.get_tag('rails.cache.key'), 'custom-key')
 

--- a/test/contrib/rails/test_helper.rb
+++ b/test/contrib/rails/test_helper.rb
@@ -83,3 +83,7 @@ when '3.0.20'
 else
   logger.error 'A Rails app for this version is not found!'
 end
+
+def app_name
+  Datadog::Contrib::Rails::Utils.app_name
+end


### PR DESCRIPTION
Instead of using static defaults (`rails-app`, `rails-controller`), we prepend the Rails app name to that value. The app name is retrieved using `::Rails.application.class` if you didn't set it. In both cases, you'll have:
```
intake
intake-controller
intake-cache
...
```
You can still override each value if you want to keep different names than the ones provided by default.