### PR TITLE
Use rack compliant keys

### DIFF
--- a/lib/ddtrace/contrib/grape/endpoint.rb
+++ b/lib/ddtrace/contrib/grape/endpoint.rb
@@ -71,7 +71,7 @@ module Datadog
             span.resource = resource
 
             # set the request span resource if it's a `rack.request` span
-            request_span = payload[:env][:datadog_rack_request_span]
+            request_span = payload[:env][Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
             if !request_span.nil? && request_span.name == 'rack.request'
               request_span.resource = resource
             end

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -13,6 +13,8 @@ module Datadog
       # application. If request tags are not set by the app, they will be set using
       # information available at the Rack level.
       class TraceMiddleware
+        RACK_REQUEST_SPAN = 'datadog.rack_request_span'.freeze
+
         def initialize(app)
           @app = app
         end
@@ -35,7 +37,7 @@ module Datadog
           # start a new request span and attach it to the current Rack environment;
           # we must ensure that the span `resource` is set later
           request_span = tracer.trace('rack.request', trace_options)
-          env[:datadog_rack_request_span] = request_span
+          env[RACK_REQUEST_SPAN] = request_span
 
           # call the rest of the stack
           status, headers, response = @app.call(env)

--- a/test/contrib/rack/helpers.rb
+++ b/test/contrib/rack/helpers.rb
@@ -40,7 +40,7 @@ class RackBaseTest < Minitest::Test
         run(proc do |env|
           # this should be considered a web framework that can alter
           # the request span after routing / controller processing
-          request_span = env[:datadog_rack_request_span]
+          request_span = env['datadog.rack_request_span']
           request_span.resource = 'GET /app/'
           request_span.set_tag('http.method', 'GET_V2')
           request_span.set_tag('http.status_code', 201)
@@ -54,7 +54,7 @@ class RackBaseTest < Minitest::Test
         run(proc do |env|
           # this should be considered a web framework that can alter
           # the request span after routing / controller processing
-          request_span = env[:datadog_rack_request_span]
+          request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
           request_span.status = 1
           request_span.set_tag('error.stack', 'Handled exception')
 
@@ -66,7 +66,7 @@ class RackBaseTest < Minitest::Test
         run(proc do |env|
           # this should be considered a web framework that can alter
           # the request span after routing / controller processing
-          request_span = env[:datadog_rack_request_span]
+          request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
           request_span.set_tag('error.stack', 'Handled exception')
 
           [500, { 'Content-Type' => 'text/html' }, 'OK']


### PR DESCRIPTION
Currently ddtrace is setting keys in env in the form `:datadog_rack_request_span`. This caused some issues in some of our code as we wrote expecting that all the keys in a request env would be strings rather than symbols.

I took a quick look at the [docs for rack](http://www.rubydoc.info/github/rack/rack/master/file/SPEC) and they don't explicitly say that env should be strings except for responses which it does explicitly require it. However it does say that keys should be named to include a `.` in them e.g. `rack.version` which suggests strings are probably the way to go anways.

Based on this I've changed the key that datadog is using from a symbol to a string and included a dot. So `:datadog_rack_request_span` becomes `'datadog.rack_request_span'` instead.

I've replaced all occurrences of this that I've found, but as I'm not terribly familiar with this code feedback on these changes and if they're even desired would be appreciated.

For our code we can thankfully fix the issue quite easily so this isn't a critical fix for anything, so accept or reject at your leisure. If any changes are needed let me know and I'll see what I can do.

