### PR TITLE
Add analytics_sample_rate to all integrations

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -798,6 +798,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `quantize` | Hash containing options for quantization. May include `:show` with an Array of keys to not quantize (or `:all` to skip quantization), or `:exclude` with Array of keys to exclude entirely. | `{ show: [:collection, :database, :operation] }` |
 | `service_name` | Service name used for `mongo` instrumentation | `'mongodb'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -384,6 +384,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | ---| --- | --- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `orm_service_name` | Service name used for the Ruby ORM portion of `active_record` instrumentation. Overrides service name for ORM spans if explicitly set, which otherwise inherit their service from their parent. | `'active_record'` |
 | `service_name` | Service name used for database portion of `active_record` instrumentation. | Name of database adapter (e.g. `'mysql2'`) |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -631,6 +631,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) | `true` |
 | `error_handler` | A `Proc` that accepts a `response` parameter. If it evaluates to a *truthy* value, the trace span is marked as an error. By default only sets 5XX responses as errors. | `nil` |
 | `service_name` | Service name for Faraday instrumentation. When provided to middleware for a specific connection, it applies only to that connection object. | `'faraday'` |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -500,6 +500,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `dalli` instrumentation | `'memcached'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1085,6 +1085,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `redis` instrumentation | `'redis'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -849,6 +849,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) | `true` |
 | `service_name` | Service name used for `http` instrumentation | `'net/http'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1150,6 +1150,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) | `true` |
 | `service_name` | Service name for `rest_client` instrumentation. | `'rest_client'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -447,6 +447,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `aws` instrumentation | `'aws'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -751,6 +751,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `grpc` instrumentation | `'grpc'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -823,6 +823,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `mysql2` instrumentation | `'mysql2'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -573,6 +573,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) | `true` |
 | `error_handler` | A `Proc` that accepts a `response` parameter. If it evaluates to a *truthy* value, the trace span is marked as an error. By default only sets 5XX responses as errors. | `nil` |
 | `service_name` | Service name for Excon instrumentation. When provided to middleware for a specific connection, it applies only to that connection object. | `'excon'` |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -547,6 +547,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `quantize` | Hash containing options for quantization. May include `:show` with an Array of keys to not quantize (or `:all` to skip quantization), or `:exclude` with Array of keys to exclude entirely. | `{}` |
 | `service_name` | Service name used for `elasticsearch` instrumentation | `'elasticsearch'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1185,6 +1185,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name for `sequel` instrumentation | Name of database adapter (e.g. `'mysql2'`) |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -355,6 +355,7 @@ ActiveModelSerializers::SerializableResource.new(test_obj).serializable_hash
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `active_model_serializers` instrumentation. | `'active_model_serializers'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -881,7 +881,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `nil` |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `racecar` instrumentation | `'racecar'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1298,7 +1298,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `nil` |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `sucker_punch` instrumentation | `'sucker_punch'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1128,7 +1128,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `nil` |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `resque` instrumentation | `'resque'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 | `workers` | An array including all worker classes you want to trace (eg `[MyJob]`) | `[]` |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1272,6 +1272,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `nil` |
 | `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `true` |
 | `headers` | Hash of HTTP request or response headers to add as tags to the `sinatra.request`. Accepts `request` and `response` keys with Array values e.g. `['Last-Modified']`. Adds `http.request.headers.*` and `http.response.headers.*` tags respectively. | `{ response: ['Content-Type', 'X-Request-ID'] }` |
 | `resource_script_names` | Prepend resource names with script name | `false` |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -666,6 +666,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `nil` |
 | `enabled` | Defines whether Grape should be traced. Useful for temporarily disabling tracing. `true` or `false` | `true` |
 | `service_name` | Service name used for `grape` instrumentation | `'grape'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -522,7 +522,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `nil` |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `DelayedJob` instrumentation | `'delayed_job'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1024,7 +1024,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `nil` |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `enabled` | Defines whether Rake tasks should be traced. Useful for temporarily disabling tracing. `true` or `false` | `true` |
 | `quantize` | Hash containing options for quantization of task arguments. See below for more details and examples. | `{}` |
 | `service_name` | Service name used for `rake` instrumentation | `'rake'` |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -691,6 +691,7 @@ The `use :graphql` method accepts the following parameters. Additional options c
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `nil` |
 | `service_name` | Service name used for `graphql` instrumentation | `'ruby-graphql'` |
 | `schemas` | Required. Array of `GraphQL::Schema` objects which to trace. Tracing will be added to all the schemas listed, using the options provided to this configuration. If you do not provide any, then tracing will not be activated. | `[]` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -977,6 +977,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `nil` |
 | `cache_service` | Cache service name used when tracing cache activity | `'<app_name>-cache'` |
 | `controller_service` | Service name used when tracing a Rails action controller | `'<app_name>'` |
 | `database_service` | Database service name used when tracing database activity | `'<app_name>-<adapter_name>'` |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1244,7 +1244,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `nil` |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `client_service_name` | Service name used for client-side `sidekiq` instrumentation | `'sidekiq-client'` |
 | `service_name` | Service name used for server-side `sidekiq` instrumentation | `'sidekiq'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1222,7 +1222,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `nil` |
+| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `shoryuken` instrumentation | `'shoryuken'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 

--- a/lib/ddtrace/contrib/active_model_serializers/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/configuration/settings.rb
@@ -7,6 +7,14 @@ module Datadog
       module Configuration
         # Custom settings for the ActiveModelSerializers integration
         class Settings < Contrib::Configuration::Settings
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :service_name, default: Ext::SERVICE_NAME
           option :tracer, default: Datadog.tracer do |value|
             (value || Datadog.tracer).tap do |v|

--- a/lib/ddtrace/contrib/active_model_serializers/event.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/event.rb
@@ -1,4 +1,5 @@
 require 'ddtrace/ext/http'
+require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/active_support/notifications/event'
 require 'ddtrace/contrib/active_model_serializers/ext'
 
@@ -29,6 +30,11 @@ module Datadog
 
           def process(span, event, _id, payload)
             span.service = configuration[:service_name]
+
+            # Set analytics sample rate
+            if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
+              Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])
+            end
 
             # Set the resource name and serializer name
             res = resource(payload[:serializer])

--- a/lib/ddtrace/contrib/active_model_serializers/ext.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/ext.rb
@@ -4,11 +4,11 @@ module Datadog
       # ActiveModelSerializers integration constants
       module Ext
         APP = 'active_model_serializers'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_ACTIVE_MODEL_SERIALIZERS_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_ACTIVE_MODEL_SERIALIZERS_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'active_model_serializers'.freeze
-
         SPAN_RENDER = 'active_model_serializers.render'.freeze
         SPAN_SERIALIZE = 'active_model_serializers.serialize'.freeze
-
         TAG_ADAPTER = 'active_model_serializers.adapter'.freeze
         TAG_SERIALIZER = 'active_model_serializers.serializer'.freeze
       end

--- a/lib/ddtrace/contrib/active_record/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_record/configuration/settings.rb
@@ -8,6 +8,14 @@ module Datadog
       module Configuration
         # Custom settings for the ActiveRecord integration
         class Settings < Contrib::Configuration::Settings
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :orm_service_name
           option :service_name, depends_on: [:tracer] do |value|
             (value || Utils.adapter_name).tap do |service_name|

--- a/lib/ddtrace/contrib/active_record/events/instantiation.rb
+++ b/lib/ddtrace/contrib/active_record/events/instantiation.rb
@@ -1,3 +1,4 @@
+require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/active_record/ext'
 require 'ddtrace/contrib/active_record/event'
 
@@ -38,6 +39,12 @@ module Datadog
 
             span.resource = payload.fetch(:class_name)
             span.span_type = Ext::SPAN_TYPE_INSTANTIATION
+
+            # Set analytics sample rate
+            if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
+              Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])
+            end
+
             span.set_tag(Ext::TAG_INSTANTIATION_CLASS_NAME, payload.fetch(:class_name))
             span.set_tag(Ext::TAG_INSTANTIATION_RECORD_COUNT, payload.fetch(:record_count))
           rescue StandardError => e

--- a/lib/ddtrace/contrib/active_record/events/sql.rb
+++ b/lib/ddtrace/contrib/active_record/events/sql.rb
@@ -1,4 +1,5 @@
 require 'ddtrace/ext/net'
+require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/active_record/ext'
 require 'ddtrace/contrib/active_record/event'
 
@@ -37,6 +38,11 @@ module Datadog
             span.service = service_name
             span.resource = payload.fetch(:sql)
             span.span_type = Datadog::Ext::SQL::TYPE
+
+            # Set analytics sample rate
+            if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
+              Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])
+            end
 
             # Find out if the SQL query has been cached in this request. This meta is really
             # helpful to users because some spans may have 0ns of duration because the query

--- a/lib/ddtrace/contrib/active_record/ext.rb
+++ b/lib/ddtrace/contrib/active_record/ext.rb
@@ -4,13 +4,12 @@ module Datadog
       # ActiveRecord integration constants
       module Ext
         APP = 'active_record'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_ACTIVE_RECORD_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_ACTIVE_RECORD_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'active_record'.freeze
-
         SPAN_INSTANTIATION = 'active_record.instantiation'.freeze
         SPAN_SQL = 'active_record.sql'.freeze
-
         SPAN_TYPE_INSTANTIATION = 'custom'.freeze
-
         TAG_DB_CACHED = 'active_record.db.cached'.freeze
         TAG_DB_NAME = 'active_record.db.name'.freeze
         TAG_DB_VENDOR = 'active_record.db.vendor'.freeze

--- a/lib/ddtrace/contrib/analytics.rb
+++ b/lib/ddtrace/contrib/analytics.rb
@@ -15,7 +15,8 @@ module Datadog
       end
 
       def set_sample_rate(span, sample_rate)
-        span.set_metric(Datadog::Ext::Analytics::TAG_SAMPLE_RATE, sample_rate) unless sample_rate.nil?
+        return if span.nil? || sample_rate.nil?
+        span.set_metric(Datadog::Ext::Analytics::TAG_SAMPLE_RATE, sample_rate)
       end
     end
   end

