### PR TITLE
fixes #630 potential performance hit logging cache key

### DIFF
--- a/lib/ddtrace/contrib/rails/active_support.rb
+++ b/lib/ddtrace/contrib/rails/active_support.rb
@@ -50,7 +50,8 @@ module Datadog
             # discard parameters from the cache_store configuration
             store, = *Array.wrap(::Rails.configuration.cache_store).flatten
             span.set_tag(Ext::TAG_CACHE_BACKEND, store)
-            cache_key = Datadog::Utils.truncate(payload.fetch(:key), Ext::QUANTIZE_CACHE_MAX_KEY_SIZE)
+            normalized_key = ActiveSupport::Cache.expand_cache_key(payload.fetch(:key))
+            cache_key = Datadog::Utils.truncate(normalized_key, Ext::QUANTIZE_CACHE_MAX_KEY_SIZE)
             span.set_tag(Ext::TAG_CACHE_KEY, cache_key)
             span.set_error(payload[:exception]) if payload[:exception]
           ensure

--- a/lib/ddtrace/contrib/rails/active_support.rb
+++ b/lib/ddtrace/contrib/rails/active_support.rb
@@ -50,7 +50,7 @@ module Datadog
             # discard parameters from the cache_store configuration
             store, = *Array.wrap(::Rails.configuration.cache_store).flatten
             span.set_tag(Ext::TAG_CACHE_BACKEND, store)
-            normalized_key = ActiveSupport::Cache.expand_cache_key(payload.fetch(:key))
+            normalized_key = ::ActiveSupport::Cache.expand_cache_key(payload.fetch(:key))
             cache_key = Datadog::Utils.truncate(normalized_key, Ext::QUANTIZE_CACHE_MAX_KEY_SIZE)
             span.set_tag(Ext::TAG_CACHE_KEY, cache_key)
             span.set_error(payload[:exception]) if payload[:exception]

--- a/test/contrib/rails/cache_test.rb
+++ b/test/contrib/rails/cache_test.rb
@@ -118,11 +118,11 @@ class CacheTracingTest < ActionController::TestCase
       end
     end
 
-    Rails.cache.write(['custom-key', 'array', User.new], 50)
+    Rails.cache.write(['custom-key', ['x', 'y'], User.new], 50)
     spans = @tracer.writer.spans()
     assert_equal(1, spans.length)
     span = spans[0]
-    assert_equal(span.get_tag('rails.cache.key'), 'custom-key/array/User:3')
+    assert_equal(span.get_tag('rails.cache.key'), 'custom-key/x/y/User:3')
   end
 
 end

--- a/test/contrib/rails/cache_test.rb
+++ b/test/contrib/rails/cache_test.rb
@@ -124,5 +124,4 @@ class CacheTracingTest < ActionController::TestCase
     span = spans[0]
     assert_equal(span.get_tag('rails.cache.key'), 'custom-key/x/y/User:3')
   end
-
 end

--- a/test/contrib/rails/cache_test.rb
+++ b/test/contrib/rails/cache_test.rb
@@ -118,7 +118,7 @@ class CacheTracingTest < ActionController::TestCase
       end
     end
 
-    Rails.cache.write(['custom-key', ['x', 'y'], User.new], 50)
+    Rails.cache.write(['custom-key', %w[x y], User.new], 50)
     spans = @tracer.writer.spans()
     assert_equal(1, spans.length)
     span = spans[0]

--- a/test/contrib/rails/cache_test.rb
+++ b/test/contrib/rails/cache_test.rb
@@ -110,4 +110,19 @@ class CacheTracingTest < ActionController::TestCase
     assert_equal(max_key_size, span.get_tag('rails.cache.key').length)
     assert(span.get_tag('rails.cache.key').end_with?('...'))
   end
+
+  test 'cache key is expanded using ActiveSupport' do
+    class User
+      def cache_key
+        'User:3'
+      end
+    end
+
+    Rails.cache.write(['custom-key', 'array', User.new], 50)
+    spans = @tracer.writer.spans()
+    assert_equal(1, spans.length)
+    span = spans[0]
+    assert_equal(span.get_tag('rails.cache.key'), 'custom-key/array/User:3')
+  end
+
 end

--- a/test/contrib/rails/redis_cache_test.rb
+++ b/test/contrib/rails/redis_cache_test.rb
@@ -147,6 +147,20 @@ class RedisCacheTracingTest < ActionController::TestCase
     assert_equal(cache.span_id, del.parent_id)
   end
 
+  test 'cache key is expanded using ActiveSupport' do
+    class User
+      def cache_key
+        'User:3'
+      end
+    end
+
+    Rails.cache.write(['custom-key', 'array', User.new], 50)
+    spans = @tracer.writer.spans()
+    assert_equal(spans.length, 2)
+    cache, redis = spans
+    assert_equal(cache.get_tag('rails.cache.key'), 'custom-key/array/User:3')
+  end
+
   private
 
   def client_from_driver(driver)

--- a/test/contrib/rails/redis_cache_test.rb
+++ b/test/contrib/rails/redis_cache_test.rb
@@ -154,11 +154,11 @@ class RedisCacheTracingTest < ActionController::TestCase
       end
     end
 
-    Rails.cache.write(['custom-key', 'array', User.new], 50)
+    Rails.cache.write(['custom-key', ['x', 'y'], User.new], 50)
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 2)
     cache, redis = spans
-    assert_equal(cache.get_tag('rails.cache.key'), 'custom-key/array/User:3')
+    assert_equal(cache.get_tag('rails.cache.key'), 'custom-key/x/y/User:3')
   end
 
   private

--- a/test/contrib/rails/redis_cache_test.rb
+++ b/test/contrib/rails/redis_cache_test.rb
@@ -157,7 +157,7 @@ class RedisCacheTracingTest < ActionController::TestCase
     Rails.cache.write(['custom-key', %w[x y], User.new], 50)
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 2)
-    cache, redis = spans
+    cache, _redis = spans
     assert_equal(cache.get_tag('rails.cache.key'), 'custom-key/x/y/User:3')
   end
 

--- a/test/contrib/rails/redis_cache_test.rb
+++ b/test/contrib/rails/redis_cache_test.rb
@@ -154,7 +154,7 @@ class RedisCacheTracingTest < ActionController::TestCase
       end
     end
 
-    Rails.cache.write(['custom-key', ['x', 'y'], User.new], 50)
+    Rails.cache.write(['custom-key', %w[x y], User.new], 50)
     spans = @tracer.writer.spans()
     assert_equal(spans.length, 2)
     cache, redis = spans


### PR DESCRIPTION
* using ActiveSupport::Cache.expand_cache_key which is also
  used by Rails to expand the cache key without enumerating
  relations