### PR TITLE
Replace net::http with httprb to optimize post requests

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'builder'
   spec.add_development_dependency 'ruby-prof'
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'http'
 
   # locking transitive dependency of webmock
   spec.add_development_dependency 'addressable', '~> 2.4.0'

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'http'
   spec.add_dependency 'msgpack'
   # TODO: Move this to Appraisals?
   spec.add_dependency 'opentracing', '>= 0.4.1'
@@ -47,7 +48,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'builder'
   spec.add_development_dependency 'ruby-prof'
   spec.add_development_dependency 'sqlite3'
-  spec.add_development_dependency 'http'
 
   # locking transitive dependency of webmock
   spec.add_development_dependency 'addressable', '~> 2.4.0'

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -117,10 +117,10 @@ module Datadog
     private
 
     def sampling_updater(action, response, api)
-      return unless action == :traces && response.is_a?(Net::HTTPOK)
+      return unless action == :traces && response.code == 200
 
       if api[:version] == HTTPTransport::V4
-        body = JSON.parse(response.body)
+        body = JSON.parse(response.body.readpartial)
         if body.is_a?(Hash) && body.key?('rate_by_service')
           @priority_sampler.update(body['rate_by_service'])
         end

--- a/spec/ddtrace/writer_spec.rb
+++ b/spec/ddtrace/writer_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 require 'ddtrace'
+require 'http'
 require 'json'
 
 RSpec.describe Datadog::Writer do
@@ -79,10 +80,11 @@ RSpec.describe Datadog::Writer do
                 before(:each) do
                   expect(callback).to receive(:call).with(
                     :traces,
-                    a_kind_of(Net::HTTPOK),
+                    a_kind_of(HTTP::Response),
                     a_kind_of(Hash)
-                  ) do |_action, _response, api|
+                  ) do |_action, response, api|
                     expect(api[:version]).to eq(api_version)
+                    expect(response.code).to eq(200)
                   end
                 end
 
@@ -104,15 +106,15 @@ RSpec.describe Datadog::Writer do
                   call_count = 0
                   allow(callback).to receive(:call).with(
                     :traces,
-                    a_kind_of(Net::HTTPResponse),
+                    a_kind_of(HTTP::Response),
                     a_kind_of(Hash)
                   ) do |_action, response, api|
                     call_count += 1
                     if call_count == 1
-                      expect(response).to be_a_kind_of(Net::HTTPNotFound)
+                      expect(response.code).to eq(404)
                       expect(api[:version]).to eq(api_version)
                     elsif call_count == 2
-                      expect(response).to be_a_kind_of(Net::HTTPOK)
+                      expect(response.code).to eq(200)
                       expect(api[:version]).to eq(fallback_version)
                     end
                   end

--- a/spec/support/http_helpers.rb
+++ b/spec/support/http_helpers.rb
@@ -1,29 +1,26 @@
 require 'time'
-require 'net/http'
 require 'spec/support/synchronization_helpers'
+require 'addressable'
+require 'http'
 
 module HttpHelpers
   def mock_http_request(options = {})
     http_method = options[:method] || :get
-    uri = URI.parse('http://localhost:3000/mock_response')
+    uri = Addressable::URI.parse('http://localhost:3000/mock_response')
     body = options[:body] || ''
     status = options[:status] || 200
 
     # Stub request
     stub = stub_request(http_method, uri).to_return(body: body, status: status)
 
-    # Create the HTTP objects
-    http = Net::HTTP.new(uri.host, uri.port)
-
     if http_method == :get
-      request = Net::HTTP::Get.new(uri.request_uri, {})
+      response = HTTP.get(uri.to_s, {})
     elsif http_method == :post
-      request = Net::HTTP::Post.new(uri.request_uri, {})
-      request.body = {}.to_json
+      response = HTTP.post(uri.to_s, {})
     end
 
     # Generate response
-    { stub: stub, request: request, response: http.request(request) }
+    { stub: stub, response: response }
   end
 
   def wait_http_server(server, delay)


### PR DESCRIPTION
As the client sends massive amount of post requests to agent, I'd like to use https://github.com/httprb/http to replace Ruby's standard `Net::HTTP`, which could, in theory, improve the client's performance and reduce the time cost.

A nice article about it:
https://twin.github.io/httprb-is-great/

Please have a look. Thanks in advance.