--- a/lib/ddtrace/contrib/aws/configuration/settings.rb
+++ b/lib/ddtrace/contrib/aws/configuration/settings.rb
@@ -7,6 +7,14 @@ module Datadog
       module Configuration
         # Custom settings for the AWS integration
         class Settings < Contrib::Configuration::Settings
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :service_name, default: Ext::SERVICE_NAME
         end
       end

--- a/lib/ddtrace/contrib/aws/ext.rb
+++ b/lib/ddtrace/contrib/aws/ext.rb
@@ -4,17 +4,16 @@ module Datadog
       # AWS integration constants
       module Ext
         APP = 'aws'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_AWS_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_AWS_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'aws'.freeze
-
         SPAN_COMMAND = 'aws.command'.freeze
-
         TAG_AGENT = 'aws.agent'.freeze
-        TAG_OPERATION = 'aws.operation'.freeze
-        TAG_REGION = 'aws.region'.freeze
-        TAG_PATH = 'path'.freeze
-        TAG_HOST = 'host'.freeze
-
         TAG_DEFAULT_AGENT = 'aws-sdk-ruby'.freeze
+        TAG_HOST = 'host'.freeze
+        TAG_OPERATION = 'aws.operation'.freeze
+        TAG_PATH = 'path'.freeze
+        TAG_REGION = 'aws.region'.freeze
       end
     end
   end

--- a/lib/ddtrace/contrib/aws/instrumentation.rb
+++ b/lib/ddtrace/contrib/aws/instrumentation.rb
@@ -1,3 +1,4 @@
+require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/aws/ext'
 
 module Datadog
@@ -27,6 +28,12 @@ module Datadog
           span.span_type = Datadog::Ext::AppTypes::WEB
           span.name = Ext::SPAN_COMMAND
           span.resource = context.safely(:resource)
+
+          # Set analytics sample rate
+          if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
+            Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])
+          end
+
           span.set_tag(Ext::TAG_AGENT, Ext::TAG_DEFAULT_AGENT)
           span.set_tag(Ext::TAG_OPERATION, context.safely(:operation))
           span.set_tag(Ext::TAG_REGION, context.safely(:region))

--- a/lib/ddtrace/contrib/dalli/configuration/settings.rb
+++ b/lib/ddtrace/contrib/dalli/configuration/settings.rb
@@ -7,6 +7,14 @@ module Datadog
       module Configuration
         # Custom settings for the Dalli integration
         class Settings < Contrib::Configuration::Settings
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :service_name, default: Ext::SERVICE_NAME
         end
       end

--- a/lib/ddtrace/contrib/dalli/ext.rb
+++ b/lib/ddtrace/contrib/dalli/ext.rb
@@ -4,9 +4,10 @@ module Datadog
       # Dalli integration constants
       module Ext
         APP = 'dalli'.freeze
-        SERVICE_NAME = 'memcached'.freeze
-
+        ENV_ANALYTICS_ENABLED = 'DD_DALLI_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_DALLI_ANALYTICS_SAMPLE_RATE'.freeze
         QUANTIZE_MAX_CMD_LENGTH = 100
+        SERVICE_NAME = 'memcached'.freeze
         SPAN_COMMAND = 'memcached.command'.freeze
         TAG_COMMAND = 'memcached.command'.freeze
       end

--- a/lib/ddtrace/contrib/dalli/instrumentation.rb
+++ b/lib/ddtrace/contrib/dalli/instrumentation.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/ext/app_types'
 require 'ddtrace/ext/net'
+require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/dalli/quantize'
 
 module Datadog
@@ -35,6 +36,12 @@ module Datadog
               span.resource = op.to_s.upcase
               span.service = datadog_configuration[:service_name]
               span.span_type = Datadog::Ext::AppTypes::CACHE
+
+              # Set analytics sample rate
+              if Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])
+                Contrib::Analytics.set_sample_rate(span, datadog_configuration[:analytics_sample_rate])
+              end
+
               span.set_tag(Datadog::Ext::NET::TARGET_HOST, hostname)
               span.set_tag(Datadog::Ext::NET::TARGET_PORT, port)
               cmd = Datadog::Contrib::Dalli::Quantize.format_command(op, args)

--- a/lib/ddtrace/contrib/delayed_job/configuration/settings.rb
+++ b/lib/ddtrace/contrib/delayed_job/configuration/settings.rb
@@ -8,7 +8,7 @@ module Datadog
         # Custom settings for the DelayedJob integration
         class Settings < Contrib::Configuration::Settings
           option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENALBED, nil) },
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
                   lazy: true
 
           option  :analytics_sample_rate,

--- a/lib/ddtrace/contrib/delayed_job/ext.rb
+++ b/lib/ddtrace/contrib/delayed_job/ext.rb
@@ -4,7 +4,7 @@ module Datadog
       # DelayedJob integration constants
       module Ext
         APP = 'delayed_job'.freeze
-        ENV_ANALYTICS_ENALBED = 'DD_DELAYED_JOB_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_DELAYED_JOB_ANALYTICS_ENABLED'.freeze
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_DELAYED_JOB_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'delayed_job'.freeze
         SPAN_JOB = 'delayed_job'.freeze

--- a/lib/ddtrace/contrib/elasticsearch/configuration/settings.rb
+++ b/lib/ddtrace/contrib/elasticsearch/configuration/settings.rb
@@ -7,6 +7,14 @@ module Datadog
       module Configuration
         # Custom settings for the Elasticsearch integration
         class Settings < Contrib::Configuration::Settings
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :quantize, default: {}
           option :service_name, default: Ext::SERVICE_NAME
         end

--- a/lib/ddtrace/contrib/elasticsearch/ext.rb
+++ b/lib/ddtrace/contrib/elasticsearch/ext.rb
@@ -4,10 +4,10 @@ module Datadog
       # Elasticsearch integration constants
       module Ext
         APP = 'elasticsearch'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_ELASTICSEARCH_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_ELASTICSEARCH_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'elasticsearch'.freeze
-
         SPAN_QUERY = 'elasticsearch.query'.freeze
-
         TAG_BODY = 'elasticsearch.body'.freeze
         TAG_METHOD = 'elasticsearch.method'.freeze
         TAG_PARAMS = 'elasticsearch.params'.freeze

--- a/lib/ddtrace/contrib/excon/configuration/settings.rb
+++ b/lib/ddtrace/contrib/excon/configuration/settings.rb
@@ -7,6 +7,14 @@ module Datadog
       module Configuration
         # Custom settings for the Excon integration
         class Settings < Contrib::Configuration::Settings
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :distributed_tracing, default: true
           option :error_handler, default: nil
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/excon/ext.rb
+++ b/lib/ddtrace/contrib/excon/ext.rb
@@ -4,8 +4,9 @@ module Datadog
       # Excon integration constants
       module Ext
         APP = 'excon'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_EXCON_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_EXCON_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'excon'.freeze
-
         SPAN_REQUEST = 'excon.request'.freeze
       end
     end

--- a/lib/ddtrace/contrib/faraday/configuration/settings.rb
+++ b/lib/ddtrace/contrib/faraday/configuration/settings.rb
@@ -12,6 +12,14 @@ module Datadog
             Datadog::Ext::HTTP::ERROR_RANGE.cover?(env[:status])
           end
 
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :distributed_tracing, default: true
           option :error_handler, default: DEFAULT_ERROR_HANDLER
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/faraday/ext.rb
+++ b/lib/ddtrace/contrib/faraday/ext.rb
@@ -4,8 +4,9 @@ module Datadog
       # Faraday integration constants
       module Ext
         APP = 'faraday'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_FARADAY_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_FARADAY_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'faraday'.freeze
-
         SPAN_REQUEST = 'faraday.request'.freeze
       end
     end

--- a/lib/ddtrace/contrib/grape/configuration/settings.rb
+++ b/lib/ddtrace/contrib/grape/configuration/settings.rb
@@ -8,6 +8,14 @@ module Datadog
       module Configuration
         # Custom settings for the Grape integration
         class Settings < Contrib::Configuration::Settings
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :enabled, default: true
           option :service_name, default: Ext::SERVICE_NAME
         end

--- a/lib/ddtrace/contrib/grape/endpoint.rb
+++ b/lib/ddtrace/contrib/grape/endpoint.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/ext/http'
 require 'ddtrace/ext/errors'
+require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/rack/ext'
 
 module Datadog
@@ -79,6 +80,11 @@ module Datadog
                 request_span.resource = resource
               end
 
+              # Set analytics sample rate
+              if analytics_enabled?
+                Contrib::Analytics.set_sample_rate(span, analytics_sample_rate)
+              end
+
               # catch thrown exceptions
               span.set_error(payload[:exception_object]) unless payload[:exception_object].nil?
 
@@ -145,6 +151,11 @@ module Datadog
             )
 
             begin
+              # Set analytics sample rate
+              if analytics_enabled?
+                Contrib::Analytics.set_sample_rate(span, analytics_sample_rate)
+              end
+
               # catch thrown exceptions
               span.set_error(payload[:exception_object]) unless payload[:exception_object].nil?
               span.set_tag(Ext::TAG_FILTER_TYPE, type.to_s)
@@ -164,6 +175,14 @@ module Datadog
 
           def service_name
             datadog_configuration[:service_name]
+          end
+
+          def analytics_enabled?
+            Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])
+          end
+
+          def analytics_sample_rate
+            datadog_configuration[:analytics_sample_rate]
           end
 
           def enabled?

--- a/lib/ddtrace/contrib/grape/ext.rb
+++ b/lib/ddtrace/contrib/grape/ext.rb
@@ -4,12 +4,12 @@ module Datadog
       # Grape integration constants
       module Ext
         APP = 'grape'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_GRAPE_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_GRAPE_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'grape'.freeze
-
         SPAN_ENDPOINT_RENDER = 'grape.endpoint_render'.freeze
         SPAN_ENDPOINT_RUN = 'grape.endpoint_run'.freeze
         SPAN_ENDPOINT_RUN_FILTERS = 'grape.endpoint_run_filters'.freeze
-
         TAG_FILTER_TYPE = 'grape.filter.type'.freeze
         TAG_ROUTE_ENDPOINT = 'grape.route.endpoint'.freeze
         TAG_ROUTE_PATH = 'grape.route.path'.freeze

