### PR TITLE
Add a development dependency on rack-test

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.1'
   spec.add_development_dependency 'minitest', '= 5.10.1'
+  spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'appraisal', '~> 2.2'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'webmock', '~> 2.0'


### PR DESCRIPTION
Otherwise running `bundle exec rake test:rack` fails.