### PR TITLE
Allow configuration of multiple databases in ActiveRecord

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,8 @@ AllCops:
   Exclude:
     - 'Appraisals'
     - '*.gemspec'
+    # TODO: Remove this when we remove Rails 3.2 support.
+    - 'lib/ddtrace/contrib/active_record/configuration/connection_specification.rb'
 
 # 80 characters is a nice goal, but not worth currently changing in existing
 # code for the sake of changing it to conform to a length set in 1928 (IBM).

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,14 @@
 AllCops:
   TargetRubyVersion: 2.1
+  Include:
+    - 'lib/**/*.rb'
+    - 'test/**/*.rb'
+    - 'spec/**/*.rb'
+    - 'Gemfile'
+    - 'Rakefile'
+  Exclude:
+    - 'Appraisals'
+    - '*.gemspec'
 
 # 80 characters is a nice goal, but not worth currently changing in existing
 # code for the sake of changing it to conform to a length set in 1928 (IBM).

--- a/Rakefile
+++ b/Rakefile
@@ -143,7 +143,7 @@ end
 
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1.0')
   RuboCop::RakeTask.new(:rubocop) do |t|
-    t.options << ['-D']
+    t.options << ['-D', '--force-exclusion']
     t.patterns = ['lib/**/*.rb', 'test/**/*.rb', 'spec/**/*.rb', 'Gemfile', 'Rakefile']
   end
 end

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -293,6 +293,40 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | --- | --- | --- |
 | ``service_name`` | Service name used for database portion of `active_record` instrumentation. | Name of database adapter (e.g. `mysql2`) |
 | ``orm_service_name`` | Service name used for the Ruby ORM portion of `active_record` instrumentation. Overrides service name for ORM spans if explicitly set, which otherwise inherit their service from their parent.  | ``active_record`` |
+| ``databases`` | Hash of tracer settings to use for each database connection. Useful if you use ActiveRecord to connect to multiple databases, and want to assign them different service names. See details below. | ``{}`` |
+
+**Configuring trace settings per database**
+
+You can provide the `databases` option to configure trace settings by database connection:
+
+```ruby
+Datadog.configure do |c|
+  c.use :active_record, service_name: 'default-db', databases: {
+    # Any of the following keys are acceptable, and equivalent to one another.
+    # Values must be a Hash, and can only contain :service_name as a setting.
+
+    # Symbol matching your database connection in config/database.yml
+    # Only available if you are using Rails with ActiveRecord.
+    secondary_database: { service_name: 'secondary-db' },
+
+    # Connection string with the following connection settings:
+    # Adapter, user, host, port, database
+    'mysql2://root@127.0.0.1:3306/mysql' => { service_name: 'secondary-db' },
+
+    # Hash with following connection settings
+    # Adapter, user, host, port, database
+    {
+      adapter:  'mysql2',
+      host:     '127.0.0.1',
+      port:     '3306',
+      database: 'mysql',
+      username: 'root'
+    } => { service_name: 'secondary-db' }
+  }
+end
+```
+
+If ActiveRecord traces an event that uses a connection described within `databases`, it will use the trace settings assigned to that connection. If the connection does not match any in the `databases` option, it will use settings defined by `c.use :active_record` instead.
 
 ### AWS
 
@@ -756,6 +790,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | ``middleware_names`` | Enables any short-circuited middleware requests to display the middleware name as resource for the trace. | `false` |
 | ``template_base_path`` | Used when the template name is parsed. If you don't store your templates in the ``views/`` folder, you may need to change this value | ``views/`` |
 | ``tracer`` | A ``Datadog::Tracer`` instance used to instrument the application. Usually you don't need to set that. | ``Datadog.tracer`` |
