### PR TITLE
Add active_root_span to Tracer

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -229,7 +229,7 @@ def finish(name, id, payload)
   end
 end
 ```
-#####Enriching traces from nested methods
+##### Enriching traces from nested methods
 
 You can tag additional information to current active span from any method. Note however that if the method is called and there is no span currently active `active_span` will be nil.
 
@@ -238,6 +238,15 @@ You can tag additional information to current active span from any method. Note 
 
 current_span = Datadog.tracer.active_span
 current_span.set_tag('my_tag', 'my_value') unless current_span.nil?
+```
+
+You can also get the root span of the current active trace using the `active_root_span` method. This method will return `nil` if there is no active trace.
+
+```ruby
+# e.g. adding tag to active root span
+
+current_root_span = Datadog.tracer.active_root_span
+current_root_span.set_tag('my_tag', 'my_value') unless current_root_span.nil?
 ```
 
 ## Integration instrumentation

--- a/lib/ddtrace/context.rb
+++ b/lib/ddtrace/context.rb
@@ -63,6 +63,12 @@ module Datadog
       end
     end
 
+    def current_root_span
+      @mutex.synchronize do
+        return @current_root_span
+      end
+    end
+
     # Add a span to the context trace list, keeping it as the last active span.
     def add_span(span)
       @mutex.synchronize do
@@ -77,6 +83,7 @@ module Datadog
           return
         end
         set_current_span(span)
+        @current_root_span = span if @trace.empty?
         @trace << span
         span.context = self
       end
@@ -158,6 +165,7 @@ module Datadog
       @sampling_priority = options.fetch(:sampling_priority, nil)
       @finished_spans = 0
       @current_span = nil
+      @current_root_span = nil
     end
 
     def set_current_span(span)

--- a/lib/ddtrace/context.rb
+++ b/lib/ddtrace/context.rb
@@ -83,7 +83,7 @@ module Datadog
           return
         end
         set_current_span(span)
-        @current_root_span = span if @trace.empty?
+        @current_root_span = span if @trace.empty? && span.parent_id.zero?
         @trace << span
         span.context = self
       end

--- a/lib/ddtrace/context.rb
+++ b/lib/ddtrace/context.rb
@@ -83,7 +83,7 @@ module Datadog
           return
         end
         set_current_span(span)
-        @current_root_span = span if @trace.empty? && span.parent_id.zero?
+        @current_root_span = span if @trace.empty?
         @trace << span
         span.context = self
       end

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -346,6 +346,11 @@ module Datadog
       call_context.current_span
     end
 
+    # Return the current active root span or +nil+.
+    def active_root_span
+      call_context.current_root_span
+    end
+
     # Send the trace to the writer to enqueue the spans list in the agent
     # sending queue.
     def write(trace)

--- a/spec/ddtrace/context_spec.rb
+++ b/spec/ddtrace/context_spec.rb
@@ -18,12 +18,25 @@ RSpec.describe Datadog::Context do
 
       it { is_expected.to be span }
 
+      context 'which is a child to another span' do
+        let(:parent_span) { Datadog::Span.new(tracer, 'span.parent') }
+        let(:span) do
+          Datadog::Span.new(
+            tracer,
+            'span.child',
+            context: context
+          ).tap { |s| s.parent = parent_span }
+        end
+
+        it { is_expected.to be nil }
+      end
+
       context 'and is reset' do
         before(:each) { context.send(:reset) }
         it { is_expected.to be nil }
       end
 
-      context 'followed by a second' do
+      context 'followed by a second span' do
         let(:span_two) { Datadog::Span.new(tracer, 'span.two', context: context) }
         before(:each) { context.add_span(span_two) }
         it { is_expected.to be span }

--- a/spec/ddtrace/context_spec.rb
+++ b/spec/ddtrace/context_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Datadog::Context do
           ).tap { |s| s.parent = parent_span }
         end
 
-        it { is_expected.to be nil }
+        it { is_expected.to be span }
       end
 
       context 'and is reset' do

--- a/spec/ddtrace/context_spec.rb
+++ b/spec/ddtrace/context_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+require 'ddtrace'
+
+RSpec.describe Datadog::Context do
+  subject(:context) { described_class.new(options) }
+  let(:options) { {} }
+  let(:tracer) { ::Datadog::Tracer.new(writer: FauxWriter.new) }
+
+  describe '#current_root_span' do
+    subject(:current_root_span) { context.current_root_span }
+
+    it { is_expected.to be nil }
+
+    context 'after a span is added' do
+      let(:span) { Datadog::Span.new(tracer, 'span.one', context: context) }
+      before(:each) { context.add_span(span) }
+
+      it { is_expected.to be span }
+
+      context 'and is reset' do
+        before(:each) { context.send(:reset) }
+        it { is_expected.to be nil }
+      end
+
+      context 'followed by a second' do
+        let(:span_two) { Datadog::Span.new(tracer, 'span.two', context: context) }
+        before(:each) { context.add_span(span_two) }
+        it { is_expected.to be span }
+      end
+    end
+  end
+end

