### PR TITLE
Adds delay metric to sidekiq traces

### DIFF
--- a/lib/ddtrace/contrib/sidekiq/tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/tracer.rb
@@ -32,6 +32,7 @@ module Datadog
             span.set_tag('sidekiq.job.retry', job['retry'])
             span.set_tag('sidekiq.job.queue', job['queue'])
             span.set_tag('sidekiq.job.wrapper', job['class']) if job['wrapped']
+            span.set_tag('sidekiq.job.delay', 1000.0 * (Time.now.utc.to_f - job['enqueued_at'].to_f))
 
             yield
           end

--- a/test/contrib/sidekiq/tracer_test.rb
+++ b/test/contrib/sidekiq/tracer_test.rb
@@ -50,6 +50,7 @@ class TracerTest < TracerTestBase
     assert_equal('sidekiq', span.service)
     assert_equal('TracerTest::EmptyWorker', span.resource)
     assert_equal('default', span.get_tag('sidekiq.job.queue'))
+    assert_not_nil(span.get_tag('sidekiq.job.delay'))
     assert_equal(0, span.status)
     assert_nil(span.parent)
   end
@@ -71,6 +72,7 @@ class TracerTest < TracerTestBase
     assert_equal('sidekiq', span.service)
     assert_equal('TracerTest::ErrorWorker', span.resource)
     assert_equal('default', span.get_tag('sidekiq.job.queue'))
+    assert_not_nil(span.get_tag('sidekiq.job.delay'))
     assert_equal(1, span.status)
     assert_equal('job error', span.get_tag(Datadog::Ext::Errors::MSG))
     assert_equal('TracerTest::TestError', span.get_tag(Datadog::Ext::Errors::TYPE))
@@ -92,6 +94,7 @@ class TracerTest < TracerTestBase
     assert_equal('sidekiq', empty.service)
     assert_equal('TracerTest::EmptyWorker', empty.resource)
     assert_equal('default', empty.get_tag('sidekiq.job.queue'))
+    assert_not_nil(empty.get_tag('sidekiq.job.delay'))
     assert_equal(0, empty.status)
     assert_nil(empty.parent)
 

--- a/test/contrib/sidekiq/tracer_test.rb
+++ b/test/contrib/sidekiq/tracer_test.rb
@@ -50,7 +50,7 @@ class TracerTest < TracerTestBase
     assert_equal('sidekiq', span.service)
     assert_equal('TracerTest::EmptyWorker', span.resource)
     assert_equal('default', span.get_tag('sidekiq.job.queue'))
-    assert_not_nil(span.get_tag('sidekiq.job.delay'))
+    refute_nil(span.get_tag('sidekiq.job.delay'))
     assert_equal(0, span.status)
     assert_nil(span.parent)
   end
@@ -72,7 +72,7 @@ class TracerTest < TracerTestBase
     assert_equal('sidekiq', span.service)
     assert_equal('TracerTest::ErrorWorker', span.resource)
     assert_equal('default', span.get_tag('sidekiq.job.queue'))
-    assert_not_nil(span.get_tag('sidekiq.job.delay'))
+    refute_nil(span.get_tag('sidekiq.job.delay'))
     assert_equal(1, span.status)
     assert_equal('job error', span.get_tag(Datadog::Ext::Errors::MSG))
     assert_equal('TracerTest::TestError', span.get_tag(Datadog::Ext::Errors::TYPE))
@@ -94,7 +94,7 @@ class TracerTest < TracerTestBase
     assert_equal('sidekiq', empty.service)
     assert_equal('TracerTest::EmptyWorker', empty.resource)
     assert_equal('default', empty.get_tag('sidekiq.job.queue'))
-    assert_not_nil(empty.get_tag('sidekiq.job.delay'))
+    refute_nil(empty.get_tag('sidekiq.job.delay'))
     assert_equal(0, empty.status)
     assert_nil(empty.parent)
 


### PR DESCRIPTION
Delay represent the time for a job spent in queue waiting to be taken by a worker, in millisecond. Such metric is useful to tell if sidekiq is under too much load and can't keep up with the throughput of new jobs being created.

cc @delner I've based commits against 0.13-dev