### PR TITLE
Rails middleware specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -258,6 +258,13 @@ task :ci do
     sh 'rvm $RAILS5_VERSIONS --verbose do appraisal rails5-postgres rake test:railsdisableenv'
     # RSpec
     sh 'rvm $LAST_STABLE --verbose do rake benchmark'
+    sh 'rvm $RAILS3_VERSIONS --verbose do appraisal rails30-postgres rake spec:rails'
+    sh 'rvm $RAILS3_VERSIONS --verbose do appraisal rails32-mysql2 rake spec:rails'
+    sh 'rvm $RAILS3_VERSIONS --verbose do appraisal rails32-postgres rake spec:rails'
+    sh 'rvm $RAILS4_VERSIONS --verbose do appraisal rails4-mysql2 rake spec:rails'
+    sh 'rvm $RAILS4_VERSIONS --verbose do appraisal rails4-postgres rake spec:rails'
+    sh 'rvm $RAILS5_VERSIONS --verbose do appraisal rails5-mysql2 rake spec:rails'
+    sh 'rvm $RAILS5_VERSIONS --verbose do appraisal rails5-postgres rake spec:rails'
   else
     puts 'Too many workers than parallel tasks'
   end

--- a/spec/ddtrace/contrib/rails/middleware_spec.rb
+++ b/spec/ddtrace/contrib/rails/middleware_spec.rb
@@ -1,0 +1,218 @@
+require 'ddtrace/contrib/rails/rails_helper'
+
+RSpec.describe 'Rails request' do
+  include Rack::Test::Methods
+  include_context 'Rails test application'
+
+  let(:routes) { { '/' => 'test#index' } }
+  let(:controllers) { [controller] }
+
+  let(:controller) do
+    stub_const('TestController', Class.new(ActionController::Base) do
+      def index
+        head :ok
+      end
+    end)
+  end
+
+  let(:tracer) { ::Datadog::Tracer.new(writer: FauxWriter.new) }
+
+  def all_spans
+    tracer.writer.spans(:keep)
+  end
+
+  before(:each) do
+    Datadog.configure do |c|
+      c.use :rack, tracer: tracer
+      c.use :rails, tracer: tracer
+    end
+  end
+
+  context 'with middleware' do
+    before(:each) { get '/' }
+
+    let(:rails_middleware) { [middleware] }
+
+    context 'that raises an exception' do
+      let(:middleware) do
+        stub_const('RaiseExceptionMiddleware', Class.new do
+          def initialize(app)
+            @app = app
+          end
+
+          def call(env)
+            @app.call(env)
+            raise NotImplementedError.new
+          end
+        end)
+      end
+
+      it do
+        expect(last_response).to be_server_error
+        expect(all_spans.length).to be >= 2
+      end
+
+      context 'rack span' do
+        subject(:span) { all_spans.first }
+
+        it do
+          expect(span.name).to eq('rack.request')
+          expect(span.span_type).to eq('http')
+          expect(span.resource).to eq('TestController#index')
+          expect(span.get_tag('http.url')).to eq('/')
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.status_code')).to eq('500')
+          expect(span.get_tag('error.type')).to eq('NotImplementedError')
+          expect(span.get_tag('error.msg')).to eq('NotImplementedError')
+          expect(span.status).to eq(Datadog::Ext::Errors::STATUS)
+          expect(span.get_tag('error.stack')).to_not be nil
+        end
+      end
+    end
+
+    context 'that raises a known NotFound exception' do
+      let(:middleware) do
+        stub_const('RaiseNotFoundMiddleware', Class.new do
+          def initialize(app)
+            @app = app
+          end
+
+          def call(env)
+            @app.call(env)
+            raise ActionController::RoutingError.new('/missing_route')
+          end
+        end)
+      end
+
+      it do
+        expect(last_response).to be_not_found
+        expect(all_spans.length).to be >= 2
+      end
+
+      context 'rack span' do
+        subject(:span) { all_spans.first }
+
+        it do
+          expect(span.name).to eq('rack.request')
+          expect(span.span_type).to eq('http')
+          expect(span.resource).to eq('TestController#index')
+          expect(span.get_tag('http.url')).to eq('/')
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.status_code')).to eq('404')
+
+          if Rails.version >= '3.2'
+            expect(span.get_tag('error.type')).to be nil
+            expect(span.get_tag('error.msg')).to be nil
+            expect(span.status).to_not eq(Datadog::Ext::Errors::STATUS)
+            expect(span.get_tag('error.stack')).to be nil
+          else
+            # Rails 3.0 raises errors for 404 routing errors
+            expect(span.get_tag('error.type')).to eq('ActionController::RoutingError')
+            expect(span.get_tag('error.msg')).to eq('/missing_route')
+            expect(span.status).to eq(Datadog::Ext::Errors::STATUS)
+            expect(span.get_tag('error.stack')).to_not be nil
+          end
+        end
+      end
+    end
+
+    context 'that raises a custom exception' do
+      let(:error_class) do
+        stub_const('CustomError', Class.new(StandardError) do
+          def message
+            'Custom error message!'
+          end
+        end)
+      end
+
+      let(:middleware) do
+        # Run this to define the error class
+        error_class
+
+        stub_const('RaiseCustomErrorMiddleware', Class.new do
+          def initialize(app)
+            @app = app
+          end
+
+          def call(env)
+            @app.call(env)
+            raise CustomError.new
+          end
+        end)
+      end
+
+      it do
+        expect(last_response).to be_server_error
+        expect(all_spans.length).to be >= 2
+      end
+
+      context 'rack span' do
+        subject(:span) { all_spans.first }
+
+        it do
+          expect(span.name).to eq('rack.request')
+          expect(span.span_type).to eq('http')
+          expect(span.resource).to eq('TestController#index')
+
+          if Rails.version >= '3.2'
+            expect(span.get_tag('http.url')).to eq('/')
+          else
+          end
+
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.status_code')).to eq('500')
+          expect(span.get_tag('error.type')).to eq('CustomError')
+          expect(span.get_tag('error.msg')).to eq('Custom error message!')
+          expect(span.status).to eq(Datadog::Ext::Errors::STATUS)
+          expect(span.get_tag('error.stack')).to_not be nil
+        end
+      end
+
+      if Rails.version >= '3.2'
+        context 'that is flagged as a custom 404' do
+          # TODO: Make a cleaner API for injecting into Rails application configuration
+          let(:initialize_block) do
+            super_block = super()
+            Proc.new do
+            self.instance_exec(&super_block)
+              config.action_dispatch.rescue_responses.merge!(
+                'CustomError' => :not_found
+              )
+            end
+          end
+
+          after(:each) do
+            # Be sure to delete configuration after, so it doesn't carry over to other examples.
+            # TODO: Clear this configuration automatically via rails_helper shared examples
+            ActionDispatch::Railtie.config.action_dispatch.rescue_responses.delete('CustomError')
+            ActionDispatch::ExceptionWrapper.class_variable_get(:@@rescue_responses).tap do |resps|
+              resps.delete('CustomError')
+            end
+          end
+
+          it do
+            expect(last_response).to be_not_found
+            expect(all_spans.length).to be >= 2
+          end
+
+          context 'rack span' do
+            subject(:span) { all_spans.first }
+
+            it do
+              expect(span.name).to eq('rack.request')
+              expect(span.span_type).to eq('http')
+              expect(span.resource).to eq('TestController#index')
+              expect(span.get_tag('http.url')).to eq('/')
+              expect(span.get_tag('http.method')).to eq('GET')
+              expect(span.get_tag('http.status_code')).to eq('404')
+              expect(span.get_tag('error.type')).to be nil
+              expect(span.get_tag('error.msg')).to be nil
+              expect(span.status).to_not eq(Datadog::Ext::Errors::STATUS)
+              expect(span.get_tag('error.stack')).to be nil
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/rails/middleware_spec.rb
+++ b/spec/ddtrace/contrib/rails/middleware_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe 'Rails request' do
           let(:initialize_block) do
             super_block = super()
             Proc.new do
