### PR TITLE
Add request and response header tags to Rack

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -585,7 +585,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | ``tracer`` | A ``Datadog::Tracer`` instance used to instrument the application. Usually you don't need to set that. | ``Datadog.tracer`` |
 | ``request_queuing`` | Track HTTP request time spent in the queue of the frontend server. See [HTTP request queuing](#http-request-queuing) for setup details. Set to `true` to enable. | ``false`` |
 | ``web_service_name`` | Service name for frontend server request queuing spans. (e.g. `'nginx'`) | ``'web-server'`` |
-| ``headers`` | Array of HTTP request or response headers to add as tags to the `rack.request`. e.g. `['Last-Modified']`. Headers are case-sensitive. Adds `http.request.headers.*` and `http.response.headers.*` tags. | ``['Content-Type', 'X-Request-ID']`` |
+| ``headers`` | Hash of HTTP request or response headers to add as tags to the `rack.request`. Accepts `request` and `response` keys with Array values e.g. `['Last-Modified']`. Adds `http.request.headers.*` and `http.response.headers.*` tags respectively. | ``{ response: ['Content-Type', 'X-Request-ID'] }`` |
 
 **Configuring URL quantization behavior**
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -585,6 +585,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | ``tracer`` | A ``Datadog::Tracer`` instance used to instrument the application. Usually you don't need to set that. | ``Datadog.tracer`` |
 | ``request_queuing`` | Track HTTP request time spent in the queue of the frontend server. See [HTTP request queuing](#http-request-queuing) for setup details. Set to `true` to enable. | ``false`` |
 | ``web_service_name`` | Service name for frontend server request queuing spans. (e.g. `'nginx'`) | ``'web-server'`` |
+| ``headers`` | Array of HTTP request or response headers to add as tags to the `rack.request`. e.g. `['Last-Modified']`. Headers are case-sensitive. Adds `http.request.headers.*` and `http.response.headers.*` tags. | ``['Content-Type', 'X-Request-ID']`` |
 
 **Configuring URL quantization behavior**
 

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -213,6 +213,13 @@ module Datadog
             Datadog.configuration[:rack][:headers].each do |header|
               if headers.key?(header)
                 result[Datadog::Ext::HTTP::ResponseHeaders.to_tag(header)] = headers[header]
+              else
+                # For case-insensitive matching, e.g. X-Request-Id vs X-Request-ID
+                uppercased_header = header.to_s.upcase
+                uppercased_headers = headers.map { |k, v| [k.upcase, v] }.to_h
+                if uppercased_headers.key?(uppercased_header)
+                  result[Datadog::Ext::HTTP::ResponseHeaders.to_tag(header)] = uppercased_headers[uppercased_header]
+                end
               end
             end
           end

--- a/lib/ddtrace/contrib/rack/patcher.rb
+++ b/lib/ddtrace/contrib/rack/patcher.rb
@@ -5,10 +5,12 @@ module Datadog
       module Patcher
         include Base
 
-        DEFAULT_HEADERS = [
-          'Content-Type',
-          'X-Request-ID'
-        ].freeze
+        DEFAULT_HEADERS = {
+          response: [
+            'Content-Type',
+            'X-Request-ID'
+          ]
+        }.freeze
 
         register_as :rack
         option :tracer, default: Datadog.tracer

--- a/lib/ddtrace/contrib/rack/patcher.rb
+++ b/lib/ddtrace/contrib/rack/patcher.rb
@@ -4,6 +4,12 @@ module Datadog
       # Provides instrumentation for `rack`
       module Patcher
         include Base
+
+        DEFAULT_HEADERS = [
+          'Content-Type',
+          'X-Request-ID'
+        ].freeze
+
         register_as :rack
         option :tracer, default: Datadog.tracer
         option :distributed_tracing, default: false
@@ -21,6 +27,7 @@ module Datadog
           end
           value
         end
+        option :headers, default: DEFAULT_HEADERS
 
         module_function
 

--- a/lib/ddtrace/ext/http.rb
+++ b/lib/ddtrace/ext/http.rb
@@ -1,14 +1,61 @@
 module Datadog
   module Ext
     module HTTP
-      TYPE = 'http'.freeze
-      TEMPLATE = 'template'.freeze
-      URL = 'http.url'.freeze
       BASE_URL = 'http.base_url'.freeze
-      METHOD = 'http.method'.freeze
-      REQUEST_ID = 'http.request_id'.freeze
-      STATUS_CODE = 'http.status_code'.freeze
       ERROR_RANGE = 500...600
+      METHOD = 'http.method'.freeze
+      STATUS_CODE = 'http.status_code'.freeze
+      TEMPLATE = 'template'.freeze
+      TYPE = 'http'.freeze
+      URL = 'http.url'.freeze
+
+      # Constants for request headers
+      module RequestHeaders
+        CACHE_CONTROL = 'http.request.headers.cache_control'.freeze
+        REQUEST_ID = 'http.request.headers.request_id'.freeze
+
+        ALL = {
+          'CACHE-CONTROL' => CACHE_CONTROL,
+          'X-CORRELATION-ID' => REQUEST_ID,
+          'X-REQUEST-ID' => REQUEST_ID
+        }.freeze
+
+        private_constant :ALL
+
+        module_function
+
+        def from_name(name)
+          ALL[name.to_s.upcase.gsub(/[_\s]/, '-')]
+        end
+      end
+
+      # Constants for response headers
+      module ResponseHeaders
+        CONTENT_TYPE = 'http.response.headers.content_type'.freeze
+        CACHE_CONTROL = 'http.response.headers.cache_control'.freeze
+        ETAG = 'http.response.headers.etag'.freeze
+        EXPIRES = 'http.response.headers.expires'.freeze
+        LAST_MODIFIED = 'http.response.headers.last_modified'.freeze
+        REQUEST_ID = 'http.response.headers.request_id'.freeze
+
+        ALL = {
+          'CONTENT-TYPE' => CONTENT_TYPE,
+          'CACHE-CONTROL' => CACHE_CONTROL,
+          'ETAG' => ETAG,
+          'EXPIRES' => EXPIRES,
+          'LAST-MODIFIED' => LAST_MODIFIED,
+          'X-CORRELATION-ID' => REQUEST_ID,
+          'X-REQUEST-ID' => REQUEST_ID
+        }.freeze
+
+        private_constant :ALL
+
+        module_function
+
+        def from_name(name)
+          ALL[name.to_s.upcase.gsub(/[_\s]/, '-')]
+        end
+      end
     end
   end
 end

--- a/lib/ddtrace/ext/http.rb
+++ b/lib/ddtrace/ext/http.rb
@@ -9,51 +9,34 @@ module Datadog
       TYPE = 'http'.freeze
       URL = 'http.url'.freeze
 
-      # Constants for request headers
-      module RequestHeaders
-        CACHE_CONTROL = 'http.request.headers.cache_control'.freeze
-        REQUEST_ID = 'http.request.headers.request_id'.freeze
-
-        ALL = {
-          'CACHE-CONTROL' => CACHE_CONTROL,
-          'X-CORRELATION-ID' => REQUEST_ID,
-          'X-REQUEST-ID' => REQUEST_ID
-        }.freeze
-
-        private_constant :ALL
-
+      # General header functionality
+      module Headers
         module_function
 
-        def from_name(name)
-          ALL[name.to_s.upcase.gsub(/[_\s]/, '-')]
+        def to_tag(name)
+          name.to_s.downcase.gsub(/[-\s]/, '_')
         end
       end
 
-      # Constants for response headers
-      module ResponseHeaders
-        CONTENT_TYPE = 'http.response.headers.content_type'.freeze
-        CACHE_CONTROL = 'http.response.headers.cache_control'.freeze
-        ETAG = 'http.response.headers.etag'.freeze
-        EXPIRES = 'http.response.headers.expires'.freeze
-        LAST_MODIFIED = 'http.response.headers.last_modified'.freeze
-        REQUEST_ID = 'http.response.headers.request_id'.freeze
-
-        ALL = {
-          'CONTENT-TYPE' => CONTENT_TYPE,
-          'CACHE-CONTROL' => CACHE_CONTROL,
-          'ETAG' => ETAG,
-          'EXPIRES' => EXPIRES,
-          'LAST-MODIFIED' => LAST_MODIFIED,
-          'X-CORRELATION-ID' => REQUEST_ID,
-          'X-REQUEST-ID' => REQUEST_ID
-        }.freeze
-
-        private_constant :ALL
+      # Request headers
+      module RequestHeaders
+        PREFIX = 'http.request.headers'.freeze
 
         module_function
 
-        def from_name(name)
-          ALL[name.to_s.upcase.gsub(/[_\s]/, '-')]
+        def to_tag(name)
+          "#{PREFIX}.#{Headers.to_tag(name)}"
+        end
+      end
+
+      # Response headers
+      module ResponseHeaders
+        PREFIX = 'http.response.headers'.freeze
+
+        module_function
+
+        def to_tag(name)
+          "#{PREFIX}.#{Headers.to_tag(name)}"
         end
       end
     end

--- a/test/contrib/rack/helpers.rb
+++ b/test/contrib/rack/helpers.rb
@@ -84,6 +84,20 @@ class RackBaseTest < Minitest::Test
 
         run(handler)
       end
+
+      map '/headers/' do
+        run(proc do |_env|
+          response_headers = {
+            'Content-Type' => 'text/html',
+            'Cache-Control' => 'max-age=3600',
+            'ETag' => '"737060cd8c284d8af7ad3082f209582d"',
+            'Expires' => 'Thu, 01 Dec 1994 16:00:00 GMT',
+            'Last-Modified' => 'Tue, 15 Nov 1994 12:45:26 GMT',
+            'X-Request-ID' => 'f058ebd6-02f7-4d3f-942e-904344e8cde5'
+          }
+          [200, response_headers, 'OK']
+        end)
+      end
     end.to_app
   end
 

--- a/test/contrib/rack/helpers.rb
+++ b/test/contrib/rack/helpers.rb
@@ -93,7 +93,8 @@ class RackBaseTest < Minitest::Test
             'ETag' => '"737060cd8c284d8af7ad3082f209582d"',
             'Expires' => 'Thu, 01 Dec 1994 16:00:00 GMT',
             'Last-Modified' => 'Tue, 15 Nov 1994 12:45:26 GMT',
-            'X-Request-ID' => 'f058ebd6-02f7-4d3f-942e-904344e8cde5'
+            'X-Request-ID' => 'f058ebd6-02f7-4d3f-942e-904344e8cde5',
+            'X-Fake-Response' => 'Don\'t tag me.'
           }
           [200, response_headers, 'OK']
         end)

