### PR TITLE
[active_record] decouple ActiveRecord and Sinatra integrations

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -129,6 +129,7 @@ if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM != 'java'
     gem 'dalli'
     gem 'resque', '< 2.0'
     gem 'racecar', '>= 0.3.5'
+    gem 'mysql2', platform: :ruby
   end
 else
   appraise 'contrib-old' do
@@ -146,5 +147,7 @@ else
     gem 'sucker_punch'
     gem 'dalli'
     gem 'resque', '< 2.0'
+    gem 'mysql2', '0.3.21', platform: :ruby
+    gem 'activerecord-mysql-adapter', platform: :ruby
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -53,6 +53,7 @@ namespace :spec do
     :mongodb,
     :racecar,
     :resque,
+    :active_record,
     :dalli
   ].each do |contrib|
     RSpec::Core::RakeTask.new(contrib) do |t|
@@ -220,9 +221,11 @@ task :ci do
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:sucker_punch'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:resque'
     # RSpec
+    sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake spec:active_record'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake spec:dalli'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake spec:racecar'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake spec:dalli'
+    sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake spec:active_record'
   when 2
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake test:sidekiq'
     sh 'rvm $SIDEKIQ_OLD_VERSIONS --verbose do appraisal contrib-old rake test:sidekiq'

--- a/gemfiles/contrib.gemfile
+++ b/gemfiles/contrib.gemfile
@@ -19,5 +19,6 @@ gem "sucker_punch"
 gem "dalli"
 gem "resque", "< 2.0"
 gem "racecar", ">= 0.3.5"
+gem "mysql2", platform: :ruby
 
 gemspec path: "../"

--- a/gemfiles/contrib_old.gemfile
+++ b/gemfiles/contrib_old.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "elasticsearch-transport"
-gem "mongo"
+gem "mongo", "< 2.5"
 gem "redis", "< 4.0"
 gem "hiredis"
 gem "rack", "1.4.7"
@@ -17,5 +17,7 @@ gem "aws-sdk", "~> 2.0"
 gem "sucker_punch"
 gem "dalli"
 gem "resque", "< 2.0"
+gem "mysql2", "0.3.21", platform: :ruby
+gem "activerecord-mysql-adapter", platform: :ruby
 
 gemspec path: "../"

--- a/lib/ddtrace/contrib/active_record/patcher.rb
+++ b/lib/ddtrace/contrib/active_record/patcher.rb
@@ -62,7 +62,7 @@ module Datadog
           return @database_service if defined?(@database_service)
 
           @database_service = get_option(:service_name) || adapter_name
-          get_option(:tracer).set_service_info(@database_service, 'sinatra', Ext::AppTypes::DB)
+          get_option(:tracer).set_service_info(@database_service, 'active_record', Ext::AppTypes::DB)
           @database_service
         end
 

--- a/spec/ddtrace/contrib/active_record/app.rb
+++ b/spec/ddtrace/contrib/active_record/app.rb
@@ -1,0 +1,36 @@
+require 'active_record'
+require 'mysql2'
+
+logger = Logger.new(STDOUT)
+logger.level = Logger::INFO
+
+# connecting to any kind of database is enough to test the integration
+ActiveRecord::Base.establish_connection('mysql2://root:root@127.0.0.1:53306/mysql')
+
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end
+
+class Article < ApplicationRecord
+end
+
+# check if the migration has been executed
+# MySQL JDBC drivers require that, otherwise we get a
+# "Table '?' already exists" error
+begin
+  Article.count()
+rescue ActiveRecord::StatementInvalid
+  logger.info 'Executing database migrations'
+  ActiveRecord::Schema.define(version: 20161003090450) do
+    create_table 'articles', force: :cascade do |t|
+      t.string   'title'
+      t.datetime 'created_at', null: false
+      t.datetime 'updated_at', null: false
+    end
+  end
+else
+  logger.info 'Database already exists; nothing to do'
+end
+
+# force an access to prevent extra spans during tests
+Article.count()

--- a/spec/ddtrace/contrib/active_record/tracer_spec.rb
+++ b/spec/ddtrace/contrib/active_record/tracer_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'ddtrace'
+
+require_relative 'app'
+
+RSpec.describe 'Dalli instrumentation' do
+  let(:tracer) { ::Datadog::Tracer.new(writer: FauxWriter.new) }
+
+  before(:each) do
+    Datadog.configure do |c|
+      c.use :active_record, tracer: tracer
+    end
+  end
+
+  it 'calls the instrumentation when is used standalone' do
+    Article.count
+    spans = tracer.writer.spans
+    expect(spans.size).to eq(1)
+
+    span = spans[0]
+    expect(span.service).to eq('mysql2')
+    expect(span.name).to eq('mysql2.query')
+    expect(span.span_type).to eq('sql')
+    expect(span.resource.strip).to eq('SELECT COUNT(*) FROM `articles`')
+    expect(span.get_tag('active_record.db.vendor')).to eq('mysql2')
+    expect(span.get_tag('active_record.db.name')).to eq('mysql')
+    expect(span.get_tag('active_record.db.cached')).to eq(nil)
+    expect(span.get_tag('out.host')).to eq('127.0.0.1')
+    expect(span.get_tag('out.port')).to eq('53306')
+    expect(span.get_tag('sql.query')).to eq(nil)
+  end
+end

--- a/spec/ddtrace/contrib/active_record/tracer_spec.rb
+++ b/spec/ddtrace/contrib/active_record/tracer_spec.rb
@@ -3,7 +3,7 @@ require 'ddtrace'
 
 require_relative 'app'
 
-RSpec.describe 'Dalli instrumentation' do
+RSpec.describe 'ActiveRecord instrumentation' do
   let(:tracer) { ::Datadog::Tracer.new(writer: FauxWriter.new) }
 
   before(:each) do
@@ -15,7 +15,11 @@ RSpec.describe 'Dalli instrumentation' do
   it 'calls the instrumentation when is used standalone' do
     Article.count
     spans = tracer.writer.spans
+    services = tracer.writer.services
+
+    # expect service and trace is sent
     expect(spans.size).to eq(1)
+    expect(services['mysql2']).to eq({'app'=>'active_record', 'app_type'=>'db'})
 
     span = spans[0]
     expect(span.service).to eq('mysql2')


### PR DESCRIPTION
### Overview

Closes #328.

When ActiveRecord is used standalone it should work without expecting other integrations to be activated. The following must be a legit instrumentation:
```ruby
Datadog.configure do |config|
  config.use :active_record, service_name: 'random-service'
  config.use :grape, service_name: 'random-service'
end
```
