### PR TITLE
Drop invalid byte sequences on `Redis::Quantize`

### DIFF
--- a/lib/ddtrace/contrib/redis/quantize.rb
+++ b/lib/ddtrace/contrib/redis/quantize.rb
@@ -12,6 +12,7 @@ module Datadog
 
         def format_arg(arg)
           str = arg.is_a?(Symbol) ? arg.to_s.upcase : arg.to_s
+          str = str.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
           Utils.truncate(str, VALUE_MAX_LEN, TOO_LONG_MARK)
         rescue StandardError => e
           Datadog::Tracer.log.debug("non formattable Redis arg #{str}: #{e}")

--- a/test/contrib/redis/quantize_test.rb
+++ b/test/contrib/redis/quantize_test.rb
@@ -30,4 +30,13 @@ class RedisQuantizeTest < Minitest::Test
     assert_equal(1000, trimmed.length)
     assert_equal('X...', trimmed[996..999])
   end
+
+  def test_invalid_byte_sequence_regression
+    # \255 is off-limits https://en.wikipedia.org/wiki/UTF-8#Codepage_layout
+    quantized = Datadog::Contrib::Redis::Quantize.format_arg(
+      "SET foo bar\255"
+    )
+
+    assert_equal('SET foo bar', quantized)
+  end
 end


### PR DESCRIPTION
This PR ensures all byte sequences considered invalid/undefined in by UTF-8 are removed from `redis` spans before they get flushed.