### PR TITLE
[OpenTracing] Fix symbol propagation

### DIFF
--- a/lib/ddtrace/opentracer/rack_propagator.rb
+++ b/lib/ddtrace/opentracer/rack_propagator.rb
@@ -48,7 +48,7 @@ module Datadog
         private
 
         def baggage_header?(header)
-          header.start_with?(BAGGAGE_PREFIX_FORMATTED)
+          header.to_s.start_with?(BAGGAGE_PREFIX_FORMATTED)
         end
 
         def header_to_baggage(key)

--- a/lib/ddtrace/opentracer/text_map_propagator.rb
+++ b/lib/ddtrace/opentracer/text_map_propagator.rb
@@ -61,7 +61,7 @@ module Datadog
         private
 
         def baggage_item?(item)
-          item.start_with?(BAGGAGE_PREFIX)
+          item.to_s.start_with?(BAGGAGE_PREFIX)
         end
 
         def item_to_baggage(key)

--- a/spec/ddtrace/opentracer/rack_propagator_spec.rb
+++ b/spec/ddtrace/opentracer/rack_propagator_spec.rb
@@ -83,15 +83,30 @@ if Datadog::OpenTracer.supported?
             end
           end
 
-          context 'without a proper prefix' do
-            let(:key) { 'HTTP_ACCOUNT_NAME' }
-            it { expect(span_context.baggage).to be_empty }
+          context 'with a symbol' do
+            context 'that does not have a proper prefix' do
+              let(:key) { :my_baggage_item }
+              it { expect(span_context.baggage).to be_empty }
+            end
+
+            context 'that has a proper prefix' do
+              let(:key) { :"#{described_class::BAGGAGE_PREFIX_FORMATTED}ACCOUNT_NAME" }
+              it { expect(span_context.baggage).to have(1).items }
+              it { expect(span_context.baggage).to include('account_name' => value) }
+            end
           end
 
-          context 'with a proper prefix' do
-            let(:key) { "#{described_class::BAGGAGE_PREFIX_FORMATTED}ACCOUNT_NAME" }
-            it { expect(span_context.baggage).to have(1).items }
-            it { expect(span_context.baggage).to include('account_name' => value) }
+          context 'with a string' do
+            context 'that does not have a proper prefix' do
+              let(:key) { 'HTTP_ACCOUNT_NAME' }
+              it { expect(span_context.baggage).to be_empty }
+            end
+
+            context 'that has a proper prefix' do
+              let(:key) { "#{described_class::BAGGAGE_PREFIX_FORMATTED}ACCOUNT_NAME" }
+              it { expect(span_context.baggage).to have(1).items }
+              it { expect(span_context.baggage).to include('account_name' => value) }
+            end
           end
         end
       end

--- a/spec/ddtrace/opentracer/text_map_propagator_spec.rb
+++ b/spec/ddtrace/opentracer/text_map_propagator_spec.rb
@@ -77,15 +77,30 @@ if Datadog::OpenTracer.supported?
           let(:value) { 'acme' }
           let(:items) { { key => value } }
 
-          context 'without a proper prefix' do
-            let(:key) { 'account_name' }
-            it { expect(span_context.baggage).to be_empty }
+          context 'with a symbol' do
+            context 'that does not have a proper prefix' do
+              let(:key) { :my_baggage_item }
+              it { expect(span_context.baggage).to be_empty }
+            end
+
+            context 'that has a proper prefix' do
+              let(:key) { :"#{described_class::BAGGAGE_PREFIX}account_name" }
+              it { expect(span_context.baggage).to have(1).items }
+              it { expect(span_context.baggage).to include('account_name' => value) }
+            end
           end
 
-          context 'with a proper prefix' do
-            let(:key) { "#{described_class::BAGGAGE_PREFIX}account_name" }
-            it { expect(span_context.baggage).to have(1).items }
-            it { expect(span_context.baggage).to include('account_name' => value) }
+          context 'with a string' do
+            context 'that does not have a proper prefix' do
+              let(:key) { 'HTTP_ACCOUNT_NAME' }
+              it { expect(span_context.baggage).to be_empty }
+            end
+
+            context 'that has a proper prefix' do
+              let(:key) { "#{described_class::BAGGAGE_PREFIX}account_name" }
+              it { expect(span_context.baggage).to have(1).items }
+              it { expect(span_context.baggage).to include('account_name' => value) }
+            end
           end
         end
 


### PR DESCRIPTION
While testing our Opentracer adapter with `ruby-rack-tracer`, we ran into an edge case where when the `Rack::Env` contains a symbol key, then propagation in our Opentracer adapter raises an error `undefined method 'start_with?' for :"ot-baggage-account_name":Symbol`.

This pull request coerces symbols to strings when attempting to do this kind of propagation.