### PR TITLE
Add out.host and out.port to Elasticsearch

### DIFF
--- a/test/contrib/elasticsearch/transport_test.rb
+++ b/test/contrib/elasticsearch/transport_test.rb
@@ -34,6 +34,8 @@ class ESTransportTest < Minitest::Test
     assert_equal('200', span.get_tag('http.status_code'))
     assert_nil(span.get_tag('elasticsearch.params'))
     assert_nil(span.get_tag('elasticsearch.body'))
+    assert_equal('127.0.0.1', span.get_tag('out.host'))
+    assert_equal('49200', span.get_tag('out.port'))
   end
 
   def test_perform_request_with_encoded_body


### PR DESCRIPTION
This pull request adds the `out.host` and `out.port` tags to traces for Elasticsearch.