### PR TITLE
Deprecate Faraday pin in favor of configuration API

### DIFF
--- a/spec/ddtrace/contrib/faraday/middleware_spec.rb
+++ b/spec/ddtrace/contrib/faraday/middleware_spec.rb
@@ -29,11 +29,6 @@ RSpec.describe 'Faraday middleware' do
     Datadog.configure do |c|
       c.use :faraday, configuration_options
     end
-
-    # Have to manually update this because its still
-    # using global pin instead of configuration.
-    # Remove this when we remove the pin.
-    Datadog::Pin.get_from(::Faraday).tracer = tracer
   end
 
   context 'when there is no interference' do

--- a/spec/ddtrace/contrib/faraday/patcher_spec.rb
+++ b/spec/ddtrace/contrib/faraday/patcher_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+
+require 'faraday'
+require 'ddtrace'
+require 'ddtrace/contrib/faraday/patcher'
+
+RSpec.describe 'Faraday instrumentation' do
+  include_context 'tracer logging'
+
+  let(:tracer) { get_test_tracer }
+  let(:configuration_options) { { tracer: tracer } }
+
+  # Enable the test tracer
+  before(:each) do
+    Datadog.configure do |c|
+      c.use :faraday, configuration_options
+    end
+  end
+
+  def reset_deprecation_warnings!(pin)
+    if pin.instance_variable_defined?(:@done_once)
+      pin.instance_variable_get(:@done_once).delete('#datadog_pin')
+      pin.instance_variable_get(:@done_once).delete('#datadog_pin=')
+    end
+  end
+
+  let(:deprecation_warnings) do
+    [
+      /.*#datadog_pin.*/,
+      /.*Use of Datadog::Pin with Faraday is DEPRECATED.*/
+    ]
+  end
+
+  it 'does not generate deprecation warnings' do
+    expect(log_buffer.length).to eq(0)
+    expect(log_buffer).to_not contain_line_with(*deprecation_warnings)
+    expect(log_buffer).to_not contain_line_with(*deprecation_warnings)
+  end
+
+  context 'when pin is referenced by' do
+    describe 'Datadog::Pin.get_from' do
+      subject(:pin) { Datadog::Pin.get_from(Faraday) }
+      before(:each) { pin }
+      after(:each) { reset_deprecation_warnings!(pin) }
+
+      it { expect(log_buffer).to contain_line_with(*deprecation_warnings).once }
+
+      context 'twice' do
+        before(:each) { Datadog::Pin.get_from(Faraday) }
+        it { expect(log_buffer).to contain_line_with(*deprecation_warnings).once }
+      end
+
+      context 'and then calls' do
+        # Make sure 'service_name' passes through to underlying configuration
+        describe '#service_name=' do
+          let(:original_service_name) { Datadog.configuration[:faraday][:service_name] }
+          let(:new_service_name) { 'new_service' }
+          after(:each) { pin.service_name = original_service_name }
+
+          it 'updates the configuration service name' do
+            expect { pin.service_name = new_service_name }
+              .to change { Datadog.configuration[:faraday][:service_name] }
+              .from(original_service_name).to(new_service_name)
+          end
+        end
+
+        # Make sure 'tracer' passes through to underlying configuration
+        describe 'tracer=' do
+          let(:new_tracer) { double('tracer') }
+          after(:each) { pin.tracer = tracer }
+
+          it 'updates the configuration service name' do
+            expect { pin.tracer = new_tracer }
+              .to change { Datadog.configuration[:faraday][:tracer] }
+              .from(tracer).to(new_tracer)
+          end
+        end
+      end
+    end
+
+    describe '#datadog_pin' do
+      subject(:pin) { Faraday.datadog_pin }
+      before(:each) { pin }
+      after(:each) { reset_deprecation_warnings!(pin) }
+      it { expect(log_buffer).to contain_line_with(*deprecation_warnings).once }
+
+      context 'twice' do
+        it { expect(log_buffer).to contain_line_with(*deprecation_warnings).once }
+      end
+    end
+
+    describe '#datadog_pin=' do
+      before(:each) do
+        # Store original pin first
+        original_pin
+
+        # Set new pin
+        Faraday.datadog_pin = new_pin
+      end
+      let(:original_pin) do
+        # We know this to create deprecation warnings...
+        # Retrieve the pin and reset the buffer
+        Faraday.datadog_pin.tap do
+          log_buffer.truncate(0)
+          log_buffer.rewind
+        end
+      end
+      let(:new_pin) { Datadog::Pin.new('new_service') }
+
+      after(:each) do
+        # Restore original pin
+        Faraday.datadog_pin = original_pin
+        reset_deprecation_warnings!(original_pin)
+      end
+
+      it { expect(log_buffer).to contain_line_with(*deprecation_warnings).once }
+    end
+  end
+end


### PR DESCRIPTION
Faraday still uses `Datadog::Pin` to drive configuration.

This pull requests changes the integration to use the configuration API, and deprecates the use of `#datadog_pin` as a means to drive configuration, and now raises warnings when it is accessed this way. Instead, when the pin is accessed and configured, it will apply the appropriate configuration via the configuration API.

Changes here should be backwards compatible; any users using old means should receive a warning to upgrade while still preserving existing functionality.