### PR TITLE
[rails] Add feature flags to Rails integration

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -651,7 +651,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | ``distributed_tracing`` | Enables [distributed tracing](#distributed-tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `false` |
 | ``middleware_names`` | Enables any short-circuited middleware requests to display the middleware name as resource for the trace. | `false` |
 | ``template_base_path`` | Used when the template name is parsed. If you don't store your templates in the ``views/`` folder, you may need to change this value | ``views/`` |
-| ``flags`` | Flags used in `rails` instrumentation. | ```{ instrument_action_view_rendering: true, instrument_action_controller_processing: true, instrument_active_support_caching: true, use_rack_integration: true, use_active_record_integration: true}``` |
+| ``flags`` | Flags used in `rails` instrumentation. | ```{ action_view_rendering: true, action_controller_processing: true, active_support_caching: true, active_record: true}``` |
 | ``tracer`` | A ``Datadog::Tracer`` instance used to instrument the application. Usually you don't need to set that. | ``Datadog.tracer`` |
 
 ### Redis

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -651,6 +651,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | ``distributed_tracing`` | Enables [distributed tracing](#distributed-tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `false` |
 | ``middleware_names`` | Enables any short-circuited middleware requests to display the middleware name as resource for the trace. | `false` |
 | ``template_base_path`` | Used when the template name is parsed. If you don't store your templates in the ``views/`` folder, you may need to change this value | ``views/`` |
+| ``features`` | Features enabled in `rails` instrumentation. | ```[:instrument_action_view_rendering, :instrument_action_controller_processing, :instrument_active_support_caching, :use_rack_integration, :use_active_record_integration ]``` |
 | ``tracer`` | A ``Datadog::Tracer`` instance used to instrument the application. Usually you don't need to set that. | ``Datadog.tracer`` |
 
 ### Redis

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -651,7 +651,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | ``distributed_tracing`` | Enables [distributed tracing](#distributed-tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `false` |
 | ``middleware_names`` | Enables any short-circuited middleware requests to display the middleware name as resource for the trace. | `false` |
 | ``template_base_path`` | Used when the template name is parsed. If you don't store your templates in the ``views/`` folder, you may need to change this value | ``views/`` |
-| ``features`` | Features enabled in `rails` instrumentation. | ```[:instrument_action_view_rendering, :instrument_action_controller_processing, :instrument_active_support_caching, :use_rack_integration, :use_active_record_integration ]``` |
+| ``flags`` | Flags used in `rails` instrumentation. | ```{ instrument_action_view_rendering: true, instrument_action_controller_processing: true, instrument_active_support_caching: true, use_rack_integration: true, use_active_record_integration: true}``` |
 | ``tracer`` | A ``Datadog::Tracer`` instance used to instrument the application. Usually you don't need to set that. | ``Datadog.tracer`` |
 
 ### Redis

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -23,8 +23,8 @@ module Datadog
         def self.setup
           config = config_with_defaults
 
-          activate_rack!(config) if datadog_configuration[:features].include?(:use_rack_integration)
-          activate_active_record!(config) if datadog_configuration[:features].include?(:use_active_record_integration)
+          activate_rack!(config) if datadog_configuration[:flags][:use_rack_integration]
+          activate_active_record!(config) if datadog_configuration[:flags][:use_active_record_integration]
 
           set_service_info!(config)
 

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -23,8 +23,8 @@ module Datadog
         def self.setup
           config = config_with_defaults
 
-          activate_rack!(config) if datadog_configuration[:flags][:use_rack_integration]
-          activate_active_record!(config) if datadog_configuration[:flags][:use_active_record_integration]
+          activate_rack!(config)
+          activate_active_record!(config) if datadog_configuration[:instrument][:active_record]
 
           set_service_info!(config)
 

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -23,8 +23,9 @@ module Datadog
         def self.setup
           config = config_with_defaults
 
-          activate_rack!(config)
-          activate_active_record!(config)
+          activate_rack!(config) if datadog_configuration[:features].include?(:use_rack_integration)
+          activate_active_record!(config) if datadog_configuration[:features].include?(:use_active_record_integration)
+
           set_service_info!(config)
 
           # By default, default service would be guessed from the script
@@ -68,6 +69,10 @@ module Datadog
           tracer = config[:tracer]
           tracer.set_service_info(config[:controller_service], 'rails', Ext::AppTypes::WEB)
           tracer.set_service_info(config[:cache_service], 'rails', Ext::AppTypes::CACHE)
+        end
+
+        def self.datadog_configuration
+          Datadog.configuration[:rails]
         end
       end
     end

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -21,6 +21,11 @@ module Datadog
         option :distributed_tracing, default: false
         option :template_base_path, default: 'views/'
         option :exception_controller, default: nil
+        option :features, default: [:instrument_action_view_rendering,
+                                    :instrument_action_controller_processing,
+                                    :instrument_active_support_caching,
+                                    :use_rack_integration,
+                                    :use_active_record_integration]
         option :tracer, default: Datadog.tracer
 
         @patched = false

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -6,6 +6,15 @@ module Datadog
       # Patcher
       module Patcher
         include Base
+
+        DEFAULT_FLAGS = {
+          instrument_action_view_rendering: true,
+          instrument_action_controller_processing: true,
+          instrument_active_support_caching: true,
+          use_rack_integration: true,
+          use_active_record_integration: true
+        }.freeze
+
         register_as :rails, auto_patch: true
 
         option :service_name
@@ -21,11 +30,7 @@ module Datadog
         option :distributed_tracing, default: false
         option :template_base_path, default: 'views/'
         option :exception_controller, default: nil
-        option :features, default: [:instrument_action_view_rendering,
-                                    :instrument_action_controller_processing,
-                                    :instrument_active_support_caching,
-                                    :use_rack_integration,
-                                    :use_active_record_integration]
+        option :flags, setter: ->(value) { DEFAULT_FLAGS.merge(value) }, default: DEFAULT_FLAGS
         option :tracer, default: Datadog.tracer
 
         @patched = false

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -7,12 +7,11 @@ module Datadog
       module Patcher
         include Base
 
-        DEFAULT_FLAGS = {
-          instrument_action_view_rendering: true,
-          instrument_action_controller_processing: true,
-          instrument_active_support_caching: true,
-          use_rack_integration: true,
-          use_active_record_integration: true
+        DEFAULT_INSTRUMENTATIONS = {
+          action_view_rendering: true,
+          action_controller_processing: true,
+          active_support_caching: true,
+          active_record: true
         }.freeze
 
         register_as :rails, auto_patch: true
@@ -30,7 +29,7 @@ module Datadog
         option :distributed_tracing, default: false
         option :template_base_path, default: 'views/'
         option :exception_controller, default: nil
-        option :flags, setter: ->(value) { DEFAULT_FLAGS.merge(value) }, default: DEFAULT_FLAGS
+        option :instrument, setter: ->(value) { DEFAULT_INSTRUMENTATIONS.merge(value) }, default: DEFAULT_INSTRUMENTATIONS
         option :tracer, default: Datadog.tracer
 
         @patched = false

--- a/lib/ddtrace/contrib/rails/railtie.rb
+++ b/lib/ddtrace/contrib/rails/railtie.rb
@@ -13,9 +13,20 @@ module Datadog
 
     config.after_initialize do
       Datadog::Contrib::Rails::Framework.setup
-      Datadog::Contrib::Rails::ActionController.instrument
-      Datadog::Contrib::Rails::ActionView.instrument
-      Datadog::Contrib::Rails::ActiveSupport.instrument
+
+      if datadog_configuration[:features].include?(:instrument_action_controller_processing)
+        Datadog::Contrib::Rails::ActionController.instrument
+      end
+      if datadog_configuration[:features].include?(:instrument_action_view_rendering)
+        Datadog::Contrib::Rails::ActionView.instrument
+      end
+      if datadog_configuration[:features] .include?(:instrument_active_support_caching)
+        Datadog::Contrib::Rails::ActiveSupport.instrument
+      end
+    end
+
+    def datadog_configuration
+      Datadog.configuration[:rails]
     end
   end
 end

--- a/lib/ddtrace/contrib/rails/railtie.rb
+++ b/lib/ddtrace/contrib/rails/railtie.rb
@@ -14,13 +14,13 @@ module Datadog
     config.after_initialize do
       Datadog::Contrib::Rails::Framework.setup
 
-      if datadog_configuration[:flags][:instrument_action_controller_processing]
+      if datadog_configuration[:instrument][:action_controller_processing]
         Datadog::Contrib::Rails::ActionController.instrument
       end
-      if datadog_configuration[:flags][:instrument_action_view_rendering]
+      if datadog_configuration[:instrument][:action_view_rendering]
         Datadog::Contrib::Rails::ActionView.instrument
       end
-      if datadog_configuration[:flags][:instrument_active_support_caching]
+      if datadog_configuration[:instrument][:active_support_caching]
         Datadog::Contrib::Rails::ActiveSupport.instrument
       end
     end

--- a/lib/ddtrace/contrib/rails/railtie.rb
+++ b/lib/ddtrace/contrib/rails/railtie.rb
@@ -14,13 +14,13 @@ module Datadog
     config.after_initialize do
       Datadog::Contrib::Rails::Framework.setup
 
-      if datadog_configuration[:features].include?(:instrument_action_controller_processing)
+      if datadog_configuration[:flags][:instrument_action_controller_processing]
         Datadog::Contrib::Rails::ActionController.instrument
       end
-      if datadog_configuration[:features].include?(:instrument_action_view_rendering)
+      if datadog_configuration[:flags][:instrument_action_view_rendering]
         Datadog::Contrib::Rails::ActionView.instrument
       end
-      if datadog_configuration[:features] .include?(:instrument_active_support_caching)
+      if datadog_configuration[:flags][:instrument_active_support_caching]
         Datadog::Contrib::Rails::ActiveSupport.instrument
       end
     end

--- a/lib/ddtrace/contrib/rails/railtie.rb
+++ b/lib/ddtrace/contrib/rails/railtie.rb
@@ -25,7 +25,7 @@ module Datadog
       end
     end
 
-    def datadog_configuration
+    def self.datadog_configuration
       Datadog.configuration[:rails]
     end
   end


### PR DESCRIPTION
Put aspects of Rails integration behind feature flags, allowing finetuning of provided tracing data depending on specific user needs. 

| Key | Description | Default |
| --- | --- | --- |
| ``flags`` | Flags used in `rails` instrumentation. | ```{ instrument_action_view_rendering: true, instrument_action_controller_processing: true, instrument_active_support_caching: true, use_rack_integration: true, use_active_record_integration: true}``` |