--- a/test/contrib/rack/middleware_test.rb
+++ b/test/contrib/rack/middleware_test.rb
@@ -361,6 +361,7 @@ class TracerTest < RackBaseTest
   end
 
   # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   def test_request_middleware_headers
     # Configure to tag headers
     Datadog.configure do |c|
@@ -371,7 +372,9 @@ class TracerTest < RackBaseTest
         'ETag',
         'Expires',
         'Last-Modified',
-        'X-Request-ID'
+        # This lowercase 'Id' header doesn't match.
+        # Ensure middleware allows for case-insensitive matching.
+        'X-Request-Id'
       ]
     end
 
@@ -411,6 +414,7 @@ class TracerTest < RackBaseTest
     assert_equal('max-age=3600', span.get_tag('http.response.headers.cache_control'))
     assert_equal('"737060cd8c284d8af7ad3082f209582d"', span.get_tag('http.response.headers.etag'))
     assert_equal('Tue, 15 Nov 1994 12:45:26 GMT', span.get_tag('http.response.headers.last_modified'))
+    assert_equal('f058ebd6-02f7-4d3f-942e-904344e8cde5', span.get_tag('http.response.headers.x_request_id'))
     # Make sure non-whitelisted headers don't become tags.
     assert_nil(span.get_tag('http.request.headers.x_fake_response'))
   end

