### PR TITLE
add option to set headers for Rails

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -962,6 +962,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `database_service` | Database service name used when tracing database activity | `'<app_name>-<adapter_name>'` |
 | `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `false` |
 | `exception_controller` | Class or Module which identifies a custom exception controller class. Tracer provides improved error behavior when it can identify custom exception controllers. By default, without this option, it 'guesses' what a custom exception controller looks like. Providing this option aids this identification. | `nil` |
+| `headers` | Hash of HTTP request or response headers to add as tags to the `rack.request`. Accepts `request` and `response` keys with Array values e.g. `['Last-Modified']`. Adds `http.request.headers.*` and `http.response.headers.*` tags respectively. | `{ response: ['Content-Type', 'X-Request-ID'] }` |
 | `middleware` | Add the trace middleware to the Rails application. Set to `false` if you don't want the middleware to load. | `true` |
 | `middleware_names` | Enables any short-circuited middleware requests to display the middleware name as resource for the trace. | `false` |
 | `service_name` | Service name used when tracing application requests (on the `rack` level) | `'<app_name>'` (inferred from your Rails application namespace) |

--- a/lib/ddtrace/contrib/rails/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rails/configuration/settings.rb
@@ -6,6 +6,10 @@ module Datadog
       module Configuration
         # Custom settings for the Rails integration
         class Settings < Contrib::Configuration::Settings
+          DEFAULT_HEADERS = {
+            response: %w[Content-Type X-Request-ID]
+          }.freeze
+
           option :cache_service
           option :controller_service
           option :database_service, depends_on: [:service_name] do |value|
@@ -16,7 +20,7 @@ module Datadog
           end
           option :distributed_tracing, default: false
           option :exception_controller, default: nil
-          option :headers, default: nil
+          option :headers, default: DEFAULT_HEADERS
           option :middleware, default: true
           option :middleware_names, default: false
           option :template_base_path, default: 'views/'

--- a/lib/ddtrace/contrib/rails/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rails/configuration/settings.rb
@@ -16,6 +16,7 @@ module Datadog
           end
           option :distributed_tracing, default: false
           option :exception_controller, default: nil
+          option :headers, default: nil
           option :middleware, default: true
           option :middleware_names, default: false
           option :template_base_path, default: 'views/'

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -45,15 +45,15 @@ module Datadog
         end
 
         def self.activate_rack!(config)
-          rack_options = {
+          Datadog.configuration.use(
+            :rack,
             tracer: config[:tracer],
             application: ::Rails.application,
             service_name: config[:service_name],
             middleware_names: config[:middleware_names],
+            headers: config[:headers],
             distributed_tracing: config[:distributed_tracing]
-          }
-          rack_options = config[:headers] if config[:headers]
-          Datadog.configuration.use(:rack, rack_options)
+          )
         end
 
         def self.activate_active_record!(config)

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -45,14 +45,15 @@ module Datadog
         end
 
         def self.activate_rack!(config)
-          Datadog.configuration.use(
-            :rack,
-            tracer: config[:tracer],
+          rack_options = {
             application: ::Rails.application,
-            service_name: config[:service_name],
+            distributed_tracing: config[:distributed_tracing],
             middleware_names: config[:middleware_names],
-            distributed_tracing: config[:distributed_tracing]
-          )
+            service_name: config[:service_name],
+            tracer: config[:tracer],
+          }
+          rack_options = config[:headers] if config[:headers]
+          Datadog.configuration.use(:rack, rack_options)
         end
 
         def self.activate_active_record!(config)

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -50,7 +50,7 @@ module Datadog
             distributed_tracing: config[:distributed_tracing],
             middleware_names: config[:middleware_names],
             service_name: config[:service_name],
-            tracer: config[:tracer],
+            tracer: config[:tracer]
           }
           rack_options = config[:headers] if config[:headers]
           Datadog.configuration.use(:rack, rack_options)

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -46,11 +46,11 @@ module Datadog
 
         def self.activate_rack!(config)
           rack_options = {
+            tracer: config[:tracer],
             application: ::Rails.application,
-            distributed_tracing: config[:distributed_tracing],
-            middleware_names: config[:middleware_names],
             service_name: config[:service_name],
-            tracer: config[:tracer]
+            middleware_names: config[:middleware_names],
+            distributed_tracing: config[:distributed_tracing]
           }
           rack_options = config[:headers] if config[:headers]
           Datadog.configuration.use(:rack, rack_options)


### PR DESCRIPTION
This PR enables users to set `headers` for the Rails integration. Note that the APM stopped registering requests when the Rails integration had `headers` specified along with `distributed_tracing` set.

Note: CircleCI failing on "ci/circleci: deploy prerelease Gem" which seems like a permissions issue.