### PR TITLE
[graphql] Fix patching for derived schema

### DIFF
--- a/lib/ddtrace/contrib/graphql/patcher.rb
+++ b/lib/ddtrace/contrib/graphql/patcher.rb
@@ -29,12 +29,20 @@ module Datadog
             tracer = get_option(:tracer)
             service_name = get_option(:service_name)
 
-            schema.define do
-              use(
+            if schema.respond_to?(:use)
+              schema.use(
                 ::GraphQL::Tracing::DataDogTracing,
                 tracer: tracer,
                 service: service_name
               )
+            else
+              schema.define do
+                use(
+                  ::GraphQL::Tracing::DataDogTracing,
+                  tracer: tracer,
+                  service: service_name
+                )
+              end
             end
           end
 

--- a/spec/ddtrace/contrib/graphql/test_types.rb
+++ b/spec/ddtrace/contrib/graphql/test_types.rb
@@ -1,14 +1,26 @@
+
 LogHelpers.without_warnings do
   require 'graphql'
 end
 
 RSpec.shared_context 'GraphQL test schema' do
-  let(:schema) do
+  let(:defined_schema) do
     qt = query_type
 
     ::GraphQL::Schema.define do
       query(qt)
     end
+  end
+
+  let(:derived_schema) do
+    class DerivedSchema < ::GraphQL::Schema
+    end
+
+    qt = query_type
+    DerivedSchema.class_eval do
+      query(qt)
+    end
+    DerivedSchema
   end
 
   let(:query_type_name) { 'Query' }


### PR DESCRIPTION
When schemas are derived from `GraphQL::Schema` instead of using `GraphQL::Schema.define`, the patching doesn't work.