### PR TITLE
Enable `Pin` configuration through `Datadog.configure`

### DIFF
--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -39,8 +39,12 @@ module Datadog
       @configuration ||= Configuration.new
     end
 
-    def configure
-      yield(configuration)
+    def configure(target = configuration)
+      target = Pin.get_from(target) unless target.is_a?(Configuration)
+
+      return target unless block_given?
+
+      yield(target)
     end
   end
 end

--- a/lib/ddtrace/pin.rb
+++ b/lib/ddtrace/pin.rb
@@ -18,6 +18,8 @@ module Datadog
     attr_accessor :tracer
     attr_accessor :config
 
+    alias service_name= service=
+
     # [ruby19] named parameters would be more idiomatic here, but would break backward compatibility
     def initialize(service, options = { app: nil, tags: nil, app_type: nil, tracer: nil, config: nil })
       @service = service

--- a/test/pin_test.rb
+++ b/test/pin_test.rb
@@ -67,4 +67,21 @@ class PinTest < Minitest::Test
     pin.onto(obj)
     assert_equal('The PIN is set!', Datadog::Pin.get_from(obj))
   end
+
+  # We're providing this API to gradually hide the Pin from customers
+  def test_configure_api_with_block
+    object = Object.new
+    Datadog::Pin.new(:foo).onto(object)
+    Datadog.configure(object) { |c| c.service_name = :bar }
+
+    assert_equal(:bar, object.datadog_pin.service)
+  end
+
+  def test_configure_api
+    object = Object.new
+    Datadog::Pin.new(:foo).onto(object)
+    Datadog.configure(object).service_name = :bar
+
+    assert_equal(:bar, object.datadog_pin.service)
+  end
 end


### PR DESCRIPTION
In order to provide a single entry point for all configuration, we're providing this wrapper around `Pin` objects, so we can "hide" this implementation detail. Objects that carry a `Pin` can now be configured through the same `Datadog.configure` method.

### Example

```rb
client = Net::HTTP.new(host, port)

Datadog.configure(client) do |c|
  c.service_name = 'external-api'
end
```
