### PR TITLE
Revert "Use rack compliant keys"

### DIFF
--- a/lib/ddtrace/contrib/grape/endpoint.rb
+++ b/lib/ddtrace/contrib/grape/endpoint.rb
@@ -71,7 +71,7 @@ module Datadog
             span.resource = resource
 
             # set the request span resource if it's a `rack.request` span
-            request_span = payload[:env][Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
+            request_span = payload[:env][:datadog_rack_request_span]
             if !request_span.nil? && request_span.name == 'rack.request'
               request_span.resource = resource
             end

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -13,8 +13,6 @@ module Datadog
       # application. If request tags are not set by the app, they will be set using
       # information available at the Rack level.
       class TraceMiddleware
-        RACK_REQUEST_SPAN = 'datadog.rack_request_span'.freeze
-
         def initialize(app)
           @app = app
         end
@@ -37,7 +35,7 @@ module Datadog
           # start a new request span and attach it to the current Rack environment;
           # we must ensure that the span `resource` is set later
           request_span = tracer.trace('rack.request', trace_options)
-          env[RACK_REQUEST_SPAN] = request_span
+          env[:datadog_rack_request_span] = request_span
 
           # Copy the original env, before the rest of the stack executes.
           # Values may change; we want values before that happens.

--- a/test/contrib/rack/helpers.rb
+++ b/test/contrib/rack/helpers.rb
@@ -40,7 +40,7 @@ class RackBaseTest < Minitest::Test
         run(proc do |env|
           # this should be considered a web framework that can alter
           # the request span after routing / controller processing
-          request_span = env['datadog.rack_request_span']
+          request_span = env[:datadog_rack_request_span]
           request_span.resource = 'GET /app/'
           request_span.set_tag('http.method', 'GET_V2')
           request_span.set_tag('http.status_code', 201)
@@ -54,7 +54,7 @@ class RackBaseTest < Minitest::Test
         run(proc do |env|
           # this should be considered a web framework that can alter
           # the request span after routing / controller processing
-          request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
+          request_span = env[:datadog_rack_request_span]
           request_span.status = 1
           request_span.set_tag('error.stack', 'Handled exception')
 
@@ -66,7 +66,7 @@ class RackBaseTest < Minitest::Test
         run(proc do |env|
           # this should be considered a web framework that can alter
           # the request span after routing / controller processing
-          request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
+          request_span = env[:datadog_rack_request_span]
           request_span.set_tag('error.stack', 'Handled exception')
 
           [500, { 'Content-Type' => 'text/html' }, 'OK']


### PR DESCRIPTION
Although we'd like to apply this change at some point, we merged it too early. This constitutes a breaking change, since some users might be depending upon Rack's `env[:datadog_rack_request_span]`.

We'll roll this out again for a minor release as a breaking change, perhaps in 0.12.0 or a future version.

Reverts DataDog/dd-trace-rb#338

