### PR TITLE
Make spec compatible with concurrent-ruby v1.1.x

### DIFF
--- a/spec/ddtrace/contrib/concurrent_ruby/integration_spec.rb
+++ b/spec/ddtrace/contrib/concurrent_ruby/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'concurrent/future'
+require 'concurrent'
 
 require 'spec_helper'
 require 'ddtrace'


### PR DESCRIPTION
In v1.0.x requiring 'concurrent/future' would pull in all the bells and whistles necessary to execute futures. In newer versions of the gem requiring that gets you *only* the `Future` class.

Instead one either needs to set up the default executors ourselves, manually require and specify the executor we want, or just require `concurrent` to get everything all loaded and set up the way the gem authors intended. This commit takes the third option.