### PR TITLE
Make integration configurations more consistent

### DIFF
--- a/lib/ddtrace/contrib/active_record/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_record/configuration/settings.rb
@@ -1,16 +1,17 @@
 require 'ddtrace/contrib/configuration/settings'
+require 'ddtrace/contrib/active_record/ext'
 require 'ddtrace/contrib/active_record/utils'
 
 module Datadog
   module Contrib
     module ActiveRecord
       module Configuration
-        # Unique settings for ActiveRecord
+        # Custom settings for the ActiveRecord integration
         class Settings < Contrib::Configuration::Settings
           option :orm_service_name
           option :service_name, depends_on: [:tracer] do |value|
             (value || Utils.adapter_name).tap do |service_name|
-              tracer.set_service_info(service_name, 'active_record', Ext::AppTypes::DB)
+              tracer.set_service_info(service_name, Ext::APP, Datadog::Ext::AppTypes::DB)
             end
           end
 

--- a/lib/ddtrace/contrib/active_record/events/instantiation.rb
+++ b/lib/ddtrace/contrib/active_record/events/instantiation.rb
@@ -1,3 +1,4 @@
+require 'ddtrace/contrib/active_record/ext'
 require 'ddtrace/contrib/active_record/event'
 
 module Datadog
@@ -9,8 +10,6 @@ module Datadog
           include ActiveRecord::Event
 
           EVENT_NAME = 'instantiation.active_record'.freeze
-          SPAN_NAME = 'active_record.instantiation'.freeze
-          DEFAULT_SERVICE_NAME = 'active_record'.freeze
 
           module_function
 
@@ -24,7 +23,7 @@ module Datadog
           end
 
           def span_name
-            self::SPAN_NAME
+            Ext::SPAN_INSTANTIATION
           end
 
           def process(span, event, _id, payload)
@@ -34,13 +33,13 @@ module Datadog
                            elsif span.parent
                              span.parent.service
                            else
-                             self::DEFAULT_SERVICE_NAME
+                             Ext::SERVICE_NAME
                            end
 
             span.resource = payload.fetch(:class_name)
-            span.span_type = 'custom'
-            span.set_tag('active_record.instantiation.class_name', payload.fetch(:class_name))
-            span.set_tag('active_record.instantiation.record_count', payload.fetch(:record_count))
+            span.span_type = Ext::SPAN_TYPE_INSTANTIATION
+            span.set_tag(Ext::TAG_INSTANTIATION_CLASS_NAME, payload.fetch(:class_name))
+            span.set_tag(Ext::TAG_INSTANTIATION_RECORD_COUNT, payload.fetch(:record_count))
           rescue StandardError => e
             Datadog::Tracer.log.debug(e.message)
           end

--- a/lib/ddtrace/contrib/active_record/events/sql.rb
+++ b/lib/ddtrace/contrib/active_record/events/sql.rb
@@ -1,3 +1,5 @@
+require 'ddtrace/ext/net'
+require 'ddtrace/contrib/active_record/ext'
 require 'ddtrace/contrib/active_record/event'
 
 module Datadog
@@ -9,7 +11,7 @@ module Datadog
           include ActiveRecord::Event
 
           EVENT_NAME = 'sql.active_record'.freeze
-          SPAN_NAME = 'active_record.sql'.freeze
+          PAYLOAD_CACHE = 'CACHE'.freeze
 
           module_function
 
@@ -18,7 +20,7 @@ module Datadog
           end
 
           def span_name
-            self::SPAN_NAME
+            Ext::SPAN_SQL
           end
 
           def process(span, event, _id, payload)
@@ -35,13 +37,13 @@ module Datadog
             # Find out if the SQL query has been cached in this request. This meta is really
             # helpful to users because some spans may have 0ns of duration because the query
             # is simply cached from memory, so the notification is fired with start == finish.
-            cached = payload[:cached] || (payload[:name] == 'CACHE')
+            cached = payload[:cached] || (payload[:name] == PAYLOAD_CACHE)
 
-            span.set_tag('active_record.db.vendor', adapter_name)
-            span.set_tag('active_record.db.name', config[:database])
-            span.set_tag('active_record.db.cached', cached) if cached
-            span.set_tag('out.host', config[:host]) if config[:host]
-            span.set_tag('out.port', config[:port]) if config[:port]
+            span.set_tag(Ext::TAG_DB_VENDOR, adapter_name)
+            span.set_tag(Ext::TAG_DB_NAME, config[:database])
+            span.set_tag(Ext::TAG_DB_CACHED, cached) if cached
+            span.set_tag(Datadog::Ext::NET::TARGET_HOST, config[:host]) if config[:host]
+            span.set_tag(Datadog::Ext::NET::TARGET_PORT, config[:port]) if config[:port]
           rescue StandardError => e
             Datadog::Tracer.log.debug(e.message)
           end

