### PR TITLE
Use full module name for ResqueJob in the patcher.

### DIFF
--- a/lib/ddtrace/contrib/resque/patcher.rb
+++ b/lib/ddtrace/contrib/resque/patcher.rb
@@ -26,7 +26,7 @@ module Datadog
             require_relative 'resque_job'
 
             add_pin
-            get_option(:workers).each { |worker| worker.extend(ResqueJob) }
+            get_option(:workers).each { |worker| worker.extend(::Datadog::Contrib::Resque::ResqueJob) }
             @patched = true
           rescue => e
             Tracer.log.error("Unable to apply Resque integration: #{e}")


### PR DESCRIPTION
We ran into a mysterious problem setting up Datadog's Resque instrumentation. When we dug deeper, it turned out that our base class for Resque jobs — which is named, appropriately enough, "ResqueJob" — was having its inheritance hierarchy mangled by the Resque patcher when it tried to add the instrumentation:

```
irb(main):001:0> ResqueJob.ancestors
=> [ResqueJob, Object, BooleanHelper, ERB::Util, Nori::CoreExt::Object, V8::Conversion::Object, PP::ObjectMixin, JSON::Ext::Generator::GeneratorMethods::Object, ActiveSupport::Dependencies::Loadable, Kernel, BasicObject]
```
Note that this class is now a descendant of itself, forming a cycle in the inheritance hierarchy. This is because the patcher calls `extend(ResqueJob)`, but the first ResqueJob which Ruby's constant lookup finds is the top-level ResqueJob class and not the Datadog::Contrib::Resque::ResqueJob one. This patch will explicitly spell out the full name to prevent any name collisions.