--- a/test/contrib/rack/middleware_test.rb
+++ b/test/contrib/rack/middleware_test.rb
@@ -360,9 +360,14 @@ class TracerTest < RackBaseTest
     assert_nil(span.parent)
   end
 
-  def test_request_middleware_request_id
+  def test_request_middleware_headers
     request_id = SecureRandom.uuid
-    get '/success/', {}, 'HTTP_X_REQUEST_ID' => request_id
+    request_headers = {
+      'HTTP_CACHE_CONTROL' => 'no-cache',
+      'HTTP_X_REQUEST_ID' => request_id
+    }
+
+    get '/headers/', {}, request_headers
     assert last_response.ok?
 
     spans = @tracer.writer.spans
@@ -375,10 +380,19 @@ class TracerTest < RackBaseTest
     assert_equal('GET 200', span.resource)
     assert_equal('GET', span.get_tag('http.method'))
     assert_equal('200', span.get_tag('http.status_code'))
-    assert_equal('/success/', span.get_tag('http.url'))
+    assert_equal('/headers/', span.get_tag('http.url'))
     assert_equal('http://example.org', span.get_tag('http.base_url'))
-    assert_equal(request_id, span.get_tag('http.request_id'))
     assert_equal(0, span.status)
     assert_nil(span.parent)
+
+    # Request headers
+    assert_equal(request_id, span.get_tag('http.request.headers.request_id'))
+    assert_equal('no-cache', span.get_tag('http.request.headers.cache_control'))
+
+    # Response headers
+    assert_equal('text/html', span.get_tag('http.response.headers.content_type'))
+    assert_equal('max-age=3600', span.get_tag('http.response.headers.cache_control'))
+    assert_equal('"737060cd8c284d8af7ad3082f209582d"', span.get_tag('http.response.headers.etag'))
+    assert_equal('Tue, 15 Nov 1994 12:45:26 GMT', span.get_tag('http.response.headers.last_modified'))
   end
 end


### PR DESCRIPTION
This pull requests allows users to define which HTTP headers appear as tags on their `rack.request` span.

To do so, add the following option to your configuration:

```ruby
Datadog.configure do |c|
  # Add this request and response header as tags
  c.use :rack, headers: { request: ['Accept-Encoding'], response: ['Content-Encoding'] }
end
```

Will result in the following tags:

 - `http.request.headers.accept_encoding`
 - `http.response.headers.content_encoding`

By default, `:headers` is set to `{ response: ['Content-Type', 'X-Request-ID'] }`.

This pull request also removes `http.request_id` in favor of `http.request.headers.x_request_id` and `http.response.headers.x_request_id`.