### PR TITLE
Cleanup Rubocop warnings for spec files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,9 @@ Metrics/ClassLength:
 
 Metrics/BlockLength:
   Max: 42
+  Exclude:
+    - test/**/*
+    - spec/**/*
 
 Metrics/ParameterLists:
   Enabled: false
@@ -49,7 +52,7 @@ Metrics/PerceivedComplexity:
   Max: 15
 
 Lint/UnusedMethodArgument:
-    Enabled: false
+  Enabled: false
 
 # Disabling advices that would lead to incompatible Ruby 1.9 code
 Style/SymbolArray:

--- a/Rakefile
+++ b/Rakefile
@@ -142,7 +142,7 @@ end
 if RUBY_VERSION >= '2.1.0'
   RuboCop::RakeTask.new(:rubocop) do |t|
     t.options << ['-D']
-    t.patterns = ['lib/**/*.rb', 'test/**/*.rb', 'Gemfile', 'Rakefile']
+    t.patterns = ['lib/**/*.rb', 'test/**/*.rb', 'spec/**/*.rb', 'Gemfile', 'Rakefile']
   end
 end
 

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -12,11 +12,11 @@ Gem::Specification.new do |spec|
   spec.email                 = ['dev@datadoghq.com']
 
   spec.summary     = 'Datadog tracing code for your Ruby applications'
-  spec.description = <<-EOS
-ddtrace is Datadog’s tracing client for Ruby. It is used to trace requests
-as they flow across web servers, databases and microservices so that developers
-have great visiblity into bottlenecks and troublesome requests.
-EOS
+  spec.description = <<-EOS.gsub(/^[\s]+/, '')
+    ddtrace is Datadog’s tracing client for Ruby. It is used to trace requests
+    as they flow across web servers, databases and microservices so that developers
+    have great visiblity into bottlenecks and troublesome requests.
+  EOS
 
   spec.homepage = 'https://github.com/DataDog/dd-trace-rb'
   spec.license  = 'BSD-3-Clause'

--- a/spec/ddtrace/contrib/active_record/tracer_spec.rb
+++ b/spec/ddtrace/contrib/active_record/tracer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'ActiveRecord instrumentation' do
 
     # expect service and trace is sent
     expect(spans.size).to eq(1)
-    expect(services['mysql2']).to eq({'app'=>'active_record', 'app_type'=>'db'})
+    expect(services['mysql2']).to eq('app' => 'active_record', 'app_type' => 'db')
 
     span = spans[0]
     expect(span.service).to eq('mysql2')
@@ -55,13 +55,13 @@ RSpec.describe 'ActiveRecord instrumentation' do
     let(:query_span) { spans.first }
 
     context 'is not set' do
-      let(:configuration_options) { super().merge({ service_name: nil }) }
+      let(:configuration_options) { super().merge(service_name: nil) }
       it { expect(query_span.service).to eq('mysql2') }
     end
 
     context 'is set' do
       let(:service_name) { 'test_active_record' }
-      let(:configuration_options) { super().merge({ service_name: service_name }) }
+      let(:configuration_options) { super().merge(service_name: service_name) }
 
       it { expect(query_span.service).to eq(service_name) }
     end

--- a/spec/ddtrace/contrib/active_record/utils_spec.rb
+++ b/spec/ddtrace/contrib/active_record/utils_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 require 'ddtrace/contrib/active_record/utils'
 
 RSpec.describe Datadog::Contrib::ActiveRecord::Utils do
-
   describe '#normalize_vendor' do
     subject(:result) { described_class.normalize_vendor(value) }
 

--- a/spec/ddtrace/contrib/active_support/notifications/subscriber_spec.rb
+++ b/spec/ddtrace/contrib/active_support/notifications/subscriber_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscriber do
                 double('span name'),
                 double('options'),
                 double('tracer'),
-                &Proc.new { }
+                &proc {}
               )
 
               is_expected.to contain_exactly(subscription)
@@ -44,7 +44,7 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscriber do
 
           context 'after #subscribe! has been called' do
             before(:each) do
