### PR TITLE
Use the advanced AS::Notifications subscriber API

### DIFF
--- a/spec/ddtrace/contrib/racecar/patcher_spec.rb
+++ b/spec/ddtrace/contrib/racecar/patcher_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe 'Racecar patcher' do
 
     context 'that doesn\'t raise an error' do
       it 'is expected to send a span' do
-        ActiveSupport::Notifications.instrument('start_process_message.racecar', payload)
         ActiveSupport::Notifications.instrument('process_message.racecar', payload)
 
         racecar_span.tap do |span|
@@ -62,7 +61,6 @@ RSpec.describe 'Racecar patcher' do
 
       it 'is expected to send a span' do
         # Emulate failure
-        ActiveSupport::Notifications.instrument('start_process_message.racecar', payload)
         begin
           ActiveSupport::Notifications.instrument('process_message.racecar', payload) do
             raise error_class
@@ -109,7 +107,6 @@ RSpec.describe 'Racecar patcher' do
 
     context 'that doesn\'t raise an error' do
       it 'is expected to send a span' do
-        ActiveSupport::Notifications.instrument('start_process_batch.racecar', payload)
         ActiveSupport::Notifications.instrument('process_batch.racecar', payload)
 
         racecar_span.tap do |span|
@@ -132,7 +129,6 @@ RSpec.describe 'Racecar patcher' do
       let(:error_class) { Class.new(StandardError) }
 
       it 'is expected to send a span' do
-        ActiveSupport::Notifications.instrument('start_process_batch.racecar', payload)
         begin
           ActiveSupport::Notifications.instrument('process_batch.racecar', payload) do
             raise error_class


### PR DESCRIPTION
This allows us to respond to the start and finish of instrumented blocks of code without the need for a separate instrumentation event.

A subscriber object that responds to `start` and `finish` will use this advanced API, as per https://github.com/rails/rails/blob/d25c2e7c4c88440154087a08fa79ba0bf3038ba3/activesupport/lib/active_support/notifications/fanout.rb#L73-L77