### PR TITLE
Fix deprecation warnings when Rack Env is re-used

### DIFF
--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -13,6 +13,7 @@ module Datadog
       # in the Rack environment so that it can be retrieved by the underlying
       # application. If request tags are not set by the app, they will be set using
       # information available at the Rack level.
+      # rubocop:disable Metrics/ClassLength
       class TraceMiddleware
         RACK_REQUEST_SPAN = 'datadog.rack_request_span'.freeze
 
@@ -58,11 +59,12 @@ module Datadog
           request_span = tracer.trace('rack.request', trace_options)
           env[RACK_REQUEST_SPAN] = request_span
 
-          # TODO: For backwards compatibility; this attribute is deprecated.
-          env[:datadog_rack_request_span] = env[RACK_REQUEST_SPAN]
-
           # Add deprecation warnings
           add_deprecation_warnings(env)
+          env.without_datadog_warnings do
+            # TODO: For backwards compatibility; this attribute is deprecated.
+            env[:datadog_rack_request_span] = env[RACK_REQUEST_SPAN]
+          end
 
           # Copy the original env, before the rest of the stack executes.
           # Values may change; we want values before that happens.
@@ -180,19 +182,30 @@ module Datadog
         def add_deprecation_warnings(env)
           env.instance_eval do
             def [](key)
-              if key == :datadog_rack_request_span && !@request_span_warning_issued
+              if key == :datadog_rack_request_span \
+                && !@datadog_span_warning_issued \
+                && !@datadog_deprecation_warnings_disabled
                 Datadog::Tracer.log.warn(REQUEST_SPAN_DEPRECATION_WARNING)
-                @request_span_warning_issued = true
+                @datadog_span_warning_issued = true
               end
               super
             end
 
             def []=(key, value)
-              if key == :datadog_rack_request_span && !@request_span_warning_issued
+              if key == :datadog_rack_request_span \
+                && !@datadog_span_warning_issued \
+                && !@datadog_deprecation_warnings_disabled
                 Datadog::Tracer.log.warn(REQUEST_SPAN_DEPRECATION_WARNING)
-                @request_span_warning_issued = true
+                @datadog_span_warning_issued = true
               end
               super
+            end
+
+            def without_datadog_warnings
+              @datadog_deprecation_warnings_disabled = true
+              yield
+            ensure
+              @datadog_deprecation_warnings_disabled = false
             end
           end
         end

--- a/spec/ddtrace/contrib/rack/middleware_spec.rb
+++ b/spec/ddtrace/contrib/rack/middleware_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+require 'rack'
+require 'ddtrace'
+require 'ddtrace/contrib/rack/middlewares'
+
+RSpec.describe Datadog::Contrib::Rack::TraceMiddleware do
+  subject(:middleware) { described_class.new(app) }
+  let(:app) { instance_double(Rack::Builder) }
+
+  let(:tracer) { Datadog::Tracer.new(writer: FauxWriter.new) }
+  let(:configuration_options) { { tracer: tracer } }
+
+  before(:each) do
+    Datadog.configure do |c|
+      c.tracer hostname: ENV.fetch('TEST_DDAGENT_HOST', 'localhost')
+      c.use :rack, configuration_options
+    end
+  end
+
+  describe '#call' do
+    subject(:middleware_call) { middleware.call(env) }
+    let(:env) { {} }
+    let(:response) { [200, { 'Content-Type' => 'text/plain' }, ['OK']] }
+
+    before(:each) do
+      allow(app).to receive(:call)
+        .with(env)
+        .and_return(response)
+    end
+
+    describe 'deprecation warnings' do
+      before(:each) { allow(Datadog::Tracer.log).to receive(:warn) }
+
+      # Expect this for backwards compatibility
+      context 'backwards compatibility' do
+        before(:each) { middleware_call }
+
+        it do
+          expect(env).to include(
+            datadog_rack_request_span: kind_of(Datadog::Span),
+            'datadog.rack_request_span' => kind_of(Datadog::Span)
+          )
+        end
+      end
+
+      context 'when :datadog_rack_request_span is accessed on the span' do
+        before(:each) do
+          allow(app).to receive(:call).with(env) do |env|
+            # Trigger deprecation warning
+            env[:datadog_rack_request_span]
+            response
+          end
+
+          middleware_call
+        end
+
+        it do
+          expect(Datadog::Tracer.log).to have_received(:warn)
+            .with(/:datadog_rack_request_span/)
+        end
+      end
+
+      context 'when the same Rack env object is run twice' do
+        before(:each) do
+          middleware.call(env)
+          middleware.call(env)
+        end
+
+        it do
+          expect(Datadog::Tracer.log).to_not have_received(:warn)
+            .with(/:datadog_rack_request_span/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
There is a deprecation warning for the Rack integration when the Rack Env is accessed using the symbol name that was deprecated. This warning is triggered on a edge case where the same Env object is passed through the middleware multiple times; presumably because a web server is re-using the object instead of allocating new memory. This most readily manifests when using Unicorn.

This pull request adds a block around Datadog's use of the deprecated symbol (which exists for backwards compatibility) so that it doesn't raise this error if the object is re-used.