-              test_class.send(:on_subscribe, &Proc.new { })
+              test_class.send(:on_subscribe, &proc {})
               test_class.send(:subscribe!)
             end
 
@@ -58,7 +58,7 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscriber do
 
             context 'when #on_subscribe' do
               context 'is defined' do
-                let(:on_subscribe_block) { Proc.new { spy.call } }
+                let(:on_subscribe_block) { proc { spy.call } }
                 let(:spy) { double(:spy) }
 
                 before(:each) { test_class.send(:on_subscribe, &on_subscribe_block) }
@@ -93,7 +93,7 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscriber do
             let(:span_name) { double('span name') }
             let(:options) { double('options') }
             let(:tracer) { double('tracer') }
-            let(:block) { Proc.new { } }
+            let(:block) { proc {} }
 
             before(:each) do
               expect(Datadog::Contrib::ActiveSupport::Notifications::Subscription).to receive(:new)
@@ -113,7 +113,7 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscriber do
             let(:span_name) { double('span name') }
             let(:options) { double('options') }
             let(:tracer) { double('tracer') }
-            let(:block) { Proc.new { } }
+            let(:block) { proc {} }
 
             before(:each) do
               expect(Datadog::Contrib::ActiveSupport::Notifications::Subscription).to receive(:new)

--- a/spec/ddtrace/contrib/active_support/notifications/subscription_spec.rb
+++ b/spec/ddtrace/contrib/active_support/notifications/subscription_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscription do
     let(:span_name) { double('span_name') }
     let(:options) { double('options') }
     let(:block) do
-      Proc.new do |span, name, id, payload|
+      proc do |span, name, id, payload|
         spy.call(span, name, id, payload)
       end
     end
@@ -39,8 +39,8 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscription do
 
         context 'when block raises an error' do
           let(:block) do
-            Proc.new do |span, name, id, payload|
-              raise ArgumentError.new('Fail!')
+            proc do |_span, _name, _id, _payload|
+              raise ArgumentError, 'Fail!'
             end
           end
 
@@ -88,7 +88,7 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscription do
 
       describe '#before_trace' do
         context 'given a block' do
-          let(:callback_block) { Proc.new { callback_spy.call } }
+          let(:callback_block) { proc { callback_spy.call } }
           let(:callback_spy) { double('callback spy') }
           before(:each) { subscription.before_trace(&callback_block) }
 
@@ -103,12 +103,17 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscription do
           end
 
           context 'that doesn\'t raise an error' do
-            let(:callback_block) { Proc.new { callback_spy.call } }
+            let(:callback_block) { proc { callback_spy.call } }
             it_behaves_like 'a before_trace callback'
           end
 
           context 'that raises an error' do
-            let(:callback_block) { Proc.new { callback_spy.call; raise ArgumentError.new('Fail!') } }
+            let(:callback_block) do
+              proc do
+                callback_spy.call
+                raise ArgumentError, 'Fail!'
+              end
+            end
             around(:each) { |example| without_errors { example.run } }
             it_behaves_like 'a before_trace callback'
           end
@@ -117,7 +122,7 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscription do
 
       describe '#after_trace' do
         context 'given a block' do
-          let(:callback_block) { Proc.new { callback_spy.call } }
+          let(:callback_block) { proc { callback_spy.call } }
           let(:callback_spy) { double('callback spy') }
           before(:each) { subscription.after_trace(&callback_block) }
 
@@ -136,12 +141,17 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscription do
           end
 
           context 'that doesn\'t raise an error' do
-            let(:callback_block) { Proc.new { callback_spy.call } }
+            let(:callback_block) { proc { callback_spy.call } }
             it_behaves_like 'an after_trace callback'
           end
 
           context 'that raises an error' do
-            let(:callback_block) { Proc.new { callback_spy.call; raise ArgumentError.new('Fail!') } }
+            let(:callback_block) do
+              proc do
+                callback_spy.call
+                raise ArgumentError, 'Fail!'
+              end
+            end
             around(:each) { |example| without_errors { example.run } }
             it_behaves_like 'an after_trace callback'
           end

