### PR TITLE
Make running benchmarks in CI more consistent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ jobs:
       - *container_postgres
       - *container_redis
       - *container_agent
-    parallelism: 1
+    parallelism: 2
     steps:
       - checkout
       - attach_workspace: *default_workspace
@@ -232,11 +232,9 @@ jobs:
           root: .
           paths:
             - 'tmp/benchmarks/**/*.csv'
-  "(1/5) benchmark": *benchmark
-  "(2/5) benchmark": *benchmark
-  "(3/5) benchmark": *benchmark
-  "(4/5) benchmark": *benchmark
-  "(5/5) benchmark": *benchmark
+  "8x benchmark":
+    <<: *benchmark
+    parallelism: 8
   "build baseline":
     <<: *job_defaults
     docker: [ image: "circleci/buildpack-deps:jessie" ]
@@ -293,19 +291,11 @@ workflows:
           cron: "0 0 * * *"
     jobs:
       - "(2.3) build"
-      - "(1/5) benchmark": &baseline_benchmark
+      - "8x benchmark": &baseline_benchmark
           requires: [ "(2.3) build" ]
-      - "(2/5) benchmark": *baseline_benchmark
-      - "(3/5) benchmark": *baseline_benchmark
-      - "(4/5) benchmark": *baseline_benchmark
-      - "(5/5) benchmark": *baseline_benchmark
       - "aggregate benchmarks":
           requires:
-            - "(1/5) benchmark"
-            - "(2/5) benchmark"
-            - "(3/5) benchmark"
-            - "(4/5) benchmark"
-            - "(5/5) benchmark"
+            - "8x benchmark"
   "benchmark baseline":
     triggers:
       - schedule:
@@ -317,19 +307,11 @@ workflows:
           requires: [ "(2.3) build" ]
       - "build baseline":
           requires: [ "benchmark baseline" ]
-      - "(1/5) benchmark": &benchmark_workflow
+      - "8x benchmark":
           requires: [ "build baseline" ]
-      - "(2/5) benchmark": *benchmark_workflow
-      - "(3/5) benchmark": *benchmark_workflow
-      - "(4/5) benchmark": *benchmark_workflow
-      - "(5/5) benchmark": *benchmark_workflow
       - "aggregate benchmarks":
           requires:
-            - "(1/5) benchmark"
-            - "(2/5) benchmark"
-            - "(3/5) benchmark"
-            - "(4/5) benchmark"
-            - "(5/5) benchmark"
+            - "8x benchmark"
   build-and-test:
     jobs:
       - "(1.9) build": *default_workflow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,13 @@ ruby_containers: &ruby_containers
 
 test_containers: &test_containers
   - &container_postgres
-    image: postgres:9.6
+    image: circleci/postgres:9.6-alpine-ram
     environment:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_DB=postgres
   - &container_mysql
-    image: mysql:5.6
+    image: circleci/mysql:5.6-ram
     environment:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_PASSWORD=mysql
@@ -36,9 +36,9 @@ test_containers: &test_containers
   - &container_elasticsearch
     image: elasticsearch:2.4
   - &container_redis
-    image: redis:3.0
+    image: circleci/redis:3
   - &container_mongo
-    image: mongo:3.5
+    image: circleci/mongo:3.5-ram
   - &container_memcached
     image: memcached:1.5-alpine
   - &container_agent
@@ -234,8 +234,6 @@ jobs:
           name: Sidekiq benchmark results
           command: bundle exec ruby .circleci/process_benchmarks.rb tmp/benchmarks/sidekiq_test/*.csv
 
-
-
 wf_aliases:
   - &filters_all_branches_and_tags
     filters:
@@ -252,6 +250,23 @@ wf_aliases:
 
 workflows:
   version: 2
+  benchmark:
+    jobs:
+      - "perform additional tests":
+          <<: *default_workflow
+          type: approval
+      - "(2.3) build":
+          <<: *default_workflow
+          requires: [ "perform additional tests" ]
+      - "(1/2) benchmark": &benchmark_workflow
+          <<: *default_workflow
+          requires: [ "(2.3) build" ]
+      - "(2/2) benchmark": *benchmark_workflow
+      - "aggregate benchmarks":
+          <<: *default_workflow
+          requires:
+            - "(1/2) benchmark"
+            - "(2/2) benchmark"
   build-and-test:
     jobs:
 #      - "(1.9) build": *default_workflow
@@ -266,14 +281,7 @@ workflows:
 #      - "(2.2) test": { <<: [ *default_workflow, requires: [ "(2.2) build" ] ] }
 #      - "(2.3) test": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
 #      - "(2.4) test": { <<: [ *default_workflow, requires: [ "(2.4) build" ] ] }
-      - "(1/2) benchmark": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
-      - "(2/2) benchmark": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
       - "static analysis": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
-      - "aggregate benchmarks":
-          <<: *default_workflow
-          requires:
-            - "(1/2) benchmark"
-            - "(2/2) benchmark"
       - "deploy release":
           <<: *filters_only_release_tags
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,8 +210,7 @@ jobs:
     parallelism: 1
     steps:
       - checkout
-      - attach_workspace:
-          at: /app
+      - attach_workspace: *default_workspace
       - run: *bundler_init
       - run: *wait_for_postgres
       - run:
@@ -222,6 +221,19 @@ jobs:
           paths:
             - 'tmp/benchmarks/**/*.csv'
   "(2/2) benchmark": *benchmark
+  "aggregate benchmarks":
+    <<: *job_defaults
+    docker: [ *container-2_3 ]
+    steps:
+      - checkout
+      - attach_workspace: *default_workspace
+      - run: *bundler_init
+      - store_artifacts:
+          path: tmp/benchmarks
+      - run:
+          name: Sidekiq benchmark results
+          command: bundle exec ruby .circleci/process_benchmarks.rb tmp/benchmarks/sidekiq_test/*.csv
+
 
 
 wf_aliases:
@@ -235,28 +247,33 @@ wf_aliases:
         ignore: /.*/
       tags:
         only: /^v\d+(\.\d+){0,3}(\.(alpha|beta|rc)\d+)?$/
-  - &job_default
+  - &default_workflow
     <<: *filters_all_branches_and_tags
 
 workflows:
   version: 2
   build-and-test:
     jobs:
-#      - "(1.9) build": *job_default
-#      - "(2.0) build": *job_default
-#      - "(2.1) build": *job_default
-#      - "(2.2) build": *job_default
-      - "(2.3) build": *job_default
-#      - "(2.4) build": *job_default
-#      - "(1.9) test": { <<: [ *job_default, requires: [ "(1.9) build" ] ] }
-#      - "(2.0) test": { <<: [ *job_default, requires: [ "(2.0) build" ] ] }
-#      - "(2.1) test": { <<: [ *job_default, requires: [ "(2.1) build" ] ] }
-#      - "(2.2) test": { <<: [ *job_default, requires: [ "(2.2) build" ] ] }
-#      - "(2.3) test": { <<: [ *job_default, requires: [ "(2.3) build" ] ] }
-#      - "(2.4) test": { <<: [ *job_default, requires: [ "(2.4) build" ] ] }
-      - "(1/2) benchmark": { <<: [ *job_default, requires: [ "(2.3) build" ] ] }
-      - "(2/2) benchmark": { <<: [ *job_default, requires: [ "(2.3) build" ] ] }
-      - "static analysis": { <<: [ *job_default, requires: [ "(2.3) build" ] ] }
+#      - "(1.9) build": *default_workflow
+#      - "(2.0) build": *default_workflow
+#      - "(2.1) build": *default_workflow
+#      - "(2.2) build": *default_workflow
+      - "(2.3) build": *default_workflow
+#      - "(2.4) build": *default_workflow
+#      - "(1.9) test": { <<: [ *default_workflow, requires: [ "(1.9) build" ] ] }
+#      - "(2.0) test": { <<: [ *default_workflow, requires: [ "(2.0) build" ] ] }
+#      - "(2.1) test": { <<: [ *default_workflow, requires: [ "(2.1) build" ] ] }
+#      - "(2.2) test": { <<: [ *default_workflow, requires: [ "(2.2) build" ] ] }
+#      - "(2.3) test": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
+#      - "(2.4) test": { <<: [ *default_workflow, requires: [ "(2.4) build" ] ] }
+      - "(1/2) benchmark": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
+      - "(2/2) benchmark": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
+      - "static analysis": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
+      - "aggregate benchmarks":
+          <<: *default_workflow
+          requires:
+            - "(1/2) benchmark"
+            - "(2/2) benchmark"
       - "deploy release":
           <<: *filters_only_release_tags
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,8 @@ job_aliases:
             export DAYS_SINCE_EPOCH=$(($(date --utc --date "$1" +%s)/86400))
             # cache build files per commit sha for at most 1 day
             export CACHE_BUSTER="${DAYS_SINCE_EPOCH}-${CIRCLE_SHA1}"
