### PR TITLE
Trace the Rack middleware stack

### DIFF
--- a/lib/ddtrace/contrib/rack/middleware_tracing.rb
+++ b/lib/ddtrace/contrib/rack/middleware_tracing.rb
@@ -1,7 +1,7 @@
 module Datadog
   module Contrib
     module Rack
-      # A module that injects Datadog tracing into the middleware stack itself.
+      # A module that injects tracing into the middleware stack itself.
       #
       # It's rather complicated due to the limited introspective capabilities of Rack
       # middlewares, as well as the requirement that middleware spans not be nested.
@@ -15,13 +15,13 @@ module Datadog
       #
       #   [A][BB][CCCCCCC][BBBB][A]
       #
-      # Otherwise the Datadog UI goes crazy.
+      # Otherwise we get very deep nesting.
       #
       # The way we go about this is the following:
       #
-      # 1) Our middleware, when initialize, travels down the middleware stack from
-      #    where it's been inserted, prepending the MiddlewareInstrumentation
-      #    module to each middleware class.
+      # 1) Our middleware, when initialized, travels down the middleware stack from
+      #    where it's been inserted, prepending the MiddlewareTracing module to each
+      #    middleware class.
       # 2) This module overwrites `call`, allowing us to hook into the point where
       #    e.g. middleware A "hands off" the request to middleware B.
       # 3) When a request is processed, an instrumented middleware will first check

--- a/lib/ddtrace/contrib/rack/middleware_tracing.rb
+++ b/lib/ddtrace/contrib/rack/middleware_tracing.rb
@@ -45,6 +45,8 @@ module Datadog
         ENV_KEY = 'ddtrace_middleware_trace'.freeze
 
         def call(env)
+          env['RESPONSE_MIDDLEWARE'] = self.class.to_s
+
           current_middleware_trace = env[ENV_KEY]
           is_first_middleware = !current_middleware_trace
           is_last_middleware = !defined?(@app)

--- a/lib/ddtrace/contrib/rack/middleware_tracing.rb
+++ b/lib/ddtrace/contrib/rack/middleware_tracing.rb
@@ -1,0 +1,88 @@
+module Datadog
+  module Contrib
+    module Rack
+      # A module that injects Datadog tracing into the middleware stack itself.
+      #
+      # It's rather complicated due to the limited introspective capabilities of Rack
+      # middlewares, as well as the requirement that middleware spans not be nested.
+      # That is, instead of this:
+      #
+      #   [AAAAAAAAAAAAAAAAAAAAA]
+      #     [BBBBBBBBBBBBBBBBBB]
+      #        [CCCCCCCC]
+      #
+      # We want this:
+      #
+      #   [A][BB][CCCCCCC][BBBB][A]
+      #
+      # Otherwise the Datadog UI goes crazy.
+      #
+      # The way we go about this is the following:
+      #
+      # 1) Our middleware, when initialize, travels down the middleware stack from
+      #    where it's been inserted, prepending the MiddlewareInstrumentation
+      #    module to each middleware class.
+      # 2) This module overwrites `call`, allowing us to hook into the point where
+      #    e.g. middleware A "hands off" the request to middleware B.
+      # 3) When a request is processed, an instrumented middleware will first check
+      #    in the Rack environment to see if there's already an open middleware span.
+      #    If there is, we call its `finish` method.
+      # 4) Then a new span is opened before calling `super` to let the actual middleware
+      #    gets to do its thing.
+      # 5) This is repeated all the way down the stack, until we reach Rails' routing
+      #    system.
+      # 6) When the response goes back up the middleware chain (in reverse order),
+      #    we want to trace the "after" part of each middleware, the part that
+      #    processes the response. So if there was a middleware span "above" our
+      #    middleware (the one stored in the Rack env) we "re-open" it by creating
+      #    a new span with the same name and resource, and store *that* in the Rack
+      #    env. Of course, if the middleware *below* us had already done that for
+      #    our middleware, we finish that span first.
+      #
+      # It's all a bit complicated, but it works!
+      module MiddlewareTracing
+        SPAN_NAME = 'middleware.call'.freeze
+        ENV_KEY = 'ddtrace_middleware_trace'.freeze
+
+        def call(env)
+          current_middleware_trace = env[ENV_KEY]
+          is_first_middleware = !current_middleware_trace
+          is_last_middleware = !defined?(@app)
+
+          # If a previous middleware has started a span, finish it here in order to avoid
+          # nesting.
+          current_middleware_trace.finish unless is_first_middleware
+
+          if is_last_middleware
+            # There are no more middlewares after this one.
+            response = super(env)
+          else
+            trace = Datadog.tracer.trace(SPAN_NAME)
+            trace.resource = "#{self.class}#call"
+
+            # Pass the trace to the next middleware.
+            env[ENV_KEY] = trace
+
+            response = super(env)
+
+            # The next middleware will set a new span here for the "after" step. Finish
+            # that as well. If there's no more middleware, we'll just finish our own trace.
+            env[ENV_KEY].finish
+          end
+
+          # If the previous middleware set a span, create a matching "after" span that
+          # includes the time spent after we return to it.
+          unless is_first_middleware
+            remainder_trace = Datadog.tracer.trace(SPAN_NAME)
+            remainder_trace.parent = current_middleware_trace.parent
+            remainder_trace.resource = current_middleware_trace.resource
+
+            env[ENV_KEY] = remainder_trace
+          end
+
+          response
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -260,8 +260,10 @@ module Datadog
         def patch_middleware(middleware)
           # We prepend the module to the singleton class of the instantiated middleware
           # so that we can call `super`.
