### PR TITLE
Refactor tracer metadata into Datadog::Metadata

### DIFF
--- a/lib/ddtrace/ext/http.rb
+++ b/lib/ddtrace/ext/http.rb
@@ -9,6 +9,12 @@ module Datadog
       TYPE = 'http'.freeze
       URL = 'http.url'.freeze
 
+      # Metadata headers
+      HEADER_META_LANG = 'Datadog-Meta-Lang'.freeze
+      HEADER_META_LANG_INTERPRETER = 'Datadog-Meta-Lang-Interpreter'.freeze
+      HEADER_META_LANG_VERSION = 'Datadog-Meta-Lang-Version'.freeze
+      HEADER_META_TRACER_VERSION = 'Datadog-Meta-Tracer-Version'.freeze
+
       # General header functionality
       module Headers
         module_function

--- a/lib/ddtrace/ext/meta.rb
+++ b/lib/ddtrace/ext/meta.rb
@@ -1,0 +1,18 @@
+require 'ddtrace/version'
+
+module Datadog
+  module Ext
+    module Meta
+      LANG = 'ruby'.freeze
+      LANG_INTERPRETER = begin
+        if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('1.9')
+          (RUBY_ENGINE + '-' + RUBY_PLATFORM)
+        else
+          ('ruby-' + RUBY_PLATFORM)
+        end
+      end.freeze
+      LANG_VERSION = RUBY_VERSION
+      TRACER_VERSION = Datadog::VERSION::STRING
+    end
+  end
+end

--- a/lib/ddtrace/ext/statsd.rb
+++ b/lib/ddtrace/ext/statsd.rb
@@ -1,0 +1,10 @@
+module Datadog
+  module Ext
+    module Statsd
+      TAG_LANG = 'datadog.tracer.meta.lang'.freeze
+      TAG_LANG_INTERPRETER = 'datadog.tracer.meta.lang_interpreter'.freeze
+      TAG_LANG_VERSION = 'datadog.tracer.meta.lang_version'.freeze
+      TAG_TRACER_VERSION = 'datadog.tracer.meta.tracer_version'.freeze
+    end
+  end
+end

--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -5,6 +5,6 @@ module Datadog
     PATCH = 1
     PRE = nil
 
-    STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.')
+    STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze
   end
 end

--- a/spec/ddtrace/transport_payload_spec.rb
+++ b/spec/ddtrace/transport_payload_spec.rb
@@ -10,8 +10,13 @@ require 'ddtrace/tracer'
 RSpec.describe 'Datadog::HTTPTransport payload' do
   include_context 'stat counts'
 
-  before(:each) { WebMock.enable! }
+  before(:each) do
+    WebMock.enable!
+    WebMock.disable_net_connect!
+  end
+
   after(:each) do
+    WebMock.allow_net_connect!
     WebMock.reset!
     WebMock.disable!
   end
@@ -69,36 +74,36 @@ RSpec.describe 'Datadog::HTTPTransport payload' do
     describe 'has a X-Datadog-Trace-Count header' do
       it_behaves_like 'a request with a header' do
         subject { @header_value.to_i }
-        let(:header) { Datadog::HTTPTransport::TRACE_COUNT_HEADER }
+        let(:header) { Datadog::HTTPTransport::HEADER_TRACE_COUNT }
         let(:expected_value) { 1 }
       end
     end
 
     describe 'has a Datadog-Meta-Lang header' do
       it_behaves_like 'a request with a header' do
-        let(:header) { Datadog::HTTPTransport::HEADER_META_LANG }
-        let(:expected_value) { 'ruby' }
-      end
-    end
-
-    describe 'has a Datadog-Meta-Version header' do
-      it_behaves_like 'a request with a header' do
-        let(:header) { Datadog::HTTPTransport::HEADER_META_LANG_VERSION }
-        let(:expected_value) { RUBY_VERSION }
+        let(:header) { Datadog::Ext::HTTP::HEADER_META_LANG }
+        let(:expected_value) { Datadog::Ext::Meta::LANG }
       end
     end
 
     describe 'has a Datadog-Meta-Interpreter header' do
       it_behaves_like 'a request with a header' do
-        let(:header) { Datadog::HTTPTransport::HEADER_META_LANG_INTERPRETER }
-        let(:expected_value) { defined?(RUBY_ENGINE) ? RUBY_ENGINE + '-' + RUBY_PLATFORM : 'ruby-' + RUBY_PLATFORM }
+        let(:header) { Datadog::Ext::HTTP::HEADER_META_LANG_INTERPRETER }
+        let(:expected_value) { Datadog::Ext::Meta::LANG_INTERPRETER }
+      end
+    end
+
+    describe 'has a Datadog-Meta-Version header' do
+      it_behaves_like 'a request with a header' do
+        let(:header) { Datadog::Ext::HTTP::HEADER_META_LANG_VERSION }
+        let(:expected_value) { Datadog::Ext::Meta::LANG_VERSION }
       end
     end
 
     describe 'has a Datadog-Meta-Tracer-Version header' do
       it_behaves_like 'a request with a header' do
-        let(:header) { Datadog::HTTPTransport::HEADER_META_TRACER_VERSION }
-        let(:expected_value) { Datadog::VERSION::STRING }
+        let(:header) { Datadog::Ext::HTTP::HEADER_META_TRACER_VERSION }
+        let(:expected_value) { Datadog::Ext::Meta::TRACER_VERSION }
       end
     end
   end


### PR DESCRIPTION
`HTTPTransport` defines a number of metadata HTTP headers that contain interesting information about the tracer.

This pull request extracts those metadata definitions into a `Datadog::Ext::Meta` namespace, so that other tracing components can freely re-use this metadata. It defines the following fields:

```ruby
Datadog::Ext::Meta::LANG
Datadog::Ext::Meta::LANG_VERSION
Datadog::Ext::Meta::LANG_INTERPRETER
Datadog::Ext::Meta::TRACER_VERSION
```