### PR TITLE
Instrument ActiveRecord instantiations

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -248,7 +248,8 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | --- | --- |
-| ``service_name`` | Service name used for `active_record` instrumentation | active_record |
+| ``service_name`` | Service name used for database portion of `active_record` instrumentation. | Name of database adapter (e.g. `mysql2`) |
+| ``orm_service_name`` | Service name used for the Ruby ORM portion of `active_record` instrumentation. Overrides service name for ORM spans if explicitly set, which otherwise inherit their service from their parent.  | ``active_record`` |
 
 ### Elastic Search
 

--- a/lib/ddtrace/contrib/active_record/patcher.rb
+++ b/lib/ddtrace/contrib/active_record/patcher.rb
@@ -44,9 +44,11 @@ module Datadog
             sql(*args)
           end
 
-          # subscribe when the active record instantiates objects
-          ::ActiveSupport::Notifications.subscribe('instantiation.active_record') do |*args|
-            instantiation(*args)
+          if instantiation_tracing_supported?
+            # subscribe when the active record instantiates objects
+            ::ActiveSupport::Notifications.subscribe('instantiation.active_record') do |*args|
+              instantiation(*args)
+            end
           end
         end
 

--- a/lib/ddtrace/contrib/active_record/patcher.rb
+++ b/lib/ddtrace/contrib/active_record/patcher.rb
@@ -51,6 +51,11 @@ module Datadog
           end
         end
 
+        def instantiation_tracing_supported?
+          Gem.loaded_specs['activerecord'] \
+            && Gem.loaded_specs['activerecord'].version >= Gem::Version.new('4.2')
+        end
+
         # NOTE: Resolve this here instead of in the option defaults,
         #       because resolving adapter name as a default causes ActiveRecord to connect,
         #       which isn't a good idea at initialization time.

--- a/lib/ddtrace/contrib/active_record/patcher.rb
+++ b/lib/ddtrace/contrib/active_record/patcher.rb
@@ -1,4 +1,3 @@
-require 'ddtrace/ext/ruby'
 require 'ddtrace/ext/sql'
 require 'ddtrace/ext/app_types'
 

--- a/lib/ddtrace/contrib/rails/active_record.rb
+++ b/lib/ddtrace/contrib/rails/active_record.rb
@@ -15,9 +15,11 @@ module Datadog
             sql(*args)
           end
 
-          # subscribe when the active record instantiates objects
-          ::ActiveSupport::Notifications.subscribe('instantiation.active_record') do |*args|
-            instantiation(*args)
+          if Datadog::Contrib::Rails::Patcher.active_record_instantiation_tracing_supported?
+            # subscribe when the active record instantiates objects
+            ::ActiveSupport::Notifications.subscribe('instantiation.active_record') do |*args|
+              instantiation(*args)
+            end
           end
         end
 

--- a/lib/ddtrace/contrib/rails/active_record.rb
+++ b/lib/ddtrace/contrib/rails/active_record.rb
@@ -62,7 +62,7 @@ module Datadog
           span = tracer.trace(
             'active_record.instantiation',
             resource: payload.fetch(:class_name),
-            span_type: Datadog::Ext::Ruby::TYPE
+            span_type: 'custom'
           )
 
           span.service = span.parent ? span.parent.service : Datadog.configuration[:rails][:service_name]

--- a/lib/ddtrace/contrib/rails/active_record.rb
+++ b/lib/ddtrace/contrib/rails/active_record.rb
@@ -1,5 +1,4 @@
 require 'ddtrace/ext/sql'
-require 'ddtrace/ext/ruby'
 require 'ddtrace/contrib/rails/utils'
 
 module Datadog

--- a/lib/ddtrace/contrib/rails/active_record.rb
+++ b/lib/ddtrace/contrib/rails/active_record.rb
@@ -53,26 +53,25 @@ module Datadog
           span.start_time = start
           span.finish(finish)
         rescue StandardError => e
