### PR TITLE
Add pry-nav for development tools

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -137,7 +137,7 @@ else
     gem 'redis', '< 4.0.0'
     gem 'hiredis'
     gem 'rack', '1.4.7'
-    gem 'rack-test'
+    gem 'rack-test', '0.7.0'
     gem 'sinatra', '1.4.5'
     gem 'sqlite3'
     gem 'activerecord', '3.2.22.5'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 
 gemspec
+
+# Add debugger for pry that's compatible with 0.10.4
+gem 'pry-nav', git: 'https://github.com/nixme/pry-nav.git', branch: 'master'

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -44,6 +44,6 @@ EOS
   # locking transitive dependency of webmock
   spec.add_development_dependency 'addressable', '~> 2.4.0'
   spec.add_development_dependency 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
-  spec.add_development_dependency 'pry', '>= 0.10.4'
-  spec.add_development_dependency 'pry-stack_explorer', '>= 0.4.9.2'
+  spec.add_development_dependency 'pry', '~> 0.10.4'
+  spec.add_development_dependency 'pry-stack_explorer', '~> 0.4.9.2'
 end

--- a/gemfiles/contrib.gemfile
+++ b/gemfiles/contrib.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "elasticsearch-transport"
 gem "mongo"
 gem "grape"

--- a/gemfiles/contrib_old.gemfile
+++ b/gemfiles/contrib_old.gemfile
@@ -2,18 +2,20 @@
 
 source "https://rubygems.org"
 
+gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "elasticsearch-transport"
 gem "mongo"
 gem "redis", "< 4.0.0"
 gem "hiredis"
 gem "rack", "1.4.7"
-gem "rack-test"
+gem "rack-test", "0.7.0"
 gem "sinatra", "1.4.5"
 gem "sqlite3"
 gem "activerecord", "3.2.22.5"
 gem "sidekiq", "4.0.0"
 gem "aws-sdk", "~> 2.0"
 gem "sucker_punch"
+gem "dalli"
 gem "resque"
 
 gemspec path: "../"

--- a/gemfiles/rails30_postgres.gemfile
+++ b/gemfiles/rails30_postgres.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "test-unit"
 gem "rails", "3.0.20"
 gem "pg", "0.15.1", platform: :ruby

--- a/gemfiles/rails30_postgres_sidekiq.gemfile
+++ b/gemfiles/rails30_postgres_sidekiq.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "test-unit"
 gem "rails", "3.0.20"
 gem "pg", "0.15.1", platform: :ruby

--- a/gemfiles/rails32_mysql2.gemfile
+++ b/gemfiles/rails32_mysql2.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "test-unit"
 gem "rails", "3.2.22.5"
 gem "mysql2", "0.3.21", platform: :ruby

--- a/gemfiles/rails32_postgres.gemfile
+++ b/gemfiles/rails32_postgres.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "test-unit"
 gem "rails", "3.2.22.5"
 gem "pg", "0.15.1", platform: :ruby

--- a/gemfiles/rails32_postgres_redis.gemfile
+++ b/gemfiles/rails32_postgres_redis.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "test-unit"
 gem "rails", "3.2.22.5"
 gem "pg", "0.15.1", platform: :ruby

--- a/gemfiles/rails32_postgres_sidekiq.gemfile
+++ b/gemfiles/rails32_postgres_sidekiq.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "test-unit"
 gem "rails", "3.2.22.5"
 gem "pg", "0.15.1", platform: :ruby

--- a/gemfiles/rails4_mysql2.gemfile
+++ b/gemfiles/rails4_mysql2.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "rails", "4.2.7.1"
 gem "mysql2", platform: :ruby
 gem "activerecord-jdbcmysql-adapter", platform: :jruby

--- a/gemfiles/rails4_postgres.gemfile
+++ b/gemfiles/rails4_postgres.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "rails", "4.2.7.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "activerecord-jdbcpostgresql-adapter", platform: :jruby

--- a/gemfiles/rails4_postgres_redis.gemfile
+++ b/gemfiles/rails4_postgres_redis.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "rails", "4.2.7.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "activerecord-jdbcpostgresql-adapter", platform: :jruby

--- a/gemfiles/rails4_postgres_sidekiq.gemfile
+++ b/gemfiles/rails4_postgres_sidekiq.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "rails", "4.2.7.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "activerecord-jdbcpostgresql-adapter", platform: :jruby

--- a/gemfiles/rails5_mysql2.gemfile
+++ b/gemfiles/rails5_mysql2.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "rails", "5.0.1"
 gem "mysql2", platform: :ruby
 

--- a/gemfiles/rails5_postgres.gemfile
+++ b/gemfiles/rails5_postgres.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "rails", "5.0.1"
 gem "pg", "< 1.0", platform: :ruby
 

--- a/gemfiles/rails5_postgres_redis.gemfile
+++ b/gemfiles/rails5_postgres_redis.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "rails", "5.0.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "redis-rails"

--- a/gemfiles/rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/rails5_postgres_sidekiq.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "rails", "5.0.1"
 gem "pg", "< 1.0", platform: :ruby
 gem "sidekiq"


### PR DESCRIPTION
This pull request adds `pry-nav` to the development dependencies to add `next`, `continue`, `step` commands to debugging sessions. It's a "nice to have" thing, so just a suggestion for tooling improvement.