--- a/spec/ddtrace/contrib/faraday/middleware_spec.rb
+++ b/spec/ddtrace/contrib/faraday/middleware_spec.rb
@@ -53,13 +53,13 @@ RSpec.describe 'Faraday middleware' do
       expect(request_span).to_not be nil
       expect(request_span.service).to eq(Datadog::Contrib::Faraday::SERVICE)
       expect(request_span.name).to eq(Datadog::Contrib::Faraday::NAME)
-      expect(request_span.resource).to eq('GET') 
-      expect(request_span.get_tag(Datadog::Ext::HTTP::METHOD)).to eq('GET') 
-      expect(request_span.get_tag(Datadog::Ext::HTTP::STATUS_CODE)).to eq('200') 
-      expect(request_span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/success') 
-      expect(request_span.get_tag(Datadog::Ext::NET::TARGET_HOST)).to eq('example.com') 
-      expect(request_span.get_tag(Datadog::Ext::NET::TARGET_PORT)).to eq('80') 
-      expect(request_span.span_type).to eq(Datadog::Ext::HTTP::TYPE) 
+      expect(request_span.resource).to eq('GET')
+      expect(request_span.get_tag(Datadog::Ext::HTTP::METHOD)).to eq('GET')
+      expect(request_span.get_tag(Datadog::Ext::HTTP::STATUS_CODE)).to eq('200')
+      expect(request_span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/success')
+      expect(request_span.get_tag(Datadog::Ext::NET::TARGET_HOST)).to eq('example.com')
+      expect(request_span.get_tag(Datadog::Ext::NET::TARGET_PORT)).to eq('80')
+      expect(request_span.span_type).to eq(Datadog::Ext::HTTP::TYPE)
       expect(request_span.status).to_not eq(Datadog::Ext::Errors::STATUS)
     end
   end
@@ -101,7 +101,7 @@ RSpec.describe 'Faraday middleware' do
     subject!(:response) { client.get('/success') }
 
     let(:middleware_options) { { split_by_domain: true } }
-    
+
     it do
       expect(request_span.name).to eq(Datadog::Contrib::Faraday::NAME)
       expect(request_span.service).to eq('example.com')

--- a/spec/ddtrace/contrib/graphql/tracer_spec.rb
+++ b/spec/ddtrace/contrib/graphql/tracer_spec.rb
@@ -2,13 +2,11 @@ require 'spec_helper'
 require 'ddtrace/contrib/graphql/test_types'
 
 require 'ddtrace'
-
-# rubocop:disable Metrics/BlockLength
 RSpec.describe 'GraphQL patcher' do
   include_context 'GraphQL test schema'
 
   # GraphQL generates tons of warnings.
-  # This suppresses those warnings. 
+  # This suppresses those warnings.
   around(:each) do |example|
     without_warnings do
       example.run

--- a/spec/ddtrace/contrib/racecar/patcher_spec.rb
+++ b/spec/ddtrace/contrib/racecar/patcher_spec.rb
@@ -4,8 +4,6 @@ require 'racecar'
 require 'racecar/cli'
 require 'active_support'
 require 'ddtrace'
-
-# rubocop:disable Metrics/BlockLength
 RSpec.describe 'Racecar patcher' do
   let(:tracer) { ::Datadog::Tracer.new(writer: FauxWriter.new) }
 

--- a/spec/ddtrace/contrib/rails/middleware_spec.rb
+++ b/spec/ddtrace/contrib/rails/middleware_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Rails request' do
 
           def call(env)
             @app.call(env)
-            raise NotImplementedError.new
+            raise NotImplementedError
           end
         end)
       end
@@ -129,7 +129,7 @@ RSpec.describe 'Rails request' do
 
           def call(env)
             @app.call(env)
-            raise ActionController::RoutingError.new('/missing_route')
+            raise ActionController::RoutingError, '/missing_route'
           end
         end)
       end
