### PR TITLE
Don't support Postgres 1.0+ with ActiveRecord in CI

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -63,13 +63,13 @@ if RUBY_VERSION < '2.4.0' && RUBY_PLATFORM != 'java'
 
     appraise 'rails4-postgres' do
       gem 'rails', '4.2.7.1'
-      gem 'pg', platform: :ruby
+      gem 'pg', '< 1.0', platform: :ruby
       gem 'activerecord-jdbcpostgresql-adapter', platform: :jruby
     end
 
     appraise 'rails4-postgres-redis' do
       gem 'rails', '4.2.7.1'
-      gem 'pg', platform: :ruby
+      gem 'pg', '< 1.0', platform: :ruby
       gem 'activerecord-jdbcpostgresql-adapter', platform: :jruby
       gem 'redis-rails'
       gem 'redis', '< 4.0'
@@ -84,26 +84,26 @@ if RUBY_VERSION < '2.4.0' && RUBY_PLATFORM != 'java'
 
     appraise 'rails5-postgres' do
       gem 'rails', '5.0.1'
-      gem 'pg', platform: :ruby
+      gem 'pg', '< 1.0', platform: :ruby
     end
 
     appraise 'rails5-postgres-redis' do
       gem 'rails', '5.0.1'
-      gem 'pg', platform: :ruby
+      gem 'pg', '< 1.0', platform: :ruby
       gem 'redis-rails'
       gem 'redis', '< 4.0'
     end
 
     appraise 'rails5-postgres-sidekiq' do
       gem 'rails', '5.0.1'
-      gem 'pg', platform: :ruby
+      gem 'pg', '< 1.0', platform: :ruby
       gem 'sidekiq'
       gem 'activejob'
     end
 
     appraise 'rails4-postgres-sidekiq' do
       gem 'rails', '4.2.7.1'
-      gem 'pg', platform: :ruby
+      gem 'pg', '< 1.0', platform: :ruby
       gem 'activerecord-jdbcpostgresql-adapter', platform: :jruby
       gem 'sidekiq'
       gem 'activejob'

--- a/gemfiles/rails4_postgres.gemfile
+++ b/gemfiles/rails4_postgres.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "4.2.7.1"
-gem "pg", platform: :ruby
+gem "pg", "< 1.0", platform: :ruby
 gem "activerecord-jdbcpostgresql-adapter", platform: :jruby
 
 gemspec path: "../"

--- a/gemfiles/rails4_postgres_redis.gemfile
+++ b/gemfiles/rails4_postgres_redis.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "4.2.7.1"
-gem "pg", platform: :ruby
+gem "pg", "< 1.0", platform: :ruby
 gem "activerecord-jdbcpostgresql-adapter", platform: :jruby
 gem "redis-rails"
 gem "redis", "< 4.0"

--- a/gemfiles/rails4_postgres_sidekiq.gemfile
+++ b/gemfiles/rails4_postgres_sidekiq.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "4.2.7.1"
-gem "pg", platform: :ruby
+gem "pg", "< 1.0", platform: :ruby
 gem "activerecord-jdbcpostgresql-adapter", platform: :jruby
 gem "sidekiq"
 gem "activejob"

--- a/gemfiles/rails5_postgres.gemfile
+++ b/gemfiles/rails5_postgres.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "5.0.1"
-gem "pg", platform: :ruby
+gem "pg", "< 1.0", platform: :ruby
 
 gemspec path: "../"

--- a/gemfiles/rails5_postgres_redis.gemfile
+++ b/gemfiles/rails5_postgres_redis.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "5.0.1"
-gem "pg", platform: :ruby
+gem "pg", "< 1.0", platform: :ruby
 gem "redis-rails"
 gem "redis", "< 4.0"
 

--- a/gemfiles/rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/rails5_postgres_sidekiq.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "5.0.1"
-gem "pg", platform: :ruby
+gem "pg", "< 1.0", platform: :ruby
 gem "sidekiq"
 gem "activejob"
 


### PR DESCRIPTION
Yesterday, they released the `pg` gem version 1.0.0, a major version change, which breaks ActiveRecord.

https://bitbucket.org/ged/ruby-pg/issues/270/pg-100-x64-mingw32-rails-server-not-start

The issue might be resolved in a future version of of ActiveRecord, but for now, it's breaking our CI which uses edge versions of gems. This pull request restricts the use of Postgres to < 1.0.0 when it runs with ActiveRecord.