### PR TITLE
Improve performance of multithreaded operation in short running processes

### DIFF
--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -106,13 +106,13 @@ module Datadog
 
       private
 
-      def flush_data
-        callback_traces && callback_services
-      end
+      alias flush_data callback_traces
 
       def perform
         loop do
           @back_off = flush_data ? @flush_interval : [@back_off * BACK_OFF_RATIO, BACK_OFF_MAX].min
+
+          callback_services
 
           @mutex.synchronize do
             return if !@run && @trace_buffer.empty? && @service_buffer.empty?

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -94,12 +94,10 @@ module Datadog
       # This check ensures that if a process doesn't own the current +Writer+, async workers
       # will be initialized again (but only once for each process).
       pid = Process.pid
-      if pid != @pid
+      if pid != @pid # avoid using Mutex when pids are equal
         @mutex_after_fork.synchronize do
-          if pid != @pid
-            # we should start threads because the worker doesn't own this
-            start()
-          end
+          # we should start threads because the worker doesn't own this
+          start if pid != @pid
         end
       end
 

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -15,7 +15,6 @@ module Datadog
       @buff_size = options.fetch(:buffer_size, 100)
       @flush_interval = options.fetch(:flush_interval, 1)
       transport_options = options.fetch(:transport_options, {})
-
       # priority sampling
       if options[:priority_sampler]
         @priority_sampler = options[:priority_sampler]
@@ -95,10 +94,12 @@ module Datadog
       # This check ensures that if a process doesn't own the current +Writer+, async workers
       # will be initialized again (but only once for each process).
       pid = Process.pid
-      @mutex_after_fork.synchronize do
-        if pid != @pid
-          # we should start threads because the worker doesn't own this
-          start()
+      if pid != @pid
+        @mutex_after_fork.synchronize do
+          if pid != @pid
+            # we should start threads because the worker doesn't own this
+            start()
+          end
         end
       end
 


### PR DESCRIPTION
- Avoid using mutex when Pids are the same, reduces lock contention improving throughput 2-3x in processes using more threads

- For short running processes we were capped at the worker timeout which was 1s. With this change the worker is shut down immediately once data is flushed. Increasing throughput of applications like resque.
