### PR TITLE
Set Rack event_sample_rate default

### DIFF
--- a/lib/ddtrace/contrib/rack/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rack/configuration/settings.rb
@@ -16,6 +16,7 @@ module Datadog
 
           option :application
           option :distributed_tracing, default: false
+          option :event_sample_rate, default: 1.0
           option :headers, default: DEFAULT_HEADERS
           option :middleware_names, default: false
           option :quantize, default: {}

--- a/spec/ddtrace/contrib/rack/configuration_spec.rb
+++ b/spec/ddtrace/contrib/rack/configuration_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe 'Rack integration configuration' do
 
   it_behaves_like 'event sample rate' do
     include_context 'an incoming HTTP request'
+    let(:default_event_sample_rate) { 1.0 }
     before { is_expected.to be_ok }
   end
 

--- a/spec/ddtrace/contrib/sampling_examples.rb
+++ b/spec/ddtrace/contrib/sampling_examples.rb
@@ -1,9 +1,11 @@
 require 'ddtrace/ext/priority'
 
 RSpec.shared_examples_for 'event sample rate' do
+  let(:default_event_sample_rate) { nil }
+
   context 'when not configured' do
     it 'is not included in the tags' do
-      expect(span.get_metric(Datadog::Ext::Priority::TAG_EVENT_SAMPLE_RATE)).to be nil
+      expect(span.get_metric(Datadog::Ext::Priority::TAG_EVENT_SAMPLE_RATE)).to eq(default_event_sample_rate)
     end
   end
 


### PR DESCRIPTION
This pull request sets `event_sample_rate` tag value to `1.0` by default for Rack.