### PR TITLE
Use ActiveSupport::Notifications::Subscriber with Racecar

### DIFF
--- a/spec/ddtrace/contrib/racecar/patcher_spec.rb
+++ b/spec/ddtrace/contrib/racecar/patcher_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe 'Racecar patcher' do
     Datadog.configure do |c|
       c.use :racecar, tracer: tracer
     end
+
+    # Make sure to update the subscription tracer,
+    # so we aren't writing to a stale tracer.
+    if Datadog::Contrib::Racecar::Patcher.patched?
+      Datadog::Contrib::Racecar::Patcher.subscriptions.each do |subscription|
+        allow(subscription).to receive(:tracer).and_return(tracer)
+      end
+    end
   end
 
   describe 'for single message processing' do


### PR DESCRIPTION
This pull request refactors the Racecar integration to use the `ActiveSupport::Notifications::Subscriber` module.

Is currently base on the parent PR #380, which must be merged first.