### PR TITLE
Add http.base_url tag to Rack

### DIFF
--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -17,20 +17,17 @@ module Datadog
           @app = app
         end
 
-        # rubocop:disable Metrics/MethodLength
         def call(env)
           # retrieve integration settings
           tracer = Datadog.configuration[:rack][:tracer]
-          service = Datadog.configuration[:rack][:service_name]
-          distributed_tracing = Datadog.configuration[:rack][:distributed_tracing]
 
           trace_options = {
-            service: service,
+            service: Datadog.configuration[:rack][:service_name],
             resource: nil,
             span_type: Datadog::Ext::HTTP::TYPE
           }
 
-          if distributed_tracing
+          if Datadog.configuration[:rack][:distributed_tracing]
             context = HTTPPropagator.extract(env)
             tracer.provider.context = context if context.trace_id
           end
@@ -57,47 +54,13 @@ module Datadog
           request_span.set_error(e) unless request_span.nil?
           raise e
         ensure
-          # the source of truth in Rack is the PATH_INFO key that holds the
-          # URL for the current request; some framework may override that
-          # value, especially during exception handling and because of that
-          # we prefer using the `REQUEST_URI` if this is available.
-          # NOTE: `REQUEST_URI` is Rails specific and may not apply for other frameworks
-          url = env['REQUEST_URI'] || env['PATH_INFO']
-
           # Rack is a really low level interface and it doesn't provide any
           # advanced functionality like routers. Because of that, we assume that
           # the underlying framework or application has more knowledge about
           # the result for this request; `resource` and `tags` are expected to
           # be set in another level but if they're missing, reasonable defaults
           # are used.
-          request_span.resource ||= resource_name_for(env, status)
-          if request_span.get_tag(Datadog::Ext::HTTP::METHOD).nil?
-            request_span.set_tag(Datadog::Ext::HTTP::METHOD, env['REQUEST_METHOD'])
-          end
-          if request_span.get_tag(Datadog::Ext::HTTP::URL).nil?
-            request_span.set_tag(Datadog::Ext::HTTP::URL, url)
-          end
-          if request_span.get_tag(Datadog::Ext::HTTP::BASE_URL).nil?
-            request_obj = ::Rack::Request.new(env)
-
-            base_url = if request_obj.respond_to?(:base_url)
-              request_obj.base_url
-            else
-              # Compatibility for older Rack versions
-              request_obj.url.chomp(request_obj.fullpath)
-            end
-
-            request_span.set_tag(Datadog::Ext::HTTP::BASE_URL, base_url)
-          end
-          if request_span.get_tag(Datadog::Ext::HTTP::STATUS_CODE).nil? && status
-            request_span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, status)
-          end
-
-          # detect if the status code is a 5xx and flag the request span as an error
-          # unless it has been already set by the underlying framework
-          if status.to_s.start_with?('5') && request_span.status.zero?
-            request_span.status = 1
-          end
+          set_request_tags!(request_span, env, status, headers, response)
 
           # ensure the request_span is finished and the context reset;
           # this assumes that the Rack middleware creates a root span
@@ -114,6 +77,44 @@ module Datadog
             "#{env['RESPONSE_MIDDLEWARE']}##{env['REQUEST_METHOD']}"
           else
             "#{env['REQUEST_METHOD']} #{status}".strip