-            self.instance_exec(&super_block)
+              self.instance_exec(&super_block)
               config.action_dispatch.rescue_responses.merge!(
                 'CustomError' => :not_found
               )

--- a/spec/ddtrace/contrib/rails/rails_helper.rb
+++ b/spec/ddtrace/contrib/rails/rails_helper.rb
@@ -12,10 +12,10 @@ logger = Logger.new(STDOUT)
 logger.level = Logger::INFO
 
 # Rails settings
-connector = Datadog::Contrib::Rails::Test::Database.configure!
+adapter = Datadog::Contrib::Rails::Test::Database.load_adapter!
 ENV['RAILS_ENV'] = 'test'
-ENV['DATABASE_URL'] = connector
+ENV['DATABASE_URL'] = adapter
 
 # switch Rails import according to installed
 # version; this is controlled with Appraisals
-logger.info "Testing against Rails #{Rails.version} with connector '#{connector}'"
+logger.info "Testing against Rails #{Rails.version} with adapter '#{adapter}'"

--- a/spec/ddtrace/contrib/rails/rails_helper.rb
+++ b/spec/ddtrace/contrib/rails/rails_helper.rb
@@ -19,3 +19,161 @@ ENV['DATABASE_URL'] = adapter
 # switch Rails import according to installed
 # version; this is controlled with Appraisals
 logger.info "Testing against Rails #{Rails.version} with adapter '#{adapter}'"