--- a/lib/ddtrace/contrib/active_record/ext.rb
+++ b/lib/ddtrace/contrib/active_record/ext.rb
@@ -1,0 +1,22 @@
+module Datadog
+  module Contrib
+    module ActiveRecord
+      # ActiveRecord integration constants
+      module Ext
+        APP = 'active_record'.freeze
+        SERVICE_NAME = 'active_record'.freeze
+
+        SPAN_INSTANTIATION = 'active_record.instantiation'.freeze
+        SPAN_SQL = 'active_record.sql'.freeze
+
+        SPAN_TYPE_INSTANTIATION = 'custom'.freeze
+
+        TAG_DB_CACHED = 'active_record.db.cached'.freeze
+        TAG_DB_NAME = 'active_record.db.name'.freeze
+        TAG_DB_VENDOR = 'active_record.db.vendor'.freeze
+        TAG_INSTANTIATION_CLASS_NAME = 'active_record.instantiation.class_name'.freeze
+        TAG_INSTANTIATION_RECORD_COUNT = 'active_record.instantiation.record_count'.freeze
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/concurrent_ruby/configuration/settings.rb
+++ b/lib/ddtrace/contrib/concurrent_ruby/configuration/settings.rb
@@ -4,6 +4,7 @@ module Datadog
   module Contrib
     module ConcurrentRuby
       module Configuration
+        # Custom settings for the ConcurrentRuby integration
         class Settings < Contrib::Configuration::Settings
           # Add any custom ConcurrentRuby configuration or behavior here.
         end

--- a/lib/ddtrace/contrib/concurrent_ruby/ext.rb
+++ b/lib/ddtrace/contrib/concurrent_ruby/ext.rb
@@ -1,0 +1,11 @@
+module Datadog
+  module Contrib
+    module ConcurrentRuby
+      # ConcurrentRuby integration constants
+      module Ext
+        APP = 'concurrent-ruby'.freeze
+        SERVICE_NAME = 'concurrent-ruby'.freeze
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/concurrent_ruby/integration.rb
+++ b/lib/ddtrace/contrib/concurrent_ruby/integration.rb
@@ -5,14 +5,18 @@ require 'ddtrace/contrib/concurrent_ruby/configuration/settings'
 module Datadog
   module Contrib
     module ConcurrentRuby
-      # Propagate Tracing context in Concurrent::Future
+      # Describes the ConcurrentRuby integration
       class Integration
         include Contrib::Integration
 
         register_as :concurrent_ruby
 
-        def self.compatible?
-          defined?(::Concurrent::Future)
+        def self.version
+          Gem.loaded_specs['concurrent-ruby'] && Gem.loaded_specs['concurrent-ruby'].version
+        end
+
+        def self.present?
+          super && defined?(::Concurrent::Future)
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/concurrent_ruby/patcher.rb
+++ b/lib/ddtrace/contrib/concurrent_ruby/patcher.rb
@@ -25,6 +25,7 @@ module Datadog
           end
         end
 
+        # Propagate tracing context in Concurrent::Future
         def patch_future
           ::Concurrent::Future.send(:include, FuturePatch)
         end

--- a/lib/ddtrace/contrib/racecar/configuration/settings.rb
+++ b/lib/ddtrace/contrib/racecar/configuration/settings.rb
@@ -5,7 +5,7 @@ module Datadog
   module Contrib
     module Racecar
       module Configuration
-        # Custom settings for the Rack integration
+        # Custom settings for the Racecar integration
         class Settings < Contrib::Configuration::Settings
           option :service_name, default: Ext::SERVICE_NAME
           option :tracer, default: Datadog.tracer do |value|

--- a/lib/ddtrace/contrib/rest_client/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rest_client/configuration/settings.rb
@@ -1,20 +1,17 @@
 require 'ddtrace/contrib/configuration/settings'
-require 'ddtrace/contrib/active_record/utils'
+require 'ddtrace/contrib/rest_client/ext'
 
 module Datadog
   module Contrib
     module RestClient
       module Configuration
-        # Unique settings for RestClient
+        # Custom settings for the RestClient integration
         class Settings < Contrib::Configuration::Settings
-          NAME = 'rest_client'.freeze
-
-          option :service_name, default: NAME, depends_on: [:tracer] do |value|
-            get_option(:tracer).set_service_info(value, NAME, Ext::AppTypes::DB)
+          option :distributed_tracing, default: false
+          option :service_name, default: Ext::SERVICE_NAME, depends_on: [:tracer] do |value|
+            get_option(:tracer).set_service_info(value, Ext::APP, Datadog::Ext::AppTypes::DB)
             value
           end
-
-          option :distributed_tracing, default: false
         end
       end
     end

--- a/lib/ddtrace/contrib/rest_client/ext.rb
+++ b/lib/ddtrace/contrib/rest_client/ext.rb
@@ -1,0 +1,13 @@
+module Datadog
+  module Contrib
+    module RestClient
+      # RestClient integration constants
+      module Ext
+        APP = 'rest_client'.freeze
+        SERVICE_NAME = 'rest_client'.freeze
+
+        SPAN_REQUEST = 'rest_client.request'.freeze
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/rest_client/integration.rb
+++ b/lib/ddtrace/contrib/rest_client/integration.rb
@@ -10,8 +10,16 @@ module Datadog
         include Contrib::Integration
         register_as :rest_client
 
