### PR TITLE
[ci] pin mongo driver to < 2.5

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -114,7 +114,7 @@ end
 if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM != 'java'
   appraise 'contrib' do
     gem 'elasticsearch-transport'
-    gem 'mongo'
+    gem 'mongo', '< 2.5'
     gem 'grape'
     gem 'rack'
     gem 'rack-test'
@@ -133,7 +133,7 @@ if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM != 'java'
 else
   appraise 'contrib-old' do
     gem 'elasticsearch-transport'
-    gem 'mongo'
+    gem 'mongo', '< 2.5'
     gem 'redis', '< 4.0'
     gem 'hiredis'
     gem 'rack', '1.4.7'


### PR DESCRIPTION
The latest release for Mongo introduces a new field making all our test fail. While I could update tests including the new field, I prefer to address the problem of testing the tracer for multiple library versions alter in a new PR.

This change doesn't mean Mongo 2.5 isn't supported, but we need to investigate the issue more.