### PR TITLE
Improve duration counting using monotonic clock

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -33,6 +33,7 @@ EOS
   spec.require_paths = ['lib']
 
   spec.add_dependency 'msgpack'
+  spec.add_dependency 'concurrent-ruby'
 
   spec.add_development_dependency 'rake', '~> 10.5'
   spec.add_development_dependency 'rubocop', '= 0.49.1' if RUBY_VERSION >= '2.1.0'

--- a/lib/ddtrace/contrib/active_support/notifications/subscription.rb
+++ b/lib/ddtrace/contrib/active_support/notifications/subscription.rb
@@ -73,8 +73,8 @@ module Datadog
 
             # Start a trace
             tracer.trace(@span_name, @options).tap do |span|
-              # Assign start time if provided
-              span.start_time = start unless start.nil?
+              # start span if time is provided
+              span.start(start) unless start.nil?
             end
           end
 

--- a/lib/ddtrace/contrib/grape/endpoint.rb
+++ b/lib/ddtrace/contrib/grape/endpoint.rb
@@ -83,7 +83,7 @@ module Datadog
             span.set_tag('grape.route.endpoint', api_view)
             span.set_tag('grape.route.path', path)
           ensure
-            span.start_time = start
+            span.start(start)
             span.finish(finish)
           end
         rescue StandardError => e
@@ -124,7 +124,7 @@ module Datadog
           begin
             span.set_error(payload[:exception_object]) unless payload[:exception_object].nil?
           ensure
-            span.start_time = start
+            span.start(start)
             span.finish(finish)
           end
         rescue StandardError => e
@@ -152,7 +152,7 @@ module Datadog
             span.set_error(payload[:exception_object]) unless payload[:exception_object].nil?
             span.set_tag('grape.filter.type', type.to_s)
           ensure
-            span.start_time = start
+            span.start(start)
             span.finish(finish)
           end
         rescue StandardError => e

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -103,6 +103,7 @@ module Datadog
       set_tag(Ext::Errors::STACK, e.backtrace) unless e.backtrace.empty?
     end
 
+    # Mark the span started at the current time.
     def start(start_time = nil)
       # A span should not be started twice. Note that this is not thread-safe,
       # start is called from multiple threads, a given span might be started
@@ -122,8 +123,9 @@ module Datadog
       self
     end
 
+    # Return whether the span is started or not
     def started?
-      !!@start_time
+      !@start_time.nil?
     end
 
     # for backwards compatibility
@@ -227,10 +229,9 @@ module Datadog
       h
     end
 
+    # Return the duration of the span, or 0 if no duration can be calculated.
     def duration
-      ((@duration_end - @duration_start) * 1e9).to_i
-    rescue
-      0
+      ((@duration_end - @duration_start) * 1e9).to_i rescue 0
     end
 
     # Return a human readable version of the span

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -1,6 +1,8 @@
 require 'time'
 require 'thread'
 
+require 'concurrent/utility/monotonic_time'
+
 require 'ddtrace/utils'
 require 'ddtrace/ext/errors'
 
@@ -269,7 +271,7 @@ module Datadog
     private
 
     def duration_marker
-      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      Concurrent.monotonic_time
     end
   end
 end

