### PR TITLE
ElasticSearch body quantization

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -274,6 +274,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | Key | Description | Default |
 | --- | --- | --- |
 | ``service_name`` | Service name used for `elasticsearch` instrumentation | elasticsearch |
+| ``quantize`` | Hash containing options for quantization. May include `:show` with an Array of keys to not quantize (or `:all` to skip quantization), or `:exclude` with Array of keys to exclude entirely. | {} |
 
 ### MongoDB
 

--- a/lib/ddtrace/contrib/elasticsearch/patcher.rb
+++ b/lib/ddtrace/contrib/elasticsearch/patcher.rb
@@ -89,7 +89,10 @@ module Datadog
                   span.set_tag(METHOD, method)
                   span.set_tag(URL, url)
                   span.set_tag(PARAMS, params) if params
-                  span.set_tag(BODY, body) if body
+                  if body
+                    quantized_body = Datadog::Contrib::Elasticsearch::Quantize.format_body(body)
+                    span.set_tag(BODY, quantized_body)
+                  end
                   span.set_tag('out.host', host) if host
                   span.set_tag('out.port', port) if port
 

--- a/lib/ddtrace/contrib/elasticsearch/patcher.rb
+++ b/lib/ddtrace/contrib/elasticsearch/patcher.rb
@@ -15,6 +15,7 @@ module Datadog
         include Base
         register_as :elasticsearch, auto_patch: true
         option :service_name, default: SERVICE
+        option :quantize, default: {}
 
         @patched = false
 
@@ -90,7 +91,8 @@ module Datadog
                   span.set_tag(URL, url)
                   span.set_tag(PARAMS, params) if params
                   if body
-                    quantized_body = Datadog::Contrib::Elasticsearch::Quantize.format_body(body)
+                    quantize_options = Datadog.configuration[:elasticsearch][:quantize]
+                    quantized_body = Datadog::Contrib::Elasticsearch::Quantize.format_body(body, quantize_options)
                     span.set_tag(BODY, quantized_body)
                   end
                   span.set_tag('out.host', host) if host

--- a/lib/ddtrace/contrib/elasticsearch/quantize.rb
+++ b/lib/ddtrace/contrib/elasticsearch/quantize.rb
@@ -3,6 +3,10 @@ module Datadog
     module Elasticsearch
       # Quantize contains ES-specific resource quantization tools.
       module Quantize
+        EXCLUDE_KEYS = [].freeze
+        SHOW_KEYS = [:_index, :_type, :_id].freeze
+        PLACEHOLDER = '?'.freeze
+
         ID_REGEXP = %r{\/([0-9]+)([\/\?]|$)}
         ID_PLACEHOLDER = '/?\2'.freeze
 
@@ -15,6 +19,47 @@ module Datadog
         def format_url(url)
           quantized_url = url.gsub(ID_REGEXP, ID_PLACEHOLDER)
           quantized_url.gsub(INDEX_REGEXP, INDEX_PLACEHOLDER)
+        end
+
+        def format_body(body, exclude = [], show = [])
+          # Determine if bulk query or not, based on content
+          statements = body.end_with?("\n") ? body.split("\n") : [body]
+
+          # Attempt to parse each
+          statements.collect do |s|
+            begin
+              JSON.dump(format_statement(JSON.parse(s), EXCLUDE_KEYS, SHOW_KEYS))
+            rescue JSON::ParserError
+              # If it can't parse/dump, don't raise an error.
+              PLACEHOLDER
+            end
+          end.join("\n")
+        end
+
+        def format_statement(statement, exclude = [], show = [])
+          case statement
+          when Hash
+            statement.each_with_object({}) do |(key, value), quantized|
+              if show == :all || show.include?(key.to_sym)
+                quantized[key] = value
+              elsif !exclude.include?(key.to_sym)
+                quantized[key] = format_value(value, exclude, show)
+              end
+            end
+          else
+            format_value(statement, exclude, show)
+          end
+        end
+
+        def format_value(value, exclude = [], show = [])
+          case value
+          when Hash
+            format_statement(value, exclude, show)
+          when Array
+            format_value(value.first, exclude, show)
+          else
+            show == :all ? value : PLACEHOLDER
+          end
         end
       end
     end