-            curl -u "${GITHUB_LABELS_READ_USER_TOKEN}" "https://api.github.com/repos/DataDog/dd-trace-rb/pulls/${CIRCLE_PR_NUMBER}" | grep 1076040432 && CACHE_BUSTER=none
+            # check if the PR is tagged with special tag
+            curl -u "${GITHUB_LABELS_READ_USER_TOKEN}" "https://api.github.com/repos/DataDog/dd-trace-rb/pulls/${CIRCLE_PULL_REQUEST##*/}" | grep 1076040432 && CACHE_BUSTER=none
             echo CACHE_BUSTER=$CACHE_BUSTER | tee .cache_buster
       - attach_workspace: *default_workspace
       - restore_cache: *build_files
@@ -285,51 +286,44 @@ wf_aliases:
 
 workflows:
   version: 2
-  "benchmarks":
+  "benchmark":
+    triggers:
+      - schedule:
+          <<: *only_on_master
+          cron: "0 0 * * *"
     jobs:
-      - "(2.3) build":
-          <<: *default_workflow
-          type: approval
-      - "benchmark baseline":
-          <<: *default_workflow
-          type: approval
+      - "(2.3) build"
+      - "(1/5) benchmark": &baseline_benchmark
           requires: [ "(2.3) build" ]
-      - "build baseline":
-          <<: *default_workflow
-          requires: [ "benchmark baseline" ]
-      - "(1/5) benchmark": *default_workflow
-      - "(2/5) benchmark": *default_workflow
-      - "(3/5) benchmark": *default_workflow
-      - "(4/5) benchmark": *default_workflow
-      - "(5/5) benchmark": *default_workflow
+      - "(2/5) benchmark": *baseline_benchmark
+      - "(3/5) benchmark": *baseline_benchmark
+      - "(4/5) benchmark": *baseline_benchmark
+      - "(5/5) benchmark": *baseline_benchmark
       - "aggregate benchmarks":
-          <<: *default_workflow
           requires:
             - "(1/5) benchmark"
             - "(2/5) benchmark"
             - "(3/5) benchmark"
             - "(4/5) benchmark"
             - "(5/5) benchmark"
-  "baseline benchmark":
+  "benchmark baseline":
+    triggers:
+      - schedule:
+          <<: *only_on_master
+          cron: "0 0 * * *"
     jobs:
-      - "(2.3) build":
-          <<: *only_on_master
+      - "(2.3) build"
       - "benchmark baseline":
-          <<: *only_on_master
-          type: approval
           requires: [ "(2.3) build" ]
       - "build baseline":
-          <<: *only_on_master
           requires: [ "benchmark baseline" ]
       - "(1/5) benchmark": &benchmark_workflow
-          <<: *only_on_master
           requires: [ "build baseline" ]
       - "(2/5) benchmark": *benchmark_workflow
       - "(3/5) benchmark": *benchmark_workflow
       - "(4/5) benchmark": *benchmark_workflow
       - "(5/5) benchmark": *benchmark_workflow
       - "aggregate benchmarks":
-          <<: *only_on_master
           requires:
             - "(1/5) benchmark"
             - "(2/5) benchmark"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,6 +224,19 @@ jobs:
   "(3/5) benchmark": *benchmark
   "(4/5) benchmark": *benchmark
   "(5/5) benchmark": *benchmark
+  "build baseline":
+    <<: *job_defaults
+    docker: [ image: "circleci/buildpack-deps:jessie" ]
+    steps:
+      - attach_workspace: *default_workspace
+      - checkout
+      - run:
+          name: Disable ddtracing gem
+          command: echo 'puts "ddtrace disabled"' > lib/ddtrace.rb
+      - persist_to_workspace:
+          root: "."
+          paths: [ "lib/ddtrace.rb" ]
+
   "aggregate benchmarks":
     <<: *job_defaults
     docker: [ *container-2_3 ]
@@ -253,38 +266,20 @@ wf_aliases:
 
 workflows:
   version: 2
-  build-and-test:
+  "baseline benchmark":
     jobs:
-      - "(1.9) build": *default_workflow
-      - "(2.0) build": *default_workflow
-      - "(2.1) build": *default_workflow
-      - "(2.2) build": *default_workflow
-      - "(2.3) build": *default_workflow
-      - "(2.4) build": *default_workflow
-      - "(1.9) test": { <<: [ *default_workflow, requires: [ "(1.9) build" ] ] }
-      - "(2.0) test": { <<: [ *default_workflow, requires: [ "(2.0) build" ] ] }
-      - "(2.1) test": { <<: [ *default_workflow, requires: [ "(2.1) build" ] ] }
-      - "(2.2) test": { <<: [ *default_workflow, requires: [ "(2.2) build" ] ] }
-      - "(2.3) test": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
-      - "(2.4) test": { <<: [ *default_workflow, requires: [ "(2.4) build" ] ] }
-      - "static analysis": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
-      - "deploy release":
-          <<: *filters_only_release_tags
-          requires:
-            - "(2.3) build"
-            - "(1.9) test"
-            - "(2.0) test"
-            - "(2.1) test"
-            - "(2.2) test"
-            - "(2.3) test"
-            - "(2.4) test"
-      - "perform benchmarks":
+      - "benchmark baseline":
           <<: *default_workflow
           type: approval
+      - "(2.3) build":
+          <<: *default_workflow
+          requires: [ "benchmark baseline" ]
+      - "build baseline":
+          <<: *default_workflow
           requires: [ "(2.3) build" ]
       - "(1/5) benchmark": &benchmark_workflow
           <<: *default_workflow
-          requires: [ "perform benchmarks" ]
+          requires: [ "build baseline" ]
       - "(2/5) benchmark": *benchmark_workflow
       - "(3/5) benchmark": *benchmark_workflow
       - "(4/5) benchmark": *benchmark_workflow
@@ -297,3 +292,47 @@ workflows:
             - "(3/5) benchmark"
             - "(4/5) benchmark"
             - "(5/5) benchmark"
+  build-and-test:
+    jobs:
+#      - "(1.9) build": *default_workflow
+#      - "(2.0) build": *default_workflow
+#      - "(2.1) build": *default_workflow
+#      - "(2.2) build": *default_workflow
+      - "(2.3) build": *default_workflow
+#      - "(2.4) build": *default_workflow
+#      - "(1.9) test": { <<: [ *default_workflow, requires: [ "(1.9) build" ] ] }
+#      - "(2.0) test": { <<: [ *default_workflow, requires: [ "(2.0) build" ] ] }
+#      - "(2.1) test": { <<: [ *default_workflow, requires: [ "(2.1) build" ] ] }
+#      - "(2.2) test": { <<: [ *default_workflow, requires: [ "(2.2) build" ] ] }
+#      - "(2.3) test": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
+#      - "(2.4) test": { <<: [ *default_workflow, requires: [ "(2.4) build" ] ] }
+      - "static analysis": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
+#      - "deploy release":
+#          <<: *filters_only_release_tags
+#          requires:
+#            - "(2.3) build"
+#            - "(1.9) test"
+#            - "(2.0) test"
+#            - "(2.1) test"
+#            - "(2.2) test"
+#            - "(2.3) test"
+#            - "(2.4) test"
+#      - "perform benchmarks":
+#          <<: *default_workflow
+#          type: approval
+#          requires: [ "(2.3) build" ]
+#      - "(1/5) benchmark": &benchmark_workflow
+#          <<: *default_workflow
+#          requires: [ "perform benchmarks" ]
+#      - "(2/5) benchmark": *benchmark_workflow
+#      - "(3/5) benchmark": *benchmark_workflow
+#      - "(4/5) benchmark": *benchmark_workflow
+#      - "(5/5) benchmark": *benchmark_workflow
+#      - "aggregate benchmarks":
+#          <<: *default_workflow
+#          requires:
+#            - "(1/5) benchmark"
+#            - "(2/5) benchmark"
+#            - "(3/5) benchmark"
+#            - "(4/5) benchmark"
+#            - "(5/5) benchmark"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ job_aliases:
       command: bundle --path vendor/bundle
   - &build_files
       root: .