--- a/lib/ddtrace/span/duration.rb
+++ b/lib/ddtrace/span/duration.rb
@@ -1,0 +1,69 @@
+require 'concurrent/utility/monotonic_time'
+module Datadog
+  class Span
+    # Stateful class used to track and calculate the duration of a Span.
+    class Duration
+      attr_reader :start_time, :end_time
+
+      def initialize
+        @start_time = nil
+        @duration_start = nil
+        @end_time = nil
+        @duration_end = nil
+        @wall_clock_duration = false
+      end
+
+      # Return whether the duration is started or not
+      def started?
+        !@start_time.nil?
+      end
+
+      # Return whether the duration is finished or not.
+      def finished?
+        !@end_time.nil?
+      end
+
+      def complete?
+        started? && finished?
+      end
+
+      def start(start_time)
+        if start_time
+          @start_time = start_time
+          @duration_start = start_time
+          @wall_clock_duration = true
+        else
+          @start_time = Time.now.utc
+          @duration_start = duration_marker
+        end
+      end
+
+      def finish(finish_time)
+        now = Time.now.utc
+
+        # Provide a default start_time if unset.
+        # Using `now` here causes duration to be 0; this is expected
+        # behavior when start_time is unknown.
+        start(finish_time || now) unless started?
+
+        if finish_time
+          @end_time = finish_time
+          @duration_start = @start_time
+          @duration_end = finish_time
+          @wall_clock_duration = true
+        else
+          @end_time = now
+          @duration_end = @wall_clock_duration ? now : duration_marker
+        end
+      end
+
+      def to_f
+        (@duration_end - @duration_start).to_f rescue 0.0
+      end
+
+      def duration_marker
+        Concurrent.monotonic_time
+      end
+    end
+  end
+end

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -203,7 +203,7 @@ module Datadog
     # * +start_time+: when the span actually starts (defaults to \now)
     # * +tags+: extra tags which should be added to the span.
     def start_span(name, options = {})
-      start_time = options.fetch(:start_time, Time.now.utc)
+      start_time = options[:start_time]
       tags = options.fetch(:tags, {})
 
       opts = options.select do |k, _v|
@@ -230,7 +230,7 @@ module Datadog
       end
       tags.each { |k, v| span.set_tag(k, v) } unless tags.empty?
       @tags.each { |k, v| span.set_tag(k, v) } unless @tags.empty?
-      span.start_time = start_time
+      span.start start_time
 
       # this could at some point be optional (start_active_span vs start_manual_span)
       ctx.add_span(span) unless ctx.nil?

--- a/spec/ddtrace/contrib/active_support/notifications/subscription_spec.rb
+++ b/spec/ddtrace/contrib/active_support/notifications/subscription_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscription do
 
         it do
           expect(tracer).to receive(:trace).with(span_name, options).and_return(span).ordered
-          expect(span).to receive(:start_time=).with(start).and_return(span).ordered
+          expect(span).to receive(:start).with(start).and_return(span).ordered
           expect(tracer).to receive(:active_span).and_return(span).ordered
           expect(spy).to receive(:call).with(span, name, id, payload).ordered
           expect(span).to receive(:finish).with(finish).and_return(span).ordered
@@ -48,7 +48,7 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscription do
 
           it 'finishes tracing anyways' do
             expect(tracer).to receive(:trace).with(span_name, options).and_return(span).ordered
-            expect(span).to receive(:start_time=).with(start).and_return(span).ordered
+            expect(span).to receive(:start).with(start).and_return(span).ordered
             expect(tracer).to receive(:active_span).and_return(span).ordered
             expect(span).to receive(:finish).with(finish).and_return(span).ordered
             is_expected.to be(span)


### PR DESCRIPTION
When measuring durations, it's preferable to use the system monotonic
clock rather than `Time.now` in order to avoid problems with the wall
clock potentially moving forwards or backwards for corrections that
would throw off calculation of elapsed time.

https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/

This was written in order to preserve the existing behavior in cases where the start time or end time were manually set.

**NEW BEHAVIOR**
* If a span has `start` and `finish` called in-order, with no explicit `start_time` or `finish_time` given it will use the monotonic clock to measure duration.

**Existing (preserved) behavior**
* If a span has `finish` called without first having called `start` the duration will be `0`
* If a span has `start` called with an explicit `start_time`, and `finish` called with no explicit `finish_time` then duration uses the wall clock for the end time
* If a span has `start` with no `start_time`, and `finish` called with an explicit `finish_time`, duration uses the wall clock for the start time

## TODO

* [ ] Needs tests for the above behavior. Existing behavior may already be tested - I am unsure, need to verify.
* [ ] Figure out problem with `appraisal rake test:grape`