### PR TITLE
Add http.request_id tag to Rack spans

### DIFF
--- a/lib/ddtrace/ext/http.rb
+++ b/lib/ddtrace/ext/http.rb
@@ -6,6 +6,7 @@ module Datadog
       URL = 'http.url'.freeze
       BASE_URL = 'http.base_url'.freeze
       METHOD = 'http.method'.freeze
+      REQUEST_ID = 'http.request_id'.freeze
       STATUS_CODE = 'http.status_code'.freeze
       ERROR_RANGE = 500...600
     end


### PR DESCRIPTION
HTTP requests sometimes have a `X-Request-Id` header with a UUID or other identifier as a means of tracing requests in logs.

This pull request adds the `http.request_id` tag to Rack spans if Rack tracing is enabled (which is default for Rails applications.) Typically, if a `X-Request-Id` header is set, it will use that value. If it's a Rails application, and no `X-Request-Id` header is set, Rails automatically generates one, which will then be used as the value for this tag.

Sample output:

![screenshot from 2018-01-31 18-11-45](https://user-images.githubusercontent.com/3237131/35654048-1612a8ee-06b9-11e8-855a-081fec738375.png)
