### PR TITLE
Add Rails middleware option

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -907,6 +907,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | ``database_service`` | Database service name used when tracing database activity | ``<app_name>-<adapter_name>`` |
 | ``exception_controller`` | Class or Module which identifies a custom exception controller class. Tracer provides improved error behavior when it can identify custom exception controllers. By default, without this option, it 'guesses' what a custom exception controller looks like. Providing this option aids this identification. | ``nil`` |
 | ``distributed_tracing`` | Enables [distributed tracing](#distributed-tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `false` |
+| ``middleware`` | Add the trace middleware to the Rails application. Set to `false` if you don't want the middleware to load. | `true` |
 | ``middleware_names`` | Enables any short-circuited middleware requests to display the middleware name as resource for the trace. | `false` |
 | ``template_base_path`` | Used when the template name is parsed. If you don't store your templates in the ``views/`` folder, you may need to change this value | ``views/`` |
 | ``tracer`` | A ``Datadog::Tracer`` instance used to instrument the application. Usually you don't need to set that. | ``Datadog.tracer`` |

--- a/lib/ddtrace/contrib/rack/patcher.rb
+++ b/lib/ddtrace/contrib/rack/patcher.rb
@@ -39,7 +39,8 @@ module Datadog
             @patched = true
           end
 
-          if !@middleware_patched && get_option(:middleware_names)
+          if (!instance_variable_defined?(:@middleware_patched) || !@middleware_patched) \
+             && get_option(:middleware_names)
             if get_option(:application)
               enable_middleware_names
               @middleware_patched = true

--- a/lib/ddtrace/contrib/rails/railtie.rb
+++ b/lib/ddtrace/contrib/rails/railtie.rb
@@ -5,11 +5,14 @@ require 'ddtrace/contrib/rack/middlewares'
 module Datadog
   # Railtie class initializes
   class Railtie < Rails::Railtie
-    config.app_middleware.insert_before(0, Datadog::Contrib::Rack::TraceMiddleware)
-    # Insert right after Rails exception handling middleware, because if it's before,
-    # it catches and swallows the error. If it's too far after, custom middleware can find itself
-    # between, and raise exceptions that don't end up getting tagged on the request properly (e.g lost stack trace.)
-    config.app_middleware.insert_after(ActionDispatch::ShowExceptions, Datadog::Contrib::Rails::ExceptionMiddleware)
+    # Add the trace middleware to the application stack
+    initializer 'datadog.add_middleware' do |app|
+      app.middleware.insert_before(0, Datadog::Contrib::Rack::TraceMiddleware)
+      # Insert right after Rails exception handling middleware, because if it's before,
+      # it catches and swallows the error. If it's too far after, custom middleware can find itself
+      # between, and raise exceptions that don't end up getting tagged on the request properly (e.g lost stack trace.)
+      app.middleware.insert_after(ActionDispatch::ShowExceptions, Datadog::Contrib::Rails::ExceptionMiddleware)
+    end
 
     config.after_initialize do
       Datadog::Contrib::Rails::Framework.setup

--- a/spec/ddtrace/contrib/rails/railtie_spec.rb
+++ b/spec/ddtrace/contrib/rails/railtie_spec.rb
@@ -1,0 +1,48 @@
+require 'ddtrace/contrib/rails/rails_helper'
+require 'ddtrace/contrib/rails/framework'
+require 'ddtrace/contrib/rails/middlewares'
+require 'ddtrace/contrib/rack/middlewares'
+
+RSpec.describe 'Rails application' do
+  include_context 'Rails test application'
+
+  let(:tracer) { ::Datadog::Tracer.new(writer: FauxWriter.new) }
+
+  RSpec::Matchers.define :have_kind_of_middleware do |expected|
+    match do |actual|
+      while actual
+        return true if actual.class <= expected
+        without_warnings { actual = actual.instance_variable_get(:@app) }
+      end
+      false
+    end
+  end
+
+  before(:each) do
+    Datadog.registry[:rails].instance_variable_set(:@patched, false)
+    Datadog.configure do |c|
+      c.tracer hostname: ENV.fetch('TEST_DDAGENT_HOST', 'localhost')
+      c.use :rails, rails_options if use_rails
+    end
+  end
+
+  let(:use_rails) { true }
+  let(:rails_options) { { tracer: tracer } }
+
+  describe 'with Rails integration #middleware option' do
+    context 'set to true' do
+      let(:rails_options) { super().merge(middleware: true) }
+
+      it { expect(app).to have_kind_of_middleware(Datadog::Contrib::Rack::TraceMiddleware) }
+      it { expect(app).to have_kind_of_middleware(Datadog::Contrib::Rails::ExceptionMiddleware) }
+    end
+
+    context 'set to false' do
+      let(:rails_options) { super().merge(middleware: false) }
+      after(:each) { Datadog.configuration[:rails][:middleware] = true }
+
+      it { expect(app).to_not have_kind_of_middleware(Datadog::Contrib::Rack::TraceMiddleware) }
+      it { expect(app).to_not have_kind_of_middleware(Datadog::Contrib::Rails::ExceptionMiddleware) }
+    end
+  end
+end

--- a/spec/ddtrace/contrib/rails/railtie_spec.rb
+++ b/spec/ddtrace/contrib/rails/railtie_spec.rb
@@ -4,9 +4,21 @@ require 'ddtrace/contrib/rails/middlewares'
 require 'ddtrace/contrib/rack/middlewares'
 
 RSpec.describe 'Rails application' do
+  before(:each) { skip 'Test not compatible with Rails < 4.0' if Rails.version < '4.0' }
   include_context 'Rails test application'
 
   let(:tracer) { ::Datadog::Tracer.new(writer: FauxWriter.new) }
+
+  let(:routes) { { '/' => 'test#index' } }
+  let(:controllers) { [controller] }
+
+  let(:controller) do
+    stub_const('TestController', Class.new(ActionController::Base) do
+      def index
+        head :ok
+      end
+    end)
+  end
 
   RSpec::Matchers.define :have_kind_of_middleware do |expected|
     match do |actual|

--- a/spec/ddtrace/contrib/rails/support/application.rb
+++ b/spec/ddtrace/contrib/rails/support/application.rb
@@ -3,6 +3,11 @@ require 'ddtrace/contrib/rails/support/base'
 RSpec.shared_context 'Rails test application' do
   include_context 'Rails base application'
 
+  before do
+    Datadog.registry[:rails].instance_variable_set(:@patched, false)
+    reset_rails_configuration!
+  end
+
   let(:app) do
     initialize_app!
     rails_test_application.instance

--- a/spec/ddtrace/contrib/rails/support/rails4.rb
+++ b/spec/ddtrace/contrib/rails/support/rails4.rb
@@ -16,7 +16,6 @@ RSpec.shared_context 'Rails 4 base application' do
   include_context 'Rails models'
 
   let(:rails_base_application) do
-    reset_rails_configuration!
     klass = Class.new(Rails::Application) do
       def config.database_configuration
         parsed = super
@@ -108,16 +107,10 @@ RSpec.shared_context 'Rails 4 base application' do
     Rails::Railtie::Configuration.class_variable_set(:@@eager_load_namespaces, nil)
     Rails::Railtie::Configuration.class_variable_set(:@@watchable_files, nil)
     Rails::Railtie::Configuration.class_variable_set(:@@watchable_dirs, nil)
-    Rails::Railtie::Configuration.class_variable_set(:@@app_middleware, app_middleware)
+    if Rails::Railtie::Configuration.class_variable_defined?(:@@app_middleware)
+      Rails::Railtie::Configuration.class_variable_set(:@@app_middleware, Rails::Configuration::MiddlewareStackProxy.new)
+    end
     Rails::Railtie::Configuration.class_variable_set(:@@app_generators, nil)
     Rails::Railtie::Configuration.class_variable_set(:@@to_prepare_blocks, nil)
-  end
-
-  def app_middleware
-    current = Rails::Railtie::Configuration.class_variable_get(:@@app_middleware)
-    Datadog::Contrib::Rails::Test::Configuration.fetch(:app_middleware, current).dup.tap do |copy|
-      copy.instance_variable_set(:@operations, (copy.instance_variable_get(:@operations) || []).dup)
-      copy.instance_variable_set(:@delete_operations, (copy.instance_variable_get(:@delete_operations) || []).dup)
-    end
   end
 end

--- a/spec/ddtrace/contrib/rails/support/rails5.rb
+++ b/spec/ddtrace/contrib/rails/support/rails5.rb
@@ -16,7 +16,6 @@ RSpec.shared_context 'Rails 5 base application' do
   include_context 'Rails models'
 
   let(:rails_base_application) do
-    reset_rails_configuration!
     klass = Class.new(Rails::Application) do
       def config.database_configuration
         parsed = super
@@ -86,16 +85,10 @@ RSpec.shared_context 'Rails 5 base application' do
     Rails::Railtie::Configuration.class_variable_set(:@@eager_load_namespaces, nil)
     Rails::Railtie::Configuration.class_variable_set(:@@watchable_files, nil)
     Rails::Railtie::Configuration.class_variable_set(:@@watchable_dirs, nil)
-    Rails::Railtie::Configuration.class_variable_set(:@@app_middleware, app_middleware)
+    if Rails::Railtie::Configuration.class_variable_defined?(:@@app_middleware)
+      Rails::Railtie::Configuration.class_variable_set(:@@app_middleware, Rails::Configuration::MiddlewareStackProxy.new)
+    end
     Rails::Railtie::Configuration.class_variable_set(:@@app_generators, nil)
     Rails::Railtie::Configuration.class_variable_set(:@@to_prepare_blocks, nil)
-  end
-
-  def app_middleware
-    current = Rails::Railtie::Configuration.class_variable_get(:@@app_middleware)
-    Datadog::Contrib::Rails::Test::Configuration.fetch(:app_middleware, current).dup.tap do |copy|
-      copy.instance_variable_set(:@operations, (copy.instance_variable_get(:@operations) || []).dup)
-      copy.instance_variable_set(:@delete_operations, (copy.instance_variable_get(:@delete_operations) || []).dup)
-    end
   end
 end


### PR DESCRIPTION
As per #149, Rails instrumentation is auto-injecting a Railtie and trace middleware into the Rails application by virtue of loading. This means that it isn't really possible to disable trace middleware in this case.

This pull request seeks to make Rails instrumentation optional, by:

 - Preventing the Railtie by loading automatically, and apply instrumentation from the Rails patcher instead.
 - Add a `middleware` option, which defaults to `true`. When set to false, trace middleware will not be added to the application.

This would be good to have for users who want to use instrumentation in Rails apps without instrumenting Rails, and for OpenTracing users who'd want to prevent conflicting middleware from running in their Rails applications.