### PR TITLE
Configuration cleanup

### DIFF
--- a/lib/ddtrace/contrib/active_record/patcher.rb
+++ b/lib/ddtrace/contrib/active_record/patcher.rb
@@ -42,21 +42,12 @@ module Datadog
           end
         end
 
-        def self.datadog_trace
-          # TODO: Consider using patcher for Rails as well.
-          # @tracer ||= defined?(::Rails) && ::Rails.configuration.datadog_trace
-          @datadog_trace ||= defined?(::Sinatra) && Datadog.configuration[:sinatra].to_h
-        end
-
         def self.adapter_name
-          @adapter_name ||= Datadog::Contrib::Rails::Utils.normalize_vendor(
-            ::ActiveRecord::Base.connection_config[:adapter]
-          )
+          @adapter_name ||= Datadog::Contrib::Rails::Utils.adapter_name
         end
 
         def self.tracer
-          return Datadog.tracer unless datadog_trace
-          @tracer ||= datadog_trace.fetch(:tracer)
+          @tracer ||= Datadog.configuration[:sinatra][:tracer]
         end
 
         def self.database_service

--- a/lib/ddtrace/contrib/http/patcher.rb
+++ b/lib/ddtrace/contrib/http/patcher.rb
@@ -36,11 +36,11 @@ module Datadog
       end
 
       def should_skip_distributed_tracing?(pin)
-        global_value = Datadog.configuration[:http][:distributed_tracing_enabled]
-        unless pin.config.nil?
-          return !pin.config.fetch(:distributed_tracing_enabled, global_value)
+        if pin.config && pin.config.key?(:distributed_tracing)
+          return !pin.config[:distributed_tracing]
         end
-        !global_value
+
+        !Datadog.configuration[:http][:distributed_tracing]
       end
 
       # Patcher enables patching of 'net/http' module.
@@ -48,7 +48,7 @@ module Datadog
       module Patcher
         include Base
         register_as :http, auto_patch: true
-        option :distributed_tracing_enabled, default: false
+        option :distributed_tracing, default: false
 
         @patched = false
 

--- a/lib/ddtrace/contrib/http/patcher.rb
+++ b/lib/ddtrace/contrib/http/patcher.rb
@@ -14,16 +14,6 @@ module Datadog
 
       module_function
 
-      # TODO: Remove this once we drop support for legacy configuration
-      def distributed_tracing_enabled
-        Datadog.configuration[:http][:distributed_tracing_enabled]
-      end
-
-      # TODO: Remove this once we drop support for legacy configuration
-      def distributed_tracing_enabled=(value)
-        Datadog.configuration[:http][:distributed_tracing_enabled] = value
-      end
-
       def should_skip_tracing?(req, address, port, transport, pin)
         # we don't want to trace our own call to the API (they use net/http)
         # when we know the host & port (from the URI) we use it, else (most-likely

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -40,8 +40,6 @@ module Datadog
           @tracer = Datadog.configuration[:rack][:tracer]
           @service = Datadog.configuration[:rack][:service_name]
           @distributed_tracing_enabled = Datadog.configuration[:rack][:distributed_tracing_enabled]
-
-          # configure the Rack service
         end
 
         # rubocop:disable Metrics/MethodLength

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -21,11 +21,11 @@ module Datadog
           get_option(:tracer).set_service_info(value, 'rack', Ext::AppTypes::WEB)
           value
         end
-        option :distributed_tracing_enabled, default: false
+        option :distributed_tracing, default: false
 
         def initialize(app, options = {})
           # update options with our configuration, unless it's already available
-          [:tracer, :service_name, :distributed_tracing_enabled].each do |k|
+          [:tracer, :service_name, :distributed_tracing].each do |k|
             Datadog.configuration[:rack][k] = options[k] unless options[k].nil?
           end
 
@@ -39,7 +39,7 @@ module Datadog
           # retrieve the current tracer and service
           @tracer = Datadog.configuration[:rack][:tracer]
           @service = Datadog.configuration[:rack][:service_name]
-          @distributed_tracing_enabled = Datadog.configuration[:rack][:distributed_tracing_enabled]
+          @distributed_tracing = Datadog.configuration[:rack][:distributed_tracing]
         end
 
         # rubocop:disable Metrics/MethodLength
@@ -55,7 +55,7 @@ module Datadog
 
           request_span = nil
           begin
-            if @distributed_tracing_enabled
+            if @distributed_tracing
               context = HTTPPropagator.extract(env)
               @tracer.provider.context = context if context.trace_id
             end

--- a/lib/ddtrace/contrib/rails/active_record.rb
+++ b/lib/ddtrace/contrib/rails/active_record.rb
@@ -20,8 +20,7 @@ module Datadog
         def self.sql(_name, start, finish, _id, payload)
           tracer = Datadog.configuration[:rails][:tracer]
           database_service = Datadog.configuration[:rails][:database_service]
