### PR TITLE
Use correct ActiveRecord connection for `sql.active_record` events

### DIFF
--- a/lib/ddtrace/contrib/rails/active_record.rb
+++ b/lib/ddtrace/contrib/rails/active_record.rb
@@ -24,14 +24,11 @@ module Datadog
         def self.sql(_name, start, finish, _id, payload)
           tracer = Datadog.configuration[:rails][:tracer]
           database_service = Datadog.configuration[:rails][:database_service]
-          adapter_name = Datadog::Contrib::Rails::Utils.adapter_name
-          database_name = Datadog::Contrib::Rails::Utils.database_name
-          adapter_host = Datadog::Contrib::Rails::Utils.adapter_host
-          adapter_port = Datadog::Contrib::Rails::Utils.adapter_port
+          connection_config = Datadog::Contrib::Rails::Utils.connection_config(payload[:connection_id])
           span_type = Datadog::Ext::SQL::TYPE
 
           span = tracer.trace(
-            "#{adapter_name}.query",
+            "#{connection_config[:adapter_name]}.query",
             resource: payload.fetch(:sql),
             service: database_service,
             span_type: span_type
@@ -46,11 +43,11 @@ module Datadog
           # so that the ``sql.query`` tag will be set in the agent with an
           # obfuscated version
           span.span_type = Datadog::Ext::SQL::TYPE
-          span.set_tag('rails.db.vendor', adapter_name)
-          span.set_tag('rails.db.name', database_name)
+          span.set_tag('rails.db.vendor', connection_config[:adapter_name])
+          span.set_tag('rails.db.name', connection_config[:database_name])
           span.set_tag('rails.db.cached', cached) if cached
-          span.set_tag('out.host', adapter_host)
-          span.set_tag('out.port', adapter_port)
+          span.set_tag('out.host', connection_config[:adapter_host])
+          span.set_tag('out.port', connection_config[:adapter_port])
           span.start_time = start
           span.finish(finish)
         rescue StandardError => e

--- a/lib/ddtrace/contrib/rails/utils.rb
+++ b/lib/ddtrace/contrib/rails/utils.rb
@@ -47,29 +47,64 @@ module Datadog
         end
 
         def self.adapter_name
-          normalize_vendor(connection_config[:adapter])
+          connection_config[:adapter_name]
         end
 
         def self.database_name
-          connection_config[:database]
+          connection_config[:database_name]
         end
 
         def self.adapter_host
-          connection_config[:host]
+          connection_config[:adapter_host]
         end
 
         def self.adapter_port
-          connection_config[:port]
+          connection_config[:adapter_port]
         end
 
-        def self.connection_config
-          @connection_config ||= begin
-            if defined?(::ActiveRecord::Base.connection_config)
-              ::ActiveRecord::Base.connection_config
-            else
-              ::ActiveRecord::Base.connection_pool.spec.config
-            end
+        def self.connection_config(object_id = nil)
+          config = object_id.nil? ? default_connection_config : connection_config_by_id(object_id)
+          {
+            adapter_name: normalize_vendor(config[:adapter]),
+            adapter_host: config[:host],
+            adapter_port: config[:port],
+            database_name: config[:database]
+          }
+        end
+
+        # Attempt to retrieve the connection from an object ID.
+        def self.connection_by_id(object_id)
+          return nil if object_id.nil?
+          ObjectSpace._id2ref(object_id)
+        rescue StandardError
+          nil
+        end
+
+        # Attempt to retrieve the connection config from an object ID.
+        # Typical of ActiveSupport::Notifications `sql.active_record`
+        def self.connection_config_by_id(object_id)
+          connection = connection_by_id(object_id)
+          return {} if connection.nil?
+
+          if connection.instance_variable_defined?(:@config)
+            connection.instance_variable_get(:@config)
+          else
+            {}
           end
+        end
+
+        def self.default_connection_config
+          return @default_connection_config unless @default_connection_config.nil?
+          current_connection_name = if ::ActiveRecord::Base.respond_to?(:connection_specification_name)
+                                      ::ActiveRecord::Base.connection_specification_name
+                                    else
+                                      ::ActiveRecord::Base
+                                    end
+
+          connection_pool = ::ActiveRecord::Base.connection_handler.retrieve_connection_pool(current_connection_name)
+          connection_pool.nil? ? {} : (@default_connection_config = connection_pool.spec.config)
+        rescue StandardError
+          {}
         end
 
         def self.exception_is_error?(exception)
@@ -83,8 +118,6 @@ module Datadog
             true
           end
         end
-
-        private_class_method :connection_config
       end
     end
   end

--- a/test/contrib/rails/tracer_test.rb
+++ b/test/contrib/rails/tracer_test.rb
@@ -29,6 +29,7 @@ class TracerTest < ActionDispatch::IntegrationTest
     services = Datadog.configuration[:rails][:tracer].services
     Datadog::Contrib::Rails::Framework.setup
     adapter_name = get_adapter_name()
+    refute_equal(adapter_name, 'defaultdb')
     assert_equal(
       {
         app_name => {


### PR DESCRIPTION
Our previous implementation of connection configuration was always getting a default adapter configuration and using that to populate host, port and database tags for `sql.active_record` events.

This pull request adds functionality to retrieve more accurate information when the connection object ID is available, which is supplied in the payload for `sql.active_record`. With this change, we use that connection to populate the tags for ActiveRecord traces.

Such a change should represent a step forward in supporting multi-DB setups although we have yet to add support for configuring different DB connections as different services.

#### Example

For a request that creates the following records into different databases with sharding via `active_record_shards`:

<img width="530" alt="screen shot 2018-03-26 at 11 34 51 am" src="https://user-images.githubusercontent.com/3237131/37916446-dac7a3d8-30e9-11e8-8773-ec23bd191a9c.png">

The resulting trace which tags different DB connections per query. Notice the database name of highlighted span (which correlates to `Article 2`):

<img width="1345" alt="screen shot 2018-03-26 at 11 31 40 am" src="https://user-images.githubusercontent.com/3237131/37916321-866e166e-30e9-11e8-95da-c6e47debf7e7.png">

The same trace, different span (corresponding to `Article 3`) using other shard:

<img width="1341" alt="screen shot 2018-03-26 at 11 31 52 am" src="https://user-images.githubusercontent.com/3237131/37916396-bef0849a-30e9-11e8-838c-37294e3c8b75.png">