--- a/spec/ddtrace/tracer_integration_spec.rb
+++ b/spec/ddtrace/tracer_integration_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe Datadog::Tracer do
       it { expect(child_span.trace_id).to eq(parent_span.trace_id) }
       it { expect(child_span.parent_id).to eq(parent_span.span_id) }
       it { expect(sampling_priority_metric(child_span)).to eq(1) }
-      # This is expected to be nil because when propagated, we don't
+      # This is expected to be child_span because when propagated, we don't
       # propagate the root span, only its ID. Therefore the span reference
-      # should be nil on the other end of the distributed trace.
-      it { expect(@child_root_span).to be nil }
+      # should be the first span on the other end of the distributed trace.
+      it { expect(@child_root_span).to be child_span }
     end
   end
 end

--- a/spec/ddtrace/tracer_integration_spec.rb
+++ b/spec/ddtrace/tracer_integration_spec.rb
@@ -27,9 +27,7 @@ RSpec.describe Datadog::Tracer do
           # Propagate it via headers
           headers = {}
           Datadog::HTTPPropagator.inject!(parent_span.context, headers)
-          headers = headers.collect do |k, v|
-            ["http-#{k}".upcase!.tr('-', '_'), v]
-          end.to_h
+          headers = Hash[headers.map { |k, v| ["http-#{k}".upcase!.tr('-', '_'), v] }]
 
           # Then extract it from the same headers
           propagated_context = Datadog::HTTPPropagator.extract(headers)

--- a/spec/ddtrace/tracer_integration_spec.rb
+++ b/spec/ddtrace/tracer_integration_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+require 'ddtrace'
+require 'ddtrace/propagation/http_propagator'
+
+RSpec.describe Datadog::Tracer do
+  subject(:tracer) { described_class.new(writer: FauxWriter.new) }
+  let(:spans) { tracer.writer.spans(:keep) }
+
+  def sampling_priority_metric(span)
+    span.get_metric(Datadog::Ext::DistributedTracing::SAMPLING_PRIORITY_KEY)
+  end
+
+  describe '#active_root_span' do
+    subject(:active_root_span) { tracer.active_root_span }
+
+    context 'when a distributed trace is propagated' do
+      let(:parent_span_name) { 'operation.parent' }
+      let(:child_span_name) { 'operation.child' }
+
+      before(:each) do
+        # Create parent span
+        tracer.trace(parent_span_name) do |parent_span|
+          @parent_span = parent_span
+          parent_span.context.sampling_priority = Datadog::Ext::Priority::AUTO_KEEP
+
+          # Propagate it via headers
+          headers = {}
+          Datadog::HTTPPropagator.inject!(parent_span.context, headers)
+          headers = headers.collect do |k, v|
+            ["http-#{k}".upcase!.tr('-', '_'), v]
+          end.to_h
+
+          # Then extract it from the same headers
+          propagated_context = Datadog::HTTPPropagator.extract(headers)
+          raise StandardError, 'Failed to propagate trace properly.' unless propagated_context.trace_id
+          tracer.provider.context = propagated_context
+
+          # And create child span from propagated context
+          tracer.trace(child_span_name) do |child_span|
+            @child_span = child_span
+            @child_root_span = tracer.active_root_span
+          end
+        end
+      end
+
+      let(:parent_span) { spans.last }
+      let(:child_span) { spans.first }
+
+      it { expect(spans).to have(2).items }
+      it { expect(parent_span.name).to eq(parent_span_name) }
+      it { expect(parent_span.finished?).to be(true) }
+      it { expect(parent_span.parent_id).to eq(0) }
+      it { expect(sampling_priority_metric(parent_span)).to eq(1) }
+      it { expect(child_span.name).to eq(child_span_name) }
+      it { expect(child_span.finished?).to be(true) }
+      it { expect(child_span.trace_id).to eq(parent_span.trace_id) }
+      it { expect(child_span.parent_id).to eq(parent_span.span_id) }
+      it { expect(sampling_priority_metric(child_span)).to eq(1) }
+      # This is expected to be nil because when propagated, we don't
+      # propagate the root span, only its ID. Therefore the span reference
+      # should be nil on the other end of the distributed trace.
+      it { expect(@child_root_span).to be nil }
+    end
+  end
+end

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -72,4 +72,14 @@ RSpec.describe Datadog::Tracer do
       end
     end
   end
+
+  describe '#active_root_span' do
+    subject(:active_root_span) { tracer.active_root_span }
+    let(:span) { instance_double(Datadog::Span) }
+
+    it do
+      expect(tracer.call_context).to receive(:current_root_span).and_return(span)
+      is_expected.to be(span)
+    end
+  end
 end


### PR DESCRIPTION
### Overview

To aid the traversal of active spans (for example to tag a trace with tags), this pull request introduces the `active_root_span` function to the Tracer, which works like the `active_span` function.

### Usage

```ruby
# e.g. adding tag to active root span
current_root_span = Datadog.tracer.active_root_span
current_root_span.set_tag('my_tag', 'my_value') unless current_root_span.nil?
```