### PR TITLE
Add on_error callback option for tracing

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -162,6 +162,7 @@ And `options` is an optional `Hash` that accepts the following parameters:
 | ``child_of``    | `Datadog::Span` / `Datadog::Context` | Parent for this span. If not provided, will automatically become current active span. | `nil` |
 | ``start_time``  | `Integer` | When the span actually starts. Useful when tracing events that have already happened. | `Time.now.utc` |
 | ``tags``        | `Hash` | Extra tags which should be added to the span. | `{}` |
+| ``on_error``    | `Proc` | Handler invoked when a block is provided to trace, and it raises an error. Provided `span` and `error` as arguments. Sets error on the span by default. | `proc { |span, error| span.set_error(error) unless span.nil? }` |
 
 It's highly recommended you set both `service` and `resource` at a minimum. Spans without a `service` or `resource` as `nil` will be discarded by the Datadog agent.
 

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe Datadog::Tracer do
 
   describe '#trace' do
     let(:name) { 'span.name' }
+    let(:options) { {} }
 
     context 'given a block' do
-      subject(:trace) { tracer.trace(name, &block) }
+      subject(:trace) { tracer.trace(name, options, &block) }
       let(:block) { proc { result } }
       let(:result) { double('result') }
 
@@ -37,6 +38,36 @@ RSpec.describe Datadog::Tracer do
               tracer.trace(name, &b)
             end.to yield_with_args(nil)
           end.to_not raise_error
+        end
+      end
+
+      context 'when the block raises an error' do
+        let(:block) { proc { raise error } }
+        let(:error) { error_class.new }
+        let(:error_class) { Class.new(StandardError) }
+
+        context 'and the on_error option' do
+          context 'is not provided' do
+            it do
+              expect_any_instance_of(Datadog::Span).to receive(:set_error)
+                .with(error)
+              expect { trace }.to raise_error(error)
+            end
+          end
+
+          context 'is a block' do
+            it 'yields to the error block and raises the error' do
+              expect_any_instance_of(Datadog::Span).to_not receive(:set_error)
+              expect do
+                expect do |b|
+                  tracer.trace(name, on_error: b.to_proc, &block)
+                end.to yield_with_args(
+                  a_kind_of(Datadog::Span),
+                  error
+                )
+              end.to raise_error(error)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
In a number of integrations, particularly HTTP integrations, instrumented can raise errors that are considered non-critical, or even quite normal. e.g. 404s, 403s, etc.

When provided a block, `Datadog::Tracer#trace` adds some default error handling. It catches any exception, adds it to the active span, then re-raises. This is desirable in most cases, but for non-critical errors like those mentioned above, this can cause spans to be tagged as errors in a way that's undesirable. Currently the only way to work around this is to use the non-block syntax, which creates some repetition, and is generally not preferred.

This pull request adds the `on_error` option to the `#trace` function, which allows users to provide a `Proc` to define custom error behavior.

For example:

```ruby
def get
  tracer.trace('http.request', on_error: method(:handle_http_error)) do
    client.get
  end
end

def handle_http_error(span, error)
  span.set_error(error) unless error.class <= HttpError && error.status < 500
end
```