### PR TITLE
Add pry to development dependencies

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -44,4 +44,5 @@ EOS
   # locking transitive dependency of webmock
   spec.add_development_dependency 'addressable', '~> 2.4.0'
   spec.add_development_dependency 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
+  spec.add_development_dependency 'pry', '>= 0.10.4'
 end

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -45,4 +45,5 @@ EOS
   spec.add_development_dependency 'addressable', '~> 2.4.0'
   spec.add_development_dependency 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
   spec.add_development_dependency 'pry', '>= 0.10.4'
+  spec.add_development_dependency 'pry-stack_explorer', '>= 0.4.9.2'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,7 @@
 require 'minitest'
 require 'minitest/autorun'
 require 'webmock/minitest'
+require 'pry'
 
 require 'ddtrace/encoding'
 require 'ddtrace/transport'


### PR DESCRIPTION
Adds `pry` and `pry-stack_explorer` to development dependencies to aid debugging.