-          Datadog::Tracer.log.error(e.message)
+          Datadog::Tracer.log.debug(e.message)
         end
 
         def self.instantiation(_name, start, finish, _id, payload)
           tracer = Datadog.configuration[:rails][:tracer]
-          rails_service = Datadog.configuration[:rails][:service_name]
 
           span = tracer.trace(
             'active_record.instantiation',
             resource: payload.fetch(:class_name),
-            service: rails_service,
             span_type: Datadog::Ext::Ruby::TYPE
           )
 
+          span.service = span.parent ? span.parent.service : Datadog.configuration[:rails][:service_name]
           span.set_tag('active_record.instantiation.class_name', payload.fetch(:class_name))
           span.set_tag('active_record.instantiation.record_count', payload.fetch(:record_count))
           span.start_time = start
           span.finish(finish)
         rescue StandardError => e
-          Datadog::Tracer.log.error(e.message)
+          Datadog::Tracer.log.debug(e.message)
         end
       end
     end

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -36,6 +36,11 @@ module Datadog
 
             defined?(::Rails::VERSION) && ::Rails::VERSION::MAJOR.to_i >= 3
           end
+
+          def active_record_instantiation_tracing_supported?
+            Gem.loaded_specs['activerecord'] \
+              && Gem.loaded_specs['activerecord'].version >= Gem::Version.new('4.2')
+          end
         end
       end
     end

--- a/lib/ddtrace/ext/ruby.rb
+++ b/lib/ddtrace/ext/ruby.rb
@@ -1,0 +1,7 @@
+module Datadog
+  module Ext
+    module Ruby
+      TYPE = 'ruby'.freeze
+    end
+  end
+end

--- a/lib/ddtrace/ext/ruby.rb
+++ b/lib/ddtrace/ext/ruby.rb
@@ -1,7 +1,0 @@
-module Datadog
-  module Ext
-    module Ruby
-      TYPE = 'ruby'.freeze
-    end
-  end
-end

--- a/spec/ddtrace/contrib/active_record/tracer_spec.rb
+++ b/spec/ddtrace/contrib/active_record/tracer_spec.rb
@@ -5,10 +5,11 @@ require_relative 'app'
 
 RSpec.describe 'ActiveRecord instrumentation' do
   let(:tracer) { ::Datadog::Tracer.new(writer: FauxWriter.new) }
+  let(:configuration_options) { { tracer: tracer } }
 
   before(:each) do
     Datadog.configure do |c|
-      c.use :active_record, tracer: tracer
+      c.use :active_record, configuration_options
     end
   end
 
@@ -32,5 +33,26 @@ RSpec.describe 'ActiveRecord instrumentation' do
     expect(span.get_tag('out.host')).to eq('127.0.0.1')
     expect(span.get_tag('out.port')).to eq('53306')
     expect(span.get_tag('sql.query')).to eq(nil)
+  end
+
+  context 'when service_name' do
+    subject(:spans) do
+      Article.count
+      tracer.writer.spans
+    end
+
+    let(:query_span) { spans.first }
+
+    context 'is not set' do
+      let(:configuration_options) { super().merge({ service_name: nil }) }
+      it { expect(query_span.service).to eq('mysql2') }
+    end
+
+    context 'is set' do
+      let(:service_name) { 'test_active_record' }
+      let(:configuration_options) { super().merge({ service_name: service_name }) }
+
+      it { expect(query_span.service).to eq(service_name) }
+    end
   end
 end

--- a/test/contrib/rails/controller_test.rb
+++ b/test/contrib/rails/controller_test.rb
@@ -117,7 +117,7 @@ class TracingControllerTest < ActionController::TestCase
     spans = @tracer.writer.spans
 
     # rubocop:disable Style/IdenticalConditionalBranches
-    if Rails.version >= '4.2'
+    if Datadog::Contrib::Rails::Patcher.active_record_instantiation_tracing_supported?
       assert_equal(spans.length, 5)
       span_instantiation, span_database, span_request, span_cache, span_template = spans
 