--- a/lib/ddtrace/contrib/graphql/configuration/settings.rb
+++ b/lib/ddtrace/contrib/graphql/configuration/settings.rb
@@ -8,6 +8,14 @@ module Datadog
       module Configuration
         # Custom settings for the GraphQL integration
         class Settings < Contrib::Configuration::Settings
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :schemas
           option :service_name, default: Ext::SERVICE_NAME, depends_on: [:tracer] do |value|
             get_option(:tracer).set_service_info(value, Ext::APP, Datadog::Ext::AppTypes::WEB)

--- a/lib/ddtrace/contrib/graphql/ext.rb
+++ b/lib/ddtrace/contrib/graphql/ext.rb
@@ -4,6 +4,8 @@ module Datadog
       # GraphQL integration constants
       module Ext
         APP = 'ruby-graphql'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_GRAPHQL_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_GRAPHQL_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'ruby-graphql'.freeze
       end
     end

--- a/lib/ddtrace/contrib/graphql/patcher.rb
+++ b/lib/ddtrace/contrib/graphql/patcher.rb
@@ -30,19 +30,25 @@ module Datadog
         def patch_schema!(schema)
           tracer = get_option(:tracer)
           service_name = get_option(:service_name)
+          analytics_enabled = Contrib::Analytics.enabled?(get_option(:analytics_enabled))
+          analytics_sample_rate = get_option(:analytics_sample_rate)
 
           if schema.respond_to?(:use)
             schema.use(
               ::GraphQL::Tracing::DataDogTracing,
               tracer: tracer,
-              service: service_name
+              service: service_name,
+              analytics_enabled: analytics_enabled,
+              analytics_sample_rate: analytics_sample_rate
             )
           else
             schema.define do
               use(
                 ::GraphQL::Tracing::DataDogTracing,
                 tracer: tracer,
-                service: service_name
+                service: service_name,
+                analytics_enabled: analytics_enabled,
+                analytics_sample_rate: analytics_sample_rate
               )
             end
           end

--- a/lib/ddtrace/contrib/grpc/configuration/settings.rb
+++ b/lib/ddtrace/contrib/grpc/configuration/settings.rb
@@ -7,6 +7,14 @@ module Datadog
       module Configuration
         # Custom settings for the gRPC integration
         class Settings < Contrib::Configuration::Settings
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :service_name, default: Ext::SERVICE_NAME
         end
       end

--- a/lib/ddtrace/contrib/grpc/datadog_interceptor.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor.rb
@@ -1,4 +1,5 @@
 require 'ddtrace/ext/app_types'
+require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/grpc/ext'
 
 module Datadog
@@ -54,6 +55,14 @@ module Datadog
 
           def service_name
             (datadog_pin && datadog_pin.service_name) || datadog_configuration[:service_name]
+          end
+
+          def analytics_enabled?
+            Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])
+          end
+
+          def analytics_sample_rate
+            datadog_configuration[:analytics_sample_rate]
           end
         end
 

--- a/lib/ddtrace/contrib/grpc/datadog_interceptor/client.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor/client.rb
@@ -1,4 +1,5 @@
 require 'ddtrace/ext/http'
+require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/grpc/ext'
 
 module Datadog
@@ -32,6 +33,9 @@ module Datadog
             metadata.each do |header, value|
               span.set_tag(header, value)
             end
+
+            # Set analytics sample rate
+            Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
 
             Datadog::GRPCPropagator
               .inject!(span.context, metadata)

--- a/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
@@ -1,4 +1,5 @@
 require 'ddtrace/ext/http'
+require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/grpc/ext'
 
 module Datadog
@@ -44,6 +45,9 @@ module Datadog
               next if reserved_headers.include?(header)
               span.set_tag(header, value)
             end
+
+            # Set analytics sample rate
+            Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
           rescue StandardError => e
             Datadog::Tracer.log.debug("GRPC client trace failed: #{e}")
           end

--- a/lib/ddtrace/contrib/grpc/ext.rb
+++ b/lib/ddtrace/contrib/grpc/ext.rb
@@ -4,8 +4,9 @@ module Datadog
       # gRPC integration constants
       module Ext
         APP = 'grpc'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_GRPC_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_GRPC_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'grpc'.freeze
-
         SPAN_CLIENT = 'grpc.client'.freeze
         SPAN_SERVICE = 'grpc.service'.freeze
       end

--- a/lib/ddtrace/contrib/http/configuration/settings.rb
+++ b/lib/ddtrace/contrib/http/configuration/settings.rb
@@ -7,6 +7,14 @@ module Datadog
       module Configuration
         # Custom settings for the HTTP integration
         class Settings < Contrib::Configuration::Settings
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :distributed_tracing, default: true
           option :service_name, default: Ext::SERVICE_NAME
         end

--- a/lib/ddtrace/contrib/http/ext.rb
+++ b/lib/ddtrace/contrib/http/ext.rb
@@ -4,8 +4,9 @@ module Datadog
       # HTTP integration constants
       module Ext
         APP = 'net/http'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_HTTP_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_HTTP_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'net/http'.freeze
-
         SPAN_REQUEST = 'http.request'.freeze
       end
     end

--- a/lib/ddtrace/contrib/mongodb/configuration/settings.rb
+++ b/lib/ddtrace/contrib/mongodb/configuration/settings.rb
@@ -9,6 +9,14 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           DEFAULT_QUANTIZE = { show: [:collection, :database, :operation] }.freeze
 
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :quantize, default: DEFAULT_QUANTIZE
           option :service_name, default: Ext::SERVICE_NAME
         end

--- a/lib/ddtrace/contrib/mongodb/ext.rb
+++ b/lib/ddtrace/contrib/mongodb/ext.rb
@@ -4,11 +4,11 @@ module Datadog
       # MongoDB integration constants
       module Ext
         APP = 'mongodb'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_MONGO_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_MONGO_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'mongodb'.freeze
-
         SPAN_COMMAND = 'mongo.cmd'.freeze
         SPAN_TYPE_COMMAND = 'mongodb'.freeze
-
         TAG_COLLECTION = 'mongodb.collection'.freeze
         TAG_DB = 'mongodb.db'.freeze
         TAG_OPERATION = 'mongodb.operation'.freeze

--- a/lib/ddtrace/contrib/mysql2/configuration/settings.rb
+++ b/lib/ddtrace/contrib/mysql2/configuration/settings.rb
@@ -7,6 +7,14 @@ module Datadog
       module Configuration
         # Custom settings for the Mysql2 integration
         class Settings < Contrib::Configuration::Settings
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :service_name, default: Ext::SERVICE_NAME
         end
       end

--- a/lib/ddtrace/contrib/mysql2/ext.rb
+++ b/lib/ddtrace/contrib/mysql2/ext.rb
@@ -4,10 +4,10 @@ module Datadog
       # Mysql2 integration constants
       module Ext
         APP = 'mysql2'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_MYSQL2_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_MYSQL2_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'mysql2'.freeze
-
         SPAN_QUERY = 'mysql2.query'.freeze
-
         TAG_DB_NAME = 'mysql2.db.name'.freeze
       end
     end

--- a/lib/ddtrace/contrib/mysql2/instrumentation.rb
+++ b/lib/ddtrace/contrib/mysql2/instrumentation.rb
@@ -1,20 +1,19 @@
 require 'ddtrace/ext/app_types'
 require 'ddtrace/ext/net'
 require 'ddtrace/ext/sql'
+require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/mysql2/ext'
 
 module Datadog
   module Contrib
     module Mysql2
       # Mysql2::Client patch module
-      module Client
-        module_function
-
-        def included(base)
+      module Instrumentation
+        def self.included(base)
           if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
             base.class_eval do
-              alias_method :aliased_query, :query
-              remove_method :query
+              # Instance methods
+              include InstanceMethodsCompatibility
               include InstanceMethods
             end
           else
@@ -24,22 +23,29 @@ module Datadog
 
         # Mysql2::Client patch 1.9.3 instance methods
         module InstanceMethodsCompatibility
-          def query(*args)
-            aliased_query(*args)
+          def self.included(base)
+            base.class_eval do
+              alias_method :query_without_datadog, :query
+              remove_method :query
+            end
+          end
+
+          def query(*args, &block)
+            query_without_datadog(*args, &block)
           end
         end
 
         # Mysql2::Client patch instance methods
         module InstanceMethods
-          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
-            include InstanceMethodsCompatibility
-          end
-
           def query(sql, options = {})
             datadog_pin.tracer.trace(Ext::SPAN_QUERY) do |span|
               span.resource = sql
               span.service = datadog_pin.service
               span.span_type = Datadog::Ext::SQL::TYPE
+
+              # Set analytics sample rate
+              Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
+
               span.set_tag(Ext::TAG_DB_NAME, query_options[:database])
               span.set_tag(Datadog::Ext::NET::TARGET_HOST, query_options[:host])
               span.set_tag(Datadog::Ext::NET::TARGET_PORT, query_options[:port])
@@ -54,6 +60,20 @@ module Datadog
               app_type: Datadog::Ext::AppTypes::DB,
               tracer: Datadog.configuration[:mysql2][:tracer]
             )
+          end
+
+          private
+
+          def datadog_configuration
+            Datadog.configuration[:mysql2]
+          end
+
+          def analytics_enabled?
+            datadog_configuration[:analytics_enabled]
+          end
+
+          def analytics_sample_rate
+            datadog_configuration[:analytics_sample_rate]
           end
         end
       end

--- a/lib/ddtrace/contrib/mysql2/patcher.rb
+++ b/lib/ddtrace/contrib/mysql2/patcher.rb
@@ -1,5 +1,5 @@
 require 'ddtrace/contrib/patcher'
-require 'ddtrace/contrib/mysql2/client'
+require 'ddtrace/contrib/mysql2/instrumentation'
 
 module Datadog
   module Contrib
@@ -25,7 +25,7 @@ module Datadog
         end
 
         def patch_mysql2_client
-          ::Mysql2::Client.send(:include, Client)
+          ::Mysql2::Client.send(:include, Instrumentation)
         end
       end
     end

--- a/lib/ddtrace/contrib/racecar/configuration/settings.rb
+++ b/lib/ddtrace/contrib/racecar/configuration/settings.rb
@@ -8,7 +8,7 @@ module Datadog
         # Custom settings for the Racecar integration
         class Settings < Contrib::Configuration::Settings
           option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENALBED, nil) },
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
                   lazy: true
 
           option  :analytics_sample_rate,

