### PR TITLE
Dockerize the test suite

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,181 @@
-version: '3'
+version: '3.2'
 services:
+  tracer-1.9:
+    build:
+      context: ./.circleci/images/primary
+      dockerfile: Dockerfile-1.9.3
+    command: /bin/bash
+    depends_on:
+      - ddagent
+      - elasticsearch
+      - memcached
+      - mongodb
+      - mysql
+      - postgres
+      - redis
+    env_file: ./.env
+    environment:
+      - TEST_DATADOG_INTEGRATION=1
+      - TEST_DDAGENT_HOST=ddagent
+      - TEST_ELASTICSEARCH_HOST=elasticsearch
+      - TEST_MEMCACHED_HOST=memcached
+      - TEST_MONGODB_HOST=mongodb
+      - TEST_MYSQL_HOST=mysql
+      - TEST_POSTGRES_HOST=postgres
+      - TEST_REDIS_HOST=redis
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/app
+      - bundle-1.9:/usr/local/bundle
+  tracer-2.0:
+    build:
+      context: ./.circleci/images/primary
+      dockerfile: Dockerfile-2.0.0
+    command: /bin/bash
+    depends_on:
+      - ddagent
+      - elasticsearch
+      - memcached
+      - mongodb
+      - mysql
+      - postgres
+      - redis
+    env_file: ./.env
+    environment:
+      - TEST_DATADOG_INTEGRATION=1
+      - TEST_DDAGENT_HOST=ddagent
+      - TEST_ELASTICSEARCH_HOST=elasticsearch
+      - TEST_MEMCACHED_HOST=memcached
+      - TEST_MONGODB_HOST=mongodb
+      - TEST_MYSQL_HOST=mysql
+      - TEST_POSTGRES_HOST=postgres
+      - TEST_REDIS_HOST=redis
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/app
+      - bundle-2.0:/usr/local/bundle
+  tracer-2.1:
+    build:
+      context: ./.circleci/images/primary
+      dockerfile: Dockerfile-2.1.10
+    command: /bin/bash
+    depends_on:
+      - ddagent
+      - elasticsearch
+      - memcached
+      - mongodb
+      - mysql
+      - postgres
+      - redis
+    env_file: ./.env
+    environment:
+      - TEST_DATADOG_INTEGRATION=1
+      - TEST_DDAGENT_HOST=ddagent
+      - TEST_ELASTICSEARCH_HOST=elasticsearch
+      - TEST_MEMCACHED_HOST=memcached
+      - TEST_MONGODB_HOST=mongodb
+      - TEST_MYSQL_HOST=mysql
+      - TEST_POSTGRES_HOST=postgres
+      - TEST_REDIS_HOST=redis
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/app
+      - bundle-2.1:/usr/local/bundle
+  tracer-2.2:
+    build:
+      context: ./.circleci/images/primary
+      dockerfile: Dockerfile-2.2.10
+    command: /bin/bash
+    depends_on:
+      - ddagent
+      - elasticsearch
+      - memcached
+      - mongodb
+      - mysql
+      - postgres
+      - redis
+    env_file: ./.env
+    environment:
+      - TEST_DATADOG_INTEGRATION=1
+      - TEST_DDAGENT_HOST=ddagent
+      - TEST_ELASTICSEARCH_HOST=elasticsearch
+      - TEST_MEMCACHED_HOST=memcached
+      - TEST_MONGODB_HOST=mongodb
+      - TEST_MYSQL_HOST=mysql
+      - TEST_POSTGRES_HOST=postgres
+      - TEST_REDIS_HOST=redis
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/app
+      - bundle-2.2:/usr/local/bundle
+  tracer-2.3:
+    build:
+      context: ./.circleci/images/primary
+      dockerfile: Dockerfile-2.3.7
+    command: /bin/bash
+    depends_on:
+      - ddagent
+      - elasticsearch
+      - memcached
+      - mongodb
+      - mysql
+      - postgres
+      - redis
+    env_file: ./.env
+    environment:
+      - TEST_DATADOG_INTEGRATION=1
+      - TEST_DDAGENT_HOST=ddagent
+      - TEST_ELASTICSEARCH_HOST=elasticsearch
+      - TEST_MEMCACHED_HOST=memcached
+      - TEST_MONGODB_HOST=mongodb
+      - TEST_MYSQL_HOST=mysql
+      - TEST_POSTGRES_HOST=postgres
+      - TEST_REDIS_HOST=redis
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/app
+      - bundle-2.3:/usr/local/bundle
+  tracer-2.4:
+    build:
+      context: ./.circleci/images/primary
+      dockerfile: Dockerfile-2.4.4
+    command: /bin/bash
+    depends_on:
+      - ddagent
+      - elasticsearch
+      - memcached
+      - mongodb
+      - mysql
+      - postgres
+      - redis
+    env_file: ./.env
+    environment:
+      - TEST_DATADOG_INTEGRATION=1
+      - TEST_DDAGENT_HOST=ddagent
+      - TEST_ELASTICSEARCH_HOST=elasticsearch
+      - TEST_MEMCACHED_HOST=memcached
+      - TEST_MONGODB_HOST=mongodb
+      - TEST_MYSQL_HOST=mysql
+      - TEST_POSTGRES_HOST=postgres
+      - TEST_REDIS_HOST=redis
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/app
+      - bundle-2.4:/usr/local/bundle
   ddagent:
     image: datadog/docker-dd-agent
     environment:
       - DD_APM_ENABLED=true
       - DD_BIND_HOST=0.0.0.0
       - DD_API_KEY=invalid_key_but_this_is_fine
