### PR TITLE
Fix HTTPTransport sampling callback for services

### DIFF
--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -117,8 +117,8 @@ module Datadog
 
     private
 
-    def sampling_updater(response, api)
-      return unless response.is_a?(Net::HTTPOK)
+    def sampling_updater(action, response, api)
+      return unless action == :traces && response.is_a?(Net::HTTPOK)
 
       if api[:version] == HTTPTransport::V4
         service_rates = JSON.parse(response.body)

--- a/spec/support/http_helpers.rb
+++ b/spec/support/http_helpers.rb
@@ -2,9 +2,11 @@ module HttpHelpers
   def mock_http_request(options = {})
     http_method = options[:method] || :get
     uri = URI.parse('http://localhost:3000/mock_response')
+    body = options[:body] || ''
+    status = options[:status] || 200
 
     # Stub request
-    stub = stub_request(http_method, uri).to_return(body: (options[:body] || ''))
+    stub = stub_request(http_method, uri).to_return(body: body, status: status)
 
     # Create the HTTP objects
     http = Net::HTTP.new(uri.host, uri.port)


### PR DESCRIPTION
If priority sampling is enabled, and HTTPTransport attempts to write service spans to the agent, it will trigger the sampling updater callback which will try to process the services response (which is `OK`) as a traces response (which is JSON), resulting in lots of parse errors.

This pull request passes the action as a parameter to the callback, so it can use that information to change how it handles responses.

Should be rebased and merged after #369.

Side note; this should probably be considered a stop-gap measure. There's a lot of coupling between Writer, Transport, and the concept of "API" which makes this design fairly brittle. Would recommend a refactor in the future.