### PR TITLE
Fix NoMethodError when ActionController::Metal#response is an Array

### DIFF
--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -221,7 +221,8 @@ module Datadog
           # process and catch request exceptions
           Datadog::Contrib::Rails::ActionController.start_processing(payload)
           result = super(*args)
-          payload[:status] = response.status
+          status = response_status
+          payload[:status] = status unless status.nil?
           result
         rescue Exception => e
           payload[:exception] = [e.class.name, e.message]
@@ -230,6 +231,19 @@ module Datadog
         end
       ensure
         Datadog::Contrib::Rails::ActionController.finish_processing(payload)
+      end
+
+      # rubocop:disable Style/EmptyElse
+      def response_status
+        case response
+        when ActionDispatch::Response
+          response.status
+        when Array
+          status = response.first
+          status.class <= Integer ? status : nil
+        else
+          nil
+        end
       end
     end
   end

--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -233,16 +233,14 @@ module Datadog
         Datadog::Contrib::Rails::ActionController.finish_processing(payload)
       end
 
-      # rubocop:disable Style/EmptyElse
       def response_status
         case response
         when ActionDispatch::Response
           response.status
         when Array
+          # Likely a Rack response array: first element is the status.
           status = response.first
           status.class <= Integer ? status : nil
-        else
-          nil
         end
       end
     end

--- a/spec/ddtrace/contrib/rails/action_controller_spec.rb
+++ b/spec/ddtrace/contrib/rails/action_controller_spec.rb
@@ -1,0 +1,80 @@
+require 'ddtrace/contrib/rails/rails_helper'
+
+RSpec.describe 'ActionController tracing' do
+  let(:tracer) { ::Datadog::Tracer.new(writer: FauxWriter.new) }
+  let(:rails_options) { { tracer: tracer } }
+
+  before(:each) do
+    Datadog::RailsActionPatcher.patch_action_controller
+    Datadog.configure do |c|
+      c.use :rails, rails_options
+    end
+  end
+
+  def all_spans
+    tracer.writer.spans(:keep)
+  end
+
+  let(:controller) do
+    stub_const('TestController', Class.new(base_class) do
+      def index
+        # Do nothing
+      end
+    end)
+  end
+  let(:name) { :index }
+  let(:base_class) { ActionController::Base }
+
+  describe '#action' do
+    subject(:result) { action.call(env) }
+    let(:action) { controller.action(name) }
+    let(:env) { {} }
+
+    shared_examples_for 'a successful dispatch' do
+      it do
+        expect { result }.to_not raise_error
+        expect(result).to be_a_kind_of(Array)
+        expect(result).to have(3).items
+        expect(all_spans).to have(1).items
+        expect(all_spans.first.name).to eq('rails.action_controller')
+      end
+    end
+
+    describe 'for a controller' do
+      context 'that inherits from ActionController::Metal' do
+        let(:base_class) { ActionController::Metal }
+
+        before(:each) do
+          # ActionController::Metal is only patched in 2.0+
+          skip 'Not supported for Ruby < 2.0' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
+        end
+
+        it_behaves_like 'a successful dispatch'
+
+        context 'when response is overridden' do
+          context 'with an Array' do
+            let(:headers) { double('headers') }
+            let(:body) { double('body') }
+
+            before(:each) do
+              expect_any_instance_of(controller).to receive(:response)
+                .at_least(:once)
+                .and_wrap_original do |m, *args|
+                  m.receiver.response = [200, headers, body]
+                  m.call(*args)
+                end
+            end
+
+            it do
+              expect { result }.to_not raise_error
+              expect(result).to be_a_kind_of(Array)
+              expect(result).to include(200, headers, body)
+              expect(all_spans).to have(1).items
+              expect(all_spans.first.name).to eq('rails.action_controller')
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/rails/action_controller_spec.rb
+++ b/spec/ddtrace/contrib/rails/action_controller_spec.rb
@@ -73,6 +73,32 @@ RSpec.describe 'ActionController tracing' do
               expect(all_spans.first.name).to eq('rails.action_controller')
             end
           end
+
+          context 'with some unknown kind of object' do
+            let(:response_object) do
+              double(
+                'response object',
+                to_a: [200, double('headers'), double('body')]
+              )
+            end
+
+            before(:each) do
+              expect_any_instance_of(controller).to receive(:response)
+                .at_least(:once)
+                .and_wrap_original do |m, *args|
+                  m.receiver.response = response_object
+                  m.call(*args)
+                end
+            end
+
+            it do
+              expect { result }.to_not raise_error
+              expect(result).to be_a_kind_of(Array)
+              expect(result).to have(3).items
+              expect(all_spans).to have(1).items
+              expect(all_spans.first.name).to eq('rails.action_controller')
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
When `ActionController::Metal#response` was an `Array` instead of a `ActionDispatch::Response`, tracing raised an error. This manifested in Devise's `FailureApp` which is [overriding the value of `response`](https://github.com/plataformatec/devise/blob/master/lib/devise/failure_app.rb#L75) with an Array, in an unexpected way. You can reproduce this by attempting to login with bad credentials.

Only affects users who use Devise and ddtrace 0.12.0.

This pull request attempts to handle both `ActionDispatch::Response` and `Array` responses, and if it doesn't receive either, it doesn't set a status.

Addresses https://github.com/DataDog/dd-trace-rb/issues/419