### PR TITLE
Fix Rails nested partial tracing

### DIFF
--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -81,23 +81,22 @@ module Datadog
     end
 
     def patch_partial_renderer(klass)
-      # rubocop:disable Metrics/BlockLength
       klass.class_eval do
         def render_with_datadog(*args, &block)
           # Create a tracing context and start the rendering span
           tracing_context = {}
           Datadog::Contrib::Rails::ActionView.start_render_partial(tracing_context: tracing_context)
-          add_tracing_context(tracing_context)
+          tracing_contexts[current_span_id] = tracing_context
 
           render_without_datadog(*args)
         rescue Exception => e
           # attach the exception to the tracing context if any
-          current_tracing_context[:exception] = e
+          tracing_contexts[current_span_id][:exception] = e
           raise e
         ensure
           # Ensure that the template `Span` is finished even during exceptions
           # Remove the existing tracing context (to avoid leaks)
-          remove_tracing_context(tracing_context)
+          tracing_contexts.delete(current_span_id)
 
           # Then finish the span associated with the context
           Datadog::Contrib::Rails::ActionView.finish_render_partial(tracing_context: tracing_context)
@@ -107,7 +106,7 @@ module Datadog
           begin
             # update the tracing context with computed values before the rendering
             template_name = Datadog::Contrib::Rails::Utils.normalize_template_name(@template.try('identifier'))
-            current_tracing_context[:template_name] = template_name
+            tracing_contexts[current_span_id][:template_name] = template_name
           rescue StandardError => e
             Datadog::Tracer.log.debug(e.message)
           end
@@ -123,28 +122,8 @@ module Datadog
           @tracing_contexts ||= {}
         end
 
-        def tracing_context_key_from_span(span)
-          return nil if span.nil?
-          span.span_id
-        end
-
-        def tracing_context_key(tracing_context)
-          return nil if tracing_context.nil?
-          tracing_context_key_from_span(tracing_context[:dd_rails_partial_span])
-        end
-
-        def add_tracing_context(tracing_context)
-          key = tracing_context_key(tracing_context)
-          tracing_contexts[key] = tracing_context unless key.nil?
-        end
-
-        def remove_tracing_context(tracing_context)
-          tracing_contexts.delete(tracing_context_key(tracing_context))
-        end
-
-        def current_tracing_context
-          current_span = Datadog.configuration[:rails][:tracer].call_context.current_span
-          tracing_contexts[tracing_context_key_from_span(current_span)]
+        def current_span_id
+          Datadog.configuration[:rails][:tracer].call_context.current_span.span_id
         end
 
         # method aliasing to patch the class

--- a/test/contrib/rails/apps/controllers.rb
+++ b/test/contrib/rails/apps/controllers.rb
@@ -17,6 +17,9 @@ class TracingController < ActionController::Base
       'views/tracing/soft_error.html.erb' => 'nothing',
       'views/tracing/not_found.html.erb' => 'nothing',
       'views/tracing/error_partial.html.erb' => 'Hello from <%= render "views/tracing/inner_error.html.erb" %>',
+      'views/tracing/nested_partial.html.erb' => 'Server says (<%= render "views/tracing/outer_partial.html.erb" %>)',
+      'views/tracing/_outer_partial.html.erb' => 'Outer partial: (<%= render "views/tracing/inner_partial.html.erb" %>)',
+      'views/tracing/_inner_partial.html.erb' => 'Inner partial',
       'views/tracing/_body.html.erb' => '_body.html.erb partial',
       'views/tracing/_inner_error.html.erb' => '<%= 1/0 %>'
     )
@@ -28,6 +31,10 @@ class TracingController < ActionController::Base
 
   def partial
     render 'views/tracing/partial.html.erb'
+  end
+
+  def nested_partial
+    render 'views/tracing/nested_partial.html.erb'
   end
 
   def error
@@ -85,6 +92,7 @@ end
 
 routes = {
   '/' => 'tracing#index',
+  '/nested_partial' => 'tracing#nested_partial',
   '/partial' => 'tracing#partial',
   '/full' => 'tracing#full',
   '/error' => 'tracing#error',


### PR DESCRIPTION
If you nest partials in a Rails application, one within another, e.g.:

```
render 'template'
  --> render 'partials/outer'
    --> render 'partials/inner'
```

You will receive an error that looks something like `root span closed but has 1 unfinished spans`. Those traces affected won't be written or propagated to your account. The bug is confirmed to affect Rails 3.2.

This was occurring because when partials were nested in one another, a certain contextual state object (whose purpose was to describe one partial) was being shared, then overwritten by its nested partial children. Overwriting this state effectively corrupted at least one span within the trace, thus causing it to not complete correctly.

This pull request implements a hash of contexts, which are each tied to an individual span by ID. This allows the existing code to find and access the context appropriate to it.

The strategy for context management for partials could benefit a great deal from a refactor. But in the mean time, this change should serve as an effective stopgap measure to address the current bug.