### PR TITLE
[OpenTracing] Add OpenTracing configuration

### DIFF
--- a/lib/ddtrace/opentracer.rb
+++ b/lib/ddtrace/opentracer.rb
@@ -10,12 +10,21 @@ module Datadog
     def load_opentracer
       require 'opentracing'
       require 'opentracing/carrier'
+      require 'ddtrace'
       require 'ddtrace/opentracer/carrier'
       require 'ddtrace/opentracer/tracer'
       require 'ddtrace/opentracer/span'
       require 'ddtrace/opentracer/span_context'
       require 'ddtrace/opentracer/scope'
       require 'ddtrace/opentracer/scope_manager'
+      require 'ddtrace/opentracer/global_tracer'
+
+      # Modify the OpenTracing module functions
+      OpenTracing.module_eval do
+        class << self
+          prepend Datadog::OpenTracer::GlobalTracer
+        end
+      end
     end
 
     load_opentracer if supported?

--- a/lib/ddtrace/opentracer/global_tracer.rb
+++ b/lib/ddtrace/opentracer/global_tracer.rb
@@ -1,0 +1,15 @@
+module Datadog
+  module OpenTracer
+    # Patch for OpenTracing module
+    module GlobalTracer
+      def global_tracer=(tracer)
+        super.tap do
+          if tracer.class <= Datadog::OpenTracer::Tracer
+            # Update the Datadog global tracer, too.
+            Datadog.instance_variable_set(:@tracer, tracer.datadog_tracer)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/opentracer/tracer.rb
+++ b/lib/ddtrace/opentracer/tracer.rb
@@ -1,6 +1,22 @@
+require 'ddtrace/tracer'
+
 module Datadog
   module OpenTracer
+    # OpenTracing adapter for Datadog::Tracer
     class Tracer < ::OpenTracing::Tracer
+      extend Forwardable
+
+      attr_reader \
+        :datadog_tracer
+
+      def_delegators \
+        :datadog_tracer,
+        :configure
+
+      def initialize(options = {})
+        super()
+        @datadog_tracer = Datadog::Tracer.new(options)
+      end
     end
   end
 end

--- a/spec/ddtrace/opentracer/global_tracer_spec.rb
+++ b/spec/ddtrace/opentracer/global_tracer_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+require 'ddtrace'
+require 'ddtrace/opentracer'
+require 'ddtrace/opentracer/helper'
+
+if Datadog::OpenTracer.supported?
+  RSpec.describe Datadog::OpenTracer::GlobalTracer do
+    include_context 'OpenTracing helpers'
+
+    context 'when included into OpenTracing' do
+      describe '#global_tracer=' do
+        subject(:global_tracer) { OpenTracing.global_tracer = tracer }
+        after(:each) { Datadog.instance_variable_set(:@tracer, Datadog::Tracer.new) }
+
+        context 'when given a Datadog::OpenTracer::Tracer' do
+          let(:tracer) { Datadog::OpenTracer::Tracer.new }
+
+          it do
+            expect(global_tracer).to be(tracer)
+            expect(Datadog.tracer).to be(tracer.datadog_tracer)
+          end
+        end
+
+        context 'when given some unknown kind of tracer' do
+          let(:tracer) { double('other tracer') }
+
+          it do
+            expect(global_tracer).to be(tracer)
+            expect(Datadog.tracer).to_not be(tracer)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/opentracer/tracer_spec.rb
+++ b/spec/ddtrace/opentracer/tracer_spec.rb
@@ -9,6 +9,43 @@ if Datadog::OpenTracer.supported?
 
     subject(:tracer) { described_class.new }
 
+    ### Datadog::OpenTracing::Tracer behavior ###
+
+    describe '#initialize' do
+      context 'when given options' do
+        subject(:tracer) { described_class.new(options) }
+        let(:options) { double('options') }
+        let(:datadog_tracer) { double('datadog_tracer') }
+
+        before(:each) do
+          expect(Datadog::Tracer).to receive(:new)
+            .with(options)
+            .and_return(datadog_tracer)
+        end
+
+        it { expect(tracer.datadog_tracer).to be(datadog_tracer) }
+      end
+    end
+
+    describe '#datadog_tracer' do
+      subject(:datadog_tracer) { tracer.datadog_tracer }
+      it { is_expected.to be_a_kind_of(Datadog::Tracer) }
+    end
+
+    describe '#configure' do
+      subject(:configure) { tracer.configure(options) }
+      let(:options) { double('options') }
+
+      before(:each) do
+        expect(tracer.datadog_tracer).to receive(:configure)
+          .with(options)
+      end
+
+      it { expect { configure }.to_not raise_error }
+    end
+
+    ### Implemented OpenTracing::Tracer behavior ###
+
     describe '#scope_manager' do
       subject(:scope_manager) { tracer.scope_manager }
       it { is_expected.to be(OpenTracing::ScopeManager::NOOP_INSTANCE) }


### PR DESCRIPTION
This pull request allows users to configure the `Datadog::OpenTracer::Tracer` with configuration settings to get the most out of their tracer setup.

```ruby
# Pass options to the constructor
# where options is a Hash of settings accepted by Datadog::Tracer#initialize
Datadog::OpenTracer::Tracer.new(options).tap do |tracer|
  # Be sure to set the global tracer
  OpenTracing.global_tracer = tracer

  # Get the underlying Datadog::Tracer
  tracer.datadog_tracer

  # Configure the tracer with additional options
  # where options is a Hash of settings accepted by Datadog::Tracer#configure
  tracer.configure(options)

  # Integrations and other settings should be activated using
  # the existing Datadog configuration API.
  Datadog.configure do |c|
    c.use :rails
  end
end
```

A more abbreviated, practical example might look like:

```ruby
# Activate Datadog open tracer
OpenTracing.global_tracer = Datadog::OpenTracer::Tracer.new(options)

# Activate and configure integrations
Datadog.configure do |c|
  c.use :rails
end
```