--- a/lib/ddtrace/contrib/racecar/ext.rb
+++ b/lib/ddtrace/contrib/racecar/ext.rb
@@ -4,7 +4,7 @@ module Datadog
       # Racecar integration constants
       module Ext
         APP = 'racecar'.freeze
-        ENV_ANALYTICS_ENALBED = 'DD_RACECAR_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_RACECAR_ANALYTICS_ENABLED'.freeze
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_RACECAR_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'racecar'.freeze
         SPAN_BATCH = 'racecar.batch'.freeze

--- a/lib/ddtrace/contrib/rack/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rack/configuration/settings.rb
@@ -15,7 +15,7 @@ module Datadog
           }.freeze
 
           option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENALBED, nil) },
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) },
                   lazy: true
 
           option  :analytics_sample_rate,

--- a/lib/ddtrace/contrib/rack/ext.rb
+++ b/lib/ddtrace/contrib/rack/ext.rb
@@ -4,7 +4,7 @@ module Datadog
       # Rack integration constants
       module Ext
         APP = 'rack'.freeze
-        ENV_ANALYTICS_ENALBED = 'DD_RACK_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_RACK_ANALYTICS_ENABLED'.freeze
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_RACK_ANALYTICS_SAMPLE_RATE'.freeze
         RACK_ENV_REQUEST_SPAN = 'datadog.rack_request_span'.freeze
         SERVICE_NAME = 'rack'.freeze

--- a/lib/ddtrace/contrib/rails/action_controller.rb
+++ b/lib/ddtrace/contrib/rails/action_controller.rb
@@ -50,6 +50,9 @@ module Datadog
               rack_request_span.resource = span.resource if rack_request_span
             end
 
+            # Set analytics sample rate
+            Utils.set_analytics_sample_rate(span)
+
             span.set_tag(Ext::TAG_ROUTE_ACTION, payload.fetch(:action))
             span.set_tag(Ext::TAG_ROUTE_CONTROLLER, payload.fetch(:controller))
 

--- a/lib/ddtrace/contrib/rails/active_support.rb
+++ b/lib/ddtrace/contrib/rails/active_support.rb
@@ -53,6 +53,7 @@ module Datadog
             normalized_key = ::ActiveSupport::Cache.expand_cache_key(payload.fetch(:key))
             cache_key = Datadog::Utils.truncate(normalized_key, Ext::QUANTIZE_CACHE_MAX_KEY_SIZE)
             span.set_tag(Ext::TAG_CACHE_KEY, cache_key)
+
             span.set_error(payload[:exception]) if payload[:exception]
           ensure
             span.finish

--- a/lib/ddtrace/contrib/rails/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rails/configuration/settings.rb
@@ -6,6 +6,14 @@ module Datadog
       module Configuration
         # Custom settings for the Rails integration
         class Settings < Contrib::Configuration::Settings
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :cache_service
           option :controller_service
           option :database_service, depends_on: [:service_name] do |value|

--- a/lib/ddtrace/contrib/rails/ext.rb
+++ b/lib/ddtrace/contrib/rails/ext.rb
@@ -4,20 +4,17 @@ module Datadog
       # Rails integration constants
       module Ext
         APP = 'rails'.freeze
-
+        ENV_ANALYTICS_ENABLED = 'DD_RAILS_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_RAILS_ANALYTICS_SAMPLE_RATE'.freeze
         QUANTIZE_CACHE_MAX_KEY_SIZE = 300
-
         RESOURCE_CACHE_DELETE = 'DELETE'.freeze
         RESOURCE_CACHE_GET = 'GET'.freeze
         RESOURCE_CACHE_SET = 'SET'.freeze
-
         SPAN_ACTION_CONTROLLER = 'rails.action_controller'.freeze
         SPAN_CACHE = 'rails.cache'.freeze
         SPAN_RENDER_PARTIAL = 'rails.render_partial'.freeze
         SPAN_RENDER_TEMPLATE = 'rails.render_template'.freeze
-
         SPAN_TYPE_CACHE = 'cache'.freeze
-
         TAG_CACHE_BACKEND = 'rails.cache.backend'.freeze
         TAG_CACHE_KEY = 'rails.cache.key'.freeze
         TAG_LAYOUT = 'rails.layout'.freeze

--- a/lib/ddtrace/contrib/rails/utils.rb
+++ b/lib/ddtrace/contrib/rails/utils.rb
@@ -1,3 +1,5 @@
+require 'ddtrace/contrib/analytics'
+
 module Datadog
   module Contrib
     module Rails
@@ -11,7 +13,7 @@ module Datadog
         def self.normalize_template_name(name)
           return if name.nil?
 
-          base_path = Datadog.configuration[:rails][:template_base_path]
+          base_path = datadog_configuration[:template_base_path]
           sections_view = name.split(base_path)
 
           if sections_view.length == 1
@@ -40,6 +42,20 @@ module Datadog
             status.to_s.starts_with?('5')
           else
             true
+          end
+        end
+
+        def self.set_analytics_sample_rate(span)
+          if Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])
+            Contrib::Analytics.set_sample_rate(span, datadog_configuration[:analytics_sample_rate])
+          end
+        end
+
+        class << self
+          private
+
+          def datadog_configuration
+            Datadog.configuration[:rails]
           end
         end
       end

--- a/lib/ddtrace/contrib/rake/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rake/configuration/settings.rb
@@ -8,7 +8,7 @@ module Datadog
         # Custom settings for the Rake integration
         class Settings < Contrib::Configuration::Settings
           option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENALBED, nil) },
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
                   lazy: true
 
           option  :analytics_sample_rate,

--- a/lib/ddtrace/contrib/rake/ext.rb
+++ b/lib/ddtrace/contrib/rake/ext.rb
@@ -4,7 +4,7 @@ module Datadog
       # Rake integration constants
       module Ext
         APP = 'rake'.freeze
-        ENV_ANALYTICS_ENALBED = 'DD_RAKE_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_RAKE_ANALYTICS_ENABLED'.freeze
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_RAKE_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'rake'.freeze
         SPAN_INVOKE = 'rake.invoke'.freeze

--- a/lib/ddtrace/contrib/redis/configuration/settings.rb
+++ b/lib/ddtrace/contrib/redis/configuration/settings.rb
@@ -7,6 +7,14 @@ module Datadog
       module Configuration
         # Custom settings for the Redis integration
         class Settings < Contrib::Configuration::Settings
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :service_name, default: Ext::SERVICE_NAME
         end
       end

--- a/lib/ddtrace/contrib/redis/ext.rb
+++ b/lib/ddtrace/contrib/redis/ext.rb
@@ -4,15 +4,14 @@ module Datadog
       # Redis integration constants
       module Ext
         APP = 'redis'.freeze
-        SERVICE_NAME = 'redis'.freeze
-        TYPE = 'redis'.freeze
-
+        ENV_ANALYTICS_ENABLED = 'DD_REDIS_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_REDIS_ANALYTICS_SAMPLE_RATE'.freeze
         METRIC_PIPELINE_LEN = 'redis.pipeline_length'.freeze
-
+        SERVICE_NAME = 'redis'.freeze
         SPAN_COMMAND = 'redis.command'.freeze
-
         TAG_DB = 'out.redis_db'.freeze
         TAG_RAW_COMMAND = 'redis.raw_command'.freeze
+        TYPE = 'redis'.freeze
       end
     end
   end

--- a/lib/ddtrace/contrib/redis/tags.rb
+++ b/lib/ddtrace/contrib/redis/tags.rb
@@ -1,4 +1,5 @@
 require 'ddtrace/ext/net'
+require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/redis/ext'
 
 module Datadog
@@ -6,13 +7,30 @@ module Datadog
     module Redis
       # Tags handles generic common tags assignment.
       module Tags
-        module_function
+        class << self
+          def set_common_tags(client, span)
+            # Set analytics sample rate
+            Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
 
-        def set_common_tags(client, span)
-          span.set_tag Datadog::Ext::NET::TARGET_HOST, client.host
-          span.set_tag Datadog::Ext::NET::TARGET_PORT, client.port
-          span.set_tag Ext::TAG_DB, client.db
-          span.set_tag Ext::TAG_RAW_COMMAND, span.resource
+            span.set_tag Datadog::Ext::NET::TARGET_HOST, client.host
+            span.set_tag Datadog::Ext::NET::TARGET_PORT, client.port
+            span.set_tag Ext::TAG_DB, client.db
+            span.set_tag Ext::TAG_RAW_COMMAND, span.resource
+          end
+
+          private
+
+          def datadog_configuration
+            Datadog.configuration[:redis]
+          end
+
+          def analytics_enabled?
+            Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])
+          end
+
+          def analytics_sample_rate
+            datadog_configuration[:analytics_sample_rate]
+          end
         end
       end
     end

--- a/lib/ddtrace/contrib/resque/configuration/settings.rb
+++ b/lib/ddtrace/contrib/resque/configuration/settings.rb
@@ -8,7 +8,7 @@ module Datadog
         # Custom settings for the Resque integration
         class Settings < Contrib::Configuration::Settings
           option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENALBED, nil) },
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
                   lazy: true
 
           option  :analytics_sample_rate,

--- a/lib/ddtrace/contrib/resque/ext.rb
+++ b/lib/ddtrace/contrib/resque/ext.rb
@@ -4,7 +4,7 @@ module Datadog
       # Resque integration constants
       module Ext
         APP = 'resque'.freeze
-        ENV_ANALYTICS_ENALBED = 'DD_RESQUE_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_RESQUE_ANALYTICS_ENABLED'.freeze
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_RESQUE_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'resque'.freeze
         SPAN_JOB = 'resque.job'.freeze

--- a/lib/ddtrace/contrib/rest_client/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rest_client/configuration/settings.rb
@@ -7,6 +7,14 @@ module Datadog
       module Configuration
         # Custom settings for the RestClient integration
         class Settings < Contrib::Configuration::Settings
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :distributed_tracing, default: true
           option :service_name, default: Ext::SERVICE_NAME, depends_on: [:tracer] do |value|
             get_option(:tracer).set_service_info(value, Ext::APP, Datadog::Ext::AppTypes::WEB)