-          class << middleware
-            prepend MiddlewareTracing
+          unless middleware.frozen?
+            class << middleware
+              prepend MiddlewareTracing
+            end
           end
 
           # This is just a convention, but it's reliably used.

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -21,7 +21,10 @@ module Datadog
         def initialize(app)
           @app = app
 
-          patch_middleware(@app)
+          # The middleware tracing uses `Class#prepend`, which was introduced in Ruby 2.0.
+          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0')
+            patch_middleware(@app)
+          end
         end
 
         def compute_queue_time(env, tracer)

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -257,7 +257,9 @@ module Datadog
         def patch_middleware(middleware)
           # We prepend the module to the singleton class of the instantiated middleware
           # so that we can call `super`.
-          middleware.singleton_class.prepend(MiddlewareTracing)
+          class << middleware
+            prepend MiddlewareTracing
+          end
 
           # This is just a convention, but it's reliably used.
           following = middleware.instance_variable_get(:@app)

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -262,7 +262,7 @@ module Datadog
           end
 
           # This is just a convention, but it's reliably used.
-          following = middleware.instance_variable_get(:@app)
+          following = middleware.instance_variable_defined?(:@app) && middleware.instance_variable_get(:@app)
 
           patch_middleware(following) if following
         end

--- a/lib/ddtrace/contrib/rack/patcher.rb
+++ b/lib/ddtrace/contrib/rack/patcher.rb
@@ -39,50 +39,11 @@ module Datadog
             @patched = true
           end
 
-          if (!instance_variable_defined?(:@middleware_patched) || !@middleware_patched) \
-             && get_option(:middleware_names)
-            if get_option(:application)
-              enable_middleware_names
-              @middleware_patched = true
-            else
-              Datadog::Tracer.log.warn(%(
-              Rack :middleware_names requires you to also pass :application.
-              Middleware names have NOT been patched; please provide :application.
-              e.g. use: :rack, middleware_names: true, application: my_rack_app).freeze)
-            end
-          end
-
-          @patched || @middleware_patched
+          @patched
         end
 
         def patched?
           @patched ||= false
-        end
-
-        def enable_middleware_names
-          retain_middleware_name(get_option(:application))
-        rescue => e
-          # We can safely ignore these exceptions since they happen only in the
-          # context of middleware patching outside a Rails server process (eg. a
-          # process that doesn't serve HTTP requests but has Rails environment
-          # loaded such as a Resque master process)
-          Tracer.log.debug("Error patching middleware stack: #{e}")
-        end
-
-        def retain_middleware_name(middleware)
-          return unless middleware && middleware.respond_to?(:call)
-
-          middleware.singleton_class.class_eval do
-            alias_method :__call, :call
-
-            def call(env)
-              env['RESPONSE_MIDDLEWARE'] = self.class.to_s
-              __call(env)
-            end
-          end
-
-          following = middleware.instance_variable_get('@app')
-          retain_middleware_name(following)
         end
       end
     end

--- a/test/contrib/rack/resource_name_test.rb
+++ b/test/contrib/rack/resource_name_test.rb
@@ -30,7 +30,7 @@ class ResourceNameTest < Minitest::Test
   def test_resource_name_full_chain
     get '/', {}, 'HTTP_AUTH_TOKEN' => '1234'
 
-    spans = @tracer.writer.spans
+    spans = @tracer.writer.spans.select { |span| span.name == 'rack.request' }
     assert(last_response.ok?)
     assert_equal(1, spans.length)
     assert_match(/BottomMiddleware#GET/, spans[0].resource)
@@ -39,7 +39,7 @@ class ResourceNameTest < Minitest::Test
   def test_resource_name_short_circuited_request
     get '/', {}, 'HTTP_AUTH_TOKEN' => 'Wrong'
 
-    spans = @tracer.writer.spans
+    spans = @tracer.writer.spans.select { |span| span.name == 'rack.request' }
     refute(last_response.ok?)
     assert_equal(1, spans.length)
     assert_match(/AuthMiddleware#GET/, spans[0].resource)


### PR DESCRIPTION
All middlewares below the TraceMiddleware will be traced, but without nesting the spans. Instead, there will be a separate span before and after a middleware calls the `@app` it wraps. This is done because APM doesn't handle deep nesting well – if that were to change, simply nesting the spans would be a lot simpler.

This also replaces the system of tracking the name of the "terminal" middleware, or the middleware that actually generates a response, to be more robust. Instead of the user having to pass the full Rack stack, we just patch all middlewares below the tracing middleware.