### PR TITLE
Add version to Integration

### DIFF
--- a/lib/ddtrace/contrib/active_record/integration.rb
+++ b/lib/ddtrace/contrib/active_record/integration.rb
@@ -15,12 +15,16 @@ module Datadog
 
         register_as :active_record, auto_patch: false
 
+        def self.version
+          Gem.loaded_specs['activerecord'] && Gem.loaded_specs['activerecord'].version
+        end
+
+        def self.present?
+          super && defined?(::ActiveRecord)
+        end
+
         def self.compatible?
-          super \
-            && RUBY_VERSION >= '1.9.3' \
-            && Gem.loaded_specs['activerecord'] \
-            && Gem.loaded_specs['activerecord'].version >= Gem::Version.new('3.0') \
-            && defined?(::ActiveRecord)
+          super && version >= Gem::Version.new('3.0')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/patchable.rb
+++ b/lib/ddtrace/contrib/patchable.rb
@@ -9,8 +9,16 @@ module Datadog
 
       # Class methods for integrations
       module ClassMethods
+        def version
+          nil
+        end
+
+        def present?
+          !version.nil?
+        end
+
         def compatible?
-          RUBY_VERSION >= '1.9.3'
+          RUBY_VERSION >= '1.9.3' && present?
         end
       end
 

--- a/lib/ddtrace/contrib/sequel/integration.rb
+++ b/lib/ddtrace/contrib/sequel/integration.rb
@@ -13,8 +13,16 @@ module Datadog
 
         register_as :sequel, auto_patch: false
 
+        def self.version
+          Gem.loaded_specs['sequel'] && Gem.loaded_specs['sequel'].version
+        end
+
+        def self.present?
+          super && defined?(::Sequel)
+        end
+
         def self.compatible?
-          RUBY_VERSION >= '2.0.0' && defined?(::Sequel)
+          super && RUBY_VERSION >= '2.0.0'
         end
 
         def default_configuration

--- a/spec/ddtrace/contrib/patchable_spec.rb
+++ b/spec/ddtrace/contrib/patchable_spec.rb
@@ -11,10 +11,42 @@ RSpec.describe Datadog::Contrib::Patchable do
     end
 
     describe 'class behavior' do
+      describe '#version' do
+        subject(:compatible) { patchable_class.version }
+        it { is_expected.to be nil }
+      end
+
+      describe '#present?' do
+        subject(:compatible) { patchable_class.present? }
+
+        context 'when version' do
+          context 'is defined' do
+            let(:version) { double('version') }
+            before(:each) { allow(patchable_class).to receive(:version).and_return(version) }
+            it { is_expected.to be true }
+          end
+
+          context 'is not defined' do
+            it { is_expected.to be false }
+          end
+        end
+      end
+
       describe '#compatible?' do
         subject(:compatible) { patchable_class.compatible? }
         let(:expected_compatibility) { RUBY_VERSION >= '1.9.3' ? true : false }
-        it { is_expected.to be expected_compatibility }
+
+        context 'when version' do
+          context 'is defined' do
+            let(:version) { double('version') }
+            before(:each) { allow(patchable_class).to receive(:version).and_return(version) }
+            it { is_expected.to be expected_compatibility }
+          end
+
+          context 'is not defined' do
+            it { is_expected.to be false }
+          end
+        end
       end
     end
 


### PR DESCRIPTION
This pull request adds `#version` and `#present?` to `Datadog::Contrib::Patchable` to expose version numbers in a more consistent manner.