### PR TITLE
Change span.resource to use AWS command name

### DIFF
--- a/lib/ddtrace/contrib/aws/instrumentation.rb
+++ b/lib/ddtrace/contrib/aws/instrumentation.rb
@@ -27,7 +27,7 @@ module Datadog
         def annotate!(span, pin, context)
           span.service = pin.service
           span.span_type = pin.app_type
-          span.name = context.safely(:resource)
+          span.name = RESOURCE
           span.resource = context.safely(:resource)
           span.set_tag('aws.agent', AGENT)
           span.set_tag('aws.operation', context.safely(:operation))

--- a/lib/ddtrace/contrib/aws/instrumentation.rb
+++ b/lib/ddtrace/contrib/aws/instrumentation.rb
@@ -28,7 +28,7 @@ module Datadog
           span.service = pin.service
           span.span_type = pin.app_type
           span.name = context.safely(:resource)
-          span.resource = RESOURCE
+          span.resource = context.safely(:resource)
           span.set_tag('aws.agent', AGENT)
           span.set_tag('aws.operation', context.safely(:operation))
           span.set_tag('aws.region', context.safely(:region))

--- a/test/contrib/aws/instrumentation_test.rb
+++ b/test/contrib/aws/instrumentation_test.rb
@@ -32,7 +32,7 @@ module Datadog
           assert_equal('s3.list_buckets', aws_span.name)
           assert_equal('aws', aws_span.service)
           assert_equal('web', aws_span.span_type)
-          assert_equal('aws.command', aws_span.resource)
+          assert_equal('s3.list_buckets', aws_span.resource)
           # check Span tags
           assert_equal('aws-sdk-ruby', aws_span.get_tag('aws.agent'))
           assert_equal('list_buckets', aws_span.get_tag('aws.operation'))

--- a/test/contrib/aws/instrumentation_test.rb
+++ b/test/contrib/aws/instrumentation_test.rb
@@ -29,7 +29,7 @@ module Datadog
           aws_span = all_spans[0]
 
           # check Span attributes
-          assert_equal('s3.list_buckets', aws_span.name)
+          assert_equal('aws.command', aws_span.name)
           assert_equal('aws', aws_span.service)
           assert_equal('web', aws_span.span_type)
           assert_equal('s3.list_buckets', aws_span.resource)


### PR DESCRIPTION
As per issue https://github.com/DataDog/dd-trace-rb/issues/374, this PR goal is to make the AWS service page behave in a similar way to other services such as Rails/Web/Redis... 

As I see it `aws.command` label does not add any value in either the service page or trace view, since AWS service will alread be defined by `AWS` by default, we can easily find out that traces are coming from there.

On the service page what we want to see is a list of methods/actions and how they are performing, each method can then be further drilled down for related traces.

The current behaviour :

![image](https://user-images.githubusercontent.com/6594266/37643632-798c28ae-2c21-11e8-8ad1-63e8e35aa0ba.png)

With this PR the service be would have each method listed : 

![image](https://user-images.githubusercontent.com/6594266/37682487-f95b0a9c-2c89-11e8-806c-32b12c5c00f5.png)