### PR TITLE
Add a facility for easily subscribing to AS::Notifications

### DIFF
--- a/lib/ddtrace/contrib/active_support/notifications.rb
+++ b/lib/ddtrace/contrib/active_support/notifications.rb
@@ -1,0 +1,40 @@
+module Datadog
+  module Contrib
+    module ActiveSupport
+      class Notifications
+        def self.subscribe(pattern, span_name, options = {}, tracer = Datadog.tracer, &block)
+          subscriber = Subscriber.new(tracer, span_name, options, &block)
+
+          ::ActiveSupport::Notifications.subscribe(pattern, subscriber)
+        end
+
+        class Subscriber
+          def initialize(tracer, span_name, options, &block)
+            @tracer = tracer
+            @span_name = span_name
+            @options = options
+            @block = block
+
+            # A stack of open spans. We want to get to the most recently opened span
+            # at any point in time.
+            @spans = []
+          end
+
+          def start(_name, _id, _payload)
+            @spans << @tracer.trace(@span_name, @options)
+          end
+
+          def finish(name, id, payload)
+            # We close spans in reverse order.
+            span = @spans.pop or raise "no spans left in stack!"
+
+            # The subscriber block needs to remember to set the name of the span.
+            @block.call(span, name, id, payload)
+
+            span.finish
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/racecar/patcher.rb
+++ b/lib/ddtrace/contrib/racecar/patcher.rb
@@ -1,4 +1,5 @@
 require 'ddtrace/ext/app_types'
+require 'ddtrace/contrib/active_support/notifications'
 
 module Datadog
   module Contrib
@@ -16,10 +17,12 @@ module Datadog
           def patch
             return patched? if patched? || !compatible?
 
-            ::ActiveSupport::Notifications.subscribe('process_batch.racecar', self)
-            ::ActiveSupport::Notifications.subscribe('process_message.racecar', self)
+            tracer = configuration[:tracer]
 
-            configuration[:tracer].set_service_info(
+            Contrib::ActiveSupport::Notifications.subscribe('process_message.racecar', NAME_MESSAGE, {}, tracer, &method(:process))
+            Contrib::ActiveSupport::Notifications.subscribe('process_batch.racecar', NAME_BATCH, {}, tracer, &method(:process))
+
+            tracer.set_service_info(
               configuration[:service_name],
               'racecar',
               Ext::AppTypes::WORKER
@@ -33,28 +36,21 @@ module Datadog
             @patched = false
           end
 
-          def start(event, _, payload)
-            ensure_clean_context!
+          def unpatch
+            @patched = false
+          end
 
-            name = event[/message/] ? NAME_MESSAGE : NAME_BATCH
-            span = configuration[:tracer].trace(name)
+          def process(span, event, _, payload)
             span.service = configuration[:service_name]
             span.resource = payload[:consumer_class]
+
             span.set_tag('kafka.topic', payload[:topic])
             span.set_tag('kafka.consumer', payload[:consumer_class])
             span.set_tag('kafka.partition', payload[:partition])
             span.set_tag('kafka.offset', payload[:offset]) if payload.key?(:offset)
             span.set_tag('kafka.first_offset', payload[:first_offset]) if payload.key?(:first_offset)
             span.set_tag('kafka.message_count', payload[:message_count]) if payload.key?(:message_count)
-          end
-
-          def finish(_, _, payload)
-            current_span = configuration[:tracer].call_context.current_span
-
-            return unless current_span
-
-            current_span.set_error(payload[:exception_object]) if payload[:exception_object]
-            current_span.finish
+            span.set_error(payload[:exception_object]) if payload[:exception_object]
           end
 
           private
@@ -65,12 +61,6 @@ module Datadog
 
           def compatible?
             defined?(::Racecar) && defined?(::ActiveSupport::Notifications)
-          end
-
-          def ensure_clean_context!
-            return unless configuration[:tracer].call_context.current_span
-
-            configuration[:tracer].provider.context = Context.new
           end
         end
       end

--- a/spec/ddtrace/contrib/racecar/patcher_spec.rb
+++ b/spec/ddtrace/contrib/racecar/patcher_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe 'Racecar patcher' do
     end
   end
 
+  after(:each) do
+    Datadog::Contrib::Racecar::Patcher.unpatch
+  end
+
   describe 'for single message processing' do
     let(:topic) { 'dd_trace_test_dummy' }
     let(:consumer) { 'DummyConsumer' }


### PR DESCRIPTION
This helper starts a span before the instrumented code starts executing,
waits for the code to finish, then calls the subscriber block with the
span and the AS::Notifications event details.

This allows you to more easily trace nested spans.