### PR TITLE
Provide `workers` option for `resque` integration

### DIFF
--- a/lib/ddtrace/contrib/resque/patcher.rb
+++ b/lib/ddtrace/contrib/resque/patcher.rb
@@ -16,14 +16,17 @@ module Datadog
         option :service_name, default: SERVICE
 
         @patched = false
+        option :workers, default: []
 
         class << self
           def patch
             return @patched if patched? || !defined?(::Resque)
 
             require 'ddtrace/ext/app_types'
+            require_relative 'resque_job'
 
             add_pin
+            get_option(:workers).each { |worker| worker.extend(ResqueJob) }
             @patched = true
           rescue => e
             Tracer.log.error("Unable to apply Resque integration: #{e}")

--- a/test/contrib/resque/hooks_test.rb
+++ b/test/contrib/resque/hooks_test.rb
@@ -82,6 +82,20 @@ module Datadog
           assert_equal('StandardError', span.get_tag(Ext::Errors::TYPE), 'wrong type of error stored in span')
         end
 
+        def test_workers_patch
+          worker_class1 = Class.new
+          worker_class2 = Class.new
+
+          remove_patch!(:resque)
+
+          Datadog.configure do |c|
+            c.use(:resque, workers: [worker_class1, worker_class2])
+          end
+
+          assert_includes(worker_class1.singleton_class.included_modules, ResqueJob)
+          assert_includes(worker_class2.singleton_class.included_modules, ResqueJob)
+        end
+
         def enable_test_tracer!
           get_test_tracer.tap { |tracer| pin.tracer = tracer }
         end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -237,3 +237,9 @@ def try_wait_until(options = {})
     attempts -= 1
   end
 end
+
+def remove_patch!(integration)
+  Datadog
+    .registry[integration]
+    .instance_variable_set('@patched', false)
+end


### PR DESCRIPTION
This PR basically obviates need for extending our module for instrumenting `resque` workers.
With this change, you can simply do:

```rb
Datadog.configure do |c|
  c.use :resque, workers: [PseudoWorker, FooWorker]
end
```