--- a/lib/ddtrace/contrib/elasticsearch/quantize.rb
+++ b/lib/ddtrace/contrib/elasticsearch/quantize.rb
@@ -3,9 +3,10 @@ module Datadog
     module Elasticsearch
       # Quantize contains ES-specific resource quantization tools.
       module Quantize
+        PLACEHOLDER = '?'.freeze
         EXCLUDE_KEYS = [].freeze
         SHOW_KEYS = [:_index, :_type, :_id].freeze
-        PLACEHOLDER = '?'.freeze
+        DEFAULT_OPTIONS = { exclude: EXCLUDE_KEYS, show: SHOW_KEYS }.freeze
 
         ID_REGEXP = %r{\/([0-9]+)([\/\?]|$)}
         ID_PLACEHOLDER = '/?\2'.freeze
@@ -21,44 +22,81 @@ module Datadog
           quantized_url.gsub(INDEX_REGEXP, INDEX_PLACEHOLDER)
         end
 
-        def format_body(body, exclude = [], show = [])
+        def format_body(body, options = {})
+          options = merge_options(DEFAULT_OPTIONS, options)
+
           # Determine if bulk query or not, based on content
           statements = body.end_with?("\n") ? body.split("\n") : [body]
 
-          # Attempt to parse each
-          statements.collect do |s|
-            begin
-              JSON.dump(format_statement(JSON.parse(s), EXCLUDE_KEYS, SHOW_KEYS))
-            rescue JSON::ParserError
-              # If it can't parse/dump, don't raise an error.
-              PLACEHOLDER
+          # Parse each statement and quantize them.
+          statements.collect do |string|
+            reserialize_json(string) do |obj|
+              format_statement(obj, options)
             end
           end.join("\n")
         end
 
-        def format_statement(statement, exclude = [], show = [])
+        def format_statement(statement, options = {})
+          return statement if options[:show] == :all
+
           case statement
           when Hash
             statement.each_with_object({}) do |(key, value), quantized|
-              if show == :all || show.include?(key.to_sym)
+              if options[:show].include?(key.to_sym)
                 quantized[key] = value
-              elsif !exclude.include?(key.to_sym)
-                quantized[key] = format_value(value, exclude, show)
+              elsif !options[:exclude].include?(key.to_sym)
+                quantized[key] = format_value(value, options)
               end
             end
           else
-            format_value(statement, exclude, show)
+            format_value(statement, options)
           end
         end
 
-        def format_value(value, exclude = [], show = [])
+        def format_value(value, options = {})
+          return value if options[:show] == :all
+
           case value
           when Hash
-            format_statement(value, exclude, show)
+            format_statement(value, options)
           when Array
-            format_value(value.first, exclude, show)
+            # If any are objects, format them.
+            if value.any? { |v| v.class <= Hash || v.class <= Array }
+              value.collect { |i| format_value(i, options) }
+            # Otherwise short-circuit and return single placeholder
+            else
+              PLACEHOLDER
+            end
           else
-            show == :all ? value : PLACEHOLDER
+            PLACEHOLDER
+          end
+        end
+
+        def merge_options(original, additional)
+          {}.tap do |options|
+            # Show
+            # If either is :all, value becomes :all
+            options[:show] = if original[:show] == :all || additional[:show] == :all
+                               :all
+                             else
+                               (original[:show] || []).dup.concat(additional[:show] || []).uniq
+                             end
+
+            # Exclude
+            options[:exclude] = (original[:exclude] || []).dup.concat(additional[:exclude] || []).uniq
+          end
+        end
+
+        # Parses a JSON object from a string, passes its value
+        # to the block provided, and dumps its result back to JSON.
+        # If JSON parsing fails, it prints fail_value.
+        def reserialize_json(string, fail_value = PLACEHOLDER)
+          return string unless block_given?
+          begin
+            JSON.dump(yield(JSON.parse(string)))
+          rescue JSON::ParserError
+            # If it can't parse/dump, don't raise an error.
+            fail_value
           end
         end
       end

