### PR TITLE
No more ruby warnings

### DIFF
--- a/lib/ddtrace/monkey.rb
+++ b/lib/ddtrace/monkey.rb
@@ -15,8 +15,6 @@ module Datadog
 
     module_function
 
-    attr_writer :registry
-
     def registry
       log_deprecation_warning('Monkey#registry')
       @registry
@@ -54,11 +52,6 @@ module Datadog
     end
 
     class << self
-      def registry
-        log_deprecation_warning('Monkey#registry')
-        @registry
-      end
-
       attr_writer :registry
     end
   end

--- a/lib/ddtrace/pin.rb
+++ b/lib/ddtrace/pin.rb
@@ -10,7 +10,7 @@ module Datadog
       obj.datadog_pin
     end
 
-    attr_accessor :service_name
+    attr_reader :service_name
     attr_accessor :app
     attr_accessor :tags
     attr_accessor :app_type


### PR DESCRIPTION
remove unnecessary duplicated code that caused Ruby to issue warnings.

