### PR TITLE
Fix `dalli` instrumentation encoding issue

### DIFF
--- a/lib/ddtrace/contrib/dalli/quantize.rb
+++ b/lib/ddtrace/contrib/dalli/quantize.rb
@@ -10,6 +10,8 @@ module Datadog
         def format_command(operation, args)
           command = [operation, *args].join(' ').strip
           Utils.truncate(command, MAX_CMD_LENGTH)
+        rescue ::Encoding::CompatibilityError
+          "#{operation} BLOB (OMITTED)"
         end
       end
     end

--- a/test/contrib/dalli/quantize_test.rb
+++ b/test/contrib/dalli/quantize_test.rb
@@ -23,6 +23,13 @@ module Datadog
           assert(command.end_with?('...'))
           assert_equal('set foo ' + 'A' * 89 + '...', command)
         end
+
+        def test_regression_different_encodings
+          op = :set
+          args = ["\xa1".force_encoding('iso-8859-1'), "\xa1\xa1".force_encoding('euc-jp')]
+
+          assert_match(/BLOB \(OMITTED\)/, Quantize.format_command(op, args))
+        end
       end
     end
   end


### PR DESCRIPTION
Since `memcached` is frequently used to store marshaled objects and other blob types, the Ruby VM might interpret `dalli` request arguments as strings with incompatible encodings. This PR adds a safe-guard for that case.