### PR TITLE
Change encoders from classes to modules

### DIFF
--- a/lib/ddtrace/encoding.rb
+++ b/lib/ddtrace/encoding.rb
@@ -5,14 +5,9 @@ module Datadog
   # Encoding module that encodes data for the AgentTransport
   module Encoding
     # Encoder interface that provides the logic to encode traces and service
-    class Encoder
-      attr_reader :content_type
-
-      # When extending the ``Encoder`` class, ``content_type`` must be set because
-      # they're used by the HTTPTransport so that it should not need to know what is
-      # the right header to suggest the decoding format to the agent
-      def initialize
-        @content_type = ''
+    module Encoder
+      def content_type
+        raise NotImplementedError
       end
 
       # Encodes a list of traces, expecting a list of items where each items
@@ -39,10 +34,15 @@ module Datadog
     end
 
     # Encoder for the JSON format
-    class JSONEncoder < Encoder
-      def initialize
-        Datadog::Tracer.log.debug('using JSON encoder; application performance may be degraded')
-        @content_type = 'application/json'
+    module JSONEncoder
+      extend Encoder
+
+      CONTENT_TYPE = 'application/json'.freeze
+
+      module_function
+
+      def content_type
+        CONTENT_TYPE
       end
 
       def encode(obj)
@@ -51,10 +51,15 @@ module Datadog
     end
 
     # Encoder for the Msgpack format
-    class MsgpackEncoder < Encoder
-      def initialize
-        Datadog::Tracer.log.debug('using Msgpack encoder')
-        @content_type = 'application/msgpack'
+    module MsgpackEncoder
+      extend Encoder
+
+      module_function
+
+      CONTENT_TYPE = 'application/msgpack'.freeze
+
+      def content_type
+        CONTENT_TYPE
       end
 
       def encode(obj)

--- a/lib/ddtrace/transport.rb
+++ b/lib/ddtrace/transport.rb
@@ -51,7 +51,7 @@ module Datadog
       @hostname = hostname
       @port = port
       @api = API.fetch(api_version)
-      @encoder = options[:encoder] || @api[:encoder].new
+      @encoder = options[:encoder] || @api[:encoder]
       @response_callback = options[:response_callback]
 
       # overwrite the Content-type with the one chosen in the Encoder
@@ -127,7 +127,7 @@ module Datadog
         fallback_version = @api.fetch(:fallback)
 
         @api = API.fetch(fallback_version)
-        @encoder = @api[:encoder].new
+        @encoder = @api[:encoder]
         @headers['Content-Type'] = @encoder.content_type
       end
     end

--- a/spec/ddtrace/transport_spec.rb
+++ b/spec/ddtrace/transport_spec.rb
@@ -40,12 +40,12 @@ RSpec.describe Datadog::HTTPTransport do
 
     shared_examples_for 'an encoded transport' do
       context 'for a JSON-encoded transport' do
-        let(:options) { { encoder: Datadog::Encoding::JSONEncoder.new } }
+        let(:options) { { encoder: Datadog::Encoding::JSONEncoder } }
         it { expect(transport.success?(code)).to be true }
       end
 
       context 'for a Msgpack-encoded transport' do
-        let(:options) { { encoder: Datadog::Encoding::MsgpackEncoder.new } }
+        let(:options) { { encoder: Datadog::Encoding::MsgpackEncoder } }
         it { expect(transport.success?(code)).to be true }
       end
     end

--- a/spec/support/spy_transport.rb
+++ b/spec/support/spy_transport.rb
@@ -10,7 +10,7 @@ class SpyTransport < Datadog::HTTPTransport
     @helper_sent = { 200 => {}, 500 => {} }
     @helper_mutex = Mutex.new
     @helper_error_mode = false
-    @helper_encoder = Datadog::Encoding::JSONEncoder.new() # easiest to inspect
+    @helper_encoder = Datadog::Encoding::JSONEncoder # easiest to inspect
   end
 
   def send(endpoint, data)

--- a/test/benchmark_test.rb
+++ b/test/benchmark_test.rb
@@ -32,7 +32,7 @@ class EncoderTest < Minitest::Test
   def test_benchmark_json_encoder
     # create and finish a huge number of spans with a single thread
     traces = get_test_traces(50)
-    json_encoder = Datadog::Encoding::JSONEncoder.new()
+    json_encoder = Datadog::Encoding::JSONEncoder
 
     Benchmark.benchmark(CAPTION, 7, FORMAT, '>total:', '>avg:') do |x|
       x.report("Encoding #{traces.length} traces with JSON:") do
@@ -44,7 +44,7 @@ class EncoderTest < Minitest::Test
   def test_benchmark_msgpack_encoder
     # create and finish a huge number of spans with a single thread
     traces = get_test_traces(50)
-    msgpack_encoder = Datadog::Encoding::MsgpackEncoder.new()
+    msgpack_encoder = Datadog::Encoding::MsgpackEncoder
 
     Benchmark.benchmark(CAPTION, 7, FORMAT, '>total:', '>avg:') do |x|
       x.report("Encoding #{traces.length} traces with Msgpack:") do

--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -5,7 +5,7 @@ require 'ddtrace/encoding'
 class TracerTest < Minitest::Test
   def test_traces_encoding_json
     # test encoding for JSON format
-    encoder = Datadog::Encoding::JSONEncoder.new()
+    encoder = Datadog::Encoding::JSONEncoder
     traces = get_test_traces(2)
     to_send = encoder.encode_traces(traces)
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -160,7 +160,7 @@ class SpyTransport < Datadog::HTTPTransport
     @helper_sent = { 200 => {}, 500 => {} }
     @helper_mutex = Mutex.new
     @helper_error_mode = false
-    @helper_encoder = Datadog::Encoding::JSONEncoder.new() # easiest to inspect
+    @helper_encoder = Datadog::Encoding::JSONEncoder # easiest to inspect
   end
 
   def send(endpoint, data)


### PR DESCRIPTION
As a minor improvement, this pull request converts the existing Encoder classes to modules, which primarily benefits performance and use of these modules.

The use of these don't fit the class/subclass paradigm very well, considering that different instantiations of the same encoder never vary in data, and the functions on these are often used in a more functional way (as opposed to an object oriented way.) Their behavior is more suited for module composition, so converting these to modules allows us to save a little bit on memory allocation while making it easier to use.