+| ``databases`` | Hash of tracer settings to use for each database connection. See [ActiveRecord](#activerecord) for more details. | ``{}`` |
 
 ### Rake
 

--- a/lib/ddtrace/contrib/active_record/configuration.rb
+++ b/lib/ddtrace/contrib/active_record/configuration.rb
@@ -1,0 +1,32 @@
+require 'ddtrace/contrib/active_record/configuration/handler'
+
+module Datadog
+  module Contrib
+    module ActiveRecord
+      # Provides some configuration functions for ActiveRecord tracing.
+      module Configuration
+        module_function
+
+        def database_settings(spec)
+          database_settings_handler.get(spec)
+        end
+
+        def database_settings=(config)
+          database_settings_handler.tap do |handler|
+            config.each do |spec, settings|
+              handler.set(spec, settings)
+            end
+          end
+        end
+
+        def clear_database_settings!
+          @database_settings_handler = ::Datadog::Contrib::ActiveRecord::Configuration::Handler.new
+        end
+
+        def database_settings_handler
+          @database_settings_handler ||= ::Datadog::Contrib::ActiveRecord::Configuration::Handler.new
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/active_record/configuration/connection_specification.rb
+++ b/lib/ddtrace/contrib/active_record/configuration/connection_specification.rb
@@ -1,0 +1,301 @@
+require 'uri'
+
+# NOTE: This code is copied directly from ActiveRecord.
+#       Its purpose is to resolve connection information.
+#       It exists here only because it doesn't exist in Rails 3.2.
+#       When support for Rails 3.2 is dropped, this can be removed.
+module Datadog
+  module Contrib
+    module ActiveRecord
+      module Configuration
+        # Copy/paste from:
+        # https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/connection_handling.rb
+        module ConnectionHandling
+          RAILS_ENV = -> { (Rails.env if defined?(Rails) && defined?(Rails.env)) || ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence }
+        end
+
+        # Copy/paste from:
+        # https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+        class ConnectionSpecification
+          attr_reader :name, :config, :adapter_method
+
+          def initialize(name, config, adapter_method)
+            @name, @config, @adapter_method = name, config, adapter_method
+          end
+
+          def initialize_dup(original)
+            @config = original.config.dup
+          end
+
+          def to_hash
+            @config.merge(name: @name)
+          end
+
+          # Expands a connection string into a hash.
+          class ConnectionUrlResolver # :nodoc:
+            # == Example
+            #
+            #   url = "postgresql://foo:bar@localhost:9000/foo_test?pool=5&timeout=3000"
+            #   ConnectionUrlResolver.new(url).to_hash
+            #   # => {
+            #     "adapter"  => "postgresql",
+            #     "host"     => "localhost",
+            #     "port"     => 9000,
+            #     "database" => "foo_test",
+            #     "username" => "foo",
+            #     "password" => "bar",
+            #     "pool"     => "5",
+            #     "timeout"  => "3000"
+            #   }
+            def initialize(url)
+              raise "Database URL cannot be empty" if url.blank?
+              @uri     = uri_parser.parse(url)
+              @adapter = @uri.scheme && @uri.scheme.tr("-", "_")
+              @adapter = "postgresql" if @adapter == "postgres"
+
+              if @uri.opaque
+                @uri.opaque, @query = @uri.opaque.split("?", 2)
+              else
+                @query = @uri.query
+              end
+            end
+
+            # Converts the given URL to a full connection hash.
+            def to_hash
+              config = raw_config.reject { |_, value| value.blank? }
+              config.map { |key, value| config[key] = uri_parser.unescape(value) if value.is_a? String }
+              config
+            end
+
+            private
+
+              def uri
+                @uri
+              end
+
+              def uri_parser
+                @uri_parser ||= URI::Parser.new
+              end
+
+              # Converts the query parameters of the URI into a hash.
+              #
+              #   "localhost?pool=5&reaping_frequency=2"
+              #   # => { "pool" => "5", "reaping_frequency" => "2" }
+              #
+              # returns empty hash if no query present.
+              #
+              #   "localhost"
+              #   # => {}
+              def query_hash
+                Hash[(@query || "").split("&").map { |pair| pair.split("=") }]
+              end
+
+              def raw_config
+                if uri.opaque
+                  query_hash.merge(
+                    "adapter"  => @adapter,
+                    "database" => uri.opaque)
+                else
+                  query_hash.merge(
+                    "adapter"  => @adapter,
+                    "username" => uri.user,
+                    "password" => uri.password,
+                    "port"     => uri.port,
+                    "database" => database_from_path,
+                    "host"     => uri.hostname)
+                end
+              end
+
+              # Returns name of the database.
+              def database_from_path
+                if @adapter == "sqlite3"
+                  # 'sqlite3:/foo' is absolute, because that makes sense. The
+                  # corresponding relative version, 'sqlite3:foo', is handled
+                  # elsewhere, as an "opaque".
+
+                  uri.path
+                else
+                  # Only SQLite uses a filename as the "database" name; for
+                  # anything else, a leading slash would be silly.
+
+                  uri.path.sub(%r{^/}, "")
+                end
+              end
+          end
+
+          ##
+          # Builds a ConnectionSpecification from user input.
+          class Resolver # :nodoc:
+            attr_reader :configurations
+
+            # Accepts a hash two layers deep, keys on the first layer represent
+            # environments such as "production". Keys must be strings.
+            def initialize(configurations)
+              @configurations = configurations
+            end
+
+            # Returns a hash with database connection information.
+            #
+            # == Examples
+            #
+            # Full hash Configuration.
+            #
+            #   configurations = { "production" => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3" } }
+            #   Resolver.new(configurations).resolve(:production)
+            #   # => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3"}
+            #
+            # Initialized with URL configuration strings.
+            #
+            #   configurations = { "production" => "postgresql://localhost/foo" }
+            #   Resolver.new(configurations).resolve(:production)
+            #   # => { "host" => "localhost", "database" => "foo", "adapter" => "postgresql" }
+            #
+            def resolve(config)
+              if config
+                resolve_connection config
+              elsif env = ConnectionHandling::RAILS_ENV.call
+                resolve_symbol_connection env.to_sym
+              else
+                raise AdapterNotSpecified
+              end
+            end
+
+            # Expands each key in @configurations hash into fully resolved hash
+            def resolve_all
+              config = configurations.dup
+
+              if env = ConnectionHandling::DEFAULT_ENV.call
+                env_config = config[env] if config[env].is_a?(Hash) && !(config[env].key?("adapter") || config[env].key?("url"))
+              end
+
+              config.reject! { |k, v| v.is_a?(Hash) && !(v.key?("adapter") || v.key?("url")) }
+              config.merge! env_config if env_config
+
+              config.each do |key, value|
+                config[key] = resolve(value) if value
+              end
+
+              config
+            end
+
+            # Returns an instance of ConnectionSpecification for a given adapter.
+            # Accepts a hash one layer deep that contains all connection information.
+            #
+            # == Example
+            #
+            #   config = { "production" => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3" } }
+            #   spec = Resolver.new(config).spec(:production)
+            #   spec.adapter_method
+            #   # => "sqlite3_connection"
+            #   spec.config
+            #   # => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3" }
+            #
+            def spec(config)
+              spec = resolve(config).symbolize_keys
+
+              raise(AdapterNotSpecified, "database configuration does not specify adapter") unless spec.key?(:adapter)
+
+              # Require the adapter itself and give useful feedback about
+              #   1. Missing adapter gems and
+              #   2. Adapter gems' missing dependencies.
+              path_to_adapter = "active_record/connection_adapters/#{spec[:adapter]}_adapter"
+              begin
+                require path_to_adapter
+              rescue LoadError => e
+                # We couldn't require the adapter itself. Raise an exception that
+                # points out config typos and missing gems.
+                if e.path == path_to_adapter
+                  # We can assume that a non-builtin adapter was specified, so it's
+                  # either misspelled or missing from Gemfile.
+                  raise e.class, "Could not load the '#{spec[:adapter]}' Active Record adapter. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile.", e.backtrace
+
+                # Bubbled up from the adapter require. Prefix the exception message
+                # with some guidance about how to address it and reraise.
+                else
+                  raise e.class, "Error loading the '#{spec[:adapter]}' Active Record adapter. Missing a gem it depends on? #{e.message}", e.backtrace
+                end
+              end
+
+              adapter_method = "#{spec[:adapter]}_connection"
+
+              unless ::ActiveRecord::Base.respond_to?(adapter_method)
+                raise AdapterNotFound, "database configuration specifies nonexistent #{spec.config[:adapter]} adapter"
+              end
+
+              ConnectionSpecification.new(spec.delete(:name) || "primary", spec, adapter_method)
+            end
+
+            private
+
+              # Returns fully resolved connection, accepts hash, string or symbol.
+              # Always returns a hash.
+              #
+              # == Examples
+              #
+              # Symbol representing current environment.
+              #
+              #   Resolver.new("production" => {}).resolve_connection(:production)
+              #   # => {}
+              #
+              # One layer deep hash of connection values.
+              #
+              #   Resolver.new({}).resolve_connection("adapter" => "sqlite3")
+              #   # => { "adapter" => "sqlite3" }
+              #
+              # Connection URL.
+              #
+              #   Resolver.new({}).resolve_connection("postgresql://localhost/foo")
+              #   # => { "host" => "localhost", "database" => "foo", "adapter" => "postgresql" }
+              #
+              def resolve_connection(spec)
+                case spec
+                when Symbol
+                  resolve_symbol_connection spec
+                when String
+                  resolve_url_connection spec
+                when Hash
+                  resolve_hash_connection spec
+                end
+              end
+
+              # Takes the environment such as +:production+ or +:development+.
+              # This requires that the @configurations was initialized with a key that
+              # matches.
+              #
+              #   Resolver.new("production" => {}).resolve_symbol_connection(:production)
+              #   # => {}
+              #
+              def resolve_symbol_connection(spec)
+                if config = configurations[spec.to_s]
+                  resolve_connection(config).merge("name" => spec.to_s)
+                else
+                  raise(AdapterNotSpecified, "'#{spec}' database is not configured. Available: #{configurations.keys.inspect}")
+                end
+              end
+
+              # Accepts a hash. Expands the "url" key that contains a
+              # URL database connection to a full connection
+              # hash and merges with the rest of the hash.
+              # Connection details inside of the "url" key win any merge conflicts
+              def resolve_hash_connection(spec)
+                if spec["url"] && spec["url"] !~ /^jdbc:/
+                  connection_hash = resolve_url_connection(spec.delete("url"))
+                  spec.merge!(connection_hash)
+                end
+                spec
+              end
+
+              # Takes a connection URL.
+              #
+              #   Resolver.new({}).resolve_url_connection("postgresql://localhost/foo")
+              #   # => { "host" => "localhost", "database" => "foo", "adapter" => "postgresql" }
+              #
+              def resolve_url_connection(url)
+                ConnectionUrlResolver.new(url).to_hash
+              end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/active_record/configuration/handler.rb
+++ b/lib/ddtrace/contrib/active_record/configuration/handler.rb
@@ -1,0 +1,30 @@
+require 'ddtrace/contrib/active_record/configuration/resolver'
+
+module Datadog
+  module Contrib
+    module ActiveRecord
+      module Configuration
+        # Resolves and stores configuration settings for connections
+        class Handler
+          def initialize(configurations = ::ActiveRecord::Base.configurations)
+            @resolver = Resolver.new(configurations)
+          end
+
+          def get(spec)
+            connection_config = @resolver.resolve(spec)
+            settings[connection_config] || {}
+          end
+
+          def set(spec, settings)
+            connection_config = @resolver.resolve(spec)
+            self.settings[connection_config] = settings unless connection_config.nil?
+          end
+
+          def settings
+            @settings ||= {}
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/active_record/configuration/resolver.rb
+++ b/lib/ddtrace/contrib/active_record/configuration/resolver.rb
@@ -1,0 +1,34 @@
+require 'ddtrace/contrib/active_record/configuration/connection_specification'
+
+module Datadog
+  module Contrib
+    module ActiveRecord
+      module Configuration
+        # Converts Symbols, Strings, and Hashes to a normalized connection settings Hash.
+        class Resolver
+          def initialize(configurations)
+            if defined?(::ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver)
+              @resolver = ::ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(configurations)
+            else
+              @resolver = ConnectionSpecification::Resolver.new(configurations)
+            end
+          end
+
+          def resolve(spec)
+            normalize(@resolver.resolve(spec).symbolize_keys)
+          end
+
+          def normalize(hash)
+            {
+              adapter:  hash[:adapter],
+              host:     hash[:host],
+              port:     hash[:port],
+              database: hash[:database],
+              username: hash[:username]
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/active_record/events/sql.rb
+++ b/lib/ddtrace/contrib/active_record/events/sql.rb
@@ -24,7 +24,7 @@ module Datadog
           def process(span, event, _id, payload)
             connection_config = Utils.connection_config(payload[:connection_id])
             span.name = "#{connection_config[:adapter_name]}.query"
-            span.service = configuration[:service_name]
+            span.service = connection_config[:tracer_settings][:service_name] || configuration[:service_name]
             span.resource = payload.fetch(:sql)
             span.span_type = Datadog::Ext::SQL::TYPE
 

--- a/lib/ddtrace/contrib/active_record/patcher.rb
+++ b/lib/ddtrace/contrib/active_record/patcher.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/ext/sql'
 require 'ddtrace/ext/app_types'
+require 'ddtrace/contrib/active_record/configuration'
 require 'ddtrace/contrib/active_record/utils'
 require 'ddtrace/contrib/active_record/events'
 
@@ -14,6 +15,12 @@ module Datadog
         option :service_name, depends_on: [:tracer] do |value|
           (value || Utils.adapter_name).tap do |v|
             get_option(:tracer).set_service_info(v, 'active_record', Ext::AppTypes::DB)
+          end
+        end
+        option :databases, default: {} do |value|
+          value.tap do
+            Configuration.clear_database_settings!
+            Configuration.database_settings = value
           end
         end
         option :orm_service_name

--- a/lib/ddtrace/contrib/active_record/utils.rb
+++ b/lib/ddtrace/contrib/active_record/utils.rb
@@ -1,3 +1,5 @@
+require 'ddtrace/contrib/active_record/configuration'
+
 module Datadog
   module Contrib
     module ActiveRecord
@@ -25,7 +27,8 @@ module Datadog
             adapter_name: Datadog::Utils::Database.normalize_vendor(config[:adapter]),
             adapter_host: config[:host],
             adapter_port: config[:port],
-            database_name: config[:database]
+            database_name: config[:database],
+            tracer_settings: Configuration.database_settings(config)
           }
         end
 

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -22,6 +22,12 @@ module Datadog
         option :template_base_path, default: 'views/'
         option :exception_controller, default: nil
         option :tracer, default: Datadog.tracer
+        option :databases, default: {} do |value|
+          # Update ActiveRecord databases too
+          value.tap do
+            Datadog.configuration[:active_record][:databases] = value
+          end
+        end
 
         @patched = false
 

--- a/spec/ddtrace/contrib/active_record/multi_db_spec.rb
+++ b/spec/ddtrace/contrib/active_record/multi_db_spec.rb
@@ -1,0 +1,159 @@
+require 'spec_helper'
+require 'ddtrace'
+
+require 'active_record'
+require 'mysql2'
+require 'sqlite3'
+
+RSpec.describe 'ActiveRecord multi-database implementation' do
+  let(:tracer) { ::Datadog::Tracer.new(writer: FauxWriter.new) }
+  let(:configuration_options) { { tracer: tracer, service_name: default_db_service_name } }
+  let(:default_db_service_name) { 'default-db' }
+
+  let(:application_record) do
+    stub_const('ApplicationRecord', Class.new(ActiveRecord::Base) do
+      self.abstract_class = true
+    end)
+  end
+
+  let!(:gadget_class) do
+    stub_const('Gadget', Class.new(application_record)).tap do |klass|
+      # Connect to the default database
+      ActiveRecord::Base.establish_connection('mysql2://root:root@127.0.0.1:53306/mysql')
+
+      begin
+        klass.count
+      rescue ActiveRecord::StatementInvalid
+        ActiveRecord::Schema.define(version: 20180101000000) do
+          create_table 'gadgets', force: :cascade do |t|
+            t.string   'title'
+            t.datetime 'created_at', null: false
+            t.datetime 'updated_at', null: false
+          end
+        end
+
+        # Prevent extraneous spans from showing up
+        klass.count
+      end
+    end
+  end
+
+  let!(:widget_class) do
+    stub_const('Widget', Class.new(application_record)).tap do |klass|
+      # Connect the Widget database
+      klass.establish_connection(adapter: 'sqlite3', database: ':memory:')
+
+      begin
+        klass.count
+      rescue ActiveRecord::StatementInvalid
+        klass.connection.create_table 'widgets', force: :cascade do |t|
+          t.string   'title'
+          t.datetime 'created_at', null: false
+          t.datetime 'updated_at', null: false
+        end
+
+        # Prevent extraneous spans from showing up
+        klass.count
+      end
+    end
+  end
+
+  subject(:spans) do
+    gadget_class.count
+    widget_class.count
+    tracer.writer.spans
+  end
+
+  let(:gadget_span) { spans[0] }
+  let(:widget_span) { spans[1] }
+
+  before(:each) do
+    Datadog.configuration[:active_record].reset_options!
+
+    Datadog.configure do |c|
+      c.use :active_record, configuration_options
+    end
+  end
+
+  after(:each) do
+    Datadog.configuration[:active_record].reset_options!
+  end
+
+  context 'when :databases is configured with' do
+    let(:configuration_options) { super().merge(databases: databases) }
+    let(:gadget_db_configuration_options) { { service_name: gadget_db_service_name } }
+    let(:gadget_db_service_name) { 'gadget-db' }
+    let(:widget_db_configuration_options) { { service_name: widget_db_service_name } }
+    let(:widget_db_service_name) { 'widget-db' }
+
+    context 'a Symbol that matches a configuration' do
+      context 'when ActiveRecord has configurations' do
+        let(:databases) do
+          # Stub ActiveRecord::Base, to pretend its been configured
+          allow(ActiveRecord::Base).to receive(:configurations).and_return(
+            'gadget' => {
+              'encoding' => 'utf8',
+              'adapter'=>'mysql2',
+              'username'=>'root',
+              'host' => '127.0.0.1',
+              'port' => 53306,
+              'password' => nil,
+              'database' => 'mysql'
+            },
+            'widget' => {
+              'adapter' => 'sqlite3',
+              'pool' => 5,
+              'timeout' => 5000,
+              'database' => ':memory:'
+            }
+          )
+
+          # Return the configuration settings
+          { gadget: gadget_db_configuration_options, widget: widget_db_configuration_options }
+        end
+
+        it do
+          # Gadget is configured to show up as its own database service
+          expect(gadget_span.service).to eq(gadget_db_service_name)
+          # Widget is configured to show up as its own database service
+          expect(widget_span.service).to eq(widget_db_service_name)
+        end
+      end
+    end
+
+    context 'a String that\'s a URL' do
+      context 'for a typical server' do
+        let(:databases) { { 'mysql2://root@127.0.0.1:53306/mysql' => gadget_db_configuration_options } }
+
+        it do
+          # Gadget is configured to show up as its own database service
+          expect(gadget_span.service).to eq(gadget_db_service_name)
+          # Widget isn't, ends up assigned to the default database service
+          expect(widget_span.service).to eq(default_db_service_name)
+        end
+      end
+
+      context 'for an in-memory database' do
+        let(:databases) { { 'sqlite3::memory:' => widget_db_configuration_options } }
+
+        it do
+          # Gadget belongs to the default database
+          expect(gadget_span.service).to eq(default_db_service_name)
+          # Widget belongs to its own database
+          expect(widget_span.service).to eq(widget_db_service_name)
+        end
+      end
+    end
+
+    context 'a Hash that describes a connection' do
+      let(:databases) { { { adapter: 'sqlite3', database: ':memory:' } => widget_db_configuration_options } }
+
+      it do
+        # Gadget belongs to the default database
+        expect(gadget_span.service).to eq(default_db_service_name)
+        # Widget belongs to its own database
+        expect(widget_span.service).to eq(widget_db_service_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Although ActiveRecord events are properly tagged with the correct connection information, its not possible to change service names per connection.

This pull request allows users to specify additional configuration in ActiveRecord to describe database connections which should use different trace settings than what's set via `c.use :active_record`.

You can provide the `databases` option to configure trace settings by database connection:

```ruby
Datadog.configure do |c|
  c.use :active_record, service_name: 'default-db', databases: {
    # Any of the following keys are acceptable, and equivalent to one another.
    # Values must be a Hash, and can only contain :service_name as a setting.

    # Symbol matching your database connection in config/database.yml
    # Only available if you are using Rails with ActiveRecord.
    secondary_database: { service_name: 'secondary-db' },

    # Connection string with the following connection settings:
    # Adapter, user, host, port, database
    'mysql2://root@127.0.0.1:3306/mysql' => { service_name: 'secondary-db' },

    # Hash with following connection settings
    # Adapter, user, host, port, database
    {
      adapter:  'mysql2',
      host:     '127.0.0.1',
      port:     '3306',
      database: 'mysql',
      username: 'root'
    } => { service_name: 'secondary-db' }
  }
end
```