-      key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-v1-bundle-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Gemfile" }}-{{ checksum "ddtrace.gemspec" }}-{{ checksum "Appraisals" }}'
+      key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ checksum ".cache_buster" }}-v1-bundle-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Gemfile" }}-{{ checksum "ddtrace.gemspec" }}-{{ checksum "Appraisals" }}'
       paths:
         - vendor/bundle
         - gemfiles/
@@ -90,6 +90,14 @@ job_aliases:
     <<: *job_defaults
     steps:
       - checkout
+      - run:
+          name: Calculate Cache Buster
+          command: |
+            export DAYS_SINCE_EPOCH=$(($(date --utc --date "$1" +%s)/86400))
+            # cache build files per commit sha for at most 1 day
+            export CACHE_BUSTER="${DAYS_SINCE_EPOCH}-${CIRCLE_SHA1}"
+            curl -u "${GITHUB_LABELS_READ_USER_TOKEN}" "https://api.github.com/repos/DataDog/dd-trace-rb/pulls/${CIRCLE_PR_NUMBER}" | grep 1076040432 && CACHE_BUSTER=none
+            echo CACHE_BUSTER=$CACHE_BUSTER | tee .cache_buster
       - attach_workspace: *default_workspace
       - restore_cache: *build_files
       - run: *bundler_init
@@ -200,7 +208,7 @@ jobs:
       - *container_mongo
       - *container_memcached
       - *container_agent
-  "(1/5) benchmark": &benchmark
+  benchmark: &benchmark
     <<: *job_defaults
     docker:
       - <<: [ *container-2_3, *docker_test_environment ]
@@ -223,6 +231,7 @@ jobs:
           root: .
           paths:
             - 'tmp/benchmarks/**/*.csv'
+  "(1/5) benchmark": *benchmark
   "(2/5) benchmark": *benchmark
   "(3/5) benchmark": *benchmark
   "(4/5) benchmark": *benchmark
@@ -267,15 +276,20 @@ wf_aliases:
         ignore: /.*/
       tags:
         only: /^v\d+(\.\d+){0,3}(\.(alpha|beta|rc)\d+)?$/
+  - &only_on_master
+    filters:
+      branches:
+        only: master
   - &default_workflow
     <<: *filters_all_branches_and_tags
 
 workflows:
   version: 2
-  "baseline benchmark":
+  "benchmarks":
     jobs:
       - "(2.3) build":
           <<: *default_workflow
+          type: approval
       - "benchmark baseline":
           <<: *default_workflow
           type: approval
@@ -283,15 +297,39 @@ workflows:
       - "build baseline":
           <<: *default_workflow
           requires: [ "benchmark baseline" ]
-      - "(1/5) benchmark": &benchmark_workflow
+      - "(1/5) benchmark": *default_workflow
+      - "(2/5) benchmark": *default_workflow
+      - "(3/5) benchmark": *default_workflow
+      - "(4/5) benchmark": *default_workflow
+      - "(5/5) benchmark": *default_workflow
+      - "aggregate benchmarks":
           <<: *default_workflow
+          requires:
+            - "(1/5) benchmark"
+            - "(2/5) benchmark"
+            - "(3/5) benchmark"
+            - "(4/5) benchmark"
+            - "(5/5) benchmark"
+  "baseline benchmark":
+    jobs:
+      - "(2.3) build":
+          <<: *only_on_master
+      - "benchmark baseline":
+          <<: *only_on_master
+          type: approval
+          requires: [ "(2.3) build" ]
+      - "build baseline":
+          <<: *only_on_master
+          requires: [ "benchmark baseline" ]
+      - "(1/5) benchmark": &benchmark_workflow
+          <<: *only_on_master
           requires: [ "build baseline" ]
       - "(2/5) benchmark": *benchmark_workflow
       - "(3/5) benchmark": *benchmark_workflow
       - "(4/5) benchmark": *benchmark_workflow
       - "(5/5) benchmark": *benchmark_workflow
       - "aggregate benchmarks":
-          <<: *default_workflow
+          <<: *only_on_master
           requires:
             - "(1/5) benchmark"
             - "(2/5) benchmark"
@@ -316,29 +354,16 @@ workflows:
       - "deploy release":
           <<: *filters_only_release_tags
           requires:
-            - "(2.3) build"
             - "(1.9) test"
             - "(2.0) test"
             - "(2.1) test"
             - "(2.2) test"
             - "(2.3) test"
             - "(2.4) test"
-      - "perform benchmarks":
+      - "benchmark": &benchmark_workflow
           <<: *default_workflow
-          type: approval
           requires: [ "(2.3) build" ]
-      - "(1/5) benchmark": &benchmark_workflow
-          <<: *default_workflow
-          requires: [ "perform benchmarks" ]
-      - "(2/5) benchmark": *benchmark_workflow
-      - "(3/5) benchmark": *benchmark_workflow
-      - "(4/5) benchmark": *benchmark_workflow
-      - "(5/5) benchmark": *benchmark_workflow
       - "aggregate benchmarks":
           <<: *default_workflow
           requires:
-            - "(1/5) benchmark"
-            - "(2/5) benchmark"
-            - "(3/5) benchmark"
-            - "(4/5) benchmark"
-            - "(5/5) benchmark"
+            - benchmark

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ job_aliases:
       command: bundle --path vendor/bundle
   - &build_files
       root: .
-      key: 'betav8-bundle-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Gemfile" }}-{{ checksum "ddtrace.gemspec" }}-{{ checksum "Appraisals" }}'
+      key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-v1-bundle-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Gemfile" }}-{{ checksum "ddtrace.gemspec" }}-{{ checksum "Appraisals" }}'
       paths:
         - vendor/bundle
         - gemfiles/
@@ -216,6 +216,9 @@ jobs:
       - run:
           name: Run sidekiq benchmark
           command: bash .circleci/run_benchmark.sh tmp/benchmarks sidekiq_test
+      - run:
+          name: Run sidekiq benchmark
+          command: bash .circleci/run_benchmark.sh tmp/benchmarks concurrent_span_test
       - persist_to_workspace:
           root: .
           paths:
@@ -249,6 +252,9 @@ jobs:
       - run:
           name: Sidekiq benchmark results
           command: bundle exec ruby .circleci/process_benchmarks.rb tmp/benchmarks/sidekiq_test/*.csv
+      - run:
+          name: Benchmark concurrent span creation
+          command: bundle exec ruby .circleci/process_benchmarks.rb tmp/benchmarks/concurrent_span_test/*.csv
 
 wf_aliases:
   - &filters_all_branches_and_tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ job_aliases:
 jobs:
   "static analysis":
     <<: *job_defaults
-    docker: [ *container-2_4 ]
+    docker: [ *container-2_3 ]
     steps:
       - checkout
       - attach_workspace: *default_workspace
@@ -115,7 +115,7 @@ jobs:
           command: bundle exec rake rubocop
   "deploy release":
     <<: *job_defaults
-    docker: [ *container-2_4 ]
+    docker: [ *container-2_3 ]
     steps:
       - checkout
       - attach_workspace: *default_workspace
@@ -200,6 +200,29 @@ jobs:
       - *container_mongo
       - *container_memcached
       - *container_agent
+  "(1/2) benchmark": &benchmark
+    <<: *job_defaults
+    docker:
+      - <<: [ *container-2_3, *docker_test_environment ]
+      - *container_postgres
+      - *container_redis
+      - *container_agent
+    parallelism: 1
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /app
+      - run: *bundler_init
+      - run: *wait_for_postgres
+      - run:
+          name: Run sidekiq benchmark
+          command: bash .circleci/run_benchmark.sh tmp/benchmarks sidekiq_test
+      - persist_to_workspace:
+          root: .
+          paths:
+            - 'tmp/benchmarks/**/*.csv'
+  "(2/2) benchmark": *benchmark
+
 
 wf_aliases:
   - &filters_all_branches_and_tags
