### PR TITLE
Allow `Datadog::Tracer.log` to be set through `Datadog.configure`

### DIFF
--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -30,6 +30,7 @@ module Datadog
       instance = options.fetch(:instance, Datadog.tracer)
 
       instance.configure(options)
+      instance.class.log = options[:log] if options[:log]
       instance.set_tags(options[:tags]) if options[:tags]
       instance.set_tags(env: options[:env]) if options[:env]
       instance.class.debug_logging = options.fetch(:debug, false)


### PR DESCRIPTION
As the title says, we're letting `Datadog::Tracer.log` be set through our `Datadog.configure` method, for the sake of providing a more standardized way of configuring tracing options.

### Example

```rb
Datadog.configure do |c|
  c.tracer log: Logger.new(STDOUT)
end
```