### PR TITLE
Add additional tracer metrics

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1663,14 +1663,37 @@ end
 
 See the [Dogstatsd documentation](https://www.rubydoc.info/github/DataDog/dogstatsd-ruby/master/frames) for more details about configuring `Datadog::Statsd`.
 
-After activation, the tracer will send the following statistics:
+After activation, the tracer will send the following metrics:
 
-| Name                                               | Type    | Description                                                      |
-| -------------------------------------------------- | ------- | ---------------------------------------------------------------- |
-| `datadog.tracer.transport.http.client_error`       | `count` | Number of HTTP requests to agent with a client error.            |
-| `datadog.tracer.transport.http.incompatible_error` | `count` | Number of HTTP requests to agent with incompatible API.          |
-| `datadog.tracer.transport.http.internal_error`     | `count` | Number of internal tracer errors produced during HTTP transport. |
-| `datadog.tracer.transport.http.server_error`       | `count` | Number of HTTP requests to agent with a server error.            |
-| `datadog.tracer.transport.http.success`            | `count` | Number of successful HTTP requests to agent.                     |
-| `datadog.tracer.services_flushed`                  | `count` | Number of services flushed.                                      |
-| `datadog.tracer.traces_flushed`                    | `count` | Number of traces flushed.                                        |
+| Name                                               | Type           | Description                                                      |
+| -------------------------------------------------- | -------------- | ---------------------------------------------------------------- |
+| `datadog.tracer.sampling_update_time`              | `timer`        | Time to update sampling rates from agent response.               |
+| `datadog.tracer.services_flushed`                  | `count`        | Number of services flushed.                                      |
+| `datadog.tracer.traces_flushed`                    | `count`        | Number of traces flushed.                                        |
+| `datadog.tracer.transport.http.client_error`       | `count`        | Number of HTTP requests to agent with a client error.            |
+| `datadog.tracer.transport.http.encode_time`        | `timer`        | Time to serialize HTTP payload prior to POST.                    |
+| `datadog.tracer.transport.http.incompatible_error` | `count`        | Number of HTTP requests to agent with incompatible API.          |
+| `datadog.tracer.transport.http.internal_error`     | `count`        | Number of internal tracer errors produced during HTTP transport. |
+| `datadog.tracer.transport.http.payload_size`       | `distribution` | Size of HTTP payload prior to POST, in bytes.                    |
+| `datadog.tracer.transport.http.post_time`          | `timer`        | Time to POST payload to agent, excluding TCP connect time.       |
+| `datadog.tracer.transport.http.roundtrip_time`     | `timer`        | Time to POST payload to agent, including TCP connect time.       |
+| `datadog.tracer.transport.http.server_error`       | `count`        | Number of HTTP requests to agent with a server error.            |
+| `datadog.tracer.transport.http.success`            | `count`        | Number of successful HTTP requests to agent.                     |
+| `datadog.tracer.writer.flush_time`                 | `timer`        | Time to flush data including serialization, TCP, and callbacks.  |
+
+In addition, all metrics will include the following tags:
+
+| Name                                   | Description                                                         |
+| -------------------------------------- | ------------------------------------------------------------------- |
+| `datadog.tracer.meta.lang`             | Programming language traced. (e.g. `ruby`)                          |
+| `datadog.tracer.meta.lang_interpreter` | Language interpreter used, if available. (e.g. `ruby-x86_64-linux`) |
+| `datadog.tracer.meta.lang_version`     | Version of language traced. (e.g. `2.3.7`)                          |
+| `datadog.tracer.meta.tracer_version`   | Version of tracer library/module. (e.g. `0.16.1` )                  |
+
+And some metrics may additionally include the following tags, if applicable:
+
+| Name                                          | Description                                                                 |
+| --------------------------------------------- | --------------------------------------------------------------------------- |
+| `datadog.tracer.priority_sampler`             | Is priority sampling enabled? (Either `true` or `false`)                    |
+| `datadog.tracer.transport.http.data_type`     | Payload data type. (Either `services` or `traces`)                          |
+| `datadog.tracer.transport.http.encoding_type` | Payload encoding type. (Either `application/json` or `application/msgpack`) |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1667,19 +1667,19 @@ After activation, the tracer will send the following metrics:
 
 | Name                                               | Type           | Description                                                      |
 | -------------------------------------------------- | -------------- | ---------------------------------------------------------------- |
-| `datadog.tracer.sampling_update_time`              | `timer`        | Time to update sampling rates from agent response.               |
+| `datadog.tracer.sampling_update_time`              | `distribution` | Time to update sampling rates from agent response.               |
 | `datadog.tracer.services_flushed`                  | `count`        | Number of services flushed.                                      |
 | `datadog.tracer.traces_flushed`                    | `count`        | Number of traces flushed.                                        |
 | `datadog.tracer.transport.http.client_error`       | `count`        | Number of HTTP requests to agent with a client error.            |
-| `datadog.tracer.transport.http.encode_time`        | `timer`        | Time to serialize HTTP payload prior to POST.                    |
+| `datadog.tracer.transport.http.encode_time`        | `distribution` | Time to serialize HTTP payload prior to POST.                    |
 | `datadog.tracer.transport.http.incompatible_error` | `count`        | Number of HTTP requests to agent with incompatible API.          |
 | `datadog.tracer.transport.http.internal_error`     | `count`        | Number of internal tracer errors produced during HTTP transport. |
 | `datadog.tracer.transport.http.payload_size`       | `distribution` | Size of HTTP payload prior to POST, in bytes.                    |
-| `datadog.tracer.transport.http.post_time`          | `timer`        | Time to POST payload to agent, excluding TCP connect time.       |
-| `datadog.tracer.transport.http.roundtrip_time`     | `timer`        | Time to POST payload to agent, including TCP connect time.       |
+| `datadog.tracer.transport.http.post_time`          | `distribution` | Time to POST payload to agent, excluding TCP connect time.       |
+| `datadog.tracer.transport.http.roundtrip_time`     | `distribution` | Time to POST payload to agent, including TCP connect time.       |
 | `datadog.tracer.transport.http.server_error`       | `count`        | Number of HTTP requests to agent with a server error.            |
 | `datadog.tracer.transport.http.success`            | `count`        | Number of successful HTTP requests to agent.                     |
-| `datadog.tracer.writer.flush_time`                 | `timer`        | Time to flush data including serialization, TCP, and callbacks.  |
+| `datadog.tracer.writer.flush_time`                 | `distribution` | Time to flush data including serialization, TCP, and callbacks.  |
 
 In addition, all metrics will include the following tags:
 
@@ -1694,6 +1694,7 @@ And some metrics may additionally include the following tags, if applicable:
 
 | Name                                          | Description                                                                 |
 | --------------------------------------------- | --------------------------------------------------------------------------- |
-| `datadog.tracer.priority_sampler`             | Is priority sampling enabled? (Either `true` or `false`)                    |
+| `datadog.tracer.priority_sampling`            | Is priority sampling enabled? (Either `true` or `false`)                    |
 | `datadog.tracer.transport.http.data_type`     | Payload data type. (Either `services` or `traces`)                          |
 | `datadog.tracer.transport.http.encoding_type` | Payload encoding type. (Either `application/json` or `application/msgpack`) |
+| `datadog.tracer.writer.data_type`             | Payload data type. (Either `services` or `traces`)                          |

--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -17,6 +17,11 @@ module Datadog
 
     protected
 
+    def distribution(stat, value, options = nil)
+      return if statsd.nil?
+      statsd.distribution(stat, value, statsd_options(options))
+    end
+
     def increment(stat, options = nil)
       return if statsd.nil?
       statsd.increment(stat, statsd_options(options))

--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -19,30 +19,22 @@ module Datadog
 
     def increment(stat, options = nil)
       return if statsd.nil?
-      statsd.increment(stat, merge_with_defaults(options))
+      statsd.increment(stat, statsd_options(options))
     end
 
     def time(stat, options = nil, &block)
       return yield if statsd.nil?
-      statsd.time(stat, merge_with_defaults(options), &block)
+      statsd.time(stat, statsd_options(options), &block)
     end
 
-    private
+    def statsd_options(options = nil)
+      return DEFAULT_OPTIONS.dup if options.nil?
+      options.dup.merge(tags: statsd_tags(options[:tags]))
+    end
 
-    def merge_with_defaults(options)
-      if options.nil?
-        # Set default options
-        DEFAULT_OPTIONS.dup
-      else
-        # Add tags to options
-        options.dup.tap do |opts|
-          opts[:tags] = if opts.key?(:tags)
-                          opts[:tags].dup.concat(DEFAULT_TAGS)
-                        else
-                          DEFAULT_TAGS.dup
-                        end
-        end
-      end
+    def statsd_tags(tags = nil)
+      return DEFAULT_TAGS.dup if tags.nil?
+      DEFAULT_TAGS.dup.concat(tags)
     end
   end
 end

--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -22,6 +22,11 @@ module Datadog
       statsd.increment(stat, merge_with_defaults(options))
     end
 
+    def time(stat, options = nil, &block)
+      return yield if statsd.nil?
+      statsd.time(stat, merge_with_defaults(options), &block)
+    end
+
     private
 
     def merge_with_defaults(options)

--- a/lib/ddtrace/transport.rb
+++ b/lib/ddtrace/transport.rb
@@ -33,6 +33,8 @@ module Datadog
     METRIC_SUCCESS = 'datadog.tracer.transport.http.success'.freeze
 
     TAG_DATA_TYPE = 'datadog.tracer.transport.http.data_type'.freeze
+    TAG_DATA_TYPE_SERVICES = 'datadog.tracer.transport.http.data_type:services'.freeze
+    TAG_DATA_TYPE_TRACES = 'datadog.tracer.transport.http.data_type:traces'.freeze
     TAG_ENCODING_TYPE = 'datadog.tracer.transport.http.encoding_type'.freeze
 
     API = {
@@ -86,7 +88,7 @@ module Datadog
     def send(endpoint, data)
       case endpoint
       when :services
-        metric_options = { tags: ["#{TAG_DATA_TYPE}:services"] }
+        metric_options = { tags: [TAG_DATA_TYPE_SERVICES] }
         payload = time(METRIC_ENCODE_TIME, metric_options) do
           @encoder.encode_services(data)
         end
@@ -98,7 +100,7 @@ module Datadog
           process_callback(:services, response)
         end
       when :traces
-        metric_options = { tags: ["#{TAG_DATA_TYPE}:traces"] }
+        metric_options = { tags: [TAG_DATA_TYPE_TRACES] }
         count = data.length
         payload = time(METRIC_ENCODE_TIME, metric_options) do
           @encoder.encode_traces(data)
@@ -233,7 +235,7 @@ module Datadog
 
     def statsd_tags(tags = nil)
       super().tap do |default_tags|
-        default_tags << "#{TAG_ENCODING_TYPE}:#{@encoder.content_type}"
+        default_tags << "#{TAG_ENCODING_TYPE}:#{@encoder.content_type}".freeze
         default_tags.concat(tags) unless tags.nil?
       end
     end

--- a/lib/ddtrace/transport.rb
+++ b/lib/ddtrace/transport.rb
@@ -216,27 +216,20 @@ module Datadog
       500
     end
 
-    private
-
-    def increment(stat, options = nil)
-      # Add default options
-      super(stat, statsd_options(options))
-    end
-
-    def time(stat, options = nil)
-      # Add default options
-      super(stat, statsd_options(options))
-    end
+    protected
 
     def statsd_options(options = nil)
-      { tags: statsd_tags(options && options[:tags]) }
+      super().merge(tags: statsd_tags(options && options[:tags]))
     end
 
     def statsd_tags(tags = nil)
-      ["#{TAG_ENCODING_TYPE}:#{@encoder.content_type}"].tap do |default_tags|
+      super().tap do |default_tags|
+        default_tags << "#{TAG_ENCODING_TYPE}:#{@encoder.content_type}"
         default_tags.concat(tags) unless tags.nil?
       end
     end
+
+    private
 
     def log_error_once(*args)
       if @count_consecutive_errors > 0

--- a/lib/ddtrace/utils/time.rb
+++ b/lib/ddtrace/utils/time.rb
@@ -1,0 +1,14 @@
+module Datadog
+  module Utils
+    # Common database-related utility functions.
+    module Time
+      PROCESS_TIME_SUPPORTED = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1.0')
+
+      module_function
+
+      def get_time
+        PROCESS_TIME_SUPPORTED ? Process.clock_gettime(Process::CLOCK_MONOTONIC) : Time.now.to_f
+      end
+    end
+  end
+end

--- a/lib/ddtrace/utils/time.rb
+++ b/lib/ddtrace/utils/time.rb
@@ -7,7 +7,7 @@ module Datadog
       module_function
 
       def get_time
-        PROCESS_TIME_SUPPORTED ? Process.clock_gettime(Process::CLOCK_MONOTONIC) : Time.now.to_f
+        PROCESS_TIME_SUPPORTED ? Process.clock_gettime(Process::CLOCK_MONOTONIC) : ::Time.now.to_f
       end
     end
   end

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -21,6 +21,8 @@ module Datadog
     TAG_DATA_TYPE_SERVICES = "#{TAG_DATA_TYPE}:services".freeze
     TAG_DATA_TYPE_TRACES = "#{TAG_DATA_TYPE}:traces".freeze
     TAG_PRIORITY_SAMPLING = 'datadog.tracer.writer.priority_sampling'.freeze
+    TAG_PRIORITY_SAMPLING_DISABLED = 'datadog.tracer.writer.priority_sampling:false'.freeze
+    TAG_PRIORITY_SAMPLING_ENABLED = 'datadog.tracer.writer.priority_sampling:true'.freeze
 
     def initialize(options = {})
       # writer and transport parameters
@@ -123,7 +125,8 @@ module Datadog
     def sampling_updater(action, response, api)
       return unless action == :traces && response.is_a?(Net::HTTPOK)
 
-      time(METRIC_SAMPLING_UPDATE_TIME, tags: ["#{TAG_PRIORITY_SAMPLING}:#{!@priority_sampler.nil?}"]) do
+      priority_sampling_tag = !@priority_sampler.nil? ? TAG_PRIORITY_SAMPLING_ENABLED : TAG_PRIORITY_SAMPLING_DISABLED
+      time(METRIC_SAMPLING_UPDATE_TIME, tags: [priority_sampling_tag]) do
         if api[:version] == HTTPTransport::V4
           body = JSON.parse(response.body)
           if body.is_a?(Hash) && body.key?('rate_by_service')

--- a/spec/ddtrace/contrib/redis/integration_spec.rb
+++ b/spec/ddtrace/contrib/redis/integration_spec.rb
@@ -6,7 +6,7 @@ require 'hiredis'
 require 'ddtrace'
 
 RSpec.describe 'Redis integration test' do
-  include_context 'metric counts'
+  include_context 'metrics'
 
   # Use real tracer
   let(:tracer) do

--- a/spec/ddtrace/contrib/redis/integration_spec.rb
+++ b/spec/ddtrace/contrib/redis/integration_spec.rb
@@ -6,7 +6,7 @@ require 'hiredis'
 require 'ddtrace'
 
 RSpec.describe 'Redis integration test' do
-  include_context 'metrics'
+  include_context 'statsd'
 
   # Use real tracer
   let(:tracer) do

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -204,6 +204,9 @@ RSpec.describe 'Tracer integration tests' do
         try_wait_until(attempts: 30) { stats[Datadog::Writer::METRIC_TRACES_FLUSHED] >= i + 1 }
 
         expect(stats[Datadog::Writer::METRIC_TRACES_FLUSHED]).to eq(i + 1)
+        expect(statsd).to time_stat(Datadog::Writer::METRIC_SAMPLING_UPDATE_TIME)
+          .with(tags: ["#{Datadog::Writer::TAG_PRIORITY_SAMPLING}:true"])
+          .exactly(i + 1).times
         expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_CLIENT_ERROR).with(any_args)
         expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_SERVER_ERROR).with(any_args)
         expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_INTERNAL_ERROR).with(any_args)

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -207,11 +207,10 @@ RSpec.describe 'Tracer integration tests' do
         try_wait_until(attempts: 30) { stats[Datadog::Writer::METRIC_TRACES_FLUSHED] >= i + 1 }
 
         expect(stats[Datadog::Writer::METRIC_TRACES_FLUSHED]).to eq(i + 1)