@@ -190,7 +190,7 @@ RSpec.describe 'Rails request' do
 
           def call(env)
             @app.call(env)
-            raise CustomError.new
+            raise CustomError
           end
         end)
       end
@@ -209,10 +209,7 @@ RSpec.describe 'Rails request' do
           expect(span.span_type).to eq('http')
           expect(span.resource).to eq('TestController#index')
 
-          if Rails.version >= '3.2'
-            expect(span.get_tag('http.url')).to eq('/')
-          else
-          end
+          expect(span.get_tag('http.url')).to eq('/') if Rails.version >= '3.2'
 
           expect(span.get_tag('http.method')).to eq('GET')
           expect(span.get_tag('http.status_code')).to eq('500')
@@ -228,8 +225,8 @@ RSpec.describe 'Rails request' do
           # TODO: Make a cleaner API for injecting into Rails application configuration
           let(:initialize_block) do
             super_block = super()
-            Proc.new do
-              self.instance_exec(&super_block)
+            proc do
+              instance_exec(&super_block)
               config.action_dispatch.rescue_responses.merge!(
                 'CustomError' => :not_found
               )

--- a/spec/ddtrace/contrib/rails/rails_helper.rb
+++ b/spec/ddtrace/contrib/rails/rails_helper.rb
@@ -51,7 +51,7 @@ logger.info "Testing against Rails #{Rails.version} with adapter '#{adapter}'"
 #
 #   let(:routes) { { '/' => 'test#index' } }
 #   let(:controllers) { [controller] }
-#   
+#
 #   let(:controller) do
 #     stub_const('TestController', Class.new(ActionController::Base) do
 #       def index
@@ -82,7 +82,7 @@ logger.info "Testing against Rails #{Rails.version} with adapter '#{adapter}'"
 #   include_context 'Rails test application'
 #
 #   let(:rails_middleware) { [middleware] }
-#   
+#
 #   let(:middleware) do
 #     stub_const('TestMiddleware', Class.new do
 #       def initialize(app)

--- a/spec/ddtrace/contrib/rails/support/base.rb
+++ b/spec/ddtrace/contrib/rails/support/base.rb
@@ -24,20 +24,20 @@ RSpec.shared_context 'Rails base application' do
     middleware = rails_middleware
     debug_mw = debug_middleware
 
-    Proc.new do
+    proc do
       config.middleware.insert_after ActionDispatch::ShowExceptions, debug_mw
       middleware.each { |m| config.middleware.use m }
     end
   end
 
   let(:before_test_initialize_block) do
-    Proc.new do
+    proc do
       append_routes!
     end
   end
 
   let(:after_test_initialize_block) do
-    Proc.new do
+    proc do
       # Force connection to initialize, and dump some spans
       application_record.connection
     end

--- a/spec/ddtrace/contrib/rails/support/configuration.rb
+++ b/spec/ddtrace/contrib/rails/support/configuration.rb
@@ -10,7 +10,7 @@ module Datadog
           end
 
           def fetch(key, value)
-            return get(key) if original.has_key?(key)
+            return get(key) if original.key?(key)
             value.tap { set(key, value) }
           end
 

--- a/spec/ddtrace/contrib/rails/support/database.rb
+++ b/spec/ddtrace/contrib/rails/support/database.rb
@@ -24,14 +24,14 @@ module Datadog
                     ::Rails::Application::Configuration.class_eval do
                       def database_configuration
                         { 'test' => { 'adapter' => 'postgresql',
-                                    'encoding' => 'utf8',
-                                    'reconnect' => false,
-                                    'database' => ENV.fetch('TEST_POSTGRES_DB', 'postgres'),
-                                    'pool' => 5,
-                                    'username' => ENV.fetch('TEST_POSTGRES_USER', 'postgres'),
-                                    'password' => ENV.fetch('TEST_POSTGRES_PASSWORD', 'postgres'),
-                                    'host' => ENV.fetch('TEST_POSTGRES_HOST', '127.0.0.1'),
-                                    'port' => ENV.fetch('TEST_POSTGRES_PORT', 5432) } }
+                                      'encoding' => 'utf8',
+                                      'reconnect' => false,
+                                      'database' => ENV.fetch('TEST_POSTGRES_DB', 'postgres'),
+                                      'pool' => 5,
+                                      'username' => ENV.fetch('TEST_POSTGRES_USER', 'postgres'),
+                                      'password' => ENV.fetch('TEST_POSTGRES_PASSWORD', 'postgres'),
+                                      'host' => ENV.fetch('TEST_POSTGRES_HOST', '127.0.0.1'),
+                                      'port' => ENV.fetch('TEST_POSTGRES_PORT', 5432) } }
                       end
                     end
                   end

