### PR TITLE
[rack] middleware refactoring; Context cleaning happens at the end of the request

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -182,20 +182,22 @@ To start using the middleware in your generic Rack application, add it to your `
 
     run app
 
-Experimental distributed tracing support is available for this library.
-You need to set the ``:distributed_tracing_enabled`` option to true, for example:
+The Rack middleware can be configured using the global configuration object:
 
     # config.ru example
+    require 'ddtrace'
     require 'ddtrace/contrib/rack/middlewares'
 
-    use Datadog::Contrib::Rack::TraceMiddleware, distributed_tracing_enabled: true
+    Datadog.configure do |c|
+      c.use :rack, service_name: 'api-intake', distributed_tracing: true
+    end
 
     app = proc do |env|
-      # trace and read 'x-datadog-trace-id' and 'x-datadog-parent-id'
       [ 200, {'Content-Type' => 'text/plain'}, "OK" ]
     end
 
-See [distributed tracing](#Distributed_Tracing) for details.
+In the example above, we've activated the Distributed Tracing flag, please
+see [distributed tracing](#Distributed_Tracing) for more details.
 
 #### Configure the tracer
 

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -23,12 +23,7 @@ module Datadog
         end
         option :distributed_tracing, default: false
 
-        def initialize(app, options = {})
-          # update options with our configuration, unless it's already available
-          [:tracer, :service_name, :distributed_tracing].each do |k|
-            Datadog.configuration[:rack][k] = options[k] unless options[k].nil?
-          end
-
+        def initialize(app)
           @app = app
         end
 

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -68,7 +68,7 @@ module Datadog
           # catch exceptions that may be raised in the middleware chain
           # Note: if a middleware catches an Exception without re raising,
           # the Exception cannot be recorded here.
-          request_span.set_error(e)
+          request_span.set_error(e) unless request_span.nil?
           raise e
         ensure
           # the source of truth in Rack is the PATH_INFO key that holds the

--- a/test/contrib/rack/distributed_test.rb
+++ b/test/contrib/rack/distributed_test.rb
@@ -14,13 +14,17 @@ class EchoApp
   end
 end
 
-class DistributedTest < Minitest::Test
+class DistributedTest < RackBaseTest
   RACK_HOST = 'localhost'.freeze
   RACK_PORT = 9292
 
   def setup
-    @tracer = get_test_tracer
+    super
     @rack_port = RACK_PORT
+
+    Datadog.configure do |c|
+      c.use :rack, tracer: @tracer, distributed_tracing: true
+    end
   end
 
   def check_distributed(tracer, client, distributed, message)
@@ -54,7 +58,7 @@ class DistributedTest < Minitest::Test
     tracer = @tracer
 
     app = Rack::Builder.new do
-      use Datadog::Contrib::Rack::TraceMiddleware, tracer: tracer, distributed_tracing: true
+      use Datadog::Contrib::Rack::TraceMiddleware
       run EchoApp.new
     end
 


### PR DESCRIPTION
### Overview

Refactoring Rack middleware:
* removing the `configure` method since we can use `Datadog.configuration` directly
* remove `begin-ensure` block for distributed tracing and `tracer.trace()`
* return `[status, headers, response]` list