+        def self.version
+          Gem.loaded_specs['rest-client'] && Gem.loaded_specs['rest-client'].version
+        end
+
+        def self.present?
+          super && defined?(::RestClient::Request)
+        end
+
         def self.compatible?
-          RUBY_VERSION >= '1.9.3' && defined?(::RestClient::Request)
+          super && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('1.9.3')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/rest_client/patcher.rb
+++ b/lib/ddtrace/contrib/rest_client/patcher.rb
@@ -1,7 +1,7 @@
 module Datadog
   module Contrib
     module RestClient
-      # RestClient integration
+      # Patcher enables patching of 'rest_client' module.
       module Patcher
         include Contrib::Patcher
 

--- a/lib/ddtrace/contrib/sequel/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sequel/configuration/settings.rb
@@ -1,9 +1,11 @@
 require 'ddtrace/contrib/configuration/settings'
+require 'ddtrace/contrib/sequel/ext'
 
 module Datadog
   module Contrib
     module Sequel
       module Configuration
+        # Custom settings for the Sequel integration
         class Settings < Contrib::Configuration::Settings
           # Add any custom Sequel settings or behavior here.
         end

--- a/lib/ddtrace/contrib/sequel/database.rb
+++ b/lib/ddtrace/contrib/sequel/database.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/ext/sql'
 require 'ddtrace/ext/app_types'
+require 'ddtrace/contrib/sequel/ext'
 require 'ddtrace/contrib/sequel/utils'
 
 module Datadog
@@ -18,11 +19,11 @@ module Datadog
 
             response = nil
 
-            datadog_pin.tracer.trace('sequel.query') do |span|
+            datadog_pin.tracer.trace(Ext::SPAN_QUERY) do |span|
               span.service = datadog_pin.service
               span.resource = opts[:query]
               span.span_type = Datadog::Ext::SQL::TYPE
-              span.set_tag('sequel.db.vendor', adapter_name)
+              span.set_tag(Ext::TAG_DB_VENDOR, adapter_name)
               response = super(sql, options)
             end
             response
@@ -31,7 +32,7 @@ module Datadog
           def datadog_pin
             @pin ||= Datadog::Pin.new(
               Datadog.configuration[:sequel][:service_name] || adapter_name,
-              app: Integration::APP,
+              app: Ext::APP,
               app_type: Datadog::Ext::AppTypes::DB,
               tracer: Datadog.configuration[:sequel][:tracer] || Datadog.tracer
             )

--- a/lib/ddtrace/contrib/sequel/dataset.rb
+++ b/lib/ddtrace/contrib/sequel/dataset.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/ext/sql'
 require 'ddtrace/ext/app_types'
+require 'ddtrace/contrib/sequel/ext'
 require 'ddtrace/contrib/sequel/utils'
 
 module Datadog
@@ -39,11 +40,11 @@ module Datadog
             opts = Utils.parse_opts(sql, options, db.opts)
             response = nil
 
-            datadog_pin.tracer.trace('sequel.query') do |span|
+            datadog_pin.tracer.trace(Ext::SPAN_QUERY) do |span|
               span.service = datadog_pin.service
               span.resource = opts[:query]
               span.span_type = Datadog::Ext::SQL::TYPE
-              span.set_tag('sequel.db.vendor', adapter_name)
+              span.set_tag(Ext::TAG_DB_VENDOR, adapter_name)
               response = super_method.call(sql, options, &block)
             end
             response

--- a/lib/ddtrace/contrib/sequel/ext.rb
+++ b/lib/ddtrace/contrib/sequel/ext.rb
@@ -1,0 +1,15 @@
+module Datadog
+  module Contrib
+    module Sequel
+      # Sequel integration constants
+      module Ext
+        APP = 'sequel'.freeze
+        SERVICE_NAME = 'sequel'.freeze
+
+        SPAN_QUERY = 'sequel.query'.freeze
+
+        TAG_DB_VENDOR = 'sequel.db.vendor'.freeze
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/sequel/integration.rb
+++ b/lib/ddtrace/contrib/sequel/integration.rb
@@ -9,8 +9,6 @@ module Datadog
       class Integration
         include Contrib::Integration
 
-        APP = 'sequel'.freeze
-
         register_as :sequel, auto_patch: false
 
         def self.version
@@ -22,7 +20,7 @@ module Datadog
         end
 
         def self.compatible?
-          super && RUBY_VERSION >= '2.0.0'
+          super && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/sequel/patcher.rb
+++ b/lib/ddtrace/contrib/sequel/patcher.rb
@@ -6,7 +6,6 @@ module Datadog
   module Contrib
     module Sequel
       # Patcher enables patching of 'sequel' module.
-      # This is used in monkey.rb to manually apply patches
       module Patcher
         include Contrib::Patcher
 


### PR DESCRIPTION
For the changes made in #544, we want to make configuration consistent across the integrations that were already converted to the new configuration API defined in #450.

This includes:

 - [x] ActiveRecord
 - [x] ConcurrentRuby
 - [x] RestClient
 - [x] Sequel

We should merge this to #544 so all changes can be deployed together.