### PR TITLE
Fix priority sampling mishandling agent response

### DIFF
--- a/lib/ddtrace/transport.rb
+++ b/lib/ddtrace/transport.rb
@@ -219,6 +219,7 @@ module Datadog
       @response_callback.call(action, response, @api)
     rescue => e
       Tracer.log.debug("Error processing callback: #{e}")
+      @mutex.synchronize { @count_internal_error += 1 }
     end
   end
 end

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -120,8 +120,10 @@ module Datadog
       return unless action == :traces && response.is_a?(Net::HTTPOK)
 
       if api[:version] == HTTPTransport::V4
-        service_rates = JSON.parse(response.body)
-        @priority_sampler.update(service_rates)
+        body = JSON.parse(response.body)
+        if body.is_a?(Hash) && body.key?('rate_by_service')
+          @priority_sampler.update(body['rate_by_service'])
+        end
         true
       else
         false

--- a/spec/ddtrace/writer_spec.rb
+++ b/spec/ddtrace/writer_spec.rb
@@ -167,8 +167,9 @@ RSpec.describe Datadog::Writer do
             context 'and is a :traces action' do
               context 'and is API v4' do
                 let(:api) { { version: Datadog::HTTPTransport::V4 } }
+                let(:body) { sampling_response.to_json }
+                let(:sampling_response) { { 'rate_by_service' => service_rates } }
                 let(:service_rates) { { 'service:a,env:test' => 0.1, 'service:b,env:test' => 0.5 } }
-                let(:body) { service_rates.to_json }
 
                 it do
                   expect(sampler).to receive(:update).with(service_rates)


### PR DESCRIPTION
While adding debugging metrics to the tracer, I discovered that when priority sampling is enabled, the writer mishandles the JSON response it receives from the agent, when trying to use it to update its sampling rates.

It was receiving a response formatted like:

```
{"rate_by_service":{"service:,env:":1,"service:rspec,env:none":1}}
```

However, the logic was written such that it didn't expect a top level key `"rate_by_service"`, so it consumes that key as a service improperly, and throws an error when trying to process the Hash like a Float.

This bug was hidden because the callback that did this was wrapped with exception handling which silently appended to a debug log, instead of raising an exception or increasing the internal error metric.

This pull request fixes the bug by consuming the value properly, and now properly asserts that the internal error metric does not increase in the test, which should prevent a similar bug from going unnoticed in the future.