+    expose:
+      - "8126"
     ports:
       - "${TEST_DDAGENT_PORT}:8126"
   elasticsearch:
@@ -14,15 +184,22 @@ services:
     # see https://github.com/docker-library/elasticsearch/issues/98 for details
     # For now, just rely on a 2.X server.
     image: elasticsearch:2.4
+    expose:
+      - "9200"
+      - "9300"
     ports:
       - "${TEST_ELASTICSEARCH_REST_PORT}:9200"
       - "${TEST_ELASTICSEARCH_NATIVE_PORT}:9300"
   memcached:
     image: memcached:1.5-alpine
+    expose:
+      - "11211"
     ports:
       - "${TEST_MEMCACHED_PORT}:11211"
   mongodb:
     image: mongo:3.5
+    expose:
+      - "27017"
     ports:
       - "${TEST_MONGODB_PORT}:27017"
   mysql:
@@ -31,6 +208,8 @@ services:
       - MYSQL_ROOT_PASSWORD=$TEST_MYSQL_ROOT_PASSWORD
       - MYSQL_PASSWORD=$TEST_MYSQL_PASSWORD
       - MYSQL_USER=$TEST_MYSQL_USER
+    expose:
+      - "3306"
     ports:
       - "${TEST_MYSQL_PORT}:3306"
   postgres:
@@ -39,9 +218,20 @@ services:
       - POSTGRES_PASSWORD=$TEST_POSTGRES_PASSWORD
       - POSTGRES_USER=$TEST_POSTGRES_USER
       - POSTGRES_DB=$TEST_POSTGRES_DB
+    expose:
+      - "5432"
     ports:
       - "${TEST_POSTGRES_PORT}:5432"
   redis:
     image: redis:3.0
+    expose:
+      - "6379"
     ports:
       - "${TEST_REDIS_PORT}:6379"
+volumes:
+  bundle-1.9:
+  bundle-2.0:
+  bundle-2.1:
+  bundle-2.2:
+  bundle-2.3:
+  bundle-2.4:

--- a/gemfiles/rails5_mysql2.gemfile
+++ b/gemfiles/rails5_mysql2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
-gem "rails", "5.1.5"
+gem "rails", "~> 5.1.6"
 gem "mysql2", "< 0.5", platform: :ruby
 
 gemspec path: "../"

--- a/gemfiles/rails5_postgres.gemfile
+++ b/gemfiles/rails5_postgres.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
-gem "rails", "5.1.5"
+gem "rails", "~> 5.1.6"
 gem "pg", "< 1.0", platform: :ruby
 
 gemspec path: "../"

--- a/gemfiles/rails5_postgres_redis.gemfile
+++ b/gemfiles/rails5_postgres_redis.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
-gem "rails", "5.1.5"
+gem "rails", "~> 5.1.6"
 gem "pg", "< 1.0", platform: :ruby
 gem "redis-rails"
 gem "redis"

--- a/gemfiles/rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/rails5_postgres_sidekiq.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "pry-nav", git: "https://github.com/nixme/pry-nav.git", branch: "master"
-gem "rails", "5.1.5"
+gem "rails", "~> 5.1.6"
 gem "pg", "< 1.0", platform: :ruby
 gem "sidekiq"
 gem "activejob"

--- a/spec/ddtrace/contrib/active_record/tracer_spec.rb
+++ b/spec/ddtrace/contrib/active_record/tracer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'ActiveRecord instrumentation' do
     Datadog.configuration[:active_record].reset_options!
 
     Datadog.configure do |c|
+      c.tracer hostname: ENV.fetch('TEST_DDAGENT_HOST', 'localhost')
       c.use :active_record, configuration_options
     end
   end

--- a/spec/ddtrace/contrib/dalli/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/dalli/instrumentation_spec.rb
@@ -5,7 +5,7 @@ require 'ddtrace'
 require 'ddtrace/contrib/dalli/patcher'
 
 RSpec.describe 'Dalli instrumentation' do
-  let(:test_host) { ENV.fetch('TEST_MEMCACHED_PORT', '127.0.0.1') }
+  let(:test_host) { ENV.fetch('TEST_MEMCACHED_HOST', '127.0.0.1') }
   let(:test_port) { ENV.fetch('TEST_MEMCACHED_PORT', '11211') }
 
   let(:client) { ::Dalli::Client.new("#{test_host}:#{test_port}") }

