### PR TITLE
CI: Test Rails 5.1 instead of Rails 5.0

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -78,24 +78,24 @@ if RUBY_VERSION < '2.4.0' && RUBY_PLATFORM != 'java'
 
   if RUBY_VERSION >= '2.2.2'
     appraise 'rails5-mysql2' do
-      gem 'rails', '5.0.1'
+      gem 'rails', '5.1.5'
       gem 'mysql2', '< 0.5', platform: :ruby
     end
 
     appraise 'rails5-postgres' do
-      gem 'rails', '5.0.1'
+      gem 'rails', '5.1.5'
       gem 'pg', '< 1.0', platform: :ruby
     end
 
     appraise 'rails5-postgres-redis' do
-      gem 'rails', '5.0.1'
+      gem 'rails', '5.1.5'
       gem 'pg', '< 1.0', platform: :ruby
       gem 'redis-rails'
       gem 'redis'
     end
 
     appraise 'rails5-postgres-sidekiq' do
-      gem 'rails', '5.0.1'
+      gem 'rails', '5.1.5'
       gem 'pg', '< 1.0', platform: :ruby
       gem 'sidekiq'
       gem 'activejob'

--- a/gemfiles/rails5_mysql2.gemfile
+++ b/gemfiles/rails5_mysql2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
-gem "rails", "5.0.1"
+gem "rails", "5.1.5"
 gem "mysql2", "< 0.5", platform: :ruby
 
 gemspec path: "../"

--- a/gemfiles/rails5_postgres.gemfile
+++ b/gemfiles/rails5_postgres.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
-gem "rails", "5.0.1"
+gem "rails", "5.1.5"
 gem "pg", "< 1.0", platform: :ruby
 
 gemspec path: "../"

--- a/gemfiles/rails5_postgres_redis.gemfile
+++ b/gemfiles/rails5_postgres_redis.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
-gem "rails", "5.0.1"
+gem "rails", "5.1.5"
 gem "pg", "< 1.0", platform: :ruby
 gem "redis-rails"
 gem "redis"

--- a/gemfiles/rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/rails5_postgres_sidekiq.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
-gem "rails", "5.0.1"
+gem "rails", "5.1.5"
 gem "pg", "< 1.0", platform: :ruby
 gem "sidekiq"
 gem "activejob"

--- a/test/contrib/rails/apps/application.rb
+++ b/test/contrib/rails/apps/application.rb
@@ -45,7 +45,6 @@ module RailsTrace
         c.use :rails
         c.use :redis
       end
-      Rails.application.config.active_job.queue_adapter = :sidekiq
 
       # Initialize the Rails application
       require 'contrib/rails/apps/controllers'

--- a/test/contrib/rails/test_helper.rb
+++ b/test/contrib/rails/test_helper.rb
@@ -68,7 +68,7 @@ ENV['DATABASE_URL'] = connector
 logger.info "Testing against Rails #{Rails.version} with connector '#{connector}'"
 
 case Rails.version
-when '5.0.1'
+when '5.0.1', '5.1.5'
   require 'contrib/rails/apps/rails5'
 when '4.2.7.1'
   require 'contrib/rails/apps/rails4'


### PR DESCRIPTION
This pull request updates our appraisal to test Rails 5.1 instead of Rails 5.0.