### PR TITLE
Use IP address instead of hostname to avoid a bug in libc

### DIFF
--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -7,7 +7,7 @@ module Datadog
   class Writer
     attr_reader :transport, :worker, :priority_sampler
 
-    HOSTNAME = 'localhost'.freeze
+    HOSTNAME = '127.0.0.1'.freeze
     PORT = '8126'.freeze
 
     def initialize(options = {})


### PR DESCRIPTION
On certain linux systems there seems to be a bug in libc which causes deadlock of Ruby interpreter. 
It only happens when ruby tries to resolve a hostname and its specifically triggered with many short-lived Ruby processes e.g. Resque. 

See issue - https://github.com/DataDog/dd-trace-rb/issues/466 - where the solution was to use IP address instead of hostname. 

Also [this comment](https://github.com/DataDog/dd-trace-rb/issues/466#issuecomment-400322260) that contains GDB trace of all threads seems to directly point to libc call to resolve hostname.  