### PR TITLE
Support Shoryuken in batch mode

### DIFF
--- a/lib/ddtrace/contrib/shoryuken/tracer.rb
+++ b/lib/ddtrace/contrib/shoryuken/tracer.rb
@@ -14,7 +14,7 @@ module Datadog
             span.resource = worker_instance.class.name
             span.set_tag(Ext::TAG_JOB_ID, sqs_msg.message_id)
             span.set_tag(Ext::TAG_JOB_QUEUE, queue)
-            span.set_tag(Ext::TAG_JOB_ATTRIBUTES, sqs_msg.attributes)
+            span.set_tag(Ext::TAG_JOB_ATTRIBUTES, sqs_msg.attributes) if sqs_msg.respond_to?(:attributes)
             span.set_tag(Ext::TAG_JOB_BODY, body)
 
             yield


### PR DESCRIPTION
Shoryuken can be run in a batch mode, in which case `sqs_msg` and `body` will be arrays.

Shoryuken [monkey patches](https://github.com/phstc/shoryuken/blob/bc7938942270a1171d1597064698d88c3f36a4ec/lib/shoryuken/manager.rb#L93) in a `message_id` method, but `attributes` won't exist on an array.