### PR TITLE
Prevent overpatching Rails

### DIFF
--- a/lib/ddtrace/contrib/rails/action_controller.rb
+++ b/lib/ddtrace/contrib/rails/action_controller.rb
@@ -6,9 +6,13 @@ module Datadog
     module Rails
       # Code used to create and handle 'rails.action_controller' spans.
       module ActionController
+        include Datadog::Patcher
+
         def self.instrument
           # patch Rails core components
-          Datadog::RailsActionPatcher.patch_action_controller
+          do_once(:instrument) do
+            Datadog::RailsActionPatcher.patch_action_controller
+          end
         end
 
         def self.start_processing(payload)

--- a/lib/ddtrace/contrib/rails/action_view.rb
+++ b/lib/ddtrace/contrib/rails/action_view.rb
@@ -5,9 +5,13 @@ module Datadog
     module Rails
       # Code used to create and handle 'rails.render_template' and 'rails.render_partial' spans.
       module ActionView
+        include Datadog::Patcher
+
         def self.instrument
           # patch Rails core components
-          Datadog::RailsRendererPatcher.patch_renderer
+          do_once(:instrument) do
+            Datadog::RailsRendererPatcher.patch_renderer
+          end
         end
 
         def self.start_render_template(payload)

--- a/lib/ddtrace/contrib/rails/active_record.rb
+++ b/lib/ddtrace/contrib/rails/active_record.rb
@@ -7,13 +7,17 @@ module Datadog
     module Rails
       # Code used to create and handle 'mysql.query', 'postgres.query', ... spans.
       module ActiveRecord
+        include Datadog::Patcher
+
         def self.instrument
           # ActiveRecord is instrumented only if it's available
           return unless defined?(::ActiveRecord)
 
-          # subscribe when the active record query has been processed
-          ::ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
-            sql(*args)
+          do_once(:instrument) do
+            # subscribe when the active record query has been processed
+            ::ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
+              sql(*args)
+            end
           end
         end
 

--- a/lib/ddtrace/contrib/rails/active_support.rb
+++ b/lib/ddtrace/contrib/rails/active_support.rb
@@ -6,9 +6,13 @@ module Datadog
     module Rails
       # Code used to create and handle 'rails.cache' spans.
       module ActiveSupport
+        include Datadog::Patcher
+
         def self.instrument
-          # patch Rails core components
-          Datadog::RailsCachePatcher.patch_cache_store
+          do_once(:instrument) do
+            # patch Rails core components
+            Datadog::RailsCachePatcher.patch_cache_store
+          end
         end
 
         def self.start_trace_cache(payload)

--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -4,193 +4,211 @@ module Datadog
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/ModuleLength
   module RailsRendererPatcher
+    include Datadog::Patcher
+
     module_function
 
     def patch_renderer
-      if defined?(::ActionView::TemplateRenderer) && defined?(::ActionView::PartialRenderer)
-        patch_template_renderer(::ActionView::TemplateRenderer)
-        patch_partial_renderer(::ActionView::PartialRenderer)
-      elsif defined?(::ActionView::Rendering) && defined?(::ActionView::Partials::PartialRenderer)
-        # NOTE: Rails < 3.1 compatibility: different classes are used
-        patch_template_renderer(::ActionView::Rendering)
-        patch_partial_renderer(::ActionView::Partials::PartialRenderer)
-      else
-        Datadog::Tracer.log.debug('Expected Template/Partial classes not found; template rendering disabled')
+      do_once(:patch_renderer) do
+        if defined?(::ActionView::TemplateRenderer) && defined?(::ActionView::PartialRenderer)
+          patch_template_renderer(::ActionView::TemplateRenderer)
+          patch_partial_renderer(::ActionView::PartialRenderer)
+        elsif defined?(::ActionView::Rendering) && defined?(::ActionView::Partials::PartialRenderer)
+          # NOTE: Rails < 3.1 compatibility: different classes are used
+          patch_template_renderer(::ActionView::Rendering)
+          patch_partial_renderer(::ActionView::Partials::PartialRenderer)
+        else
+          Datadog::Tracer.log.debug('Expected Template/Partial classes not found; template rendering disabled')
+        end
       end
     end
 
     def patch_template_renderer(klass)
