### PR TITLE
Reduce CI building time

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -147,13 +147,11 @@ task :ci do
   case ENV['CIRCLE_NODE_INDEX'].to_i
   when 0
     sh 'rvm $MRI_VERSIONS,$MRI_OLD_VERSIONS,$JRUBY_VERSIONS --verbose do rake test:main'
-    sh 'rvm $LAST_STABLE --verbose do rake benchmark'
   when 1
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:elasticsearch'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:http'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:redis'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:sinatra'
-    sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:sidekiq'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:rack'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:grape'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:faraday'
@@ -174,8 +172,9 @@ task :ci do
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:sucker_punch'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:dalli'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:resque'
-    sh 'rvm $SIDEKIQ_OLD_VERSIONS --verbose do appraisal contrib-old rake test:sidekiq'
   when 2
+    sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:sidekiq'
+    sh 'rvm $SIDEKIQ_OLD_VERSIONS --verbose do appraisal contrib-old rake test:sidekiq'
     sh 'rvm $RAILS3_VERSIONS --verbose do appraisal rails30-postgres rake test:rails'
     sh 'rvm $RAILS3_VERSIONS --verbose do appraisal rails30-postgres rake test:railsdisableenv'
     sh 'rvm $RAILS3_VERSIONS --verbose do appraisal rails32-mysql2 rake test:rails'
@@ -196,6 +195,7 @@ task :ci do
     sh 'rvm $RAILS5_VERSIONS --verbose do appraisal rails5-postgres-sidekiq rake test:railssidekiq'
     sh 'rvm $RAILS5_VERSIONS --verbose do appraisal rails5-postgres-sidekiq rake test:railsactivejob'
     sh 'rvm $RAILS5_VERSIONS --verbose do appraisal rails5-postgres rake test:railsdisableenv'
+    sh 'rvm $LAST_STABLE --verbose do rake benchmark'
   else
     puts 'Too many workers than parallel tasks'
   end

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,9 @@
 machine:
   services:
     - docker
+  ruby:
+    version:
+      2.2.7
   environment:
     LAST_STABLE: 2.4.1
     EARLY_STABLE: 2.2.7
@@ -15,36 +18,26 @@ machine:
     JRUBY_VERSIONS: jruby-9.1.13.0
     AGENT_BUILD_PATH: "/home/ubuntu/agent"
     TEST_DATADOG_INTEGRATION: 1
-  post:
-    - |
-      rvm get head
-      mkdir -p ~/rvm_binaries
-      for version in $(echo "$MRI_VERSIONS,$MRI_OLD_VERSIONS" | tr "," "\n"); do
-        ruby_bin=$(find ~/rvm_binaries -name "*${version}*")
-        if [[ -n "$ruby_bin" ]]; then
-          rvm mount "$ruby_bin"
-        else
-          rvm install "$version" --rubygems 2.6.11
-          cd ~/rvm_binaries && rvm prepare "$version"
-        fi
-      done
-      rvm install $JRUBY_VERSIONS --rubygems 2.6.11
-      rvm use $EARLY_STABLE --default
-
 
 dependencies:
   cache_directories:
     # Cache Ruby binaries and gems
     - "/opt/circleci/.rvm/"
-    - ~/rvm_binaries
+    - ~/rubies_cache
   pre:
+    - mkdir -p ~/rubies_cache
+    - rsync -a -v --ignore-existing ~/rubies_cache/ /opt/circleci/.rvm/rubies
     # we should use an old docker-compose because CircleCI supports
     # only docker-engine==1.9
     - pip install docker-compose==1.7.1
     - docker-compose up -d | cat
     # installing dev dependencies
-    # remove line below once `msgpack` have a consistent version for jruby
+    - |
+      for version in $(echo "$MRI_VERSIONS,$MRI_OLD_VERSIONS,$JRUBY_VERSIONS" | tr "," "\n"); do
+        $(rvm list | grep -q $version) || rvm install $version --rubygems 2.6.11
+      done
     - gem install bundler
+    # remove line below once `msgpack` have a consistent version for jruby
     - bundle inject msgpack 1.1.0 && sed -i "y/\"/'/" Gemfile
     - bundle install
   override:
@@ -52,6 +45,8 @@ dependencies:
     - rvm $MRI_VERSIONS,$MRI_OLD_VERSIONS,$JRUBY_VERSIONS --verbose do bundle install
     # [FIXME] appraisal does not work with jruby (problem with native ext, eg sqlite3)
     - rvm $MRI_VERSIONS,$MRI_OLD_VERSIONS --verbose do appraisal install || echo FIX-ME: Ignoring non-zero exit status