-        expect(statsd).to have_received(:time)
-          .with(
-            Datadog::Writer::METRIC_SAMPLING_UPDATE_TIME,
-            metric_options(tags: ["#{Datadog::Writer::TAG_PRIORITY_SAMPLING}:true"])
-          ).exactly(i + 1).times
+        expect(statsd).to have_received_time_metric(
+          Datadog::Writer::METRIC_SAMPLING_UPDATE_TIME,
+          tags: ["#{Datadog::Writer::TAG_PRIORITY_SAMPLING}:true"]
+        ).exactly(i + 1).times
         expect_no_error_metrics
       end
     end

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe 'Tracer integration tests' do
 
     def agent_receives_span_step1
       expect(stats[Datadog::Writer::METRIC_TRACES_FLUSHED]).to eq(0)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_SUCCESS)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_CLIENT_ERROR)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_SERVER_ERROR)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_INTERNAL_ERROR)
+      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_SUCCESS).with(any_args)
+      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_CLIENT_ERROR).with(any_args)
+      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_SERVER_ERROR).with(any_args)
+      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_INTERNAL_ERROR).with(any_args)
     end
 
     def agent_receives_span_step2
@@ -59,9 +59,9 @@ RSpec.describe 'Tracer integration tests' do
       expect(statsd).to increment_stat(Datadog::HTTPTransport::METRIC_SUCCESS)
         .with(transport_options)
         .exactly(2).times
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_CLIENT_ERROR)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_SERVER_ERROR)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_INTERNAL_ERROR)
+      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_CLIENT_ERROR).with(any_args)
+      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_SERVER_ERROR).with(any_args)
+      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_INTERNAL_ERROR).with(any_args)
     end
 
     def agent_receives_span_step3
