### PR TITLE
[OpenTracing] Fix distributed tracing signed int ids

### DIFF
--- a/lib/ddtrace/opentracer/distributed_headers.rb
+++ b/lib/ddtrace/opentracer/distributed_headers.rb
@@ -17,15 +17,11 @@ module Datadog
       end
 
       def trace_id
-        value = @carrier[HTTP_HEADER_TRACE_ID].to_i
-        return if value <= 0 || value >= Datadog::Span::MAX_ID
-        value
+        id HTTP_HEADER_TRACE_ID
       end
 
       def parent_id
-        value = @carrier[HTTP_HEADER_PARENT_ID].to_i
-        return if value <= 0 || value >= Datadog::Span::MAX_ID
-        value
+        id HTTP_HEADER_PARENT_ID
       end
 
       def sampling_priority
@@ -36,6 +32,14 @@ module Datadog
         value = hdr.to_i
         return if value < 0
         value
+      end
+
+      private
+
+      def id(header)
+        value = @carrier[header].to_i
+        return if value.zero? || value >= Datadog::Span::MAX_ID
+        value < 0 ? value + 0x1_0000_0000_0000_0000 : value
       end
     end
   end

--- a/spec/ddtrace/opentracer/distributed_headers_spec.rb
+++ b/spec/ddtrace/opentracer/distributed_headers_spec.rb
@@ -64,6 +64,12 @@ if Datadog::OpenTracer.supported?
         context 'and the value is in range' do
           let(:value) { (Datadog::Span::MAX_ID - 1).to_s }
           it { is_expected.to eq value.to_i }
+
+          context 'as a negative signed integer' do
+            # Convert signed int to unsigned int.
+            let(:value) { -8809075535603237910.to_s }
+            it { is_expected.to eq 9637668538106313706 }
+          end
         end
       end
     end
@@ -90,6 +96,12 @@ if Datadog::OpenTracer.supported?
         context 'and the value is in range' do
           let(:value) { (Datadog::Span::MAX_ID - 1).to_s }
           it { is_expected.to eq value.to_i }
+
+          context 'as a negative signed integer' do
+            # Convert signed int to unsigned int.
+            let(:value) { -8809075535603237910.to_s }
+            it { is_expected.to eq 9637668538106313706 }
+          end
         end
       end
     end


### PR DESCRIPTION
Analogous to #530 , OpenTracing was discarding signed integers displayed as negative integers received via distributed tracing from other tracers. This pull request applies the same kind of conversion of signed to unsigned int, to provide compatibility.