--- a/lib/ddtrace/contrib/rest_client/ext.rb
+++ b/lib/ddtrace/contrib/rest_client/ext.rb
@@ -4,8 +4,9 @@ module Datadog
       # RestClient integration constants
       module Ext
         APP = 'rest_client'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_REST_CLIENT_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_REST_CLIENT_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'rest_client'.freeze
-
         SPAN_REQUEST = 'rest_client.request'.freeze
       end
     end

--- a/lib/ddtrace/contrib/rest_client/request_patch.rb
+++ b/lib/ddtrace/contrib/rest_client/request_patch.rb
@@ -47,6 +47,10 @@ module Datadog
 
           def datadog_tag_request(uri, span)
             span.resource = method.to_s.upcase
+
+            # Set analytics sample rate
+            Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
+
             span.set_tag(Datadog::Ext::HTTP::URL, uri.path)
             span.set_tag(Datadog::Ext::HTTP::METHOD, method.to_s.upcase)
             span.set_tag(Datadog::Ext::NET::TARGET_HOST, uri.host)
@@ -82,8 +86,18 @@ module Datadog
             span.finish
           end
 
+          private
+
           def datadog_configuration
             Datadog.configuration[:rest_client]
+          end
+
+          def analytics_enabled?
+            Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])
+          end
+
+          def analytics_sample_rate
+            datadog_configuration[:analytics_sample_rate]
           end
         end
       end

--- a/lib/ddtrace/contrib/sequel/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sequel/configuration/settings.rb
@@ -7,7 +7,13 @@ module Datadog
       module Configuration
         # Custom settings for the Sequel integration
         class Settings < Contrib::Configuration::Settings
-          # Add any custom Sequel settings or behavior here.
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
         end
       end
     end

--- a/lib/ddtrace/contrib/sequel/database.rb
+++ b/lib/ddtrace/contrib/sequel/database.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/ext/sql'
 require 'ddtrace/ext/app_types'
+require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/sequel/ext'
 require 'ddtrace/contrib/sequel/utils'
 
@@ -23,6 +24,7 @@ module Datadog
               span.service = datadog_pin.service
               span.resource = opts[:query]
               span.span_type = Datadog::Ext::SQL::TYPE
+              Utils.set_analytics_sample_rate(span)
               span.set_tag(Ext::TAG_DB_VENDOR, adapter_name)
               response = super(sql, options)
             end

--- a/lib/ddtrace/contrib/sequel/dataset.rb
+++ b/lib/ddtrace/contrib/sequel/dataset.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/ext/sql'
 require 'ddtrace/ext/app_types'
+require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/sequel/ext'
 require 'ddtrace/contrib/sequel/utils'
 
@@ -44,6 +45,7 @@ module Datadog
               span.service = datadog_pin.service
               span.resource = opts[:query]
               span.span_type = Datadog::Ext::SQL::TYPE
+              Utils.set_analytics_sample_rate(span)
               span.set_tag(Ext::TAG_DB_VENDOR, adapter_name)
               response = super_method.call(sql, options, &block)
             end

--- a/lib/ddtrace/contrib/sequel/ext.rb
+++ b/lib/ddtrace/contrib/sequel/ext.rb
@@ -4,10 +4,10 @@ module Datadog
       # Sequel integration constants
       module Ext
         APP = 'sequel'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_SEQUEL_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_SEQUEL_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'sequel'.freeze
-
         SPAN_QUERY = 'sequel.query'.freeze
-
         TAG_DB_VENDOR = 'sequel.db.vendor'.freeze
       end
     end

--- a/lib/ddtrace/contrib/sequel/utils.rb
+++ b/lib/ddtrace/contrib/sequel/utils.rb
@@ -3,24 +3,42 @@ module Datadog
     module Sequel
       # General purpose functions for Sequel
       module Utils
-        module_function
-
-        def adapter_name(database)
-          Datadog::Utils::Database.normalize_vendor(database.adapter_scheme.to_s)
-        end
-
-        def parse_opts(sql, opts, db_opts)
-          if ::Sequel::VERSION >= '4.37.0' && !sql.is_a?(String)
-            # In 4.37.0, sql was converted to a prepared statement object
-            sql = sql.prepared_sql unless sql.is_a?(Symbol)
+        class << self
+          def adapter_name(database)
+            Datadog::Utils::Database.normalize_vendor(database.adapter_scheme.to_s)
           end
 
-          {
-            name: opts[:type],
-            query: sql,
-            database: db_opts[:database],
-            host: db_opts[:host]
-          }
+          def parse_opts(sql, opts, db_opts)
+            if ::Sequel::VERSION >= '4.37.0' && !sql.is_a?(String)
+              # In 4.37.0, sql was converted to a prepared statement object
+              sql = sql.prepared_sql unless sql.is_a?(Symbol)
+            end
+
+            {
+              name: opts[:type],
+              query: sql,
+              database: db_opts[:database],
+              host: db_opts[:host]
+            }
+          end
+
+          def set_analytics_sample_rate(span)
+            Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
+          end
+
+          private
+
+          def datadog_configuration
+            Datadog.configuration[:sequel]
+          end
+
+          def analytics_enabled?
+            Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])
+          end
+
+          def analytics_sample_rate
+            datadog_configuration[:analytics_sample_rate]
+          end
         end
       end
     end

--- a/lib/ddtrace/contrib/shoryuken/configuration/settings.rb
+++ b/lib/ddtrace/contrib/shoryuken/configuration/settings.rb
@@ -7,7 +7,7 @@ module Datadog
         # Default settings for the Shoryuken integration
         class Settings < Contrib::Configuration::Settings
           option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENALBED, nil) },
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
                   lazy: true
 
           option  :analytics_sample_rate,

--- a/lib/ddtrace/contrib/shoryuken/ext.rb
+++ b/lib/ddtrace/contrib/shoryuken/ext.rb
@@ -4,7 +4,7 @@ module Datadog
       # Shoryuken integration constants
       module Ext
         APP = 'shoryuken'.freeze
-        ENV_ANALYTICS_ENALBED = 'DD_SHORYUKEN_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_SHORYUKEN_ANALYTICS_ENABLED'.freeze
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_SHORYUKEN_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'shoryuken'.freeze
         SPAN_JOB = 'shoryuken.job'.freeze

--- a/lib/ddtrace/contrib/sidekiq/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sidekiq/configuration/settings.rb
@@ -8,7 +8,7 @@ module Datadog
         # Custom settings for the Sidekiq integration
         class Settings < Contrib::Configuration::Settings
           option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENALBED, nil) },
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
                   lazy: true
 
           option  :analytics_sample_rate,

--- a/lib/ddtrace/contrib/sidekiq/ext.rb
+++ b/lib/ddtrace/contrib/sidekiq/ext.rb
@@ -5,7 +5,7 @@ module Datadog
       module Ext
         APP = 'sidekiq'.freeze
         CLIENT_SERVICE_NAME = 'sidekiq-client'.freeze
-        ENV_ANALYTICS_ENALBED = 'DD_SIDEKIQ_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_SIDEKIQ_ANALYTICS_ENABLED'.freeze
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_SIDEKIQ_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'sidekiq'.freeze
         SPAN_PUSH = 'sidekiq.push'.freeze

--- a/lib/ddtrace/contrib/sinatra/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sinatra/configuration/settings.rb
@@ -12,6 +12,14 @@ module Datadog
             response: %w[Content-Type X-Request-ID]
           }.freeze
 
+          option  :analytics_enabled,
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) },
+                  lazy: true
+
+          option  :analytics_sample_rate,
+                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
+                  lazy: true
+
           option :distributed_tracing, default: true
           option :headers, default: DEFAULT_HEADERS
           option :resource_script_names, default: false

--- a/lib/ddtrace/contrib/sinatra/ext.rb
+++ b/lib/ddtrace/contrib/sinatra/ext.rb
@@ -4,13 +4,12 @@ module Datadog
       # Sinatra integration constants
       module Ext
         APP = 'sinatra'.freeze
-        SERVICE_NAME = 'sinatra'.freeze
-
+        ENV_ANALYTICS_ENABLED = 'DD_SINATRA_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_SAMPLE_RATE = 'DD_SINATRA_ANALYTICS_SAMPLE_RATE'.freeze
         RACK_ENV_REQUEST_SPAN = 'datadog.sinatra_request_span'.freeze
-
+        SERVICE_NAME = 'sinatra'.freeze
         SPAN_RENDER_TEMPLATE = 'sinatra.render_template'.freeze
         SPAN_REQUEST = 'sinatra.request'.freeze
-
         TAG_ROUTE_PATH = 'sinatra.route.path'.freeze
         TAG_TEMPLATE_NAME = 'sinatra.template_name'.freeze
       end

--- a/lib/ddtrace/contrib/sinatra/tracer.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer.rb
@@ -41,6 +41,7 @@ module Datadog
                   # If data is a string, it is a literal template and we don't
                   # want to record it.
                   span.set_tag(Ext::TAG_TEMPLATE_NAME, data) if data.is_a? Symbol
+
                   output = super
                 end
               else

--- a/lib/ddtrace/contrib/sinatra/tracer_middleware.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer_middleware.rb
@@ -1,3 +1,4 @@
+require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/sinatra/ext'
 require 'ddtrace/contrib/sinatra/env'
 require 'ddtrace/contrib/sinatra/headers'
@@ -37,6 +38,9 @@ module Datadog
               span.set_tag(name, value) if span.get_tag(name).nil?
             end
 
+            # Set analytics sample rate
+            Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
+
             [status, headers, response_body]
           end
         end
@@ -45,6 +49,14 @@ module Datadog
 
         def tracer
           configuration[:tracer]
+        end
+
+        def analytics_enabled?
+          Contrib::Analytics.enabled?(configuration[:analytics_enabled])
+        end
+
+        def analytics_sample_rate
+          configuration[:analytics_sample_rate]
         end
 
         def configuration

--- a/lib/ddtrace/contrib/sucker_punch/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sucker_punch/configuration/settings.rb
@@ -8,7 +8,7 @@ module Datadog
         # Custom settings for the SuckerPunch integration
         class Settings < Contrib::Configuration::Settings
           option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENALBED, nil) },