+          end
+        end
+
+        def set_request_tags!(request_span, env, status, headers, response)
+          # the source of truth in Rack is the PATH_INFO key that holds the
+          # URL for the current request; some framework may override that
+          # value, especially during exception handling and because of that
+          # we prefer using the `REQUEST_URI` if this is available.
+          # NOTE: `REQUEST_URI` is Rails specific and may not apply for other frameworks
+          url = env['REQUEST_URI'] || env['PATH_INFO']
+
+          request_span.resource ||= resource_name_for(env, status)
+          if request_span.get_tag(Datadog::Ext::HTTP::METHOD).nil?
+            request_span.set_tag(Datadog::Ext::HTTP::METHOD, env['REQUEST_METHOD'])
+          end
+          if request_span.get_tag(Datadog::Ext::HTTP::URL).nil?
+            request_span.set_tag(Datadog::Ext::HTTP::URL, url)
+          end
+          if request_span.get_tag(Datadog::Ext::HTTP::BASE_URL).nil?
+            request_obj = ::Rack::Request.new(env)
+
+            base_url = if request_obj.respond_to?(:base_url)
+                         request_obj.base_url
+                       else
+                         # Compatibility for older Rack versions
+                         request_obj.url.chomp(request_obj.fullpath)
+                       end
+
+            request_span.set_tag(Datadog::Ext::HTTP::BASE_URL, base_url)
+          end
+          if request_span.get_tag(Datadog::Ext::HTTP::STATUS_CODE).nil? && status
+            request_span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, status)
+          end
+
+          # detect if the status code is a 5xx and flag the request span as an error
+          # unless it has been already set by the underlying framework
+          if status.to_s.start_with?('5') && request_span.status.zero?
+            request_span.status = 1
           end
         end
       end

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -17,6 +17,7 @@ module Datadog
           @app = app
         end
 
+        # rubocop:disable Metrics/MethodLength
         def call(env)
           # retrieve integration settings
           tracer = Datadog.configuration[:rack][:tracer]
@@ -75,6 +76,18 @@ module Datadog
           end
           if request_span.get_tag(Datadog::Ext::HTTP::URL).nil?
             request_span.set_tag(Datadog::Ext::HTTP::URL, url)
+          end
+          if request_span.get_tag(Datadog::Ext::HTTP::BASE_URL).nil?
+            request_obj = ::Rack::Request.new(env)
+
+            base_url = if request_obj.respond_to?(:base_url)
+              request_obj.base_url
+            else
+              # Compatibility for older Rack versions
+              request_obj.url.chomp(request_obj.fullpath)
+            end
+
+            request_span.set_tag(Datadog::Ext::HTTP::BASE_URL, base_url)
           end
           if request_span.get_tag(Datadog::Ext::HTTP::STATUS_CODE).nil? && status
             request_span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, status)

--- a/lib/ddtrace/ext/http.rb
+++ b/lib/ddtrace/ext/http.rb
@@ -4,6 +4,7 @@ module Datadog
       TYPE = 'http'.freeze
       TEMPLATE = 'template'.freeze
       URL = 'http.url'.freeze
+      BASE_URL = 'http.base_url'.freeze
       METHOD = 'http.method'.freeze
       STATUS_CODE = 'http.status_code'.freeze
       ERROR_RANGE = 500...600

--- a/test/contrib/rack/middleware_test.rb
+++ b/test/contrib/rack/middleware_test.rb
@@ -18,6 +18,7 @@ class TracerTest < RackBaseTest
     assert_equal('GET', span.get_tag('http.method'))
     assert_equal('200', span.get_tag('http.status_code'))
     assert_equal('/success/', span.get_tag('http.url'))
+    assert_equal('http://example.org', span.get_tag('http.base_url'))
     assert_equal(0, span.status)
     assert_nil(span.parent)
   end
@@ -38,6 +39,7 @@ class TracerTest < RackBaseTest
     assert_equal('POST', span.get_tag('http.method'))
     assert_equal('200', span.get_tag('http.status_code'))
     assert_equal('/success/', span.get_tag('http.url'))
+    assert_equal('http://example.org', span.get_tag('http.base_url'))
     assert_equal(0, span.status)
     assert_nil(span.parent)
   end
@@ -58,6 +60,7 @@ class TracerTest < RackBaseTest
     assert_equal('GET', span.get_tag('http.method'))
     assert_equal('200', span.get_tag('http.status_code'))
     assert_equal('/success/100', span.get_tag('http.url'))
+    assert_equal('http://example.org', span.get_tag('http.base_url'))
     assert_equal(0, span.status)
     assert_nil(span.parent)
   end
@@ -78,6 +81,7 @@ class TracerTest < RackBaseTest
     assert_equal('GET', span.get_tag('http.method'))
     assert_equal('404', span.get_tag('http.status_code'))
     assert_equal('/not/exists/', span.get_tag('http.url'))
