### PR TITLE
Add tests to verify active_span can be tagged from within controller methods

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -231,8 +231,8 @@ class TracingController < ActionController::Base
   def index
     return head :not_found unless authenticated?
     
-    tracer = Datadog.configuration[:rails][:tracer]
-    tracer.active_span&.set_tag('authenticated', true)
+    current_span = Datadog.tracer.active_span
+    current_span.set_tag('authenticated', true) unless current_span.nil?
 
     head :ok
   end

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -226,17 +226,10 @@ end
 You can tag additional information to current active span from any method. Note however that if the method is called and there is no span currently active `active_span` will be nil. 
 
 ```ruby
-# e.g. Adding authenticated tag to active span from within controller method.
-class TracingController < ActionController::Base
-  def index
-    return head :not_found unless authenticated?
+# e.g. adding tag to active span
     
-    current_span = Datadog.tracer.active_span
-    current_span.set_tag('authenticated', true) unless current_span.nil?
-
-    head :ok
-  end
-end
+current_span = Datadog.tracer.active_span
+current_span.set_tag('my_tag', 'my_value') unless current_span.nil?
 ```
 
 ## Integration instrumentation

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -221,6 +221,23 @@ def finish(name, id, payload)
   end
 end
 ```
+#####Enriching traces from nested methods
+
+You can tag additional information to current active span from any method. Note however that if the method is called and there is no span currently active `active_span` will be nil. 
+
+```ruby
+# e.g. Adding authenticated tag to active span from within controller method.
+class TracingController < ActionController::Base
+  def index
+    return head :not_found unless authenticated?
+    
+    tracer = Datadog.configuration[:rails][:tracer]
+    tracer.active_span&.set_tag('authenticated', true)
+
+    head :ok
+  end
+end
+```
 
 ## Integration instrumentation
 

--- a/lib/ddtrace/contrib/rails/action_controller_patch.rb
+++ b/lib/ddtrace/contrib/rails/action_controller_patch.rb
@@ -1,0 +1,63 @@
+module Datadog
+  module Contrib
+    module Rails
+      # Instrument ActiveController processing
+      module ActionControllerPatch
+        def self.included(base)
+          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')
+            base.send(:prepend, ProcessActionPatch)
+          else
+            base.class_eval do
+              alias_method :process_action_without_datadog, :process_action
+
+              include ProcessActionPatch
+            end
+          end
+        end
+
+        # Compatibility module for Ruby versions not supporting #prepend
+        module ProcessActionCompatibilityPatch
+          def process_action(*args)
+            process_action_without_datadog(*args)
+          end
+        end
+
+        # ActionController patch
+        module ProcessActionPatch
+          # compatibility module for Ruby versions not supporting #prepend
+          include ProcessActionCompatibilityPatch unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')
+
+          def process_action(*args)
+            # mutable payload with a tracing context that is used in two different
+            # signals; it propagates the request span so that it can be finished
+            # no matter what
+            payload = {
+                controller: self.class,
+                action: action_name,
+                headers: {
+                    # The exception this controller was given in the request,
+                    # which is typical if the controller is configured to handle exceptions.
+                    request_exception: request.headers['action_dispatch.exception']
+                },
+                tracing_context: {}
+            }
+
+            begin
+              # process and catch request exceptions
+              Datadog::Contrib::Rails::ActionController.start_processing(payload)
+              result = super(*args)
+              payload[:status] = response.status
+              result
+            rescue Exception => e
+              payload[:exception] = [e.class.name, e.message]
+              payload[:exception_object] = e
+              raise e
+            end
+          ensure
+            Datadog::Contrib::Rails::ActionController.finish_processing(payload)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/rails/action_controller_patch.rb
+++ b/lib/ddtrace/contrib/rails/action_controller_patch.rb
@@ -32,14 +32,14 @@ module Datadog
             # signals; it propagates the request span so that it can be finished
             # no matter what
             payload = {
-                controller: self.class,
-                action: action_name,
-                headers: {
-                    # The exception this controller was given in the request,
-                    # which is typical if the controller is configured to handle exceptions.
-                    request_exception: request.headers['action_dispatch.exception']
-                },
-                tracing_context: {}
+              controller: self.class,
+              action: action_name,
+              headers: {
+                # The exception this controller was given in the request,
+                # which is typical if the controller is configured to handle exceptions.
+                request_exception: request.headers['action_dispatch.exception']
+              },
+              tracing_context: {}
             }
 
             begin
@@ -49,11 +49,13 @@ module Datadog
               status = datadog_response_status
               payload[:status] = status unless status.nil?
               result
+            # rubocop:disable Lint/RescueException
             rescue Exception => e
               payload[:exception] = [e.class.name, e.message]
               payload[:exception_object] = e
               raise e
             end
+          # rubocop:enable Lint/RescueException
           ensure
             Datadog::Contrib::Rails::ActionController.finish_processing(payload)
           end

--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -192,7 +192,6 @@ module Datadog
         # mutable payload with a tracing context that is used in two different
         # signals; it propagates the request span so that it can be finished
         # no matter what
-
         payload = {
           controller: self.class,
           action: action_name,

--- a/lib/ddtrace/contrib/rails/core_extensions.rb
+++ b/lib/ddtrace/contrib/rails/core_extensions.rb
@@ -159,7 +159,7 @@ module Datadog
       do_once(:patch_process_action) do
         require 'ddtrace/contrib/rails/action_controller_patch'
 
-        ::ActionController::Metal.include(Datadog::Contrib::Rails::ActionControllerPatch)
+        ::ActionController::Metal.send(:include, Datadog::Contrib::Rails::ActionControllerPatch)
       end
     end
   end

--- a/test/contrib/rails/apps/controllers.rb
+++ b/test/contrib/rails/apps/controllers.rb
@@ -94,6 +94,13 @@ class TracingController < ActionController::Base
     tracer.active_span.resource = 'custom-resource'
     head :ok
   end
+
+  def custom_tag
+    tracer = Datadog.configuration[:rails][:tracer]
+    tracer.active_span.set_tag('custom-tag', 'custom-tag-value')
+
+    head :ok
+  end
 end
 
 class ErrorsController < ActionController::Base
@@ -116,6 +123,7 @@ routes = {
   '/missing_template' => 'tracing#missing_template',
   '/missing_partial' => 'tracing#missing_partial',
   '/custom_resource' => 'tracing#custom_resource',
+  '/custom_tag' => 'tracing#custom_tag',
   '/internal_server_error' => 'errors#internal_server_error'
 }
 

--- a/test/contrib/rails/controller_test.rb
+++ b/test/contrib/rails/controller_test.rb
@@ -234,6 +234,17 @@ class TracingControllerTest < ActionController::TestCase
     end
   end
 
+  test 'custom tags can be set' do
+    get :custom_tag
+    assert_response :success
+    spans = @tracer.writer.spans
+    assert_equal(spans.length, 1)
+
+    spans.first.tap do |span|
+      assert_equal('custom-tag-value', span.get_tag('custom-tag'))
+    end
+  end
+
   test 'combining rails and custom tracing is supported' do
     @tracer.trace('a-parent') do
       get :index


### PR DESCRIPTION
While implementing possible alternative solution to https://github.com/DataDog/dd-trace-rb/pull/436
I've found that we already support tagging spans from within Controller methods.

This PR is meant to salvage some of that work

Todo:
- [x]  add documentation on how to access span from within nested method