@@ -219,26 +242,28 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - "(1.9) build": *job_default
-      - "(2.0) build": *job_default
-      - "(2.1) build": *job_default
-      - "(2.2) build": *job_default
+#      - "(1.9) build": *job_default
+#      - "(2.0) build": *job_default
+#      - "(2.1) build": *job_default
+#      - "(2.2) build": *job_default
       - "(2.3) build": *job_default
-      - "(2.4) build": *job_default
-      - "(1.9) test": { <<: [ *job_default, requires: [ "(1.9) build" ] ] }
-      - "(2.0) test": { <<: [ *job_default, requires: [ "(2.0) build" ] ] }
-      - "(2.1) test": { <<: [ *job_default, requires: [ "(2.1) build" ] ] }
-      - "(2.2) test": { <<: [ *job_default, requires: [ "(2.2) build" ] ] }
-      - "(2.3) test": { <<: [ *job_default, requires: [ "(2.3) build" ] ] }
-      - "(2.4) test": { <<: [ *job_default, requires: [ "(2.4) build" ] ] }
-      - "static analysis": { <<: [ *job_default, requires: [ "(2.4) build" ] ] }
+#      - "(2.4) build": *job_default
+#      - "(1.9) test": { <<: [ *job_default, requires: [ "(1.9) build" ] ] }
+#      - "(2.0) test": { <<: [ *job_default, requires: [ "(2.0) build" ] ] }
+#      - "(2.1) test": { <<: [ *job_default, requires: [ "(2.1) build" ] ] }
+#      - "(2.2) test": { <<: [ *job_default, requires: [ "(2.2) build" ] ] }
+#      - "(2.3) test": { <<: [ *job_default, requires: [ "(2.3) build" ] ] }
+#      - "(2.4) test": { <<: [ *job_default, requires: [ "(2.4) build" ] ] }
+      - "(1/2) benchmark": { <<: [ *job_default, requires: [ "(2.3) build" ] ] }
+      - "(2/2) benchmark": { <<: [ *job_default, requires: [ "(2.3) build" ] ] }
+      - "static analysis": { <<: [ *job_default, requires: [ "(2.3) build" ] ] }
       - "deploy release":
           <<: *filters_only_release_tags
           requires:
-            - "(2.4) build"
-            - "(1.9) test"
-            - "(2.0) test"
-            - "(2.1) test"
-            - "(2.2) test"
-            - "(2.3) test"
-            - "(2.4) test"
+            - "(2.3) build"
+#            - "(1.9) test"
+#            - "(2.0) test"
+#            - "(2.1) test"
+#            - "(2.2) test"
+#            - "(2.3) test"
+#            - "(2.4) test"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,30 +4,21 @@ job_defaults: &job_defaults
   shell: /bin/bash --login
 
 ruby_containers: &ruby_containers
+  - &container_defaults
+      environment:
+        - BUNDLE_GEMFILE=/app/Gemfile
   - &container-1_9
-    image: datadog/docker-library:ddtrace_rb_1_9_3
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
+    <<: [ image: 'datadog/docker-library:ddtrace_rb_1_9_3', *container_defaults ]
   - &container-2_0
-    image: datadog/docker-library:ddtrace_rb_2_0_0
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
+    <<: [ image: 'datadog/docker-library:ddtrace_rb_2_0_0', *container_defaults ]
   - &container-2_1
-    image: datadog/docker-library:ddtrace_rb_2_1_10
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
+    <<: [ image: 'datadog/docker-library:ddtrace_rb_2_1_10', *container_defaults ]
   - &container-2_2
-    image: datadog/docker-library:ddtrace_rb_2_2_10
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
+    <<: [ image: 'datadog/docker-library:ddtrace_rb_2_2_10', *container_defaults ]
   - &container-2_3
-    image: datadog/docker-library:ddtrace_rb_2_3_7
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
+    <<: [ image: 'datadog/docker-library:ddtrace_rb_2_3_7', *container_defaults ]
   - &container-2_4
-    image: datadog/docker-library:ddtrace_rb_2_4_4
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
+    <<: [ image: 'datadog/docker-library:ddtrace_rb_2_4_4', *container_defaults ]
 
 test_containers: &test_containers
   - &container_postgres
@@ -57,494 +48,197 @@ test_containers: &test_containers
       - DD_BIND_HOST=0.0.0.0
       - DD_API_KEY=invalid_key_but_this_is_fine
 
-step_init_bundle_checksum: &step_init_bundle_checksum
-  run:
-    name: Initialize bundle cache key
-    command: |
-      touch .circleci/bundle_checksum
-step_bundle_install: &step_bundle_install
-  run:
-    name: Install gem dependencies
-    command: bundle install
-step_rubocop: &step_rubocop
-  run:
-    name: Delint with Rubocop
-    command: bundle exec rake rubocop
-step_appraisal_install: &step_appraisal_install
-  run:
-    name: Install Appraisal gems
-    command: bundle exec appraisal install
-step_compute_bundle_checksum: &step_compute_bundle_checksum
-  run:
-    name: Compute bundle checksum
-    command: |
-      cat Gemfile.lock gemfiles/*.gemfile.lock > .circleci/bundle_checksum
-step_run_all_tests: &step_run_all_tests
-  run:
-    name: Run tests
-    command: bundle exec rake ci
-step_release_docs: &step_release_docs
-  run:
-    name: Upload release docs
-    command: S3_DIR=trace bundle exec rake release:docs
-
-filters_all_branches_and_tags: &filters_all_branches_and_tags
-  filters:
-    tags:
-      only: /.*/
-filters_only_release_tags: &filters_only_release_tags
-  filters:
-    branches:
-      ignore: /.*/
-    tags:
-      only: /^v\d+(\.\d+){0,3}(\.(alpha|beta|rc)\d+)?$/
-
 version: 2.0