@@ -76,9 +76,9 @@ RSpec.describe 'Tracer integration tests' do
       expect(statsd).to increment_stat(Datadog::HTTPTransport::METRIC_SUCCESS)
         .with(transport_options)
         .exactly(3).times
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_CLIENT_ERROR)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_SERVER_ERROR)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_INTERNAL_ERROR)
+      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_CLIENT_ERROR).with(any_args)
+      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_SERVER_ERROR).with(any_args)
+      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_INTERNAL_ERROR).with(any_args)
     end
 
     it do
@@ -107,9 +107,9 @@ RSpec.describe 'Tracer integration tests' do
       expect(@span.finished?).to be true
       expect(statsd).to increment_stat(Datadog::Writer::METRIC_TRACES_FLUSHED).with(by: 1)
       expect(statsd).to increment_stat(Datadog::Writer::METRIC_SERVICES_FLUSHED)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_CLIENT_ERROR)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_SERVER_ERROR)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_INTERNAL_ERROR)
+      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_CLIENT_ERROR).with(any_args)
+      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_SERVER_ERROR).with(any_args)
+      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_INTERNAL_ERROR).with(any_args)
     end
   end
 
@@ -137,9 +137,9 @@ RSpec.describe 'Tracer integration tests' do
       expect(@shutdown_results.count(true)).to eq(1)
       expect(statsd).to increment_stat(Datadog::Writer::METRIC_TRACES_FLUSHED).with(by: 1)
       expect(statsd).to increment_stat(Datadog::Writer::METRIC_SERVICES_FLUSHED)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_CLIENT_ERROR)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_SERVER_ERROR)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_INTERNAL_ERROR)
