### PR TITLE
Prevent HttpPropagator errors given a nil Context

### DIFF
--- a/lib/ddtrace/propagation/http_propagator.rb
+++ b/lib/ddtrace/propagation/http_propagator.rb
@@ -9,6 +9,12 @@ module Datadog
 
     # inject! popolates the env with span ID, trace ID and sampling priority
     def self.inject!(context, env)
+      # Prevent propagation from being attempted if context provided is nil.
+      if context.nil?
+        Datadog::Tracer.log.debug('Cannot inject context into env to propagate over HTTP: context is nil.'.freeze)
+        return
+      end
+
       env[HTTP_HEADER_TRACE_ID] = context.trace_id.to_s
       env[HTTP_HEADER_PARENT_ID] = context.span_id.to_s
       env[HTTP_HEADER_SAMPLING_PRIORITY] = context.sampling_priority.to_s

--- a/spec/ddtrace/propagation/http_propagator_spec.rb
+++ b/spec/ddtrace/propagation/http_propagator_spec.rb
@@ -9,6 +9,15 @@ RSpec.describe Datadog::HTTPPropagator do
   describe '#inject!' do
     let(:env) { { 'something' => 'alien' } }
 
+    context 'given a nil context' do
+      it do
+        tracer.trace('caller') do |_span|
+          Datadog::HTTPPropagator.inject!(nil, env)
+          expect(env).to eq('something' => 'alien')
+        end
+      end
+    end
+
     context 'given a context and env' do
       context 'without any explicit sampling priority' do
         it do

--- a/spec/ddtrace/propagation/propagation_integration_spec.rb
+++ b/spec/ddtrace/propagation/propagation_integration_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+require 'ddtrace'
+require 'ddtrace/propagation/http_propagator'
+
+RSpec.describe 'Context propagation' do
+  let(:tracer) { Datadog::Tracer.new(writer: FauxWriter.new) }
+
+  describe 'when max context size is exceeded' do
+    let(:max_size) { 3 }
+
+    before(:each) { stub_const('Datadog::Context::DEFAULT_MAX_LENGTH', max_size) }
+
+    # Creates scenario for when size is exceeded, and yields.
+    # (Would rather use #around but it doesn't support stubs.)
+    def on_size_exceeded
+      tracer.trace('operation.parent') do
+        # Fill the trace over the capacity of the context
+        max_size.times do |i|
+          tracer.trace('operation.sibling') do |span|
+            yield(span) if i + 1 == max_size
+          end
+        end
+      end
+    end
+
+    context 'and the context is injected via HTTP propagation' do
+      let(:env) { {} }
+
+      it 'does not raise an error or propagate the trace' do
+        on_size_exceeded do |span|
+          # Verify warning message is produced.
+          allow(Datadog::Tracer.log).to receive(:debug)
+          expect { Datadog::HTTPPropagator.inject!(span.context, env) }.to_not raise_error
+          expect(Datadog::Tracer.log).to have_received(:debug).with(/Cannot inject context/)
+
+          # The context has reached its max size and cannot be propagated.
+          # Check headers aren't present.
+          expect(env).to_not include(Datadog::HTTPPropagator::HTTP_HEADER_TRACE_ID)
+          expect(env).to_not include(Datadog::HTTPPropagator::HTTP_HEADER_PARENT_ID)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
If you provide `HttpPropagator#inject!` a nil `Context`, it will raise an error. This pull request adds a simple check to avoid errors if traces can't be propagated for this reason.

Depends on #501 which refactors some tests.