### PR TITLE
Sidekiq client-side tracing

### DIFF
--- a/lib/ddtrace/contrib/sidekiq/base_tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/base_tracer.rb
@@ -4,6 +4,8 @@ require 'ddtrace/contrib/sidekiq/ext'
 module Datadog
   module Contrib
     module Sidekiq
+      # Abstract class with common functionality used by both client-side and
+      # server-side tracers.
       class BaseTracer
         def initialize(options = {})
           @tracer = options[:tracer] || Datadog.configuration[:sidekiq][:tracer]

--- a/lib/ddtrace/contrib/sidekiq/base_tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/base_tracer.rb
@@ -1,0 +1,64 @@
+require 'ddtrace/ext/app_types'
+require 'ddtrace/contrib/sidekiq/ext'
+
+module Datadog
+  module Contrib
+    module Sidekiq
+      class BaseTracer
+        def initialize(options = {})
+          @tracer = options[:tracer] || Datadog.configuration[:sidekiq][:tracer]
+          @sidekiq_service = options[:service_name] || Datadog.configuration[:sidekiq][:service_name]
+        end
+
+        protected
+
+        # If class is wrapping something else, the interesting resource info
+        # is the underlying, wrapped class, and not the wrapper. This is
+        # primarily to support `ActiveJob`.
+        def job_resource(job)
+          if job['wrapped']
+            job['wrapped']
+          else
+            job['class']
+          end
+        end
+
+        # Extract any custom tracer configuration from the worker class.
+        def worker_config(worker_klass)
+          if worker_klass.respond_to?(:datadog_tracer_config)
+            worker_klass.datadog_tracer_config
+          else
+            {}
+          end
+        end
+
+        def sidekiq_service(resource)
+          # The resource (ie. a worker) might already be a class or it might
+          # be a string class name.
+          klass = if resource.is_a?(Class)
+                    resource
+                  else
+                    begin
+                      Object.const_get(resource)
+                    rescue NameError
+                      nil
+                    end
+                  end
+
+          service = worker_config(klass).fetch(:service_name, @sidekiq_service)
+
+          # Ensure the tracer knows about this service.
+          unless @tracer.services[service]
+            @tracer.set_service_info(
+              service,
+              Ext::APP,
+              Datadog::Ext::AppTypes::WORKER
+            )
+          end
+
+          service
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/sidekiq/client_tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/client_tracer.rb
@@ -1,0 +1,36 @@
+require 'sidekiq/api'
+
+require 'ddtrace/ext/app_types'
+require 'ddtrace/contrib/sidekiq/ext'
+
+module Datadog
+  module Contrib
+    module Sidekiq
+      # Tracer is a Sidekiq client-side middleware which traces job enqueues/pushes
+      class ClientTracer
+        def initialize(options = {})
+          @tracer = options[:tracer] || Datadog.configuration[:sidekiq][:tracer]
+        end
+
+        # Client middleware arguments are documented here:
+        #   https://github.com/mperham/sidekiq/wiki/Middleware#client-middleware
+        def call(worker_class, job, queue, redis_pool)
+          resource = if job['wrapped']
+                       job['wrapped']
+                     else
+                       job['class']
+                     end
+
+          @tracer.trace(Ext::SPAN_PUSH, span_type: Datadog::Ext::AppTypes::WORKER) do |span|
+            span.resource = resource
+            span.set_tag(Ext::TAG_JOB_ID, job['jid'])
+            span.set_tag(Ext::TAG_JOB_QUEUE, job['queue'])
+            span.set_tag(Ext::TAG_JOB_WRAPPER, job['class']) if job['wrapped']
+
+            yield
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/sidekiq/client_tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/client_tracer.rb
@@ -21,7 +21,7 @@ module Datadog
                        job['class']
                      end
 
-          @tracer.trace(Ext::SPAN_PUSH, span_type: Datadog::Ext::AppTypes::WORKER) do |span|
+          @tracer.trace(Ext::SPAN_PUSH) do |span|
             span.resource = resource
             span.set_tag(Ext::TAG_JOB_ID, job['jid'])
             span.set_tag(Ext::TAG_JOB_QUEUE, job['queue'])

