### PR TITLE
[ci] Deploy release and prerelease gems to private repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -458,7 +458,7 @@ jobs:
           keys:
             - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-2.4-{{ checksum ".circleci/bundle_checksum" }}'
       - *step_run_all_tests
-  deploy-release:
+  "deploy release":
     <<: *job_defaults
     docker:
       - *container-2_4
@@ -470,81 +470,120 @@ jobs:
             apt-get -y -qq install awscli
       - *step_bundle_install
       - *step_release_docs
+      - run:
+          name: Upload release Gem and rebuild index
+          command: S3_DIR=release bundle exec rake release:gem
+      - store_artifacts:
+          path: pkg/
+          destination: gem
+  "deploy prerelease Gem":
+    <<: *job_defaults
+    docker:
+      - *container-2_4
+    steps:
+      - checkout
+      - run:
+          command: |
+            apt-get -y -qq update
+            apt-get -y -qq install awscli
+      - *step_bundle_install
+      - run:
+          name: Rename to pre-release version based on branch name and build number
+          command: |
+             # create safe version string
+             PRE=$(echo "${CIRCLE_BRANCH:-unknown}.${CIRCLE_BUILD_NUM:-R$RANDOM}" | sed -e 's/[^a-zA-Z0-9+]\{1,\}/./g')
+             echo PRE=$PRE
+             sed lib/ddtrace/version.rb -i -e "s/^\([\t ]*PRE\) *=*/\1 = \'${PRE}\' #/g"
+      - run:
+          name: Upload prereleas Gem and rebuild index
+          command: S3_DIR=prerelease bundle exec rake release:gem
+      - store_artifacts:
+          path: pkg/
+          destination: gem
 
 workflows:
   version: 2
   build-and-test:
     jobs:
-      - checkout-1.9:
-          <<: *filters_all_branches_and_tags
-      - build-1.9:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - checkout-1.9
-      - test-1.9:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - build-1.9
-      - checkout-2.0:
-          <<: *filters_all_branches_and_tags
-      - build-2.0:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - checkout-2.0
-      - test-2.0:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - build-2.0
-      - checkout-2.1:
-          <<: *filters_all_branches_and_tags
-      - build-2.1:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - checkout-2.1
-      - test-2.1:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - build-2.1
-      - checkout-2.2:
-          <<: *filters_all_branches_and_tags
-      - build-2.2:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - checkout-2.2
-      - test-2.2:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - build-2.2
-      - checkout-2.3:
-          <<: *filters_all_branches_and_tags
-      - build-2.3:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - checkout-2.3
-      - test-2.3:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - build-2.3
-      - benchmark-2.3:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - build-2.3
-      - checkout-2.4:
-          <<: *filters_all_branches_and_tags
-      - build-2.4:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - checkout-2.4
-      - test-2.4:
-          <<: *filters_all_branches_and_tags
-          requires:
-            - build-2.4
-      - deploy-release:
-          <<: *filters_only_release_tags
-          requires:
-            - test-1.9
-            - test-2.0
-            - test-2.1
-            - test-2.2
-            - test-2.3
-            - test-2.4
+       - checkout-1.9:
+           <<: *filters_all_branches_and_tags
+       - build-1.9:
+           <<: *filters_all_branches_and_tags
+           requires:
+             - checkout-1.9
+       - test-1.9:
+           <<: *filters_all_branches_and_tags
+           requires:
+             - build-1.9
+       - checkout-2.0:
+           <<: *filters_all_branches_and_tags
+       - build-2.0:
+           <<: *filters_all_branches_and_tags
+           requires:
+             - checkout-2.0
+       - test-2.0:
+           <<: *filters_all_branches_and_tags
+           requires:
+             - build-2.0
+       - checkout-2.1:
+           <<: *filters_all_branches_and_tags
+       - build-2.1:
+           <<: *filters_all_branches_and_tags
+           requires:
+             - checkout-2.1
+       - test-2.1:
+           <<: *filters_all_branches_and_tags
+           requires:
+             - build-2.1
+       - checkout-2.2:
+           <<: *filters_all_branches_and_tags
+       - build-2.2:
+           <<: *filters_all_branches_and_tags
+           requires:
+             - checkout-2.2
+       - test-2.2:
+           <<: *filters_all_branches_and_tags
+           requires:
+             - build-2.2
+       - checkout-2.3:
+           <<: *filters_all_branches_and_tags
+       - build-2.3:
+           <<: *filters_all_branches_and_tags
+           requires:
+             - checkout-2.3
+       - test-2.3:
+           <<: *filters_all_branches_and_tags
+           requires:
+             - build-2.3
+       - benchmark-2.3:
+           <<: *filters_all_branches_and_tags
+           requires:
+             - build-2.3
+       - checkout-2.4:
+           <<: *filters_all_branches_and_tags
+       - build-2.4:
+           <<: *filters_all_branches_and_tags
+           requires:
+             - checkout-2.4
+       - test-2.4:
+           <<: *filters_all_branches_and_tags
+           requires:
+             - build-2.4
+       - "deploy prerelease Gem":
+           <<: *filters_all_branches_and_tags
+           requires:
+             - test-1.9
+             - test-2.0
+             - test-2.1
+             - test-2.2
+             - test-2.3
+             - test-2.4
+       - "deploy release":
+           <<: *filters_only_release_tags
+           requires:
+             - test-1.9
+             - test-2.0
+             - test-2.1
+             - test-2.2
+             - test-2.3
+             - test-2.4

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,8 @@ require 'rake/testtask'
 require 'appraisal'
 require 'yard'
 
