### PR TITLE
Add :service_prefix option for service names

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1233,6 +1233,7 @@ Available options are:
  - ``hostname``: set the hostname of the trace agent.
  - ``port``: set the port the trace agent is listening on.
  - ``env``: set the environment. Rails users may set it to ``Rails.env`` to use their application settings.
+ - ``service_prefix``: prefix to append to all service names by default. Value should be a string e.g. `'myapp_'`.
  - ``tags``: set global tags that should be applied to all spans. Defaults to an empty hash
  - ``log``: defines a custom logger.
  - ``partial_flush``: set to ``true`` to enable partial trace flushing (for long running traces.) Disabled by default. *Experimental.*

--- a/lib/ddtrace/contrib/configuration/settings.rb
+++ b/lib/ddtrace/contrib/configuration/settings.rb
@@ -29,6 +29,16 @@ module Datadog
         def []=(name, value)
           respond_to?("#{name}=") ? send("#{name}=", value) : set_option(name, value)
         end
+
+        # Override set_option to allow service_prefix to be added.
+        def set_option(name, value)
+          if name.to_sym == :service_name && !value.nil?
+            tracer = get_option(:tracer)
+            super(name, "#{tracer.service_prefix}#{value}")
+          else
+            super
+          end
+        end
       end
     end
   end

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -20,7 +20,7 @@ module Datadog
   # rubocop:disable Metrics/ClassLength
   class Tracer
     attr_reader :sampler, :services, :tags, :provider
-    attr_accessor :enabled, :writer
+    attr_accessor :enabled, :writer, :service_prefix
     attr_writer :default_service
 
     ALLOWED_SPAN_OPTIONS = [:service, :resource, :span_type].freeze
@@ -106,6 +106,7 @@ module Datadog
       @mutex = Mutex.new
       @services = {}
       @tags = {}
+      @service_prefix = options.fetch(:service_prefix, nil)
     end
 
     # Updates the current \Tracer instance, so that the tracer can be configured after the
@@ -123,6 +124,7 @@ module Datadog
       enabled = options.fetch(:enabled, nil)
       hostname = options.fetch(:hostname, nil)
       port = options.fetch(:port, nil)
+      @service_prefix = options.fetch(:service_prefix, nil)
 
       # Those are rare "power-user" options.
       sampler = options.fetch(:sampler, nil)

--- a/spec/ddtrace/contrib/configuration/settings_spec.rb
+++ b/spec/ddtrace/contrib/configuration/settings_spec.rb
@@ -12,4 +12,52 @@ RSpec.describe Datadog::Contrib::Configuration::Settings do
     it { is_expected.to include(:service_name) }
     it { is_expected.to include(:tracer) }
   end
+
+  describe 'when setting :service_name' do
+    shared_examples_for 'prefixed name' do
+      let(:original_service_name) { 'bar' }
+      let(:tracer) { instance_double(Datadog::Tracer, service_prefix: service_prefix) }
+
+      before(:each) { settings.set_option(:tracer, tracer) }
+
+      describe 'via #set_option' do
+        subject(:service_name) { settings.set_option(:service_name, original_service_name) }
+        it do
+          expect { service_name }.to change { settings.service_name }
+            .from(nil)
+            .to("#{service_prefix}#{original_service_name}")
+        end
+      end
+
+      describe 'via #[]=' do
+        subject(:service_name) { settings[:service_name] = original_service_name }
+        it do
+          expect { service_name }.to change { settings.service_name }
+            .from(nil)
+            .to("#{service_prefix}#{original_service_name}")
+        end
+      end
+
+      describe 'via #service_name' do
+        subject(:service_name) { settings.service_name = original_service_name }
+        it do
+          expect { service_name }.to change { settings.service_name }
+            .from(nil)
+            .to("#{service_prefix}#{original_service_name}")
+        end
+      end
+    end
+
+    context 'without a :service_prefix on the Tracer' do
+      it_behaves_like 'prefixed name' do
+        let(:service_prefix) { nil }
+      end
+    end
+
+    context 'with :service_prefix on the Tracer' do
+      it_behaves_like 'prefixed name' do
+        let(:service_prefix) { 'foo_' }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Following up on the request from #513 , this pull request adds an option to the configuration that allows you to define a prefix to add to all service names by default.

```ruby
Datadog.configure do |c|
  c.tracer service_prefix: 'myapp_'
  c.use :sinatra
end
```

The above sample will produce Sinatra spans with `myapp_sinatra`.