### PR TITLE
Add distributed_tracing option to Sinatra

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -107,6 +107,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | --- | --- | --- |
 | ``service_name`` | Service name used for `sinatra` instrumentation | sinatra |
 | ``resource_script_names`` | Prepend resource names with script name | ``false`` |
+| ``distributed_tracing`` | Enables [distributed tracing](#Distributed_Tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `false` |
 | ``tracer`` | A ``Datadog::Tracer`` instance used to instrument the application. Usually you don't need to set that. | ``Datadog.tracer`` |
 
 ### Rack

--- a/lib/ddtrace/contrib/sinatra/tracer.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer.rb
@@ -83,8 +83,9 @@ module Datadog
             end
 
             tracer = Datadog.configuration[:sinatra][:tracer]
+            distributed_tracing = Datadog.configuration[:sinatra][:distributed_tracing]
 
-            if Datadog.configuration[:sinatra][:distributed_tracing]
+            if distributed_tracing && tracer.provider.context.trace_id.nil?
               context = HTTPPropagator.extract(request.env)
               tracer.provider.context = context if context.trace_id
             end


### PR DESCRIPTION
Currently Sinatra doesn't support distributed tracing out of the box. It required the user to configure Rack as a service first, e.g.:

```ruby
Datadog.configure do |c|
  c.use :sinatra, resource_script_names: true, service_name: 'knowledge-api',
  c.use :rack, distributed_tracing: true
end
```

This pull request implements `distributed_tracing` as an option for Sinatra, so you only have to:

```ruby
Datadog.configure do |c|
  c.use :sinatra, distributed_tracing: true
end
```