+
+# ################################
+# #### Testing Rails in RSpec ####
+# ################################
+#
+# This Rails helper adds some shared contexts, which provide specs with a mock Rails application
+# that can be fully configured with models, controllers, middleware and other settings, so you
+# can test all kinds of Rails application setups.
+#
+# The quickest way to get started is by adding the shared context to your spec:
+#
+# ```
+# describe 'My Rails test' do
+#   include Rack::Test::Methods
+#   include_context 'Rails test application'
+# end
+# ```
+#
+# Then you can add some of the following variables that will decorate your
+# mock Rails application with features.
+#
+# ### Controllers ###
+#
+# Add controllers by setting the `routes` and `controllers` variables:
+#
+# ```
+# describe 'My Rails test' do
+#   include Rack::Test::Methods
+#   include_context 'Rails test application'
+#
+#   let(:routes) { { '/' => 'test#index' } }
+#   let(:controllers) { [controller] }
+#   
+#   let(:controller) do
+#     stub_const('TestController', Class.new(ActionController::Base) do
+#       def index
+#         head :ok
+#       end
+#     end)
+#   end
+#
+#   it do
+#     get '/'
+#     expect(last_response).to be_ok
+#   end
+# end
+# ```
+#
+# `routes` must be a Hash of paths to resource names, where the resource name must match the controller's name.
+# `controllers` must be an Array of classes that implement `ActionController::Base`.
+#
+#
+#
+# ### Middleware ###
+#
+# Add middleware by setting the `rails_middleware` variable.
+#
+# ```
+# describe 'My Rails test' do
+#   include Rack::Test::Methods
+#   include_context 'Rails test application'
+#
+#   let(:rails_middleware) { [middleware] }
+#   
+#   let(:middleware) do
+#     stub_const('TestMiddleware', Class.new do
+#       def initialize(app)
+#         @app = app
+#       end
+#
+#       def call(env)
+#         @app.call(env)
+#       end
+#     end)
+#   end
+# end
+# ```
+#
+# `rails_middleware`:
+#    Must be an Array of classes that implement the Rack middleware pattern.
+#    It will apply the middleware with `use` in order of the Array.
+#
+#
+#
+# ### Rails configuration ###
+#
+# You can define custom Rails application settings by setting `initialize_block`:
+#
+# ```
+# describe 'My Rails test' do
+#   include Rack::Test::Methods
+#   include_context 'Rails test application'
+#
+#   let(:initialize_block) do
+#     super_block = super()
+#     Proc.new do
+#       self.instance_exec(&super_block)
+#       config.action_dispatch.rescue_responses.merge!(
+#         'CustomError' => :not_found
+#       )
+#     end
+#   end
+# end
+# ```
+#
+# `initialize_block`:
+#   Must be a Proc, which will be executed in the context of the Rails application.
+#   NOTE: Right now you should call super() as shown above if you change this setting.
+#
+#
+#
+# ### Rails application lifecycle ###
+#
+# This implementation of Rails testing works differently than other testing suites.
+# Unlike the Minitest suite in `ddtrace`, it does not create only one Rails application at
+# load time. Instead it dynamically recreates Rails applications per example. This is how
+# it is able to allow specs to define custom middleware and Rails configuration settings.
+#
+# To accomplish this, it uses RSpec's `let` blocks. `let` blocks are lazy variables that are
+# only resolve their value once they are referenced for the first time. Every time thereafter,
+# the return the same value they returned the first time they were referenced.
+#
+# The lifetime of these lazy variables is limited to the scope of an RSpec example, or an `it` block.
+# Each time RSpec completes an `it`, it clears the old `let` variables. When it encounters the next
+# `it` block, it will then re-run test setup again.
+#
+# This implementation of Rails testing takes advantage of this lifecycle. By defining the Rails application
+# within a `let` block, it will recycle and recreate Rails applications for each `it` block, allowing specs
+# to override `let` values, and thus customize application configuration per example.
+#
+# In a nutshell, the resulting sequence of events looks like:
+#
+# 1. RSpec loads "My Rails test" example group
+# 2. "My Rails test" adds "Rails test application" context containing default `let` and `before(:each)`.
+# 3. RSpec discovers `it` inside "My Rails test"
+# 4. RSpec runs `before(:each)` inherited from "Rails test application", begins initializing the application.
+# 5. RSpec uses the overridden `let` blocks from "My Rails test" to initialize the application.
+# 6. `it` runs, calls `get '/'`, which references `let(:app)`, which references `let(:rails_test_application)`.
+# 7. Request runs against `let(:rails_test_application)`.
+# 8. `it` asserts and completes, RSpec discards all `let` values, including the Rails application.
+# 9. RSpec looks for the next `it`. If it finds one, it loops back to #3. Otherwise it exits.
+#
+# Reinitializing Rails apps like this is somewhat complicated, and slow. However, it does allow the
+# suite to test things that would otherwise not be possible. It is recommended for performance to keep
+# assertions in as few `it` blocks as reasonably possible, so RSpec doesn't unnecessarily reload the
+# Rails application.
+#
+# ### Some other important considerations ###
+#
+# - We would happily substitute this for a gem like `rspec-rails` if it were possible. However,
+#   `rspec-rails` is for testing a Rails application. It doesn't create mock Rails apps for testing
+#   against, like we need to in `ddtrace`.
+# - The most challenging part of implementation is that Rails wasn't designed to be re-initialized
+#   like this. There are a number of places, particularly with Rails::Configuration and Railties that
+#   use global, constant-level variables to hold application configuration. This configuration can and
+#   does often carry over between examples, sometimes breaking them. It's important to try to reset this
+#   global configuration back to its original state between examples, whenever possible.
+#

--- a/spec/ddtrace/contrib/rails/rails_helper.rb
+++ b/spec/ddtrace/contrib/rails/rails_helper.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+require 'logger'
+require 'rails'
+
+require 'ddtrace/contrib/rails/support/configuration'
+require 'ddtrace/contrib/rails/support/database'
+require 'ddtrace/contrib/rails/support/application'
+
+# logger
+logger = Logger.new(STDOUT)
+logger.level = Logger::INFO
+
+# Rails settings
+connector = Datadog::Contrib::Rails::Test::Database.configure!
+ENV['RAILS_ENV'] = 'test'
+ENV['DATABASE_URL'] = connector
+
+# switch Rails import according to installed
+# version; this is controlled with Appraisals
+logger.info "Testing against Rails #{Rails.version} with connector '#{connector}'"

--- a/spec/ddtrace/contrib/rails/rails_helper.rb
+++ b/spec/ddtrace/contrib/rails/rails_helper.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 require 'logger'
 require 'rails'
 
-require 'ddtrace/contrib/rails/support/configuration'
-require 'ddtrace/contrib/rails/support/database'
-require 'ddtrace/contrib/rails/support/application'
+require 'spec/ddtrace/contrib/rails/support/configuration'
+require 'spec/ddtrace/contrib/rails/support/database'
+require 'spec/ddtrace/contrib/rails/support/application'
 
 # logger
 logger = Logger.new(STDOUT)

--- a/spec/ddtrace/contrib/rails/support/application.rb
+++ b/spec/ddtrace/contrib/rails/support/application.rb
@@ -1,0 +1,45 @@
+require 'ddtrace/contrib/rails/support/base'
+
+RSpec.shared_context 'Rails test application' do
+  include_context 'Rails base application'
+
+  let(:app) do
+    if Rails.version >= '3.2'
+      rails_test_application.to_app
+    else
+      rails_test_application
+    end
+  end
+
+  before(:each) do
+    # Reinitializing Rails applications generates a lot of warnings.
+    without_warnings do
+      # Initialize the application and stub Rails with the test app
+      rails_test_application.test_initialize!
+    end
+  end
+
+  if Rails.version < '4.0'
+    around(:each) do |example|
+      without_warnings do
+        example.run
+      end
+    end
+  end
+
+  if Rails.version >= '5.0'
+    let(:rails_test_application) do
+      stub_const('Rails5::Application', Class.new(rails_base_application))
+    end
+  elsif Rails.version >= '4.0'
+    let(:rails_test_application) do
+      stub_const('Rails4::Application', Class.new(rails_base_application))
+    end
+  elsif Rails.version >= '3.0'
+    let(:rails_test_application) do
+      rails_base_application
+    end
+  else
+    logger.error 'A Rails app for this version is not found!'
+  end
+end

--- a/spec/ddtrace/contrib/rails/support/base.rb
+++ b/spec/ddtrace/contrib/rails/support/base.rb
@@ -6,12 +6,6 @@ if ENV['USE_SIDEKIQ']
   require 'ddtrace/contrib/sidekiq/tracer'
 end
 
