### PR TITLE
Fix sqlite3 1.4.0 from breaking build with ActiveRecord.

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -86,7 +86,7 @@ elsif Gem::Version.new('1.9.3') <= Gem::Version.new(RUBY_VERSION) \
       gem 'sequel', '~> 4.0', '< 4.37'
       gem 'sidekiq', '~> 3.5.4'
       gem 'sinatra', '1.4.5'
-      gem 'sqlite3'
+      gem 'sqlite3', '~> 1.3.6'
       gem 'sucker_punch'
       gem 'timers', '< 4.2'
     end
@@ -171,7 +171,7 @@ elsif Gem::Version.new('2.0.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'sequel', '~> 4.0', '< 4.37'
       gem 'sidekiq', '~> 3.5.4'
       gem 'sinatra', '1.4.5'
-      gem 'sqlite3'
+      gem 'sqlite3', '~> 1.3.6'
       gem 'sucker_punch'
       gem 'timers', '< 4.2'
     end
@@ -277,7 +277,7 @@ elsif Gem::Version.new('2.1.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'shoryuken'
       gem 'sidekiq', '~> 3.5.4'
       gem 'sinatra', '1.4.5'
-      gem 'sqlite3'
+      gem 'sqlite3', '~> 1.3.6'
       gem 'sucker_punch'
       gem 'timers', '< 4.2'
     end
@@ -417,7 +417,7 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'shoryuken'
       gem 'sidekiq'
       gem 'sinatra'
-      gem 'sqlite3'
+      gem 'sqlite3', '~> 1.3.6'
       gem 'sucker_punch'
     end
   end
@@ -556,7 +556,7 @@ elsif Gem::Version.new('2.3.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'shoryuken'
       gem 'sidekiq'
       gem 'sinatra'
-      gem 'sqlite3'
+      gem 'sqlite3', '~> 1.3.6'
       gem 'sucker_punch'
     end
   end
@@ -589,7 +589,7 @@ elsif Gem::Version.new('2.4.0') <= Gem::Version.new(RUBY_VERSION)
       gem 'shoryuken'
       gem 'sidekiq'
       gem 'sinatra'
-      gem 'sqlite3'
+      gem 'sqlite3', '~> 1.3.6'
       gem 'sucker_punch'
     end
   end

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 2.0'
   spec.add_development_dependency 'builder'
   spec.add_development_dependency 'ruby-prof'
-  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sqlite3', '~> 1.3.6'
 
   # locking transitive dependency of webmock
   spec.add_development_dependency 'addressable', '~> 2.4.0'


### PR DESCRIPTION
With the release of sqlite3 1.4.0, ActiveRecord fails to load sqlite as an adapter to run tests. This is because ActiveRecord has some hard checks against adapter gems, so occasionally releases like this will break most Rails user's builds. See [this issue](https://github.com/rails/rails/issues/35161) for more details.

While they fix the problem in Rails, this affixes the version number of sqlite3 to prevent conflict with the various versions of Rails we test with.