### PR TITLE
Make documentation more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ databases and microservices so that developers have great visiblity into bottlen
 
 ## Getting started
 
-For installation instructions, check out our [setup documenation][setup docs].
+For a basic product overview, check out our [setup documentation][setup docs].
 
-For configuration instructions and details about using the API, check out our [API documentation][api docs] and [gem documentation][gem docs].
+For installation, configuration, and details about using the API, check out our [API documentation][api docs] and [gem documentation][gem docs].
 
-For descriptions of terminology used in APM, take a look at the [official documentation][terminology docs].
+For descriptions of terminology used in APM, take a look at the [official documentation][visualization docs].
 
 [setup docs]: https://docs.datadoghq.com/tracing/setup/ruby/
 [api docs]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md
 [gem docs]: http://gems.datadoghq.com/trace/docs/
-[terminology docs]: https://docs.datadoghq.com/tracing/terminology/
+[visualization docs]: https://docs.datadoghq.com/tracing/visualization/
 
 ## Development
 
@@ -35,23 +35,7 @@ You can launch tests using the following Rake commands:
     ...
 
 Run ``rake --tasks`` for the list of available Rake tasks.
-
-Available appraisals are:
-
-* ``contrib``: default for integrations
-* ``contrib-old``: default for integrations, with version suited for old Ruby (possibly unmaintained) versions
-* ``rails3-mysql2``: Rails3 with Mysql
-* ``rails3-postgres``: Rails 3 with Postgres
-* ``rails3-postgres-redis``: Rails 3 with Postgres and Redis
-* ``rails3-postgres-sidekiq``: Rails 3 with Postgres and Sidekiq
-* ``rails4-mysql2``: Rails4 with Mysql
-* ``rails4-postgres``: Rails 4 with Postgres
-* ``rails4-postgres-redis``: Rails 4 with Postgres and Redis
-* ``rails4-postgres-sidekiq``: Rails 4 with Postgres and Sidekiq
-* ``rails5-mysql2``: Rails5 with Mysql
-* ``rails5-postgres``: Rails 5 with Postgres
-* ``rails5-postgres-redis``: Rails 5 with Postgres and Redis
-* ``rails5-postgres-sidekiq``: Rails 5 with Postgres and Sidekiq
+Run ``appraisal list`` for the list of available appraisals.
 
 The test suite requires many backing services (PostgreSQL, MySQL, Redis, ...) and we're using
 ``docker`` and ``docker-compose`` to start these services in the CI.

--- a/README.md
+++ b/README.md
@@ -1,123 +1,22 @@
-# dd-trace-rb
+# Datadog Trace Client
 
 [![CircleCI](https://circleci.com/gh/DataDog/dd-trace-rb/tree/master.svg?style=svg&circle-token=b0bd5ef866ec7f7b018f48731bb495f2d1372cc1)](https://circleci.com/gh/DataDog/dd-trace-rb/tree/master)
 
-## Documentation
-
-You can find the latest documentation on [rubydoc.info][docs]
-
-[docs]: http://gems.datadoghq.com/trace/docs/
+``ddtrace`` is Datadog’s tracing client for Ruby. It is used to trace requests as they flow across web servers,
+databases and microservices so that developers have great visiblity into bottlenecks and troublesome requests.
 
 ## Getting started
 
-### Install
+For installation instructions, check out our [setup documenation][setup docs].
 
-Install the Ruby client with the ``gem`` command:
+For configuration instructions and details about using the API, check out our [API documentation][api docs] and [gem documentation][gem docs].
 
-```
-gem install ddtrace
-```
+For descriptions of terminology used in APM, take a look at the [official documentation][terminology docs].
 
-If you're using ``Bundler``, just update your ``Gemfile`` as follows:
-
-```ruby
-source 'https://rubygems.org'
-
-# tracing gem
-gem 'ddtrace'
-```
-
-To use a development/preview version, use:
-
-```ruby
-gem 'ddtrace', :github => 'DataDog/dd-trace-rb', :branch => 'me/my-feature-branch'
-```
-
-### Quickstart (manual instrumentation)
-
-If you aren't using a supported framework instrumentation, you may want to to manually instrument your code.
-Adding tracing to your code is very simple. As an example, let’s imagine we have a web server and we want
-to trace requests to the home page:
-
-```ruby
-require 'ddtrace'
-require 'sinatra'
-require 'active_record'
-
-# a generic tracer that you can use across your application
-tracer = Datadog.tracer
-
-get '/' do
-  tracer.trace('web.request') do |span|
-    # set some span metadata
-    span.service = 'my-web-site'
-    span.resource = '/'
-    span.set_tag('http.method', request.request_method)
-
-    # trace the activerecord call
-    tracer.trace('posts.fetch') do
-      @posts = Posts.order(created_at: :desc).limit(10)
-    end
-
-    # trace the template rendering
-    tracer.trace('template.render') do
-      erb :index
-    end
-  end
-end
-```
-
-### Quickstart (integration)
-
-Instead of doing the above manually, whenever an integration is available,
-you can activate it. The example above would become:
-
-```ruby
-require 'ddtrace'
-require 'sinatra'
-require 'active_record'
-
-Datadog.configure do |c|
-  c.use :sinatra
-  c.use :active_record
-end
-
-# now write your code naturally, it's traced automatically
-get '/' do
-  @posts = Posts.order(created_at: :desc).limit(10)
-  erb :index
-end
-```
-
-This will automatically trace any app inherited from `Sinatra::Application`.
-To trace apps inherited from `Sinatra::Base`, you should manually register
-the tracer inside your class.
-
-```ruby
-require "ddtrace"
-require "ddtrace/contrib/sinatra/tracer"
-
-class App < Sinatra::Base
-  register Datadog::Contrib::Sinatra::Tracer
-end
-```
-
-To configure the Datadog Tracer, you can define the `configure` block as follows:
-
-```ruby
-Datadog.configure do |c|
-  c.tracer enabled: false, hostname: 'trace-agent.local'
-  # [...]
-end
-```
-
-For a list of available options, check the [Tracer documentation](http://gems.datadoghq.com/trace/docs/#Configure_the_tracer).
-
-
-To know if a given framework or lib is supported by our client,
-please consult our [integrations][contrib] list.
-
-[contrib]: http://www.rubydoc.info/github/DataDog/dd-trace-rb/Datadog/Contrib
+[setup docs]: https://docs.datadoghq.com/tracing/setup/ruby/
+[api docs]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md
+[gem docs]: http://gems.datadoghq.com/trace/docs/
+[terminology docs]: https://docs.datadoghq.com/tracing/terminology/
 
 ## Development
 


### PR DESCRIPTION
Our documentation needs some love. In an effort to consolidate information, and make features and API descriptions more discoverable, this pull request reworks README and GettingStarted.

Our documentation collection should henceforth look like:

 - Quick start instructions: https://docs.datadoghq.com/tracing/setup/ruby/
 - Development and contributing: https://github.com/DataDog/dd-trace-rb/blob/master/README.md
 - Installation, configuration, API details: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md
 - Using the APM UI: https://docs.datadoghq.com/tracing/visualization/
 - Current gem documentation (same as GettingStarted): http://gems.datadoghq.com/trace/docs/