-      klass.class_eval do
-        def render_with_datadog(*args, &block)
-          # create a tracing context and start the rendering span
-          # NOTE: Rails < 3.1 compatibility: preserve the tracing
-          # context when a partial is rendered
-          @tracing_context ||= {}
-          if @tracing_context.empty?
-            Datadog::Contrib::Rails::ActionView.start_render_template(tracing_context: @tracing_context)
+      do_once(:patch_template_renderer) do
+        klass.class_eval do
+          def render_with_datadog(*args, &block)
+            # create a tracing context and start the rendering span
+            # NOTE: Rails < 3.1 compatibility: preserve the tracing
+            # context when a partial is rendered
+            @tracing_context ||= {}
+            if @tracing_context.empty?
+              Datadog::Contrib::Rails::ActionView.start_render_template(tracing_context: @tracing_context)
+            end
+
+            render_without_datadog(*args)
+          rescue Exception => e
+            # attach the exception to the tracing context if any
+            @tracing_context[:exception] = e
+            raise e
+          ensure
+            # ensure that the template `Span` is finished even during exceptions
+            Datadog::Contrib::Rails::ActionView.finish_render_template(tracing_context: @tracing_context)
           end
 
-          render_without_datadog(*args)
-        rescue Exception => e
-          # attach the exception to the tracing context if any
-          @tracing_context[:exception] = e
-          raise e
-        ensure
-          # ensure that the template `Span` is finished even during exceptions
-          Datadog::Contrib::Rails::ActionView.finish_render_template(tracing_context: @tracing_context)
-        end
+          def render_template_with_datadog(*args)
+            begin
+              # arguments based on render_template signature (stable since Rails 3.2)
+              template = args[0]
+              layout_name = args[1]
 
-        def render_template_with_datadog(*args)
-          begin
-            # arguments based on render_template signature (stable since Rails 3.2)
-            template = args[0]
-            layout_name = args[1]
+              # update the tracing context with computed values before the rendering
+              template_name = template.try('identifier')
+              template_name = Datadog::Contrib::Rails::Utils.normalize_template_name(template_name)
+              layout = if layout_name.is_a?(String)
+                         # NOTE: Rails < 3.1 compatibility: the second argument is the layout name
+                         layout_name
+                       else
+                         layout_name.try(:[], 'virtual_path')
+                       end
+              @tracing_context[:template_name] = template_name
+              @tracing_context[:layout] = layout
+            rescue StandardError => e
+              Datadog::Tracer.log.debug(e.message)
+            end
 
-            # update the tracing context with computed values before the rendering
-            template_name = template.try('identifier')
-            template_name = Datadog::Contrib::Rails::Utils.normalize_template_name(template_name)
-            layout = if layout_name.is_a?(String)
-                       # NOTE: Rails < 3.1 compatibility: the second argument is the layout name
-                       layout_name
-                     else
-                       layout_name.try(:[], 'virtual_path')
-                     end
-            @tracing_context[:template_name] = template_name
-            @tracing_context[:layout] = layout
-          rescue StandardError => e
-            Datadog::Tracer.log.debug(e.message)
+            # execute the original function anyway
+            render_template_without_datadog(*args)
           end
 
-          # execute the original function anyway
-          render_template_without_datadog(*args)
-        end
+          # method aliasing to patch the class
+          alias_method :render_without_datadog, :render
+          alias_method :render, :render_with_datadog
 