--- a/lib/ddtrace/contrib/sidekiq/client_tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/client_tracer.rb
@@ -1,10 +1,12 @@
-require 'ddtrace/contrib/sidekiq/base_tracer'
+require 'ddtrace/contrib/sidekiq/tracing'
 
 module Datadog
   module Contrib
     module Sidekiq
       # Tracer is a Sidekiq client-side middleware which traces job enqueues/pushes
-      class ClientTracer < BaseTracer
+      class ClientTracer
+        include Tracing
+
         # Client middleware arguments are documented here:
         #   https://github.com/mperham/sidekiq/wiki/Middleware#client-middleware
         def call(worker_class, job, queue, redis_pool)

--- a/lib/ddtrace/contrib/sidekiq/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sidekiq/configuration/settings.rb
@@ -8,6 +8,7 @@ module Datadog
         # Custom settings for the Sidekiq integration
         class Settings < Contrib::Configuration::Settings
           option :service_name, default: Ext::SERVICE_NAME
+          option :client_service_name, default: Ext::CLIENT_SERVICE_NAME
         end
       end
     end

--- a/lib/ddtrace/contrib/sidekiq/ext.rb
+++ b/lib/ddtrace/contrib/sidekiq/ext.rb
@@ -5,6 +5,7 @@ module Datadog
       module Ext
         APP = 'sidekiq'.freeze
         SERVICE_NAME = 'sidekiq'.freeze
+        CLIENT_SERVICE_NAME = 'sidekiq-client'.freeze
 
         SPAN_PUSH = 'sidekiq.push'.freeze
         SPAN_JOB = 'sidekiq.job'.freeze

--- a/lib/ddtrace/contrib/sidekiq/ext.rb
+++ b/lib/ddtrace/contrib/sidekiq/ext.rb
@@ -6,6 +6,7 @@ module Datadog
         APP = 'sidekiq'.freeze
         SERVICE_NAME = 'sidekiq'.freeze
 
+        SPAN_PUSH = 'sidekiq.push'.freeze
         SPAN_JOB = 'sidekiq.job'.freeze
 
         TAG_JOB_DELAY = 'sidekiq.job.delay'.freeze

--- a/lib/ddtrace/contrib/sidekiq/patcher.rb
+++ b/lib/ddtrace/contrib/sidekiq/patcher.rb
@@ -16,6 +16,13 @@ module Datadog
         def patch
           do_once(:sidekiq) do
             begin
+              require 'ddtrace/contrib/sidekiq/client_tracer'
+              ::Sidekiq.configure_client do |config|
+                config.client_middleware do |chain|
+                  chain.add(Sidekiq::ClientTracer)
+                end
+              end
+
               require 'ddtrace/contrib/sidekiq/server_tracer'
               ::Sidekiq.configure_server do |config|
                 config.server_middleware do |chain|

--- a/lib/ddtrace/contrib/sidekiq/patcher.rb
+++ b/lib/ddtrace/contrib/sidekiq/patcher.rb
@@ -16,10 +16,10 @@ module Datadog
         def patch
           do_once(:sidekiq) do
             begin
-              require 'ddtrace/contrib/sidekiq/tracer'
+              require 'ddtrace/contrib/sidekiq/server_tracer'
               ::Sidekiq.configure_server do |config|
                 config.server_middleware do |chain|
-                  chain.add(Sidekiq::Tracer)
+                  chain.add(Sidekiq::ServerTracer)
                 end
               end
             rescue StandardError => e

--- a/lib/ddtrace/contrib/sidekiq/server_tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/server_tracer.rb
@@ -1,30 +1,13 @@
-require 'sidekiq/api'
-
-require 'ddtrace/ext/app_types'
-require 'ddtrace/contrib/sidekiq/ext'
+require 'ddtrace/contrib/sidekiq/base_tracer'
 
 module Datadog
   module Contrib
     module Sidekiq
       # Tracer is a Sidekiq server-side middleware which traces executed jobs
