### PR TITLE
Set span types for integrations

### DIFF
--- a/lib/ddtrace/contrib/aws/patcher.rb
+++ b/lib/ddtrace/contrib/aws/patcher.rb
@@ -23,6 +23,7 @@ module Datadog
 
             add_pin
             add_plugin(Seahorse::Client::Base, *loaded_constants)
+            Datadog.tracer.set_service_info(get_option(:service_name), 'aws', Ext::AppTypes::WEB)
 
             @patched = true
           rescue => e

--- a/lib/ddtrace/contrib/dalli/patcher.rb
+++ b/lib/ddtrace/contrib/dalli/patcher.rb
@@ -22,6 +22,7 @@ module Datadog
 
             add_pin!
             Instrumentation.patch!
+            Datadog.tracer.set_service_info(get_option(:service_name), 'dalli', Ext::AppTypes::CACHE)
 
             @patched = true
           rescue => e
@@ -42,7 +43,7 @@ module Datadog
           end
 
           def add_pin!
-            Pin.new(get_option(:service_name), app_type: Ext::AppTypes::DB).tap do |pin|
+            Pin.new(get_option(:service_name), app_type: Ext::AppTypes::CACHE).tap do |pin|
               pin.onto(::Dalli)
             end
           end

--- a/lib/ddtrace/contrib/elasticsearch/patcher.rb
+++ b/lib/ddtrace/contrib/elasticsearch/patcher.rb
@@ -9,7 +9,6 @@ module Datadog
       BODY = 'elasticsearch.body'.freeze
 
       SERVICE = 'elasticsearch'.freeze
-      SPAN_TYPE = 'elasticsearch'.freeze
 
       # Patcher enables patching of 'elasticsearch/transport' module.
       # This is used in monkey.rb to automatically apply patches
@@ -35,6 +34,7 @@ module Datadog
               require 'ddtrace/contrib/elasticsearch/quantize'
 
               patch_elasticsearch_transport_client()
+              Datadog.tracer.set_service_info(get_option(:service_name), 'elasticsearch', Ext::AppTypes::DB)
 
               @patched = true
             rescue StandardError => e
@@ -78,7 +78,7 @@ module Datadog
               pin.tracer.trace('elasticsearch.query') do |span|
                 begin
                   span.service = pin.service
-                  span.span_type = SPAN_TYPE
+                  span.span_type = Ext::AppTypes::DB
 
                   # load JSON for the following fields unless they're already strings
                   params = JSON.generate(params) if params && !params.is_a?(String)

--- a/lib/ddtrace/contrib/sidekiq/tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/tracer.rb
@@ -40,7 +40,7 @@ module Datadog
           service = sidekiq_service(resource_worker(resource))
           set_service_info(service)
 
-          @tracer.trace('sidekiq.job', service: service, span_type: 'job') do |span|
+          @tracer.trace('sidekiq.job', service: service, span_type: Datadog::Ext::AppTypes::WORKER) do |span|
             span.resource = resource
             span.set_tag('sidekiq.job.id', job['jid'])
             span.set_tag('sidekiq.job.retry', job['retry'])

--- a/lib/ddtrace/contrib/sinatra/tracer.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer.rb
@@ -56,7 +56,7 @@ module Datadog
               output = ''
               tracer = Datadog.configuration[:sinatra][:tracer]
               if tracer.enabled
-                tracer.trace('sinatra.render_template') do |span|
+                tracer.trace('sinatra.render_template', span_type: Datadog::Ext::HTTP::TEMPLATE) do |span|
                   # If data is a string, it is a literal template and we don't
                   # want to record it.
                   span.set_tag('sinatra.template_name', data) if data.is_a? Symbol

--- a/lib/ddtrace/contrib/sucker_punch/patcher.rb
+++ b/lib/ddtrace/contrib/sucker_punch/patcher.rb
@@ -24,6 +24,7 @@ module Datadog
           add_pin!
           ExceptionHandler.patch!
           Instrumentation.patch!
+          Datadog.tracer.set_service_info(get_option(:service_name), 'sucker_punch', Ext::AppTypes::WORKER)
 
           @patched = true
         rescue => e

--- a/lib/ddtrace/ext/app_types.rb
+++ b/lib/ddtrace/ext/app_types.rb
@@ -5,6 +5,7 @@ module Datadog
       DB = 'db'.freeze
       CACHE = 'cache'.freeze
       WORKER = 'worker'.freeze
+      CUSTOM = 'custom'.freeze
     end
   end
 end


### PR DESCRIPTION
This pull request ensures we're correctly tagging our spans for each service integration, for a better UI experience. After these changes are applied, the following integrations should have these service and span types:

```
                  Service         Span
 X ActiveRecord  - DB              SQL::TYPE
 X AWS           - WEB             WEB
 X Dalli         - CACHE           CACHE
 X ElasticSearch - DB              DB
 X Faraday       - WEB             HTTP::TYPE
 X Grape         - WEB             HTTP::TYPE
 ? HTTP          - ???             HTTP::TYPE
 X MongoDB       - DB              Mongo::TYPE
 X Rack          - WEB             HTTP::TYPE
 X Rails         - WEB, CACHE, DB  HTTP::TYPE, HTTP::TEMPLATE, SQL::TYPE, CACHE
 X Redis         - DB              Redis::TYPE
 X Resque        - WORKER          WORKER
 X Sidekiq       - WORKER          WORKER
 X Sinatra       - WEB             HTTP::TYPE, HTTP::TEMPLATE
 X SuckerPunch   - WORKER          WORKER
```