### PR TITLE
[resque] Shutdown tracer and flush data on job finish instead of using SyncWriter.

### DIFF
--- a/lib/ddtrace/contrib/resque/resque_job.rb
+++ b/lib/ddtrace/contrib/resque/resque_job.rb
@@ -17,7 +17,7 @@ module Datadog
             span.service = pin.service
           end
         ensure
-          Datadog.tracer.shutdown!
+          pin.tracer.shutdown! if pin && pin.tracer
         end
       end
     end

--- a/lib/ddtrace/contrib/resque/resque_job.rb
+++ b/lib/ddtrace/contrib/resque/resque_job.rb
@@ -16,19 +16,12 @@ module Datadog
             yield
             span.service = pin.service
           end
+        ensure
+          Datadog.tracer.shutdown!
         end
       end
     end
   end
-end
-
-Resque.before_first_fork do
-  pin = Datadog::Pin.get_from(Resque)
-  next unless pin && pin.tracer
-
-  # Create SyncWriter instance before forking
-  sync_writer = Datadog::SyncWriter.new(transport: pin.tracer.writer.transport)
-  Datadog::Contrib::Resque.sync_writer = sync_writer
 end
 
 Resque.after_fork do
@@ -37,5 +30,4 @@ Resque.after_fork do
   next unless pin && pin.tracer
   # clean the state so no CoW happens
   pin.tracer.provider.context = nil
-  pin.tracer.writer = Datadog::Contrib::Resque.sync_writer
 end


### PR DESCRIPTION
Using latest improvements to how shutdown is performed - we can safely and quickly flush all data manually when the job has finished running.

Its faster and safer than SyncWriter that needs to spawn two threads and connection to the agent on each trace write.