### PR TITLE
Use new configuration API `sidekiq`

### DIFF
--- a/lib/ddtrace/contrib/sidekiq/patcher.rb
+++ b/lib/ddtrace/contrib/sidekiq/patcher.rb
@@ -1,0 +1,33 @@
+module Datadog
+  module Contrib
+    module Sidekiq
+      # Provides instrumentation support for Sidekiq
+      module Patcher
+        include Base
+        VERSION_REQUIRED = Gem::Version.new('4.0.0')
+        register_as :sidekiq
+        option :service_name, default: 'sidekiq'
+        option :tracer, default: Datadog.tracer
+
+        module_function
+
+        def patch
+          return unless compatible?
+
+          require_relative 'tracer'
+
+          ::Sidekiq.configure_server do |config|
+            config.server_middleware do |chain|
+              chain.add(Sidekiq::Tracer)
+            end
+          end
+        end
+
+        def compatible?
+          defined?(::Sidekiq) &&
+            Gem::Version.new(::Sidekiq::VERSION) >= VERSION_REQUIRED
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/sidekiq/tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/tracer.rb
@@ -2,25 +2,11 @@ require 'sidekiq/api'
 
 require 'ddtrace/ext/app_types'
 
-sidekiq_vs = Gem::Version.new(Sidekiq::VERSION)
-sidekiq_min_vs = Gem::Version.new('4.0.0')
-if sidekiq_vs < sidekiq_min_vs
-  raise "sidekiq version #{sidekiq_vs} is not supported yet " \
-        + "(supporting versions >=#{sidekiq_min_vs})"
-end
-
-Datadog::Tracer.log.debug("Activating instrumentation for Sidekiq '#{sidekiq_vs}'")
-
 module Datadog
   module Contrib
     module Sidekiq
-      # Middleware is a Sidekiq server-side middleware which traces executed jobs
+      # Tracer is a Sidekiq server-side middleware which traces executed jobs
       class Tracer
-        include Base
-        register_as :sidekiq
-        option :service_name, default: 'sidekiq'
-        option :tracer, default: Datadog.tracer
-
         def initialize(options = {})
           config = Datadog.configuration[:sidekiq].merge(options)
           @tracer = config[:tracer]

--- a/lib/ddtrace/monkey.rb
+++ b/lib/ddtrace/monkey.rb
@@ -18,6 +18,7 @@ require 'ddtrace/contrib/mongodb/patcher'
 require 'ddtrace/contrib/dalli/patcher'
 require 'ddtrace/contrib/resque/patcher'
 require 'ddtrace/contrib/racecar/patcher'
+require 'ddtrace/contrib/sidekiq/patcher'
 
 module Datadog
   # Monkey is used for monkey-patching 3rd party libs.

--- a/test/monkey_test.rb
+++ b/test/monkey_test.rb
@@ -26,6 +26,7 @@ class MonkeyTest < Minitest::Test
       dalli: true,
       resque: true,
       active_record: false,
+      sidekiq: false,
       racecar: false
     }
 


### PR DESCRIPTION
This PR simplifies the process of configuring tracing for `sidekiq`.

#### Old configuration
```rb
require 'ddtrace/contrib/sidekiq/tracer'

Sidekiq.configure_server do |config|
  config.server_middleware do |chain|
    chain.add(
      Datadog::Contrib::Sidekiq::Tracer,
      sidekiq_service: 'sidekiq-notifications'
    )
  end
end
```

#### New configuration
```rb
Datadog.configure do |c|
  c.use :sidekiq, service_name: 'sidekiq-notifications'
end
```