### PR TITLE
Add out.host and out.port to ActiveRecord

### DIFF
--- a/lib/ddtrace/contrib/active_record/patcher.rb
+++ b/lib/ddtrace/contrib/active_record/patcher.rb
@@ -46,6 +46,18 @@ module Datadog
           @adapter_name ||= Datadog::Contrib::Rails::Utils.adapter_name
         end
 
+        def self.database_name
+          @database_name ||= Datadog::Contrib::Rails::Utils.database_name
+        end
+
+        def self.adapter_host
+          @adapter_host ||= Datadog::Contrib::Rails::Utils.adapter_host
+        end
+
+        def self.adapter_port
+          @adapter_port ||= Datadog::Contrib::Rails::Utils.adapter_port
+        end
+
         def self.tracer
           @tracer ||= Datadog.configuration[:sinatra][:tracer]
         end
@@ -73,6 +85,9 @@ module Datadog
           # obfuscated version
           span.span_type = Datadog::Ext::SQL::TYPE
           span.set_tag('active_record.db.vendor', adapter_name)
+          span.set_tag('active_record.db.name', database_name)
+          span.set_tag('out.host', adapter_host)
+          span.set_tag('out.port', adapter_port)
           span.start_time = start
           span.finish(finish)
         rescue StandardError => e

--- a/lib/ddtrace/contrib/rails/active_record.rb
+++ b/lib/ddtrace/contrib/rails/active_record.rb
@@ -22,6 +22,8 @@ module Datadog
           database_service = Datadog.configuration[:rails][:database_service]
           adapter_name = Datadog::Contrib::Rails::Utils.adapter_name
           database_name = Datadog::Contrib::Rails::Utils.database_name
+          adapter_host = Datadog::Contrib::Rails::Utils.adapter_host
+          adapter_port = Datadog::Contrib::Rails::Utils.adapter_port
           span_type = Datadog::Ext::SQL::TYPE
 
           span = tracer.trace(
@@ -46,6 +48,8 @@ module Datadog
           span.set_tag('rails.db.vendor', adapter_name)
           span.set_tag('rails.db.name', database_name)
           span.set_tag('rails.db.cached', cached) if cached
+          span.set_tag('out.host', adapter_host)
+          span.set_tag('out.port', adapter_port)
           span.start_time = start
           span.finish(finish)
         rescue StandardError => e

--- a/lib/ddtrace/contrib/rails/utils.rb
+++ b/lib/ddtrace/contrib/rails/utils.rb
@@ -54,6 +54,14 @@ module Datadog
           connection_config[:database]
         end
 
+        def self.adapter_host
+          connection_config[:host]
+        end
+
+        def self.adapter_port
+          connection_config[:port]
+        end
+
         def self.connection_config
           if defined?(::ActiveRecord::Base.connection_config)
             ::ActiveRecord::Base.connection_config

--- a/test/contrib/rails/database_test.rb
+++ b/test/contrib/rails/database_test.rb
@@ -22,12 +22,16 @@ class DatabaseTracingTest < ActiveSupport::TestCase
     span = spans.first
     adapter_name = get_adapter_name
     database_name = get_database_name
+    adapter_host = get_adapter_host
+    adapter_port = get_adapter_port
     assert_equal(span.name, "#{adapter_name}.query")
     assert_equal(span.span_type, 'sql')
     assert_equal(span.service, adapter_name)
     assert_equal(span.get_tag('rails.db.vendor'), adapter_name)
     assert_equal(span.get_tag('rails.db.name'), database_name)
     assert_nil(span.get_tag('rails.db.cached'))
+    assert_equal(adapter_host.to_s, span.get_tag('out.host'))
+    assert_equal(adapter_port.to_s, span.get_tag('out.port'))
     assert_includes(span.resource, 'SELECT COUNT(*) FROM')
     # ensure that the sql.query tag is not set
     assert_nil(span.get_tag('sql.query'))

--- a/test/contrib/sinatra/tracer_activerecord_test.rb
+++ b/test/contrib/sinatra/tracer_activerecord_test.rb
@@ -43,9 +43,17 @@ class TracerActiveRecordTest < TracerTestBase
     sinatra_span = spans[0]
     sqlite_span = spans[spans.length - 1]
 
+    adapter_name = Datadog::Contrib::Rails::Utils.adapter_name
+    database_name = Datadog::Contrib::Rails::Utils.database_name
+    adapter_host = Datadog::Contrib::Rails::Utils.adapter_host
+    adapter_port = Datadog::Contrib::Rails::Utils.adapter_port
+
     assert_equal('sqlite', sqlite_span.service)
     assert_equal('SELECT 42', sqlite_span.resource)
-    assert_equal('sqlite', sqlite_span.get_tag('active_record.db.vendor'))
+    assert_equal(adapter_name, sqlite_span.get_tag('active_record.db.vendor'))
+    assert_equal(database_name, sqlite_span.get_tag('active_record.db.name'))
+    assert_equal(adapter_host.to_s, sqlite_span.get_tag('out.host'))
+    assert_equal(adapter_port.to_s, sqlite_span.get_tag('out.port'))
     assert_equal(Datadog::Ext::SQL::TYPE, sqlite_span.span_type)
     assert_equal(0, sqlite_span.status)
     assert_equal(sinatra_span, sqlite_span.parent)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -72,6 +72,14 @@ def get_database_name
   Datadog::Contrib::Rails::Utils.database_name
 end
 
+def get_adapter_host
+  Datadog::Contrib::Rails::Utils.adapter_host
+end
+
+def get_adapter_port
+  Datadog::Contrib::Rails::Utils.adapter_port
+end
+
 # FauxWriter is a dummy writer that buffers spans locally.
 class FauxWriter < Datadog::Writer
   def initialize(options = {})


### PR DESCRIPTION
This pull request adds the `out.host` and `out.port` tags to SQL traces in Rails ActiveRecord implementations. It additionally adds `active_record.db.name`, `out.host`, and `out.port` to Sinatra ActiveRecord implementations.