### PR TITLE
prevent race condition while running tests

### DIFF
--- a/spec/ddtrace/contrib/grpc/support/grpc_helper.rb
+++ b/spec/ddtrace/contrib/grpc/support/grpc_helper.rb
@@ -10,7 +10,7 @@ module GRPCHelper
   end
 
   def run_server_streamer(address = '0.0.0.0:50054', client = nil)
-    runner(address, client) { |c| c.stream_from_server(TestMessage.new) }
+    runner(address, client) { |c| c.stream_from_server(TestMessage.new); sleep 0.01 }
   end
 
   def run_bidi_streamer(address = '0.0.0.0:50055', client = nil)


### PR DESCRIPTION
Approximately 5% of server streams complete and exit before the FauxWriter can grab the mutex to record the server spans. This fix adds a 10ms sleep at the end of the server~>client stream to give the
FauxWriter enough time to record the span.

This happens only during the integration test. I verified both the rate of failure and the fix by running the following several times:

```shell
for i in {1..100}; do
  BUNDLE_GEMFILE=/Users/jared/code/dd-trace-rb/gemfiles/contrib.gemfile bundle exec rspec spec/ddtrace/contrib/grpc
done
```