-jobs:
-  checkout-1.9:
-    <<: *job_defaults
-    docker:
-      - *container-1_9
-    steps:
-      - checkout
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-1.9-{{ .Environment.CIRCLE_SHA1 }}'
-          paths:
-            - /app
-  build-1.9:
-    <<: *job_defaults
-    docker:
-      - *container-1_9
-    steps:
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-1.9-{{ .Environment.CIRCLE_SHA1 }}'
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-1.9-{{ .Environment.CIRCLE_SHA1 }}'
-      - *step_init_bundle_checksum
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-1.9-{{ checksum ".circleci/bundle_checksum" }}'
-      - *step_bundle_install
-      - *step_appraisal_install
-      - *step_compute_bundle_checksum
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-1.9-{{ .Environment.CIRCLE_SHA1 }}'
-          paths:
-            - /app
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-1.9-{{ checksum ".circleci/bundle_checksum" }}'
-          paths:
-            - /usr/local/bundle
-  test-1.9:
-    <<: *job_defaults
-    docker:
-      - <<: *container-1_9
-        environment:
-          - TEST_DATADOG_INTEGRATION: 1
-      - *container_postgres
-      - *container_mysql
-      - *container_elasticsearch
-      - *container_redis
-      - *container_mongo
-      - *container_memcached
-      - *container_agent
-    steps:
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-1.9-{{ .Environment.CIRCLE_SHA1 }}'
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-1.9-{{ checksum ".circleci/bundle_checksum" }}'
-      - *step_run_all_tests
-  checkout-2.0:
-    <<: *job_defaults
-    docker:
-      - *container-2_0
-    steps:
-      - checkout
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-2.0-{{ .Environment.CIRCLE_SHA1 }}'
-          paths:
-            - /app
-  build-2.0:
-    <<: *job_defaults
-    docker:
-      - *container-2_0
-    steps:
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-2.0-{{ .Environment.CIRCLE_SHA1 }}'
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-2.0-{{ .Environment.CIRCLE_SHA1 }}'
-      - *step_init_bundle_checksum
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.0-{{ checksum ".circleci/bundle_checksum" }}'
-      - *step_bundle_install
-      - *step_appraisal_install
-      - *step_compute_bundle_checksum
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-2.0-{{ .Environment.CIRCLE_SHA1 }}'
-          paths:
-            - /app
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.0-{{ checksum ".circleci/bundle_checksum" }}'
-          paths:
-            - /usr/local/bundle
-  test-2.0:
-    <<: *job_defaults
-    docker:
-      - <<: *container-2_0
-        environment:
-          - TEST_DATADOG_INTEGRATION: 1
-      - *container_postgres
-      - *container_mysql
-      - *container_elasticsearch
-      - *container_redis
-      - *container_mongo
-      - *container_memcached
-      - *container_agent
-    steps:
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-2.0-{{ .Environment.CIRCLE_SHA1 }}'
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.0-{{ checksum ".circleci/bundle_checksum" }}'
-      - *step_run_all_tests
-  checkout-2.1:
-    <<: *job_defaults
-    docker:
-      - *container-2_1
-    steps:
-      - checkout
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-2.1-{{ .Environment.CIRCLE_SHA1 }}'
-          paths:
-            - /app
-  build-2.1:
-    <<: *job_defaults
-    docker:
-      - *container-2_1
-    steps:
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-2.1-{{ .Environment.CIRCLE_SHA1 }}'
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-2.1-{{ .Environment.CIRCLE_SHA1 }}'
-      - *step_init_bundle_checksum
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.1-{{ checksum ".circleci/bundle_checksum" }}'
-      - *step_bundle_install
-      - *step_rubocop
-      - *step_appraisal_install
-      - *step_compute_bundle_checksum
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-2.1-{{ .Environment.CIRCLE_SHA1 }}'
-          paths:
-            - /app
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.1-{{ checksum ".circleci/bundle_checksum" }}'
-          paths:
-            - /usr/local/bundle
-  test-2.1:
-    <<: *job_defaults
-    docker:
-      - <<: *container-2_1
-        environment:
-          - TEST_DATADOG_INTEGRATION: 1
-      - *container_postgres
-      - *container_mysql
-      - *container_elasticsearch
-      - *container_redis
-      - *container_mongo
-      - *container_memcached
-      - *container_agent
-    steps:
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-2.1-{{ .Environment.CIRCLE_SHA1 }}'
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.1-{{ checksum ".circleci/bundle_checksum" }}'
-      - *step_run_all_tests
-  checkout-2.2:
-    <<: *job_defaults
-    docker:
-      - *container-2_2
-    steps:
-      - checkout
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-2.2-{{ .Environment.CIRCLE_SHA1 }}'
-          paths:
-            - /app
-  build-2.2:
-    <<: *job_defaults
-    docker:
-      - *container-2_2
-    steps:
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-2.2-{{ .Environment.CIRCLE_SHA1 }}'
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-2.2-{{ .Environment.CIRCLE_SHA1 }}'
-      - *step_init_bundle_checksum
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.2-{{ checksum ".circleci/bundle_checksum" }}'
-      - *step_bundle_install
-      - *step_rubocop
-      - *step_appraisal_install
-      - *step_compute_bundle_checksum
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-2.2-{{ .Environment.CIRCLE_SHA1 }}'
-          paths:
-            - /app
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.2-{{ checksum ".circleci/bundle_checksum" }}'
-          paths:
-            - /usr/local/bundle
-  test-2.2:
-    <<: *job_defaults
-    docker:
-      - <<: *container-2_2
-        environment:
-          - TEST_DATADOG_INTEGRATION: 1
-      - *container_postgres
-      - *container_mysql
-      - *container_elasticsearch
-      - *container_redis
-      - *container_mongo
-      - *container_memcached
-      - *container_agent
-    steps:
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-2.2-{{ .Environment.CIRCLE_SHA1 }}'
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.2-{{ checksum ".circleci/bundle_checksum" }}'
-      - *step_run_all_tests
-  checkout-2.3:
-    <<: *job_defaults
-    docker:
-      - *container-2_3
-    steps:
-      - checkout
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-2.3-{{ .Environment.CIRCLE_SHA1 }}'
-          paths:
-            - /app
-  build-2.3:
-    <<: *job_defaults
-    docker:
-      - *container-2_3
-    steps:
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-2.3-{{ .Environment.CIRCLE_SHA1 }}'
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-2.3-{{ .Environment.CIRCLE_SHA1 }}'
-      - *step_init_bundle_checksum
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.3-{{ checksum ".circleci/bundle_checksum" }}'
-      - *step_bundle_install
-      - *step_rubocop
-      - *step_appraisal_install
-      - *step_compute_bundle_checksum
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-2.3-{{ .Environment.CIRCLE_SHA1 }}'
-          paths:
-            - /app
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.3-{{ checksum ".circleci/bundle_checksum" }}'
-          paths:
-            - /usr/local/bundle
-  test-2.3:
-    <<: *job_defaults
-    docker:
-      - <<: *container-2_3
-        environment:
-          - TEST_DATADOG_INTEGRATION: 1
-      - *container_postgres
-      - *container_mysql
-      - *container_elasticsearch
-      - *container_redis
-      - *container_mongo
-      - *container_memcached
-      - *container_agent
-    steps:
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-2.3-{{ .Environment.CIRCLE_SHA1 }}'
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.3-{{ checksum ".circleci/bundle_checksum" }}'
-      - *step_run_all_tests
-  benchmark-2.3:
-    <<: *job_defaults
-    docker:
-      - <<: *container-2_3
-        environment:
-          - TEST_DATADOG_INTEGRATION: 1
-      - *container_postgres
-      - *container_redis
-      - *container_agent
-    steps:
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-2.3-{{ .Environment.CIRCLE_SHA1 }}'
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.3-{{ checksum ".circleci/bundle_checksum" }}'
-      - run:
-          name: Run Benchmark
-          command: bundle exec appraisal rails5-postgres-sidekiq ruby benchmarks/sidekiq_test.rb 2>&1 1> /dev/null | tee benchmark_results.csv
-      - run:
-          name: Run Benchmark without ddtracer
-          command: rm -f lib/ddtrace.rb && bundle exec appraisal rails5-postgres-sidekiq ruby benchmarks/sidekiq_test.rb 2>&1 1> /dev/null | tee benchmark_results.csv
 
-  checkout-2.4:
+job_aliases:
+  - &default_workspace
+      at: /app
+  - &docker_test_environment
+      environment:
+        - TEST_DATADOG_INTEGRATION: 1
+  - &bundler_init
+      name: Initializing Bundler vendor path
+      command: bundle --path vendor/bundle
+  - &build_files
+      root: .
+      key: 'betav7-bundle-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Gemfile" }}-{{ checksum "ddtrace.gemspec" }}-{{ checksum "Appraisals" }}'
+      paths:
+        - vendor/bundle
+        - gemfiles/
+        - Gemfile.lock
+  - &wait_for_postgres
+      name: Waiting for Postgres to be ready
+      command: |
+        for i in `seq 1 30`;
+        do
+          nc -z localhost 5432 && echo Success && exit 0
+          echo -n .
+          sleep 1
+        done
+        echo Failed waiting for Postgres && exit 1
+  - &test_base
+      <<: *job_defaults
+      steps:
+        - checkout
+        - attach_workspace: *default_workspace
+        - run: *bundler_init
+        - run: *wait_for_postgres
+        - run:
+            name: Run tests
+            command: bundle exec rake ci
+  - &build_base
     <<: *job_defaults
-    docker:
-      - *container-2_4
     steps:
       - checkout
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-2.4-{{ .Environment.CIRCLE_SHA1 }}'
-          paths:
-            - /app
-  build-2.4:
-    <<: *job_defaults
-    docker:
-      - *container-2_4
-    steps:
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-2.4-{{ .Environment.CIRCLE_SHA1 }}'
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-2.4-{{ .Environment.CIRCLE_SHA1 }}'
-      - *step_init_bundle_checksum
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.4-{{ checksum ".circleci/bundle_checksum" }}'
-      - *step_bundle_install
-      - *step_rubocop
-      - *step_appraisal_install
-      - *step_compute_bundle_checksum
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-2.4-{{ .Environment.CIRCLE_SHA1 }}'
-          paths:
-            - /app
-      - save_cache:
-          key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.4-{{ checksum ".circleci/bundle_checksum" }}'
-          paths:
-            - /usr/local/bundle
-  test-2.4:
-    <<: *job_defaults
-    docker:
-      - <<: *container-2_4
-        environment:
-          - TEST_DATADOG_INTEGRATION: 1
-      - *container_postgres
-      - *container_mysql
-      - *container_elasticsearch
-      - *container_redis
-      - *container_mongo
-      - *container_memcached
-      - *container_agent
-    steps:
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-2.4-{{ .Environment.CIRCLE_SHA1 }}'
-      - restore_cache:
-          keys:
-            - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.4-{{ checksum ".circleci/bundle_checksum" }}'
-      - *step_run_all_tests
-  deploy-release:
-    <<: *job_defaults
-    docker:
-      - *container-2_4
-    steps:
-      - checkout
+      - attach_workspace: *default_workspace
+      - restore_cache: *build_files
+      - run: *bundler_init
+      - run: &bundle_install
+          name: Install gem dependencies
+          command: bundle install
       - run:
