### PR TITLE
Add support for including the path in the resource for Faraday

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -625,6 +625,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `error_handler` | A `Proc` that accepts a `response` parameter. If it evaluates to a *truthy* value, the trace span is marked as an error. By default only sets 5XX responses as errors. | `nil` |
 | `service_name` | Service name for Faraday instrumentation. When provided to middleware for a specific connection, it applies only to that connection object. | `'faraday'` |
 | `split_by_domain` | Uses the request domain as the service name when set to `true`. | `false` |
+| `path_in_resource` | Include the request path in the name of the resource. | `false` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 
 ### Grape

--- a/lib/ddtrace/contrib/faraday/configuration/settings.rb
+++ b/lib/ddtrace/contrib/faraday/configuration/settings.rb
@@ -16,6 +16,7 @@ module Datadog
           option :error_handler, default: DEFAULT_ERROR_HANDLER
           option :service_name, default: Ext::SERVICE_NAME
           option :split_by_domain, default: false
+          option :path_in_resource, default: false
         end
       end
     end

--- a/lib/ddtrace/contrib/faraday/middleware.rb
+++ b/lib/ddtrace/contrib/faraday/middleware.rb
@@ -31,13 +31,23 @@ module Datadog
         attr_reader :app, :options, :tracer
 
         def annotate!(span, env)
-          span.resource = env[:method].to_s.upcase
+          span.resource = resource_name(env)
           span.service = service_name(env)
           span.span_type = Datadog::Ext::HTTP::TYPE
           span.set_tag(Datadog::Ext::HTTP::URL, env[:url].path)
           span.set_tag(Datadog::Ext::HTTP::METHOD, env[:method].to_s.upcase)
           span.set_tag(Datadog::Ext::NET::TARGET_HOST, env[:url].host)
           span.set_tag(Datadog::Ext::NET::TARGET_PORT, env[:url].port)
+        end
+
+        def resource_name(env)
+          method = env[:method].to_s.upcase
+          path = env[:url].path
+          if options[:path_in_resource]
+            "#{method} #{path}"
+          else
+            method
+          end
         end
 
         def handle_response(span, env)

--- a/spec/ddtrace/contrib/faraday/middleware_spec.rb
+++ b/spec/ddtrace/contrib/faraday/middleware_spec.rb
@@ -109,6 +109,16 @@ RSpec.describe 'Faraday middleware' do
     end
   end
 
+  context 'when path included in resource' do
+    subject!(:response) { client.get('/success') }
+
+    let(:middleware_options) { { path_in_resource: true } }
+
+    it do
+      expect(request_span.resource).to eq('GET /success')
+    end
+  end
+
   context 'default request headers' do
     subject(:response) { client.get('/success') }
 


### PR DESCRIPTION
I realised that I'd find it useful to have per-path reporting in Datadog for my Faraday traces: then I can see which endpoints on the services I'm calling are slow. I'd been talking to Fanny Jiang from Datadog support about this, and then I realised that I could make a pull request myself.