### PR TITLE
[rack] Remove deprecation warning on :datadog_rack_request_span

### DIFF
--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -65,11 +65,13 @@ module Datadog
           # TODO: Add deprecation warnings back in
           # DEV: Some third party Gems will loop over the rack env causing our deprecation
           #      warnings to be shown even when the user is not accessing them directly
-          # `add_deprecation_warnings(env)`
-          env.without_datadog_warnings do
-            # TODO: For backwards compatibility; this attribute is deprecated.
-            env[:datadog_rack_request_span] = env[RACK_REQUEST_SPAN]
-          end
+          #
+          # add_deprecation_warnings(env)
+          # env.without_datadog_warnings do
+          #   # TODO: For backwards compatibility; this attribute is deprecated.
+          #   env[:datadog_rack_request_span] = env[RACK_REQUEST_SPAN]
+          # end
+          env[:datadog_rack_request_span] = env[RACK_REQUEST_SPAN]
 
           # Copy the original env, before the rest of the stack executes.
           # Values may change; we want values before that happens.

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -62,8 +62,10 @@ module Datadog
           request_span = tracer.trace(Ext::SPAN_REQUEST, trace_options)
           env[RACK_REQUEST_SPAN] = request_span
 
-          # Add deprecation warnings
-          add_deprecation_warnings(env)
+          # TODO: Add deprecation warnings back in
+          # DEV: Some third party Gems will loop over the rack env causing our deprecation
+          #      warnings to be shown even when the user is not accessing them directly
+          # `add_deprecation_warnings(env)`
           env.without_datadog_warnings do
             # TODO: For backwards compatibility; this attribute is deprecated.
             env[:datadog_rack_request_span] = env[RACK_REQUEST_SPAN]

--- a/spec/ddtrace/contrib/rack/middleware_spec.rb
+++ b/spec/ddtrace/contrib/rack/middleware_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Datadog::Contrib::Rack::TraceMiddleware do
         end
 
         it do
-          expect(Datadog::Tracer.log).to have_received(:warn)
+          expect(Datadog::Tracer.log).to_not have_received(:warn)
             .with(/:datadog_rack_request_span/)
         end
       end


### PR DESCRIPTION
We previously added in a deprecation warning when we moved away from `:datadog_rack_request_span` key in the Rack env.

However, even if a user isn't trying to access this key directly some third party Gems will loop over all keys in the Rack env causing this deprecation warning to be shown. If this happens on every request then we could very easily be spamming the user's logs, which is not ideal.

The solution here is to remove the deprecation warning for now.