### PR TITLE
Use incoming sample priority to decide if the span should be sampled or not

### DIFF
--- a/lib/ddtrace/sampler.rb
+++ b/lib/ddtrace/sampler.rb
@@ -99,7 +99,7 @@ module Datadog
 
     def sample(span)
       return perform_sampling(span) unless span.context
-      return priority_keep?(span.context.sampling_priority) if span.context.sampling_priority
+      return sampled_by_upstream(span) if span.context.sampling_priority
 
       perform_sampling(span).tap do |sampled|
         span.context.sampling_priority = if sampled
@@ -113,6 +113,10 @@ module Datadog
     def_delegators :@post_sampler, :update
 
     private
+
+    def sampled_by_upstream(span)
+      span.sampled = priority_keep?(span.context.sampling_priority)
+    end
 
     def priority_keep?(sampling_priority)
       sampling_priority == Datadog::Ext::Priority::USER_KEEP || sampling_priority == Datadog::Ext::Priority::AUTO_KEEP

--- a/test/sampler_test.rb
+++ b/test/sampler_test.rb
@@ -98,20 +98,32 @@ class SamplerTest < Minitest::Test
 
   def test_priority_sampler_handling_existing_priority
     tracer = get_test_tracer
+    tracer.provider.context = Datadog::Context.new
     tracer.configure(sampler: Datadog::PrioritySampler.new)
 
     tracer.provider.context.sampling_priority = Datadog::Ext::Priority::USER_KEEP
-    tracer.trace('test_keep', trace_id: 1) { }
+    tracer.trace('test_keep', trace_id: 1) {}
 
     tracer.provider.context.sampling_priority = Datadog::Ext::Priority::AUTO_KEEP
-    tracer.trace('test_keep', trace_id: 2) { }
+    tracer.trace('test_keep', trace_id: 2) {}
 
     tracer.provider.context.sampling_priority = Datadog::Ext::Priority::AUTO_REJECT
-    tracer.trace('test_reject', trace_id: 3) { }
+    tracer.trace('test_reject', trace_id: 3) {}
 
     tracer.provider.context.sampling_priority = Datadog::Ext::Priority::USER_REJECT
-    tracer.trace('test_reject', trace_id: 4) { }
+    tracer.trace('test_reject', trace_id: 4) {}
 
-    assert_equal(tracer.writer.spans.length, 2)
+    assert_equal(2, tracer.writer.spans.length)
+  end
+
+  def test_priority_sampler_with_no_pre_set_priority
+    tracer = get_test_tracer
+    tracer.configure(sampler: Datadog::PrioritySampler.new)
+    tracer.provider.context = Datadog::Context.new
+
+    assert_nil(tracer.provider.context.sampling_priority)
+    tracer.trace('test', trace_id: 1) {}
+
+    assert_equal(1, tracer.writer.spans.length)
   end
 end

--- a/test/sampler_test.rb
+++ b/test/sampler_test.rb
@@ -113,7 +113,12 @@ class SamplerTest < Minitest::Test
     tracer.provider.context.sampling_priority = Datadog::Ext::Priority::USER_REJECT
     tracer.trace('test_reject', trace_id: 4) {}
 
-    assert_equal(2, tracer.writer.spans.length)
+    spans = tracer.writer.spans
+
+    spans.each do |span|
+      assert_equal('test_keep', span.name)
+    end
+    assert_equal(2, spans.length)
   end
 
   def test_priority_sampler_with_no_pre_set_priority

--- a/test/sampler_test.rb
+++ b/test/sampler_test.rb
@@ -95,4 +95,23 @@ class SamplerTest < Minitest::Test
       assert_equal(0.5, span.get_metric(Datadog::RateSampler::SAMPLE_RATE_METRIC_KEY))
     end
   end
+
+  def test_priority_sampler_handling_existing_priority
+    tracer = get_test_tracer
+    tracer.configure(sampler: Datadog::PrioritySampler.new)
+
+    tracer.provider.context.sampling_priority = Datadog::Ext::Priority::USER_KEEP
+    tracer.trace('test_keep', trace_id: 1) { }
+
+    tracer.provider.context.sampling_priority = Datadog::Ext::Priority::AUTO_KEEP
+    tracer.trace('test_keep', trace_id: 2) { }
+
+    tracer.provider.context.sampling_priority = Datadog::Ext::Priority::AUTO_REJECT
+    tracer.trace('test_reject', trace_id: 3) { }
+
+    tracer.provider.context.sampling_priority = Datadog::Ext::Priority::USER_REJECT
+    tracer.trace('test_reject', trace_id: 4) { }
+
+    assert_equal(tracer.writer.spans.length, 2)
+  end
 end


### PR DESCRIPTION
If sampling_priority was set on context from incoming headers or manually by the user. That value then got ignored and overwritten by `PrioritySampler`.

This PR fixes this issue.

TODO:
- [x] add tests