### PR TITLE
[faraday] Add hostname to faraday annotation

### DIFF
--- a/lib/ddtrace/contrib/faraday/middleware.rb
+++ b/lib/ddtrace/contrib/faraday/middleware.rb
@@ -30,7 +30,7 @@ module Datadog
         attr_reader :app, :options, :tracer
 
         def annotate!(span, env)
-          span.resource = env[:method].to_s.upcase
+          span.resource = [env[:method].to_s.upcase, env[:url].host].join(" ")
           span.service = service_name(env)
           span.span_type = Ext::HTTP::TYPE
           span.set_tag(Ext::HTTP::URL, env[:url].path)

--- a/lib/ddtrace/contrib/faraday/middleware.rb
+++ b/lib/ddtrace/contrib/faraday/middleware.rb
@@ -30,7 +30,7 @@ module Datadog
         attr_reader :app, :options, :tracer
 
         def annotate!(span, env)
-          span.resource = [env[:method].to_s.upcase, env[:url].host].join(" ")
+          span.resource = [env[:method].to_s.upcase, env[:url].host].join(' ')
           span.service = service_name(env)
           span.span_type = Ext::HTTP::TYPE
           span.set_tag(Ext::HTTP::URL, env[:url].path)

--- a/test/contrib/faraday/middleware_test.rb
+++ b/test/contrib/faraday/middleware_test.rb
@@ -33,7 +33,7 @@ module Datadog
 
           assert_equal(SERVICE, span.service)
           assert_equal(NAME, span.name)
-          assert_equal('GET', span.resource)
+          assert_equal('GET example.com', span.resource)
           assert_equal('GET', span.get_tag(Ext::HTTP::METHOD))
           assert_equal('200', span.get_tag(Ext::HTTP::STATUS_CODE))
           assert_equal('/success', span.get_tag(Ext::HTTP::URL))
@@ -49,7 +49,7 @@ module Datadog
 
           assert_equal(SERVICE, span.service)
           assert_equal(NAME, span.name)
-          assert_equal('POST', span.resource)
+          assert_equal('POST example.com', span.resource)
           assert_equal('POST', span.get_tag(Ext::HTTP::METHOD))
           assert_equal('/failure', span.get_tag(Ext::HTTP::URL))
           assert_equal('500', span.get_tag(Ext::HTTP::STATUS_CODE))
@@ -82,7 +82,7 @@ module Datadog
 
           assert_equal(span.name, NAME)
           assert_equal(span.service, 'example.com')
-          assert_equal(span.resource, 'GET')
+          assert_equal(span.resource, 'GET example.com')
         end
 
         def test_default_tracing_headers


### PR DESCRIPTION
Faraday integration is not very informative right now:
![screen shot 2018-03-29 at 5 29 07 pm](https://user-images.githubusercontent.com/833724/38081522-d68fcdd8-3376-11e8-98d8-2ffb3cfde9cc.png)
So i added hostname to the resource name