-require 'set'
-$configs = Set.new
-$applications = Set.new
-$middlewares = Set.new
-$route_sets = Set.new
-
 RSpec.shared_context 'Rails base application' do
   if Rails.version >= '5.0'
     require 'ddtrace/contrib/rails/support/rails5'
@@ -44,7 +38,8 @@ RSpec.shared_context 'Rails base application' do
 
   let(:after_test_initialize_block) do
     Proc.new do
-      models
+      # Force connection to initialize, and dump some spans
+      application_record.connection
     end
   end
 end

--- a/spec/ddtrace/contrib/rails/support/base.rb
+++ b/spec/ddtrace/contrib/rails/support/base.rb
@@ -1,0 +1,50 @@
+require 'rails/all'
+require 'ddtrace'
+
+if ENV['USE_SIDEKIQ']
+  require 'sidekiq/testing'
+  require 'ddtrace/contrib/sidekiq/tracer'
+end
+
+require 'set'
+$configs = Set.new
+$applications = Set.new
+$middlewares = Set.new
+$route_sets = Set.new
+
+RSpec.shared_context 'Rails base application' do
+  if Rails.version >= '5.0'
+    require 'ddtrace/contrib/rails/support/rails5'
+    include_context 'Rails 5 base application'
+  elsif Rails.version >= '4.0'
+    require 'ddtrace/contrib/rails/support/rails4'
+    include_context 'Rails 4 base application'
+  elsif Rails.version >= '3.0'
+    require 'ddtrace/contrib/rails/support/rails3'
+    include_context 'Rails 3 base application'
+  else
+    logger.error 'A Rails app for this version is not found!'
+  end
+
+  let(:initialize_block) do
+    middleware = rails_middleware
+    debug_mw = debug_middleware
+
+    Proc.new do
+      config.middleware.insert_before 0, debug_mw
+      middleware.each { |m| config.middleware.use m }
+    end
+  end
+
+  let(:before_test_initialize_block) do
+    Proc.new do
+      append_routes!
+    end
+  end
+
+  let(:after_test_initialize_block) do
+    Proc.new do
+      models
+    end
+  end
+end

--- a/spec/ddtrace/contrib/rails/support/configuration.rb
+++ b/spec/ddtrace/contrib/rails/support/configuration.rb
@@ -1,0 +1,23 @@
+module Datadog
+  module Contrib
+    module Rails
+      module Test
+        module Configuration
+          module_function
+
+          def original
+            @original ||= {}
+          end
+
+          def set(key, value)
+            original[key] = value
+          end
+
+          def get(key)
+            original[key]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/rails/support/configuration.rb
+++ b/spec/ddtrace/contrib/rails/support/configuration.rb
@@ -9,6 +9,11 @@ module Datadog
             @original ||= {}
           end
 
+          def fetch(key, value)
+            return get(key) if original.has_key?(key)
+            value.tap { set(key, value) }
+          end
+
           def set(key, value)
             original[key] = value
           end

--- a/spec/ddtrace/contrib/rails/support/controllers.rb
+++ b/spec/ddtrace/contrib/rails/support/controllers.rb
@@ -1,0 +1,6 @@
+require 'action_view/testing/resolvers'
+
+RSpec.shared_context 'Rails controllers' do
+  let(:controllers) { [] }
+  let(:routes) { {} }
+end

--- a/spec/ddtrace/contrib/rails/support/core_extensions.rb
+++ b/spec/ddtrace/contrib/rails/support/core_extensions.rb
@@ -1,0 +1,17 @@
+if ::Rails::VERSION::MAJOR.to_i == 3
+  # Rails 3.x unsubscribes all render_template handlers during the test teardown
+  # because it uses some subscribers to load @layouts @templates and @partials.
+  # In our case, this disables the instrumentation after each test and because this is
+  # an unwanted behavior, we simply disable this functionality. Removing both methods,
+  # makes some tests assertions not possible (such as assert_template) but because we're
+  # testing the tracer and not a Rails app, it's a reasonable choice.
+  #
+  # Reference: https://github.com/rails/rails/blob/v3.2.22.5/actionpack/lib/action_controller/test_case.rb#L45
+  module ActionController
+    module TemplateAssertions
+      def setup_subscriptions; end
+
+      def teardown_subscriptions; end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/rails/support/database.rb
+++ b/spec/ddtrace/contrib/rails/support/database.rb
@@ -1,0 +1,62 @@
+# load the right adapter according to installed gem
+module Datadog
+  module Contrib
+    module Rails
+      module Test
+        module Database
+          module_function
+
+          def configure!
+            begin
+              require 'pg'
+              connector = 'postgres://postgres:postgres@127.0.0.1:55432/postgres'
+
+              # old versions of Rails (eg 3.0) require that sort of Monkey Patching,
+              # since using ActiveRecord is tricky (version mismatch etc.)
+              if ::Rails.version < '3.2.22.5'
+                ::Rails::Application::Configuration.class_eval do
+                  def database_configuration
+                    { 'test' => { 'adapter' => 'postgresql',
+                                'encoding' => 'utf8',
+                                'reconnect' => false,
+                                'database' => 'postgres',
+                                'pool' => 5,
+                                'username' => 'postgres',
+                                'password' => 'postgres',
+                                'host' => 'localhost',
+                                'port' => '55432' } }
+                  end
+                end
+              end
+            rescue LoadError
+              puts 'pg gem not found, trying another connector'
+            end
+
+            begin
+              require 'mysql2'
+              connector = 'mysql2://root:root@127.0.0.1:53306/mysql'
+            rescue LoadError
+              puts 'mysql2 gem not found, trying another connector'
+            end
+
+            begin
+              require 'activerecord-jdbcpostgresql-adapter'
+              connector = 'postgres://postgres:postgres@127.0.0.1:55432/postgres'
+            rescue LoadError
+              puts 'jdbc-postgres gem not found, trying another connector'
+            end
+
+            begin
+              require 'activerecord-jdbcmysql-adapter'
+              connector = 'mysql2://root:root@127.0.0.1:53306/mysql'
+            rescue LoadError
+              puts 'jdbc-mysql gem not found, trying another connector'
+            end
+
+            connector
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/rails/support/database.rb
+++ b/spec/ddtrace/contrib/rails/support/database.rb
@@ -6,7 +6,7 @@ module Datadog
         module Database
           module_function
 
