### PR TITLE
Truncate cache metadata

### DIFF
--- a/lib/ddtrace/contrib/rails/active_support.rb
+++ b/lib/ddtrace/contrib/rails/active_support.rb
@@ -45,7 +45,8 @@ module Datadog
             # discard parameters from the cache_store configuration
             store, = *Array.wrap(::Rails.configuration.cache_store).flatten
             span.set_tag('rails.cache.backend', store)
-            span.set_tag('rails.cache.key', payload.fetch(:key))
+            cache_key = Datadog::Utils.truncate(payload.fetch(:key), Ext::CACHE::MAX_KEY_SIZE)
+            span.set_tag('rails.cache.key', cache_key)
             span.set_error(payload[:exception]) if payload[:exception]
           ensure
             span.finish()

--- a/lib/ddtrace/contrib/redis/quantize.rb
+++ b/lib/ddtrace/contrib/redis/quantize.rb
@@ -5,8 +5,8 @@ module Datadog
       module Quantize
         PLACEHOLDER = '?'.freeze
         TOO_LONG_MARK = '...'.freeze
-        VALUE_MAX_LEN = 100
-        CMD_MAX_LEN = 1000
+        VALUE_MAX_LEN = 50
+        CMD_MAX_LEN = 500
 
         module_function
 

--- a/lib/ddtrace/ext/cache.rb
+++ b/lib/ddtrace/ext/cache.rb
@@ -2,6 +2,7 @@ module Datadog
   module Ext
     module CACHE
       TYPE = 'cache'.freeze
+      MAX_KEY_SIZE = 300
     end
   end
 end

--- a/test/contrib/redis/quantize_test.rb
+++ b/test/contrib/redis/quantize_test.rb
@@ -12,9 +12,9 @@ class RedisQuantizeTest < Minitest::Test
   def test_format_arg
     expected = { '' => '',
                  'HGETALL' => 'HGETALL',
-                 'A' * 100 => 'A' * 100,
-                 'B' * 101 => 'B' * 97 + '...',
-                 'C' * 1000 => 'C' * 97 + '...',
+                 'A' * 50 => 'A' * 50,
+                 'B' * 101 => 'B' * 47 + '...',
+                 'C' * 1000 => 'C' * 47 + '...',
                  nil => '',
                  Unstringable.new => '?' }
     expected.each do |k, v|
@@ -27,7 +27,7 @@ class RedisQuantizeTest < Minitest::Test
     command_args = []
     20.times { command_args << ('X' * 90) }
     trimmed = Datadog::Contrib::Redis::Quantize.format_command_args(command_args)
-    assert_equal(1000, trimmed.length)
-    assert_equal('X...', trimmed[996..999])
+    assert_equal(500, trimmed.length)
+    assert_equal('X...', trimmed[496..499])
   end
 end

--- a/test/contrib/redis/redis_test.rb
+++ b/test/contrib/redis/redis_test.rb
@@ -107,17 +107,17 @@ class RedisTest < Minitest::Test
 
   def test_quantize
     @drivers.each do |_d, driver|
-      driver.set 'K', 'x' * 10000
+      driver.set 'K', 'x' * 500
       response = driver.get 'K'
-      assert_equal('x' * 10000, response)
+      assert_equal('x' * 500, response)
       spans = @tracer.writer.spans()
       assert_operator(2, :<=, spans.length)
       get, set = spans[-2..-1]
       check_common_tags(set)
       assert_equal('redis.command', set.name)
       assert_equal('redis', set.service)
-      assert_equal('SET K ' + 'x' * 97 + '...', set.resource)
-      assert_equal('SET K ' + 'x' * 97 + '...', set.get_tag('redis.raw_command'))
+      assert_equal('SET K ' + 'x' * 47 + '...', set.resource)
+      assert_equal('SET K ' + 'x' * 47 + '...', set.get_tag('redis.raw_command'))
       check_common_tags(get)
       assert_equal('redis.command', get.name)
       assert_equal('redis', get.service)


### PR DESCRIPTION
This PR enforces a hard-limit on the meta-data that's embedded in spans generated by `rails` cache instrumentation.

I'm also lowering the maximum size of `redis` commands.