### PR TITLE
Add exception_controller option to Rails

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -77,7 +77,8 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | ``service_name`` | Service name used when tracing application requests (on the `rack` level) | ``<app_name>`` (inferred from your Rails application namespace) |
 | ``controller_service`` | Service name used when tracing a Rails action controller | ``<app_name>-controller`` |
 | ``cache_service`` | Cache service name used when tracing cache activity | ``<app_name>-cache`` |
-| ``database_service`` | Database service name used when tracing database activity | ``<app_name>-<adapter_name>``. |
+| ``database_service`` | Database service name used when tracing database activity | ``<app_name>-<adapter_name>`` |
+| ``exception_controller`` | Class or Module which identifies a custom exception controller class. Tracer provides improved error behavior when it can identify custom exception controllers. By default, without this option, it 'guesses' what a custom exception controller looks like. Providing this option aids this identification. | ``nil`` |
 | ``distributed_tracing`` | Enables [distributed tracing](#Distributed_Tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `false` |
 | ``template_base_path`` | Used when the template name is parsed. If you don't store your templates in the ``views/`` folder, you may need to change this value | ``views/`` |
 | ``tracer`` | A ``Datadog::Tracer`` instance used to instrument the application. Usually you don't need to set that. | ``Datadog.tracer`` |

--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -150,8 +150,13 @@ module Datadog
           # signals; it propagates the request span so that it can be finished
           # no matter what
           payload = {
-            controller: self.class.name,
+            controller: self.class,
             action: action_name,
+            headers: {
+              # The exception this controller was given in the request,
+              # which is typical if the controller is configured to handle exceptions.
+              request_exception: request.headers['action_dispatch.exception']
+            },
             tracing_context: {}
           }
 

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -12,6 +12,7 @@ module Datadog
         option :database_service
         option :distributed_tracing, default: false
         option :template_base_path, default: 'views/'
+        option :exception_controller, default: nil
         option :tracer, default: Datadog.tracer
 
         @patched = false

--- a/test/contrib/rails/apps/controllers.rb
+++ b/test/contrib/rails/apps/controllers.rb
@@ -96,6 +96,12 @@ class TracingController < ActionController::Base
   end
 end
 
+class ErrorsController < ActionController::Base
+  def internal_server_error
+    head :internal_server_error
+  end
+end
+
 routes = {
   '/' => 'tracing#index',
   '/nested_partial' => 'tracing#nested_partial',
@@ -109,7 +115,8 @@ routes = {
   '/error_partial' => 'tracing#error_partial',
   '/missing_template' => 'tracing#missing_template',
   '/missing_partial' => 'tracing#missing_partial',
-  '/custom_resource' => 'tracing#custom_resource'
+  '/custom_resource' => 'tracing#custom_resource',
+  '/internal_server_error' => 'errors#internal_server_error'
 }
 
 if Rails.version >= '3.2.22.5'


### PR DESCRIPTION
If a Rails app has a custom error controller defined via `config.exceptions_app=` for the purpose of rendering errors, the name of this custom error controller and action will supersede the name of the controller that originally raised the exception for the trace. This is because the errors controller runs afterwards, and replaces the name on the parent span, no matter what. Ultimately, it results in all error traces being listed under "ErrorsController#internal_server_error" or similarly named resource, which isn't a great experience.

This pull request introduces the `exception_class` option to Rails configuration, which allows a user to specify a class or module to identify a custom exception controller with. Spans for any controller that matches this definition will not override the parent span's resource name.

If you do not specify this option, the tracer will "guess" if the controller is an error controller, by looking for the presence and value of an `action_dispatch.exception` header, [which is typically provided to error controllers in Rails](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/show_exceptions.rb). Most users should see improved behavior without any additional configuration.

In practice:

```ruby
Datadog.configure do |c|
  # Implicitly guess at exception controllers
  c.use :rails
end
```

OR

```ruby
Datadog.configure do |c|
  # Explicitly defining an exception controller
  c.use :rails, exception_controller: ErrorsController
end
```

And a resulting trace with improved resource name:

<img width="1338" alt="screen shot 2018-01-19 at 1 21 21 pm" src="https://user-images.githubusercontent.com/3237131/35165989-574984f8-fd1e-11e7-9e24-22be2381dd5b.png">
