### PR TITLE
Fix missing CI test for racecar

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -161,6 +161,7 @@ task :ci do
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:sucker_punch'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:dalli'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:resque'
+    sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:racecar'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:monkey'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:elasticsearch'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:http'


### PR DESCRIPTION
Racecar tests weren't running in our CI pipeline, evidently. This pull request remedies that.