+      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_CLIENT_ERROR).with(any_args)
+      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_SERVER_ERROR).with(any_args)
+      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_INTERNAL_ERROR).with(any_args)
     end
   end
 
@@ -204,9 +204,9 @@ RSpec.describe 'Tracer integration tests' do
         try_wait_until(attempts: 30) { stats[Datadog::Writer::METRIC_TRACES_FLUSHED] >= i + 1 }
 
         expect(stats[Datadog::Writer::METRIC_TRACES_FLUSHED]).to eq(i + 1)
-        expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_CLIENT_ERROR)
-        expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_SERVER_ERROR)
-        expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_INTERNAL_ERROR)
+        expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_CLIENT_ERROR).with(any_args)
+        expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_SERVER_ERROR).with(any_args)
+        expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_INTERNAL_ERROR).with(any_args)
       end
     end
   end

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -5,7 +5,7 @@ require 'ddtrace/tracer'
 require 'thread'
 
 RSpec.describe 'Tracer integration tests' do
-  include_context 'transport metric counts'
+  include_context 'transport metrics'
 
   shared_context 'agent-based test' do
     before(:each) { skip unless ENV['TEST_DATADOG_INTEGRATION'] }

--- a/spec/ddtrace/metrics_spec.rb
+++ b/spec/ddtrace/metrics_spec.rb
@@ -13,6 +13,52 @@ RSpec.describe Datadog::Metrics do
 
     it { is_expected.to have_attributes(statsd: nil) }
 