--- a/lib/ddtrace/contrib/elasticsearch/quantize.rb
+++ b/lib/ddtrace/contrib/elasticsearch/quantize.rb
@@ -23,6 +23,12 @@ module Datadog
         end
 
         def format_body(body, options = {})
+          format_body!(body, options)
+        rescue StandardError
+          PLACEHOLDER
+        end
+
+        def format_body!(body, options = {})
           options = merge_options(DEFAULT_OPTIONS, options)
 
           # Determine if bulk query or not, based on content

--- a/test/contrib/elasticsearch/quantize_test.rb
+++ b/test/contrib/elasticsearch/quantize_test.rb
@@ -21,4 +21,26 @@ class ESQuantizeTest < Minitest::Test
   def test_combine
     assert_equal('/my?/thing/?', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123/thing/456789'))
   end
+
+  def test_body
+    # MGet format
+    body = "{\"ids\":[\"1\",\"2\",\"3\"]}"
+    quantized_body = "{\"ids\":\"?\"}"
+    assert_equal(quantized_body, Datadog::Contrib::Elasticsearch::Quantize.format_body(body))
+
+    # Search format
+    body = "{\"query\":{\"match\":{\"title\":\"test\"}}}"
+    quantized_body = "{\"query\":{\"match\":{\"title\":\"?\"}}}"
+    assert_equal(quantized_body, Datadog::Contrib::Elasticsearch::Quantize.format_body(body))
+
+    # MSearch format
+    body = "{}\n{\"query\":{\"match_all\":{}}}\n{\"index\":\"myindex\",\"type\":\"mytype\"}\n{\"query\":{\"query_string\":{\"query\":\"\\\"test\\\"\"}}}\n{\"search_type\":\"count\"}\n{\"aggregations\":{\"published\":{\"terms\":{\"field\":\"published\"}}}}\n"
+    quantized_body = "{}\n{\"query\":{\"match_all\":{}}}\n{\"index\":\"?\",\"type\":\"?\"}\n{\"query\":{\"query_string\":{\"query\":\"?\"}}}\n{\"search_type\":\"?\"}\n{\"aggregations\":{\"published\":{\"terms\":{\"field\":\"?\"}}}}"
+    assert_equal(quantized_body, Datadog::Contrib::Elasticsearch::Quantize.format_body(body))
+
+    # Bulk format
+    body = "{\"index\":{\"_index\":\"myindex\",\"_type\":\"mytype\",\"_id\":1}}\n{\"title\":\"foo\"}\n{\"index\":{\"_index\":\"myindex\",\"_type\":\"mytype\",\"_id\":2}}\n{\"title\":\"foo\"}\n"
+    quantized_body = "{\"index\":{\"_index\":\"myindex\",\"_type\":\"mytype\",\"_id\":1}}\n{\"title\":\"?\"}\n{\"index\":{\"_index\":\"myindex\",\"_type\":\"mytype\",\"_id\":2}}\n{\"title\":\"?\"}"
+    assert_equal(quantized_body, Datadog::Contrib::Elasticsearch::Quantize.format_body(body))
+  end
 end

--- a/test/contrib/elasticsearch/quantize_test.rb
+++ b/test/contrib/elasticsearch/quantize_test.rb
@@ -22,6 +22,8 @@ class ESQuantizeTest < Minitest::Test
     assert_equal('/my?/thing/?', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123/thing/456789'))
   end
 
+  # rubocop:disable Metrics/LineLength
+  # rubocop:disable Style/StringLiterals
   def test_body
     # MGet format
     body = "{\"ids\":[\"1\",\"2\",\"3\"]}"
@@ -42,5 +44,29 @@ class ESQuantizeTest < Minitest::Test
     body = "{\"index\":{\"_index\":\"myindex\",\"_type\":\"mytype\",\"_id\":1}}\n{\"title\":\"foo\"}\n{\"index\":{\"_index\":\"myindex\",\"_type\":\"mytype\",\"_id\":2}}\n{\"title\":\"foo\"}\n"
     quantized_body = "{\"index\":{\"_index\":\"myindex\",\"_type\":\"mytype\",\"_id\":1}}\n{\"title\":\"?\"}\n{\"index\":{\"_index\":\"myindex\",\"_type\":\"mytype\",\"_id\":2}}\n{\"title\":\"?\"}"
     assert_equal(quantized_body, Datadog::Contrib::Elasticsearch::Quantize.format_body(body))
+  end
+
+  def test_body_show
+    body = "{\"query\":{\"match\":{\"title\":\"test\",\"subtitle\":\"test\"}}}"
+    quantized_body = "{\"query\":{\"match\":{\"title\":\"test\",\"subtitle\":\"?\"}}}"
+    assert_equal(quantized_body, Datadog::Contrib::Elasticsearch::Quantize.format_body(body, show: [:title]))
+
+    body = "{\"query\":{\"match\":{\"title\":\"test\",\"subtitle\":\"test\"}}}"
+    quantized_body = "{\"query\":{\"match\":{\"title\":\"test\",\"subtitle\":\"test\"}}}"
+    assert_equal(quantized_body, Datadog::Contrib::Elasticsearch::Quantize.format_body(body, show: :all))
+
+    body = "[{\"foo\":\"foo\"},{\"bar\":\"bar\"}]"
+    quantized_body = "[{\"foo\":\"foo\"},{\"bar\":\"bar\"}]"
+    assert_equal(quantized_body, Datadog::Contrib::Elasticsearch::Quantize.format_body(body, show: :all))
+
+    body = "[\"foo\",\"bar\"]"
+    quantized_body = "[\"foo\",\"bar\"]"
+    assert_equal(quantized_body, Datadog::Contrib::Elasticsearch::Quantize.format_body(body, show: :all))
+  end
+
+  def test_body_exclude
+    body = "{\"query\":{\"match\":{\"title\":\"test\",\"subtitle\":\"test\"}}}"
+    quantized_body = "{\"query\":{\"match\":{\"subtitle\":\"?\"}}}"
+    assert_equal(quantized_body, Datadog::Contrib::Elasticsearch::Quantize.format_body(body, exclude: [:title]))
   end
 end

--- a/test/contrib/elasticsearch/transport_test.rb
+++ b/test/contrib/elasticsearch/transport_test.rb
@@ -55,7 +55,7 @@ class ESTransportTest < Minitest::Test
     assert_equal('PUT', span.get_tag('elasticsearch.method'))
     assert_equal('201', span.get_tag('http.status_code'))
     assert_equal("{\"refresh\":true\}", span.get_tag('elasticsearch.params'))
-    assert_equal('{"data1":"D1","data2":"D2"}', span.get_tag('elasticsearch.body'))
+    assert_equal('{"data1":"?","data2":"?"}', span.get_tag('elasticsearch.body'))
   end
 
   def roundtrip_put
@@ -71,7 +71,7 @@ class ESTransportTest < Minitest::Test
     assert_equal('PUT', span.get_tag('elasticsearch.method'))
     assert_equal('201', span.get_tag('http.status_code'))
     assert_equal("{\"refresh\":true\}", span.get_tag('elasticsearch.params'))
-    assert_equal('{"data1":"D1","data2":"D2"}', span.get_tag('elasticsearch.body'))
+    assert_equal('{"data1":"?","data2":"?"}', span.get_tag('elasticsearch.body'))
   end
 
   def roundtrip_get


### PR DESCRIPTION
Adds enhanced quantization for ElasticSearch body tags. This behavior is activated by default, but can be configured with:

```ruby
Datadog.configure do |c|
  c.use :elasticsearch, quantize: { show: [:category_id], exclude: [:edit_date] }
end
```

Which would change:

```
{"query":{"match":{"title":"?","category_id":"?","edit_date":"?"}}}
```

Into:

```
{"query":{"match":{"title":"?","category_id":"285"}}}
```