### PR TITLE
Release 0.12.0.beta2

### DIFF
--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -310,7 +310,8 @@ module Datadog
     end
 
     def self.reload_cache_store
-      return unless Datadog.registry[:redis].patched?
+      redis = Datadog.registry[:redis]
+      return unless redis && redis.patched?
 
       return unless defined?(::ActiveSupport::Cache::RedisStore) &&
                     defined?(::Rails.cache) &&

--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -3,7 +3,7 @@ module Datadog
     MAJOR = 0
     MINOR = 12
     PATCH = 0
-    PRE = 'beta1'.freeze
+    PRE = 'beta2'.freeze
 
     STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.')
   end


### PR DESCRIPTION
Hotfix release for 0.12.0.beta2.

 - Addresses an issue for loading ddtrace after a Rails app that has been fully initialized.