+                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
                   lazy: true
 
           option  :analytics_sample_rate,

--- a/lib/ddtrace/contrib/sucker_punch/ext.rb
+++ b/lib/ddtrace/contrib/sucker_punch/ext.rb
@@ -4,7 +4,7 @@ module Datadog
       # SuckerPunch integration constants
       module Ext
         APP = 'sucker_punch'.freeze
-        ENV_ANALYTICS_ENALBED = 'DD_SUCKER_PUNCH_ANALYTICS_ENABLED'.freeze
+        ENV_ANALYTICS_ENABLED = 'DD_SUCKER_PUNCH_ANALYTICS_ENABLED'.freeze
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_SUCKER_PUNCH_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'sucker_punch'.freeze
         SPAN_PERFORM = 'sucker_punch.perform'.freeze

--- a/spec/ddtrace/contrib/active_record/tracer_spec.rb
+++ b/spec/ddtrace/contrib/active_record/tracer_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'ddtrace/contrib/analytics_examples'
 require 'ddtrace'
 
 require_relative 'app'
@@ -19,46 +20,54 @@ RSpec.describe 'ActiveRecord instrumentation' do
     end
   end
 
-  it 'calls the instrumentation when is used standalone' do
-    Article.count
-    spans = tracer.writer.spans
-    services = tracer.writer.services
-
-    # expect service and trace is sent
-    expect(spans.size).to eq(1)
-    expect(services).to_not be_empty
-    expect(services['mysql2']).to eq('app' => 'active_record', 'app_type' => 'db')
-
-    span = spans[0]
-    expect(span.service).to eq('mysql2')
-    expect(span.name).to eq('mysql2.query')
-    expect(span.span_type).to eq('sql')
-    expect(span.resource.strip).to eq('SELECT COUNT(*) FROM `articles`')
-    expect(span.get_tag('active_record.db.vendor')).to eq('mysql2')
-    expect(span.get_tag('active_record.db.name')).to eq('mysql')
-    expect(span.get_tag('active_record.db.cached')).to eq(nil)
-    expect(span.get_tag('out.host')).to eq(ENV.fetch('TEST_MYSQL_HOST', '127.0.0.1'))
-    expect(span.get_tag('out.port')).to eq(ENV.fetch('TEST_MYSQL_PORT', 3306).to_s)
-    expect(span.get_tag('sql.query')).to eq(nil)
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:active_record].reset_configuration!
+    example.run
+    Datadog.registry[:active_record].reset_configuration!
   end
 
-  context 'when service_name' do
-    subject(:spans) do
-      Article.count
-      tracer.writer.spans
+  context 'when query is made' do
+    before(:each) { Article.count }
+
+    let(:spans) { tracer.writer.spans }
+    let(:span) { spans.first }
+    let(:services) { tracer.writer.services }
+
+    it_behaves_like 'analytics for integration' do
+      let(:analytics_enabled_var) { Datadog::Contrib::ActiveRecord::Ext::ENV_ANALYTICS_ENABLED }
+      let(:analytics_sample_rate_var) { Datadog::Contrib::ActiveRecord::Ext::ENV_ANALYTICS_SAMPLE_RATE }
     end
 
-    let(:query_span) { spans.first }
+    it 'calls the instrumentation when is used standalone' do
+      # expect service and trace is sent
+      expect(spans.size).to eq(1)
+      expect(services).to_not be_empty
+      expect(services['mysql2']).to eq('app' => 'active_record', 'app_type' => 'db')
 
-    context 'is not set' do
-      it { expect(query_span.service).to eq('mysql2') }
+      expect(span.service).to eq('mysql2')
+      expect(span.name).to eq('mysql2.query')
+      expect(span.span_type).to eq('sql')
+      expect(span.resource.strip).to eq('SELECT COUNT(*) FROM `articles`')
+      expect(span.get_tag('active_record.db.vendor')).to eq('mysql2')
+      expect(span.get_tag('active_record.db.name')).to eq('mysql')
+      expect(span.get_tag('active_record.db.cached')).to eq(nil)
+      expect(span.get_tag('out.host')).to eq(ENV.fetch('TEST_MYSQL_HOST', '127.0.0.1'))
+      expect(span.get_tag('out.port')).to eq(ENV.fetch('TEST_MYSQL_PORT', 3306).to_s)
+      expect(span.get_tag('sql.query')).to eq(nil)
     end
 
-    context 'is set' do
-      let(:service_name) { 'test_active_record' }
-      let(:configuration_options) { super().merge(service_name: service_name) }
+    context 'and service_name' do
+      context 'is not set' do
+        it { expect(span.service).to eq('mysql2') }
+      end
 
-      it { expect(query_span.service).to eq(service_name) }
+      context 'is set' do
+        let(:service_name) { 'test_active_record' }
+        let(:configuration_options) { super().merge(service_name: service_name) }
+
+        it { expect(span.service).to eq(service_name) }
+      end
     end
   end
 end

--- a/spec/ddtrace/contrib/delayed_job/plugin_spec.rb
+++ b/spec/ddtrace/contrib/delayed_job/plugin_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Datadog::Contrib::DelayedJob::Plugin, :delayed_job_active_record 
       end
 
       it_behaves_like 'analytics for integration' do
-        let(:analytics_enabled_var) { Datadog::Contrib::DelayedJob::Ext::ENV_ANALYTICS_ENALBED }
+        let(:analytics_enabled_var) { Datadog::Contrib::DelayedJob::Ext::ENV_ANALYTICS_ENABLED }
         let(:analytics_sample_rate_var) { Datadog::Contrib::DelayedJob::Ext::ENV_ANALYTICS_SAMPLE_RATE }
       end
 

--- a/spec/ddtrace/contrib/elasticsearch/transport_spec.rb
+++ b/spec/ddtrace/contrib/elasticsearch/transport_spec.rb
@@ -23,15 +23,18 @@ RSpec.describe 'Elasticsearch::Transport::Client tracing' do
 
   let(:client) { Elasticsearch::Client.new(url: server) }
   let(:tracer) { get_test_tracer }
+  let(:configuration_options) { { tracer: tracer } }
 
   let(:spans) { tracer.writer.spans }
   let(:span) { spans.first }
 
   before(:each) do
     Datadog.configure do |c|
-      c.use :elasticsearch, tracer: tracer
+      c.use :elasticsearch, configuration_options
     end
   end
+
+  after(:each) { Datadog.registry[:elasticsearch].reset_configuration! }
 
   context 'when configured with middleware' do
     let(:client) do

--- a/spec/ddtrace/contrib/graphql/tracer_spec.rb
+++ b/spec/ddtrace/contrib/graphql/tracer_spec.rb
@@ -64,6 +64,10 @@ RSpec.describe 'GraphQL patcher' do
         expect(root_span.name).to eq('execute.graphql')
         expect(root_span.resource).to eq('execute.graphql')
 
+        # TODO: Assert GraphQL root span sets analytics sample rate.
+        #       Need to wait on pull request to be merged and GraphQL released.
+        #       See https://github.com/rmosolgo/graphql-ruby/pull/2154
+
         # Expect each span to be properly named
         all_spans.each do |span|
           expect(span.service).to eq('graphql-test')

--- a/spec/ddtrace/contrib/grpc/datadog_interceptor/client_spec.rb
+++ b/spec/ddtrace/contrib/grpc/datadog_interceptor/client_spec.rb
@@ -1,19 +1,27 @@
 require 'spec_helper'
+require 'ddtrace/contrib/analytics_examples'
+
 require 'grpc'
 require 'ddtrace'
 
 RSpec.describe 'tracing on the client connection' do
   subject(:client) { Datadog::Contrib::GRPC::DatadogInterceptor::Client.new }
   let(:tracer) { get_test_tracer }
+  let(:configuration_options) { { tracer: tracer, service_name: 'rspec' } }
 
   let(:span) { tracer.writer.spans.first }
 
   before do
     Datadog.configure do |c|
-      c.use :grpc,
-            tracer: tracer,
-            service_name: 'rspec'
+      c.use :grpc, configuration_options
     end
+  end
+
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:grpc].reset_configuration!
+    example.run
+    Datadog.registry[:grpc].reset_configuration!
   end
 
   context 'using client-specific configurations' do
@@ -52,6 +60,11 @@ RSpec.describe 'tracing on the client connection' do
     specify { expect(span.resource).to eq 'myservice.endpoint' }
     specify { expect(span.get_tag('error.stack')).to be_nil }
     specify { expect(span.get_tag(:some)).to eq 'datum' }
+
+    it_behaves_like 'analytics for integration' do
+      let(:analytics_enabled_var) { Datadog::Contrib::GRPC::Ext::ENV_ANALYTICS_ENABLED }
+      let(:analytics_sample_rate_var) { Datadog::Contrib::GRPC::Ext::ENV_ANALYTICS_SAMPLE_RATE }
+    end
   end
 
   describe '#request_response' do

--- a/spec/ddtrace/contrib/grpc/interception_context_spec.rb
+++ b/spec/ddtrace/contrib/grpc/interception_context_spec.rb
@@ -1,20 +1,30 @@
 require 'spec_helper'
+require 'ddtrace/contrib/analytics_examples'
+
 require 'grpc'
 require 'ddtrace'
 
 RSpec.describe GRPC::InterceptionContext do
   subject(:interception_context) { described_class.new }
   let(:tracer) { get_test_tracer }
+  let(:configuration_options) { { tracer: tracer, service_name: 'rspec' } }
 
   describe '#intercept!' do
     let(:span) { tracer.writer.spans.first }
 
     before do
       Datadog.configure do |c|
-        c.use :grpc, tracer: tracer, service_name: 'rspec'
+        c.use :grpc, configuration_options
       end
 
       subject.intercept!(type, keywords) {}
+    end
+
+    around do |example|
+      # Reset before and after each example; don't allow global state to linger.
+      Datadog.registry[:grpc].reset_configuration!
+      example.run
+      Datadog.registry[:grpc].reset_configuration!
     end
 
     context 'when intercepting on the client' do
