### PR TITLE
Add URL query string quantization to Rack

### DIFF
--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -104,7 +104,8 @@ module Datadog
             request_span.set_tag(Datadog::Ext::HTTP::METHOD, env['REQUEST_METHOD'])
           end
           if request_span.get_tag(Datadog::Ext::HTTP::URL).nil?
-            request_span.set_tag(Datadog::Ext::HTTP::URL, url)
+            options = Datadog.configuration[:rack][:quantize]
+            request_span.set_tag(Datadog::Ext::HTTP::URL, Datadog::Quantization::HTTP.url(url, options))
           end
           if request_span.get_tag(Datadog::Ext::HTTP::BASE_URL).nil?
             request_obj = ::Rack::Request.new(env)

--- a/lib/ddtrace/contrib/rack/patcher.rb
+++ b/lib/ddtrace/contrib/rack/patcher.rb
@@ -8,6 +8,7 @@ module Datadog
         option :tracer, default: Datadog.tracer
         option :distributed_tracing, default: false
         option :middleware_names, default: false
+        option :quantize, default: {}
         option :application
         option :service_name, default: 'rack', depends_on: [:tracer] do |value|
           get_option(:tracer).set_service_info(value, 'rack', Ext::AppTypes::WEB)

--- a/test/contrib/rack/middleware_test.rb
+++ b/test/contrib/rack/middleware_test.rb
@@ -64,6 +64,35 @@ class TracerTest < RackBaseTest
     assert_equal('200', span.get_tag('http.status_code'))
     # Since REQUEST_URI is set (usually provided by WEBrick/Puma)
     # it uses REQUEST_URI, which has query string parameters.
+    # However, that query string will be quantized.
+    assert_equal('/success?foo', span.get_tag('http.url'))
+    assert_equal('http://example.org', span.get_tag('http.base_url'))
+    assert_equal(0, span.status)
+    assert_nil(span.parent)
+  end
+
+  def test_request_middleware_get_with_request_uri_and_quantize_option
+    Datadog.configure do |c|
+      c.use :rack, quantize: { query: { show: ['foo'] } }
+    end
+
+    # ensure the Rack request is properly traced
+    get '/success?foo=bar', {}, 'REQUEST_URI' => '/success?foo=bar'
+    assert last_response.ok?
+
+    spans = @tracer.writer.spans
+    assert_equal(1, spans.length)
+
+    span = spans[0]
+    assert_equal('rack.request', span.name)
+    assert_equal('http', span.span_type)
+    assert_equal('rack', span.service)
+    assert_equal('GET 200', span.resource)
+    assert_equal('GET', span.get_tag('http.method'))
+    assert_equal('200', span.get_tag('http.status_code'))
+    # Since REQUEST_URI is set (usually provided by WEBrick/Puma)
+    # it uses REQUEST_URI, which has query string parameters.
+    # However, that query string will be quantized.
     assert_equal('/success?foo=bar', span.get_tag('http.url'))
     assert_equal('http://example.org', span.get_tag('http.base_url'))
     assert_equal(0, span.status)


### PR DESCRIPTION
Adds quantization for Rack URL query string parameters. This behavior is activated by default, but can be configured with:

```
Datadog.configure do |c|
  # Default behavior: all values are quantized, fragment is removed.
  # http://example.com/path?category_id=1&sort_by=asc#featured --> http://example.com/path?category_id&sort_by
  # http://example.com/path?categories[]=1&categories[]=2 --> http://example.com/path?categories[]

  # Show values for any query string parameter matching 'category_id' exactly
  # http://example.com/path?category_id=1&sort_by=asc#featured --> http://example.com/path?category_id=1&sort_by
  c.use :rack, quantize: { query: { show: ['category_id'] } }

  # Show all values for all query string parameters
  # http://example.com/path?category_id=1&sort_by=asc#featured --> http://example.com/path?category_id=1&sort_by=asc
  c.use :rack, quantize: { query: { show: :all } }

  # Totally exclude any query string parameter matching 'sort_by' exactly
  # http://example.com/path?category_id=1&sort_by=asc#featured --> http://example.com/path?category_id
  c.use :rack, quantize: { query: { exclude: ['sort_by'] } }

  # Remove the query string entirely
  # http://example.com/path?category_id=1&sort_by=asc#featured --> http://example.com/path
  c.use :rack, quantize: { query: { exclude: :all } }

  # Show URL fragments
  # http://example.com/path?category_id=1&sort_by=asc#featured --> http://example.com/path?category_id&sort_by#featured
  c.use :rack, quantize: { fragment: :show }
end
```