-        # method aliasing to patch the class
-        alias_method :render_without_datadog, :render
-        alias_method :render, :render_with_datadog
-
-        if klass.private_method_defined?(:render_template) || klass.method_defined?(:render_template)
-          alias_method :render_template_without_datadog, :render_template
-          alias_method :render_template, :render_template_with_datadog
-        else
-          # NOTE: Rails < 3.1 compatibility: the method name is different
-          alias_method :render_template_without_datadog, :_render_template
-          alias_method :_render_template, :render_template_with_datadog
+          if klass.private_method_defined?(:render_template) || klass.method_defined?(:render_template)
+            alias_method :render_template_without_datadog, :render_template
+            alias_method :render_template, :render_template_with_datadog
+          else
+            # NOTE: Rails < 3.1 compatibility: the method name is different
+            alias_method :render_template_without_datadog, :_render_template
+            alias_method :_render_template, :render_template_with_datadog
+          end
         end
       end
     end
 
     def patch_partial_renderer(klass)
-      klass.class_eval do
-        def render_with_datadog(*args, &block)
-          # Create a tracing context and start the rendering span
-          tracing_context = {}
-          Datadog::Contrib::Rails::ActionView.start_render_partial(tracing_context: tracing_context)
-          tracing_contexts[current_span_id] = tracing_context
+      do_once(:patch_partial_renderer) do
+        klass.class_eval do
+          def render_with_datadog(*args, &block)
+            # Create a tracing context and start the rendering span
+            tracing_context = {}
+            Datadog::Contrib::Rails::ActionView.start_render_partial(tracing_context: tracing_context)
+            tracing_contexts[current_span_id] = tracing_context
 
-          render_without_datadog(*args)
-        rescue Exception => e
-          # attach the exception to the tracing context if any
-          tracing_contexts[current_span_id][:exception] = e
-          raise e
-        ensure
-          # Ensure that the template `Span` is finished even during exceptions
-          # Remove the existing tracing context (to avoid leaks)
-          tracing_contexts.delete(current_span_id)
+            render_without_datadog(*args)
+          rescue Exception => e
+            # attach the exception to the tracing context if any
+            tracing_contexts[current_span_id][:exception] = e
+            raise e
+          ensure
+            # Ensure that the template `Span` is finished even during exceptions
+            # Remove the existing tracing context (to avoid leaks)
+            tracing_contexts.delete(current_span_id)
 
-          # Then finish the span associated with the context
-          Datadog::Contrib::Rails::ActionView.finish_render_partial(tracing_context: tracing_context)
-        end
-
-        def render_partial_with_datadog(*args)
-          begin
-            # update the tracing context with computed values before the rendering
-            template_name = Datadog::Contrib::Rails::Utils.normalize_template_name(@template.try('identifier'))
-            tracing_contexts[current_span_id][:template_name] = template_name
-          rescue StandardError => e
-            Datadog::Tracer.log.debug(e.message)
+            # Then finish the span associated with the context
+            Datadog::Contrib::Rails::ActionView.finish_render_partial(tracing_context: tracing_context)
           end
 
-          # execute the original function anyway
-          render_partial_without_datadog(*args)
-        end
+          def render_partial_with_datadog(*args)
+            begin
+              # update the tracing context with computed values before the rendering
+              template_name = Datadog::Contrib::Rails::Utils.normalize_template_name(@template.try('identifier'))
+              tracing_contexts[current_span_id][:template_name] = template_name
+            rescue StandardError => e
+              Datadog::Tracer.log.debug(e.message)
+            end
 
-        # Table of tracing contexts, one per partial/span, keyed by span_id
-        # because there will be multiple concurrent contexts, depending on how
-        # many partials are nested within one another.
-        def tracing_contexts
-          @tracing_contexts ||= {}
-        end
+            # execute the original function anyway
+            render_partial_without_datadog(*args)
+          end
 
-        def current_span_id
-          Datadog.configuration[:rails][:tracer].call_context.current_span.span_id
-        end
+          # Table of tracing contexts, one per partial/span, keyed by span_id
+          # because there will be multiple concurrent contexts, depending on how
+          # many partials are nested within one another.
+          def tracing_contexts
+            @tracing_contexts ||= {}
+          end
 
