### PR TITLE
Better handle different encodings

### DIFF
--- a/lib/ddtrace/contrib/dalli/quantize.rb
+++ b/lib/ddtrace/contrib/dalli/quantize.rb
@@ -13,7 +13,7 @@ module Datadog
           command = Utils.utf8_encode(command, binary: true, placeholder: placeholder)
           Utils.truncate(command, MAX_CMD_LENGTH)
         rescue => e
-          Tracer.log.error("Error sanitizing Dalli operation: #{e}")
+          Tracer.log.debug("Error sanitizing Dalli operation: #{e}")
           placeholder
         end
       end

--- a/lib/ddtrace/contrib/dalli/quantize.rb
+++ b/lib/ddtrace/contrib/dalli/quantize.rb
@@ -8,10 +8,13 @@ module Datadog
         module_function
 
         def format_command(operation, args)
+          placeholder = "#{operation} BLOB (OMITTED)"
           command = [operation, *args].join(' ').strip
+          command = Utils.utf8_encode(command, binary: true, placeholder: placeholder)
           Utils.truncate(command, MAX_CMD_LENGTH)
-        rescue ::Encoding::CompatibilityError
-          "#{operation} BLOB (OMITTED)"
+        rescue => e
+          Tracer.log.error("Error sanitizing Dalli operation: #{e}")
+          placeholder
         end
       end
     end

--- a/lib/ddtrace/contrib/redis/quantize.rb
+++ b/lib/ddtrace/contrib/redis/quantize.rb
@@ -12,9 +12,9 @@ module Datadog
 
         def format_arg(arg)
           str = arg.is_a?(Symbol) ? arg.to_s.upcase : arg.to_s
-          str = str.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+          str = Utils.utf8_encode(str, binary: true, placeholder: PLACEHOLDER)
           Utils.truncate(str, VALUE_MAX_LEN, TOO_LONG_MARK)
-        rescue StandardError => e
+        rescue => e
           Datadog::Tracer.log.debug("non formattable Redis arg #{str}: #{e}")
           PLACEHOLDER
         end

--- a/lib/ddtrace/error.rb
+++ b/lib/ddtrace/error.rb
@@ -16,22 +16,9 @@ module Datadog
 
     def initialize(type = nil, message = nil, backtrace = nil)
       backtrace = Array(backtrace).join("\n")
-      @type = sanitize(type)
-      @message = sanitize(message)
-      @backtrace = sanitize(backtrace)
-    end
-
-    private
-
-    def sanitize(value)
-      value = value.to_s
-
-      return value if value.encoding == ::Encoding::UTF_8
-
-      value.encode(::Encoding::UTF_8)
-    rescue => e
-      Tracer.log.error("Error converting error message to UTF-8: #{e.message}")
-      nil
+      @type = Utils.utf8_encode(type, placeholder: nil)
+      @message = Utils.utf8_encode(message, placeholder: nil)
+      @backtrace = Utils.utf8_encode(backtrace, placeholder: nil)
     end
 
     BlankError = Error.new

--- a/lib/ddtrace/error.rb
+++ b/lib/ddtrace/error.rb
@@ -16,9 +16,9 @@ module Datadog
 
     def initialize(type = nil, message = nil, backtrace = nil)
       backtrace = Array(backtrace).join("\n")
-      @type = Utils.utf8_encode(type, placeholder: nil)
-      @message = Utils.utf8_encode(message, placeholder: nil)
-      @backtrace = Utils.utf8_encode(backtrace, placeholder: nil)
+      @type = Utils.utf8_encode(type)
+      @message = Utils.utf8_encode(message)
+      @backtrace = Utils.utf8_encode(backtrace)
     end
 
     BlankError = Error.new

--- a/lib/ddtrace/error.rb
+++ b/lib/ddtrace/error.rb
@@ -29,6 +29,9 @@ module Datadog
       return value if value.encoding == ::Encoding::UTF_8
 
       value.encode(::Encoding::UTF_8)