--- a/spec/ddtrace/contrib/rails/support/middleware.rb
+++ b/spec/ddtrace/contrib/rails/support/middleware.rb
@@ -9,8 +9,10 @@ RSpec.shared_context 'Rails middleware' do
 
       def call(env)
         @app.call(env)
-      rescue Exception => e
+        # rubocop:disable Lint/RescueException
+      rescue Exception => _e
         raise
+        # ruboco:enable Lint/RescueException
       end
     end)
   end

--- a/spec/ddtrace/contrib/rails/support/rails4.rb
+++ b/spec/ddtrace/contrib/rails/support/rails4.rb
@@ -17,55 +17,56 @@ RSpec.shared_context 'Rails 4 base application' do
 
   let(:rails_base_application) do
     reset_rails_configuration!
-    Class.new(Rails::Application) do
+    klass = Class.new(Rails::Application) do
       def config.database_configuration
         parsed = super
         raise parsed.to_yaml # Replace this line to add custom connections to the hash from database.yml
       end
-    end.tap do |klass|
-      during_init = initialize_block
+    end
 
-      klass.send(:define_method, :initialize) do |*args|
-        super(*args)
-        redis_cache = [:redis_store, { url: ENV['REDIS_URL'] }]
-        file_cache = [:file_store, '/tmp/ddtrace-rb/cache/']
+    during_init = initialize_block
 
-        config.secret_key_base = 'f624861242e4ccf20eacb6bb48a886da'
-        config.cache_store = ENV['REDIS_URL'] ? redis_cache : file_cache
-        config.eager_load = false
-        config.consider_all_requests_local = true
-        config.active_support.test_order = :random
-        config.middleware.delete ActionDispatch::DebugExceptions
-        self.instance_eval(&during_init)
+    klass.send(:define_method, :initialize) do |*args|
+      super(*args)
+      redis_cache = [:redis_store, { url: ENV['REDIS_URL'] }]
+      file_cache = [:file_store, '/tmp/ddtrace-rb/cache/']
 
-        if ENV['USE_SIDEKIQ']
-          config.active_job.queue_adapter = :sidekiq
-          # add Sidekiq middleware
-          Sidekiq::Testing.server_middleware do |chain|
-            chain.add(
-              Datadog::Contrib::Sidekiq::Tracer
-            )
-          end
+      config.secret_key_base = 'f624861242e4ccf20eacb6bb48a886da'
+      config.cache_store = ENV['REDIS_URL'] ? redis_cache : file_cache
+      config.eager_load = false
+      config.consider_all_requests_local = true
+      config.active_support.test_order = :random
+      config.middleware.delete ActionDispatch::DebugExceptions
+      instance_eval(&during_init)
+
+      if ENV['USE_SIDEKIQ']
+        config.active_job.queue_adapter = :sidekiq
+        # add Sidekiq middleware
+        Sidekiq::Testing.server_middleware do |chain|
+          chain.add(
+            Datadog::Contrib::Sidekiq::Tracer
+          )
         end
-      end
-
-      before_test_init = before_test_initialize_block
-      after_test_init = after_test_initialize_block
-
-      klass.send(:define_method, :test_initialize!) do
-        # Enables the auto-instrumentation for the testing application
-        Datadog.configure do |c|
-          c.use :rails
-          c.use :redis
-        end
-
-        Rails.application.config.active_job.queue_adapter = :sidekiq
-
-        before_test_init.call
-        initialize!
-        after_test_init.call
       end
     end