-      class ServerTracer
-        def initialize(options = {})
-          @tracer = options[:tracer] || Datadog.configuration[:sidekiq][:tracer]
-          @sidekiq_service = options[:service_name] || Datadog.configuration[:sidekiq][:service_name]
-        end
-
+      class ServerTracer < BaseTracer
         def call(worker, job, queue)
-          # If class is wrapping something else, the interesting resource info
-          # is the underlying, wrapped class, and not the wrapper.
-          resource = if job['wrapped']
-                       job['wrapped']
-                     else
-                       job['class']
-                     end
-
-          # configure Sidekiq service
-          service = sidekiq_service(resource_worker(resource))
-          set_service_info(service)
+          resource = job_resource(job)
+          service = sidekiq_service(resource)
 
           @tracer.trace(Ext::SPAN_JOB, service: service, span_type: Datadog::Ext::AppTypes::WORKER) do |span|
             span.resource = resource
@@ -36,35 +19,6 @@ module Datadog
 
             yield
           end
-        end
-
-        private
-
-        # rubocop:disable Lint/HandleExceptions
-        def resource_worker(resource)
-          Object.const_get(resource)
-        rescue NameError
-        end
-
-        def worker_config(worker)
-          if worker.respond_to?(:datadog_tracer_config)
-            worker.datadog_tracer_config
-          else
-            {}
-          end
-        end
-
-        def sidekiq_service(resource)
-          worker_config(resource).fetch(:service_name, @sidekiq_service)
-        end
-
-        def set_service_info(service)
-          return if @tracer.services[service]
-          @tracer.set_service_info(
-            service,
-            Ext::APP,
-            Datadog::Ext::AppTypes::WORKER
-          )
         end
       end
     end

--- a/lib/ddtrace/contrib/sidekiq/server_tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/server_tracer.rb
@@ -1,10 +1,12 @@
-require 'ddtrace/contrib/sidekiq/base_tracer'
+require 'ddtrace/contrib/sidekiq/tracing'
 
 module Datadog
   module Contrib
     module Sidekiq
       # Tracer is a Sidekiq server-side middleware which traces executed jobs
-      class ServerTracer < BaseTracer
+      class ServerTracer
+        include Tracing
+
         def call(worker, job, queue)
           resource = job_resource(job)
           service = sidekiq_service(resource)

--- a/lib/ddtrace/contrib/sidekiq/server_tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/server_tracer.rb
@@ -7,7 +7,7 @@ module Datadog
   module Contrib
     module Sidekiq
       # Tracer is a Sidekiq server-side middleware which traces executed jobs
-      class Tracer
+      class ServerTracer
         def initialize(options = {})
           @tracer = options[:tracer] || Datadog.configuration[:sidekiq][:tracer]
           @sidekiq_service = options[:service_name] || Datadog.configuration[:sidekiq][:service_name]

--- a/lib/ddtrace/contrib/sidekiq/tracing.rb
+++ b/lib/ddtrace/contrib/sidekiq/tracing.rb
@@ -8,7 +8,6 @@ module Datadog
       module Tracing
         def initialize(options = {})
           @tracer = options[:tracer] || Datadog.configuration[:sidekiq][:tracer]
-          @sidekiq_service = options[:service_name] || Datadog.configuration[:sidekiq][:service_name]
         end
 
         protected
@@ -24,40 +23,14 @@ module Datadog
           end
         end
 
-        # Extract any custom tracer configuration from the worker class.
-        def worker_config(worker_klass)
-          if worker_klass.respond_to?(:datadog_tracer_config)
-            worker_klass.datadog_tracer_config
-          else
-            {}
-          end
-        end
-
-        def sidekiq_service(resource)
-          # The resource (ie. a worker) might already be a class or it might
-          # be a string class name.
-          klass = if resource.is_a?(Class)
-                    resource
-                  else
-                    begin
-                      Object.const_get(resource)
-                    rescue NameError
-                      nil
-                    end
-                  end
-
-          service = worker_config(klass).fetch(:service_name, @sidekiq_service)
-
+        def set_service_info(service)
           # Ensure the tracer knows about this service.
