### PR TITLE
Fix missing Rack::TraceMiddleware constant for Grape

### DIFF
--- a/lib/ddtrace/contrib/grape/endpoint.rb
+++ b/lib/ddtrace/contrib/grape/endpoint.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/ext/http'
 require 'ddtrace/ext/errors'
+require 'ddtrace/contrib/rack/middlewares'
 
 module Datadog
   module Contrib


### PR DESCRIPTION
As raised in #525 , this pull request adds a missing require so Grape can be loaded normally.