-          def configure!
+          def load_adapter!
             begin
               require 'pg'
               connector = 'postgres://postgres:postgres@127.0.0.1:55432/postgres'

--- a/spec/ddtrace/contrib/rails/support/middleware.rb
+++ b/spec/ddtrace/contrib/rails/support/middleware.rb
@@ -1,0 +1,17 @@
+RSpec.shared_context 'Rails middleware' do
+  let(:rails_middleware) { [] }
+
+  let(:debug_middleware) do
+    stub_const('DebugMiddleware', Class.new do
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        @app.call(env)
+      rescue Exception => e
+        raise
+      end
+    end)
+  end
+end

--- a/spec/ddtrace/contrib/rails/support/models.rb
+++ b/spec/ddtrace/contrib/rails/support/models.rb
@@ -4,48 +4,4 @@ RSpec.shared_context 'Rails models' do
       self.abstract_class = true
     end)
   end
-
-  let(:models) do
-    # Force connection to initialize, and dump some spans
-    # TODO: Refactor this... needs it badly.
-    [].tap { application_record.connection }
-  end
-
-  # TODO: Figure out how to run database migrations to setup models
-  # let(:article_model) do
-  #   stub_const('Article', Class.new(application_record))
-  # end
-
-  # let(:article_migration) do
-  #   Proc.new do
-  #     create_table 'articles', force: :cascade do |t|
-  #       t.string   'title'
-  #       t.datetime 'created_at', null: false
-  #       t.datetime 'updated_at', null: false
-  #     end
-  #   end
-  # end
-
-  # let(:table_migrations) do
-  #   [article_migration]
-  # end
-
-  # let(:run_database_migrations!) do
-  #   # check if the migration has been executed
-  #   # MySQL JDBC drivers require that, otherwise we get a
-  #   # "Table '?' already exists" error
-  #   begin
-  #     models.each(&:count)
-  #   rescue ActiveRecord::StatementInvalid
-  #     logger.info 'Executing database migrations'
-  #     ActiveRecord::Schema.define(version: 20161003090450) do
-  #       table_migrations.each { |m| self.instance_eval(&m) }
-  #     end
-  #   else
-  #     logger.info 'Database already exists; nothing to do'
-  #   end
-
-  #   # force an access to prevent extra spans during tests
-  #   article_model.count
-  # end
 end

--- a/spec/ddtrace/contrib/rails/support/models.rb
+++ b/spec/ddtrace/contrib/rails/support/models.rb
@@ -1,0 +1,51 @@
+RSpec.shared_context 'Rails models' do
+  let(:application_record) do
+    stub_const('ApplicationRecord', Class.new(ActiveRecord::Base) do
+      self.abstract_class = true
+    end)
+  end
+
+  let(:models) do
+    # Force connection to initialize, and dump some spans
+    # TODO: Refactor this... needs it badly.
+    [].tap { application_record.connection }
+  end
+
+  # TODO: Figure out how to run database migrations to setup models
+  # let(:article_model) do
+  #   stub_const('Article', Class.new(application_record))
+  # end
+
+  # let(:article_migration) do
+  #   Proc.new do
+  #     create_table 'articles', force: :cascade do |t|
+  #       t.string   'title'
+  #       t.datetime 'created_at', null: false
+  #       t.datetime 'updated_at', null: false
+  #     end
+  #   end
+  # end
+
+  # let(:table_migrations) do
+  #   [article_migration]
+  # end
+
+  # let(:run_database_migrations!) do
+  #   # check if the migration has been executed
+  #   # MySQL JDBC drivers require that, otherwise we get a
+  #   # "Table '?' already exists" error
+  #   begin
+  #     models.each(&:count)
+  #   rescue ActiveRecord::StatementInvalid
+  #     logger.info 'Executing database migrations'
+  #     ActiveRecord::Schema.define(version: 20161003090450) do
+  #       table_migrations.each { |m| self.instance_eval(&m) }
+  #     end
+  #   else
+  #     logger.info 'Database already exists; nothing to do'
+  #   end
+
+  #   # force an access to prevent extra spans during tests
+  #   article_model.count
+  # end
+end

