### PR TITLE
Make sure to correctly preserve block for Elasticsearch::Transport::Client

### DIFF
--- a/lib/ddtrace/contrib/elasticsearch/patcher.rb
+++ b/lib/ddtrace/contrib/elasticsearch/patcher.rb
@@ -52,11 +52,11 @@ module Datadog
               remove_method :initialize
             end
 
-            def initialize(*args)
+            def initialize(*args, &block)
               service = Datadog.configuration[:elasticsearch][:service_name]
               pin = Datadog::Pin.new(service, app: 'elasticsearch', app_type: Datadog::Ext::AppTypes::DB)
               pin.onto(self)
-              initialize_without_datadog(*args)
+              initialize_without_datadog(*args, &block)
             end
 
             alias_method :perform_request_without_datadog, :perform_request

--- a/test/contrib/elasticsearch/dummy_faraday_middleware.rb
+++ b/test/contrib/elasticsearch/dummy_faraday_middleware.rb
@@ -1,0 +1,11 @@
+require 'faraday'
+
+class DummyFaradayMiddleware < Faraday::Middleware
+  def initialize(app)
+    super(app)
+  end
+
+  def call(env)
+    @app.call(env)
+  end
+end


### PR DESCRIPTION
`Elasticsearch::Client` is a convenience wrapper for `Elasticsearch::Transport::Client`.
Which provides the ability to initialize the client with a block while allowing
to configure the faraday instance directly.

Now, because `Datadog::Contrib::Elasticsearch` monkey patches this behavior,
and calls the parent/original `initialize` function (aliased as `initialize_without_datadog`),
it however misses to pass in the block, and only sends the arguments.

Which means, using the dd-trace gem in applications which initialize `Elasticsearch::Client`
with block becomes risky, as custom faraday configurations are lost.

This PR fixes the issue.