### PR TITLE
Pin mysql2 < 0.5.0 to prevent CI build from breaking

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -57,7 +57,7 @@ if RUBY_VERSION < '2.4.0' && RUBY_PLATFORM != 'java'
   if RUBY_VERSION >= '2.1.10'
     appraise 'rails4-mysql2' do
       gem 'rails', '4.2.7.1'
-      gem 'mysql2', platform: :ruby
+      gem 'mysql2', '< 0.5', platform: :ruby
       gem 'activerecord-jdbcmysql-adapter', platform: :jruby
     end
 
@@ -79,7 +79,7 @@ if RUBY_VERSION < '2.4.0' && RUBY_PLATFORM != 'java'
   if RUBY_VERSION >= '2.2.2'
     appraise 'rails5-mysql2' do
       gem 'rails', '5.0.1'
-      gem 'mysql2', platform: :ruby
+      gem 'mysql2', '< 0.5', platform: :ruby
     end
 
     appraise 'rails5-postgres' do
@@ -129,7 +129,7 @@ if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM != 'java'
     gem 'dalli'
     gem 'resque', '< 2.0'
     gem 'racecar', '>= 0.3.5'
-    gem 'mysql2', platform: :ruby
+    gem 'mysql2', '< 0.5', platform: :ruby
   end
 else
   appraise 'contrib-old' do

--- a/gemfiles/contrib.gemfile
+++ b/gemfiles/contrib.gemfile
@@ -19,6 +19,6 @@ gem "sucker_punch"
 gem "dalli"
 gem "resque", "< 2.0"
 gem "racecar", ">= 0.3.5"
-gem "mysql2", platform: :ruby
+gem "mysql2", "< 0.5", platform: :ruby
 
 gemspec path: "../"

--- a/gemfiles/rails4_mysql2.gemfile
+++ b/gemfiles/rails4_mysql2.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "rails", "4.2.7.1"
-gem "mysql2", platform: :ruby
+gem "mysql2", "< 0.5", platform: :ruby
 gem "activerecord-jdbcmysql-adapter", platform: :jruby
 
 gemspec path: "../"

--- a/gemfiles/rails5_mysql2.gemfile
+++ b/gemfiles/rails5_mysql2.gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 
 gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
 gem "rails", "5.0.1"
-gem "mysql2", platform: :ruby
+gem "mysql2", "< 0.5", platform: :ruby
 
 gemspec path: "../"


### PR DESCRIPTION
`mysql2` version 0.5.0 was released yesterday, and following in ActiveRecord tradition, new adapter versions break ActiveRecord, which in turn is breaking our CI build.

This pull request pins the gem version to < 0.5.0, until the Rails guys fix the issue. See https://github.com/rails/rails/pull/32310.