-        # method aliasing to patch the class
-        alias_method :render_without_datadog, :render
-        alias_method :render, :render_with_datadog
-        alias_method :render_partial_without_datadog, :render_partial
-        alias_method :render_partial, :render_partial_with_datadog
+          def current_span_id
+            Datadog.configuration[:rails][:tracer].call_context.current_span.span_id
+          end
+
+          # method aliasing to patch the class
+          alias_method :render_without_datadog, :render
+          alias_method :render, :render_with_datadog
+          alias_method :render_partial_without_datadog, :render_partial
+          alias_method :render_partial, :render_partial_with_datadog
+        end
       end
     end
   end
 
   # RailsActionPatcher contains functions to patch Rails action controller instrumentation
   module RailsActionPatcher
+    include Datadog::Patcher
+
     module_function
 
     def patch_action_controller
-      patch_process_action
+      do_once(:patch_action_controller) do
+        patch_process_action
+      end
     end
 
     def patch_process_action
-      ::ActionController::Instrumentation.class_eval do
-        def process_action_with_datadog(*args)
-          # mutable payload with a tracing context that is used in two different
-          # signals; it propagates the request span so that it can be finished
-          # no matter what
-          payload = {
-            controller: self.class,
-            action: action_name,
-            headers: {
-              # The exception this controller was given in the request,
-              # which is typical if the controller is configured to handle exceptions.
-              request_exception: request.headers['action_dispatch.exception']
-            },
-            tracing_context: {}
-          }
+      do_once(:patch_process_action) do
+        ::ActionController::Instrumentation.class_eval do
+          def process_action_with_datadog(*args)
+            # mutable payload with a tracing context that is used in two different
+            # signals; it propagates the request span so that it can be finished
+            # no matter what
+            payload = {
+              controller: self.class,
+              action: action_name,
+              headers: {
+                # The exception this controller was given in the request,
+                # which is typical if the controller is configured to handle exceptions.
+                request_exception: request.headers['action_dispatch.exception']
+              },
+              tracing_context: {}
+            }
 
-          begin
-            # process and catch request exceptions
-            Datadog::Contrib::Rails::ActionController.start_processing(payload)
-            result = process_action_without_datadog(*args)
-            payload[:status] = response.status
-            result
-          rescue Exception => e
-            payload[:exception] = [e.class.name, e.message]
-            payload[:exception_object] = e
-            raise e
+            begin
+              # process and catch request exceptions
+              Datadog::Contrib::Rails::ActionController.start_processing(payload)
+              result = process_action_without_datadog(*args)
+              payload[:status] = response.status
+              result
+            rescue Exception => e
+              payload[:exception] = [e.class.name, e.message]
+              payload[:exception_object] = e
+              raise e
+            end
+          ensure
+            Datadog::Contrib::Rails::ActionController.finish_processing(payload)
           end
-        ensure
-          Datadog::Contrib::Rails::ActionController.finish_processing(payload)
-        end
 
-        alias_method :process_action_without_datadog, :process_action
-        alias_method :process_action, :process_action_with_datadog
+          alias_method :process_action_without_datadog, :process_action
+          alias_method :process_action, :process_action_with_datadog
+        end
       end
     end
   end
 
   # RailsCachePatcher contains function to patch Rails caching libraries.
   module RailsCachePatcher
+    include Datadog::Patcher
+
     module_function
 
     def patch_cache_store
-      patch_cache_store_read
-      patch_cache_store_fetch
-      patch_cache_store_write
-      patch_cache_store_delete
-      reload_cache_store
+      do_once(:patch_cache_store) do
+        patch_cache_store_read
+        patch_cache_store_fetch
+        patch_cache_store_write
+        patch_cache_store_delete
+        reload_cache_store
+      end
     end
 
     def cache_store_class(k)
