### PR TITLE
Fix release docs in CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,10 @@ step_run_all_tests: &step_run_all_tests
   run:
     name: Run tests
     command: bundle exec rake ci
+step_release_docs: &step_release_docs
+  run:
+    name: Upload release docs
+    command: S3_DIR=trace bundle exec rake release:docs
 
 filters_all_branches_and_tags: &filters_all_branches_and_tags
   filters:
@@ -431,6 +435,14 @@ jobs:
           keys:
             - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.4-{{ checksum ".circleci/bundle_checksum" }}'
       - *step_run_all_tests
+  deploy-release:
+    <<: *job_defaults
+    docker:
+      - *container-2_4
+    steps:
+      - checkout
+      - *step_bundle_install
+      - *step_release_docs
 workflows:
   version: 2
   build-and-test:
@@ -495,3 +507,12 @@ workflows:
           <<: *filters_all_branches_and_tags
           requires:
             - build-2.4
+      - deploy-release:
+          <<: *filters_only_release_tags
+          requires:
+            - test-1.9
+            - test-2.0
+            - test-2.1
+            - test-2.2
+            - test-2.3
+            - test-2.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,17 @@ step_run_all_tests: &step_run_all_tests
     name: Run tests
     command: bundle exec rake ci
 
+filters_all_branches_and_tags: &filters_all_branches_and_tags
+  filters:
+    tags:
+      only: /.*/
+filters_only_release_tags: &filters_only_release_tags
+  filters:
+    branches:
+      ignore: /.*/
+    tags:
+      only: /^v\d+(\.\d+){0,3}(\.(alpha|beta|rc)\d+)?$/
+
 version: 2.0
 jobs:
   checkout-1.9:
@@ -424,45 +435,63 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - checkout-1.9
+      - checkout-1.9:
+          <<: *filters_all_branches_and_tags
       - build-1.9:
+          <<: *filters_all_branches_and_tags
           requires:
             - checkout-1.9
       - test-1.9:
+          <<: *filters_all_branches_and_tags
           requires:
             - build-1.9
-      - checkout-2.0
+      - checkout-2.0:
+          <<: *filters_all_branches_and_tags
       - build-2.0:
+          <<: *filters_all_branches_and_tags
           requires:
             - checkout-2.0
       - test-2.0:
+          <<: *filters_all_branches_and_tags
           requires:
             - build-2.0
-      - checkout-2.1
+      - checkout-2.1:
+          <<: *filters_all_branches_and_tags
       - build-2.1:
+          <<: *filters_all_branches_and_tags
           requires:
             - checkout-2.1
       - test-2.1:
+          <<: *filters_all_branches_and_tags
           requires:
             - build-2.1
-      - checkout-2.2
+      - checkout-2.2:
+          <<: *filters_all_branches_and_tags
       - build-2.2:
+          <<: *filters_all_branches_and_tags
           requires:
             - checkout-2.2
       - test-2.2:
+          <<: *filters_all_branches_and_tags
           requires:
             - build-2.2
-      - checkout-2.3
+      - checkout-2.3:
+          <<: *filters_all_branches_and_tags
       - build-2.3:
+          <<: *filters_all_branches_and_tags
           requires:
             - checkout-2.3
       - test-2.3:
+          <<: *filters_all_branches_and_tags
           requires:
             - build-2.3
-      - checkout-2.4
+      - checkout-2.4:
+          <<: *filters_all_branches_and_tags
       - build-2.4:
+          <<: *filters_all_branches_and_tags
           requires:
             - checkout-2.4
       - test-2.4:
+          <<: *filters_all_branches_and_tags
           requires:
             - build-2.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -441,8 +441,13 @@ jobs:
       - *container-2_4
     steps:
       - checkout
+      - run:
+          command: |
+            apt-get -y -qq update
+            apt-get -y -qq install awscli
       - *step_bundle_install
       - *step_release_docs
+
 workflows:
   version: 2
   build-and-test:


### PR DESCRIPTION
Since CircleCI 2.0, we haven't been building for tag pushes, or generating and releasing documentation for them.

This pull request adds a deploy step at the end of the build, that runs only when a tag is pushed that matches a version pattern.