### PR TITLE
Improve `faraday` configuration

### DIFF
--- a/lib/ddtrace/configurable.rb
+++ b/lib/ddtrace/configurable.rb
@@ -20,7 +20,7 @@ module Datadog
       def get_option(name)
         __assert_valid!(name)
 
-        return __options[name][:default] unless __options[name][:set_flag]
+        return __default_value(name) unless __options[name][:set_flag]
 
         __options[name][:value]
       end
@@ -47,6 +47,7 @@ module Datadog
         name = name.to_sym
         meta[:setter] ||= (block || IDENTITY)
         meta[:depends_on] ||= []
+        meta[:lazy] ||= false
         __options[name] = meta
       end
 
@@ -71,6 +72,11 @@ module Datadog
         __options.each_with_object({}) do |(name, meta), graph|
           graph[name] = meta[:depends_on]
         end
+      end
+
+      def __default_value(name)
+        return __options[name][:default].call if __options[name][:lazy]
+        __options[name][:default]
       end
     end
   end

--- a/lib/ddtrace/configuration/proxy.rb
+++ b/lib/ddtrace/configuration/proxy.rb
@@ -11,11 +11,7 @@ module Datadog
       end
 
       def [](param)
-        value = @integration.get_option(param)
-
-        return value.call if value.respond_to?(:call)
-
-        value
+        @integration.get_option(param)
       end
 
       def []=(param, value)

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -54,7 +54,7 @@ module Datadog
     def test_lazy_option
       integration = Module.new do
         include Contrib::Base
-        option :option1, default: -> { 1 + 1 }
+        option :option1, default: -> { 1 + 1 }, lazy: true
       end
 
       @registry.add(:example, integration)


### PR DESCRIPTION
This PR let's `faraday` be customized globally and on a *per-connection* basis.

#### Setting a global *service_name*
```rb
Datadog.configure do |c|
  c.use :faraday, service_name: 'http'
end
```
#### Setting a connection-specific *service_name*
```rb
connection = Faraday.new('http://example.com') do |builder|
  builder.use(:ddtrace, service_name: 'example-request')
end
```