@@ -210,101 +228,109 @@ module Datadog
     end
 
     def patch_cache_store_read
-      cache_store_class(:read).class_eval do
-        alias_method :read_without_datadog, :read
-        def read(*args, &block)
-          payload = {
-            action: 'GET',
-            key: args[0],
-            tracing_context: {}
-          }
+      do_once(:patch_cache_store_read) do
+        cache_store_class(:read).class_eval do
+          alias_method :read_without_datadog, :read
+          def read(*args, &block)
+            payload = {
+              action: 'GET',
+              key: args[0],
+              tracing_context: {}
+            }
 
-          begin
-            # process and catch cache exceptions
-            Datadog::Contrib::Rails::ActiveSupport.start_trace_cache(payload)
-            read_without_datadog(*args, &block)
-          rescue Exception => e
-            payload[:exception] = [e.class.name, e.message]
-            payload[:exception_object] = e
-            raise e
+            begin
+              # process and catch cache exceptions
+              Datadog::Contrib::Rails::ActiveSupport.start_trace_cache(payload)
+              read_without_datadog(*args, &block)
+            rescue Exception => e
+              payload[:exception] = [e.class.name, e.message]
+              payload[:exception_object] = e
+              raise e
+            end
+          ensure
+            Datadog::Contrib::Rails::ActiveSupport.finish_trace_cache(payload)
           end
-        ensure
-          Datadog::Contrib::Rails::ActiveSupport.finish_trace_cache(payload)
         end
       end
     end
 
     def patch_cache_store_fetch
-      cache_store_class(:fetch).class_eval do
-        alias_method :fetch_without_datadog, :fetch
-        def fetch(*args, &block)
-          payload = {
-            action: 'GET',
-            key: args[0],
-            tracing_context: {}
-          }
+      do_once(:patch_cache_store_fetch) do
+        cache_store_class(:fetch).class_eval do
+          alias_method :fetch_without_datadog, :fetch
+          def fetch(*args, &block)
+            payload = {
+              action: 'GET',
+              key: args[0],
+              tracing_context: {}
+            }
 
-          begin
-            # process and catch cache exceptions
-            Datadog::Contrib::Rails::ActiveSupport.start_trace_cache(payload)
-            fetch_without_datadog(*args, &block)
-          rescue Exception => e
-            payload[:exception] = [e.class.name, e.message]
-            payload[:exception_object] = e
-            raise e
+            begin
+              # process and catch cache exceptions
+              Datadog::Contrib::Rails::ActiveSupport.start_trace_cache(payload)
+              fetch_without_datadog(*args, &block)
+            rescue Exception => e
+              payload[:exception] = [e.class.name, e.message]
+              payload[:exception_object] = e
+              raise e
+            end
+          ensure
+            Datadog::Contrib::Rails::ActiveSupport.finish_trace_cache(payload)
           end
-        ensure
-          Datadog::Contrib::Rails::ActiveSupport.finish_trace_cache(payload)
         end
       end
     end
 
     def patch_cache_store_write
-      cache_store_class(:write).class_eval do
-        alias_method :write_without_datadog, :write
-        def write(*args, &block)
-          payload = {
-            action: 'SET',
-            key: args[0],
-            tracing_context: {}
-          }
+      do_once(:patch_cache_store_write) do
+        cache_store_class(:write).class_eval do
+          alias_method :write_without_datadog, :write
+          def write(*args, &block)
+            payload = {
+              action: 'SET',
+              key: args[0],
+              tracing_context: {}
+            }
 