--- a/spec/ddtrace/contrib/rails/support/rails3.rb
+++ b/spec/ddtrace/contrib/rails/support/rails3.rb
@@ -1,0 +1,131 @@
+require 'rails/all'
+require 'ddtrace'
+
+if ENV['USE_SIDEKIQ']
+  require 'sidekiq/testing'
+  require 'ddtrace/contrib/sidekiq/tracer'
+end
+
+require 'ddtrace/contrib/rails/support/controllers'
+require 'ddtrace/contrib/rails/support/middleware'
+require 'ddtrace/contrib/rails/support/models'
+
+# Patch Rails::Application so it doesn't raise an exception
+# when we reinitialize applications.
+Rails::Application.class_eval do
+  class << self
+    def inherited(base)
+      # raise "You cannot have more than one Rails::Application" if Rails.application
+      super
+      Rails.application = base.instance
+      Rails.application.add_lib_to_load_path!
+      ActiveSupport.run_load_hooks(:before_configuration, base.instance)
+    end
+  end
+end
+
+RSpec.shared_context 'Rails 3 base application' do
+  include_context 'Rails controllers'
+  include_context 'Rails middleware'
+  include_context 'Rails models'
+
+  let(:rails_base_application) do
+    reset_rails_configuration!
+    during_init = initialize_block
+    Class.new(Rails::Application) do
+      redis_cache = [:redis_store, { url: ENV['REDIS_URL'] }]
+      file_cache = [:file_store, '/tmp/ddtrace-rb/cache/']
+
+      config.secret_token = 'f624861242e4ccf20eacb6bb48a886da'
+      config.cache_store = ENV['REDIS_URL'] ? redis_cache : file_cache
+      config.active_support.test_order = :random
+      config.active_support.deprecation = :stderr
+      config.consider_all_requests_local = true
+      config.action_view.javascript_expansions = {}
+      config.action_view.stylesheet_expansions = {}
+      config.middleware.delete ActionDispatch::DebugExceptions if Rails.version >= '3.2.22.5'
+      self.instance_eval(&during_init)
+    end.tap do |klass|
+      klass.send(:define_method, :initialize) do |*args|
+        super(*args)
+        self.instance_eval(&during_init)
+      end
+
+      before_test_init = before_test_initialize_block
+      after_test_init = after_test_initialize_block
+
+      klass.send(:define_method, :test_initialize!) do
+        # Enables the auto-instrumentation for the testing application
+        Datadog.configure do |c|
+          c.use :rails
+          c.use :redis
+        end
+
+        before_test_init.call
+        initialize!
+        after_test_init.call
+      end
+    end
+  end
+
+  def append_routes!
+    # Make sure to load controllers first
+    # otherwise routes won't draw properly.
+    controllers
+    delegate = method(:draw_test_routes!)
+
+    # Then set the routes
+    if Rails.version >= '3.2.22.5'
+      rails_test_application.instance.routes.append do
+        delegate.call(self)
+      end
+    else
+      rails_test_application.instance.routes.draw do
+        delegate.call(self)
+      end
+    end
+  end
+
+  def draw_test_routes!(mapper)
+    # Rails 4 accumulates these route drawing
+    # blocks errantly, and this prevents them from
+    # drawing more than once.
+    return if @drawn
+
+    test_routes = routes
+    mapper.instance_exec do
+      if Rails.version >= '3.2.22.5'
+        test_routes.each do |k, v|
+          get k => v
+        end
+      else
+        test_routes.each do |k, v|
+          get k, to: v
+        end
+      end
+    end
+    @drawn = true
+  end
+
+  # Rails 3 leaves a bunch of global class configuration on Rails::Railtie::Configuration in class variables
+  # We need to reset these so they don't carry over between example runs
+  def reset_rails_configuration!
+    Rails.class_variable_set(:@@application, nil)
+    Rails::Application.class_variable_set(:@@instance, nil)
+    Rails::Railtie::Configuration.class_variable_set(:@@app_middleware, app_middleware)
+    Rails::Railtie::Configuration.class_variable_set(:@@app_generators, nil)
+    Rails::Railtie::Configuration.class_variable_set(:@@to_prepare_blocks, nil)
+  end
+
+  def app_middleware
+    if Datadog::Contrib::Rails::Test::Configuration.get(:app_middleware).nil?
+      current = Rails::Railtie::Configuration.class_variable_get(:@@app_middleware)
+      Datadog::Contrib::Rails::Test::Configuration.set(:app_middleware, current)
+    end
+
+    Datadog::Contrib::Rails::Test::Configuration.get(:app_middleware).dup.tap do |copy|
+      copy.instance_variable_set(:@operations, (copy.instance_variable_get(:@operations) || [] ).dup)
+      copy.instance_variable_set(:@delete_operations, (copy.instance_variable_get(:@delete_operations) || []).dup)
+    end
+  end
+end

--- a/spec/ddtrace/contrib/rails/support/rails3.rb
+++ b/spec/ddtrace/contrib/rails/support/rails3.rb
@@ -87,7 +87,7 @@ RSpec.shared_context 'Rails 3 base application' do
   end
 
   def draw_test_routes!(mapper)
-    # Rails 4 accumulates these route drawing
+    # Rails 3 accumulates these route drawing
     # blocks errantly, and this prevents them from
     # drawing more than once.
     return if @drawn
@@ -118,12 +118,8 @@ RSpec.shared_context 'Rails 3 base application' do
   end
 
   def app_middleware
-    if Datadog::Contrib::Rails::Test::Configuration.get(:app_middleware).nil?
-      current = Rails::Railtie::Configuration.class_variable_get(:@@app_middleware)
-      Datadog::Contrib::Rails::Test::Configuration.set(:app_middleware, current)
-    end
-
-    Datadog::Contrib::Rails::Test::Configuration.get(:app_middleware).dup.tap do |copy|
+    current = Rails::Railtie::Configuration.class_variable_get(:@@app_middleware)
+    Datadog::Contrib::Rails::Test::Configuration.fetch(:app_middleware, current).dup.tap do |copy|
       copy.instance_variable_set(:@operations, (copy.instance_variable_get(:@operations) || [] ).dup)
       copy.instance_variable_set(:@delete_operations, (copy.instance_variable_get(:@delete_operations) || []).dup)
     end

--- a/spec/ddtrace/contrib/rails/support/rails4.rb
+++ b/spec/ddtrace/contrib/rails/support/rails4.rb
@@ -112,14 +112,9 @@ RSpec.shared_context 'Rails 4 base application' do
     Rails::Railtie::Configuration.class_variable_set(:@@to_prepare_blocks, nil)
   end
 
-
   def app_middleware
-    if Datadog::Contrib::Rails::Test::Configuration.get(:app_middleware).nil?
-      current = Rails::Railtie::Configuration.class_variable_get(:@@app_middleware)
-      Datadog::Contrib::Rails::Test::Configuration.set(:app_middleware, current)
-    end
-
-    Datadog::Contrib::Rails::Test::Configuration.get(:app_middleware).dup.tap do |copy|
+    current = Rails::Railtie::Configuration.class_variable_get(:@@app_middleware)
+    Datadog::Contrib::Rails::Test::Configuration.fetch(:app_middleware, current).dup.tap do |copy|
       copy.instance_variable_set(:@operations, (copy.instance_variable_get(:@operations) || [] ).dup)
       copy.instance_variable_set(:@delete_operations, (copy.instance_variable_get(:@delete_operations) || []).dup)
     end