-          unless @tracer.services[service]
-            @tracer.set_service_info(
-              service,
-              Ext::APP,
-              Datadog::Ext::AppTypes::WORKER
-            )
-          end
-
-          service
+          return if @tracer.services[service]
+          @tracer.set_service_info(
+            service,
+            Ext::APP,
+            Datadog::Ext::AppTypes::WORKER
+          )
         end
       end
     end

--- a/lib/ddtrace/contrib/sidekiq/tracing.rb
+++ b/lib/ddtrace/contrib/sidekiq/tracing.rb
@@ -4,9 +4,8 @@ require 'ddtrace/contrib/sidekiq/ext'
 module Datadog
   module Contrib
     module Sidekiq
-      # Abstract class with common functionality used by both client-side and
-      # server-side tracers.
-      class BaseTracer
+      # Common functionality used by both client-side and server-side tracers.
+      module Tracing
         def initialize(options = {})
           @tracer = options[:tracer] || Datadog.configuration[:sidekiq][:tracer]
           @sidekiq_service = options[:service_name] || Datadog.configuration[:sidekiq][:service_name]

--- a/spec/ddtrace/contrib/rails/support/base.rb
+++ b/spec/ddtrace/contrib/rails/support/base.rb
@@ -3,7 +3,7 @@ require 'ddtrace'
 
 if ENV['USE_SIDEKIQ']
   require 'sidekiq/testing'
-  require 'ddtrace/contrib/sidekiq/tracer'
+  require 'ddtrace/contrib/sidekiq/server_tracer'
 end
 
 RSpec.shared_context 'Rails base application' do

--- a/spec/ddtrace/contrib/rails/support/rails3.rb
+++ b/spec/ddtrace/contrib/rails/support/rails3.rb
@@ -3,7 +3,7 @@ require 'ddtrace'
 
 if ENV['USE_SIDEKIQ']
   require 'sidekiq/testing'
-  require 'ddtrace/contrib/sidekiq/tracer'
+  require 'ddtrace/contrib/sidekiq/server_tracer'
 end
 
 require 'ddtrace/contrib/rails/support/controllers'

--- a/spec/ddtrace/contrib/rails/support/rails4.rb
+++ b/spec/ddtrace/contrib/rails/support/rails4.rb
@@ -3,7 +3,7 @@ require 'ddtrace'
 
 if ENV['USE_SIDEKIQ']
   require 'sidekiq/testing'
-  require 'ddtrace/contrib/sidekiq/tracer'
+  require 'ddtrace/contrib/sidekiq/server_tracer'
 end
 
 require 'ddtrace/contrib/rails/support/controllers'
@@ -43,7 +43,7 @@ RSpec.shared_context 'Rails 4 base application' do
         # add Sidekiq middleware
         Sidekiq::Testing.server_middleware do |chain|
           chain.add(
-            Datadog::Contrib::Sidekiq::Tracer
+            Datadog::Contrib::Sidekiq::ServerTracer
           )
         end
       end

--- a/spec/ddtrace/contrib/rails/support/rails5.rb
+++ b/spec/ddtrace/contrib/rails/support/rails5.rb
@@ -3,7 +3,7 @@ require 'ddtrace'
 
 if ENV['USE_SIDEKIQ']
   require 'sidekiq/testing'
-  require 'ddtrace/contrib/sidekiq/tracer'
+  require 'ddtrace/contrib/sidekiq/server_tracer'
 end
 
 require 'ddtrace/contrib/rails/support/controllers'
@@ -41,7 +41,7 @@ RSpec.shared_context 'Rails 5 base application' do
         # add Sidekiq middleware
         Sidekiq::Testing.server_middleware do |chain|
           chain.add(
-            Datadog::Contrib::Sidekiq::Tracer
+            Datadog::Contrib::Sidekiq::ServerTracer
           )
         end
       end

--- a/test/contrib/rails/apps/application.rb
+++ b/test/contrib/rails/apps/application.rb
@@ -3,7 +3,7 @@ require 'rails/test_help'
 require 'ddtrace'
 if ENV['USE_SIDEKIQ']
   require 'sidekiq/testing'
-  require 'ddtrace/contrib/sidekiq/tracer'
+  require 'ddtrace/contrib/sidekiq/server_tracer'
 end
 
 module RailsTrace