-          begin
-            # process and catch cache exceptions
-            Datadog::Contrib::Rails::ActiveSupport.start_trace_cache(payload)
-            write_without_datadog(*args, &block)
-          rescue Exception => e
-            payload[:exception] = [e.class.name, e.message]
-            payload[:exception_object] = e
-            raise e
+            begin
+              # process and catch cache exceptions
+              Datadog::Contrib::Rails::ActiveSupport.start_trace_cache(payload)
+              write_without_datadog(*args, &block)
+            rescue Exception => e
+              payload[:exception] = [e.class.name, e.message]
+              payload[:exception_object] = e
+              raise e
+            end
+          ensure
+            Datadog::Contrib::Rails::ActiveSupport.finish_trace_cache(payload)
           end
-        ensure
-          Datadog::Contrib::Rails::ActiveSupport.finish_trace_cache(payload)
         end
       end
     end
 
     def patch_cache_store_delete
-      cache_store_class(:delete).class_eval do
-        alias_method :delete_without_datadog, :delete
-        def delete(*args, &block)
-          payload = {
-            action: 'DELETE',
-            key: args[0],
-            tracing_context: {}
-          }
+      do_once(:patch_cache_store_delete) do
+        cache_store_class(:delete).class_eval do
+          alias_method :delete_without_datadog, :delete
+          def delete(*args, &block)
+            payload = {
+              action: 'DELETE',
+              key: args[0],
+              tracing_context: {}
+            }
 
-          begin
-            # process and catch cache exceptions
-            Datadog::Contrib::Rails::ActiveSupport.start_trace_cache(payload)
-            delete_without_datadog(*args, &block)
-          rescue Exception => e
-            payload[:exception] = [e.class.name, e.message]
-            payload[:exception_object] = e
-            raise e
+            begin
+              # process and catch cache exceptions
+              Datadog::Contrib::Rails::ActiveSupport.start_trace_cache(payload)
+              delete_without_datadog(*args, &block)
+            rescue Exception => e
+              payload[:exception] = [e.class.name, e.message]
+              payload[:exception_object] = e
+              raise e
+            end
+          ensure
+            Datadog::Contrib::Rails::ActiveSupport.finish_trace_cache(payload)
           end
-        ensure
-          Datadog::Contrib::Rails::ActiveSupport.finish_trace_cache(payload)
         end
       end
     end

--- a/lib/ddtrace/patcher.rb
+++ b/lib/ddtrace/patcher.rb
@@ -1,18 +1,40 @@
 module Datadog
   # Defines some useful patching methods for integrations
   module Patcher
-    module_function
+    def self.included(base)
+      base.send(:extend, CommonMethods)
+      base.send(:include, CommonMethods)
+    end
 
-    def without_warnings
-      # This is typically used when monkey patching functions such as
-      # intialize, which Ruby advices you not to. Use cautiously.
-      v = $VERBOSE
-      $VERBOSE = nil
-      begin
-        yield
-      ensure
-        $VERBOSE = v
+    # Defines some common methods for patching, that can be used
+    # at the instance, class, or module level.
+    module CommonMethods
+      def without_warnings
+        # This is typically used when monkey patching functions such as
+        # intialize, which Ruby advices you not to. Use cautiously.
+        v = $VERBOSE
+        $VERBOSE = nil
+        begin
+          yield
+        ensure
+          $VERBOSE = v
+        end
+      end
+
+      def do_once(key = nil)
+        # If already done, don't do again
+        @done_once ||= {}
+        return @done_once[key] if @done_once.key?(key)
+
+        # Otherwise 'do'
+        yield.tap do
+          # Then add the key so we don't do again.
+          @done_once[key] = true
+        end
       end
     end
+
+    # Extend the common methods so they're available as a module function.
+    extend(CommonMethods)
   end
 end

