### PR TITLE
Use Rack compliant keys with deprecation

### DIFF
--- a/lib/ddtrace/contrib/grape/endpoint.rb
+++ b/lib/ddtrace/contrib/grape/endpoint.rb
@@ -71,7 +71,7 @@ module Datadog
             span.resource = resource
 
             # set the request span resource if it's a `rack.request` span
-            request_span = payload[:env][:datadog_rack_request_span]
+            request_span = payload[:env][Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
             if !request_span.nil? && request_span.name == 'rack.request'
               request_span.resource = resource
             end

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -43,6 +43,9 @@ module Datadog
           #       Will be removed in version 0.13.0.
           env[:datadog_rack_request_span] = env[RACK_REQUEST_SPAN]
 
+          # Add deprecation warnings
+          add_deprecation_warnings(env)
+
           # Copy the original env, before the rest of the stack executes.
           # Values may change; we want values before that happens.
           original_env = env.dup
@@ -144,6 +147,34 @@ module Datadog
         def get_request_id(headers, env)
           headers ||= {}
           headers['X-Request-Id'] || headers['X-Request-ID'] || env['HTTP_X_REQUEST_ID']
+        end
+
+        private
+
+        REQUEST_SPAN_DEPRECATION_WARNING = %(
+          :datadog_rack_request_span is considered an internal symbol in the Rack env,
+          and has been been DEPRECATED. Public support for its usage is discontinued.
+          If you need the Rack request span, try using `Datadog.tracer.active_span`.
+          This key will be removed in version 0.13.0).freeze
+
+        def add_deprecation_warnings(env)
+          env.instance_eval do
+            def [](key)
+              if key == :datadog_rack_request_span && !@request_span_warning_issued
+                Datadog::Tracer.log.warn(REQUEST_SPAN_DEPRECATION_WARNING)
+                @request_span_warning_issued = true
+              end
+              super
+            end
+
+            def []=(key, value)
+              if key == :datadog_rack_request_span && !@request_span_warning_issued
+                Datadog::Tracer.log.warn(REQUEST_SPAN_DEPRECATION_WARNING)
+                @request_span_warning_issued = true
+              end
+              super
+            end
+          end
         end
       end
     end

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -13,6 +13,8 @@ module Datadog
       # application. If request tags are not set by the app, they will be set using
       # information available at the Rack level.
       class TraceMiddleware
+        RACK_REQUEST_SPAN = 'datadog.rack_request_span'.freeze
+
         def initialize(app)
           @app = app
         end
@@ -35,7 +37,11 @@ module Datadog
           # start a new request span and attach it to the current Rack environment;
           # we must ensure that the span `resource` is set later
           request_span = tracer.trace('rack.request', trace_options)
-          env[:datadog_rack_request_span] = request_span
+          env[RACK_REQUEST_SPAN] = request_span
+
+          # TODO: For backwards compatibility; this attribute is deprecated.
+          #       Will be removed in version 0.13.0.
+          env[:datadog_rack_request_span] = env[RACK_REQUEST_SPAN]
 
           # Copy the original env, before the rest of the stack executes.
           # Values may change; we want values before that happens.

--- a/test/contrib/rack/helpers.rb
+++ b/test/contrib/rack/helpers.rb
@@ -40,7 +40,7 @@ class RackBaseTest < Minitest::Test
         run(proc do |env|
           # this should be considered a web framework that can alter
           # the request span after routing / controller processing
-          request_span = env[:datadog_rack_request_span]
+          request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
           request_span.resource = 'GET /app/'
           request_span.set_tag('http.method', 'GET_V2')
           request_span.set_tag('http.status_code', 201)
@@ -54,7 +54,7 @@ class RackBaseTest < Minitest::Test
         run(proc do |env|
           # this should be considered a web framework that can alter
           # the request span after routing / controller processing
-          request_span = env[:datadog_rack_request_span]
+          request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
           request_span.status = 1
           request_span.set_tag('error.stack', 'Handled exception')
 
@@ -66,7 +66,7 @@ class RackBaseTest < Minitest::Test
         run(proc do |env|
           # this should be considered a web framework that can alter
           # the request span after routing / controller processing
-          request_span = env[:datadog_rack_request_span]
+          request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
           request_span.set_tag('error.stack', 'Handled exception')
 
           [500, { 'Content-Type' => 'text/html' }, 'OK']


### PR DESCRIPTION
This pull request is a reissue of #338 , which fixed an issue with use of symbols with Rack, by converting a key to a string instead.

That pull request had to be reverted since it introduced a breaking change for anyone dependent on `env[:datadog_rack_request_span]`. This pull request seeks to re-add those changes, but with backwards compatibility and a deprecation warning.

In a future version, likely 0.13.0, we will remove both the deprecation warning and the backwards compatibility present here.