### PR TITLE
Add error handling during middleware patch

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -6,7 +6,7 @@ require 'ddtrace/version'
 
 Gem::Specification.new do |spec|
   spec.name                  = 'ddtrace'
-  spec.version               = "#{Datadog::VERSION::STRING}#{ENV['VERSION_SUFFIX']}"
+  spec.version               = "#{Datadog::VERSION::STRING}.beta2#{ENV['VERSION_SUFFIX']}"
   spec.required_ruby_version = '>= 1.9.1'
   spec.authors               = ['Datadog, Inc.']
   spec.email                 = ['dev@datadoghq.com']

--- a/lib/ddtrace/contrib/rack/patcher.rb
+++ b/lib/ddtrace/contrib/rack/patcher.rb
@@ -22,14 +22,18 @@ module Datadog
           require_relative 'middlewares'
           @patched = true
 
-          return unless get_option(:middleware_names)
-
-          top = get_option(:application) || rails_app
-          retain_middleware_name(top)
+          enable_middleware_names if get_option(:middleware_names)
         end
 
         def patched?
           @patched ||= false
+        end
+
+        def enable_middleware_names
+          root = get_option(:application) || rails_app
+          retain_middleware_name(root)
+        rescue => e
+          Tracer.log.debug("Error patching middleware stack: #{e}")
         end
 
         def rails_app

--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -1,7 +1,7 @@
 module Datadog
   module VERSION
     MAJOR = 0
-    MINOR = 10
+    MINOR = 11
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].compact.join('.')


### PR DESCRIPTION
This PR simply provides error handling during rack middleware patching. These errors are expected when the code executes outside a `rails server` process – that is, processes that don't serve HTTP requests but load the Rails environment through `config/environment.rb`