+  post:
+    - rsync -a -v --ignore-existing /opt/circleci/.rvm/rubies/ ~/rubies_cache
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -12,31 +12,42 @@ machine:
     RAILS5_VERSIONS: 2.3.4,2.2.7
     RAILS3_SIDEKIQ_VERSIONS: 2.1.10,2.0.0
     RAILS4_SIDEKIQ_VERSIONS: 2.3.4,2.2.7
-    JRUBY_VERSIONS: jruby-9.1.5.0
+    JRUBY_VERSIONS: jruby-9.1.13.0
     AGENT_BUILD_PATH: "/home/ubuntu/agent"
     TEST_DATADOG_INTEGRATION: 1
+  post:
+    - |
+      rvm get head
+      mkdir -p ~/rvm_binaries
+      for version in $(echo "$MRI_VERSIONS,$MRI_OLD_VERSIONS" | tr "," "\n"); do
+        ruby_bin=$(find ~/rvm_binaries -name "*${version}*")
+        if [[ -n "$ruby_bin" ]]; then
+          rvm mount "$ruby_bin"
+        else
+          rvm install "$version" --rubygems 2.6.11
+          cd ~/rvm_binaries && rvm prepare "$version"
+        fi
+      done
+      rvm install $JRUBY_VERSIONS --rubygems 2.6.11
+      rvm use $EARLY_STABLE --default
+
 
 dependencies:
   cache_directories:
     # Cache Ruby binaries and gems
     - "/opt/circleci/.rvm/"
+    - ~/rvm_binaries
   pre:
     # we should use an old docker-compose because CircleCI supports
     # only docker-engine==1.9
     - pip install docker-compose==1.7.1
     - docker-compose up -d | cat
     # installing dev dependencies
-    - gem update --system=2.6.11
-    - gem install builder
-    - gem update bundler
     # remove line below once `msgpack` have a consistent version for jruby
+    - gem install bundler
     - bundle inject msgpack 1.1.0 && sed -i "y/\"/'/" Gemfile
     - bundle install
-    # configure Ruby interpreters
-    - rvm get head
-    - rvm install $MRI_VERSIONS,$MRI_OLD_VERSIONS,$JRUBY_VERSIONS
   override:
-    - rvm $MRI_VERSIONS,$MRI_OLD_VERSIONS,$JRUBY_VERSIONS --verbose do gem update --system=2.6.11
     - rvm $MRI_VERSIONS,$MRI_OLD_VERSIONS,$JRUBY_VERSIONS --verbose do gem install bundler
     - rvm $MRI_VERSIONS,$MRI_OLD_VERSIONS,$JRUBY_VERSIONS --verbose do bundle install
     # [FIXME] appraisal does not work with jruby (problem with native ext, eg sqlite3)

--- a/circle.yml
+++ b/circle.yml
@@ -44,15 +44,15 @@ dependencies:
     - rvm $MRI_VERSIONS,$MRI_OLD_VERSIONS,$JRUBY_VERSIONS --verbose do gem install bundler
     - rvm $MRI_VERSIONS,$MRI_OLD_VERSIONS,$JRUBY_VERSIONS --verbose do bundle install
     # [FIXME] appraisal does not work with jruby (problem with native ext, eg sqlite3)
-    - rvm $MRI_VERSIONS,$MRI_OLD_VERSIONS --verbose do appraisal install || echo FIX-ME: Ignoring non-zero exit status
+    - rvm $MRI_VERSIONS,$MRI_OLD_VERSIONS --verbose do bundle exec appraisal install || echo FIX-ME: Ignoring non-zero exit status
   post:
     - rsync -a -v --ignore-existing /opt/circleci/.rvm/rubies/ ~/rubies_cache
 
 test:
   override:
-    - rvm $EARLY_STABLE --verbose do rake rubocop
+    - rvm $EARLY_STABLE --verbose do bundle exec rake rubocop
     # TODO: integration tests should run with the master branch of the agent
-    - rake ci:
+    - bundle exec rake ci:
         parallel: true
 
 deployment:


### PR DESCRIPTION
This PR provides a couple of optimizations speed up our builds. I've observed a`~35%` improvement.

Notice we should migrate our pipeline to CircleCI 2.0 which will yield greater improvements.