### PR TITLE
Make sure spans are closed when processing notifications

### DIFF
--- a/lib/ddtrace/contrib/active_support/notifications/subscription.rb
+++ b/lib/ddtrace/contrib/active_support/notifications/subscription.rb
@@ -75,11 +75,12 @@ module Datadog
             tracer.trace(@span_name, @options).tap do |span|
               # Assign start time if provided
               span.start_time = start unless start.nil?
+              payload[:datadog_span] = span
             end
           end
 
           def finish_span(name, id, payload, finish = nil)
-            tracer.active_span.tap do |span|
+            payload[:datadog_span].tap do |span|
               # If no active span, return.
               return nil if span.nil?
 


### PR DESCRIPTION
In multithreaded setup and when using connection pool while performing many SQL queries, the `active_span` in finishing of event was not always the same to span created at the start of an event.

This caused some odd spans to not properly close - leaking memory in the process. Benchmark application memory use did baloon 2-4x in a matter of minutes

This PR addresses this issue.

Its possible it might one of the causes of #431, as this regression was introduced in 0.12.0 and affects multithreaded apps - i.e. Sidekiq.

Todo:

- [x] fix tests to align with new implementation