+Dir.glob('tasks/*.rake').each { |r| import r }
+
 desc 'Run RSpec'
 # rubocop:disable Metrics/BlockLength
 namespace :spec do
@@ -169,40 +171,6 @@ end
 # Deploy tasks
 S3_BUCKET = 'gems.datadoghq.com'.freeze
 S3_DIR = ENV['S3_DIR']
-
-desc 'create a new indexed repository'
-task :'release:gem' do
-  raise 'Missing environment variable S3_DIR' if !S3_DIR || S3_DIR.empty?
-  # load existing deployed gems
-  sh "aws s3 cp --exclude 'docs/*' --recursive s3://#{S3_BUCKET}/#{S3_DIR}/ ./rubygems/"
-
-  # create folders
-  sh 'mkdir -p ./gems'
-  sh 'mkdir -p ./rubygems/gems/'
-  sh 'mkdir -p ./rubygems/quick/'
-
-  # copy previous builds
-  sh 'cp ./rubygems/gems/* ./gems/'
-
-  # build the gem
-  Rake::Task['build'].execute
-
-  # copy the output in the indexed folder
-  sh 'cp pkg/*.gem ./gems/'
-
-  # generate the gems index
-  sh 'gem generate_index'
-
-  # namespace everything under ./rubygems/
-  sh 'cp -r ./gems/* ./rubygems/gems/'
-  sh 'cp -r specs.* ./rubygems/'
-  sh 'cp -r latest_specs.* ./rubygems/'
-  sh 'cp -r prerelease_specs.* ./rubygems/'
-  sh 'cp -r ./quick/* ./rubygems/quick/'
-
-  # deploy a static gem registry
-  sh "aws s3 cp --recursive ./rubygems/ s3://#{S3_BUCKET}/#{S3_DIR}/"
-end
 
 desc 'release the docs website'
 task :'release:docs' => :docs do

--- a/tasks/release_gem.rake
+++ b/tasks/release_gem.rake
@@ -1,0 +1,28 @@
+desc 'create a new indexed repository'
+task :'release:gem' do
+  raise 'Missing environment variable S3_DIR' if !S3_DIR || S3_DIR.empty?
+  # load existing deployed gems
+  sh "aws s3 cp --exclude 'docs/*' --recursive s3://#{S3_BUCKET}/#{S3_DIR}/ ./rubygems/"
+
+  # create folders
+  sh 'mkdir -p ./gems'
+  sh 'mkdir -p ./rubygems/gems'
+
+  # build the gem
+  Rake::Task['build'].execute
+
+  # copy the output in the indexed folder
+  sh 'cp pkg/*.gem ./rubygems/gems/'
+
+  # generate the gems index
+  sh 'gem generate_index -v --no-modern -d ./rubygems'
+
+  # remove all local repository gems to limit files needed to be uploaded
+  sh 'rm -f ./rubygems/gems/*'
+
+  # re-add new gems
+  sh 'cp pkg/*.gem ./rubygems/gems/'
+
+  # deploy a static gem registry
+  sh "aws s3 cp --recursive ./rubygems/ s3://#{S3_BUCKET}/#{S3_DIR}/"
+end


### PR DESCRIPTION
Improve sharing of build artifacts by deploying gems to a S3 bucket thats actually a gem repository.

Current its available at `http://gems.datadoghq.com/prerelease`
So on can use gems built by this CI step by writing following in the Gemfile:
```
source 'http://gems.datadoghq.com/prerelease' do
  gem 'ddtrace', '>= 0.16.0.ci.bring.back.builds.17511', '< 0.16.0'
end
```