### PR TITLE
Reduce possible contention when creating spans by avoiding using Mutex in RateByServiceSampler

### DIFF
--- a/lib/ddtrace/sampler.rb
+++ b/lib/ddtrace/sampler.rb
@@ -83,7 +83,7 @@ module Datadog
 
           env, service = entry
 
-          if is_fallback_entry(env, service)
+          if fallback_entry?(env, service)
             new_fallback = rate_sampler(rate)
           elsif valid_entry_for_env(env, service)
             new_sampler[service] = rate_sampler(rate)
@@ -121,10 +121,10 @@ module Datadog
       match = PARSER.match(key).to_a
       _, service, env = match && match.to_a
 
-      [ env, service ] if env && service
+      [env, service] if env && service
     end
 
-    def is_fallback_entry(env, service)
+    def fallback_entry?(env, service)
       service.empty? && env.empty?
     end
   end


### PR DESCRIPTION
This PR improves the performance of `RateByServiceSampler` by avoiding the use of Mutex when fetching active Sampler configuration when performing sampling. 

Sampler update code was updated to shorten the time window where Sampler is in undefined state - i.e. "#sample" method uses part old and part new (post update) sampling configuration. 

Additionally, the sampler configuration lookup has been changed to move key processing into update portion. 
Making the lookup as fast as possible and not requiring any temporary strings creation.

This PR should reduce both the thread contention and GC pressure.