### PR TITLE
Set the Rails controller as the Rack resource more reliably

### DIFF
--- a/lib/ddtrace/contrib/rails/action_controller_patch.rb
+++ b/lib/ddtrace/contrib/rails/action_controller_patch.rb
@@ -34,6 +34,7 @@ module Datadog
             payload = {
               controller: self.class,
               action: action_name,
+              env: request.env,
               headers: {
                 # The exception this controller was given in the request,
                 # which is typical if the controller is configured to handle exceptions.


### PR DESCRIPTION
Don't rely on the immediate parent being the Rack span.