+    describe '#distribution' do
+      subject(:distribution) { test_object.send(:distribution, stat, value, options) }
+      let(:stat) { :foo }
+      let(:value) { 100 }
+      let(:options) { nil }
+
+      context 'when #statsd is nil' do
+        before(:each) { distribution }
+        it { expect(statsd).to_not have_received_distribution_metric(stat) }
+      end
+
+      context 'when #statsd is a Datadog::Statsd' do
+        before(:each) do
+          test_object.statsd = statsd
+          distribution
+        end
+
+        context 'and given no options' do
+          it { expect(statsd).to have_received_distribution_metric(stat) }
+        end
+
+        context 'and given options' do
+          context 'that are empty' do
+            let(:options) { {} }
+            it { expect(statsd).to have_received_distribution_metric(stat) }
+          end
+
+          context 'that are frozen' do
+            let(:options) { {}.freeze }
+            it { expect(statsd).to have_received_distribution_metric(stat) }
+          end
+
+          context 'that contain :tags' do
+            let(:options) { { tags: tags } }
+            let(:tags) { %w[foo bar] }
+            it { expect(statsd).to have_received_distribution_metric(stat, kind_of(Numeric), options) }
+
+            context 'which are frozen' do
+              let(:tags) { super().freeze }
+              it { expect(statsd).to have_received_distribution_metric(stat, kind_of(Numeric), options) }
+            end
+          end
+        end
+      end
+    end
+
     describe '#increment' do
       subject(:increment) { test_object.send(:increment, stat, options) }
       let(:stat) { :foo }