--- a/spec/ddtrace/contrib/rails/support/rails4.rb
+++ b/spec/ddtrace/contrib/rails/support/rails4.rb
@@ -1,0 +1,127 @@
+require 'rails/all'
+require 'ddtrace'
+
+if ENV['USE_SIDEKIQ']
+  require 'sidekiq/testing'
+  require 'ddtrace/contrib/sidekiq/tracer'
+end
+
+require 'ddtrace/contrib/rails/support/controllers'
+require 'ddtrace/contrib/rails/support/middleware'
+require 'ddtrace/contrib/rails/support/models'
+
+RSpec.shared_context 'Rails 4 base application' do
+  include_context 'Rails controllers'
+  include_context 'Rails middleware'
+  include_context 'Rails models'
+
+  let(:rails_base_application) do
+    reset_rails_configuration!
+    Class.new(Rails::Application) do
+      def config.database_configuration
+        parsed = super
+        raise parsed.to_yaml # Replace this line to add custom connections to the hash from database.yml
+      end
+    end.tap do |klass|
+      during_init = initialize_block
+
+      klass.send(:define_method, :initialize) do |*args|
+        super(*args)
+        redis_cache = [:redis_store, { url: ENV['REDIS_URL'] }]
+        file_cache = [:file_store, '/tmp/ddtrace-rb/cache/']
+
+        config.secret_key_base = 'f624861242e4ccf20eacb6bb48a886da'
+        config.cache_store = ENV['REDIS_URL'] ? redis_cache : file_cache
+        config.eager_load = false
+        config.consider_all_requests_local = true
+        config.active_support.test_order = :random
+        config.middleware.delete ActionDispatch::DebugExceptions
+        self.instance_eval(&during_init)
+
+        if ENV['USE_SIDEKIQ']
+          config.active_job.queue_adapter = :sidekiq
+          # add Sidekiq middleware
+          Sidekiq::Testing.server_middleware do |chain|
+            chain.add(
+              Datadog::Contrib::Sidekiq::Tracer
+            )
+          end
+        end
+      end
+
+      before_test_init = before_test_initialize_block
+      after_test_init = after_test_initialize_block
+
+      klass.send(:define_method, :test_initialize!) do
+        # Enables the auto-instrumentation for the testing application
+        Datadog.configure do |c|
+          c.use :rails
+          c.use :redis
+        end
+
+        Rails.application.config.active_job.queue_adapter = :sidekiq
+
+        before_test_init.call
+        initialize!
+        after_test_init.call
+      end
+    end
+  end
+
+  def append_routes!
+    # Make sure to load controllers first
+    # otherwise routes won't draw properly.
+    controllers
+    delegate = method(:draw_test_routes!)
+
+    # Then set the routes
+    if Rails.version >= '3.2.22.5'
+      rails_test_application.instance.routes.append do
+        delegate.call(self)
+      end
+    else
+      rails_test_application.instance.routes.draw do
+        delegate.call(self)
+      end
+    end
+  end
+
+  def draw_test_routes!(mapper)
+    # Rails 4 accumulates these route drawing
+    # blocks errantly, and this prevents them from
+    # drawing more than once.
+    return if @drawn
+
+    test_routes = routes
+    mapper.instance_exec do
+      test_routes.each do |k, v|
+        get k => v
+      end
+    end
+    @drawn = true
+  end
+
+  # Rails 4 leaves a bunch of global class configuration on Rails::Railtie::Configuration in class variables
+  # We need to reset these so they don't carry over between example runs
+  def reset_rails_configuration!
+    Rails::Railtie::Configuration.class_variable_set(:@@eager_load_namespaces, nil)
+    Rails::Railtie::Configuration.class_variable_set(:@@watchable_files, nil)
+    Rails::Railtie::Configuration.class_variable_set(:@@watchable_dirs, nil)
+    Rails::Railtie::Configuration.class_variable_set(:@@app_middleware, app_middleware)
+    Rails::Railtie::Configuration.class_variable_set(:@@app_generators, nil)
+    Rails::Railtie::Configuration.class_variable_set(:@@to_prepare_blocks, nil)
+  end
+
+
+  def app_middleware
+    if Datadog::Contrib::Rails::Test::Configuration.get(:app_middleware).nil?
+      current = Rails::Railtie::Configuration.class_variable_get(:@@app_middleware)
+      Datadog::Contrib::Rails::Test::Configuration.set(:app_middleware, current)
+    end
+
+    Datadog::Contrib::Rails::Test::Configuration.get(:app_middleware).dup.tap do |copy|
+      copy.instance_variable_set(:@operations, (copy.instance_variable_get(:@operations) || [] ).dup)
+      copy.instance_variable_set(:@delete_operations, (copy.instance_variable_get(:@delete_operations) || []).dup)
+    end
+  end
+end

