### PR TITLE
[dual sampling] support -1 as a priority sampling value

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -45,4 +45,5 @@ EOS
   spec.add_development_dependency 'addressable', '~> 2.4.0'
   spec.add_development_dependency 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
   spec.add_development_dependency 'pry', '>= 0.10.4'
+  spec.add_development_dependency 'pry-stack_explorer', '>= 0.4.9.2'
 end

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -722,10 +722,10 @@ overhead.
 
 Priority sampling consists in deciding if a trace will be kept by using a priority attribute that will be propagated for distributed traces. Its value gives indication to the Agent and to the backend on how important the trace is.
 
-* -1: The user asked not to keep the trace.
-* 0: The sampler automatically decided not to keep the trace.
-* 1: The sampler automatically decided to keep the trace.
-* 2: The user asked to keep the trace.
+The sampler can set the priority to the following values:
+
+* `Datadog::Ext::Priority::AUTO_REJECT`: the sampler automatically decided to reject the trace.
+* `Datadog::Ext::Priority::AUTO_KEEP`: the sampler automatically decided to keep the trace.
 
 For now, priority sampling is disabled by default. Enabling it ensures that your sampled distributed traces will be complete. To enable the priority sampling:
 
@@ -735,17 +735,26 @@ Datadog.tracer.configure(priority_sampling: true)
 
 Once enabled, the sampler will automatically assign a priority of 0 or 1 to traces, depending on their service and volume.
 
-You can also set this priority manually to either drop a non-interesting trace or to keep an important one. For that, set the `context#sampling_priority` to `-1` or `2`. It has to be done before any context propagation (fork, RPC calls) to be effective.
-For example, it is possible to select some traces based on some existing bit of information such as a user or transaction ID.
-But it is generally not possible to select a trace based on its error status,
-as this information typically happens later in the process, when context has already been propagated:
+You can also set this priority manually to either drop a non-interesting trace or to keep an important one. For that, set the `context#sampling_priority` to:
+
+* `Datadog::Ext::Priority::USER_REJECT`: the user asked to reject the trace.
+* `Datadog::Ext::Priority::USER_KEEP`: the user asked to keep the trace.
+
+When not using [distributed tracing](#Distributed_Tracing), you may change the priority at any time,
+as long as the trace is not finished yet.
+But it has to be done before any context propagation (fork, RPC calls) to be effective in a distributed context.
+Changing the priority after context has been propagated causes different parts of a distributed trace
+to use different priorities. Some parts might be kept, some parts might be rejected,
+and this can cause the trace to be partially stored and remain incomplete.
+
+If you change the priority, we recommend you do it as soon as possible, when the root span has just been created.
 
 ```rb
-# Indicate to not keep the trace
-span.context.sampling_priority = -1
+# Indicate to reject the trace
+span.context.sampling_priority = Datadog::Ext::Priority::USER_REJECT
 
 # Indicate to keep the trace
-span.context.sampling_priority = 2
+span.context.sampling_priority = Datadog::Ext::Priority::USER_KEEP
 ```
 
 ### Distributed Tracing

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -725,7 +725,7 @@ Priority sampling consists in deciding if a trace will be kept by using a priori
 * -1: The user asked not to keep the trace.
 * 0: The sampler automatically decided not to keep the trace.
 * 1: The sampler automatically decided to keep the trace.
-* 2: The user asked the keep the trace.
+* 2: The user asked to keep the trace.
 
 For now, priority sampling is disabled by default. Enabling it ensures that your sampled distributed traces will be complete. To enable the priority sampling:
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -722,7 +722,8 @@ overhead.
 
 Priority sampling consists in deciding if a trace will be kept by using a priority attribute that will be propagated for distributed traces. Its value gives indication to the Agent and to the backend on how important the trace is.
 
-* 0: Don’t keep the trace.
+* -1: The user asked not to keep the trace.
+* 0: The sampler automatically decided not to keep the trace.
 * 1: The sampler automatically decided to keep the trace.
 * 2: The user asked the keep the trace.
 
@@ -734,11 +735,14 @@ Datadog.tracer.configure(priority_sampling: true)
 
 Once enabled, the sampler will automatically assign a priority of 0 or 1 to traces, depending on their service and volume.
 
-You can also set this priority manually to either drop a non-interesting trace or to keep an important one. For that, set the `context#sampling_priority` to 0 or 2. It has to be done before any context propagation (fork, RPC calls) to be effective:
+You can also set this priority manually to either drop a non-interesting trace or to keep an important one. For that, set the `context#sampling_priority` to `-1` or `2`. It has to be done before any context propagation (fork, RPC calls) to be effective.
+For example, it is possible to select some traces based on some existing bit of information such as a user or transaction ID.
+But it is generally not possible to select a trace based on its error status,
+as this information typically happens later in the process, when context has already been propagated:
 
 ```rb
 # Indicate to not keep the trace
-span.context.sampling_priority = 0
+span.context.sampling_priority = -1
 
 # Indicate to keep the trace
 span.context.sampling_priority = 2

--- a/lib/ddtrace/ext/priority.rb
+++ b/lib/ddtrace/ext/priority.rb
@@ -1,9 +1,15 @@
 module Datadog
   module Ext
+    # Priority is a hint given to the backend so that it knows which traces to reject or kept.
+    # In a distributed context, it should be set before any context propagation (fork, RPC calls) to be effective.
     module Priority
+      # Use this to explicitely inform the backend that a trace should be rejected and not stored.
       USER_REJECT = -1
+      # Used by the builtin sampler to inform the backend that a trace should be rejected and not stored.
       AUTO_REJECT = 0
+      # Used by the builtin sampler to inform the backend that a trace should be kept and stored.
       AUTO_KEEP = 1
+      # Use this to explicitely inform the backend that a trace should be kept and stored.
       USER_KEEP = 2
     end
   end

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -59,7 +59,7 @@ class ContextTest < Minitest::Test
 
     assert_nil(ctx.sampling_priority)
 
-    [0, 1, 2, nil, 999].each do |sampling_priority|
+    [-1, 0, 1, 2, nil, 999].each do |sampling_priority|
       ctx.sampling_priority = sampling_priority
       if sampling_priority
         assert_equal(sampling_priority, ctx.sampling_priority)

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -59,7 +59,11 @@ class ContextTest < Minitest::Test
 
     assert_nil(ctx.sampling_priority)
 
-    [-1, 0, 1, 2, nil, 999].each do |sampling_priority|
+    [Datadog::Ext::Priority::USER_REJECT,
+     Datadog::Ext::Priority::AUTO_REJECT,
+     Datadog::Ext::Priority::AUTO_KEEP,
+     Datadog::Ext::Priority::USER_KEEP,
+     nil, 999].each do |sampling_priority|
       ctx.sampling_priority = sampling_priority
       if sampling_priority
         assert_equal(sampling_priority, ctx.sampling_priority)


### PR DESCRIPTION
Allow usage of  `-1` as a priority sampling value. Here there's no real impact, it's mostly about writing tests ensuring this works and updating the docs.