### PR TITLE
Add `Configuration::PinSetup`

### DIFF
--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -39,12 +39,12 @@ module Datadog
       @configuration ||= Configuration.new
     end
 
-    def configure(target = configuration)
-      target = Pin.get_from(target) unless target.is_a?(Configuration)
-
-      return target unless block_given?
-
-      yield(target)
+    def configure(target = configuration, opts = {})
+      if target.is_a?(Configuration)
+        yield(target)
+      else
+        Configuration::PinSetup.new(target, opts).call
+      end
     end
   end
 end

--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -1,5 +1,6 @@
 require_relative 'configuration/proxy'
 require_relative 'configuration/resolver'
+require_relative 'configuration/pin_setup'
 
 module Datadog
   # Configuration provides a unique access point for configurations

--- a/lib/ddtrace/configuration/pin_setup.rb
+++ b/lib/ddtrace/configuration/pin_setup.rb
@@ -1,0 +1,30 @@
+module Datadog
+  class Configuration
+    # PinSetup translates a flat hash into a Pin configuration
+    # This class should be removed if we ever remove/refactor the Pin class
+    class PinSetup
+      def initialize(target, opts = {})
+        @pin = Pin.get_from(target)
+        @opts = opts
+      end
+
+      def call
+        return unless pin
+
+        ATTRS.each { |key| pin.public_send("#{key}=", opts[key]) if opts[key] }
+
+        pin.config = opts.reject { |key, _| ATTRS.include?(key) }
+
+        true
+      end
+
+      private
+
+      attr_reader :pin, :opts
+
+      ATTRS = [:service_name, :app, :tags, :app_type, :name, :tracer].freeze
+
+      private_constant :ATTRS
+    end
+  end
+end

--- a/test/configuration/pin_setup_test.rb
+++ b/test/configuration/pin_setup_test.rb
@@ -1,0 +1,50 @@
+require 'ddtrace/configuration'
+
+module Datadog
+  class Configuration
+    class PinSetupTest < Minitest::Test
+      def setup
+        @target = Object.new
+
+        Pin
+          .new('original-service', app: 'original-app')
+          .onto(@target)
+      end
+
+      def test_setting_options
+        custom_tracer = Object.new
+
+        custom_options = {
+          service_name: 'my-service',
+          app: 'my-app',
+          app_type: :cache,
+          tracer: custom_tracer,
+          tags: { env: :prod },
+          distributed_tracing: true
+        }
+
+        PinSetup.new(@target, custom_options).call
+
+        assert_equal('my-service', @target.datadog_pin.service)
+        assert_equal('my-app', @target.datadog_pin.app)
+        assert_equal({ env: :prod }, @target.datadog_pin.tags)
+        assert_equal({ distributed_tracing: true }, @target.datadog_pin.config)
+        assert_equal(custom_tracer, @target.datadog_pin.tracer)
+      end
+
+      def test_missing_options_are_not_set
+        PinSetup.new(@target, app: 'custom-app').call
+
+        assert_equal('custom-app', @target.datadog_pin.app)
+        assert_equal('original-service', @target.datadog_pin.service)
+      end
+
+      def test_configure_api
+        Datadog.configure(@target, service_name: :foo, extra: :bar)
+
+        assert_equal(:foo, @target.datadog_pin.service)
+        assert_equal({ extra: :bar }, @target.datadog_pin.config)
+      end
+    end
+  end
+end

--- a/test/pin_test.rb
+++ b/test/pin_test.rb
@@ -67,21 +67,4 @@ class PinTest < Minitest::Test
     pin.onto(obj)
     assert_equal('The PIN is set!', Datadog::Pin.get_from(obj))
   end
-
-  # We're providing this API to gradually hide the Pin from customers
-  def test_configure_api_with_block
-    object = Object.new
-    Datadog::Pin.new(:foo).onto(object)
-    Datadog.configure(object) { |c| c.service_name = :bar }
-
-    assert_equal(:bar, object.datadog_pin.service)
-  end
-
-  def test_configure_api
-    object = Object.new
-    Datadog::Pin.new(:foo).onto(object)
-    Datadog.configure(object).service_name = :bar
-
-    assert_equal(:bar, object.datadog_pin.service)
-  end
 end


### PR DESCRIPTION
This PR is one step further towards a more standardized configuration API.

* We're hiding the `Pin` object altogether instead of yielding it in a block;
* The options must now be provided as a hash instead of setter methods, matching the current `c.use :integration, option1: value1, option2: value2` syntax;
* All configurations are provided as a "flat" hash, instead of a set of attributes AND a `config` hash (see example below).

### Example

Per-connection configuration must now be done following this API:

```rb
client = Net::HTTP.new(host, port)
Datadog.configure(client, service_name: 'external-api', distributed_tracing: true)
```

Instead of

```rb
client = Net::HTTP.new(host, port)
Datadog.configure(client) do |c|
  c.service_name = 'external-api'
  c.config = { distributed_tracing: true }
end
```
