### PR TITLE
Fix ActionView tracing contexts when span limit is reached

### DIFF
--- a/lib/ddtrace/contrib/rails/action_view.rb
+++ b/lib/ddtrace/contrib/rails/action_view.rb
@@ -13,40 +13,6 @@ module Datadog
             Datadog::RailsRendererPatcher.patch_renderer
           end
         end
-
-        def self.start_render_template(payload)
-          # retrieve the tracing context
-          tracing_context = payload.fetch(:tracing_context)
-
-          # create a new Span and add it to the tracing context
-          tracer = Datadog.configuration[:rails][:tracer]
-          span = tracer.trace('rails.render_template', span_type: Datadog::Ext::HTTP::TEMPLATE)
-          tracing_context[:dd_rails_template_span] = span
-        rescue StandardError => e
-          Datadog::Tracer.log.debug(e.message)
-        end
-
-        def self.finish_render_template(payload)
-          # retrieve the tracing context and the latest active span
-          tracing_context = payload.fetch(:tracing_context)
-          span = tracing_context[:dd_rails_template_span]
-          return if !span || span.finished?
-
-          # finish the tracing and update the execution time
-          begin
-            template_name = tracing_context[:template_name]
-            layout = tracing_context[:layout]
-            exception = tracing_context[:exception]
-
-            span.set_tag('rails.template_name', template_name) if template_name
-            span.set_tag('rails.layout', layout) if layout
-            span.set_error(exception) if exception
-          ensure
-            span.finish()
-          end
-        rescue StandardError => e
-          Datadog::Tracer.log.debug(e.message)
-        end
       end
     end
   end

--- a/lib/ddtrace/contrib/rails/action_view.rb
+++ b/lib/ddtrace/contrib/rails/action_view.rb
@@ -47,37 +47,6 @@ module Datadog
         rescue StandardError => e
           Datadog::Tracer.log.debug(e.message)
         end
-
-        def self.start_render_partial(payload)
-          # retrieve the tracing context
-          tracing_context = payload.fetch(:tracing_context)
-
-          tracer = Datadog.configuration[:rails][:tracer]
-          span = tracer.trace('rails.render_partial', span_type: Datadog::Ext::HTTP::TEMPLATE)
-          tracing_context[:dd_rails_partial_span] = span
-        rescue StandardError => e
-          Datadog::Tracer.log.debug(e.message)
-        end
-
-        def self.finish_render_partial(payload)
-          # retrieve the tracing context and the latest active span
-          tracing_context = payload.fetch(:tracing_context)
-          span = tracing_context[:dd_rails_partial_span]
-          return if !span || span.finished?
-
-          # finish the tracing and update the execution time
-          begin
-            template_name = tracing_context[:template_name]
-            exception = tracing_context[:exception]
-
-            span.set_tag('rails.template_name', template_name) if template_name
-            span.set_error(exception) if exception
-          ensure
-            span.finish()
-          end
-        rescue StandardError => e
-          Datadog::Tracer.log.debug(e.message)
-        end
       end
     end
   end

--- a/test/contrib/rails/errors_test.rb
+++ b/test/contrib/rails/errors_test.rb
@@ -96,12 +96,6 @@ class TracingControllerTest < ActionController::TestCase
                   'Missing partial tracing/ouch.html'
                 end
 
-    template_error_type = if Rails.version >= '3.2.22.5'
-                            'ActionView::Template::Error'
-                          else
-                            'ActionView::MissingTemplate'
-                          end
-
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 3)
     span_request, span_partial, span_template = spans
@@ -131,7 +125,7 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_template.get_tag('rails.template_name'), 'tracing/missing_partial.html.erb')
     assert_equal(span_template.get_tag('rails.layout'), 'layouts/application')
     assert_includes(span_template.get_tag('error.msg'), error_msg)
-    assert_equal(span_template.get_tag('error.type'), template_error_type)
+    assert_equal(span_template.get_tag('error.type'), 'ActionView::Template::Error')
   end
 
   test 'error in the template must be traced' do


### PR DESCRIPTION
As revealed by #445, when the hard-cap span limit is reached for a trace (~100K), the Rails renderer tracing starts mishandling spans. This is because it was relying on `tracer.call_context.current_span` which returns the last span in the context when the context fills, as opposed to the most recently instantiated span.

Although addressing the behavior of `tracer.call_context.current_span` and its equivalent `tracer.active_span` remains an issue at large, we can avoid this altogether in the Rails code.

This pull request removes "tracing context" management and context-specific code from the Rails patch altogether, and opts for a much simpler `tracer.trace` approach instead. This should resolve #445 by simply avoiding the code path in question altogether.