### PR TITLE
Allow customization of Rails controller resource names

### DIFF
--- a/lib/ddtrace/contrib/rails/action_controller.rb
+++ b/lib/ddtrace/contrib/rails/action_controller.rb
@@ -32,12 +32,14 @@ module Datadog
           return unless span && !span.finished?
 
           begin
-            resource = "#{payload.fetch(:controller)}##{payload.fetch(:action)}"
-            span.resource = resource
+            # Set the resource name, if it's still the default name
+            if span.resource == span.name
+              span.resource = "#{payload.fetch(:controller)}##{payload.fetch(:action)}"
+            end
 
             # set the parent resource if it's a `rack.request` span
             if !span.parent.nil? && span.parent.name == 'rack.request'
-              span.parent.resource = resource
+              span.parent.resource = span.resource
             end
 
             span.set_tag('rails.route.action', payload.fetch(:action))

--- a/test/contrib/rails/apps/controllers.rb
+++ b/test/contrib/rails/apps/controllers.rb
@@ -88,6 +88,12 @@ class TracingController < ActionController::Base
     @value = Rails.cache.write('empty-key', 50)
     render 'views/tracing/full.html.erb'
   end
+
+  def custom_resource
+    tracer = Datadog.configuration[:rails][:tracer]
+    tracer.active_span.resource = 'custom-resource'
+    head :ok
+  end
 end
 
 routes = {
@@ -102,7 +108,8 @@ routes = {
   '/error_template' => 'tracing#error_template',
   '/error_partial' => 'tracing#error_partial',
   '/missing_template' => 'tracing#missing_template',
-  '/missing_partial' => 'tracing#missing_partial'
+  '/missing_partial' => 'tracing#missing_partial',
+  '/custom_resource' => 'tracing#custom_resource'
 }
 
 if Rails.version >= '3.2.22.5'

--- a/test/contrib/rails/controller_test.rb
+++ b/test/contrib/rails/controller_test.rb
@@ -179,6 +179,17 @@ class TracingControllerTest < ActionController::TestCase
     assert_nil(span.get_tag('error.stack'), 'no error stack')
   end
 
+  test 'custom resource names can be set' do
+    get :custom_resource
+    assert_response :success
+    spans = @tracer.writer.spans
+    assert_equal(spans.length, 1)
+
+    spans.first.tap do |span|
+      assert_equal('custom-resource', span.resource)
+    end
+  end
+
   test 'combining rails and custom tracing is supported' do
     @tracer.trace('a-parent') do
       get :index


### PR DESCRIPTION
You can modify the resource of a span in a controller by doing the following:

```ruby
class FooController < ApplicationController
  def index
    tracer = Datadog.configuration[:rails][:tracer]
    tracer.active_span.resource = "custom-resource-name"
    # ...
  end
end
```

However this wasn't working because resource names were being overridden by default names when the span was completed.

This pull request allows the above to work, by not applying default resource names if a custom resource name has already been set.

Example of it working:

<img width="1340" alt="screen shot 2018-01-19 at 2 07 05 pm" src="https://user-images.githubusercontent.com/3237131/35167078-1f5155cc-fd22-11e7-80d7-dca87b58a742.png">