@@ -25,7 +25,7 @@ module RailsTrace
         # add Sidekiq middleware
         Sidekiq::Testing.server_middleware do |chain|
           chain.add(
-            Datadog::Contrib::Sidekiq::Tracer
+            Datadog::Contrib::Sidekiq::ServerTracer
           )
         end
       end

--- a/test/contrib/rails/rails_active_job_test.rb
+++ b/test/contrib/rails/rails_active_job_test.rb
@@ -7,7 +7,7 @@ ENV['USE_SIDEKIQ'] = 'true'
 require 'helper'
 require 'sidekiq/testing'
 require 'contrib/rails/test_helper'
-require 'ddtrace/contrib/sidekiq/tracer'
+require 'ddtrace/contrib/sidekiq/server_tracer'
 require 'active_job'
 
 class RailsActiveJobTest < ActionController::TestCase

--- a/test/contrib/rails/rails_sidekiq_test.rb
+++ b/test/contrib/rails/rails_sidekiq_test.rb
@@ -4,7 +4,7 @@
 require 'helper'
 require 'sidekiq/testing'
 require 'contrib/rails/test_helper'
-require 'ddtrace/contrib/sidekiq/tracer'
+require 'ddtrace/contrib/sidekiq/server_tracer'
 
 class RailsSidekiqTest < ActionController::TestCase
   setup do
@@ -43,7 +43,7 @@ class RailsSidekiqTest < ActionController::TestCase
 
     # add Sidekiq middleware
     Sidekiq::Testing.server_middleware do |chain|
-      chain.add(Datadog::Contrib::Sidekiq::Tracer, tracer: @tracer, service_name: 'rails-sidekiq')
+      chain.add(Datadog::Contrib::Sidekiq::ServerTracer, tracer: @tracer, service_name: 'rails-sidekiq')
     end
 
     # do something to force middleware execution

--- a/test/contrib/sidekiq/client_tracer_test.rb
+++ b/test/contrib/sidekiq/client_tracer_test.rb
@@ -1,0 +1,44 @@
+require 'contrib/sidekiq/tracer_test_base'
+
+class ClientTracerTest < TracerTestBase
+  class EmptyWorker
+    include Sidekiq::Worker
+
+    def perform(); end
+  end
+
+  def setup
+    super
+
+    Sidekiq.configure_client do |config|
+      config.client_middleware.clear
+
+      config.client_middleware do |chain|
+        chain.add(Datadog::Contrib::Sidekiq::ClientTracer,
+                  tracer: @tracer, enabled: true)
+      end
+    end
+
+    Sidekiq::Testing.server_middleware.clear
+  end
+
+  def test_empty
+    @tracer.trace('parent.span', service: 'parent-service') do
+      EmptyWorker.perform_async
+    end
+
+    spans = @writer.spans
+    assert_equal(2, spans.length)
+
+    parent_span = spans[0]
+    assert_equal('parent.span', parent_span.name)
+    assert_equal(0, parent_span.status)
+    assert_nil(parent_span.parent)
+
+    child_span = spans[1]
+    assert_equal('ClientTracerTest::EmptyWorker', child_span.resource)
+    assert_equal('default', child_span.get_tag('sidekiq.job.queue'))
+    assert_equal(0, child_span.status)
+    assert_equal(parent_span, child_span.parent)
+  end
+end

--- a/test/contrib/sidekiq/client_tracer_test.rb
+++ b/test/contrib/sidekiq/client_tracer_test.rb
@@ -36,7 +36,7 @@ class ClientTracerTest < TracerTestBase
     assert_equal(0, parent_span.status)
     assert_nil(parent_span.parent)
 
-    assert_equal('sidekiq', child_span.service)
+    assert_equal('sidekiq-client', child_span.service)
     assert_equal('ClientTracerTest::EmptyWorker', child_span.resource)
     assert_equal('default', child_span.get_tag('sidekiq.job.queue'))
     assert_equal(0, child_span.status)
@@ -50,7 +50,7 @@ class ClientTracerTest < TracerTestBase
     assert_equal(1, spans.length)
 
     span = spans.first