@@ -20,7 +66,7 @@ RSpec.describe Datadog::Metrics do
 
       context 'when #statsd is nil' do
         before(:each) { increment }
-        it { expect(statsd).to_not increment_stat(stat) }
+        it { expect(statsd).to_not have_received_increment_metric(stat) }
       end
 
       context 'when #statsd is a Datadog::Statsd' do
@@ -30,34 +76,84 @@ RSpec.describe Datadog::Metrics do
         end
 
         context 'and given no options' do
-          it { expect(statsd).to increment_stat(stat) }
+          it { expect(statsd).to have_received_increment_metric(stat) }
         end
 
         context 'and given options' do
           context 'that are empty' do
             let(:options) { {} }
-            it { expect(statsd).to increment_stat(stat) }
+            it { expect(statsd).to have_received_increment_metric(stat) }
           end
 
           context 'that are frozen' do
             let(:options) { {}.freeze }
-            it { expect(statsd).to increment_stat(stat) }
+            it { expect(statsd).to have_received_increment_metric(stat) }
           end
 
           context 'that contain :by' do
             let(:options) { { by: count } }
             let(:count) { 1 }
-            it { expect(statsd).to increment_stat(stat).with(options) }
+            it { expect(statsd).to have_received_increment_metric(stat, options) }
           end
 
           context 'that contain :tags' do
             let(:options) { { tags: tags } }
             let(:tags) { %w[foo bar] }
-            it { expect(statsd).to increment_stat(stat).with(options) }
+            it { expect(statsd).to have_received_increment_metric(stat, options) }
 
             context 'which are frozen' do
               let(:tags) { super().freeze }
-              it { expect(statsd).to increment_stat(stat).with(options) }
+              it { expect(statsd).to have_received_increment_metric(stat, options) }
+            end
+          end
+        end
+      end
+    end
+
+    describe '#time' do
+      subject(:time) { test_object.send(:time, stat, options, &block) }
+      let(:stat) { :foo }
+      let(:options) { nil }
+      let(:block) { proc {} }
+
+      context 'when #statsd is nil' do
+        before(:each) { time }
+        it { expect(statsd).to_not have_received_time_metric(stat) }
+      end
+
+      context 'when #statsd is a Datadog::Statsd' do
+        before(:each) do
+          test_object.statsd = statsd
+          time
+        end
+
+        context 'and given a block' do
+          it { expect { |b| test_object.send(:time, stat, &b) }.to yield_control }
+        end
+
+        context 'and given no options' do
+          it { expect(statsd).to have_received_time_metric(stat) }
+        end
+
+        context 'and given options' do
+          context 'that are empty' do
+            let(:options) { {} }
+            it { expect(statsd).to have_received_time_metric(stat) }
+          end
+
+          context 'that are frozen' do
+            let(:options) { {}.freeze }
+            it { expect(statsd).to have_received_time_metric(stat) }
+          end
+
+          context 'that contain :tags' do
+            let(:options) { { tags: tags } }
+            let(:tags) { %w[foo bar] }
+            it { expect(statsd).to have_received_time_metric(stat, options) }
+
+            context 'which are frozen' do
+              let(:tags) { super().freeze }
+              it { expect(statsd).to have_received_time_metric(stat, options) }
             end
           end
         end

--- a/spec/ddtrace/metrics_spec.rb
+++ b/spec/ddtrace/metrics_spec.rb
@@ -5,7 +5,7 @@ require 'ddtrace/metrics'
 require 'benchmark'
 
 RSpec.describe Datadog::Metrics do
-  include_context 'metric counts'
+  include_context 'metrics'
 
   describe 'implementing class' do
     subject(:test_object) { test_class.new }