--- a/test/contrib/rails/database_test.rb
+++ b/test/contrib/rails/database_test.rb
@@ -51,8 +51,8 @@ class DatabaseTracingTest < ActiveSupport::TestCase
 
         instantiation_span = spans.first
         assert_equal(instantiation_span.name, 'active_record.instantiation')
-        assert_equal(instantiation_span.span_type, 'sql')
-        assert_equal(instantiation_span.service, get_adapter_name)
+        assert_equal(instantiation_span.span_type, 'ruby')
+        assert_equal(instantiation_span.service, Datadog.configuration[:rails][:service_name])
         assert_equal(instantiation_span.resource, 'Article')
         assert_equal(instantiation_span.get_tag('active_record.instantiation.class_name'), 'Article')
         assert_equal(instantiation_span.get_tag('active_record.instantiation.record_count'), '1')

--- a/test/contrib/rails/database_test.rb
+++ b/test/contrib/rails/database_test.rb
@@ -51,7 +51,7 @@ class DatabaseTracingTest < ActiveSupport::TestCase
 
         instantiation_span = spans.first
         assert_equal(instantiation_span.name, 'active_record.instantiation')
-        assert_equal(instantiation_span.span_type, 'ruby')
+        assert_equal(instantiation_span.span_type, 'custom')
         assert_equal(instantiation_span.service, Datadog.configuration[:rails][:service_name])
         assert_equal(instantiation_span.resource, 'Article')
         assert_equal(instantiation_span.get_tag('active_record.instantiation.class_name'), 'Article')

--- a/test/contrib/rails/database_test.rb
+++ b/test/contrib/rails/database_test.rb
@@ -37,6 +37,31 @@ class DatabaseTracingTest < ActiveSupport::TestCase
     assert_nil(span.get_tag('sql.query'))
   end
 
+  test 'active record traces instantiation' do
+    # Only supported in Rails 4.2+
+    if Rails.version >= '4.2'
+      begin
+        Article.create(title: 'Instantiation test')
+        @tracer.writer.spans # Clear spans
+
+        # make the query and assert the proper spans
+        Article.all.entries
+        spans = @tracer.writer.spans
+        assert_equal(2, spans.length)
+
+        instantiation_span = spans.first
+        assert_equal(instantiation_span.name, 'active_record.instantiation')
+        assert_equal(instantiation_span.span_type, 'sql')
+        assert_equal(instantiation_span.service, get_adapter_name)
+        assert_equal(instantiation_span.resource, 'Article')
+        assert_equal(instantiation_span.get_tag('active_record.instantiation.class_name'), 'Article')
+        assert_equal(instantiation_span.get_tag('active_record.instantiation.record_count'), '1')
+      ensure
+        Article.delete_all
+      end
+    end
+  end
+
   test 'active record is sets cached tag' do
     # Make sure query caching is enabled...
     Article.cache do

--- a/test/contrib/rails/database_test.rb
+++ b/test/contrib/rails/database_test.rb
@@ -38,8 +38,7 @@ class DatabaseTracingTest < ActiveSupport::TestCase
   end
 
   test 'active record traces instantiation' do
-    # Only supported in Rails 4.2+
-    if Rails.version >= '4.2'
+    if Datadog::Contrib::Rails::Patcher.active_record_instantiation_tracing_supported?
       begin
         Article.create(title: 'Instantiation test')
         @tracer.writer.spans # Clear spans

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -75,8 +75,8 @@ class FullStackTest < ActionDispatch::IntegrationTest
 
     if Rails.version >= '4.2'
       assert_equal(instantiation_span.name, 'active_record.instantiation')
