### PR TITLE
Fix app type configuration of RestClient

### DIFF
--- a/lib/ddtrace/contrib/rest_client/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rest_client/configuration/settings.rb
@@ -9,7 +9,7 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :distributed_tracing, default: false
           option :service_name, default: Ext::SERVICE_NAME, depends_on: [:tracer] do |value|
-            get_option(:tracer).set_service_info(value, Ext::APP, Datadog::Ext::AppTypes::DB)
+            get_option(:tracer).set_service_info(value, Ext::APP, Datadog::Ext::AppTypes::WEB)
             value
           end
         end


### PR DESCRIPTION
So the UI displays the correct icon and label.

![rest_client_db](https://user-images.githubusercontent.com/6256480/46627972-779c2c00-cb3c-11e8-8fde-3569df3b009e.png)