+          name: Install Appraisal gems
+          command: bundle exec appraisal install
+      - save_cache: *build_files
+      - persist_to_workspace: *build_files
+
+jobs:
+  "static analysis":
+    <<: *job_defaults
+    docker: [ *container-2_4 ]
+    steps:
+      - checkout
+      - attach_workspace: *default_workspace
+      - run: *bundler_init
+      - run:
+          name: Delint with Rubocop
+          command: bundle exec rake rubocop
+  "deploy release":
+    <<: *job_defaults
+    docker: [ *container-2_4 ]
+    steps:
+      - checkout
+      - attach_workspace: *default_workspace
+      - run: *bundler_init
+      - run:
+          name: Install AWS cli
           command: |
             apt-get -y -qq update
             apt-get -y -qq install awscli
-      - *step_bundle_install
-      - *step_release_docs
+      - run:
+          name: Upload release docs
+          command: S3_DIR=trace bundle exec rake release:docs
+  "(1.9) build": { <<: [ *build_base, docker: [ *container-1_9 ] ] }
+  "(2.0) build": { <<: [ *build_base, docker: [ *container-2_0 ] ] }
+  "(2.1) build": { <<: [ *build_base, docker: [ *container-2_1 ] ] }
+  "(2.2) build": { <<: [ *build_base, docker: [ *container-2_2 ] ] }
+  "(2.3) build": { <<: [ *build_base, docker: [ *container-2_3 ] ] }
+  "(2.4) build": { <<: [ *build_base, docker: [ *container-2_4 ] ] }
+  "(1.9) test":
+    <<: *test_base
+    docker:
+      - <<: [ *container-1_9, *docker_test_environment ]
+      - *container_postgres
+      - *container_mysql
+      - *container_elasticsearch
+      - *container_redis
+      - *container_mongo
+      - *container_memcached
+      - *container_agent
+  "(2.0) test":
+    <<: *test_base
+    docker:
+      - <<: [ *container-2_0, *docker_test_environment ]
+      - *container_postgres
+      - *container_mysql
+      - *container_elasticsearch
+      - *container_redis
+      - *container_mongo
+      - *container_memcached
+      - *container_agent
+  "(2.1) test":
+    <<: *test_base
+    docker:
+      - <<: [ *container-2_1, *docker_test_environment ]
+      - *container_postgres
+      - *container_mysql
+      - *container_elasticsearch
+      - *container_redis
+      - *container_mongo
+      - *container_memcached
+      - *container_agent
+  "(2.2) test":
+    <<: *test_base
+    docker:
+      - <<: [ *container-2_2, *docker_test_environment ]
+      - *container_postgres
+      - *container_mysql
+      - *container_elasticsearch
+      - *container_redis
+      - *container_mongo
+      - *container_memcached
+      - *container_agent
+  "(2.3) test":
+    <<: *test_base
+    docker:
+      - <<: [ *container-2_3, *docker_test_environment ]
+      - *container_postgres
+      - *container_mysql
+      - *container_elasticsearch
+      - *container_redis
+      - *container_mongo
+      - *container_memcached
+      - *container_agent
+  "(2.4) test":
+    <<: *test_base
+    docker:
+      - <<: [ *container-2_4, *docker_test_environment ]
+      - *container_postgres
+      - *container_mysql
+      - *container_elasticsearch
+      - *container_redis
+      - *container_mongo
+      - *container_memcached
+      - *container_agent
+
+wf_aliases:
+  - &filters_all_branches_and_tags
+    filters:
+      tags:
+        only: /.*/
+  - &filters_only_release_tags
+    filters:
+      branches:
+        ignore: /.*/
+      tags:
+        only: /^v\d+(\.\d+){0,3}(\.(alpha|beta|rc)\d+)?$/
+  - &job_default
+    <<: *filters_all_branches_and_tags
 
 workflows:
   version: 2
   build-and-test:
     jobs:
-      - checkout-1.9:
-          <<: *filters_all_branches_and_tags
-      - build-1.9:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - checkout-1.9
-      - test-1.9:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - build-1.9
-      - checkout-2.0:
-          <<: *filters_all_branches_and_tags
-      - build-2.0:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - checkout-2.0
-      - test-2.0:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - build-2.0
-      - checkout-2.1:
-          <<: *filters_all_branches_and_tags
-      - build-2.1:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - checkout-2.1
-      - test-2.1:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - build-2.1
-      - checkout-2.2:
-          <<: *filters_all_branches_and_tags
-      - build-2.2:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - checkout-2.2
-      - test-2.2:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - build-2.2
-      - checkout-2.3:
-          <<: *filters_all_branches_and_tags
-      - build-2.3:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - checkout-2.3
-      - test-2.3:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - build-2.3
-      - benchmark-2.3:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - build-2.3
-      - checkout-2.4:
-          <<: *filters_all_branches_and_tags
-      - build-2.4:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - checkout-2.4
-      - test-2.4:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - build-2.4
-      - deploy-release:
+      - "(1.9) build": *job_default
+      - "(2.0) build": *job_default
+      - "(2.1) build": *job_default
+      - "(2.2) build": *job_default
+      - "(2.3) build": *job_default
+      - "(2.4) build": *job_default
+      - "(1.9) test": { <<: [ *job_default, requires: [ "(1.9) build" ] ] }
+      - "(2.0) test": { <<: [ *job_default, requires: [ "(2.0) build" ] ] }
+      - "(2.1) test": { <<: [ *job_default, requires: [ "(2.1) build" ] ] }
+      - "(2.2) test": { <<: [ *job_default, requires: [ "(2.2) build" ] ] }
+      - "(2.3) test": { <<: [ *job_default, requires: [ "(2.3) build" ] ] }
+      - "(2.4) test": { <<: [ *job_default, requires: [ "(2.4) build" ] ] }
+      - "static analysis": { <<: [ *job_default, requires: [ "(2.4) build" ] ] }
+      - "deploy release":
           <<: *filters_only_release_tags
           requires:
-            - test-1.9
-            - test-2.0
-            - test-2.1
-            - test-2.2
-            - test-2.3
-            - test-2.4
+            - "(2.4) build"
+            - "(1.9) test"
+            - "(2.0) test"
+            - "(2.1) test"
+            - "(2.2) test"
+            - "(2.3) test"
+            - "(2.4) test"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 # Common variables, containers, jobs and steps.
 job_defaults: &job_defaults
-  working_directory: /app
+  working_directory: ~/app
   shell: /bin/bash --login
 
 ruby_containers: &ruby_containers
   - &container_defaults
       environment:
-        - BUNDLE_GEMFILE=/app/Gemfile
+        - BUNDLE_GEMFILE=~/app/Gemfile
   - &container-1_9
     <<: [ image: 'datadog/docker-library:ddtrace_rb_1_9_3', *container_defaults ]
   - &container-2_0
@@ -52,7 +52,7 @@ version: 2.0
 
 job_aliases:
   - &default_workspace
-      at: /app
+      at: ~/app
   - &docker_test_environment
       environment:
         - TEST_DATADOG_INTEGRATION: 1
@@ -61,7 +61,7 @@ job_aliases:
       command: bundle --path vendor/bundle
   - &build_files
       root: .
-      key: 'betav7-bundle-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Gemfile" }}-{{ checksum "ddtrace.gemspec" }}-{{ checksum "Appraisals" }}'
+      key: 'betav8-bundle-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Gemfile" }}-{{ checksum "ddtrace.gemspec" }}-{{ checksum "Appraisals" }}'
       paths:
         - vendor/bundle
         - gemfiles/