+    rescue => e
+      Tracer.log.error("Error converting error message to UTF-8: #{e.message}")
+      nil
     end
 
     BlankError = Error.new

--- a/lib/ddtrace/utils.rb
+++ b/lib/ddtrace/utils.rb
@@ -47,7 +47,7 @@ module Datadog
         str.encode(::Encoding::UTF_8)
       end
     rescue => e
-      Tracer.log.error("Error encoding string in UTF-8: #{e}")
+      Tracer.log.debug("Error encoding string in UTF-8: #{e}")
 
       options.fetch(:placeholder, STRING_PLACEHOLDER)
     end

--- a/lib/ddtrace/utils.rb
+++ b/lib/ddtrace/utils.rb
@@ -1,7 +1,7 @@
 module Datadog
   # Utils contains low-level utilities, typically to provide pseudo-random trace IDs.
   module Utils
-    STRING_PLACEHOLDER = ''.encode(Encoding::UTF_8).freeze
+    STRING_PLACEHOLDER = ''.encode(::Encoding::UTF_8).freeze
     # We use a custom random number generator because we want no interference
     # with the default one. Using the default prng, we could break code that
     # would rely on srand/rand sequences.
@@ -41,15 +41,15 @@ module Datadog
         # This option is useful for "gracefully" displaying binary data that
         # often contains text such as marshalled objects
         str.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
-      elsif str.encoding?(Encoding::UTF_8)
+      elsif str.encoding == ::Encoding::UTF_8
         str
       else
-        str.encode(Encoding::UTF_8)
+        str.encode(::Encoding::UTF_8)
       end
     rescue => e
       Tracer.log.error("Error encoding string in UTF-8: #{e}")
 
-      options[:placeholder] || STRING_PLACEHOLDER
+      options.fetch(:placeholder, STRING_PLACEHOLDER)
     end
   end
 end

--- a/lib/ddtrace/utils.rb
+++ b/lib/ddtrace/utils.rb
@@ -33,20 +33,22 @@ module Datadog
       string.slice(0, size - omission.size) + omission
     end
 
-    def utf8_encode(str, options = {})
-      placeholder = options[:placeholder] || STRING_PLACEHOLDER
+    def self.utf8_encode(str, options = {})
+      str = str.to_s
 
-      if str.encoding?(Encoding::UTF_8)
-        str
-      elsif options[:binary]
+      if options[:binary]
+        # This option is useful for "gracefully" displaying binary data that
+        # often contains text such as marshalled objects
         str.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+      elsif str.encoding?(Encoding::UTF_8)
+        str
       else
         str.encode(Encoding::UTF_8)
       end
     rescue => e
       Tracer.log.error("Error encoding string in UTF-8: #{e}")
 
-      placeholder
+      options[:placeholder] || STRING_PLACEHOLDER
     end
 
     STRING_PLACEHOLDER = ''.freeze

--- a/lib/ddtrace/utils.rb
+++ b/lib/ddtrace/utils.rb
@@ -51,6 +51,6 @@ module Datadog
       options[:placeholder] || STRING_PLACEHOLDER
     end
 
-    STRING_PLACEHOLDER = ''.freeze
+    STRING_PLACEHOLDER = ''.encode(Encoding::UTF_8).freeze
   end
 end

--- a/lib/ddtrace/utils.rb
+++ b/lib/ddtrace/utils.rb
@@ -1,6 +1,7 @@
 module Datadog
   # Utils contains low-level utilities, typically to provide pseudo-random trace IDs.
   module Utils
+    STRING_PLACEHOLDER = ''.encode(Encoding::UTF_8).freeze
     # We use a custom random number generator because we want no interference
     # with the default one. Using the default prng, we could break code that
     # would rely on srand/rand sequences.
@@ -50,7 +51,5 @@ module Datadog
 
       options[:placeholder] || STRING_PLACEHOLDER
     end
