### PR TITLE
Add script name to resource for Sinatra if available

### DIFF
--- a/lib/ddtrace/contrib/sinatra/tracer.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer.rb
@@ -30,11 +30,19 @@ module Datadog
 
         option :tracer, default: Datadog.tracer
 
+        option :resource_script_names, default: false
+
         def route(verb, action, *)
           # Keep track of the route name when the app is instantiated for an
           # incoming request.
           condition do
-            @datadog_route = "#{request.script_name}#{action}"
+            # If the option to prepend script names is enabled, then
+            # prepend the script name from the request onto the action.
+            @datadog_route = if Datadog.configuration[:sinatra][:resource_script_names]
+                               "#{request.script_name}#{action}"
+                             else
+                               action
+                             end
           end
 
           super

--- a/lib/ddtrace/contrib/sinatra/tracer.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer.rb
@@ -34,7 +34,7 @@ module Datadog
           # Keep track of the route name when the app is instantiated for an
           # incoming request.
           condition do
-            @datadog_route = action
+            @datadog_route = "#{request.script_name}#{action}"
           end
 
           super

--- a/test/contrib/sinatra/first_test_app.rb
+++ b/test/contrib/sinatra/first_test_app.rb
@@ -1,0 +1,11 @@
+require 'contrib/sinatra/tracer_test_base'
+
+class MultiAppTest < TracerTestBase
+  class FirstTestApp < Sinatra::Base
+    register Datadog::Contrib::Sinatra::Tracer
+
+    get '/endpoint' do
+      '1'
+    end
+  end
+end

--- a/test/contrib/sinatra/multi_app_test.rb
+++ b/test/contrib/sinatra/multi_app_test.rb
@@ -1,0 +1,61 @@
+require 'contrib/sinatra/tracer_test_base'
+require 'contrib/sinatra/first_test_app'
+require 'contrib/sinatra/second_test_app'
+
+class MultiAppTest < TracerTestBase
+  def app
+    Rack::Builder.new do
+      map '/one' do
+        run FirstTestApp
+      end
+
+      map '/two' do
+        run SecondTestApp
+      end
+    end.to_app
+  end
+
+  def setup
+    @writer = FauxWriter.new()
+    FirstTestApp.set :datadog_test_writer, @writer
+    SecondTestApp.set :datadog_test_writer, @writer
+
+    tracer = Datadog::Tracer.new(writer: @writer, enabled: true)
+    Datadog.configuration[:sinatra][:tracer] = tracer
+
+    super
+  end
+
+  def test_resource_name_without_script_name
+    first_path = '/one/endpoint'
+    get first_path, {}, 'SCRIPT_NAME' => ''
+
+    spans = @writer.spans.select { |s| s.name == 'sinatra.request' }
+    assert_equal(1, spans.length)
+
+    spans.first.tap do |span|
+      assert_equal("GET #{first_path}", span.resource)
+    end
+  end
+
+  def test_resource_name_with_script_name
+    first_path = '/one/endpoint'
+    first_script = '/foo'
+    get first_path, {}, 'SCRIPT_NAME' => first_script
+
+    second_path = '/two/endpoint'
+    second_script = '/bar'
+    get second_path, {}, 'SCRIPT_NAME' => second_script
+
+    spans = @writer.spans.select { |s| s.name == 'sinatra.request' }
+    assert_equal(2, spans.length)
+
+    spans.last.tap do |span|
+      assert_equal("GET #{first_script}#{first_path}", span.resource)
+    end
+
+    spans.first.tap do |span|
+      assert_equal("GET #{second_script}#{second_path}", span.resource)
+    end
+  end
+end

--- a/test/contrib/sinatra/second_test_app.rb
+++ b/test/contrib/sinatra/second_test_app.rb
@@ -1,0 +1,11 @@
+require 'contrib/sinatra/tracer_test_base'
+
+class MultiAppTest < TracerTestBase
+  class SecondTestApp < Sinatra::Base
+    register Datadog::Contrib::Sinatra::Tracer
+
+    get '/endpoint' do
+      '2'
+    end
+  end
+end


### PR DESCRIPTION
This pull request prepends `request.script_name` to Sinatra trace resource names, if available and enabled. e.g. `get '/endpoint'` from a Sinatra app rooted in Rack via `map '/foo'` would change the trace `resource` from `/endpoint` to `/foo/endpoint`.

This new behavior is disabled by default. It can be enabled by adding the `resource_script_names` flag to the configuration. e.g.

```
Datadog.configure do |c|
  c.use :sinatra, resource_script_names: true
end
```

Or via `Datadog.configuration[:sinatra][:resource_script_names] = true`

This flag is useful for particular cases where there are multiple Sinatra apps configured in a `config.ru` that have overlapping endpoints rooted at different namespaces. Take for example the following app:

**config.ru:**

```
require 'bundler'
Bundler.require

require './lib/sinatra/app'

map '/foo' do
  run FooApp
end

map '/bar' do
  run BarApp
end
```

**lib/sinatra/app.rb:**

```
require 'ddtrace'
require 'ddtrace/contrib/sinatra/tracer'
require 'sinatra'

require_relative 'app/foo'
require_relative 'app/bar'
```

**lib/sinatra/app/foo.rb:**

```
class FooApp < Sinatra::Base
  register Datadog::Contrib::Sinatra::Tracer

  get '/endpoint' do
    'Foo!'
  end
end
```

**lib/sinatra/app/bar.rb:**

```
class BarApp < Sinatra::Base
  register Datadog::Contrib::Sinatra::Tracer

  get '/endpoint' do
    'Bar!'
  end
end
```

If you were to call `GET /foo/endpoint`, then `GET /bar/endpoint`, you would hit each of the apps correctly on their respective paths. However, the two traces created from these requests would report the same resource as `/endpoint` in the UI, which could lead to some confusion (since they are not the same app.)

By adding `request.script_name` onto the front of a path (see [Rack specification](http://www.rubydoc.info/github/rack/rack/file/SPEC) for more info), it allows these traces to be disambiguated as `GET /foo/endpoint` and `GET /bar/endpoint` for a less confusing user experience.