### PR TITLE
Instrument ActiveModelSerializers

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -113,6 +113,7 @@ end
 
 if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM != 'java'
   appraise 'contrib' do
+    gem 'active_model_serializers', '>= 0.10.0'
     gem 'elasticsearch-transport'
     gem 'mongo', '< 2.5'
     gem 'graphql'
@@ -135,6 +136,7 @@ if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM != 'java'
   end
 else
   appraise 'contrib-old' do
+    gem 'active_model_serializers', '~> 0.9.0'
     gem 'elasticsearch-transport'
     gem 'mongo', '< 2.5'
     gem 'redis', '< 4.0'

--- a/Rakefile
+++ b/Rakefile
@@ -40,6 +40,7 @@ namespace :spec do
   end
 
   [
+    :active_model_serializers,
     :active_record,
     :active_support,
     :aws,
@@ -219,6 +220,7 @@ task :ci do
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:aws'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake test:sucker_punch'
     # RSpec
+    sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake spec:active_model_serializers'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake spec:active_record'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake spec:active_support'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake spec:dalli'
@@ -229,6 +231,7 @@ task :ci do
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake spec:redis'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake spec:resque'
     sh 'rvm $MRI_VERSIONS --verbose do appraisal contrib rake spec:sequel'
+    sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake spec:active_model_serializers'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake spec:active_record'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake spec:active_support'
     sh 'rvm $MRI_OLD_VERSIONS --verbose do appraisal contrib-old rake spec:dalli'

--- a/gemfiles/contrib.gemfile
+++ b/gemfiles/contrib.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
+gem "active_model_serializers", ">= 0.10.0"
 gem "elasticsearch-transport"
 gem "mongo", "< 2.5"
 gem "graphql"

--- a/gemfiles/contrib_old.gemfile
+++ b/gemfiles/contrib_old.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
+gem "active_model_serializers", "~> 0.9.0"
 gem "elasticsearch-transport"
 gem "mongo", "< 2.5"
 gem "redis", "< 4.0"

--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -56,6 +56,7 @@ end
 require 'ddtrace/contrib/base'
 require 'ddtrace/contrib/rack/patcher'
 require 'ddtrace/contrib/rails/patcher'
+require 'ddtrace/contrib/active_model_serializers/patcher'
 require 'ddtrace/contrib/active_record/patcher'
 require 'ddtrace/contrib/sequel/patcher'
 require 'ddtrace/contrib/elasticsearch/patcher'

--- a/lib/ddtrace/contrib/active_model_serializers/event.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/event.rb
@@ -1,0 +1,57 @@
+require 'ddtrace/contrib/active_support/notifications/event'
+
+module Datadog
+  module Contrib
+    module ActiveModelSerializers
+      # Defines basic behaviors for an ActiveModelSerializers event.
+      module Event
+        def self.included(base)
+          base.send(:include, ActiveSupport::Notifications::Event)
+          base.send(:extend, ClassMethods)
+        end
+
+        # Class methods for ActiveModelSerializers events.
+        # Note, they share the same process method and before_trace method.
+        module ClassMethods
+          def span_options
+            { service: configuration[:service_name] }
+          end
+
+          def tracer
+            configuration[:tracer]
+          end
+
+          def configuration
+            Datadog.configuration[:active_model_serializers]
+          end
+
+          def process(span, event, _id, payload)
+            span.service = configuration[:service_name]
+
+            # Set the resource name and serializer name
+            res = resource(payload[:serializer])
+            span.resource = res
+            span.set_tag('active_model_serializers.serializer', res)
+
+            span.span_type = Datadog::Ext::HTTP::TEMPLATE
+
+            # Will be nil in 0.9
+            span.set_tag('active_model_serializers.adapter', payload[:adapter].class) unless payload[:adapter].nil?
+          end
+
+          private
+
+          def resource(serializer)
+            # Depending on the version of ActiveModelSerializers
+            # serializer will be a string or an object.
+            if serializer.respond_to?(:name)
+              serializer.name
+            else
+              serializer
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/active_model_serializers/events.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/events.rb
@@ -1,0 +1,30 @@
+require 'ddtrace/contrib/active_model_serializers/events/render'
+require 'ddtrace/contrib/active_model_serializers/events/serialize'
+
+module Datadog
+  module Contrib
+    module ActiveModelSerializers
+      # Defines collection of instrumented ActiveModelSerializers events
+      module Events
+        ALL = [
+          Events::Render,
+          Events::Serialize
+        ].freeze
+
+        module_function
+
+        def all
+          self::ALL
+        end
+
+        def subscriptions
+          all.collect(&:subscriptions).collect(&:to_a).flatten
+        end
+
+        def subscribe!
+          all.each(&:subscribe!)
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/active_model_serializers/events/render.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/events/render.rb
@@ -1,0 +1,32 @@
+require 'ddtrace/contrib/active_model_serializers/event'
+
+module Datadog
+  module Contrib
+    module ActiveModelSerializers
+      module Events
+        # Defines instrumentation for render.active_model_serializers event
+        module Render
+          include ActiveModelSerializers::Event
+
+          EVENT_NAME = 'render.active_model_serializers'.freeze
+          SPAN_NAME = 'active_model_serializers.render'.freeze
+
+          module_function
+
+          def supported?
+            Gem.loaded_specs['active_model_serializers'] \
+              && Gem.loaded_specs['active_model_serializers'].version >= Gem::Version.new('0.10')
+          end
+
+          def event_name
+            self::EVENT_NAME
+          end
+
+          def span_name
+            self::SPAN_NAME
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/active_model_serializers/events/serialize.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/events/serialize.rb
@@ -1,0 +1,35 @@
+require 'ddtrace/contrib/active_model_serializers/event'
+
+module Datadog
+  module Contrib
+    module ActiveModelSerializers
+      module Events
+        # Defines instrumentation for !serialize.active_model_serializers event
+        module Serialize
+          include ActiveModelSerializers::Event
+
+          EVENT_NAME = '!serialize.active_model_serializers'.freeze
+          SPAN_NAME = 'active_model_serializers.serialize'.freeze
+
+          module_function
+
+          def supported?
+            Gem.loaded_specs['active_model_serializers'] \
+              && ( \
+                Gem.loaded_specs['active_model_serializers'].version >= Gem::Version.new('0.9') \
+                && Gem.loaded_specs['active_model_serializers'].version < Gem::Version.new('0.10') \
+              )
+          end
+
+          def event_name
+            self::EVENT_NAME
+          end
+
+          def span_name
+            self::SPAN_NAME
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/active_model_serializers/patcher.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/patcher.rb
@@ -1,0 +1,62 @@
+require 'ddtrace/ext/app_types'
+require 'ddtrace/ext/http'
+require 'ddtrace/contrib/active_model_serializers/events'
+
+module Datadog
+  module Contrib
+    module ActiveModelSerializers
+      # Provides instrumentation for ActiveModelSerializers through ActiveSupport instrumentation signals
+      module Patcher
+        include Base
+
+        VERSION_REQUIRED = Gem::Version.new('0.9.0')
+
+        register_as :active_model_serializers
+
+        option :service_name, default: 'active_model_serializers'
+        option :tracer, default: Datadog.tracer do |value|
+          (value || Datadog.tracer).tap do |v|
+            # Make sure to update tracers of all subscriptions
+            Events.subscriptions.each do |subscription|
+              subscription.tracer = v
+            end
+          end
+        end
+
+        class << self
+          def patch
+            return patched? if patched? || !compatible?
+
+            # Subscribe to ActiveModelSerializers events
+            Events.subscribe!
+
+            # Set service info
+            configuration[:tracer].set_service_info(
+              configuration[:service_name],
+              'active_model_serializers',
+              Ext::AppTypes::WEB
+            )
+
+            @patched = true
+          end
+
+          def patched?
+            return @patched if defined?(@patched)
+            @patched = false
+          end
+
+          private
+
+          def configuration
+            Datadog.configuration[:active_model_serializers]
+          end
+
+          def compatible?
+            Gem.loaded_specs['active_model_serializers'] && Gem.loaded_specs['activesupport'] \
+              && Gem.loaded_specs['active_model_serializers'].version >= VERSION_REQUIRED
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/active_model_serializers/helpers.rb
+++ b/spec/ddtrace/contrib/active_model_serializers/helpers.rb
@@ -1,0 +1,61 @@
+module ActiveModelSerializersHelpers
+  class << self
+    def ams_0_10_or_newer?
+      Gem.loaded_specs['active_model_serializers'] \
+        && Gem.loaded_specs['active_model_serializers'].version >= Gem::Version.new('0.10')
+    end
+
+    def disable_logging
+      if ams_0_10_or_newer?
+        ActiveModelSerializers.logger.level = Logger::Severity::UNKNOWN
+      end
+    end
+  end
+end
+
+RSpec.shared_context 'AMS serializer' do
+  let(:serializer_class) do
+  end
+
+  if ActiveModelSerializersHelpers.ams_0_10_or_newer?
+    before(:each) do
+      stub_const('Model', Class.new(ActiveModelSerializers::Model) do
+        attr_writer :id
+      end)
+
+      stub_const('TestModel', Class.new(Model) do
+        attributes :name
+      end)
+
+      stub_const('TestModelSerializer', Class.new(ActiveModel::Serializer) do
+        attributes :name
+      end)
+    end
+  else
+    before(:each) do
+      stub_const('Model', Class.new do
+        attr_writer :id
+
+        def initialize(hash = {})
+          @attributes = hash
+        end
+
+        def read_attribute_for_serialization(name)
+          if [:id, 'id'].include?(name)
+            object_id
+          elsif respond_to?(name)
+            send name
+          else
+            @attributes[name]
+          end
+        end
+      end)
+
+      stub_const('TestModel', Class.new(Model))
+
+      stub_const('TestModelSerializer', Class.new(ActiveModel::Serializer) do
+        attributes :name
+      end)
+    end
+  end
+end

--- a/spec/ddtrace/contrib/active_model_serializers/patcher_spec.rb
+++ b/spec/ddtrace/contrib/active_model_serializers/patcher_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+require 'spec/ddtrace/contrib/active_model_serializers/helpers'
+
+require 'active_support/all'
+require 'active_model_serializers'
+require 'ddtrace'
+require 'ddtrace/contrib/active_model_serializers/patcher'
+require 'ddtrace/ext/http'
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe 'ActiveModelSerializers patcher' do
+  include_context 'AMS serializer'
+
+  let(:tracer) { ::Datadog::Tracer.new(writer: FauxWriter.new) }
+
+  def all_spans
+    tracer.writer.spans(:keep)
+  end
+
+  before(:each) do
+    # Supress active_model_serializers log output in the test run
+    ActiveModelSerializersHelpers.disable_logging
+
+    Datadog.configure do |c|
+      c.use :active_model_serializers, tracer: tracer
+    end
+
+    # Make sure to update the subscription tracer,
+    # so we aren't writing to a stale tracer.
+    if Datadog::Contrib::ActiveModelSerializers::Patcher.patched?
+      Datadog::Contrib::ActiveModelSerializers::Events.subscriptions.each do |subscription|
+        allow(subscription).to receive(:tracer).and_return(tracer)
+      end
+    end
+  end
+
+  describe 'on render' do
+    let(:test_obj) { TestModel.new(name: 'test object') }
+    let(:serializer) { 'TestModelSerializer' }
+    let(:adapter) { 'ActiveModelSerializers::Adapter::Attributes' }
+    let(:event) { Datadog::Contrib::ActiveModelSerializers::Patcher.send(:event_name) }
+    let(:name) do
+      if ActiveModelSerializersHelpers.ams_0_10_or_newer?
+        Datadog::Contrib::ActiveModelSerializers::Events::Render.span_name
+      else
+        Datadog::Contrib::ActiveModelSerializers::Events::Serialize.span_name
+      end
+    end
+
+    let(:active_model_serializers_span) do
+      all_spans.select { |s| s.name == name }.first
+    end
+
+    if ActiveModelSerializersHelpers.ams_0_10_or_newer?
+      context 'when adapter is set' do
+        it 'is expected to send a span' do
+          ActiveModelSerializers::SerializableResource.new(test_obj).serializable_hash
+
+          active_model_serializers_span.tap do |span|
+            expect(span).to_not be_nil
+            expect(span.name).to eq(name)
+            expect(span.resource).to eq(serializer)
+            expect(span.service).to eq('active_model_serializers')
+            expect(span.span_type).to eq(Datadog::Ext::HTTP::TEMPLATE)
+            expect(span.get_tag('active_model_serializers.serializer')).to eq(serializer)
+            expect(span.get_tag('active_model_serializers.adapter')).to eq(adapter)
+          end
+        end
+      end
+    end
+
+    context 'when adapter is nil' do
+      if ActiveModelSerializersHelpers.ams_0_10_or_newer?
+        it 'is expected to send a span with adapter tag equal to the model name' do
+          ActiveModelSerializers::SerializableResource.new(test_obj, adapter: nil).serializable_hash
+
+          active_model_serializers_span.tap do |span|
+            expect(span).to_not be_nil
+            expect(span.name).to eq(name)
+            expect(span.resource).to eq(serializer)
+            expect(span.service).to eq('active_model_serializers')
+            expect(span.span_type).to eq(Datadog::Ext::HTTP::TEMPLATE)
+            expect(span.get_tag('active_model_serializers.serializer')).to eq(serializer)
+            expect(span.get_tag('active_model_serializers.adapter')).to eq(test_obj.class.to_s)
+          end
+        end
+      else
+        it 'is expected to send a span with no adapter tag' do
+          TestModelSerializer.new(test_obj).as_json
+
+          active_model_serializers_span.tap do |span|
+            expect(span).to_not be_nil
+            expect(span.name).to eq(name)
+            expect(span.resource).to eq(serializer)
+            expect(span.service).to eq('active_model_serializers')
+            expect(span.span_type).to eq(Datadog::Ext::HTTP::TEMPLATE)
+            expect(span.get_tag('active_model_serializers.serializer')).to eq(serializer)
+            expect(span.get_tag('active_model_serializers.adapter')).to be_nil
+          end
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/ddtrace/contrib/active_support/notifications/subscription_spec.rb
+++ b/spec/ddtrace/contrib/active_support/notifications/subscription_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscription do
     subject(:subscription) { described_class.new(tracer, span_name, options, &block) }
     let(:tracer) { ::Datadog::Tracer.new(writer: FauxWriter.new) }
     let(:span_name) { double('span_name') }
-    let(:options) { double('options') }
+    let(:options) { {} }
     let(:block) do
       Proc.new do |span, name, id, payload|
         spy.call(span, name, id, payload)
@@ -67,6 +67,11 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscription do
         it do
           expect(tracer).to receive(:trace).with(span_name, options).and_return(span)
           is_expected.to be(span)
+        end
+
+        it 'sets the parent span' do
+          parent = tracer.trace('parent_span')
+          expect(subject.parent_id).to eq parent.span_id
         end
       end
 


### PR DESCRIPTION
I'm currently using ActiveModelSerializers on a few different Rails projects, and want to be able to trace the serialization like a rails view. This implementation borrows heavily from the racecar patcher.

* Subscribe to the appropriate event for AMS 0.10 and AMS 0.9
  * 0.10 - https://github.com/rails-api/active_model_serializers/blob/v0.10.6/docs/general/instrumentation.md
  * 0.9 - https://github.com/rails-api/active_model_serializers/blob/v0.10.6/docs/general/instrumentation.md
* Trace a span with the serializer as the name

I still need to write tests, but wanted to open the PR early to get feedback on the implementation. Thanks!