### PR TITLE
[rack] add request queuing option to the Rack middleware

### DIFF
--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -27,6 +27,7 @@ module Datadog
           request_start = Datadog::Contrib::Rack::QueueTime.get_request_start(env)
           return if request_start.nil?
 
+          Datadog::Tracer.log.debug('[experimental] creating request.enqueuing span')
           tracer.trace(
             'request.enqueuing',
             start_time: request_start,

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -1,6 +1,7 @@
 require 'ddtrace/ext/app_types'
 require 'ddtrace/ext/http'
 require 'ddtrace/propagation/http_propagator'
+require 'ddtrace/contrib/rack/request_queue'
 
 module Datadog
   module Contrib
@@ -19,9 +20,27 @@ module Datadog
           @app = app
         end
 
+        def compute_queueing_time(env, tracer)
+          return unless Datadog.configuration[:rack][:request_queuing]
+
+          # parse the request enqueue time
+          request_start = Datadog::Contrib::Rack::QueueTime.get_request_start(env)
+          return if request_start.nil?
+
+          tracer.trace(
+            'request.enqueuing',
+            start_time: request_start,
+            service: Datadog.configuration[:rack][:web_service_name]
+          )
+        end
+
         def call(env)
           # retrieve integration settings
           tracer = Datadog.configuration[:rack][:tracer]
+
+          # [experimental] create a root Span to keep track of frontend web servers
+          # (i.e. Apache, nginx) if the header is properly set
+          frontend_span = compute_queueing_time(env, tracer)
 
           trace_options = {
             service: Datadog.configuration[:rack][:service_name],
@@ -77,6 +96,7 @@ module Datadog
           # ensure the request_span is finished and the context reset;
           # this assumes that the Rack middleware creates a root span
           request_span.finish
+          frontend_span.finish unless frontend_span.nil?
 
           # TODO: Remove this once we change how context propagation works. This
           # ensures we clean thread-local variables on each HTTP request avoiding

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -20,16 +20,15 @@ module Datadog
           @app = app
         end
 
-        def compute_queueing_time(env, tracer)
+        def compute_queue_time(env, tracer)
           return unless Datadog.configuration[:rack][:request_queuing]
 
-          # parse the request enqueue time
+          # parse the request queue time
           request_start = Datadog::Contrib::Rack::QueueTime.get_request_start(env)
           return if request_start.nil?
 
-          Datadog::Tracer.log.debug('[experimental] creating request.enqueuing span')
           tracer.trace(
-            'request.enqueuing',
+            'http_server.queue',
             start_time: request_start,
             service: Datadog.configuration[:rack][:web_service_name]
           )
@@ -41,7 +40,7 @@ module Datadog
 
           # [experimental] create a root Span to keep track of frontend web servers
           # (i.e. Apache, nginx) if the header is properly set
-          frontend_span = compute_queueing_time(env, tracer)
+          frontend_span = compute_queue_time(env, tracer)
 
           trace_options = {
             service: Datadog.configuration[:rack][:service_name],

--- a/lib/ddtrace/contrib/rack/patcher.rb
+++ b/lib/ddtrace/contrib/rack/patcher.rb
@@ -14,6 +14,13 @@ module Datadog
           get_option(:tracer).set_service_info(value, 'rack', Ext::AppTypes::WEB)
           value
         end
+        option :request_queuing, default: false
+        option :web_service_name, default: 'web-server', depends_on: [:tracer, :request_queuing] do |value|
+          if get_option(:request_queuing)
+            get_option(:tracer).set_service_info(value, 'webserver', Ext::AppTypes::WEB)
+          end
+          value
+        end
 
         module_function
 

--- a/lib/ddtrace/contrib/rack/request_queue.rb
+++ b/lib/ddtrace/contrib/rack/request_queue.rb
@@ -4,11 +4,12 @@ module Datadog
       # QueueTime simply...
       module QueueTime
         REQUEST_START = 'HTTP_X_REQUEST_START'.freeze
+        QUEUE_START = 'HTTP_X_QUEUE_START'.freeze
 
         module_function
 
         def get_request_start(env, now = Time.now.utc)
-          header = env[REQUEST_START]
+          header = env[REQUEST_START] || env[QUEUE_START]
           return unless header
 
           # nginx header is in the format "t=1512379167.574"

--- a/lib/ddtrace/contrib/rack/request_queue.rb
+++ b/lib/ddtrace/contrib/rack/request_queue.rb
@@ -21,9 +21,10 @@ module Datadog
           # current time, to avoid significant clock skew
           request_start = Time.at(time_string.to_f)
           request_start.utc > now ? nil : request_start
-        rescue
+        rescue StandardError => e
           # in case of an Exception we don't create a
           # `request.enqueuing` span
+          Datadog::Tracer.log.debug("[experimental] unable to parse request enqueuing: #{e}")
           nil
         end
       end

--- a/lib/ddtrace/contrib/rack/request_queue.rb
+++ b/lib/ddtrace/contrib/rack/request_queue.rb
@@ -1,0 +1,32 @@
+module Datadog
+  module Contrib
+    module Rack
+      # QueueTime simply...
+      module QueueTime
+        REQUEST_START = 'HTTP_X_REQUEST_START'.freeze
+
+        module_function
+
+        def get_request_start(env, now = Time.now.utc)
+          header = env[REQUEST_START]
+          return unless header
+
+          # nginx header is in the format "t=1512379167.574"
+          # TODO: this should be generic enough to work with any
+          # frontend web server or load balancer
+          time_string = header.split('t=')[1]
+          return if time_string.nil?
+
+          # return the request_start only if it's lesser than
+          # current time, to avoid significant clock skew
+          request_start = Time.at(time_string.to_f)
+          request_start.utc > now ? nil : request_start
+        rescue
+          # in case of an Exception we don't create a
+          # `request.enqueuing` span
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/rack/request_queue.rb
+++ b/lib/ddtrace/contrib/rack/request_queue.rb
@@ -24,8 +24,8 @@ module Datadog
           request_start.utc > now ? nil : request_start
         rescue StandardError => e
           # in case of an Exception we don't create a
-          # `request.enqueuing` span
-          Datadog::Tracer.log.debug("[experimental] unable to parse request enqueuing: #{e}")
+          # `request.queuing` span
+          Datadog::Tracer.log.debug("[rack] unable to parse request queue headers: #{e}")
           nil
         end
       end

--- a/test/contrib/rack/request_parser_test.rb
+++ b/test/contrib/rack/request_parser_test.rb
@@ -1,0 +1,13 @@
+require 'ddtrace/contrib/rack/request_queue'
+
+class QueueTimeParserTest < Minitest::Test
+  include Rack::Test::Methods
+
+  def test_nginx_header
+    # ensure nginx headers are properly parsed
+    headers = {}
+    headers['HTTP_X_REQUEST_START'] = 't=1512379167.574'
+    request_start = Datadog::Contrib::Rack::QueueTime.get_request_start(headers)
+    assert_equal(1512379167.574, request_start.to_f)
+  end
+end

--- a/test/contrib/rack/request_queueing_test.rb
+++ b/test/contrib/rack/request_queueing_test.rb
@@ -1,0 +1,96 @@
+require 'contrib/rack/helpers'
+
+class RequestQueuingTest < RackBaseTest
+  def setup
+    super
+    # enable request_queueing
+    Datadog.configuration[:rack][:request_queuing] = true
+  end
+
+  def test_request_queuing_header
+    # ensure a queuing Span is created if the header is available
+    request_start = (Time.now.utc - 5).to_i
+    header 'x-request-start', "t=#{request_start}"
+    get '/success/'
+    assert last_response.ok?
+
+    spans = @tracer.writer.spans()
+    assert_equal(2, spans.length)
+
+    rack_span = spans[0]
+    frontend_span = spans[1]
+    assert_equal('rack.request', rack_span.name)
+    assert_equal('request.enqueuing', frontend_span.name)
+
+    assert_equal('http', rack_span.span_type)
+    assert_equal('rack', rack_span.service)
+    assert_equal('GET 200', rack_span.resource)
+    assert_equal('GET', rack_span.get_tag('http.method'))
+    assert_equal('200', rack_span.get_tag('http.status_code'))
+    assert_equal('/success/', rack_span.get_tag('http.url'))
+    assert_equal(0, rack_span.status)
+    assert_equal(frontend_span.span_id, rack_span.parent_id)
+
+    assert_equal('web-server', frontend_span.service)
+    assert_equal(request_start, frontend_span.start_time.to_i)
+  end
+
+  def test_request_queuing_service_name
+    # ensure a queuing Span is created if the header is available
+    Datadog.configuration[:rack][:web_service_name] = 'nginx'
+    request_start = (Time.now.utc - 5).to_i
+    header 'x-request-start', "t=#{request_start}"
+    get '/success/'
+    assert last_response.ok?
+
+    spans = @tracer.writer.spans()
+    assert_equal(2, spans.length)
+
+    rack_span = spans[0]
+    frontend_span = spans[1]
+    assert_equal('rack.request', rack_span.name)
+    assert_equal('request.enqueuing', frontend_span.name)
+
+    assert_equal('nginx', frontend_span.service)
+  end
+
+  def test_clock_skew
+    # ensure a queuing Span is NOT created if there is a clock skew
+    # where the starting time is greater than current host Time.now
+    request_start = (Time.now.utc + 5).to_i
+    header 'x-request-start', "t=#{request_start}"
+    get '/success/'
+    assert last_response.ok?
+
+    spans = @tracer.writer.spans()
+    assert_equal(1, spans.length)
+
+    rack_span = spans[0]
+    assert_equal('rack.request', rack_span.name)
+  end
+
+  def test_wrong_header
+    # ensure a queuing Span is NOT created if the header is wrong
+    header 'x-request-start', 'something_weird'
+    get '/success/'
+    assert last_response.ok?
+
+    spans = @tracer.writer.spans()
+    assert_equal(1, spans.length)
+
+    rack_span = spans[0]
+    assert_equal('rack.request', rack_span.name)
+  end
+
+  def test_enabled_missing_header
+    # ensure a queuing Span is NOT created if the header is missing
+    get '/success/'
+    assert last_response.ok?
+
+    spans = @tracer.writer.spans()
+    assert_equal(1, spans.length)
+
+    rack_span = spans[0]
+    assert_equal('rack.request', rack_span.name)
+  end
+end

--- a/test/contrib/rack/request_queueing_test.rb
+++ b/test/contrib/rack/request_queueing_test.rb
@@ -35,6 +35,34 @@ class RequestQueuingTest < RackBaseTest
     assert_equal(request_start, frontend_span.start_time.to_i)
   end
 
+  def test_request_alternative_queuing_header
+    # ensure a queuing Span is created if the header is available
+    request_start = (Time.now.utc - 5).to_i
+    header 'x-queue-start', "t=#{request_start}"
+    get '/success/'
+    assert last_response.ok?
+
+    spans = @tracer.writer.spans()
+    assert_equal(2, spans.length)
+
+    rack_span = spans[0]
+    frontend_span = spans[1]
+    assert_equal('rack.request', rack_span.name)
+    assert_equal('request.enqueuing', frontend_span.name)
+
+    assert_equal('http', rack_span.span_type)
+    assert_equal('rack', rack_span.service)
+    assert_equal('GET 200', rack_span.resource)
+    assert_equal('GET', rack_span.get_tag('http.method'))
+    assert_equal('200', rack_span.get_tag('http.status_code'))
+    assert_equal('/success/', rack_span.get_tag('http.url'))
+    assert_equal(0, rack_span.status)
+    assert_equal(frontend_span.span_id, rack_span.parent_id)
+
+    assert_equal('web-server', frontend_span.service)
+    assert_equal(request_start, frontend_span.start_time.to_i)
+  end
+
   def test_request_queuing_service_name
     # ensure a queuing Span is created if the header is available
     Datadog.configuration[:rack][:web_service_name] = 'nginx'

--- a/test/contrib/rack/request_queuing_test.rb
+++ b/test/contrib/rack/request_queuing_test.rb
@@ -3,7 +3,7 @@ require 'contrib/rack/helpers'
 class RequestQueuingTest < RackBaseTest
   def setup
     super
-    # enable request_queueing
+    # enable request_queuing
     Datadog.configuration[:rack][:request_queuing] = true
   end
 
@@ -14,13 +14,13 @@ class RequestQueuingTest < RackBaseTest
     get '/success/'
     assert last_response.ok?
 
-    spans = @tracer.writer.spans()
+    spans = @tracer.writer.spans
     assert_equal(2, spans.length)
 
-    rack_span = spans[0]
-    frontend_span = spans[1]
-    assert_equal('rack.request', rack_span.name)
-    assert_equal('request.enqueuing', frontend_span.name)
+    rack_span = spans.find { |s| s.name == 'rack.request' }
+    frontend_span = spans.find { |s| s.name == 'http_server.queue' }
+    refute_nil(rack_span)
+    refute_nil(frontend_span)
 
     assert_equal('http', rack_span.span_type)
     assert_equal('rack', rack_span.service)
@@ -42,13 +42,13 @@ class RequestQueuingTest < RackBaseTest
     get '/success/'
     assert last_response.ok?
 
-    spans = @tracer.writer.spans()
+    spans = @tracer.writer.spans
     assert_equal(2, spans.length)
 
-    rack_span = spans[0]
-    frontend_span = spans[1]
-    assert_equal('rack.request', rack_span.name)
-    assert_equal('request.enqueuing', frontend_span.name)
+    rack_span = spans.find { |s| s.name == 'rack.request' }
+    frontend_span = spans.find { |s| s.name == 'http_server.queue' }
+    refute_nil(rack_span)
+    refute_nil(frontend_span)
 
     assert_equal('http', rack_span.span_type)
     assert_equal('rack', rack_span.service)
@@ -71,13 +71,13 @@ class RequestQueuingTest < RackBaseTest
     get '/success/'
     assert last_response.ok?
 
-    spans = @tracer.writer.spans()
+    spans = @tracer.writer.spans
     assert_equal(2, spans.length)
 
-    rack_span = spans[0]
-    frontend_span = spans[1]
-    assert_equal('rack.request', rack_span.name)
-    assert_equal('request.enqueuing', frontend_span.name)
+    rack_span = spans.find { |s| s.name == 'rack.request' }
+    frontend_span = spans.find { |s| s.name == 'http_server.queue' }
+    refute_nil(rack_span)
+    refute_nil(frontend_span)
 
     assert_equal('nginx', frontend_span.service)
   end
@@ -90,7 +90,7 @@ class RequestQueuingTest < RackBaseTest
     get '/success/'
     assert last_response.ok?
 
-    spans = @tracer.writer.spans()
+    spans = @tracer.writer.spans
     assert_equal(1, spans.length)
 
     rack_span = spans[0]
@@ -103,7 +103,7 @@ class RequestQueuingTest < RackBaseTest
     get '/success/'
     assert last_response.ok?
 
-    spans = @tracer.writer.spans()
+    spans = @tracer.writer.spans
     assert_equal(1, spans.length)
 
     rack_span = spans[0]
@@ -115,7 +115,7 @@ class RequestQueuingTest < RackBaseTest
     get '/success/'
     assert last_response.ok?
 
-    spans = @tracer.writer.spans()
+    spans = @tracer.writer.spans
     assert_equal(1, spans.length)
 
     rack_span = spans[0]


### PR DESCRIPTION
### Overview

Provides the request queuing time from the Rack middleware if a frontend web server or load balancer sets a specific header. This is considered an **experimental** feature and may have breaking changes in the future.

### Usage
* your web server should set the `x-request-start` header
* your Rack integration should be configured with the following options
```ruby
Datadog.configure do |c|
  # web_service_name is optional and has `web-server` as default
  c.use :rack, request_queuing: true, web_service_name: 'nginx'
end
```

### Supported format

At the time of writing, only `nginx` headers are supported in the format of `t=1512379167.574`.