### PR TITLE
Add 'rails.db.name' tag to ActiveRecord

### DIFF
--- a/lib/ddtrace/contrib/rails/active_record.rb
+++ b/lib/ddtrace/contrib/rails/active_record.rb
@@ -21,6 +21,7 @@ module Datadog
           tracer = Datadog.configuration[:rails][:tracer]
           database_service = Datadog.configuration[:rails][:database_service]
           adapter_name = Datadog::Contrib::Rails::Utils.adapter_name
+          database_name = Datadog::Contrib::Rails::Utils.database_name
           span_type = Datadog::Ext::SQL::TYPE
 
           span = tracer.trace(
@@ -43,6 +44,7 @@ module Datadog
           # obfuscated version
           span.span_type = Datadog::Ext::SQL::TYPE
           span.set_tag('rails.db.vendor', adapter_name)
+          span.set_tag('rails.db.name', database_name)
           span.set_tag('rails.db.cached', cached) if cached
           span.start_time = start
           span.finish(finish)

--- a/lib/ddtrace/contrib/rails/utils.rb
+++ b/lib/ddtrace/contrib/rails/utils.rb
@@ -50,6 +50,10 @@ module Datadog
           normalize_vendor(connection_adapter)
         end
 
+        def self.database_name
+          connection_database
+        end
+
         def self.connection_adapter
           if defined?(::ActiveRecord::Base.connection_config)
             ::ActiveRecord::Base.connection_config[:adapter]
@@ -58,7 +62,15 @@ module Datadog
           end
         end
 
-        private_class_method :connection_adapter
+        def self.connection_database
+          if defined?(::ActiveRecord::Base.connection_config)
+            ::ActiveRecord::Base.connection_config[:database]
+          else
+            ::ActiveRecord::Base.connection_pool.spec.config[:database]
+          end
+        end
+
+        private_class_method :connection_adapter, :connection_database
       end
     end
   end

--- a/lib/ddtrace/contrib/rails/utils.rb
+++ b/lib/ddtrace/contrib/rails/utils.rb
@@ -47,30 +47,22 @@ module Datadog
         end
 
         def self.adapter_name
-          normalize_vendor(connection_adapter)
+          normalize_vendor(connection_config[:adapter])
         end
 
         def self.database_name
-          connection_database
+          connection_config[:database]
         end
 
-        def self.connection_adapter
+        def self.connection_config
           if defined?(::ActiveRecord::Base.connection_config)
-            ::ActiveRecord::Base.connection_config[:adapter]
+            ::ActiveRecord::Base.connection_config
           else
-            ::ActiveRecord::Base.connection_pool.spec.config[:adapter]
+            ::ActiveRecord::Base.connection_pool.spec.config
           end
         end
 
-        def self.connection_database
-          if defined?(::ActiveRecord::Base.connection_config)
-            ::ActiveRecord::Base.connection_config[:database]
-          else
-            ::ActiveRecord::Base.connection_pool.spec.config[:database]
-          end
-        end
-
-        private_class_method :connection_adapter, :connection_database
+        private_class_method :connection_config
       end
     end
   end

--- a/test/contrib/rails/database_test.rb
+++ b/test/contrib/rails/database_test.rb
@@ -16,15 +16,17 @@ class DatabaseTracingTest < ActiveSupport::TestCase
   test 'active record is properly traced' do
     # make the query and assert the proper spans
     Article.count
-    spans = @tracer.writer.spans()
+    spans = @tracer.writer.spans
     assert_equal(spans.length, 1)
 
     span = spans.first
-    adapter_name = get_adapter_name()
+    adapter_name = get_adapter_name
+    database_name = get_database_name
     assert_equal(span.name, "#{adapter_name}.query")
     assert_equal(span.span_type, 'sql')
     assert_equal(span.service, adapter_name)
     assert_equal(span.get_tag('rails.db.vendor'), adapter_name)
+    assert_equal(span.get_tag('rails.db.name'), database_name)
     assert_nil(span.get_tag('rails.db.cached'))
     assert_includes(span.resource, 'SELECT COUNT(*) FROM')
     # ensure that the sql.query tag is not set
@@ -44,6 +46,6 @@ class DatabaseTracingTest < ActiveSupport::TestCase
     assert_equal(span.service, 'customer-db')
 
     # reset the original configuration
-    reset_config()
+    reset_config
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -68,6 +68,10 @@ def get_adapter_name
   Datadog::Contrib::Rails::Utils.adapter_name
 end
 
+def get_database_name
+  Datadog::Contrib::Rails::Utils.database_name
+end
+
 # FauxWriter is a dummy writer that buffers spans locally.
 class FauxWriter < Datadog::Writer
   def initialize(options = {})


### PR DESCRIPTION
This pull request adds the database name as a tag (`rails.db.name`) to ActiveRecord traces.