### PR TITLE
[OpenTracing] Span and SpanContext implementation

### DIFF
--- a/lib/ddtrace/opentracer.rb
+++ b/lib/ddtrace/opentracer.rb
@@ -15,6 +15,7 @@ module Datadog
       require 'ddtrace/opentracer/tracer'
       require 'ddtrace/opentracer/span'
       require 'ddtrace/opentracer/span_context'
+      require 'ddtrace/opentracer/span_context_factory'
       require 'ddtrace/opentracer/scope'
       require 'ddtrace/opentracer/scope_manager'
       require 'ddtrace/opentracer/global_tracer'

--- a/lib/ddtrace/opentracer.rb
+++ b/lib/ddtrace/opentracer.rb
@@ -4,7 +4,7 @@ module Datadog
     module_function
 
     def supported?
-      Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0')
+      Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1')
     end
 
     def load_opentracer

--- a/lib/ddtrace/opentracer/span.rb
+++ b/lib/ddtrace/opentracer/span.rb
@@ -39,7 +39,7 @@ module Datadog
         tap do
           # SpanContext is immutable, so to make changes
           # build a new span context.
-          @span_context = SpanContextFactory.build(
+          @span_context = SpanContextFactory.clone(
             span_context: context,
             baggage: { key => value }
           )

--- a/lib/ddtrace/opentracer/span.rb
+++ b/lib/ddtrace/opentracer/span.rb
@@ -1,6 +1,83 @@
 module Datadog
   module OpenTracer
+    # OpenTracing adapter for Datadog::Span
     class Span < ::OpenTracing::Span
+      attr_reader \
+        :datadog_span
+
+      def initialize(datadog_span:, span_context:)
+        @datadog_span = datadog_span
+        @span_context = span_context
+      end
+
+      # Set the name of the operation
+      #
+      # @param [String] name
+      def operation_name=(name)
+        datadog_span.name = name
+      end
+
+      # Span Context
+      #
+      # @return [SpanContext]
+      def context
+        @span_context
+      end
+
+      # Set a tag value on this span
+      # @param key [String] the key of the tag
+      # @param value [String, Numeric, Boolean] the value of the tag. If it's not
+      # a String, Numeric, or Boolean it will be encoded with to_s
+      def set_tag(key, value)
+        tap { datadog_span.set_tag(key, value) }
+      end
+
+      # Set a baggage item on the span
+      # @param key [String] the key of the baggage item
+      # @param value [String] the value of the baggage item
+      def set_baggage_item(key, value)
+        tap { context.baggage[key] = value }
+      end
+
+      # Get a baggage item
+      # @param key [String] the key of the baggage item
+      # @return [String] value of the baggage item
+      def get_baggage_item(key)
+        context.baggage[key]
+      end
+
+      # @deprecated Use {#log_kv} instead.
+      # Reason: event is an optional standard log field defined in spec and not required.  Also,
+      # method name {#log_kv} is more consistent with other language implementations such as Python and Go.
+      #
+      # Add a log entry to this span
+      # @param event [String] event name for the log
+      # @param timestamp [Time] time of the log
+      # @param fields [Hash] Additional information to log
+      def log(event: nil, timestamp: Time.now, **fields)
+        super # Log deprecation warning
+
+        # If the fields specify an error
+        if fields.key?(:'error.object')
+          datadog_span.set_error(fields[:'error.object'])
+        end
+      end
+
+      # Add a log entry to this span
+      # @param timestamp [Time] time of the log
+      # @param fields [Hash] Additional information to log
+      def log_kv(timestamp: Time.now, **fields)
+        # If the fields specify an error
+        if fields.key?(:'error.object')
+          datadog_span.set_error(fields[:'error.object'])
+        end
+      end
+
+      # Finish the {Span}
+      # @param end_time [Time] custom end time, if not now
+      def finish(end_time: Time.now)
+        datadog_span.finish(end_time)
+      end
     end
   end
 end

--- a/lib/ddtrace/opentracer/span.rb
+++ b/lib/ddtrace/opentracer/span.rb
@@ -36,7 +36,14 @@ module Datadog
       # @param key [String] the key of the baggage item
       # @param value [String] the value of the baggage item
       def set_baggage_item(key, value)
-        tap { context.baggage[key] = value }
+        tap do
+          # SpanContext is immutable, so to make changes
+          # build a new span context.
+          @span_context = SpanContextFactory.build(
+            span_context: context,
+            baggage: { key => value }
+          )
+        end
       end
 
       # Get a baggage item

--- a/lib/ddtrace/opentracer/span_context.rb
+++ b/lib/ddtrace/opentracer/span_context.rb
@@ -1,6 +1,11 @@
 module Datadog
   module OpenTracer
+    # OpenTracing adapter for SpanContext
     class SpanContext < ::OpenTracing::SpanContext
+      def initialize(baggage: {})
+        super
+        @baggage = baggage
+      end
     end
   end
 end

--- a/lib/ddtrace/opentracer/span_context.rb
+++ b/lib/ddtrace/opentracer/span_context.rb
@@ -4,7 +4,7 @@ module Datadog
     class SpanContext < ::OpenTracing::SpanContext
       def initialize(baggage: {})
         super
-        @baggage = baggage
+        @baggage = baggage.freeze
       end
     end
   end

--- a/lib/ddtrace/opentracer/span_context.rb
+++ b/lib/ddtrace/opentracer/span_context.rb
@@ -2,8 +2,16 @@ module Datadog
   module OpenTracer
     # OpenTracing adapter for SpanContext
     class SpanContext < ::OpenTracing::SpanContext
-      def initialize(baggage: {})
-        super
+      attr_reader \
+        :span_id,
+        :trace_id,
+        :parent_id
+
+      def initialize(span_id:, trace_id:, parent_id:, baggage: {})
+        super(baggage: baggage)
+        @span_id = span_id
+        @trace_id = trace_id
+        @parent_id = parent_id
         @baggage = baggage.freeze
       end
     end

--- a/lib/ddtrace/opentracer/span_context.rb
+++ b/lib/ddtrace/opentracer/span_context.rb
@@ -3,15 +3,10 @@ module Datadog
     # OpenTracing adapter for SpanContext
     class SpanContext < ::OpenTracing::SpanContext
       attr_reader \
-        :span_id,
-        :trace_id,
-        :parent_id
+        :datadog_context
 
-      def initialize(span_id:, trace_id:, parent_id:, baggage: {})
-        super(baggage: baggage)
-        @span_id = span_id
-        @trace_id = trace_id
-        @parent_id = parent_id
+      def initialize(datadog_context:, baggage: {})
+        @datadog_context = datadog_context
         @baggage = baggage.freeze
       end
     end

--- a/lib/ddtrace/opentracer/span_context_factory.rb
+++ b/lib/ddtrace/opentracer/span_context_factory.rb
@@ -4,20 +4,16 @@ module Datadog
     module SpanContextFactory
       module_function
 
-      def build(span_id:, trace_id:, parent_id:, baggage: {})
+      def build(datadog_context:, baggage: {})
         SpanContext.new(
-          span_id: span_id,
-          trace_id: trace_id,
-          parent_id: parent_id,
+          datadog_context: datadog_context,
           baggage: baggage.dup
         )
       end
 
-      def clone(span_context:, span_id: nil, trace_id: nil, parent_id: nil, baggage: {})
+      def clone(span_context:, baggage: {})
         SpanContext.new(
-          span_id: span_id || span_context.span_id,
-          trace_id: trace_id || span_context.trace_id,
-          parent_id: parent_id || span_context.parent_id,
+          datadog_context: span_context.datadog_context,
           # Merge baggage from previous SpanContext
           baggage: span_context.baggage.merge(baggage)
         )

--- a/lib/ddtrace/opentracer/span_context_factory.rb
+++ b/lib/ddtrace/opentracer/span_context_factory.rb
@@ -1,0 +1,15 @@
+module Datadog
+  module OpenTracer
+    # Creates new Datadog::OpenTracer::SpanContext
+    module SpanContextFactory
+      module_function
+
+      def build(span_context: nil, baggage: {})
+        # Merge baggage from previous SpanContext
+        baggage = span_context.nil? ? baggage.dup : span_context.baggage.merge(baggage)
+
+        SpanContext.new(baggage: baggage)
+      end
+    end
+  end
+end

--- a/lib/ddtrace/opentracer/span_context_factory.rb
+++ b/lib/ddtrace/opentracer/span_context_factory.rb
@@ -4,11 +4,23 @@ module Datadog
     module SpanContextFactory
       module_function
 
-      def build(span_context: nil, baggage: {})
-        # Merge baggage from previous SpanContext
-        baggage = span_context.nil? ? baggage.dup : span_context.baggage.merge(baggage)
+      def build(span_id:, trace_id:, parent_id:, baggage: {})
+        SpanContext.new(
+          span_id: span_id,
+          trace_id: trace_id,
+          parent_id: parent_id,
+          baggage: baggage.dup
+        )
+      end
 
-        SpanContext.new(baggage: baggage)
+      def clone(span_context:, span_id: nil, trace_id: nil, parent_id: nil, baggage: {})
+        SpanContext.new(
+          span_id: span_id || span_context.span_id,
+          trace_id: trace_id || span_context.trace_id,
+          parent_id: parent_id || span_context.parent_id,
+          # Merge baggage from previous SpanContext
+          baggage: span_context.baggage.merge(baggage)
+        )
       end
     end
   end

--- a/spec/ddtrace/opentracer/span_context_factory_spec.rb
+++ b/spec/ddtrace/opentracer/span_context_factory_spec.rb
@@ -9,25 +9,18 @@ if Datadog::OpenTracer.supported?
 
     describe 'class methods' do
       describe '#build' do
-        context 'given span_id, trace_id, parent_id' do
+        context 'given Datadog::Context' do
           subject(:span_context) do
             described_class.build(
-              span_id: span_id,
-              trace_id: trace_id,
-              parent_id: parent_id
+              datadog_context: datadog_context
             )
           end
-
-          let(:span_id) { double('span_id') }
-          let(:trace_id) { double('trace_id') }
-          let(:parent_id) { double('parent_id') }
+          let(:datadog_context) { instance_double(Datadog::Context) }
 
           it { is_expected.to be_a_kind_of(Datadog::OpenTracer::SpanContext) }
 
           describe 'builds a SpanContext where' do
-            it { expect(span_context.span_id).to be(span_id) }
-            it { expect(span_context.trace_id).to be(trace_id) }
-            it { expect(span_context.parent_id).to be(parent_id) }
+            it { expect(span_context.datadog_context).to be(datadog_context) }
 
             describe '#baggage' do
               subject(:baggage) { span_context.baggage }
@@ -39,9 +32,7 @@ if Datadog::OpenTracer.supported?
           context 'and baggage' do
             subject(:span_context) do
               described_class.build(
-                span_id: span_id,
-                trace_id: trace_id,
-                parent_id: parent_id,
+                datadog_context: datadog_context,
                 baggage: original_baggage
               )
             end
@@ -50,9 +41,7 @@ if Datadog::OpenTracer.supported?
             it { is_expected.to be_a_kind_of(Datadog::OpenTracer::SpanContext) }
 
             describe 'builds a SpanContext where' do
-              it { expect(span_context.span_id).to be(span_id) }
-              it { expect(span_context.trace_id).to be(trace_id) }
-              it { expect(span_context.parent_id).to be(parent_id) }
+              it { expect(span_context.datadog_context).to be(datadog_context) }
 
               describe '#baggage' do
                 subject(:baggage) { span_context.baggage }
@@ -74,23 +63,17 @@ if Datadog::OpenTracer.supported?
           let(:original_span_context) do
             instance_double(
               Datadog::OpenTracer::SpanContext,
-              span_id: original_span_id,
-              trace_id: original_trace_id,
-              parent_id: original_parent_id,
+              datadog_context: original_datadog_context,
               baggage: original_baggage
             )
           end
-          let(:original_span_id) { double('original_span_id') }
-          let(:original_trace_id) { double('original_trace_id') }
-          let(:original_parent_id) { double('original_parent_id') }
+          let(:original_datadog_context) { instance_double(Datadog::Context) }
           let(:original_baggage) { {} }
 
           it { is_expected.to be_a_kind_of(Datadog::OpenTracer::SpanContext) }
 
           describe 'builds a SpanContext where' do
-            it { expect(span_context.span_id).to be(original_span_id) }
-            it { expect(span_context.trace_id).to be(original_trace_id) }
-            it { expect(span_context.parent_id).to be(original_parent_id) }
+            it { expect(span_context.datadog_context).to be(original_datadog_context) }
 
             describe '#baggage' do
               subject(:baggage) { span_context.baggage }
@@ -101,27 +84,6 @@ if Datadog::OpenTracer.supported?
                 it { is_expected.to include('org_id' => '4321') }
                 it { is_expected.to_not be(original_baggage) }
               end
-            end
-          end
-
-          context 'and span_id, trace_id, parent_id' do
-            subject(:span_context) do
-              described_class.clone(
-                span_context: original_span_context,
-                span_id: span_id,
-                trace_id: trace_id,
-                parent_id: parent_id
-              )
-            end
-
-            let(:span_id) { double('span_id') }
-            let(:trace_id) { double('trace_id') }
-            let(:parent_id) { double('parent_id') }
-
-            describe 'builds a SpanContext where' do
-              it { expect(span_context.span_id).to be(span_id) }
-              it { expect(span_context.trace_id).to be(trace_id) }
-              it { expect(span_context.parent_id).to be(parent_id) }
             end
           end
 

--- a/spec/ddtrace/opentracer/span_context_factory_spec.rb
+++ b/spec/ddtrace/opentracer/span_context_factory_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+require 'ddtrace/opentracer'
+require 'ddtrace/opentracer/helper'
+
+if Datadog::OpenTracer.supported?
+  RSpec.describe Datadog::OpenTracer::SpanContextFactory do
+    include_context 'OpenTracing helpers'
+
+    describe 'class methods' do
+      describe '#build' do
+        context 'given nothing' do
+          subject(:span_context) { described_class.build }
+
+          it { is_expected.to be_a_kind_of(Datadog::OpenTracer::SpanContext) }
+
+          describe 'builds a SpanContext where' do
+            describe '#baggage' do
+              subject(:baggage) { span_context.baggage }
+              it { is_expected.to be_a_kind_of(Hash) }
+              it { is_expected.to be_empty }
+            end
+          end
+        end
+
+        context 'given a SpanContext' do
+          subject(:span_context) { described_class.build(span_context: original_span_context) }
+          let(:original_span_context) do
+            instance_double(
+              Datadog::OpenTracer::SpanContext,
+              baggage: original_baggage
+            )
+          end
+          let(:original_baggage) { {} }
+
+          it { is_expected.to be_a_kind_of(Datadog::OpenTracer::SpanContext) }
+
+          describe 'builds a SpanContext where' do
+            describe '#baggage' do
+              subject(:baggage) { span_context.baggage }
+              it { is_expected.to be_a_kind_of(Hash) }
+
+              context 'when the original SpanContext contains baggage' do
+                let(:original_baggage) { { 'org_id' => '4321' } }
+                it { is_expected.to include('org_id' => '4321') }
+                it { is_expected.to_not be(original_baggage) }
+              end
+            end
+          end
+        end
+
+        context 'given baggage' do
+          subject(:span_context) { described_class.build(baggage: original_baggage) }
+          let(:original_baggage) { { 'account_id' => '1234' } }
+
+          it { is_expected.to be_a_kind_of(Datadog::OpenTracer::SpanContext) }
+
+          describe 'builds a SpanContext where' do
+            describe '#baggage' do
+              subject(:baggage) { span_context.baggage }
+              it { is_expected.to be_a_kind_of(Hash) }
+
+              context 'when the original baggage contains data' do
+                it { is_expected.to include('account_id' => '1234') }
+                it { is_expected.to_not be(original_baggage) }
+              end
+            end
+          end
+        end
+
+        context 'given a SpanContext and baggage' do
+          subject(:span_context) { described_class.build(span_context: original_span_context, baggage: param_baggage) }
+          let(:original_span_context) do
+            instance_double(
+              Datadog::OpenTracer::SpanContext,
+              baggage: span_context_baggage
+            )
+          end
+          let(:span_context_baggage) { {} }
+          let(:param_baggage) { {} }
+
+          it { is_expected.to be_a_kind_of(Datadog::OpenTracer::SpanContext) }
+
+          describe 'builds a SpanContext where' do
+            describe '#baggage' do
+              subject(:baggage) { span_context.baggage }
+              it { is_expected.to be_a_kind_of(Hash) }
+
+              context 'when the original SpanContext contains baggage' do
+                let(:span_context_baggage) { { 'org_id' => '4321' } }
+                it { is_expected.to include('org_id' => '4321') }
+                it { is_expected.to_not be(span_context_baggage) }
+              end
+
+              context 'when the original baggage contains data' do
+                let(:param_baggage) { { 'account_id' => '1234' } }
+                it { is_expected.to include('account_id' => '1234') }
+                it { is_expected.to_not be(param_baggage) }
+              end
+
+              context 'when the original SpanContext baggage and param baggage contains data' do
+                context 'that doesn\'t overlap' do
+                  let(:span_context_baggage) { { 'org_id' => '4321' } }
+                  let(:param_baggage) { { 'account_id' => '1234' } }
+                  it { is_expected.to include('org_id' => '4321', 'account_id' => '1234') }
+                  it { is_expected.to_not be(span_context_baggage) }
+                  it { is_expected.to_not be(param_baggage) }
+                end
+
+                context 'that overlaps' do
+                  let(:span_context_baggage) { { 'org_id' => '4321' } }
+                  let(:param_baggage) { { 'org_id' => '1234' } }
+                  it { is_expected.to include('org_id' => '1234') }
+                  it { is_expected.to_not be(span_context_baggage) }
+                  it { is_expected.to_not be(param_baggage) }
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/opentracer/span_context_factory_spec.rb
+++ b/spec/ddtrace/opentracer/span_context_factory_spec.rb
@@ -9,33 +9,89 @@ if Datadog::OpenTracer.supported?
 
     describe 'class methods' do
       describe '#build' do
-        context 'given nothing' do
-          subject(:span_context) { described_class.build }
+        context 'given span_id, trace_id, parent_id' do
+          subject(:span_context) do
+            described_class.build(
+              span_id: span_id,
+              trace_id: trace_id,
+              parent_id: parent_id
+            )
+          end
+
+          let(:span_id) { double('span_id') }
+          let(:trace_id) { double('trace_id') }
+          let(:parent_id) { double('parent_id') }
 
           it { is_expected.to be_a_kind_of(Datadog::OpenTracer::SpanContext) }
 
           describe 'builds a SpanContext where' do
+            it { expect(span_context.span_id).to be(span_id) }
+            it { expect(span_context.trace_id).to be(trace_id) }
+            it { expect(span_context.parent_id).to be(parent_id) }
+
             describe '#baggage' do
               subject(:baggage) { span_context.baggage }
               it { is_expected.to be_a_kind_of(Hash) }
               it { is_expected.to be_empty }
             end
           end
-        end
 
+          context 'and baggage' do
+            subject(:span_context) do
+              described_class.build(
+                span_id: span_id,
+                trace_id: trace_id,
+                parent_id: parent_id,
+                baggage: original_baggage
+              )
+            end
+            let(:original_baggage) { { 'account_id' => '1234' } }
+
+            it { is_expected.to be_a_kind_of(Datadog::OpenTracer::SpanContext) }
+
+            describe 'builds a SpanContext where' do
+              it { expect(span_context.span_id).to be(span_id) }
+              it { expect(span_context.trace_id).to be(trace_id) }
+              it { expect(span_context.parent_id).to be(parent_id) }
+
+              describe '#baggage' do
+                subject(:baggage) { span_context.baggage }
+                it { is_expected.to be_a_kind_of(Hash) }
+
+                context 'when the original baggage contains data' do
+                  it { is_expected.to include('account_id' => '1234') }
+                  it { is_expected.to_not be(original_baggage) }
+                end
+              end
+            end
+          end
+        end
+      end
+
+      describe '#clone' do
         context 'given a SpanContext' do
-          subject(:span_context) { described_class.build(span_context: original_span_context) }
+          subject(:span_context) { described_class.clone(span_context: original_span_context) }
           let(:original_span_context) do
             instance_double(
               Datadog::OpenTracer::SpanContext,
+              span_id: original_span_id,
+              trace_id: original_trace_id,
+              parent_id: original_parent_id,
               baggage: original_baggage
             )
           end
+          let(:original_span_id) { double('original_span_id') }
+          let(:original_trace_id) { double('original_trace_id') }
+          let(:original_parent_id) { double('original_parent_id') }
           let(:original_baggage) { {} }
 
           it { is_expected.to be_a_kind_of(Datadog::OpenTracer::SpanContext) }
 
           describe 'builds a SpanContext where' do
+            it { expect(span_context.span_id).to be(original_span_id) }
+            it { expect(span_context.trace_id).to be(original_trace_id) }
+            it { expect(span_context.parent_id).to be(original_parent_id) }
+
             describe '#baggage' do
               subject(:baggage) { span_context.baggage }
               it { is_expected.to be_a_kind_of(Hash) }
@@ -47,72 +103,67 @@ if Datadog::OpenTracer.supported?
               end
             end
           end
-        end
 
-        context 'given baggage' do
-          subject(:span_context) { described_class.build(baggage: original_baggage) }
-          let(:original_baggage) { { 'account_id' => '1234' } }
+          context 'and span_id, trace_id, parent_id' do
+            subject(:span_context) do
+              described_class.clone(
+                span_context: original_span_context,
+                span_id: span_id,
+                trace_id: trace_id,
+                parent_id: parent_id
+              )
+            end
 
-          it { is_expected.to be_a_kind_of(Datadog::OpenTracer::SpanContext) }
+            let(:span_id) { double('span_id') }
+            let(:trace_id) { double('trace_id') }
+            let(:parent_id) { double('parent_id') }
 
-          describe 'builds a SpanContext where' do
-            describe '#baggage' do
-              subject(:baggage) { span_context.baggage }
-              it { is_expected.to be_a_kind_of(Hash) }
-
-              context 'when the original baggage contains data' do
-                it { is_expected.to include('account_id' => '1234') }
-                it { is_expected.to_not be(original_baggage) }
-              end
+            describe 'builds a SpanContext where' do
+              it { expect(span_context.span_id).to be(span_id) }
+              it { expect(span_context.trace_id).to be(trace_id) }
+              it { expect(span_context.parent_id).to be(parent_id) }
             end
           end
-        end
 
-        context 'given a SpanContext and baggage' do
-          subject(:span_context) { described_class.build(span_context: original_span_context, baggage: param_baggage) }
-          let(:original_span_context) do
-            instance_double(
-              Datadog::OpenTracer::SpanContext,
-              baggage: span_context_baggage
-            )
-          end
-          let(:span_context_baggage) { {} }
-          let(:param_baggage) { {} }
+          context 'and baggage' do
+            subject(:span_context) { described_class.clone(span_context: original_span_context, baggage: param_baggage) }
+            let(:param_baggage) { {} }
 
-          it { is_expected.to be_a_kind_of(Datadog::OpenTracer::SpanContext) }
+            it { is_expected.to be_a_kind_of(Datadog::OpenTracer::SpanContext) }
 
-          describe 'builds a SpanContext where' do
-            describe '#baggage' do
-              subject(:baggage) { span_context.baggage }
-              it { is_expected.to be_a_kind_of(Hash) }
+            describe 'builds a SpanContext where' do
+              describe '#baggage' do
+                subject(:baggage) { span_context.baggage }
+                it { is_expected.to be_a_kind_of(Hash) }
 
-              context 'when the original SpanContext contains baggage' do
-                let(:span_context_baggage) { { 'org_id' => '4321' } }
-                it { is_expected.to include('org_id' => '4321') }
-                it { is_expected.to_not be(span_context_baggage) }
-              end
+                context 'when the original SpanContext contains baggage' do
+                  let(:original_baggage) { { 'org_id' => '4321' } }
+                  it { is_expected.to include('org_id' => '4321') }
+                  it { is_expected.to_not be(original_baggage) }
+                end
 
-              context 'when the original baggage contains data' do
-                let(:param_baggage) { { 'account_id' => '1234' } }
-                it { is_expected.to include('account_id' => '1234') }
-                it { is_expected.to_not be(param_baggage) }
-              end
-
-              context 'when the original SpanContext baggage and param baggage contains data' do
-                context 'that doesn\'t overlap' do
-                  let(:span_context_baggage) { { 'org_id' => '4321' } }
+                context 'when the original baggage contains data' do
                   let(:param_baggage) { { 'account_id' => '1234' } }
-                  it { is_expected.to include('org_id' => '4321', 'account_id' => '1234') }
-                  it { is_expected.to_not be(span_context_baggage) }
+                  it { is_expected.to include('account_id' => '1234') }
                   it { is_expected.to_not be(param_baggage) }
                 end
 
-                context 'that overlaps' do
-                  let(:span_context_baggage) { { 'org_id' => '4321' } }
-                  let(:param_baggage) { { 'org_id' => '1234' } }
-                  it { is_expected.to include('org_id' => '1234') }
-                  it { is_expected.to_not be(span_context_baggage) }
-                  it { is_expected.to_not be(param_baggage) }
+                context 'when the original SpanContext baggage and param baggage contains data' do
+                  context 'that doesn\'t overlap' do
+                    let(:original_baggage) { { 'org_id' => '4321' } }
+                    let(:param_baggage) { { 'account_id' => '1234' } }
+                    it { is_expected.to include('org_id' => '4321', 'account_id' => '1234') }
+                    it { is_expected.to_not be(original_baggage) }
+                    it { is_expected.to_not be(param_baggage) }
+                  end
+
+                  context 'that overlaps' do
+                    let(:original_baggage) { { 'org_id' => '4321' } }
+                    let(:param_baggage) { { 'org_id' => '1234' } }
+                    it { is_expected.to include('org_id' => '1234') }
+                    it { is_expected.to_not be(original_baggage) }
+                    it { is_expected.to_not be(param_baggage) }
+                  end
                 end
               end
             end

--- a/spec/ddtrace/opentracer/span_context_spec.rb
+++ b/spec/ddtrace/opentracer/span_context_spec.rb
@@ -7,23 +7,49 @@ if Datadog::OpenTracer.supported?
   RSpec.describe Datadog::OpenTracer::SpanContext do
     include_context 'OpenTracing helpers'
 
-    subject(:span_context) { described_class.new }
-
-    it { is_expected.to have_attributes(baggage: {}) }
-
     describe '#initialize' do
-      context 'given baggage' do
-        subject(:span_context) { described_class.new(baggage: original_baggage) }
-        let(:original_baggage) { { account_id: '1234' } }
+      context 'given span_id, trace_id, parent_id' do
+        subject(:span_context) do
+          described_class.new(
+            span_id: span_id,
+            trace_id: trace_id,
+            parent_id: parent_id
+          )
+        end
 
-        it { is_expected.to be_a_kind_of(described_class) }
+        let(:span_id) { double('span_id') }
+        let(:trace_id) { double('trace_id') }
+        let(:parent_id) { double('parent_id') }
 
-        describe 'builds a SpanContext where' do
-          describe '#baggage' do
-            subject(:baggage) { span_context.baggage }
-            it { is_expected.to be(original_baggage) }
-            it 'is immutable' do
-              expect { baggage[1] = 2 }.to raise_error(RuntimeError)
+        it do
+          is_expected.to have_attributes(
+            span_id: span_id,
+            trace_id: trace_id,
+            parent_id: parent_id,
+            baggage: {}
+          )
+        end
+
+        context 'and baggage' do
+          subject(:span_context) do
+            described_class.new(
+              span_id: span_id,
+              trace_id: trace_id,
+              parent_id: parent_id,
+              baggage: original_baggage
+            )
+          end
+          let(:original_baggage) { { account_id: '1234' } }
+
+          it { is_expected.to be_a_kind_of(described_class) }
+
+          describe 'builds a SpanContext where' do
+            describe '#baggage' do
+              subject(:baggage) { span_context.baggage }
+              it { is_expected.to be(original_baggage) }
+              it 'is immutable' do
+                expect { baggage[1] = 2 }.to raise_error(RuntimeError)
+              end
             end
           end
         end

--- a/spec/ddtrace/opentracer/span_context_spec.rb
+++ b/spec/ddtrace/opentracer/span_context_spec.rb
@@ -13,10 +13,20 @@ if Datadog::OpenTracer.supported?
 
     describe '#initialize' do
       context 'given baggage' do
-        subject(:span_context) { described_class.new(baggage: baggage) }
-        let(:baggage) { { account_id: '1234' } }
+        subject(:span_context) { described_class.new(baggage: original_baggage) }
+        let(:original_baggage) { { account_id: '1234' } }
+
         it { is_expected.to be_a_kind_of(described_class) }
-        it { expect(span_context.baggage).to be(baggage) }
+
+        describe 'builds a SpanContext where' do
+          describe '#baggage' do
+            subject(:baggage) { span_context.baggage }
+            it { is_expected.to be(original_baggage) }
+            it 'is immutable' do
+              expect { baggage[1] = 2 }.to raise_error(RuntimeError)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/ddtrace/opentracer/span_context_spec.rb
+++ b/spec/ddtrace/opentracer/span_context_spec.rb
@@ -8,24 +8,13 @@ if Datadog::OpenTracer.supported?
     include_context 'OpenTracing helpers'
 
     describe '#initialize' do
-      context 'given span_id, trace_id, parent_id' do
-        subject(:span_context) do
-          described_class.new(
-            span_id: span_id,
-            trace_id: trace_id,
-            parent_id: parent_id
-          )
-        end
-
-        let(:span_id) { double('span_id') }
-        let(:trace_id) { double('trace_id') }
-        let(:parent_id) { double('parent_id') }
+      context 'given a Datadog::Context' do
+        subject(:span_context) { described_class.new(datadog_context: datadog_context) }
+        let(:datadog_context) { instance_double(Datadog::Context) }
 
         it do
           is_expected.to have_attributes(
-            span_id: span_id,
-            trace_id: trace_id,
-            parent_id: parent_id,
+            datadog_context: datadog_context,
             baggage: {}
           )
         end
@@ -33,9 +22,7 @@ if Datadog::OpenTracer.supported?
         context 'and baggage' do
           subject(:span_context) do
             described_class.new(
-              span_id: span_id,
-              trace_id: trace_id,
-              parent_id: parent_id,
+              datadog_context: datadog_context,
               baggage: original_baggage
             )
           end

--- a/spec/ddtrace/opentracer/span_context_spec.rb
+++ b/spec/ddtrace/opentracer/span_context_spec.rb
@@ -9,13 +9,14 @@ if Datadog::OpenTracer.supported?
 
     subject(:span_context) { described_class.new }
 
-    it { is_expected.to have_attributes(baggage: nil) }
+    it { is_expected.to have_attributes(baggage: {}) }
 
     describe '#initialize' do
       context 'given baggage' do
         subject(:span_context) { described_class.new(baggage: baggage) }
         let(:baggage) { { account_id: '1234' } }
         it { is_expected.to be_a_kind_of(described_class) }
+        it { expect(span_context.baggage).to be(baggage) }
       end
     end
   end

--- a/spec/ddtrace/opentracer/span_spec.rb
+++ b/spec/ddtrace/opentracer/span_spec.rb
@@ -7,24 +7,28 @@ if Datadog::OpenTracer.supported?
   RSpec.describe Datadog::OpenTracer::Span do
     include_context 'OpenTracing helpers'
 
-    subject(:span) { described_class.new }
+    subject(:span) { described_class.new(datadog_span: datadog_span, span_context: span_context) }
+    let(:datadog_span) { instance_double(Datadog::Span) }
+    let(:span_context) { instance_double(Datadog::OpenTracer::SpanContext) }
 
     describe '#operation_name=' do
       subject(:result) { span.operation_name = name }
       let(:name) { 'execute_job' }
 
+      before(:each) { expect(datadog_span).to receive(:name=).with(name).and_return(name) }
       it { expect(result).to eq(name) }
     end
 
     describe '#context' do
       subject(:context) { span.context }
-      it { is_expected.to be(OpenTracing::SpanContext::NOOP_INSTANCE) }
+      it { is_expected.to be(span_context) }
     end
 
     describe '#set_tag' do
       subject(:result) { span.set_tag(key, value) }
       let(:key) { 'account_id' }
       let(:value) { '1234' }
+      before(:each) { expect(datadog_span).to receive(:set_tag).with(key, value) }
       it { is_expected.to be(span) }
     end
 
@@ -32,13 +36,23 @@ if Datadog::OpenTracer.supported?
       subject(:result) { span.set_baggage_item(key, value) }
       let(:key) { 'account_id' }
       let(:value) { '1234' }
+      let(:baggage) { instance_double(Hash) }
+
+      before(:each) do
+        allow(span_context).to receive(:baggage).and_return(baggage)
+        expect(baggage).to receive(:[]=).with(key, value)
+      end
+
       it { is_expected.to be(span) }
     end
 
     describe '#get_baggage_item' do
       subject(:result) { span.get_baggage_item(key) }
       let(:key) { 'account_id' }
-      it { is_expected.to be nil }
+      let(:value) { '1234' }
+      let(:baggage) { { key => value } }
+      before(:each) { allow(span_context).to receive(:baggage).and_return(baggage) }
+      it { is_expected.to be(value) }
     end
 
     describe '#log' do
@@ -47,23 +61,30 @@ if Datadog::OpenTracer.supported?
       let(:timestamp) { Time.now }
       let(:fields) { { time_started: Time.now, account_id: '1234' } }
 
-      before(:each) do
+      # Expect a deprecation warning to be output.
+      it do
         expect { log }.to output("Span#log is deprecated.  Please use Span#log_kv instead.\n").to_stderr
       end
-
-      it { is_expected.to be nil }
     end
 
     describe '#log_kv' do
       subject(:log_kv) { span.log_kv(timestamp: timestamp, **fields) }
       let(:timestamp) { Time.now }
-      let(:fields) { { time_started: Time.now, account_id: '1234' } }
 
-      before(:each) do
-        expect { log_kv }.to_not output.to_stderr
+      context 'when given arbitrary key/value pairs' do
+        let(:fields) { { time_started: Time.now, account_id: '1234' } }
+        # We don't expect this to do anything right now.
+        it { is_expected.to be nil }
       end
 
-      it { is_expected.to be nil }
+      context 'when given an \'error.object\'' do
+        let(:fields) { { :'error.object' => error_object } }
+        let(:error_object) { instance_double(StandardError) }
+
+        before(:each) { expect(datadog_span).to receive(:set_error).with(error_object) }
+
+        it { is_expected.to be nil }
+      end
     end
   end
 end

--- a/spec/ddtrace/opentracer/span_spec.rb
+++ b/spec/ddtrace/opentracer/span_spec.rb
@@ -36,14 +36,16 @@ if Datadog::OpenTracer.supported?
       subject(:result) { span.set_baggage_item(key, value) }
       let(:key) { 'account_id' }
       let(:value) { '1234' }
-      let(:baggage) { instance_double(Hash) }
+      let(:new_span_context) { instance_double(Datadog::OpenTracer::SpanContext) }
 
-      before(:each) do
-        allow(span_context).to receive(:baggage).and_return(baggage)
-        expect(baggage).to receive(:[]=).with(key, value)
+      it 'creates a new SpanContext with the baggage item' do
+        expect(Datadog::OpenTracer::SpanContextFactory).to receive(:build)
+          .with(span_context: span_context, baggage: hash_including(key => value))
+          .and_return(new_span_context)
+
+        is_expected.to be(span)
+        expect(span.context).to be(new_span_context)
       end
-
-      it { is_expected.to be(span) }
     end
 
     describe '#get_baggage_item' do

--- a/spec/ddtrace/opentracer/span_spec.rb
+++ b/spec/ddtrace/opentracer/span_spec.rb
@@ -39,7 +39,7 @@ if Datadog::OpenTracer.supported?
       let(:new_span_context) { instance_double(Datadog::OpenTracer::SpanContext) }
 
       it 'creates a new SpanContext with the baggage item' do
-        expect(Datadog::OpenTracer::SpanContextFactory).to receive(:build)
+        expect(Datadog::OpenTracer::SpanContextFactory).to receive(:clone)
           .with(span_context: span_context, baggage: hash_including(key => value))
           .and_return(new_span_context)
 


### PR DESCRIPTION
This pull request implements the OpenTracing `Span` and `SpanContext`. In their current forms, they are very simple, and may not represent the full scope of what will ultimately be supported.

Some worthwhile notes:

 - The constructors for `Span` and `SpanContext` are still somewhat undetermined. They may require changes depending on how and where we actually construct and configure spans. The current plan is that they are treated like simple data structs, that are not responsible for building sophisticated Spans or SpanContexts. That logic is anticipated to be a part of the Tracer, or some kind of factory pattern.
 - There's some ambiguity as to how `log` and `log_kv` should be implemented. For now, they simply set errors, if provided with one. Otherwise they do nothing. We didn't interpret these functions to have responsibilities beyond setting some "debug tags", as opposed to doing logging in the traditional sense.
 - We might want to add `span_id` and `trace_id` to the `SpanContext`, since this object is meant to be a serializable layer of data for sharing trace data across process boundaries (particularly for the purposes of distributed tracing.)