### PR TITLE
Add event_sample_rate configuration option

### DIFF
--- a/lib/ddtrace/contrib/configuration/settings.rb
+++ b/lib/ddtrace/contrib/configuration/settings.rb
@@ -9,6 +9,7 @@ module Datadog
 
         option :service_name
         option :tracer, default: Datadog.tracer
+        option :event_sample_rate
 
         def initialize(options = {})
           configure(options)

--- a/lib/ddtrace/ext/priority.rb
+++ b/lib/ddtrace/ext/priority.rb
@@ -3,6 +3,8 @@ module Datadog
     # Priority is a hint given to the backend so that it knows which traces to reject or kept.
     # In a distributed context, it should be set before any context propagation (fork, RPC calls) to be effective.
     module Priority
+      # Tag for span sample rate; used by agent to determine whether event is emitted.
+      TAG_EVENT_SAMPLE_RATE = '_dd1.sr.eausr'.freeze
       # Use this to explicitely inform the backend that a trace should be rejected and not stored.
       USER_REJECT = -1
       # Used by the builtin sampler to inform the backend that a trace should be rejected and not stored.

--- a/spec/ddtrace/contrib/configuration/settings_spec.rb
+++ b/spec/ddtrace/contrib/configuration/settings_spec.rb
@@ -9,7 +9,23 @@ RSpec.describe Datadog::Contrib::Configuration::Settings do
 
   describe '#options' do
     subject(:options) { settings.options }
-    it { is_expected.to include(:service_name) }
-    it { is_expected.to include(:tracer) }
+
+    describe ':service_name' do
+      subject(:option) { options[:service_name] }
+      it { expect(options).to include(:service_name) }
+      it { expect(option.get).to be nil }
+    end
+
+    describe ':tracer' do
+      subject(:option) { options[:tracer] }
+      it { expect(options).to include(:tracer) }
+      it { expect(option.get).to be Datadog.tracer }
+    end
+
+    describe ':event_sample_rate' do
+      subject(:option) { options[:event_sample_rate] }
+      it { expect(options).to include(:event_sample_rate) }
+      it { expect(option.get).to be nil }
+    end
   end
 end


### PR DESCRIPTION
To aid sampling of interesting events, this pull request adds an `event_sample_rate` to the configuration of all integrations. This will allow integrations to tag their spans with the `event_sample_rate` and its own configured value.