-          adapter_name = ::ActiveRecord::Base.connection_config[:adapter]
-          adapter_name = Datadog::Contrib::Rails::Utils.normalize_vendor(adapter_name)
+          adapter_name = Datadog::Contrib::Rails::Utils.adapter_name
           span_type = Datadog::Ext::SQL::TYPE
 
           span = tracer.trace(

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -29,7 +29,7 @@ module Datadog
             :rack,
             tracer: tracer,
             service_name: config[:service_name],
-            distributed_tracing_enabled: config[:distributed_tracing_enabled]
+            distributed_tracing: config[:distributed_tracing]
           )
 
           config[:controller_service] ||= config[:service_name]

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -11,17 +11,6 @@ require 'ddtrace/contrib/rails/active_record'
 require 'ddtrace/contrib/rails/active_support'
 require 'ddtrace/contrib/rails/utils'
 
-# Rails < 3.1
-if defined?(::ActiveRecord) && !defined?(::ActiveRecord::Base.connection_config)
-  ActiveRecord::Base.class_eval do
-    class << self
-      def connection_config
-        connection_pool.spec.config
-      end
-    end
-  end
-end
-
 module Datadog
   module Contrib
     # Instrument Rails.
@@ -31,12 +20,10 @@ module Datadog
       # - instrument parts of the framework when needed
       module Framework
         # configure Datadog settings
-        def self.configure(rails_config)
-          user_config = rails_config[:config].datadog_trace rescue {}
-          Datadog.configuration.use(:rails, user_config)
+        def self.setup
           config = Datadog.configuration[:rails]
-          tracer = config[:tracer]
           config[:service_name] ||= Utils.app_name
