### PR TITLE
Fix no Sequel pin when initialized before patched

### DIFF
--- a/lib/ddtrace/contrib/sequel/dataset.rb
+++ b/lib/ddtrace/contrib/sequel/dataset.rb
@@ -29,15 +29,18 @@ module Datadog
             trace_execute(proc { super(sql, options, &block) }, sql, options, &block)
           end
 
+          def datadog_pin
+            Datadog::Pin.get_from(db)
+          end
+
           private
 
           def trace_execute(super_method, sql, options, &block)
-            pin = Datadog::Pin.get_from(db)
             opts = Utils.parse_opts(sql, options, db.opts)
             response = nil
 
-            pin.tracer.trace('sequel.query') do |span|
-              span.service = pin.service
+            datadog_pin.tracer.trace('sequel.query') do |span|
+              span.service = datadog_pin.service
               span.resource = opts[:query]
               span.span_type = Datadog::Ext::SQL::TYPE
               span.set_tag('sequel.db.vendor', adapter_name)

--- a/spec/ddtrace/contrib/sequel/configuration_spec.rb
+++ b/spec/ddtrace/contrib/sequel/configuration_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+require 'time'
+require 'sequel'
+require 'ddtrace'
+require 'ddtrace/contrib/sequel/patcher'
+
+RSpec.describe 'Sequel configuration' do
+  let(:tracer) { Datadog::Tracer.new(writer: FauxWriter.new) }
+  let(:spans) { tracer.writer.spans }
+  let(:span) { spans.first }
+
+  before(:each) do
+    skip unless Datadog::Contrib::Sequel::Patcher.compatible?
+  end
+
+  describe 'for a SQLite database' do
+    let(:sequel) do
+      Sequel.sqlite(':memory:').tap do |db|
+        db.create_table(:table) do
+          String :name
+        end
+      end
+    end
+
+    def perform_query!
+      sequel[:table].insert(name: 'data1')
+    end
+
+    describe 'when configured' do
+      after(:each) { Datadog.configuration[:sequel].reset_options! }
+
+      context 'only with defaults' do
+        # Expect it to be the normalized adapter name.
+        it do
+          Datadog.configure { |c| c.use :sequel, tracer: tracer }
+          perform_query!
+          expect(span.service).to eq('sqlite')
+        end
+      end
+
+      context 'with options set via #use' do
+        let(:service_name) { 'my-sequel' }
+
+        it do
+          Datadog.configure { |c| c.use :sequel, tracer: tracer, service_name: service_name }
+          perform_query!
+          expect(span.service).to eq(service_name)
+        end
+      end
+
+      context 'with options set on Sequel::Database' do
+        let(:service_name) { 'custom-sequel' }
+
+        it do
+          Datadog.configure { |c| c.use :sequel, tracer: tracer }
+          Datadog.configure(sequel, service_name: service_name)
+          perform_query!
+          expect(span.service).to eq(service_name)
+        end
+      end
+
+      context 'after the database has been initialized' do
+        # NOTE: This test really only works when run in isolation.
+        #       It relies on Sequel not being patched, and there's
+        #       no way to unpatch it once its happened in other tests.
+        it do
+          sequel
+          Datadog.configure { |c| c.use :sequel, tracer: tracer }
+          perform_query!
+          expect(span.service).to eq('sqlite')
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/sequel/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/sequel/instrumentation_spec.rb
@@ -35,33 +35,6 @@ RSpec.describe 'Sequel instrumentation' do
       end
     end
 
-    describe 'when configured' do
-      let(:span) { spans.first }
-
-      shared_examples_for 'a configured Sequel::Database' do
-        before(:each) { sequel[:table].insert(name: 'data1') }
-        it { expect(span.service).to eq(service_name) }
-      end
-
-      context 'only with defaults' do
-        # Expect it to be the normalized adapter name.
-        let(:service_name) { 'sqlite' }
-        it_behaves_like 'a configured Sequel::Database'
-      end
-
-      context 'with options set via #use' do
-        let(:configuration_options) { super().merge(service_name: service_name) }
-        let(:service_name) { 'my-sequel' }
-        it_behaves_like 'a configured Sequel::Database'
-      end
-
-      context 'with options set on Sequel::Database' do
-        let(:service_name) { 'custom-sequel' }
-        before(:each) { Datadog.configure(sequel, service_name: service_name) }
-        it_behaves_like 'a configured Sequel::Database'
-      end
-    end
-
     describe 'when queried through a Sequel::Database object' do
       before(:each) { sequel.run(query) }
       let(:query) { 'SELECT * FROM \'table\' WHERE `name` = \'John Doe\'' }


### PR DESCRIPTION
As reported [here](https://github.com/DataDog/dd-trace-rb/pull/171#issuecomment-383942175), and can be replicated in [this Gist](https://gist.github.com/twe4ked/590db5a686104770a53a78b657eacc3d), if you initialize a Sequel database before patching `Sequel` with `Datadog.configure`, then the already initialized databases will be missing pins, and fail to trace.

This pull request bumps Pin setup out of the `initialize` method and into the `datadog_pin` method, where it's lazily instantiated. It adds a test for it, and refactors some of the existing configuration tests for Sequel.