### PR TITLE
Ensure trace yield on #start_span error

### DIFF
--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+require 'ddtrace'
+
+RSpec.describe Datadog::Tracer do
+  subject(:tracer) { described_class.new(writer: FauxWriter.new) }
+
+  describe '#trace' do
+    let(:name) { 'span.name' }
+
+    context 'given a block' do
+      subject(:trace) { tracer.trace(name, &block) }
+      let(:block) { proc { result } }
+      let(:result) { double('result') }
+
+      context 'when starting a span' do
+        it do
+          expect { |b| tracer.trace(name, &b) }.to yield_with_args(
+            a_kind_of(Datadog::Span)
+          )
+        end
+
+        it { expect(trace).to eq(result) }
+      end
+
+      context 'when starting a span fails' do
+        before(:each) do
+          allow(tracer).to receive(:start_span).and_raise(error)
+        end
+
+        let(:error) { error_class.new }
+        let(:error_class) { Class.new(StandardError) }
+
+        it 'still yields to the block and does not raise an error' do
+          expect do
+            expect do |b|
+              tracer.trace(name, &b)
+            end.to yield_with_args(nil)
+          end.to_not raise_error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When tracing code with block syntax such as:

```ruby
tracer.trace('http.request') do |span|
  client.get
end
```

...the tracer automatically creates a span and yields to the block. However, if the tracer were to raise an error before the block were invoked, the instrumented code might never run (in this example `client.get`.) This could break application behavior in an undesirable way.

This pull request treats the block as an `ensure`: it should always run regardless of whether tracing is working or not. If an error occurs when the tracing begins, it catches it, logs it in debug, then yields `nil` to the block to continue execution. This should make for less intrusive behavior if tracing were to somehow malfunction.