### PR TITLE
Add open_timeout to http connection to the agent.

### DIFF
--- a/lib/ddtrace/transport.rb
+++ b/lib/ddtrace/transport.rb
@@ -107,7 +107,9 @@ module Datadog
         request = Net::HTTP::Post.new(url, headers)
         request.body = data
 
-        response = Net::HTTP.start(@hostname, @port, read_timeout: TIMEOUT) { |http| http.request(request) }
+        response = Net::HTTP.start(@hostname, @port, open_timeout: TIMEOUT, read_timeout: TIMEOUT) do |http|
+          http.request(request)
+        end
         handle_response(response)
       rescue StandardError => e
         log_error_once(e.message)


### PR DESCRIPTION
Default open_timeout is 60 s. 
This is too long.
This PR sets it to 1s.