### PR TITLE
[elasticsearch] Expand quantization, to cut out all request segments containing numbers

### DIFF
--- a/lib/ddtrace/contrib/elasticsearch/quantize.rb
+++ b/lib/ddtrace/contrib/elasticsearch/quantize.rb
@@ -12,18 +12,16 @@ module Datadog
           placeholder: PLACEHOLDER
         }.freeze
 
-        ID_REGEXP = %r{\/([0-9]+)([\/\?]|$)}
-        ID_PLACEHOLDER = '/?\2'.freeze
-
-        INDEX_REGEXP = /[0-9]{2,}/
-        INDEX_PLACEHOLDER = '?'.freeze
+        # Taken from https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java#L16
+        # Matches any path segments with numbers in them. (exception for versioning: "/v1/")
+        CAPTURE_PATH_SEGMENTS_WITH_NUMBERS_REGEXP = %r{(?<=/)(?![vV]\d\{1,2\}/)(?:[^/\d\?]*[\d]+[^/\?]*)}
+        QUERY_STRING_REGEXP = /\?.*$/
 
         module_function
 
-        # Very basic quantization, complex processing should be done in the agent
         def format_url(url)
-          quantized_url = url.gsub(ID_REGEXP, ID_PLACEHOLDER)
-          quantized_url.gsub(INDEX_REGEXP, INDEX_PLACEHOLDER)
+          url.gsub(QUERY_STRING_REGEXP, ''.freeze)
+             .gsub(CAPTURE_PATH_SEGMENTS_WITH_NUMBERS_REGEXP, PLACEHOLDER)
         end
 
         def format_body(body, options = {})

--- a/lib/ddtrace/contrib/elasticsearch/quantize.rb
+++ b/lib/ddtrace/contrib/elasticsearch/quantize.rb
@@ -12,15 +12,17 @@ module Datadog
           placeholder: PLACEHOLDER
         }.freeze
 
-        # Taken from https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java#L16
-        # Matches any path segments with numbers in them. (exception for versioning: "/v1/")
-        CAPTURE_PATH_SEGMENTS_WITH_NUMBERS_REGEXP = %r{(?<=/)(?![vV]\d\{1,2\}/)(?:[^/\d\?]*[\d]+[^/\?]*)}
+        # Based on regexp from https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java#L16
+        # Matches any path segments with numbers in them. (exception for index name)
+        CAPTURE_PATH_SEGMENTS_WITH_NUMBERS_REGEXP = %r{(?<=/)(?![vV]\d\{1,2\}/)(?:[^/\d]*[\d]+[^/]*)}
+        TOKENIZE_INDEX_NAME_REGEXP = %r{^(/?[^\d/]+)(?:\d[^/]+)}
         QUERY_STRING_REGEXP = /\?.*$/
 
         module_function
 
         def format_url(url)
           url.gsub(QUERY_STRING_REGEXP, ''.freeze)
+             .gsub(TOKENIZE_INDEX_NAME_REGEXP, '\1?'.freeze)
              .gsub(CAPTURE_PATH_SEGMENTS_WITH_NUMBERS_REGEXP, PLACEHOLDER)
         end
 

--- a/lib/ddtrace/contrib/elasticsearch/quantize.rb
+++ b/lib/ddtrace/contrib/elasticsearch/quantize.rb
@@ -76,7 +76,7 @@ module Datadog
           return url unless index_end
 
           index_part = url.slice(0, index_end)
-          index_part.gsub!(/\d+/, '?')
+          index_part.gsub!(/\d+/, PLACEHOLDER)
 
           index_part << url.slice(index_end..-1)
         end

--- a/lib/ddtrace/contrib/elasticsearch/quantize.rb
+++ b/lib/ddtrace/contrib/elasticsearch/quantize.rb
@@ -14,7 +14,7 @@ module Datadog
 
         # Based on regexp from https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java#L16
         # Matches any path segments with numbers in them.