-    assert_equal('sidekiq', span.service)
+    assert_equal('sidekiq-client', span.service)
     assert_equal('ClientTracerTest::EmptyWorker', span.resource)
     assert_equal('default', span.get_tag('sidekiq.job.queue'))
     assert_equal(0, span.status)

--- a/test/contrib/sidekiq/client_tracer_test.rb
+++ b/test/contrib/sidekiq/client_tracer_test.rb
@@ -30,12 +30,12 @@ class ClientTracerTest < TracerTestBase
     spans = @writer.spans
     assert_equal(2, spans.length)
 
-    parent_span = spans[0]
+    parent_span, child_span = spans
+
     assert_equal('parent.span', parent_span.name)
     assert_equal(0, parent_span.status)
     assert_nil(parent_span.parent)
 
-    child_span = spans[1]
     assert_equal('sidekiq', child_span.service)
     assert_equal('ClientTracerTest::EmptyWorker', child_span.resource)
     assert_equal('default', child_span.get_tag('sidekiq.job.queue'))

--- a/test/contrib/sidekiq/client_tracer_test.rb
+++ b/test/contrib/sidekiq/client_tracer_test.rb
@@ -42,4 +42,18 @@ class ClientTracerTest < TracerTestBase
     assert_equal(0, child_span.status)
     assert_equal(parent_span, child_span.parent)
   end
+
+  def test_empty_parentless
+    EmptyWorker.perform_async
+
+    spans = @writer.spans
+    assert_equal(1, spans.length)
+
+    span = spans.first
+    assert_equal('sidekiq', span.service)
+    assert_equal('ClientTracerTest::EmptyWorker', span.resource)
+    assert_equal('default', span.get_tag('sidekiq.job.queue'))
+    assert_equal(0, span.status)
+    assert_nil(span.parent)
+  end
 end

--- a/test/contrib/sidekiq/client_tracer_test.rb
+++ b/test/contrib/sidekiq/client_tracer_test.rb
@@ -36,6 +36,7 @@ class ClientTracerTest < TracerTestBase
     assert_nil(parent_span.parent)
 
     child_span = spans[1]
+    assert_equal('sidekiq', child_span.service)
     assert_equal('ClientTracerTest::EmptyWorker', child_span.resource)
     assert_equal('default', child_span.get_tag('sidekiq.job.queue'))
     assert_equal(0, child_span.status)

--- a/test/contrib/sidekiq/disabled_tracer_test.rb
+++ b/test/contrib/sidekiq/disabled_tracer_test.rb
@@ -13,7 +13,7 @@ class DisabledTracerTest < TracerTestBase
 
     Sidekiq::Testing.server_middleware do |chain|
       @tracer.configure(enabled: false)
-      chain.add(Datadog::Contrib::Sidekiq::Tracer, tracer: @tracer)
+      chain.add(Datadog::Contrib::Sidekiq::ServerTracer, tracer: @tracer)
     end
   end
 

--- a/test/contrib/sidekiq/server_tracer_test.rb
+++ b/test/contrib/sidekiq/server_tracer_test.rb
@@ -47,7 +47,7 @@ class ServerTracerTest < TracerTestBase
 
     span = spans[0]
     assert_equal('sidekiq', span.service)
-    assert_equal('TracerTest::EmptyWorker', span.resource)
+    assert_equal('ServerTracerTest::EmptyWorker', span.resource)
     assert_equal('default', span.get_tag('sidekiq.job.queue'))
     refute_nil(span.get_tag('sidekiq.job.delay'))
     assert_equal(0, span.status)
@@ -69,12 +69,12 @@ class ServerTracerTest < TracerTestBase
 
     span = spans[0]
     assert_equal('sidekiq', span.service)
-    assert_equal('TracerTest::ErrorWorker', span.resource)
+    assert_equal('ServerTracerTest::ErrorWorker', span.resource)
     assert_equal('default', span.get_tag('sidekiq.job.queue'))
     refute_nil(span.get_tag('sidekiq.job.delay'))
     assert_equal(1, span.status)
     assert_equal('job error', span.get_tag(Datadog::Ext::Errors::MSG))