--- a/spec/ddtrace/transport_payload_spec.rb
+++ b/spec/ddtrace/transport_payload_spec.rb
@@ -47,11 +47,23 @@ RSpec.describe 'Datadog::HTTPTransport payload' do
 
       expect(WebMock).to have_requested(:post, %r{#{hostname}:#{port}/v\d+\.\d+/traces})
 
-      expect(statsd).to increment_stat(Datadog::Writer::METRIC_TRACES_FLUSHED).with(by: 1).once
-      expect(statsd).to increment_stat(Datadog::HTTPTransport::METRIC_SUCCESS).with(transport_options)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_CLIENT_ERROR)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_SERVER_ERROR)
-      expect(statsd).to_not increment_stat(Datadog::HTTPTransport::METRIC_INTERNAL_ERROR)
+      expect(statsd).to have_received_increment_metric(Datadog::Writer::METRIC_TRACES_FLUSHED, by: 1).once
+      expect(statsd).to have_received_increment_transport_metric(Datadog::HTTPTransport::METRIC_SUCCESS)
+
+      expect(statsd).to_not have_received_increment_transport_metric(
+        Datadog::HTTPTransport::METRIC_CLIENT_ERROR,
+        any_args
+      )
+
+      expect(statsd).to_not have_received_increment_transport_metric(
+        Datadog::HTTPTransport::METRIC_SERVER_ERROR,
+        any_args
+      )
+
+      expect(statsd).to_not have_received_increment_transport_metric(
+        Datadog::HTTPTransport::METRIC_INTERNAL_ERROR,
+        any_args
+      )
     end
 
     let(:transport) { tracer.writer.transport }

--- a/spec/ddtrace/transport_payload_spec.rb
+++ b/spec/ddtrace/transport_payload_spec.rb
@@ -8,7 +8,7 @@ require 'ddtrace'
 require 'ddtrace/tracer'
 
 RSpec.describe 'Datadog::HTTPTransport payload' do
-  include_context 'transport metric counts'
+  include_context 'transport metrics'
 
   before(:each) do
     WebMock.enable!

--- a/spec/ddtrace/transport_spec.rb
+++ b/spec/ddtrace/transport_spec.rb
@@ -146,6 +146,12 @@ RSpec.describe Datadog::HTTPTransport do
                       tags: ["#{described_class::TAG_DATA_TYPE}:#{type}"] do
         let(:encoder) { encoder }
       end
+
+      it_behaves_like 'a transport operation that sends distribution stat',
+                      described_class::METRIC_PAYLOAD_SIZE,
+                      tags: ["#{described_class::TAG_DATA_TYPE}:#{type}"] do
+        let(:encoder) { encoder }
+      end
     end
 
     context 'traces' do

--- a/spec/ddtrace/transport_spec.rb
+++ b/spec/ddtrace/transport_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'ddtrace'
 
 RSpec.describe Datadog::HTTPTransport do
-  include_context 'transport metric counts'
+  include_context 'transport metrics'
 
   let(:transport) do
     described_class.new(

--- a/spec/ddtrace/workers_integration_spec.rb
+++ b/spec/ddtrace/workers_integration_spec.rb
@@ -9,7 +9,7 @@ require 'ddtrace/writer'
 require 'ddtrace/pipeline'
 
 RSpec.describe 'Datadog::Workers::AsyncTransport integration tests' do
-  include_context 'metric counts'
+  include_context 'metrics'
 
   let(:hostname) { 'http://127.0.0.1' }
   let(:port) { 1234 }

--- a/spec/ddtrace/writer_spec.rb
+++ b/spec/ddtrace/writer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Datadog::Writer do
   end
 
   describe 'instance' do
-    subject(:writer) { described_class.new(options) }
+    subject(:writer) { described_class.new(options).tap { |w| w.statsd = statsd } }
     let(:options) { {} }
 
     describe 'behavior' do
@@ -176,7 +176,7 @@ RSpec.describe Datadog::Writer do
                 before(:each) { expect(sampler).to receive(:update).with(service_rates) }
 
                 it { is_expected.to be true }
-                it_behaves_like 'an operation that times stat',
+                it_behaves_like 'an operation that sends time metric',
                                 Datadog::Writer::METRIC_SAMPLING_UPDATE_TIME,
                                 tags: ["#{Datadog::Writer::TAG_PRIORITY_SAMPLING}:true"]
               end
@@ -188,7 +188,7 @@ RSpec.describe Datadog::Writer do
                 before(:each) { expect(sampler).to_not receive(:update) }
 
                 it { is_expected.to be false }
-                it_behaves_like 'an operation that times stat',
+                it_behaves_like 'an operation that sends time metric',
                                 Datadog::Writer::METRIC_SAMPLING_UPDATE_TIME,
                                 tags: ["#{Datadog::Writer::TAG_PRIORITY_SAMPLING}:true"]
               end

--- a/spec/support/metric_helpers.rb
+++ b/spec/support/metric_helpers.rb
@@ -34,20 +34,14 @@ module MetricHelpers
       ]
     end
 