@@ -25,6 +35,11 @@ RSpec.describe GRPC::InterceptionContext do
         specify { expect(span.resource).to eq 'myservice.endpoint' }
         specify { expect(span.get_tag('error.stack')).to be_nil }
         specify { expect(span.get_tag(:some)).to eq 'datum' }
+
+        it_behaves_like 'analytics for integration' do
+          let(:analytics_enabled_var) { Datadog::Contrib::GRPC::Ext::ENV_ANALYTICS_ENABLED }
+          let(:analytics_sample_rate_var) { Datadog::Contrib::GRPC::Ext::ENV_ANALYTICS_SAMPLE_RATE }
+        end
       end
 
       context 'request response call type' do
@@ -90,6 +105,11 @@ RSpec.describe GRPC::InterceptionContext do
         specify { expect(span.resource).to eq 'my.server.endpoint' }
         specify { expect(span.get_tag('error.stack')).to be_nil }
         specify { expect(span.get_tag(:some)).to eq 'datum' }
+
+        it_behaves_like 'analytics for integration' do
+          let(:analytics_enabled_var) { Datadog::Contrib::GRPC::Ext::ENV_ANALYTICS_ENABLED }
+          let(:analytics_sample_rate_var) { Datadog::Contrib::GRPC::Ext::ENV_ANALYTICS_SAMPLE_RATE }
+        end
       end
 
       context 'request response call type' do

--- a/spec/ddtrace/contrib/http/request_spec.rb
+++ b/spec/ddtrace/contrib/http/request_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+require 'ddtrace/contrib/analytics_examples'
+
 require 'ddtrace'
 require 'net/http'
 require 'time'
@@ -17,12 +19,19 @@ RSpec.describe 'net/http requests' do
 
   let(:client) { Net::HTTP.new(host, port) }
   let(:tracer) { get_test_tracer }
+  let(:configuration_options) { { tracer: tracer } }
 
   let(:spans) { tracer.writer.spans }
 
   before(:each) do
-    Datadog.configure { |c| c.use :http }
-    Datadog::Pin.get_from(client).tracer = tracer
+    Datadog.configure { |c| c.use :http, configuration_options }
+  end
+
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:http].reset_configuration!
+    example.run
+    Datadog.registry[:http].reset_configuration!
   end
 
   describe '#get' do
@@ -47,6 +56,12 @@ RSpec.describe 'net/http requests' do
         expect(span.get_tag('out.host')).to eq(host)
         expect(span.get_tag('out.port')).to eq(port.to_s)
         expect(span.status).to eq(0)
+      end
+
+      it_behaves_like 'analytics for integration' do
+        let(:analytics_enabled_var) { Datadog::Contrib::HTTP::Ext::ENV_ANALYTICS_ENABLED }
+        let(:analytics_sample_rate_var) { Datadog::Contrib::HTTP::Ext::ENV_ANALYTICS_SAMPLE_RATE }
+        before(:each) { response }
       end
     end
 

--- a/spec/ddtrace/contrib/mongodb/client_spec.rb
+++ b/spec/ddtrace/contrib/mongodb/client_spec.rb
@@ -1,10 +1,12 @@
 require 'spec_helper'
+require 'ddtrace/contrib/analytics_examples'
 
 require 'ddtrace'
 require 'mongo'
 
 RSpec.describe 'Mongo::Client instrumentation' do
   let(:tracer) { get_test_tracer }
+  let(:configuration_options) { { tracer: tracer } }
 
   let(:client) { Mongo::Client.new(["#{host}:#{port}"], client_options) }
   let(:client_options) { { database: database } }
@@ -13,7 +15,6 @@ RSpec.describe 'Mongo::Client instrumentation' do
   let(:database) { 'test' }
   let(:collection) { :artists }
 
-  let(:pin) { Datadog::Pin.get_from(client) }
   let(:spans) { tracer.writer.spans(:keep) }
   let(:span) { spans.first }
 
@@ -26,18 +27,18 @@ RSpec.describe 'Mongo::Client instrumentation' do
     Mongo::Logger.logger.level = ::Logger::WARN
 
     Datadog.configure do |c|
-      c.use :mongo
+      c.use :mongo, configuration_options
     end
-
-    # Have to manually update this because its still
-    # using global pin instead of configuration.
-    # Remove this when we remove the pin.
-    pin.tracer = tracer
   end
 
   # Clear data between tests
   let(:drop_database?) { true }
-  after(:each) do
+
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:mongo].reset_configuration!
+    example.run
+    Datadog.registry[:mongo].reset_configuration!
     client.database.drop if drop_database?
   end
 
@@ -45,16 +46,10 @@ RSpec.describe 'Mongo::Client instrumentation' do
     expect { |b| Mongo::Client.new(["#{host}:#{port}"], client_options, &b) }.to yield_control
   end
 
-  context 'pin' do
-    it 'has the correct attributes' do
-      expect(pin.service).to eq('mongodb')
-      expect(pin.app).to eq('mongodb')
-      expect(pin.app_type).to eq('db')
-    end
-
-    context 'when the service is changed' do
+  context 'when the client is configured' do
+    context 'with a different service name' do
       let(:service) { 'mongodb-primary' }
-      before(:each) { pin.service = service }
+      before(:each) { Datadog.configure(client, service_name: service) }
 
       it 'produces spans with the correct service' do
         client[collection].insert_one(name: 'FKA Twigs')
@@ -63,8 +58,8 @@ RSpec.describe 'Mongo::Client instrumentation' do
       end
     end
 
-    context 'when the tracer is disabled' do
-      before(:each) { pin.tracer.enabled = false }
+    context 'to disable the tracer' do
+      before(:each) { tracer.enabled = false }
 
       it 'produces spans with the correct service' do
         client[collection].insert_one(name: 'FKA Twigs')
@@ -78,12 +73,17 @@ RSpec.describe 'Mongo::Client instrumentation' do
     shared_examples_for 'a MongoDB trace' do
       it 'has basic properties' do
         expect(spans).to have(1).items
-        expect(span.service).to eq(pin.service)
+        expect(span.service).to eq('mongodb')
         expect(span.span_type).to eq('mongodb')
         expect(span.get_tag('mongodb.db')).to eq(database)
         expect(span.get_tag('mongodb.collection')).to eq(collection.to_s)
         expect(span.get_tag('out.host')).to eq(host)
         expect(span.get_tag('out.port')).to eq(port.to_s)
+      end
+
+      it_behaves_like 'analytics for integration' do
+        let(:analytics_enabled_var) { Datadog::Contrib::MongoDB::Ext::ENV_ANALYTICS_ENABLED }
+        let(:analytics_sample_rate_var) { Datadog::Contrib::MongoDB::Ext::ENV_ANALYTICS_SAMPLE_RATE }
       end
     end
 

--- a/spec/ddtrace/contrib/mysql2/patcher_spec.rb
+++ b/spec/ddtrace/contrib/mysql2/patcher_spec.rb
@@ -1,10 +1,13 @@
 require 'spec_helper'
+require 'ddtrace/contrib/analytics_examples'
 
 require 'ddtrace'
 require 'mysql2'
 
 RSpec.describe 'Mysql2::Client patcher' do
   let(:tracer) { get_test_tracer }
+  let(:service_name) { 'my-sql' }
+  let(:configuration_options) { { tracer: tracer, service_name: service_name } }
 
   let(:client) do
     Mysql2::Client.new(
@@ -22,19 +25,27 @@ RSpec.describe 'Mysql2::Client patcher' do
   let(:username) { ENV.fetch('TEST_MYSQL_USER') { 'root' } }
   let(:password) { ENV.fetch('TEST_MYSQL_PASSWORD') { 'root' } }
 
-  let(:pin) { client.datadog_pin }
   let(:spans) { tracer.writer.spans(:keep) }
   let(:span) { spans.first }
 
   before(:each) do
     Datadog.configure do |c|
-      c.use :mysql2, service_name: 'my-sql', tracer: tracer
+      c.use :mysql2, configuration_options
     end
   end
 
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:mysql2].reset_configuration!
+    example.run
+    Datadog.registry[:mysql2].reset_configuration!
+  end
+
   context 'pin' do
+    subject(:pin) { client.datadog_pin }
+
     it 'has the correct attributes' do
-      expect(pin.service).to eq('my-sql')
+      expect(pin.service).to eq(service_name)
       expect(pin.app).to eq('mysql2')
       expect(pin.app_type).to eq('db')
     end
@@ -42,7 +53,7 @@ RSpec.describe 'Mysql2::Client patcher' do
 
   describe 'tracing' do
     describe '#query' do
-      describe 'disabled tracer' do
+      context 'when the tracer is disabled' do
         before(:each) { tracer.enabled = false }
 
         it 'does not write spans' do
@@ -51,21 +62,31 @@ RSpec.describe 'Mysql2::Client patcher' do
         end
       end
 
-      it 'traces successful queries' do
-        client.query('SELECT 1')
-        expect(spans.count).to eq(1)
-        expect(span.get_tag('mysql2.db.name')).to eq(database)
-        expect(span.get_tag('out.host')).to eq(host)
-        expect(span.get_tag('out.port')).to eq(port)
+      context 'when a successful query is made' do
+        before(:each) { client.query('SELECT 1') }
+
+        it 'produces a trace' do
+          expect(spans.count).to eq(1)
+          expect(span.get_tag('mysql2.db.name')).to eq(database)
+          expect(span.get_tag('out.host')).to eq(host)
+          expect(span.get_tag('out.port')).to eq(port)
+        end
+
+        it_behaves_like 'analytics for integration' do
+          let(:analytics_enabled_var) { Datadog::Contrib::Mysql2::Ext::ENV_ANALYTICS_ENABLED }
+          let(:analytics_sample_rate_var) { Datadog::Contrib::Mysql2::Ext::ENV_ANALYTICS_SAMPLE_RATE }
+        end
       end
 
-      it 'traces failed queries' do
-        expect { client.query('SELECT INVALID') }.to raise_error(Mysql2::Error)
+      context 'when a failed query is made' do
+        before(:each) { expect { client.query('SELECT INVALID') }.to raise_error(Mysql2::Error) }
 