--- a/spec/ddtrace/patcher_spec.rb
+++ b/spec/ddtrace/patcher_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper'
+
+require 'ddtrace'
+
+RSpec.describe Datadog::Patcher do
+  shared_examples_for 'common patcher behavior' do
+    describe '#without_warnings' do
+      it { expect { |b| patcher.without_warnings(&b) }.to yield_control }
+    end
+
+    describe '#do_once' do
+      let(:integration) { double('integration', patch: patch_result) }
+      let(:patch_result) { double('patch_result') }
+
+      # Because we might be mutating a global level constant,
+      # we have to make sure to reset its state.
+      after(:each) { patcher.instance_variable_set(:@done_once, nil) }
+
+      context 'when called without a key' do
+        subject(:result) { patcher.do_once { integration.patch } }
+
+        it do
+          expect(integration).to receive(:patch).once.and_return(patch_result)
+          expect(result).to be(patch_result)
+        end
+        
+        context 'then called a second time' do
+          context 'without a key' do
+            subject(:result) do
+              patcher.do_once { integration.patch }
+              patcher.do_once { integration.patch }
+            end
+
+            it do
+              expect(integration).to receive(:patch).once.and_return(patch_result)
+              expect(result).to be true # Because second block doesn't run
+            end
+          end
+
+          context 'with a key' do
+            subject(:result) do
+              patcher.do_once { integration.patch }
+              patcher.do_once(key) { integration.patch }
+            end
+
+            let(:key) { double('key') }
+
+            it do
+              expect(integration).to receive(:patch).twice.and_return(patch_result)
+              expect(result).to be(patch_result)
+            end
+          end
+        end
+      end
+
+      context 'when called with a key' do
+        subject(:result) { patcher.do_once(key) { integration.patch } }
+
+        let(:key) { double('key') }
+
+        it do
+          expect(integration).to receive(:patch).once.and_return(patch_result)
+          expect(result).to be(patch_result)
+        end
+
+        context 'then called a second time' do
+          context 'without a key' do
+            subject(:result) do
+              patcher.do_once(key) { integration.patch }
+              patcher.do_once { integration.patch }
+            end
+
+            it do
+              expect(integration).to receive(:patch).twice.and_return(patch_result)
+              expect(result).to be(patch_result)
+            end
+          end
+
+          context 'with a key' do
+            context 'that is the same' do
+              subject(:result) do
+                patcher.do_once(key) { integration.patch }
+                patcher.do_once(key) { integration.patch }
+              end
+
+              it do
+                expect(integration).to receive(:patch).once.and_return(patch_result)
+                expect(result).to be true # Because second block doesn't run
+              end
+            end
+
+            context 'that is different' do
+              subject(:result) do
+                patcher.do_once(key) { integration.patch }
+                patcher.do_once(key_two) { integration.patch }
+              end
+
+              let(:key_two) { double('key_two') }
+
+              it do
+                expect(integration).to receive(:patch).twice.and_return(patch_result)
+                expect(result).to be(patch_result)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe 'implemented' do
+    subject(:patcher_class) do
+      Class.new.tap do |klass|
+        klass.send(:include, described_class)
+      end
+    end
+
+    describe 'class' do
+      it_behaves_like 'common patcher behavior' do
+        let(:patcher) { patcher_class }
+      end
+    end
+
+    describe 'instance' do
+      subject(:patcher) { patcher_class.new }
+
+      it_behaves_like 'common patcher behavior'
+    end
+  end
+
+  describe 'module' do
+    it_behaves_like 'common patcher behavior' do
+      let(:patcher) { described_class }
+    end
+  end
+end


### PR DESCRIPTION
In our current implementation, although there are guards around the Rails::Patcher module, there are no such guards around the constituent modules (e.g. in `CoreExtensions`) it uses to actually patch Rails code. It's possible to call these and overpatch Rails methods, causing infinite loops and other nasty behaviors. This has actually occurred when Railties reload, as they do in our test suite.

This pull request adds a helper function to `Datadog::Patcher` called `do_once` which is a really simple singleton-like function that prevents a function being called more than once. It's equivalent to the old `return @patched if @patched; patcher.patch_code; @patched = true`, just a little nicer looking and abstracts away the pattern.

I think this one could warrant some critical opinion, since the new function brings up questions about the direction of our patching API.