-
-    STRING_PLACEHOLDER = ''.encode(Encoding::UTF_8).freeze
   end
 end

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -73,5 +73,14 @@ module Datadog
       assert_empty(error.message)
       assert_empty(error.backtrace)
     end
+
+    def test_regression_non_utf8_compatible
+      exception = StandardError.new("\xC2".force_encoding(::Encoding::ASCII_8BIT))
+      error = Error.build_from(exception)
+
+      assert_equal('StandardError', @error.type)
+      assert_nil(error.message)
+      assert_empty(error.backtrace)
+    end
   end
 end

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -79,7 +79,7 @@ module Datadog
       error = Error.build_from(exception)
 
       assert_equal('StandardError', @error.type)
-      assert_nil(error.message)
+      assert_empty(error.message)
       assert_empty(error.backtrace)
     end
   end

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -60,9 +60,10 @@ class UtilsTest < Minitest::Test
   end
 
   def test_utf8_encoding_happy_path
-    str = 'pristine ✓'
+    # we can't use utf-8 literals because our tests run against ruby 1.9.3
+    str = "pristine \U+FFE2".encode(Encoding::UTF_8)
 
-    assert_equal('pristine ✓', Datadog::Utils.utf8_encode(str))
+    assert_equal("pristine \U+FFE2", Datadog::Utils.utf8_encode(str))
 
     assert_equal(::Encoding::UTF_8, Datadog::Utils.utf8_encode(str).encoding)
 
@@ -74,7 +75,7 @@ class UtilsTest < Minitest::Test
     time_bomb = "\xC2".force_encoding(::Encoding::ASCII_8BIT)
 
     # making sure this is indeed a problem
-    assert_raises(Encoding::CompatibilityError) do
+    assert_raises(Encoding::UndefinedConversionError) do
       time_bomb.encode(Encoding::UTF_8)
     end
 
@@ -85,8 +86,8 @@ class UtilsTest < Minitest::Test
   end
 
   def test_binary_data
-    byte_array = "keep what \xC2 is valid".force_encoding(::Encoding::ASCII_8BIT)
+    byte_array = "keep what\xC2 is valid".force_encoding(::Encoding::ASCII_8BIT)
 
-    assert_equal('keep what is valid', Utils.utf8_encode(byte_array, binary: true))
+    assert_equal('keep what is valid', Datadog::Utils.utf8_encode(byte_array, binary: true))
   end
 end

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -58,4 +58,35 @@ class UtilsTest < Minitest::Test
     refute_equal(Datadog::Utils.next_id, r.read.chomp.to_i)
     r.close
   end
+
+  def test_utf8_encoding_happy_path
+    str = 'pristine ✓'
+
+    assert_equal('pristine ✓', Datadog::Utils.utf8_encode(str))
+
+    assert_equal(::Encoding::UTF_8, Datadog::Utils.utf8_encode(str).encoding)
+
+    # we don't allocate new objects when a valid UTF-8 string is provided
+    assert_same(str, Datadog::Utils.utf8_encode(str))
+  end
+
+  def test_utf8_encoding_invalid_conversion
+    time_bomb = "\xC2".force_encoding(::Encoding::ASCII_8BIT)
+
+    # making sure this is indeed a problem
+    assert_raises(Encoding::CompatibilityError) do
+      time_bomb.encode(Encoding::UTF_8)
+    end
+
+    assert_equal(Datadog::Utils::STRING_PLACEHOLDER, Datadog::Utils.utf8_encode(time_bomb))
+
+    # we can also set a custom placeholder
+    assert_equal('?', Datadog::Utils.utf8_encode(time_bomb, placeholder: '?'))
+  end
+
+  def test_binary_data
+    byte_array = "keep what \xC2 is valid".force_encoding(::Encoding::ASCII_8BIT)
+
+    assert_equal('keep what is valid', Utils.utf8_encode(byte_array, binary: true))
+  end
 end


### PR DESCRIPTION
This PR provides `Datadog::Utils.utf8_encode` utility method.
We're also refactoring parts of the code that used to perform encoding operations.