--- a/spec/ddtrace/contrib/rails/support/rails5.rb
+++ b/spec/ddtrace/contrib/rails/support/rails5.rb
@@ -1,0 +1,105 @@
+require 'rails/all'
+require 'ddtrace'
+
+if ENV['USE_SIDEKIQ']
+  require 'sidekiq/testing'
+  require 'ddtrace/contrib/sidekiq/tracer'
+end
+
+require 'ddtrace/contrib/rails/support/controllers'
+require 'ddtrace/contrib/rails/support/middleware'
+require 'ddtrace/contrib/rails/support/models'
+
+RSpec.shared_context 'Rails 5 base application' do
+  include_context 'Rails controllers'
+  include_context 'Rails middleware'
+  include_context 'Rails models'
+
+  let(:rails_base_application) do
+    reset_rails_configuration!
+    Class.new(Rails::Application) do
+      def config.database_configuration
+        parsed = super
+        raise parsed.to_yaml # Replace this line to add custom connections to the hash from database.yml
+      end
+    end.tap do |klass|
+      during_init = initialize_block
+
+      klass.send(:define_method, :initialize) do |*args|
+        super(*args)
+        redis_cache = [:redis_store, { url: ENV['REDIS_URL'] }]
+        file_cache = [:file_store, '/tmp/ddtrace-rb/cache/']
+
+        config.secret_key_base = 'f624861242e4ccf20eacb6bb48a886da'
+        config.cache_store = ENV['REDIS_URL'] ? redis_cache : file_cache
+        config.eager_load = false
+        config.consider_all_requests_local = true
+        config.middleware.delete ActionDispatch::DebugExceptions
+        self.instance_eval(&during_init)
+
+        if ENV['USE_SIDEKIQ']
+          config.active_job.queue_adapter = :sidekiq
+          # add Sidekiq middleware
+          Sidekiq::Testing.server_middleware do |chain|
+            chain.add(
+              Datadog::Contrib::Sidekiq::Tracer
+            )
+          end
+        end
+      end
+
+      before_test_init = before_test_initialize_block
+      after_test_init = after_test_initialize_block
+
+      klass.send(:define_method, :test_initialize!) do
+        # Enables the auto-instrumentation for the testing application
+        Datadog.configure do |c|
+          c.use :rails
+          c.use :redis
+        end
+
+        Rails.application.config.active_job.queue_adapter = :sidekiq
+
+        before_test_init.call
+        initialize!
+        after_test_init.call
+      end
+    end
+  end
+
+  def append_routes!
+    # Make sure to load controllers first
+    # otherwise routes won't draw properly.
+    controllers
+    test_routes = routes
+
+    rails_test_application.instance.routes.append do
+      test_routes.each do |k, v|
+        get k => v
+      end
+    end
+  end
+
+  # Rails 5 leaves a bunch of global class configuration on Rails::Railtie::Configuration in class variables
+  # We need to reset these so they don't carry over between example runs
+  def reset_rails_configuration!
+    Rails::Railtie::Configuration.class_variable_set(:@@eager_load_namespaces, nil)
+    Rails::Railtie::Configuration.class_variable_set(:@@watchable_files, nil)
+    Rails::Railtie::Configuration.class_variable_set(:@@watchable_dirs, nil)
+    Rails::Railtie::Configuration.class_variable_set(:@@app_middleware, app_middleware)
+    Rails::Railtie::Configuration.class_variable_set(:@@app_generators, nil)
+    Rails::Railtie::Configuration.class_variable_set(:@@to_prepare_blocks, nil)
+  end
+
+  def app_middleware
+    if Datadog::Contrib::Rails::Test::Configuration.get(:app_middleware).nil?
+      current = Rails::Railtie::Configuration.class_variable_get(:@@app_middleware)
+      Datadog::Contrib::Rails::Test::Configuration.set(:app_middleware, current)
+    end
+
+    Datadog::Contrib::Rails::Test::Configuration.get(:app_middleware).dup.tap do |copy|
+      copy.instance_variable_set(:@operations, (copy.instance_variable_get(:@operations) || [] ).dup)
+      copy.instance_variable_set(:@delete_operations, (copy.instance_variable_get(:@delete_operations) || []).dup)
+    end
+  end
+end

--- a/spec/ddtrace/contrib/rails/support/rails5.rb
+++ b/spec/ddtrace/contrib/rails/support/rails5.rb
@@ -92,12 +92,8 @@ RSpec.shared_context 'Rails 5 base application' do
   end
 
   def app_middleware
-    if Datadog::Contrib::Rails::Test::Configuration.get(:app_middleware).nil?
-      current = Rails::Railtie::Configuration.class_variable_get(:@@app_middleware)
-      Datadog::Contrib::Rails::Test::Configuration.set(:app_middleware, current)
-    end
-
-    Datadog::Contrib::Rails::Test::Configuration.get(:app_middleware).dup.tap do |copy|
+    current = Rails::Railtie::Configuration.class_variable_get(:@@app_middleware)
+    Datadog::Contrib::Rails::Test::Configuration.fetch(:app_middleware, current).dup.tap do |copy|
       copy.instance_variable_set(:@operations, (copy.instance_variable_get(:@operations) || [] ).dup)
       copy.instance_variable_set(:@delete_operations, (copy.instance_variable_get(:@delete_operations) || []).dup)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require 'support/faux_writer'
 # require 'support/rails_active_record_helpers'
 # require 'support/configuration_helpers'
 require 'support/synchronization_helpers'
+require 'support/log_helpers'
 
 WebMock.allow_net_connect!
 WebMock.disable!
@@ -25,6 +26,7 @@ RSpec.configure do |config|
   # config.include RailsActiveRecordHelpers
   # config.include ConfigurationHelpers
   config.include SynchronizationHelpers
+  config.include LogHelpers
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+$LOAD_PATH.unshift File.expand_path('../../', __FILE__)
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'pry'
 require 'rspec/collection_matchers'

--- a/spec/support/log_helpers.rb
+++ b/spec/support/log_helpers.rb
@@ -1,0 +1,15 @@
+module LogHelpers
+  def without_warnings(&block)
+    LogHelpers.without_warnings(&block)
+  end
+
+  def self.without_warnings
+    v = $VERBOSE
+    $VERBOSE = nil
+    begin
+      yield
+    ensure
+      $VERBOSE = v
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds middleware specs for Rails, and tests for behavior when custom middleware is injected.

Due to limitations of the Minitest setup where we can't modify Rails middleware stacks after the application loads, this pull request implements some Rails environment setup in RSpec.

From a mechanical perspective, the biggest difference between the two concerns application lifecycle. The Minitest suite depends upon a static Rails application, defined at load time, and then that application is used for all examples. By contrast the RSpec test suite dynamically recreates and reinitializes Rails apps per example.

The benefit we derive from this, that was necessary for this set of feature tests, is that we can now modify application initialization and middleware on an example by example basis. This is a big win, because now we can test a bunch of custom middleware setups that emulate users' own Rails applications that we couldn't previously test before.

To get a good sense of how it's useful, checkout the `middleware_spec.rb` added in this PR.

The Rails RSpec setup is still a bit rough around the edges (needs refactoring) and doesn't fully support all features of Rails that we need to test yet (e.g. ActiveRecord migrations), but the current form should work for these middleware tests.