-    def merge_with_defaults(options)
-      if options.nil?
-        # Set default options
-        Datadog::Metrics::DEFAULT_OPTIONS.dup
-      else
-        # Add tags to options
-        options.dup.tap do |opts|
-          opts[:tags] = if opts.key?(:tags)
-                          opts[:tags].dup.concat(Datadog::Metrics::DEFAULT_TAGS)
-                        else
-                          Datadog::Metrics::DEFAULT_TAGS.dup
-                        end
-        end
-      end
+    def statsd_options(options = nil)
+      return Datadog::Metrics::DEFAULT_OPTIONS.dup if options.nil?
+      options.dup.merge(tags: statsd_tags(options[:tags]))
+    end
+
+    def statsd_tags(tags = nil)
+      return Datadog::Metrics::DEFAULT_TAGS.dup if tags.nil?
+      Datadog::Metrics::DEFAULT_TAGS.dup.concat(tags)
     end
   end
 
@@ -63,7 +57,7 @@ module MetricHelpers
     end
 
     def with(*args)
-      with_constraint[2] = merge_with_defaults(args.first)
+      with_constraint[2] = statsd_options(args.first)
       self
     end
 
@@ -90,7 +84,7 @@ module MetricHelpers
     end
 
     def with(*args)
-      with_constraint[2] = merge_with_defaults(args.first)
+      with_constraint[2] = statsd_options(args.first)
       self
     end
 

--- a/spec/support/metric_helpers.rb
+++ b/spec/support/metric_helpers.rb
@@ -36,6 +36,7 @@ module MetricHelpers
 
     def statsd_options(options = nil)
       return Datadog::Metrics::DEFAULT_OPTIONS.dup if options.nil?
+      return options unless options.kind_of?(Hash)
       options.dup.merge(tags: statsd_tags(options[:tags]))
     end
 

--- a/spec/support/statsd_helpers.rb
+++ b/spec/support/statsd_helpers.rb
@@ -1,0 +1,31 @@
+module StatsdHelpers
+  shared_context 'statsd' do
+    let(:statsd) { spy('statsd') } # TODO: Make this an instance double.
+    let(:stats) { Hash.new(0) }
+    let(:stats_mutex) { Mutex.new }
+
+    before(:each) do
+      allow(statsd).to receive(:distribution) do |name, _value, _options = {}|
+        stats_mutex.synchronize do
+          stats[name] = 0 unless stats.key?(name)
+          stats[name] += 1
+        end
+      end
+
+      allow(statsd).to receive(:increment) do |name, options = {}|
+        stats_mutex.synchronize do
+          stats[name] = 0 unless stats.key?(name)
+          stats[name] += options.key?(:by) ? options[:by] : 1
+        end
+      end
+
+      allow(statsd).to receive(:time) do |name, _options = {}, &block|
+        stats_mutex.synchronize do
+          stats[name] = 0 unless stats.key?(name)
+          stats[name] += 1
+        end
+        block.call
+      end
+    end
+  end
+end


### PR DESCRIPTION
Building off of #594 and #595 , this pull request adds a number of other internal tracing metrics to give more insight into the health of the tracer.

The following metrics are added with the additional following tags:

- *distribution* `datadog.tracer.transport.http.encode_time`: Time to encode the payload.
  - `datadog.tracer.transport.http.encoding_type`: Encoding type of data (either `application/json` or `application/msgpack`)
  - `datadog.tracer.transport.http.data_type`: Type of data encoded (either `services` or `traces`)
- *distribution* `datadog.tracer.transport.http.payload_size`: Byte size of the payload.
  - `datadog.tracer.transport.http.encoding_type`: Encoding type of data (either `application/json` or `application/msgpack`)
  - `datadog.tracer.transport.http.data_type`: Type of data encoded (either `services` or `traces`)
- *distribution* `datadog.tracer.transport.http.post_time`: Time to POST, excluding TCP connect.
  - `datadog.tracer.transport.http.data_type`: Type of data encoded (either `services` or `traces`)
- *distribution* `datadog.tracer.transport.http.roundtrip_time`: Time to TCP connect and POST.
  - `datadog.tracer.transport.http.data_type`: Type of data encoded (either `services` or `traces`)
- *distribution* `datadog.tracer.sampling_update_time`: Time to update sampling rates.
  - `datadog.tracer.priority_sampler`: Is priority sampling enabled. (either `true` or `false`)
- *distribution* `datadog.tracer.writer.flush_time`: Time to encode, TCP, POST and callback.
  - `datadog.tracer.writer.http.data_type`: Type of data encoded (either `services` or `traces`)