### PR TITLE
Prevent Rails load hooks applying patch twice

### DIFF
--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -32,10 +32,12 @@ module Datadog
         end
 
         def before_intialize(app)
-          # Middleware must be added before the application is initialized.
-          # Otherwise the middleware stack will be frozen.
-          # Sometimes we don't want to activate middleware e.g. OpenTracing, etc.
-          add_middleware(app) if Datadog.configuration[:rails][:middleware]
+          do_once(:rails_before_initialize, for: app) do
+            # Middleware must be added before the application is initialized.
+            # Otherwise the middleware stack will be frozen.
+            # Sometimes we don't want to activate middleware e.g. OpenTracing, etc.
+            add_middleware(app) if Datadog.configuration[:rails][:middleware]
+          end
         end
 
         def add_middleware(app)
@@ -59,10 +61,12 @@ module Datadog
         end
 
         def after_intialize(app)
-          # Finish configuring the tracer after the application is initialized.
-          # We need to wait for some things, like application name, middleware stack, etc.
-          setup_tracer
-          instrument_rails
+          do_once(:rails_after_initialize, for: app) do
+            # Finish configuring the tracer after the application is initialized.
+            # We need to wait for some things, like application name, middleware stack, etc.
+            setup_tracer
+            instrument_rails
+          end
         end
 
         # Configure Rails tracing with settings

--- a/lib/ddtrace/patcher.rb
+++ b/lib/ddtrace/patcher.rb
@@ -21,21 +21,23 @@ module Datadog
         end
       end
 
-      def do_once(key = nil)
+      def do_once(key = nil, options = {})
         # If already done, don't do again
-        @done_once ||= {}
-        return @done_once[key] if @done_once.key?(key)
+        @done_once ||= Hash.new { |h, k| h[k] = {} }
+        if @done_once.key?(key) && @done_once[key].key?(options[:for])
+          return @done_once[key][options[:for]]
+        end
 
         # Otherwise 'do'
         yield.tap do
           # Then add the key so we don't do again.
-          @done_once[key] = true
+          @done_once[key][options[:for]] = true
         end
       end
 
-      def done?(key)
+      def done?(key, options = {})
         return false unless instance_variable_defined?(:@done_once)
-        !@done_once.nil? && @done_once.key?(key)
+        !@done_once.nil? && @done_once.key?(key) && @done_once[key].key?(options[:for])
       end
     end
 

--- a/spec/ddtrace/contrib/concurrent_ruby/integration_spec.rb
+++ b/spec/ddtrace/contrib/concurrent_ruby/integration_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Datadog::Contrib::ConcurrentRuby::Integration do
     example.run
     ::Concurrent.send(:remove_const, :Future)
     ::Concurrent.const_set('Future', unmodified_future)
-    Datadog.registry[:concurrent_ruby].patcher.instance_variable_set(:@done_once, {})
+    remove_patch!(:concurrent_ruby)
   end
 
   let(:tracer) { ::Datadog::Tracer.new(writer: FauxWriter.new) }


### PR DESCRIPTION
After refactoring the Rails integration in #552 and #540, we applied a new patching strategy that used `ActiveSupport.on_load(:before_initialize)` to run Rails patching code once at the appropriate time.

Turns out in some applications, these load hooks can run twice, which injects the middleware twice and causes bad side effects.

Although Rails 5.0+ offers a `run_once` option for these load hooks, they aren't available for Rails 3.0 - 4.2, which we currently support. Instead, I added a `:for` option to our existing `do_once` function which adds a second dimension to the patch hash, then used the Rails application instance as a key.