### PR TITLE
Set host or address as resource for Net::HTTP

### DIFF
--- a/lib/ddtrace/contrib/http/patcher.rb
+++ b/lib/ddtrace/contrib/http/patcher.rb
@@ -119,7 +119,7 @@ module Datadog
                   span.service = pin.service
                   span.span_type = Datadog::Ext::HTTP::TYPE
 
-                  span.resource = host_address
+                  span.resource = "#{host_address}:#{host_port}"
                   span.set_tag(Datadog::Ext::HTTP::URL, req.path)
                   span.set_tag(Datadog::Ext::HTTP::METHOD, req.method)
 

--- a/test/contrib/http/miniapp_test.rb
+++ b/test/contrib/http/miniapp_test.rb
@@ -33,7 +33,7 @@ class HTTPMiniAppTest < Minitest::Test
   def check_span_get(span, parent_id, trace_id)
     assert_equal('http.request', span.name)
     assert_equal('net/http', span.service)
-    assert_equal(ELASTICSEARCH_HOST, span.resource)
+    assert_equal("#{ELASTICSEARCH_HOST}:#{ELASTICSEARCH_PORT}", span.resource)
     assert_equal('_cluster/health', span.get_tag('http.url'))
     assert_equal('GET', span.get_tag('http.method'))
     assert_equal('200', span.get_tag('http.status_code'))

--- a/test/contrib/http/miniapp_test.rb
+++ b/test/contrib/http/miniapp_test.rb
@@ -33,7 +33,7 @@ class HTTPMiniAppTest < Minitest::Test
   def check_span_get(span, parent_id, trace_id)
     assert_equal('http.request', span.name)
     assert_equal('net/http', span.service)
-    assert_equal('GET', span.resource)
+    assert_equal(ELASTICSEARCH_HOST, span.resource)
     assert_equal('_cluster/health', span.get_tag('http.url'))
     assert_equal('GET', span.get_tag('http.method'))
     assert_equal('200', span.get_tag('http.status_code'))

--- a/test/contrib/http/request_test.rb
+++ b/test/contrib/http/request_test.rb
@@ -36,7 +36,7 @@ class HTTPRequestTest < Minitest::Test
     span = spans[0]
     assert_equal('http.request', span.name)
     assert_equal('net/http', span.service)
-    assert_equal('GET', span.resource)
+    assert_equal(ELASTICSEARCH_HOST, span.resource)
     assert_equal('_cluster/health', span.get_tag('http.url'))
     assert_equal('GET', span.get_tag('http.method'))
     assert_equal('200', span.get_tag('http.status_code'))
@@ -52,7 +52,7 @@ class HTTPRequestTest < Minitest::Test
     span = spans[0]
     assert_equal('http.request', span.name)
     assert_equal('net/http', span.service)
-    assert_equal('POST', span.resource)
+    assert_equal(ELASTICSEARCH_HOST, span.resource)
     assert_equal('/my/thing/42', span.get_tag('http.url'))
     assert_equal('POST', span.get_tag('http.method'))
     assert_equal('127.0.0.1', span.get_tag('out.host'))
@@ -68,7 +68,7 @@ class HTTPRequestTest < Minitest::Test
     span = spans[0]
     assert_equal('http.request', span.name)
     assert_equal('net/http', span.service)
-    assert_equal('GET', span.resource)
+    assert_equal(ELASTICSEARCH_HOST, span.resource)
     assert_equal('/admin.php?user=admin&passwd=123456', span.get_tag('http.url'))
     assert_equal('GET', span.get_tag('http.method'))
     assert_equal('404', span.get_tag('http.status_code'))
@@ -93,7 +93,7 @@ class HTTPRequestTest < Minitest::Test
       span = spans[0]
       assert_equal('http.request', span.name)
       assert_equal('net/http', span.service)
-      assert_equal('GET', span.resource)
+      assert_equal(ELASTICSEARCH_HOST, span.resource)
       assert_equal('/_cluster/health', span.get_tag('http.url'))
       assert_equal('GET', span.get_tag('http.method'))
       assert_equal('200', span.get_tag('http.status_code'))

--- a/test/contrib/http/request_test.rb
+++ b/test/contrib/http/request_test.rb
@@ -36,7 +36,7 @@ class HTTPRequestTest < Minitest::Test
     span = spans[0]
     assert_equal('http.request', span.name)
     assert_equal('net/http', span.service)
-    assert_equal(ELASTICSEARCH_HOST, span.resource)
+    assert_equal("#{ELASTICSEARCH_HOST}:#{ELASTICSEARCH_PORT}", span.resource)
     assert_equal('_cluster/health', span.get_tag('http.url'))
     assert_equal('GET', span.get_tag('http.method'))
     assert_equal('200', span.get_tag('http.status_code'))
@@ -52,7 +52,7 @@ class HTTPRequestTest < Minitest::Test
     span = spans[0]
     assert_equal('http.request', span.name)
     assert_equal('net/http', span.service)
-    assert_equal(ELASTICSEARCH_HOST, span.resource)
+    assert_equal("#{ELASTICSEARCH_HOST}:#{ELASTICSEARCH_PORT}", span.resource)
     assert_equal('/my/thing/42', span.get_tag('http.url'))
     assert_equal('POST', span.get_tag('http.method'))
     assert_equal('127.0.0.1', span.get_tag('out.host'))
@@ -68,7 +68,7 @@ class HTTPRequestTest < Minitest::Test
     span = spans[0]
     assert_equal('http.request', span.name)
     assert_equal('net/http', span.service)
-    assert_equal(ELASTICSEARCH_HOST, span.resource)
+    assert_equal("#{ELASTICSEARCH_HOST}:#{ELASTICSEARCH_PORT}", span.resource)
     assert_equal('/admin.php?user=admin&passwd=123456', span.get_tag('http.url'))
     assert_equal('GET', span.get_tag('http.method'))
     assert_equal('404', span.get_tag('http.status_code'))
@@ -93,7 +93,7 @@ class HTTPRequestTest < Minitest::Test
       span = spans[0]
       assert_equal('http.request', span.name)
       assert_equal('net/http', span.service)
-      assert_equal(ELASTICSEARCH_HOST, span.resource)
+      assert_equal("#{ELASTICSEARCH_HOST}:#{ELASTICSEARCH_PORT}", span.resource)
       assert_equal('/_cluster/health', span.get_tag('http.url'))
       assert_equal('GET', span.get_tag('http.method'))
       assert_equal('200', span.get_tag('http.status_code'))


### PR DESCRIPTION
Tracking external requests by host is more useful for understanding performance issues than tracking by HTTP method. By using the host we should have a smaller potential list than if we were tracking by URL/endpoint.

We don't always have a hostname, so lets use logic that exists for falling back to address.

Testing Notes: I didn't add scenarios for testing `req.uri.host` vs `@address`