+
+    before_test_init = before_test_initialize_block
+    after_test_init = after_test_initialize_block
+
+    klass.send(:define_method, :test_initialize!) do
+      # Enables the auto-instrumentation for the testing application
+      Datadog.configure do |c|
+        c.use :rails
+        c.use :redis
+      end
+
+      Rails.application.config.active_job.queue_adapter = :sidekiq
+
+      before_test_init.call
+      initialize!
+      after_test_init.call
+    end
+    klass
   end
 
   def append_routes!
@@ -115,7 +116,7 @@ RSpec.shared_context 'Rails 4 base application' do
   def app_middleware
     current = Rails::Railtie::Configuration.class_variable_get(:@@app_middleware)
     Datadog::Contrib::Rails::Test::Configuration.fetch(:app_middleware, current).dup.tap do |copy|
-      copy.instance_variable_set(:@operations, (copy.instance_variable_get(:@operations) || [] ).dup)
+      copy.instance_variable_set(:@operations, (copy.instance_variable_get(:@operations) || []).dup)
       copy.instance_variable_set(:@delete_operations, (copy.instance_variable_get(:@delete_operations) || []).dup)
     end
   end

--- a/spec/ddtrace/contrib/redis/integration_spec.rb
+++ b/spec/ddtrace/contrib/redis/integration_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe 'Redis integration test' do
   let(:port) { ENV.fetch('TEST_REDIS_PORT', 6379).to_i }
 
   it do
-    expect(redis.set 'FOO', 'bar').to eq('OK')
-    expect(redis.get 'FOO').to eq('bar')
+    expect(redis.set('FOO', 'bar')).to eq('OK')
+    expect(redis.get('FOO')).to eq('bar')
     try_wait_until(attempts: 30) { tracer.writer.stats[:traces_flushed] >= 2 }
     expect(tracer.writer.stats[:traces_flushed]).to be >= 2
   end

--- a/spec/ddtrace/contrib/redis/quantize_spec.rb
+++ b/spec/ddtrace/contrib/redis/quantize_spec.rb
@@ -41,7 +41,13 @@ RSpec.describe Datadog::Contrib::Redis::Quantize do
 
       context 'an object that can\'t be converted to a string' do
         let(:arg) { object_class.new }
-        let(:object_class) { Class.new { def to_s; raise "can't make a string of me" end } }
+        let(:object_class) do
+          Class.new do
+            def to_s
+              raise "can't make a string of me"
+            end
+          end
+        end
         it { is_expected.to eq('?') }
       end
 

--- a/spec/ddtrace/contrib/redis/redis_spec.rb
+++ b/spec/ddtrace/contrib/redis/redis_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe 'Redis test' do
 
       it do
         expect(services).to have(1).items
-        expect(services[service_name]).to eq({ 'app' => 'redis', 'app_type' => 'cache' })
+        expect(services[service_name]).to eq('app' => 'redis', 'app_type' => 'cache')
       end
     end
   end

--- a/spec/ddtrace/patcher_spec.rb
+++ b/spec/ddtrace/patcher_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Datadog::Patcher do
           expect(integration).to receive(:patch).once.and_return(patch_result)
           expect(result).to be(patch_result)
         end
-        
+
         context 'then called a second time' do
           context 'without a key' do
             subject(:result) do

--- a/spec/ddtrace/quantization/http_spec.rb
+++ b/spec/ddtrace/quantization/http_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 require 'spec_helper'
 
 require 'ddtrace/quantization/http'
@@ -47,7 +48,7 @@ RSpec.describe Datadog::Quantization::HTTP do
 
       context 'with Unicode characters' do
         # URLs do not permit unencoded non-ASCII characters in the URL.