-        CAPTURE_PATH_SEGMENTS_WITH_NUMBERS_REGEXP = %r{(?<=/)(?:[^/\d]*[\d]+[^?/]*)}
+        CAPTURE_PATH_SEGMENTS_WITH_NUMBERS_REGEXP = %r{(?<=/)(?:[^\?/\d]*[\d]+[^\?/]*)}
 
         module_function
 

--- a/lib/ddtrace/contrib/elasticsearch/quantize.rb
+++ b/lib/ddtrace/contrib/elasticsearch/quantize.rb
@@ -13,8 +13,8 @@ module Datadog
         }.freeze
 
         # Based on regexp from https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java#L16
-        # Matches any path segments with numbers in them. (exception for index name)
-        CAPTURE_PATH_SEGMENTS_WITH_NUMBERS_REGEXP = %r{(?<=/)(?![vV]\d\{1,2\}/)(?:[^/\d]*[\d]+[^/]*)}
+        # Matches any path segments with numbers in them.
+        CAPTURE_PATH_SEGMENTS_WITH_NUMBERS_REGEXP = %r{(?<=/)(?:[^/\d]*[\d]+[^/]*)}
         TOKENIZE_INDEX_NAME_REGEXP = %r{^(/?[^\d/]+)(?:\d[^/]+)}
         QUERY_STRING_REGEXP = /\?.*$/
 

--- a/lib/ddtrace/contrib/elasticsearch/quantize.rb
+++ b/lib/ddtrace/contrib/elasticsearch/quantize.rb
@@ -15,13 +15,12 @@ module Datadog
         # Based on regexp from https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java#L16
         # Matches any path segments with numbers in them.
         CAPTURE_PATH_SEGMENTS_WITH_NUMBERS_REGEXP = %r{(?<=/)(?:[^/\d]*[\d]+[^?/]*)}
-        TOKENIZE_INDEX_NAME_REGEXP = %r{^(/?[^\d/]+)(?:\d[^/]+)}
 
         module_function
 
         def format_url(url)
-          url.gsub(TOKENIZE_INDEX_NAME_REGEXP, '\1?'.freeze)
-             .gsub(CAPTURE_PATH_SEGMENTS_WITH_NUMBERS_REGEXP, PLACEHOLDER)
+          sanitize_index_in_url(url)
+            .gsub(CAPTURE_PATH_SEGMENTS_WITH_NUMBERS_REGEXP, PLACEHOLDER)
         end
 
         def format_body(body, options = {})
@@ -70,6 +69,16 @@ module Datadog
             # If it can't parse/dump, don't raise an error.
             fail_value
           end
+        end
+
+        def sanitize_index_in_url(url)
+          index_end = url.index('/'.freeze, 1)
+          return url unless index_end
+
+          index_part = url.slice(0, index_end)
+          index_part.gsub!(/\d+/, '?')
+
+          index_part << url.slice(index_end..-1)
         end
       end
     end

--- a/lib/ddtrace/contrib/elasticsearch/quantize.rb
+++ b/lib/ddtrace/contrib/elasticsearch/quantize.rb
@@ -14,15 +14,13 @@ module Datadog
 
         # Based on regexp from https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java#L16
         # Matches any path segments with numbers in them.
-        CAPTURE_PATH_SEGMENTS_WITH_NUMBERS_REGEXP = %r{(?<=/)(?:[^/\d]*[\d]+[^/]*)}
+        CAPTURE_PATH_SEGMENTS_WITH_NUMBERS_REGEXP = %r{(?<=/)(?:[^/\d]*[\d]+[^?/]*)}
         TOKENIZE_INDEX_NAME_REGEXP = %r{^(/?[^\d/]+)(?:\d[^/]+)}
-        QUERY_STRING_REGEXP = /\?.*$/
 
         module_function
 
         def format_url(url)