@@ -228,8 +228,8 @@ jobs:
     <<: *job_defaults
     docker: [ image: "circleci/buildpack-deps:jessie" ]
     steps:
-      - attach_workspace: *default_workspace
       - checkout
+      - attach_workspace: *default_workspace
       - run:
           name: Disable ddtracing gem
           command: echo 'puts "ddtrace disabled"' > lib/ddtrace.rb
@@ -268,15 +268,15 @@ workflows:
   version: 2
   "baseline benchmark":
     jobs:
+      - "(2.3) build":
+          <<: *default_workflow
       - "benchmark baseline":
           <<: *default_workflow
           type: approval
-      - "(2.3) build":
-          <<: *default_workflow
-          requires: [ "benchmark baseline" ]
+          requires: [ "(2.3) build" ]
       - "build baseline":
           <<: *default_workflow
-          requires: [ "(2.3) build" ]
+          requires: [ "benchmark baseline" ]
       - "(1/5) benchmark": &benchmark_workflow
           <<: *default_workflow
           requires: [ "build baseline" ]
@@ -294,45 +294,45 @@ workflows:
             - "(5/5) benchmark"
   build-and-test:
     jobs:
-#      - "(1.9) build": *default_workflow
-#      - "(2.0) build": *default_workflow
-#      - "(2.1) build": *default_workflow
-#      - "(2.2) build": *default_workflow
+      - "(1.9) build": *default_workflow
+      - "(2.0) build": *default_workflow
+      - "(2.1) build": *default_workflow
+      - "(2.2) build": *default_workflow
       - "(2.3) build": *default_workflow
-#      - "(2.4) build": *default_workflow
-#      - "(1.9) test": { <<: [ *default_workflow, requires: [ "(1.9) build" ] ] }
-#      - "(2.0) test": { <<: [ *default_workflow, requires: [ "(2.0) build" ] ] }
-#      - "(2.1) test": { <<: [ *default_workflow, requires: [ "(2.1) build" ] ] }
-#      - "(2.2) test": { <<: [ *default_workflow, requires: [ "(2.2) build" ] ] }
-#      - "(2.3) test": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
-#      - "(2.4) test": { <<: [ *default_workflow, requires: [ "(2.4) build" ] ] }
+      - "(2.4) build": *default_workflow
+      - "(1.9) test": { <<: [ *default_workflow, requires: [ "(1.9) build" ] ] }
+      - "(2.0) test": { <<: [ *default_workflow, requires: [ "(2.0) build" ] ] }
+      - "(2.1) test": { <<: [ *default_workflow, requires: [ "(2.1) build" ] ] }
+      - "(2.2) test": { <<: [ *default_workflow, requires: [ "(2.2) build" ] ] }
+      - "(2.3) test": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
+      - "(2.4) test": { <<: [ *default_workflow, requires: [ "(2.4) build" ] ] }
       - "static analysis": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
-#      - "deploy release":
-#          <<: *filters_only_release_tags
-#          requires:
-#            - "(2.3) build"
-#            - "(1.9) test"
-#            - "(2.0) test"
-#            - "(2.1) test"
-#            - "(2.2) test"
-#            - "(2.3) test"
-#            - "(2.4) test"
-#      - "perform benchmarks":
-#          <<: *default_workflow
-#          type: approval
-#          requires: [ "(2.3) build" ]
-#      - "(1/5) benchmark": &benchmark_workflow
-#          <<: *default_workflow
-#          requires: [ "perform benchmarks" ]
-#      - "(2/5) benchmark": *benchmark_workflow
-#      - "(3/5) benchmark": *benchmark_workflow
-#      - "(4/5) benchmark": *benchmark_workflow
-#      - "(5/5) benchmark": *benchmark_workflow
-#      - "aggregate benchmarks":
-#          <<: *default_workflow
-#          requires:
-#            - "(1/5) benchmark"
-#            - "(2/5) benchmark"
-#            - "(3/5) benchmark"
-#            - "(4/5) benchmark"
-#            - "(5/5) benchmark"
+      - "deploy release":
+          <<: *filters_only_release_tags
+          requires:
+            - "(2.3) build"
+            - "(1.9) test"
+            - "(2.0) test"
+            - "(2.1) test"
+            - "(2.2) test"
+            - "(2.3) test"
+            - "(2.4) test"
+      - "perform benchmarks":
+          <<: *default_workflow
+          type: approval
+          requires: [ "(2.3) build" ]
+      - "(1/5) benchmark": &benchmark_workflow
+          <<: *default_workflow
+          requires: [ "perform benchmarks" ]
+      - "(2/5) benchmark": *benchmark_workflow
+      - "(3/5) benchmark": *benchmark_workflow
+      - "(4/5) benchmark": *benchmark_workflow
+      - "(5/5) benchmark": *benchmark_workflow
+      - "aggregate benchmarks":
+          <<: *default_workflow
+          requires:
+            - "(1/5) benchmark"
+            - "(2/5) benchmark"
+            - "(3/5) benchmark"
+            - "(4/5) benchmark"
+            - "(5/5) benchmark"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,11 +38,11 @@ test_containers: &test_containers
   - &container_redis
     image: circleci/redis:3
   - &container_mongo
-    image: circleci/mongo:3.5-ram
+    image: circleci/mongo:3.5.13-ram
   - &container_memcached
     image: memcached:1.5-alpine
   - &container_agent
-    image: datadog/docker-dd-agent
+    image: datadog/docker-dd-agent:latest
     environment:
       - DD_APM_ENABLED=true
       - DD_BIND_HOST=0.0.0.0
@@ -200,7 +200,7 @@ jobs:
       - *container_mongo
       - *container_memcached
       - *container_agent
-  "(1/2) benchmark": &benchmark
+  "(1/5) benchmark": &benchmark
     <<: *job_defaults
     docker:
       - <<: [ *container-2_3, *docker_test_environment ]
@@ -220,7 +220,10 @@ jobs:
           root: .
           paths:
             - 'tmp/benchmarks/**/*.csv'
-  "(2/2) benchmark": *benchmark
+  "(2/5) benchmark": *benchmark
+  "(3/5) benchmark": *benchmark
+  "(4/5) benchmark": *benchmark
+  "(5/5) benchmark": *benchmark
   "aggregate benchmarks":
     <<: *job_defaults
     docker: [ *container-2_3 ]
@@ -250,45 +253,47 @@ wf_aliases:
 
 workflows:
   version: 2
-  benchmark:
-    jobs:
-      - "perform additional tests":
-          <<: *default_workflow
-          type: approval
-      - "(2.3) build":
-          <<: *default_workflow
-          requires: [ "perform additional tests" ]
-      - "(1/2) benchmark": &benchmark_workflow
-          <<: *default_workflow
-          requires: [ "(2.3) build" ]
-      - "(2/2) benchmark": *benchmark_workflow
-      - "aggregate benchmarks":
-          <<: *default_workflow
-          requires:
-            - "(1/2) benchmark"
-            - "(2/2) benchmark"
   build-and-test:
     jobs:
-#      - "(1.9) build": *default_workflow
-#      - "(2.0) build": *default_workflow
-#      - "(2.1) build": *default_workflow
-#      - "(2.2) build": *default_workflow
+      - "(1.9) build": *default_workflow
+      - "(2.0) build": *default_workflow
+      - "(2.1) build": *default_workflow
+      - "(2.2) build": *default_workflow
       - "(2.3) build": *default_workflow