-        let(:url) { "http://example.com/path?繋がってて" }
+        let(:url) { 'http://example.com/path?繋がってて' }
         it { is_expected.to eq(described_class::PLACEHOLDER) }
       end
     end

--- a/spec/ddtrace/registry_spec.rb
+++ b/spec/ddtrace/registry_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 require 'ddtrace'
-
-# rubocop:disable Metrics/BlockLength
 RSpec.describe Datadog::Registry do
   describe 'instance' do
     subject(:registry) { described_class.new }

--- a/spec/ddtrace/transport_spec.rb
+++ b/spec/ddtrace/transport_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Datadog::HTTPTransport do
   end
 
   describe '#send' do
-    before(:each) { skip "TEST_DATADOG_INTEGRATION not set." unless ENV['TEST_DATADOG_INTEGRATION'] }
+    before(:each) { skip 'TEST_DATADOG_INTEGRATION not set.' unless ENV['TEST_DATADOG_INTEGRATION'] }
 
     shared_examples_for 'an encoded transport' do
       context 'for a JSON-encoded transport' do

--- a/spec/ddtrace/writer_spec.rb
+++ b/spec/ddtrace/writer_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Datadog::Writer do
           context 'when the transport uses' do
             let(:options) { super().merge!(transport_options: { api_version: api_version, response_callback: callback }) }
             let(:callback) { double('callback method') }
-            
+
             let!(:request) { stub_request(:post, endpoint).to_return(response) }
             let(:endpoint) { "#{Datadog::Writer::HOSTNAME}:#{Datadog::Writer::PORT}/#{api_version}/traces" }
             let(:response) { { body: body } }
@@ -81,7 +81,7 @@ RSpec.describe Datadog::Writer do
                     :traces,
                     a_kind_of(Net::HTTPOK),
                     a_kind_of(Hash)
-                  ) do |action, response, api|
+                  ) do |_action, _response, api|
                     expect(api[:version]).to eq(api_version)
                   end
                 end
@@ -95,7 +95,9 @@ RSpec.describe Datadog::Writer do
               context 'but falls back to v3' do
                 let(:response) { super().merge!(status: 404) }
                 let!(:fallback_request) { stub_request(:post, fallback_endpoint).to_return(body: body) }
-                let(:fallback_endpoint) { "#{Datadog::Writer::HOSTNAME}:#{Datadog::Writer::PORT}/#{fallback_version}/traces" }
+                let(:fallback_endpoint) do
+                  "#{Datadog::Writer::HOSTNAME}:#{Datadog::Writer::PORT}/#{fallback_version}/traces"
+                end
                 let(:body) { 'body' }
 
                 before(:each) do
@@ -104,7 +106,7 @@ RSpec.describe Datadog::Writer do
                     :traces,
                     a_kind_of(Net::HTTPResponse),
                     a_kind_of(Hash)
-                  ) do |action, response, api|
+                  ) do |_action, response, api|
                     call_count += 1
                     if call_count == 1
                       expect(response).to be_a_kind_of(Net::HTTPNotFound)

--- a/test/contrib/rack/helpers.rb
+++ b/test/contrib/rack/helpers.rb
@@ -11,8 +11,6 @@ class RackBaseTest < Minitest::Test
   # rubocop:disable Metrics/MethodLength
   def app
     tracer = @tracer
-
-    # rubocop:disable Metrics/BlockLength
     Rack::Builder.new do
       use Datadog::Contrib::Rack::TraceMiddleware
 

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -24,8 +24,6 @@ class FullStackTest < ActionDispatch::IntegrationTest
     Datadog.configuration[:rails][:tracer] = @rails_tracer
     Rails.application.app.instance_variable_set(:@tracer, @rack_tracer)
   end
-
-  # rubocop:disable Metrics/BlockLength
   test 'a full request is properly traced' do
     # make the request and assert the proper span
     get '/full'


### PR DESCRIPTION
I've found out spec files are not following Rubocop linting configuration. 

This PR aligns the code in spec with Rubocop configuration. Its mostly a product of running `rubocop -a ` in a loop.