### PR TITLE
Refactored: Disable datadog only if DISABLE_DATADOG_RAILS is set but not '0'

### DIFF
--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -40,7 +40,7 @@ module Datadog
           end
 
           def compatible?
-            return if ENV['DISABLE_DATADOG_RAILS']
+            return if ENV['DISABLE_DATADOG_RAILS'].match(/^(true|t|yes|y|1)?$/i)
 
             defined?(::Rails::VERSION) && ::Rails::VERSION::MAJOR.to_i >= 3
           end

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -40,7 +40,7 @@ module Datadog
           end
 
           def compatible?
-            return if ENV['DISABLE_DATADOG_RAILS']&.match(/^(true|t|yes|y|1|disable|disabled)?$/i)
+            return if ENV['DISABLE_DATADOG_RAILS'] && ENV['DISABLE_DATADOG_RAILS'] != '0'
 
             defined?(::Rails::VERSION) && ::Rails::VERSION::MAJOR.to_i >= 3
           end

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -40,7 +40,7 @@ module Datadog
           end
 
           def compatible?
-            return if ENV['DISABLE_DATADOG_RAILS'].match(/^(true|t|yes|y|1)?$/i)
+            return if ENV['DISABLE_DATADOG_RAILS']&.match(/^(true|t|yes|y|1|disable|disabled)?$/i)
 
             defined?(::Rails::VERSION) && ::Rails::VERSION::MAJOR.to_i >= 3
           end

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -40,7 +40,7 @@ module Datadog
           end
 
           def compatible?
-            return if ENV['DISABLE_DATADOG_RAILS'] && ENV['DISABLE_DATADOG_RAILS'] != '0'
+            return unless [nil, '0', 'false'].include?(ENV['DISABLE_DATADOG_RAILS'])
 
             defined?(::Rails::VERSION) && ::Rails::VERSION::MAJOR.to_i >= 3
           end


### PR DESCRIPTION
I would like to be able to have a default value for DISABLE_DATADOG_RAILS in order to disable datadog by default. I only want to enable datadog, if the value is something like 0. Unfortunately, my environment requires the DISABLE_DATADOG_RAILS always to be set to something, otherwise it will default to the default value. Since the current code only checks for the existence of the environment value, any value, even an empty string will disable datadog, thus making it impossible to enable datadog without removing the variable altogether.

With this PR I am proposing to disable datadog with DISABLE_DATADOG_RAILS only if its value is not '0'
