### PR TITLE
Add ActiveRecord cached tag

### DIFF
--- a/lib/ddtrace/contrib/active_record/patcher.rb
+++ b/lib/ddtrace/contrib/active_record/patcher.rb
@@ -80,12 +80,18 @@ module Datadog
             span_type: span_type
           )
 
+          # Find out if the SQL query has been cached in this request. This meta is really
+          # helpful to users because some spans may have 0ns of duration because the query
+          # is simply cached from memory, so the notification is fired with start == finish.
+          cached = payload[:cached] || (payload[:name] == 'CACHE')
+
           # the span should have the query ONLY in the Resource attribute,
           # so that the ``sql.query`` tag will be set in the agent with an
           # obfuscated version
           span.span_type = Datadog::Ext::SQL::TYPE
           span.set_tag('active_record.db.vendor', adapter_name)
           span.set_tag('active_record.db.name', database_name)
+          span.set_tag('active_record.db.cached', cached) if cached
           span.set_tag('out.host', adapter_host)
           span.set_tag('out.port', adapter_port)
           span.start_time = start

--- a/lib/ddtrace/contrib/rails/active_record.rb
+++ b/lib/ddtrace/contrib/rails/active_record.rb
@@ -33,13 +33,10 @@ module Datadog
             span_type: span_type
           )
 
-          # find out if the SQL query has been cached in this request. This meta is really
+          # Find out if the SQL query has been cached in this request. This meta is really
           # helpful to users because some spans may have 0ns of duration because the query
           # is simply cached from memory, so the notification is fired with start == finish.
-          # TODO[manu]: this feature has been merged into master but has not yet released.
-          # We're supporting this action as a best effort, but we should add a test after
-          # a new version of Rails is out.
-          cached = payload[:cached]
+          cached = payload[:cached] || (payload[:name] == 'CACHE')
 
           # the span should have the query ONLY in the Resource attribute,
           # so that the ``sql.query`` tag will be set in the agent with an

--- a/test/contrib/rails/database_test.rb
+++ b/test/contrib/rails/database_test.rb
@@ -48,9 +48,11 @@ class DatabaseTracingTest < ActiveSupport::TestCase
       spans = @tracer.writer.spans
       assert_equal(spans.length, 2)
 
-      # Assert cached flag set correctly
-      span = spans.last
-      assert_equal(true, span.get_tag('rails.db.cached'))
+      # Assert cached flag not present on first query
+      assert_nil(spans.first.get_tag('rails.db.cached'))
+
+      # Assert cached flag set correctly on second query
+      assert_equal('true', spans.last.get_tag('rails.db.cached'))
     end
   end
 


### PR DESCRIPTION
Add the `cached` tag to ActiveRecord query spans that are cached.

The old implementation was not correctly tagging ActiveRecord queries that were resolved through the query cache. This pull requests fixes that implementation, adds the same tag for ActiveRecord integrations outside of Rails, and adds test coverage for both scenarios.

Still need to ascertain what milestone this should be applied to.