-      assert_equal(instantiation_span.span_type, 'sql')
-      assert_equal(instantiation_span.service, adapter_name)
+      assert_equal(instantiation_span.span_type, 'ruby')
+      assert_equal(instantiation_span.service, Datadog.configuration[:rails][:service_name])
       assert_equal(instantiation_span.resource, 'Article')
       assert_equal(instantiation_span.get_tag('active_record.instantiation.class_name'), 'Article')
       assert_equal(instantiation_span.get_tag('active_record.instantiation.record_count'), '0')

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -37,7 +37,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     # spans are sorted alphabetically, and ... controller names start
     # either by m or p (MySQL or PostGreSQL) so the database span is always
     # the first one. Would fail with an adapter named z-something.
-    if Rails.version >= '4.2'
+    if Datadog::Contrib::Rails::Patcher.active_record_instantiation_tracing_supported?
       assert_equal(spans.length, 6)
       instantiation_span, database_span, request_span, controller_span, cache_span, render_span = spans
     else
@@ -63,7 +63,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_equal(render_span.resource, 'rails.render_template')
     assert_equal(render_span.get_tag('rails.template_name'), 'tracing/full.html.erb')
 
-    adapter_name = get_adapter_name()
+    adapter_name = get_adapter_name
     assert_equal(database_span.name, "#{adapter_name}.query")
     assert_equal(database_span.span_type, 'sql')
     assert_equal(database_span.service, adapter_name)
@@ -73,7 +73,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_includes(database_span.resource, 'FROM')
     assert_includes(database_span.resource, 'articles')
 
-    if Rails.version >= '4.2'
+    if Datadog::Contrib::Rails::Patcher.active_record_instantiation_tracing_supported?
       assert_equal(instantiation_span.name, 'active_record.instantiation')
       assert_equal(instantiation_span.span_type, 'custom')
       assert_equal(instantiation_span.service, Datadog.configuration[:rails][:service_name])

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -75,7 +75,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
 
     if Rails.version >= '4.2'
       assert_equal(instantiation_span.name, 'active_record.instantiation')
-      assert_equal(instantiation_span.span_type, 'ruby')
+      assert_equal(instantiation_span.span_type, 'custom')
       assert_equal(instantiation_span.service, Datadog.configuration[:rails][:service_name])
       assert_equal(instantiation_span.resource, 'Article')
       assert_equal(instantiation_span.get_tag('active_record.instantiation.class_name'), 'Article')

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -25,19 +25,25 @@ class FullStackTest < ActionDispatch::IntegrationTest
     Rails.application.app.instance_variable_set(:@tracer, @rack_tracer)
   end
 
+  # rubocop:disable Metrics/BlockLength
   test 'a full request is properly traced' do
     # make the request and assert the proper span
     get '/full'
     assert_response :success
 
     # get spans
-    spans = @tracer.writer.spans()
-    assert_equal(spans.length, 5)
+    spans = @tracer.writer.spans
 
     # spans are sorted alphabetically, and ... controller names start
     # either by m or p (MySQL or PostGreSQL) so the database span is always
     # the first one. Would fail with an adapter named z-something.
-    database_span, request_span, controller_span, cache_span, render_span = spans
+    if Rails.version >= '4.2'
+      assert_equal(spans.length, 6)
+      instantiation_span, database_span, request_span, controller_span, cache_span, render_span = spans
+    else
+      assert_equal(spans.length, 5)
+      database_span, request_span, controller_span, cache_span, render_span = spans
+    end
 
     assert_equal(request_span.name, 'rack.request')
     assert_equal(request_span.span_type, 'http')
@@ -66,6 +72,15 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_includes(database_span.resource, 'SELECT')
     assert_includes(database_span.resource, 'FROM')
     assert_includes(database_span.resource, 'articles')
+
+    if Rails.version >= '4.2'
+      assert_equal(instantiation_span.name, 'active_record.instantiation')
+      assert_equal(instantiation_span.span_type, 'sql')
+      assert_equal(instantiation_span.service, adapter_name)
+      assert_equal(instantiation_span.resource, 'Article')
+      assert_equal(instantiation_span.get_tag('active_record.instantiation.class_name'), 'Article')
+      assert_equal(instantiation_span.get_tag('active_record.instantiation.record_count'), '0')
+    end
 
     assert_equal(cache_span.name, 'rails.cache')
     assert_equal(cache_span.span_type, 'cache')