+    assert_equal('http://example.org', span.get_tag('http.base_url'))
     assert_equal(0, span.status)
     assert_nil(span.parent)
   end
@@ -99,6 +103,7 @@ class TracerTest < RackBaseTest
     assert_equal('GET', span.get_tag('http.method'))
     assert_equal('400', span.get_tag('http.status_code'))
     assert_equal('/failure/', span.get_tag('http.url'))
+    assert_equal('http://example.org', span.get_tag('http.base_url'))
     assert_equal(0, span.status)
     assert_nil(span.parent)
   end
@@ -121,6 +126,7 @@ class TracerTest < RackBaseTest
     assert_equal('GET', span.get_tag('http.method'))
     assert_nil(span.get_tag('http.status_code'))
     assert_equal('/exception/', span.get_tag('http.url'))
+    assert_equal('http://example.org', span.get_tag('http.base_url'))
     assert_equal('StandardError', span.get_tag('error.type'))
     assert_equal('Unable to process the request', span.get_tag('error.msg'))
     refute_nil(span.get_tag('error.stack'))
@@ -144,6 +150,7 @@ class TracerTest < RackBaseTest
     assert_equal('GET_V2', span.get_tag('http.method'))
     assert_equal('201', span.get_tag('http.status_code'))
     assert_equal('/app/static/', span.get_tag('http.url'))
+    assert_equal('http://example.org', span.get_tag('http.base_url'))
     assert_equal(0, span.status)
     assert_nil(span.parent)
   end
@@ -165,6 +172,7 @@ class TracerTest < RackBaseTest
     assert_equal('GET', span.get_tag('http.method'))
     assert_equal('500', span.get_tag('http.status_code'))
     assert_equal('/500/', span.get_tag('http.url'))
+    assert_equal('http://example.org', span.get_tag('http.base_url'))
     assert_nil(span.get_tag('error.stack'))
     assert_equal(1, span.status)
     assert_nil(span.parent)
@@ -187,6 +195,7 @@ class TracerTest < RackBaseTest
     assert_equal('GET', span.get_tag('http.method'))
     assert_equal('500', span.get_tag('http.status_code'))
     assert_equal('/app/500/', span.get_tag('http.url'))
+    assert_equal('http://example.org', span.get_tag('http.base_url'))
     assert_equal(1, span.status)
     assert_equal('Handled exception', span.get_tag('error.stack'))
     assert_nil(span.parent)
@@ -210,6 +219,7 @@ class TracerTest < RackBaseTest
     assert_equal('GET', span.get_tag('http.method'))
     assert_equal('500', span.get_tag('http.status_code'))
     assert_equal('/app/500/no_status/', span.get_tag('http.url'))
+    assert_equal('http://example.org', span.get_tag('http.base_url'))
     assert_equal(1, span.status)
     assert_equal('Handled exception', span.get_tag('error.stack'))
     assert_nil(span.parent)
@@ -233,6 +243,7 @@ class TracerTest < RackBaseTest
     assert_equal('GET', span.get_tag('http.method'))
     assert_nil(span.get_tag('http.status_code'))
     assert_equal('/nomemory/', span.get_tag('http.url'))
+    assert_equal('http://example.org', span.get_tag('http.base_url'))
     assert_equal('NoMemoryError', span.get_tag('error.type'))
     assert_equal('Non-standard error', span.get_tag('error.msg'))
     refute_nil(span.get_tag('error.stack'))
@@ -268,6 +279,7 @@ class TracerTest < RackBaseTest
     assert_equal('GET', span.get_tag('http.method'))
     assert_equal('200', span.get_tag('http.status_code'))
     assert_equal('/success/', span.get_tag('http.url'))
+    assert_equal('http://example.org', span.get_tag('http.base_url'))
     assert_equal(0, span.status)
     assert_nil(span.parent)
   end


### PR DESCRIPTION
This pull request adds the `http.base_url` tag for Rack integrations, which is the equivalent of `Rack::Request#base_url`, e.g. "http://example.org" Addresses #301 