### PR TITLE
Allow custom metrics to be set via action controller

### DIFF
--- a/lib/ddtrace/contrib/rails/action_controller.rb
+++ b/lib/ddtrace/contrib/rails/action_controller.rb
@@ -15,6 +15,10 @@ module Datadog
           end
         end
 
+        def self.custom_span_tags
+          @@custom_span_tags ||= {}
+        end
+
         def self.start_processing(payload)
           # trace the execution
           tracer = Datadog.configuration[:rails][:tracer]
@@ -49,6 +53,10 @@ module Datadog
 
             span.set_tag('rails.route.action', payload.fetch(:action))
             span.set_tag('rails.route.controller', payload.fetch(:controller))
+
+            custom_span_tags.each do |k, v|
+              span.set_tag(k, v)
+            end
 
             exception = payload[:exception_object]
             if exception.nil?


### PR DESCRIPTION
Datadog trace gem allows to set customer span tag via Rack middleware which is amazing, I do something similar to:
```
class DdtraceMiddleware
  def initialize(app)
    @app = app
  end

  def call(env)
    @app.call(env)
  ensure
    request_span = env[:datadog_rack_request_span] || env['datadog_rack_request_span']
    request_span.set_tag("custom_tag_a", 1)
    request_span.set_tag("custom_tag_b, 2)
   end
end
```

Custom tags are super powerful and allow me to build reports that couldn't be done using many alternative APM providers. But the problem is not every metric is available on Rack middleware layer, something is accessible only as part of Action Controller, and I can't find an easy way to extend `dd_request_span` with custom tags via controller. 

This PR addresses the problem by having a hash of key/value pairs I can have in any controller in order to bring these tags to APM. I'm open to any suggestions and alternative variants!