--- a/test/contrib/sinatra/tracer_activerecord_test.rb
+++ b/test/contrib/sinatra/tracer_activerecord_test.rb
@@ -137,7 +137,7 @@ class TracerActiveRecordTest < TracerTestBase
     instantiation_span, sinatra_span, sqlite_span = spans
 
     assert_equal(instantiation_span.name, 'active_record.instantiation')
-    assert_equal(instantiation_span.span_type, 'ruby')
+    assert_equal(instantiation_span.span_type, 'custom')
     assert_equal(instantiation_span.service, sinatra_span.service)
     assert_equal(instantiation_span.resource, 'TracerActiveRecordTest::Article')
     assert_equal(instantiation_span.get_tag('active_record.instantiation.class_name'), 'TracerActiveRecordTest::Article')

--- a/test/contrib/sinatra/tracer_activerecord_test.rb
+++ b/test/contrib/sinatra/tracer_activerecord_test.rb
@@ -120,7 +120,7 @@ class TracerActiveRecordTest < TracerTestBase
 
   def test_instantiation_tracing
     # Only supported in Rails 4.2+
-    skip unless Gem.loaded_specs['activerecord'].version >= Gem::Version.new('4.2')
+    skip unless Datadog::Contrib::ActiveRecord::Patcher.instantiation_tracing_supported?
 
     # Make sure Article table exists
     migrate_db

--- a/test/contrib/sinatra/tracer_activerecord_test.rb
+++ b/test/contrib/sinatra/tracer_activerecord_test.rb
@@ -138,7 +138,7 @@ class TracerActiveRecordTest < TracerTestBase
 
     assert_equal(instantiation_span.name, 'active_record.instantiation')
     assert_equal(instantiation_span.span_type, 'ruby')
-    assert_equal(instantiation_span.service, Datadog.configuration[:active_record][:service_name])
+    assert_equal(instantiation_span.service, sinatra_span.service)
     assert_equal(instantiation_span.resource, 'TracerActiveRecordTest::Article')
     assert_equal(instantiation_span.get_tag('active_record.instantiation.class_name'), 'TracerActiveRecordTest::Article')
     assert_equal(instantiation_span.get_tag('active_record.instantiation.record_count'), '1')

--- a/test/contrib/sinatra/tracer_activerecord_test.rb
+++ b/test/contrib/sinatra/tracer_activerecord_test.rb
@@ -137,8 +137,8 @@ class TracerActiveRecordTest < TracerTestBase
     instantiation_span, sinatra_span, sqlite_span = spans
 
     assert_equal(instantiation_span.name, 'active_record.instantiation')
-    assert_equal(instantiation_span.span_type, 'sql')
-    assert_equal(instantiation_span.service, get_adapter_name)
+    assert_equal(instantiation_span.span_type, 'ruby')
+    assert_equal(instantiation_span.service, Datadog.configuration[:active_record][:service_name])
     assert_equal(instantiation_span.resource, 'TracerActiveRecordTest::Article')
     assert_equal(instantiation_span.get_tag('active_record.instantiation.class_name'), 'TracerActiveRecordTest::Article')
     assert_equal(instantiation_span.get_tag('active_record.instantiation.record_count'), '1')


### PR DESCRIPTION
For #311 , sometimes ActiveRecord can take significant time instantiating records.

This pull request traces the `instantiation.active_record` event, for versions of ActiveRecord 4.2+. The additional span has two tags associated with it: `active_record.instantiation.class_name` and `active_record.instantiation.record_count`.

Sample output:

<img width="1252" alt="screen shot 2018-02-06 at 3 31 08 pm" src="https://user-images.githubusercontent.com/3237131/35882814-6502cad0-0b53-11e8-93fb-52aee0b92e5c.png">
