### PR TITLE
Change configuration resolution misses to return default configuration

### DIFF
--- a/lib/ddtrace/contrib/active_record/events/sql.rb
+++ b/lib/ddtrace/contrib/active_record/events/sql.rb
@@ -27,7 +27,11 @@ module Datadog
             config = Utils.connection_config(payload[:connection_id])
             settings = Datadog.configuration[:active_record, config]
             adapter_name = Datadog::Utils::Database.normalize_vendor(config[:adapter])
-            service_name = !settings.nil? ? settings.service_name : configuration[:service_name]
+            service_name = if settings.service_name != Datadog::Utils::Database::VENDOR_DEFAULT
+                             settings.service_name
+                           else
+                             adapter_name
+                           end
 
             span.name = "#{adapter_name}.query"
             span.service = service_name

--- a/lib/ddtrace/contrib/configurable.rb
+++ b/lib/ddtrace/contrib/configurable.rb
@@ -20,11 +20,8 @@ module Datadog
           @resolver = nil
         end
 
-        def configuration(name = :default)
-          name = :default if name.nil?
-          name = resolver.resolve(name)
-          return nil unless configurations.key?(name)
-          configurations[name]
+        def configuration(key = :default)
+          configurations[resolve_configuration_key(key)]
         end
 
         def configurations
@@ -33,12 +30,12 @@ module Datadog
           end
         end
 
-        def configure(name, options = {}, &block)
-          name = resolver.resolve(name || :default)
+        def configure(key, options = {}, &block)
+          key = resolver.resolve(key || :default)
 
-          configurations[name].tap do |settings|
+          configurations[key].tap do |settings|
             settings.configure(options, &block)
-            configurations[name] = settings
+            configurations[key] = settings
           end
         end
 
@@ -48,6 +45,13 @@ module Datadog
 
         def resolver
           @resolver ||= Configuration::Resolver.new
+        end
+
+        def resolve_configuration_key(key = :default)
+          key = :default if key.nil?
+          key = resolver.resolve(key)
+          key = :default unless configurations.key?(key)
+          key
         end
       end
     end

--- a/lib/ddtrace/utils/database.rb
+++ b/lib/ddtrace/utils/database.rb
@@ -2,16 +2,20 @@ module Datadog
   module Utils
     # Common database-related utility functions.
     module Database
+      VENDOR_DEFAULT = 'defaultdb'.freeze
+      VENDOR_POSTGRES = 'postgres'.freeze
+      VENDOR_SQLITE = 'sqlite'.freeze
+
       module_function
 
       def normalize_vendor(vendor)
         case vendor
         when nil
-          'defaultdb'
+          VENDOR_DEFAULT
         when 'postgresql'
-          'postgres'
+          VENDOR_POSTGRES
         when 'sqlite3'
-          'sqlite'
+          VENDOR_SQLITE
         else
           vendor
         end

--- a/spec/ddtrace/contrib/configurable_spec.rb
+++ b/spec/ddtrace/contrib/configurable_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Datadog::Contrib::Configurable do
           end
 
           context 'but the configuration doesn\'t exist' do
-            it { is_expected.to be nil }
+            it { is_expected.to be_a_kind_of(Datadog::Contrib::Configuration::Settings) }
+            it { is_expected.to be(configurable_object.configurations[:default]) }
           end
         end
       end
@@ -92,7 +93,7 @@ RSpec.describe Datadog::Contrib::Configurable do
           context 'that does not match any configuration' do
             it do
               expect { configure }.to change { configurable_object.configuration(name) }
-                .from(nil)
+                .from(configurable_object.configurations[:default])
                 .to(a_kind_of(Datadog::Contrib::Configuration::Settings))
             end
           end


### PR DESCRIPTION
This pull request changes a few things:

 - `Datadog::Utils::Database` values to constants.
 - Return the default configuration instead of `nil` when a configuration with a mismatching key is requested.
 - In ActiveRecord, if the tracer settings have a service name with the default value `defaultdb`, then default instead to the adapter name.

These changes were in order to get ActiveRecord to return service names more consistently. If connections were manually established after the AR integration was activated (when it could not determine a good default service name from a connection), spans could end up with bad service names (`defaultdb`).

By always returning at minimum the default settings object, ActiveRecord could then use those settings to determine the best name for the span based on what's available.