+          tracer = config[:tracer]
 
           Datadog.configuration.use(
             :rack,
@@ -50,25 +37,22 @@ module Datadog
 
           tracer.set_service_info(config[:controller_service], 'rails', Ext::AppTypes::WEB)
           tracer.set_service_info(config[:cache_service], 'rails', Ext::AppTypes::CACHE)
+          set_database_service
 
           # By default, default service would be guessed from the script
           # being executed, but here we know better, get it from Rails config.
           tracer.default_service = config[:service_name]
+        end
 
-          if defined?(::ActiveRecord)
-            begin
-              # set default database service details and store it in the configuration
-              conn_cfg = ::ActiveRecord::Base.connection_config()
-              adapter_name = Datadog::Contrib::Rails::Utils.normalize_vendor(conn_cfg[:adapter])
-              config[:database_service] ||= "#{config[:service_name]}-#{adapter_name}"
-              tracer.set_service_info(config[:database_service], adapter_name, Ext::AppTypes::DB)
-            rescue StandardError => e
-              Datadog::Tracer.log.warn("Unable to get database config (#{e}), skipping ActiveRecord instrumentation")
-            end
-          end
+        def self.set_database_service
+          return unless defined?(::ActiveRecord)
 
-          # update global configurations
-          ::Rails.configuration.datadog_trace = Datadog.registry[:rails].to_h
+          config = Datadog.configuration[:rails]
+          adapter_name = Utils.adapter_name
+          config[:database_service] ||= "#{config[:service_name]}-#{adapter_name}"
+          config[:tracer].set_service_info(config[:database_service], adapter_name, Ext::AppTypes::DB)
+        rescue => e
+          Tracer.log.warn("Unable to get database config (#{e}), skipping ActiveRecord instrumentation")
         end
       end
     end

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -10,7 +10,7 @@ module Datadog
         option :controller_service
         option :cache_service
         option :database_service
-        option :distributed_tracing_enabled, default: false
+        option :distributed_tracing, default: false
         option :template_base_path, default: 'views/'
         option :tracer, default: Datadog.tracer
 

--- a/lib/ddtrace/contrib/rails/railtie.rb
+++ b/lib/ddtrace/contrib/rails/railtie.rb
@@ -8,8 +8,8 @@ module Datadog
     config.app_middleware.insert_before(0, Datadog::Contrib::Rack::TraceMiddleware)
     config.app_middleware.use(Datadog::Contrib::Rails::ExceptionMiddleware)
 
-    config.after_initialize do |app|
-      Datadog::Contrib::Rails::Framework.configure(config: app.config)
+    config.after_initialize do
+      Datadog::Contrib::Rails::Framework.setup
       Datadog::Contrib::Rails::ActionController.instrument
       Datadog::Contrib::Rails::ActionView.instrument
       Datadog::Contrib::Rails::ActiveRecord.instrument

--- a/lib/ddtrace/contrib/rails/utils.rb
+++ b/lib/ddtrace/contrib/rails/utils.rb
@@ -45,6 +45,20 @@ module Datadog
             ::Rails.application.class.to_s.underscore
           end
         end
+
+        def self.adapter_name
+          normalize_vendor(connection_adapter)
+        end
+
+        def self.connection_adapter
+          if defined?(::ActiveRecord::Base.connection_config)
+            ::ActiveRecord::Base.connection_config[:adapter]
+          else
+            ::ActiveRecord::Base.connection_pool.spec.config[:adapter]
+          end
+        end
+
+        private_class_method :connection_adapter
       end
     end
   end

--- a/test/contrib/http/request_test.rb
+++ b/test/contrib/http/request_test.rb
@@ -111,7 +111,7 @@ class HTTPRequestTest < Minitest::Test
   end
 
   def test_distributed_tracing_headers
-    Datadog.configuration[:http][:distributed_tracing_enabled] = true
+    Datadog.configuration[:http][:distributed_tracing] = true
 
     pin = Datadog::Pin.get_from(@client)
     spy = StringIO.new
@@ -127,11 +127,11 @@ class HTTPRequestTest < Minitest::Test
     assert_match(/x-datadog-trace-id/i, request_data)
     assert_match(/x-datadog-sampling-priority: 10/i, request_data)
 
-    Datadog.configuration[:http][:distributed_tracing_enabled] = false
+    Datadog.configuration[:http][:distributed_tracing] = false
   end
 
   def test_disabled_distributed_tracing
-    Datadog.configuration[:http][:distributed_tracing_enabled] = false
+    Datadog.configuration[:http][:distributed_tracing] = false
 
     spy = StringIO.new
     @client.set_debug_output(spy)
@@ -144,7 +144,7 @@ class HTTPRequestTest < Minitest::Test
   end
 
   def test_distributed_tracing_when_tracer_is_disabled
-    Datadog.configuration[:http][:distributed_tracing_enabled] = true
+    Datadog.configuration[:http][:distributed_tracing] = true
     pin = Datadog::Pin.get_from(@client)
     pin.tracer.configure(enabled: false)
 

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -15,7 +15,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     Datadog.registry[:rails].reset_options!
     Datadog.configuration[:rails][:tracer] = @tracer
     Datadog.configuration[:rails][:database_service] = get_adapter_name
-    Datadog::Contrib::Rails::Framework.configure({})
+    Datadog::Contrib::Rails::Framework.setup
   end
 
   teardown do

--- a/test/contrib/rails/rails_sidekiq_test.rb
+++ b/test/contrib/rails/rails_sidekiq_test.rb
@@ -38,7 +38,7 @@ class RailsSidekiqTest < ActionController::TestCase
 
   test 'Sidekiq middleware uses Rails configuration if available' do
     @tracer.configure(enabled: false, debug: true, host: 'tracer.example.com', port: 7777)
-    Datadog::Contrib::Rails::Framework.configure({})
+    Datadog::Contrib::Rails::Framework.setup
     db_adapter = get_adapter_name()
 
     # add Sidekiq middleware

--- a/test/contrib/rails/tracer_test.rb
+++ b/test/contrib/rails/tracer_test.rb
@@ -16,7 +16,7 @@ class TracerTest < ActionDispatch::IntegrationTest
   end
 
   test 'the configuration is correctly called' do
-    Datadog::Contrib::Rails::Framework.configure({})
+    Datadog::Contrib::Rails::Framework.setup
     assert_equal(app_name, @config[:service_name])
     assert_equal(@config[:service_name], @config[:controller_service])
     assert_equal("#{app_name}-cache", @config[:cache_service])
@@ -27,7 +27,7 @@ class TracerTest < ActionDispatch::IntegrationTest
 
   test 'a default service and database should be properly set' do
     services = Datadog.configuration[:rails][:tracer].services
-    Datadog::Contrib::Rails::Framework.configure({})
+    Datadog::Contrib::Rails::Framework.setup
     adapter_name = get_adapter_name()
     assert_equal(
       {

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -65,8 +65,7 @@ def get_test_services
 end
 
 def get_adapter_name
-  adapter_name = ::ActiveRecord::Base.connection_config[:adapter]
-  Datadog::Contrib::Rails::Utils.normalize_vendor(adapter_name)
+  Datadog::Contrib::Rails::Utils.adapter_name
 end
 
 # FauxWriter is a dummy writer that buffers spans locally.
@@ -202,7 +201,7 @@ end
 # * +value+: the value of the key
 def update_config(key, value)
   Datadog.configuration[:rails][key] = value
-  Datadog::Contrib::Rails::Framework.configure({})
+  Datadog::Contrib::Rails::Framework.setup
 end
 
 # reset default configuration and replace any dummy tracer
@@ -213,8 +212,7 @@ def reset_config
     c.use :redis
   end
 
-  config = { config: ::Rails.application.config }
-  Datadog::Contrib::Rails::Framework.configure(config)
+  Datadog::Contrib::Rails::Framework.setup
 end
 
 def test_repeat


### PR DESCRIPTION
This PR removes both dead and deprecated code associated to the old configuration API and renames the `distributed_tracing_enabled` configuration parameter to `distributed_tracing`.

For enabling both inbound and outbound distributed tracing, just do as follows:

```rb
Datadog.configure do
  c.use :rails, distributed_tracing: true # inbound distributed tracing
  c.use :http, distributed_tracing: true # outbund distributed tracing
end
```