-#      - "(2.4) build": *default_workflow
-#      - "(1.9) test": { <<: [ *default_workflow, requires: [ "(1.9) build" ] ] }
-#      - "(2.0) test": { <<: [ *default_workflow, requires: [ "(2.0) build" ] ] }
-#      - "(2.1) test": { <<: [ *default_workflow, requires: [ "(2.1) build" ] ] }
-#      - "(2.2) test": { <<: [ *default_workflow, requires: [ "(2.2) build" ] ] }
-#      - "(2.3) test": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
-#      - "(2.4) test": { <<: [ *default_workflow, requires: [ "(2.4) build" ] ] }
+      - "(2.4) build": *default_workflow
+      - "(1.9) test": { <<: [ *default_workflow, requires: [ "(1.9) build" ] ] }
+      - "(2.0) test": { <<: [ *default_workflow, requires: [ "(2.0) build" ] ] }
+      - "(2.1) test": { <<: [ *default_workflow, requires: [ "(2.1) build" ] ] }
+      - "(2.2) test": { <<: [ *default_workflow, requires: [ "(2.2) build" ] ] }
+      - "(2.3) test": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
+      - "(2.4) test": { <<: [ *default_workflow, requires: [ "(2.4) build" ] ] }
       - "static analysis": { <<: [ *default_workflow, requires: [ "(2.3) build" ] ] }
       - "deploy release":
           <<: *filters_only_release_tags
           requires:
             - "(2.3) build"
-#            - "(1.9) test"
-#            - "(2.0) test"
-#            - "(2.1) test"
-#            - "(2.2) test"
-#            - "(2.3) test"
-#            - "(2.4) test"
+            - "(1.9) test"
+            - "(2.0) test"
+            - "(2.1) test"
+            - "(2.2) test"
+            - "(2.3) test"
+            - "(2.4) test"
+      - "perform benchmarks":
+          <<: *default_workflow
+          type: approval
+          requires: [ "(2.3) build" ]
+      - "(1/5) benchmark": &benchmark_workflow
+          <<: *default_workflow
+          requires: [ "perform benchmarks" ]
+      - "(2/5) benchmark": *benchmark_workflow
+      - "(3/5) benchmark": *benchmark_workflow
+      - "(4/5) benchmark": *benchmark_workflow
+      - "(5/5) benchmark": *benchmark_workflow
+      - "aggregate benchmarks":
+          <<: *default_workflow
+          requires:
+            - "(1/5) benchmark"
+            - "(2/5) benchmark"
+            - "(3/5) benchmark"
+            - "(4/5) benchmark"
+            - "(5/5) benchmark"

--- a/.circleci/process_benchmarks.rb
+++ b/.circleci/process_benchmarks.rb
@@ -1,0 +1,21 @@
+require 'descriptive-statistics'
+require 'yaml'
+
+filenames = ARGV
+
+def read_execution_time(filename)
+    IO.readlines(filename).last.split(',').first.to_f
+  end
+
+times = filenames.map(&method(:read_execution_time))
+
+def print_stats(data)
+    stats = DescriptiveStatistics::Stats.new(data)
+    o = {}
+    %w{sum mean median variance population_variance}.each do |m|
+        o[m] = stats.method(m).call
+      end
+    puts YAML.dump(o)
+  end
+
+print_stats(times)

--- a/.circleci/run_benchmark.sh
+++ b/.circleci/run_benchmark.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+STORAGE_DIR=$1
+TEST_NAME=$2
+TEST_FILE=benchmarks/$TEST_NAME.rb
+
+RESULT_DIR=$STORAGE_DIR/$TEST_NAME
+RESULT_FILE=$RESULT_DIR/benchmark-$CIRCLE_BUILD_NUM-$CIRCLE_NODE_INDEX.csv
+mkdir -p $RESULT_DIR
+
+bundle exec appraisal rails5-postgres-sidekiq ruby $TEST_FILE 2>&1 1>/dev/null | tee $RESULT_FILE

--- a/benchmarks/concurrent_span_test.rb
+++ b/benchmarks/concurrent_span_test.rb
@@ -1,0 +1,147 @@
+ENV['RAILS_ENV'] = 'production'
+require 'English'
+
+# Benchmark Configuration container
+module TestConfiguration
+  module_function
+
+  def iteration_count
+    10000
+  end
+end
+
+require 'bundler/setup'
+require 'ddtrace'
+require 'concurrent/atomic/atomic_fixnum'
+
+# approximate operations
+class TestWithoutDatadog
+  def perform(iterations = 100)
+    iterations.times do
+      (proc { sleep(0.001) }).call
+    end
+  end
+end
+
+# real test
+class Test
+  def perform(iterations = 100)
+
+    iterations.times do
+      Datadog.tracer.trace('test', service: 'test') do
+        Datadog.tracer.trace('test_inner', service: 'test') do
+          sleep(0.001)
+        end
+      end
+    end
+  end
+end
+
+class ThreadRunner
+  attr_reader :iterations_count, :conditional_variable
+
+  def initialize(iterations)
+    @iterations_count = Concurrent::AtomicFixnum.new(iterations)
+    @iterations = iterations
+    @conditional_variable = ConditionVariable.new
+    @test = if Datadog.respond_to?(:configure)
+              Test.new
+            else
+              TestWithoutDatadog.new
+            end
+  end
+
+  def prepare
+    @threads = []
+    @iterations_count = Concurrent::AtomicFixnum.new(@iterations)
+
+    @iterations.times do
+      @threads << Thread.new do
+        @iterations_count.decrement
+        @test.perform
+      end
+    end
+  end
+
+  def await
+    @threads.each(&:join)
+    conditional_variable.broadcast
+  end
+end
+
+class BatchRunner
+  attr_reader :iterations_count, :conditional_variable
+
+  def initialize(iterations, runner)
+    @runner = runner
+    @iterations_count = Concurrent::AtomicFixnum.new(iterations)
+    @iterations = iterations
+    @conditional_variable = ConditionVariable.new
+  end
+
+  def prepare
+    @iterations_count = Concurrent::AtomicFixnum.new(@iterations)
+
+    @worker = Thread.new do
+      while @iterations_count.value > 0
+        @iterations_count.decrement
+
+        @runner.prepare
+        @runner.await
+      end
+    end
+  end
+
+  def await
+    @worker.join
+    conditional_variable.broadcast
+  end
+end
+
+if Datadog.respond_to?(:configure)
+  Datadog.configure do |d|
+    processor = Datadog::Pipeline::SpanProcessor.new do |span|
+      true if span.service == 'B'
+
+    end
+    d.use :http
+
+    Datadog::Pipeline.before_flush(processor)
+  end
+end
+
+def current_memory
+  `ps -o rss #{$PROCESS_ID}`.split("\n")[1].to_f / 1024
+end
+
+def time
+  Process.clock_gettime(Process::CLOCK_MONOTONIC)
+end
+
+def wait_and_measure(iterations, runner)
+  start = time
+
+  STDERR.puts "#{time - start}, #{current_memory}"
+
+  mutex = Mutex.new
+
+  while runner.iterations_count.value > 0
+    mutex.synchronize do
+      runner.conditional_variable.wait(mutex, 1)
+      STDERR.puts "#{time - start}, #{current_memory}"
+    end
+  end
+
+  yield if block_given?
+  STDERR.puts "#{time - start}, #{current_memory}"
+end
+
+runner = ThreadRunner.new(TestConfiguration.iteration_count/100)
+batch_runner = BatchRunner.new(100, runner)
+batch_runner.prepare
+
+wait_and_measure(TestConfiguration.iteration_count, batch_runner) do
+  batch_runner.await
+  Datadog.tracer.shutdown! if Datadog.respond_to?(:configure)
+end
+

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'builder'
   spec.add_development_dependency 'ruby-prof'
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'descriptive-statistics'
 
   # locking transitive dependency of webmock
   spec.add_development_dependency 'addressable', '~> 2.4.0'


### PR DESCRIPTION
This PR was made in an effort to isolate and measure performance improvements. 

#### Background: 
Due to complex nature our current benchmark have high variability in results. This means that its hard/impossible to compare the results looking for improvements or regressions.

#### Description:

This PR allows running multiple benchmarks in parallel and collecting + processing the results. 

Basically using fork + join pattern. 

#### Additional improvements:

In addition this PR include a few improvements to CI like:
- postgres using RAM disk as DB store
- optimized redis
- optimized mongodb
- cached bundler install and apprisal install - this shaves off 1-4 minutes of off each build
- removed checkout build - instead every build does its own git checkout + workspace is used to transfer data downstream in builds

Thus in addition to benchmark this PR optimizes the CI runtime ~2x.


#### Benchmarks:

All benchmarks are optional not to use too much resources, additionally they are currently limited in how much resources they use.  I.e. they are split into 5 parts each with parallelism of 1. If we've had more resources we might increase parallelism to run more jobs and make our data even more trustworthy.