--- a/spec/ddtrace/contrib/redis/integration_spec.rb
+++ b/spec/ddtrace/contrib/redis/integration_spec.rb
@@ -7,7 +7,11 @@ require 'ddtrace'
 
 RSpec.describe 'Redis integration test' do
   # Use real tracer
-  let(:tracer) { Datadog::Tracer.new }
+  let(:tracer) do
+    Datadog::Tracer.new.tap do |tracer|
+      tracer.configure(hostname: ENV.fetch('TEST_DDAGENT_HOST', 'localhost'))
+    end
+  end
 
   before(:each) do
     skip unless ENV['TEST_DATADOG_INTEGRATION']

--- a/spec/ddtrace/contrib/redis/method_replaced_spec.rb
+++ b/spec/ddtrace/contrib/redis/method_replaced_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Redis replace method test' do
     skip unless ENV['TEST_DATADOG_INTEGRATION']
 
     Datadog.configure do |c|
+      c.tracer hostname: ENV.fetch('TEST_DDAGENT_HOST', 'localhost')
       c.use :redis
     end
   end

--- a/test/contrib/elasticsearch/integration_test.rb
+++ b/test/contrib/elasticsearch/integration_test.rb
@@ -11,6 +11,7 @@ class ESIntegrationTest < Minitest::Test
     skip unless ENV['TEST_DATADOG_INTEGRATION'] # requires a running agent
 
     Datadog.configure do |c|
+      c.tracer hostname: ENV.fetch('TEST_DDAGENT_HOST', 'localhost')
       c.use :elasticsearch
     end
 

--- a/test/contrib/http/integration_test.rb
+++ b/test/contrib/http/integration_test.rb
@@ -11,6 +11,7 @@ class HTTPIntegrationTest < Minitest::Test
     skip unless ENV['TEST_DATADOG_INTEGRATION'] # requires a running agent
 
     Datadog.configure do |c|
+      c.tracer hostname: ENV.fetch('TEST_DDAGENT_HOST', 'localhost')
       c.use :http
     end
 

--- a/test/contrib/http/miniapp_test.rb
+++ b/test/contrib/http/miniapp_test.rb
@@ -16,6 +16,7 @@ class HTTPMiniAppTest < Minitest::Test
 
   def setup
     Datadog.configure do |c|
+      c.tracer hostname: ENV.fetch('TEST_DDAGENT_HOST', 'localhost')
       c.use :http
     end
 

--- a/test/contrib/http/request_test.rb
+++ b/test/contrib/http/request_test.rb
@@ -11,6 +11,7 @@ class HTTPRequestTest < Minitest::Test
 
   def setup
     Datadog.configure do |c|
+      c.tracer hostname: ENV.fetch('TEST_DDAGENT_HOST', 'localhost')
       c.use :http
     end
 

--- a/test/contrib/rack/helpers.rb
+++ b/test/contrib/rack/helpers.rb
@@ -94,6 +94,7 @@ class RackBaseTest < Minitest::Test
     @tracer = get_test_tracer
 
     Datadog.configure do |c|
+      c.tracer hostname: ENV.fetch('TEST_DDAGENT_HOST', 'localhost')
       c.use :http
       c.use :rack, tracer: @tracer
     end

--- a/test/contrib/rails/apps/application.rb
+++ b/test/contrib/rails/apps/application.rb
@@ -42,6 +42,7 @@ module RailsTrace
     def test_config
       # Enables the auto-instrumentation for the testing application
       Datadog.configure do |c|
+        c.tracer hostname: ENV.fetch('TEST_DDAGENT_HOST', 'localhost')
         c.use :rails
         c.use :redis
       end

--- a/test/contrib/rails/apps/rails3.rb
+++ b/test/contrib/rails/apps/rails3.rb
@@ -17,6 +17,7 @@ end
 
 # Enables the auto-instrumentation for the testing application
 Datadog.configure do |c|
+  c.tracer hostname: ENV.fetch('TEST_DDAGENT_HOST', 'localhost')
   c.use :rails
   c.use :redis
 end

--- a/test/contrib/sinatra/tracer_activerecord_test.rb
+++ b/test/contrib/sinatra/tracer_activerecord_test.rb
@@ -46,7 +46,10 @@ class TracerActiveRecordTest < TracerTestBase
                                                    database: ':memory:')
     app().set :datadog_test_conn, conn
 
-    Datadog.configuration.use(:active_record)
+    Datadog.configure do |c|
+      c.tracer hostname: ENV.fetch('TEST_DDAGENT_HOST', 'localhost')
+      c.use :active_record
+    end
 
     super
   end


### PR DESCRIPTION
In order to more faithfully recreate a development environment that mirrors our CI pipeline and environment, we can use Docker compose to run tests locally in Docker containers.

This pull request uses the same images from our CI pipeline for use in `docker-compose.yml`, making it easy to spin up and run tests in a local environment. Now to debug a broken CI test locally, you can just:

1. Run `docker-compose run --rm tracer-2.3` (or whatever Ruby version you wish.)
2. In the container, run `bundle install` then `appraisal install`.
3. Run `rake ci` to run the same tests Circle runs.