-    assert_equal('TracerTest::TestError', span.get_tag(Datadog::Ext::Errors::TYPE))
+    assert_equal('ServerTracerTest::TestError', span.get_tag(Datadog::Ext::Errors::TYPE))
     assert_nil(span.parent)
   end
 
@@ -91,14 +91,14 @@ class ServerTracerTest < TracerTestBase
     custom, empty = spans
 
     assert_equal('sidekiq', empty.service)
-    assert_equal('TracerTest::EmptyWorker', empty.resource)
+    assert_equal('ServerTracerTest::EmptyWorker', empty.resource)
     assert_equal('default', empty.get_tag('sidekiq.job.queue'))
     refute_nil(empty.get_tag('sidekiq.job.delay'))
     assert_equal(0, empty.status)
     assert_nil(empty.parent)
 
     assert_equal('sidekiq-slow', custom.service)
-    assert_equal('TracerTest::CustomWorker', custom.resource)
+    assert_equal('ServerTracerTest::CustomWorker', custom.resource)
     assert_equal('default', custom.get_tag('sidekiq.job.queue'))
     assert_equal(0, custom.status)
     assert_nil(custom.parent)

--- a/test/contrib/sidekiq/server_tracer_test.rb
+++ b/test/contrib/sidekiq/server_tracer_test.rb
@@ -1,7 +1,6 @@
-
 require 'contrib/sidekiq/tracer_test_base'
 
-class TracerTest < TracerTestBase
+class ServerTracerTest < TracerTestBase
   class TestError < StandardError; end
 
   class EmptyWorker
@@ -32,7 +31,7 @@ class TracerTest < TracerTestBase
     super
 
     Sidekiq::Testing.server_middleware do |chain|
-      chain.add(Datadog::Contrib::Sidekiq::Tracer,
+      chain.add(Datadog::Contrib::Sidekiq::ServerTracer,
                 tracer: @tracer, enabled: true)
     end
   end

--- a/test/contrib/sidekiq/tracer_configure_test.rb
+++ b/test/contrib/sidekiq/tracer_configure_test.rb
@@ -10,7 +10,7 @@ class TracerTest < TracerTestBase
   def test_configuration_defaults
     # it should configure the tracer with reasonable defaults
     Sidekiq::Testing.server_middleware do |chain|
-      chain.add(Datadog::Contrib::Sidekiq::Tracer, tracer: @tracer)
+      chain.add(Datadog::Contrib::Sidekiq::ServerTracer, tracer: @tracer)
     end
     EmptyWorker.perform_async()
 
@@ -27,7 +27,7 @@ class TracerTest < TracerTestBase
     @tracer.configure(enabled: false)
     Sidekiq::Testing.server_middleware do |chain|
       chain.add(
-        Datadog::Contrib::Sidekiq::Tracer,
+        Datadog::Contrib::Sidekiq::ServerTracer,
         tracer: @tracer,
         service_name: 'my-sidekiq'
       )

--- a/test/contrib/sidekiq/tracer_test_base.rb
+++ b/test/contrib/sidekiq/tracer_test_base.rb
@@ -1,7 +1,7 @@
 
 require 'sidekiq/testing'
 require 'ddtrace'
-require 'ddtrace/contrib/sidekiq/tracer'
+require 'ddtrace/contrib/sidekiq/server_tracer'
 require 'helper'
 
 class TracerTestBase < Minitest::Test

--- a/test/contrib/sidekiq/tracer_test_base.rb
+++ b/test/contrib/sidekiq/tracer_test_base.rb
@@ -1,6 +1,7 @@
 
 require 'sidekiq/testing'
 require 'ddtrace'
+require 'ddtrace/contrib/sidekiq/client_tracer'
 require 'ddtrace/contrib/sidekiq/server_tracer'
 require 'helper'
 


### PR DESCRIPTION
Sidekiq enqueues are _normally_ fast, but it seems like it'd be nice to have tracing of those enqueue/push events and therefore be able to monitor the latency of enqueues in case they aren't fast (as these can often be a good warning sign of Redis issues).

Note that I made a number of guesses here, especially concerning the span name and omitting the service (ie. that client-side enqueues should inherit their parent's service).