### PR TITLE
Add missing version number for mongo in Gemfile

### DIFF
--- a/gemfiles/contrib.gemfile
+++ b/gemfiles/contrib.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "elasticsearch-transport"
-gem "mongo"
+gem "mongo", "< 2.5"
 gem "grape"
 gem "rack"
 gem "rack-test"


### PR DESCRIPTION
I think someone might have dropped this?