### PR TITLE
CI: Fix timers gem not supporting < Ruby 2.2.1

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -88,6 +88,7 @@ elsif Gem::Version.new('1.9.3') <= Gem::Version.new(RUBY_VERSION) \
       gem 'sinatra', '1.4.5'
       gem 'sqlite3'
       gem 'sucker_punch'
+      gem 'timers', '< 4.2'
     end
   end
 elsif Gem::Version.new('2.0.0') <= Gem::Version.new(RUBY_VERSION) \
@@ -172,6 +173,7 @@ elsif Gem::Version.new('2.0.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'sinatra', '1.4.5'
       gem 'sqlite3'
       gem 'sucker_punch'
+      gem 'timers', '< 4.2'
     end
   end
 elsif Gem::Version.new('2.1.0') <= Gem::Version.new(RUBY_VERSION) \
@@ -276,6 +278,7 @@ elsif Gem::Version.new('2.1.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'sinatra', '1.4.5'
       gem 'sqlite3'
       gem 'sucker_punch'
+      gem 'timers', '< 4.2'
     end
   end
 elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \


### PR DESCRIPTION
`timers` 4.2.0 dropped support for older versions of Ruby and broke our builds for < Ruby 2.2.1. This pull request sets version requirements to avoid this.