-          url.gsub(QUERY_STRING_REGEXP, ''.freeze)
-             .gsub(TOKENIZE_INDEX_NAME_REGEXP, '\1?'.freeze)
+          url.gsub(TOKENIZE_INDEX_NAME_REGEXP, '\1?'.freeze)
              .gsub(CAPTURE_PATH_SEGMENTS_WITH_NUMBERS_REGEXP, PLACEHOLDER)
         end
 

--- a/test/contrib/elasticsearch/quantize_test.rb
+++ b/test/contrib/elasticsearch/quantize_test.rb
@@ -10,6 +10,10 @@ class ESQuantizeTest < Minitest::Test
     assert_equal('/my/thing/?/is/cool', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1/is/cool'))
     assert_equal('/my/thing/??is=cool', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1?is=cool'))
     assert_equal('/my/thing/?/z', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z'))
+    assert_equal('/my/thing/?/z/', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z/'))
+    assert_equal('/my/thing/?/z?a=b', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z?a=b'))
+    assert_equal('/my/thing/?/abcdefg', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/abcdefg'))
+    assert_equal('/my/thing/?/abcdefg/', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/abcdefg/'))
   end
 
   def test_index

--- a/test/contrib/elasticsearch/quantize_test.rb
+++ b/test/contrib/elasticsearch/quantize_test.rb
@@ -8,18 +8,18 @@ class ESQuantizeTest < Minitest::Test
     assert_equal('/my/thing/?', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1'))
     assert_equal('/my/thing/?/', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1/'))
     assert_equal('/my/thing/?/is/cool', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1/is/cool'))
-    assert_equal('/my/thing/??is=cool', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1?is=cool'))
-    assert_equal('/my/thing/1two3/z', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z'))
+    assert_equal('/my/thing/?', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1?is=cool'))
+    assert_equal('/my/thing//z', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z'))
   end
 
   def test_index
-    assert_equal('/my?/thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456/thing'))
-    assert_equal('/my?more/thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456more/thing'))
-    assert_equal('/my?and?/thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456and789/thing'))
+    assert_equal('/?/thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456/thing'))
+    assert_equal('//thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456more/thing'))
+    assert_equal('//thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456and789/thing'))
   end
 
   def test_combine
-    assert_equal('/my?/thing/?', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123/thing/456789'))
+    assert_equal('//thing/?', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123/thing/456789'))
   end
 
   # rubocop:disable Metrics/LineLength

--- a/test/contrib/elasticsearch/quantize_test.rb
+++ b/test/contrib/elasticsearch/quantize_test.rb
@@ -14,8 +14,8 @@ class ESQuantizeTest < Minitest::Test
 
   def test_index
     assert_equal('/my?/thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456/thing'))
-    assert_equal('/my?/thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456more/thing'))
-    assert_equal('/my?/thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456and789/thing'))
+    assert_equal('/my?more/thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456more/thing'))
+    assert_equal('/my?and?/thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456and789/thing'))
   end
 
   def test_combine

--- a/test/contrib/elasticsearch/quantize_test.rb
+++ b/test/contrib/elasticsearch/quantize_test.rb
@@ -12,6 +12,7 @@ class ESQuantizeTest < Minitest::Test
     assert_equal('/my/thing/?/z', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z'))
     assert_equal('/my/thing/?/z/', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z/'))
     assert_equal('/my/thing/?/z?a=b', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z?a=b'))
+    assert_equal('/my/thing/?/z?a=b123', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z?a=b123'))
     assert_equal('/my/thing/?/abcdefg', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/abcdefg'))
     assert_equal('/my/thing/?/abcdefg/', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/abcdefg/'))
   end

--- a/test/contrib/elasticsearch/quantize_test.rb
+++ b/test/contrib/elasticsearch/quantize_test.rb
@@ -8,7 +8,7 @@ class ESQuantizeTest < Minitest::Test
     assert_equal('/my/thing/?', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1'))
     assert_equal('/my/thing/?/', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1/'))
     assert_equal('/my/thing/?/is/cool', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1/is/cool'))
-    assert_equal('/my/thing/?', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1?is=cool'))
+    assert_equal('/my/thing/??is=cool', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1?is=cool'))
     assert_equal('/my/thing/?/z', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z'))
   end
 

--- a/test/contrib/elasticsearch/quantize_test.rb
+++ b/test/contrib/elasticsearch/quantize_test.rb
@@ -9,17 +9,17 @@ class ESQuantizeTest < Minitest::Test
     assert_equal('/my/thing/?/', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1/'))
     assert_equal('/my/thing/?/is/cool', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1/is/cool'))
     assert_equal('/my/thing/?', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1?is=cool'))
-    assert_equal('/my/thing//z', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z'))
+    assert_equal('/my/thing/?/z', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z'))
   end
 
   def test_index
-    assert_equal('/?/thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456/thing'))
-    assert_equal('//thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456more/thing'))
-    assert_equal('//thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456and789/thing'))
+    assert_equal('/my?/thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456/thing'))
+    assert_equal('/my?/thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456more/thing'))
+    assert_equal('/my?/thing', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123456and789/thing'))
   end
 
   def test_combine
-    assert_equal('//thing/?', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123/thing/456789'))
+    assert_equal('/my?/thing/?', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my123/thing/456789'))
   end
 
   # rubocop:disable Metrics/LineLength

--- a/test/contrib/elasticsearch/quantize_test.rb
+++ b/test/contrib/elasticsearch/quantize_test.rb
@@ -12,11 +12,14 @@ class ESQuantizeTest < Minitest::Test
     assert_equal('/my/thing/?/z', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z'))
     assert_equal('/my/thing/?/z/', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z/'))
     assert_equal('/my/thing/?/z?a=b', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z?a=b'))
-    assert_equal('/my/thing/?/z?a=b123', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z?a=b123'))
-    assert_equal('/my/thing/?/abcdefg', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/abcdefg'))
-    assert_equal('/my/thing/?/abcdefg/', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/abcdefg/'))
+    assert_equal('/my/thing/?/z?a=b?', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z?a=b123'))
+    assert_equal('/my/thing/?/abc', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/abc'))
+    assert_equal('/my/thing/?/abc/', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/abc/'))
+    assert_equal('/my/thing?/?/abc/', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing231/1two3/abc/'))
     assert_equal('/my/thing/?/_termvector', Datadog::Contrib::Elasticsearch::Quantize
                                                 .format_url('/my/thing/1447990c-811a-4a83-b7e2-c3e8a4a6ff54/_termvector'))
+    assert_equal('app_prod/user/?/_termvector',
+                 Datadog::Contrib::Elasticsearch::Quantize.format_url('app_prod/user/1fff2c9dc2f3e/_termvector'))
   end
 
   def test_index

--- a/test/contrib/elasticsearch/quantize_test.rb
+++ b/test/contrib/elasticsearch/quantize_test.rb
@@ -15,6 +15,8 @@ class ESQuantizeTest < Minitest::Test
     assert_equal('/my/thing/?/z?a=b123', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/z?a=b123'))
     assert_equal('/my/thing/?/abcdefg', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/abcdefg'))
     assert_equal('/my/thing/?/abcdefg/', Datadog::Contrib::Elasticsearch::Quantize.format_url('/my/thing/1two3/abcdefg/'))
+    assert_equal('/my/thing/?/_termvector', Datadog::Contrib::Elasticsearch::Quantize
+                                                .format_url('/my/thing/1447990c-811a-4a83-b7e2-c3e8a4a6ff54/_termvector'))
   end
 
   def test_index


### PR DESCRIPTION
This PR fixes quantization of URLs in ES client. It does so by replacing any path segment that has numbers in them with '?'.

https://github.com/DataDog/dd-trace-rb/blob/20eda5d1597ecf442a9621cac6ce64fcc12e5a63/test/contrib/elasticsearch/quantize_test.rb#L12