### PR TITLE
Guard the rails core extensions against null Redis registry

### DIFF
--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -336,7 +336,7 @@ module Datadog
     end
 
     def self.reload_cache_store
-      return unless Datadog.registry[:redis].patched?
+      return unless Datadog.registry[:redis].try(:patched?)
 
       return unless defined?(::ActiveSupport::Cache::RedisStore) &&
                     defined?(::Rails.cache) &&

--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -336,7 +336,8 @@ module Datadog
     end
 
     def self.reload_cache_store
-      return unless Datadog.registry[:redis].try(:patched?)
+      redis = Datadog.registry[:redis]
+      return unless redis && redis.patched?
 
       return unless defined?(::ActiveSupport::Cache::RedisStore) &&
                     defined?(::Rails.cache) &&


### PR DESCRIPTION
/cc @delner @palazzem 

Here's the stack trace:
```
/gems/ddtrace-0.12.0.beta1/lib/ddtrace/contrib/rails/core_extensions.rb:313:in `reload_cache_store': undefined method `patched?' for nil:NilClass (NoMethodError)
	from /gems/ddtrace-0.12.0.beta1/lib/ddtrace/contrib/rails/core_extensions.rb:193:in `patch_cache_store'
	from /gems/ddtrace-0.12.0.beta1/lib/ddtrace/contrib/rails/active_support.rb:11:in `instrument'
	from /gems/ddtrace-0.12.0.beta1/lib/ddtrace/contrib/rails/railtie.rb:16:in `block in <class:Railtie>'
	from /gems/activesupport-3.2.22.4/lib/active_support/lazy_load_hooks.rb:34:in `call'
	from /gems/activesupport-3.2.22.4/lib/active_support/lazy_load_hooks.rb:34:in `execute_hook'
	from /gems/activesupport-3.2.22.4/lib/active_support/lazy_load_hooks.rb:26:in `block in on_load'
	from /gems/activesupport-3.2.22.4/lib/active_support/lazy_load_hooks.rb:25:in `each'
	from /gems/activesupport-3.2.22.4/lib/active_support/lazy_load_hooks.rb:25:in `on_load'
	from /gems/railties-3.2.22.4/lib/rails/railtie/configuration.rb:59:in `after_initialize'
	from /gems/ddtrace-0.12.0.beta1/lib/ddtrace/contrib/rails/railtie.rb:11:in `<class:Railtie>'
	from /gems/ddtrace-0.12.0.beta1/lib/ddtrace/contrib/rails/railtie.rb:7:in `<module:Datadog>'
	from /gems/ddtrace-0.12.0.beta1/lib/ddtrace/contrib/rails/railtie.rb:5:in `<top (required)>'
	from /gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
	from /gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
	from /gems/activesupport-3.2.22.4/lib/active_support/dependencies.rb:251:in `block in require'
	from /gems/activesupport-3.2.22.4/lib/active_support/dependencies.rb:236:in `load_dependency'
	from /gems/activesupport-3.2.22.4/lib/active_support/dependencies.rb:251:in `require'
	from /gems/ddtrace-0.12.0.beta1/lib/ddtrace/contrib/rails/patcher.rb:50:in `<top (required)>'
	from /gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
	from /gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
	from /gems/activesupport-3.2.22.4/lib/active_support/dependencies.rb:251:in `block in require'
	from /gems/activesupport-3.2.22.4/lib/active_support/dependencies.rb:236:in `load_dependency'
	from /gems/activesupport-3.2.22.4/lib/active_support/dependencies.rb:251:in `require'
	from /gems/ddtrace-0.12.0.beta1/lib/ddtrace.rb:57:in `<top (required)>'
	from /gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
	from /gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
	from /gems/activesupport-3.2.22.4/lib/active_support/dependencies.rb:251:in `block in require'
	from /gems/activesupport-3.2.22.4/lib/active_support/dependencies.rb:236:in `load_dependency'
	from /gems/activesupport-3.2.22.4/lib/active_support/dependencies.rb:251:in `require'
	from ./test/lib/datadog_apm_test.rb:2:in `<main>' # require 'ddtrace'
```

From what I understand, the rails patcher triggers the railtie which loads the core extensions of Rails which expects the redis patcher to be registered. Sadly it's not yet because it's lower down the list of requires.