-        expect(spans.count).to eq(1)
-        expect(span.status).to eq(1)
-        expect(span.get_tag('error.msg'))
-          .to eq("Unknown column 'INVALID' in 'field list'")
+        it 'traces failed queries' do
+          expect(spans.count).to eq(1)
+          expect(span.status).to eq(1)
+          expect(span.get_tag('error.msg'))
+            .to eq("Unknown column 'INVALID' in 'field list'")
+        end
       end
     end
   end

--- a/spec/ddtrace/contrib/racecar/patcher_spec.rb
+++ b/spec/ddtrace/contrib/racecar/patcher_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe 'Racecar patcher' do
 
     it_behaves_like 'analytics for integration' do
       before { ActiveSupport::Notifications.instrument('process_message.racecar', payload) }
-      let(:analytics_enabled_var) { Datadog::Contrib::Racecar::Ext::ENV_ANALYTICS_ENALBED }
+      let(:analytics_enabled_var) { Datadog::Contrib::Racecar::Ext::ENV_ANALYTICS_ENABLED }
       let(:analytics_sample_rate_var) { Datadog::Contrib::Racecar::Ext::ENV_ANALYTICS_SAMPLE_RATE }
     end
   end
@@ -168,7 +168,7 @@ RSpec.describe 'Racecar patcher' do
 
     it_behaves_like 'analytics for integration' do
       before { ActiveSupport::Notifications.instrument('process_batch.racecar', payload) }
-      let(:analytics_enabled_var) { Datadog::Contrib::Racecar::Ext::ENV_ANALYTICS_ENALBED }
+      let(:analytics_enabled_var) { Datadog::Contrib::Racecar::Ext::ENV_ANALYTICS_ENABLED }
       let(:analytics_sample_rate_var) { Datadog::Contrib::Racecar::Ext::ENV_ANALYTICS_SAMPLE_RATE }
     end
   end

--- a/spec/ddtrace/contrib/rack/configuration_spec.rb
+++ b/spec/ddtrace/contrib/rack/configuration_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Rack integration configuration' do
   it_behaves_like 'analytics for integration' do
     include_context 'an incoming HTTP request'
     before { is_expected.to be_ok }
-    let(:analytics_enabled_var) { Datadog::Contrib::Rack::Ext::ENV_ANALYTICS_ENALBED }
+    let(:analytics_enabled_var) { Datadog::Contrib::Rack::Ext::ENV_ANALYTICS_ENABLED }
     let(:analytics_sample_rate_var) { Datadog::Contrib::Rack::Ext::ENV_ANALYTICS_SAMPLE_RATE }
   end
 

--- a/spec/ddtrace/contrib/rails/analytics_spec.rb
+++ b/spec/ddtrace/contrib/rails/analytics_spec.rb
@@ -1,0 +1,61 @@
+require 'ddtrace/contrib/analytics_examples'
+require 'ddtrace/contrib/rails/rails_helper'
+
+RSpec.describe 'Rails trace analytics' do
+  let(:tracer) { get_test_tracer }
+  let(:configuration_options) { { tracer: tracer } }
+
+  before(:each) do
+    Datadog::RailsActionPatcher.patch_action_controller
+    Datadog.configure do |c|
+      c.use :rails, configuration_options
+    end
+  end
+
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:rails].reset_configuration!
+    example.run
+    Datadog.registry[:rails].reset_configuration!
+  end
+
+  let(:span) { spans.first }
+  let(:spans) { tracer.writer.spans(:keep) }
+
+  describe 'for a controller action' do
+    subject(:result) { action.call(env) }
+    let(:controller) do
+      stub_const('TestController', Class.new(base_class) do
+        def index
+          # Do nothing
+        end
+      end)
+    end
+    let(:name) { :index }
+    let(:base_class) { ActionController::Metal }
+    let(:action) { controller.action(name) }
+    let(:env) { {} }
+
+    before(:each) do
+      # ActionController::Metal is only patched in 2.0+
+      skip 'Not supported for Ruby < 2.0' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
+    end
+
+    shared_examples_for 'a successful dispatch' do
+      it do
+        expect { result }.to_not raise_error
+        expect(result).to be_a_kind_of(Array)
+        expect(result).to have(3).items
+        expect(spans).to have(1).items
+        expect(span.name).to eq('rails.action_controller')
+      end
+    end
+
+    it_behaves_like 'analytics for integration' do
+      before { expect { result }.to_not raise_error }
+      let(:analytics_enabled_var) { Datadog::Contrib::Rails::Ext::ENV_ANALYTICS_ENABLED }
+      let(:analytics_sample_rate_var) { Datadog::Contrib::Rails::Ext::ENV_ANALYTICS_SAMPLE_RATE }
+      it_behaves_like 'a successful dispatch'
+    end
+  end
+end

--- a/spec/ddtrace/contrib/rake/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/rake/instrumentation_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Datadog::Contrib::Rake::Instrumentation do
 
         it_behaves_like 'analytics for integration' do
           let(:span) { invoke_span }
-          let(:analytics_enabled_var) { Datadog::Contrib::Rake::Ext::ENV_ANALYTICS_ENALBED }
+          let(:analytics_enabled_var) { Datadog::Contrib::Rake::Ext::ENV_ANALYTICS_ENABLED }
           let(:analytics_sample_rate_var) { Datadog::Contrib::Rake::Ext::ENV_ANALYTICS_SAMPLE_RATE }
         end
       end

--- a/spec/ddtrace/contrib/resque/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/resque/instrumentation_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Resque instrumentation' do
       end
 
       it_behaves_like 'analytics for integration' do
-        let(:analytics_enabled_var) { Datadog::Contrib::Resque::Ext::ENV_ANALYTICS_ENALBED }
+        let(:analytics_enabled_var) { Datadog::Contrib::Resque::Ext::ENV_ANALYTICS_ENABLED }
         let(:analytics_sample_rate_var) { Datadog::Contrib::Resque::Ext::ENV_ANALYTICS_SAMPLE_RATE }
       end
     end

--- a/spec/ddtrace/contrib/shoryuken/tracer_spec.rb
+++ b/spec/ddtrace/contrib/shoryuken/tracer_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Datadog::Contrib::Shoryuken::Tracer do
     it_behaves_like 'analytics for integration' do
       include_context 'Shoryuken::Worker'
       let(:body) { {} }
-      let(:analytics_enabled_var) { Datadog::Contrib::Shoryuken::Ext::ENV_ANALYTICS_ENALBED }
+      let(:analytics_enabled_var) { Datadog::Contrib::Shoryuken::Ext::ENV_ANALYTICS_ENABLED }
       let(:analytics_sample_rate_var) { Datadog::Contrib::Shoryuken::Ext::ENV_ANALYTICS_SAMPLE_RATE }
       before { call }
     end

--- a/spec/ddtrace/contrib/sinatra/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/tracer_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'ddtrace/contrib/analytics_examples'
 require 'rack/test'
 
 require 'sinatra/base'
@@ -10,18 +11,23 @@ RSpec.describe 'Sinatra instrumentation' do
   include Rack::Test::Methods
 
   let(:tracer) { get_test_tracer }
-  let(:options) { { tracer: tracer } }
+  let(:configuration_options) { { tracer: tracer } }
 
   let(:span) { spans.first }
   let(:spans) { tracer.writer.spans }
 
   before(:each) do
     Datadog.configure do |c|
-      c.use :sinatra, options
+      c.use :sinatra, configuration_options
     end
   end
 
-  after(:each) { Datadog.registry[:sinatra].reset_configuration! }
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:sinatra].reset_configuration!
+    example.run
+    Datadog.registry[:sinatra].reset_configuration!
+  end
 
   shared_context 'app with simple route' do
     let(:app) do
@@ -52,6 +58,12 @@ RSpec.describe 'Sinatra instrumentation' do
           expect(span.span_type).to eq(Datadog::Ext::HTTP::TYPE)
           expect(span.status).to eq(0)
           expect(span.parent).to be nil
+        end
+
+        it_behaves_like 'analytics for integration' do
+          before { is_expected.to be_ok }
+          let(:analytics_enabled_var) { Datadog::Contrib::Sinatra::Ext::ENV_ANALYTICS_ENABLED }
+          let(:analytics_sample_rate_var) { Datadog::Contrib::Sinatra::Ext::ENV_ANALYTICS_SAMPLE_RATE }
         end
 
         context 'which sets X-Request-Id on the response' do
@@ -278,7 +290,7 @@ RSpec.describe 'Sinatra instrumentation' do
     end
 
     context 'with a custom service name' do
-      let(:options) { super().merge(service_name: service_name) }
+      let(:configuration_options) { super().merge(service_name: service_name) }
       let(:service_name) { 'my-sinatra-app' }
 
       context 'and a simple request is made' do
@@ -325,7 +337,7 @@ RSpec.describe 'Sinatra instrumentation' do
     end
 
     context 'with distributed tracing disabled' do
-      let(:options) { super().merge(distributed_tracing: false) }
+      let(:configuration_options) { super().merge(distributed_tracing: false) }
 
       context 'and a simple request is made' do
         include_context 'app with simple route'
@@ -355,7 +367,7 @@ RSpec.describe 'Sinatra instrumentation' do
     end
 
     context 'with header tags' do
-      let(:options) { super().merge(headers: { request: request_headers, response: response_headers }) }
+      let(:configuration_options) { super().merge(headers: { request: request_headers, response: response_headers }) }
       let(:request_headers) { [] }
       let(:response_headers) { [] }
 
@@ -392,7 +404,7 @@ RSpec.describe 'Sinatra instrumentation' do
     end
 
     context 'with script names' do
-      let(:options) { super().merge(resource_script_names: true) }
+      let(:configuration_options) { super().merge(resource_script_names: true) }
 
       let(:app) do
         Class.new(Sinatra::Application) do


### PR DESCRIPTION
Using the feature defined in #665, and as a follow up to #666, this pull request adds the event sample rate tag, if configured, to the following integrations:

- [x] active_model_serializers
- [x] active_record
- [x] aws
- [x] dalli
- [x] elasticsearch
- [x] excon
- [x] faraday
- [x] grape
- [x] graphql (https://github.com/rmosolgo/graphql-ruby/pull/2154)
- [x] grpc
- [x] http
- [x] mongodb
- [x] mysql2
- [x] rails
- [x] redis
- [x] rest_client
- [x] sequel
- [x] sinatra