### PR TITLE
Fix variable names in rescue blocks

### DIFF
--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -43,7 +43,7 @@ module Datadog
           # ensures that the thread will not die because of an exception.
           # TODO[manu]: findout the reason and reschedule the send if it's not
           # a fatal exception
-          Datadog::Tracer.log.error("Error during traces flush: dropped #{items.length} items. Cause: #{e}")
+          Datadog::Tracer.log.error("Error during traces flush: dropped #{traces.length} items. Cause: #{e}")
         end
       end
 
@@ -58,7 +58,7 @@ module Datadog
           # ensures that the thread will not die because of an exception.
           # TODO[manu]: findout the reason and reschedule the send if it's not
           # a fatal exception
-          Datadog::Tracer.log.error("Error during services flush: dropped #{items.length} items. Cause: #{e}")
+          Datadog::Tracer.log.error("Error during services flush: dropped #{services.length} items. Cause: #{e}")
         end
       end
 

--- a/spec/ddtrace/workers_spec.rb
+++ b/spec/ddtrace/workers_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe Datadog::Workers::AsyncTransport do
+  describe 'callbacks' do
+    describe 'when raising errors' do
+      it 'does not re-raise' do
+        buf = StringIO.new
+        Datadog::Tracer.log = Datadog::Logger.new(buf)
+        task = proc { raise StandardError }
+        worker = Datadog::Workers::AsyncTransport.new(nil, 100, task, task, 0.5)
+
+        worker.enqueue_trace(get_test_traces(1))
+        worker.enqueue_service(get_test_services)
+
+        expect { worker.callback_traces }.to_not raise_error
+        expect { worker.callback_services }.to_not raise_error
+
+        lines = buf.string.lines
+        expect(lines.count).to eq 2
+      end
+    end
+  end
+end


### PR DESCRIPTION
When running the gem in production, we came across the following error:
```
09:24:55.681 .../bundle/ruby/2.5.0/gems/ddtrace-0.13.0/lib/ddtrace/workers.rb:46:in `rescue in callback_traces': undefined local variable or method `items' for #<Datadog::Workers::AsyncTransport:0x000055cecd711640> (NameError)
09:24:55.681 .../bundle/ruby/2.5.0/gems/ddtrace-0.13.0/lib/ddtrace/workers.rb:38:in `callback_traces'
09:24:55.681 .../bundle/ruby/2.5.0/gems/ddtrace-0.13.0/lib/ddtrace/workers.rb:111:in `block in perform
 ```

And noticed that [this commit](https://github.com/DataDog/dd-trace-rb/commit/43d67d5063a37647468f1ac3a3da40157bc3c828?diff=split#diff-0aa40585cc9b770a220ef7fc86b6655fR30) changed the variable name in the method body but not in the rescue block.

This PR updates the variable names to the proper ones in rescue blocks.