### PR TITLE
[core] Propagate synthetics origin headers

### DIFF
--- a/lib/ddtrace/ext/distributed.rb
+++ b/lib/ddtrace/ext/distributed.rb
@@ -14,6 +14,7 @@ module Datadog
       GRPC_METADATA_TRACE_ID = 'x-datadog-trace-id'.freeze
       GRPC_METADATA_PARENT_ID = 'x-datadog-parent-id'.freeze
       GRPC_METADATA_SAMPLING_PRIORITY = 'x-datadog-sampling-priority'.freeze
+      GRPC_METADATA_ORIGIN = 'x-datadog-origin'.freeze
     end
   end
 end

--- a/lib/ddtrace/ext/distributed.rb
+++ b/lib/ddtrace/ext/distributed.rb
@@ -7,6 +7,8 @@ module Datadog
       HTTP_HEADER_PARENT_ID = 'x-datadog-parent-id'.freeze
       HTTP_HEADER_SAMPLING_PRIORITY = 'x-datadog-sampling-priority'.freeze
       SAMPLING_PRIORITY_KEY = '_sampling_priority_v1'.freeze
+      HTTP_HEADER_ORIGIN = 'x-datadog-origin'.freeze
+      ORIGIN_KEY = '_dd.origin'.freeze
 
       # gRPC metadata keys for distributed tracing. https://github.com/grpc/grpc-go/blob/v1.10.x/Documentation/grpc-metadata.md
       GRPC_METADATA_TRACE_ID = 'x-datadog-trace-id'.freeze

--- a/lib/ddtrace/opentracer/distributed_headers.rb
+++ b/lib/ddtrace/opentracer/distributed_headers.rb
@@ -34,6 +34,12 @@ module Datadog
         value
       end
 
+      def origin
+        hdr = @carrier[HTTP_HEADER_ORIGIN]
+        # Only return the value if it is not an empty string
+        hdr if hdr != ''
+      end
+
       private
 
       def id(header)

--- a/lib/ddtrace/opentracer/text_map_propagator.rb
+++ b/lib/ddtrace/opentracer/text_map_propagator.rb
@@ -21,6 +21,7 @@ module Datadog
             carrier[HTTP_HEADER_TRACE_ID] = datadog_context.trace_id
             carrier[HTTP_HEADER_PARENT_ID] = datadog_context.span_id
             carrier[HTTP_HEADER_SAMPLING_PRIORITY] = datadog_context.sampling_priority
+            carrier[HTTP_HEADER_ORIGIN] = datadog_context.origin
           end
 
           # Inject baggage
@@ -43,7 +44,8 @@ module Datadog
                               Datadog::Context.new(
                                 trace_id: headers.trace_id,
                                 span_id: headers.parent_id,
-                                sampling_priority: headers.sampling_priority
+                                sampling_priority: headers.sampling_priority,
+                                origin: headers.origin
                               )
                             else
                               Datadog::Context.new

--- a/lib/ddtrace/propagation/distributed_headers.rb
+++ b/lib/ddtrace/propagation/distributed_headers.rb
@@ -11,7 +11,7 @@ module Datadog
     end
 
     def valid?
-      # Sampling priority is optional.
+      # Sampling priority and origin are optional.
       trace_id && parent_id
     end
 
@@ -31,6 +31,12 @@ module Datadog
       value = hdr.to_i
       return if value < 0
       value
+    end
+
+    def origin
+      hdr = header(HTTP_HEADER_ORIGIN)
+      # Only return the value if it is not an empty string
+      return hdr if hdr != ''
     end
 
     private

--- a/lib/ddtrace/propagation/distributed_headers.rb
+++ b/lib/ddtrace/propagation/distributed_headers.rb
@@ -36,7 +36,7 @@ module Datadog
     def origin
       hdr = header(HTTP_HEADER_ORIGIN)
       # Only return the value if it is not an empty string
-      return hdr if hdr != ''
+      hdr if hdr != ''
     end
 
     private

--- a/lib/ddtrace/propagation/grpc_propagator.rb
+++ b/lib/ddtrace/propagation/grpc_propagator.rb
@@ -13,6 +13,7 @@ module Datadog
       metadata[GRPC_METADATA_TRACE_ID] = context.trace_id.to_s
       metadata[GRPC_METADATA_PARENT_ID] = context.span_id.to_s
       metadata[GRPC_METADATA_SAMPLING_PRIORITY] = context.sampling_priority.to_s if context.sampling_priority
+      metadata[GRPC_METADATA_ORIGIN] = context.origin.to_s if context.origin
     end
 
     def self.extract(metadata)
@@ -20,7 +21,8 @@ module Datadog
       return Datadog::Context.new unless metadata.valid?
       Datadog::Context.new(trace_id: metadata.trace_id,
                            span_id: metadata.parent_id,
-                           sampling_priority: metadata.sampling_priority)
+                           sampling_priority: metadata.sampling_priority,
+                           origin: metadata.origin)
     end
 
     # opentracing.io compliant carrier object
@@ -48,6 +50,11 @@ module Datadog
       def sampling_priority
         value = @metadata[GRPC_METADATA_SAMPLING_PRIORITY]
         value && value.to_i
+      end
+
+      def origin
+        value = @metadata[GRPC_METADATA_ORIGIN]
+        value if value != ''
       end
     end
   end

--- a/lib/ddtrace/propagation/http_propagator.rb
+++ b/lib/ddtrace/propagation/http_propagator.rb
@@ -18,7 +18,7 @@ module Datadog
       env[HTTP_HEADER_TRACE_ID] = context.trace_id.to_s
       env[HTTP_HEADER_PARENT_ID] = context.span_id.to_s
       env[HTTP_HEADER_SAMPLING_PRIORITY] = context.sampling_priority.to_s
-      env[HTTP_HEADER_ORIGIN] = context.origin.to_s
+      env[HTTP_HEADER_ORIGIN] = context.origin.to_s if context.origin
       env.delete(HTTP_HEADER_SAMPLING_PRIORITY) unless context.sampling_priority
     end
 

--- a/lib/ddtrace/propagation/http_propagator.rb
+++ b/lib/ddtrace/propagation/http_propagator.rb
@@ -18,6 +18,7 @@ module Datadog
       env[HTTP_HEADER_TRACE_ID] = context.trace_id.to_s
       env[HTTP_HEADER_PARENT_ID] = context.span_id.to_s
       env[HTTP_HEADER_SAMPLING_PRIORITY] = context.sampling_priority.to_s
+      env[HTTP_HEADER_ORIGIN] = context.origin.to_s
       env.delete(HTTP_HEADER_SAMPLING_PRIORITY) unless context.sampling_priority
     end
 
@@ -28,7 +29,8 @@ module Datadog
       return Datadog::Context.new unless headers.valid?
       Datadog::Context.new(trace_id: headers.trace_id,
                            span_id: headers.parent_id,
-                           sampling_priority: headers.sampling_priority)
+                           sampling_priority: headers.sampling_priority,
+                           origin: headers.origin)
     end
   end
 end

--- a/spec/ddtrace/context_spec.rb
+++ b/spec/ddtrace/context_spec.rb
@@ -43,4 +43,22 @@ RSpec.describe Datadog::Context do
       end
     end
   end
+
+  describe '#origin' do
+    context 'with nil' do
+      before(:each) { context.origin = nil }
+      it { expect(context.origin).to be_nil }
+    end
+
+    context 'with empty string' do
+      # We do not do any filtering based on value
+      before(:each) { context.origin = '' }
+      it { expect(context.origin).to eq('') }
+    end
+
+    context 'with synthetics' do
+      before(:each) { context.origin = 'synthetics' }
+      it { expect(context.origin).to eq('synthetics') }
+    end
+  end
 end

--- a/spec/ddtrace/contrib/rack/distributed_spec.rb
+++ b/spec/ddtrace/contrib/rack/distributed_spec.rb
@@ -40,11 +40,13 @@ RSpec.describe 'Rack integration distributed tracing' do
     let(:trace_id) { 8694058539399423136 }
     let(:parent_id) { 3605612475141592985 }
     let(:sampling_priority) { Datadog::Ext::Priority::AUTO_KEEP }
+    let(:origin) { 'synthetics' }
 
     before(:each) do
       header Datadog::Ext::DistributedTracing::HTTP_HEADER_TRACE_ID, trace_id
       header Datadog::Ext::DistributedTracing::HTTP_HEADER_PARENT_ID, parent_id
       header Datadog::Ext::DistributedTracing::HTTP_HEADER_SAMPLING_PRIORITY, sampling_priority
+      header Datadog::Ext::DistributedTracing::HTTP_HEADER_ORIGIN, origin
     end
   end
 
@@ -52,6 +54,7 @@ RSpec.describe 'Rack integration distributed tracing' do
     let(:trace_id) { nil }
     let(:parent_id) { nil }
     let(:sampling_priority) { nil }
+    let(:origin) { nil }
   end
 
   shared_examples_for 'a Rack request with distributed tracing' do
@@ -62,6 +65,7 @@ RSpec.describe 'Rack integration distributed tracing' do
       expect(span.trace_id).to eq(trace_id)
       expect(span.parent_id).to eq(parent_id)
       expect(span.get_metric(Datadog::Ext::DistributedTracing::SAMPLING_PRIORITY_KEY)).to eq(sampling_priority)
+      expect(span.get_tag(Datadog::Ext::DistributedTracing::ORIGIN_KEY)).to eq(origin)
     end
   end
 
@@ -73,6 +77,7 @@ RSpec.describe 'Rack integration distributed tracing' do
       expect(span.trace_id).to_not eq(trace_id)
       expect(span.parent_id).to eq(0)
       expect(span.get_metric(Datadog::Ext::DistributedTracing::SAMPLING_PRIORITY_KEY)).to be nil
+      expect(span.get_tag(Datadog::Ext::DistributedTracing::ORIGIN_KEY)).to be nil
     end
   end
 

--- a/spec/ddtrace/contrib/sinatra/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/tracer_spec.rb
@@ -309,7 +309,8 @@ RSpec.describe 'Sinatra instrumentation' do
             {
               'HTTP_X_DATADOG_TRACE_ID' => '1',
               'HTTP_X_DATADOG_PARENT_ID' => '2',
-              'HTTP_X_DATADOG_SAMPLING_PRIORITY' => Datadog::Ext::Priority::USER_KEEP.to_s
+              'HTTP_X_DATADOG_SAMPLING_PRIORITY' => Datadog::Ext::Priority::USER_KEEP.to_s,
+              'HTTP_X_DATADOG_ORIGIN' => 'synthetics'
             }
           end
 
@@ -319,6 +320,7 @@ RSpec.describe 'Sinatra instrumentation' do
             expect(span.trace_id).to eq(1)
             expect(span.parent_id).to eq(2)
             expect(span.get_metric(Datadog::Ext::DistributedTracing::SAMPLING_PRIORITY_KEY)).to eq(2.0)
+            expect(span.get_tag(Datadog::Ext::DistributedTracing::ORIGIN_KEY)).to eq('synthetics')
           end
         end
       end

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -175,6 +175,31 @@ RSpec.describe 'Tracer integration tests' do
     end
   end
 
+  describe 'origin tag' do
+    # Sampling priority is enabled by default
+    let(:tracer) { get_test_tracer }
+
+    context 'when #sampling_priority is set on a parent span' do
+      let(:parent_span) { tracer.start_span('parent span') }
+
+      before(:each) do
+        parent_span.tap do
+          parent_span.context.origin = 'synthetics'
+        end.finish
+
+        try_wait_until { tracer.writer.spans(:keep).any? }
+      end
+
+      it do
+        tag_value = parent_span.get_tag(
+          Datadog::Ext::DistributedTracing::ORIGIN_KEY
+        )
+
+        expect(tag_value).to eq('synthetics')
+      end
+    end
+  end
+
   describe 'sampling priority integration' do
     include_context 'agent-based test'
 

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -180,6 +180,7 @@ RSpec.describe 'Tracer integration tests' do
     let(:tracer) { get_test_tracer }
 
     context 'when #sampling_priority is set on a parent span' do
+      subject(:tag_value) { parent_span.get_tag(Datadog::Ext::DistributedTracing::ORIGIN_KEY) }
       let(:parent_span) { tracer.start_span('parent span') }
 
       before(:each) do
@@ -190,13 +191,7 @@ RSpec.describe 'Tracer integration tests' do
         try_wait_until { tracer.writer.spans(:keep).any? }
       end
 
-      it do
-        tag_value = parent_span.get_tag(
-          Datadog::Ext::DistributedTracing::ORIGIN_KEY
-        )
-
-        expect(tag_value).to eq('synthetics')
-      end
+      it { is_expected.to eq('synthetics') }
     end
   end
 

--- a/spec/ddtrace/opentracer/propagation_integration_spec.rb
+++ b/spec/ddtrace/opentracer/propagation_integration_spec.rb
@@ -15,6 +15,10 @@ if Datadog::OpenTracer.supported?
       span.get_metric(Datadog::OpenTracer::TextMapPropagator::SAMPLING_PRIORITY_KEY)
     end
 
+    def origin_tag(span)
+      span.get_tag(Datadog::OpenTracer::TextMapPropagator::ORIGIN_KEY)
+    end
+
     describe 'via OpenTracing::FORMAT_TEXT_MAP' do
       def baggage_to_carrier_format(baggage)
         baggage.map { |k, v| [Datadog::OpenTracer::TextMapPropagator::BAGGAGE_PREFIX + k, v] }.to_h
@@ -87,6 +91,7 @@ if Datadog::OpenTracer.supported?
           it { expect(datadog_span.trace_id).to eq(trace_id) }
           it { expect(datadog_span.parent_id).to eq(parent_id) }
           it { expect(sampling_priority_metric(datadog_span)).to eq(sampling_priority) }
+          it { expect(origin_tag(datadog_span)).to eq(origin) }
           it { expect(@scope.span.context.baggage).to include(baggage) }
         end
 
@@ -134,6 +139,7 @@ if Datadog::OpenTracer.supported?
         it { expect(sender_datadog_span.finished?).to be(true) }
         it { expect(sender_datadog_span.parent_id).to eq(0) }
         it { expect(sampling_priority_metric(sender_datadog_span)).to eq(1) }
+        it { expect(origin_tag(sender_datadog_span)).to eq('synthetics') }
         it { expect(receiver_datadog_span.name).to eq(receiver_span_name) }
         it { expect(receiver_datadog_span.finished?).to be(true) }
         it { expect(receiver_datadog_span.trace_id).to eq(sender_datadog_span.trace_id) }

--- a/spec/ddtrace/opentracer/rack_propagator_spec.rb
+++ b/spec/ddtrace/opentracer/rack_propagator_spec.rb
@@ -23,13 +23,15 @@ if Datadog::OpenTracer.supported?
           Datadog::Context,
           trace_id: trace_id,
           span_id: span_id,
-          sampling_priority: sampling_priority
+          sampling_priority: sampling_priority,
+          origin: origin
         )
       end
 
       let(:trace_id) { double('trace ID') }
       let(:span_id) { double('span ID') }
       let(:sampling_priority) { double('sampling priority') }
+      let(:origin) { double('synthetics') }
 
       let(:baggage) { { 'account_name' => 'acme' } }
 
@@ -43,6 +45,8 @@ if Datadog::OpenTracer.supported?
           .with(Datadog::HTTPPropagator::HTTP_HEADER_PARENT_ID, span_id.to_s)
         expect(carrier).to receive(:[]=)
           .with(Datadog::HTTPPropagator::HTTP_HEADER_SAMPLING_PRIORITY, sampling_priority.to_s)
+        expect(carrier).to receive(:[]=)
+          .with(Datadog::HTTPPropagator::HTTP_HEADER_ORIGIN, origin.to_s)
       end
 
       # Expect carrier to be set with OpenTracing baggage

--- a/spec/ddtrace/opentracer/text_map_propagator_spec.rb
+++ b/spec/ddtrace/opentracer/text_map_propagator_spec.rb
@@ -23,13 +23,15 @@ if Datadog::OpenTracer.supported?
           Datadog::Context,
           trace_id: trace_id,
           span_id: span_id,
-          sampling_priority: sampling_priority
+          sampling_priority: sampling_priority,
+          origin: origin
         )
       end
 
       let(:trace_id) { double('trace ID') }
       let(:span_id) { double('span ID') }
       let(:sampling_priority) { double('sampling priority') }
+      let(:origin) { double('synthetics') }
 
       let(:baggage) { { 'account_name' => 'acme' } }
 
@@ -43,6 +45,8 @@ if Datadog::OpenTracer.supported?
           .with(Datadog::OpenTracer::DistributedHeaders::HTTP_HEADER_PARENT_ID, span_id)
         expect(carrier).to receive(:[]=)
           .with(Datadog::OpenTracer::DistributedHeaders::HTTP_HEADER_SAMPLING_PRIORITY, sampling_priority)
+        expect(carrier).to receive(:[]=)
+          .with(Datadog::OpenTracer::DistributedHeaders::HTTP_HEADER_ORIGIN, origin)
       end
 
       # Expect carrier to be set with OpenTracing baggage
@@ -116,6 +120,7 @@ if Datadog::OpenTracer.supported?
           it { expect(datadog_context.trace_id).to be nil }
           it { expect(datadog_context.span_id).to be nil }
           it { expect(datadog_context.sampling_priority).to be nil }
+          it { expect(datadog_context.origin).to be nil }
 
           it_behaves_like 'baggage'
         end
@@ -127,18 +132,21 @@ if Datadog::OpenTracer.supported?
               valid?: true,
               trace_id: trace_id,
               parent_id: parent_id,
-              sampling_priority: sampling_priority
+              sampling_priority: sampling_priority,
+              origin: origin
             )
           end
 
           let(:trace_id) { double('trace ID') }
           let(:parent_id) { double('parent span ID') }
           let(:sampling_priority) { double('sampling priority') }
+          let(:origin) { double('synthetics') }
 
           it { is_expected.to be_a_kind_of(Datadog::OpenTracer::SpanContext) }
           it { expect(datadog_context.trace_id).to be trace_id }
           it { expect(datadog_context.span_id).to be parent_id }
           it { expect(datadog_context.sampling_priority).to be sampling_priority }
+          it { expect(datadog_context.origin).to be origin }
 
           it_behaves_like 'baggage'
         end

--- a/spec/ddtrace/propagation/distributed_headers_spec.rb
+++ b/spec/ddtrace/propagation/distributed_headers_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe Datadog::DistributedHeaders do
 
     context 'incorrect header' do
       [
-        'X-DATADOG-ORIGN',  # Typo
+        'X-DATADOG-ORIGN', # Typo
         'DATADOG-ORIGIN',
         'X-ORIGIN',
         'ORIGIN'
       ].each do |header|
         context header do
-          let(:env) { {env_header(header) => 'synthetics'} }
+          let(:env) { { env_header(header) => 'synthetics' } }
 
           it { expect(headers.origin).to be_nil }
         end
@@ -38,11 +38,11 @@ RSpec.describe Datadog::DistributedHeaders do
     context 'origin in header' do
       [
         ['', nil],
-        ['synthetics', 'synthetics'],
-        ['origin', 'origin']
+        %w[synthetics synthetics],
+        %w[origin origin]
       ].each do |value, expected|
         context "set to #{value}" do
-          let(:env) { {env_header(Datadog::Ext::DistributedTracing::HTTP_HEADER_ORIGIN) => value} }
+          let(:env) { { env_header(Datadog::Ext::DistributedTracing::HTTP_HEADER_ORIGIN) => value } }
 
           it { expect(headers.origin).to eq(expected) }
         end

--- a/spec/ddtrace/propagation/distributed_headers_spec.rb
+++ b/spec/ddtrace/propagation/distributed_headers_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+require 'ddtrace'
+require 'ddtrace/ext/distributed'
+require 'ddtrace/propagation/distributed_headers'
+
+RSpec.describe Datadog::DistributedHeaders do
+  subject(:headers) do
+    described_class.new(env)
+  end
+  let(:env) { {} }
+
+  # Helper to format env header keys
+  def env_header(name)
+    "http-#{name}".upcase!.tr('-', '_')
+  end
+
+  describe '#origin' do
+    context 'no origin header' do
+      it { expect(headers.origin).to be_nil }
+    end
+
+    context 'incorrect header' do
+      [
+        'X-DATADOG-ORIGN',  # Typo
+        'DATADOG-ORIGIN',
+        'X-ORIGIN',
+        'ORIGIN'
+      ].each do |header|
+        context header do
+          let(:env) { {env_header(header) => 'synthetics'} }
+
+          it { expect(headers.origin).to be_nil }
+        end
+      end
+    end
+
+    context 'origin in header' do
+      [
+        ['', nil],
+        ['synthetics', 'synthetics'],
+        ['origin', 'origin']
+      ].each do |value, expected|
+        context "set to #{value}" do
+          let(:env) { {env_header(Datadog::Ext::DistributedTracing::HTTP_HEADER_ORIGIN) => value} }
+
+          it { expect(headers.origin).to eq(expected) }
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/tracer_integration_spec.rb
+++ b/spec/ddtrace/tracer_integration_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Datadog::Tracer do
       it { expect(child_span.trace_id).to eq(parent_span.trace_id) }
       it { expect(child_span.parent_id).to eq(parent_span.span_id) }
       it { expect(sampling_priority_metric(child_span)).to eq(1) }
-      it { expect(origin_tag(child_span)).to be_nil }
+      it { expect(origin_tag(child_span)).to eq('synthetics') }
       # This is expected to be child_span because when propagated, we don't
       # propagate the root span, only its ID. Therefore the span reference
       # should be the first span on the other end of the distributed trace.

--- a/spec/ddtrace/tracer_integration_spec.rb
+++ b/spec/ddtrace/tracer_integration_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Datadog::Tracer do
     span.get_metric(Datadog::Ext::DistributedTracing::SAMPLING_PRIORITY_KEY)
   end
 
+  def origin_tag(span)
+    span.get_tag(Datadog::Ext::DistributedTracing::ORIGIN_KEY)
+  end
+
   describe '#active_root_span' do
     subject(:active_root_span) { tracer.active_root_span }
 
@@ -23,6 +27,7 @@ RSpec.describe Datadog::Tracer do
         tracer.trace(parent_span_name) do |parent_span|
           @parent_span = parent_span
           parent_span.context.sampling_priority = Datadog::Ext::Priority::AUTO_KEEP
+          parent_span.context.origin = 'synthetics'
 
           # Propagate it via headers
           headers = {}
@@ -50,11 +55,13 @@ RSpec.describe Datadog::Tracer do
       it { expect(parent_span.finished?).to be(true) }
       it { expect(parent_span.parent_id).to eq(0) }
       it { expect(sampling_priority_metric(parent_span)).to eq(1) }
+      it { expect(origin_tag(parent_span)).to eq('synthetics') }
       it { expect(child_span.name).to eq(child_span_name) }
       it { expect(child_span.finished?).to be(true) }
       it { expect(child_span.trace_id).to eq(parent_span.trace_id) }
       it { expect(child_span.parent_id).to eq(parent_span.span_id) }
       it { expect(sampling_priority_metric(child_span)).to eq(1) }
+      it { expect(origin_tag(child_span)).to be_nil }
       # This is expected to be child_span because when propagated, we don't
       # propagate the root span, only its ID. Therefore the span reference
       # should be the first span on the other end of the distributed trace.

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -82,21 +82,6 @@ class ContextTest < Minitest::Test
     end
   end
 
-  def test_origin
-    ctx = Datadog::Context.new
-
-    assert_nil(ctx.origin)
-
-    [nil, '', 'synthetics', 'origin'].each do |origin|
-      ctx.origin = origin
-      if origin
-        assert_equal(origin, ctx.origin)
-      else
-        assert_nil(ctx.origin)
-      end
-    end
-  end
-
   def test_add_span
     tracer = get_test_tracer
     ctx = Datadog::Context.new

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -19,6 +19,7 @@ class ContextTest < Minitest::Test
     assert_nil(ctx.trace_id)
     assert_nil(ctx.span_id)
     assert_nil(ctx.sampling_priority)
+    assert_nil(ctx.origin)
     assert_equal(false, ctx.sampled)
     assert_equal(false, ctx.finished?)
 
@@ -26,6 +27,14 @@ class ContextTest < Minitest::Test
     assert_equal(123, ctx.trace_id)
     assert_equal(456, ctx.span_id)
     assert_equal(1, ctx.sampling_priority)
+    assert_equal(true, ctx.sampled)
+    assert_equal(false, ctx.finished?)
+
+    ctx = Datadog::Context.new(trace_id: 123, span_id: 456, sampling_priority: 1, origin: 'synthetics', sampled: true)
+    assert_equal(123, ctx.trace_id)
+    assert_equal(456, ctx.span_id)
+    assert_equal(1, ctx.sampling_priority)
+    assert_equal('synthetics', ctx.origin)
     assert_equal(true, ctx.sampled)
     assert_equal(false, ctx.finished?)
   end
@@ -69,6 +78,21 @@ class ContextTest < Minitest::Test
         assert_equal(sampling_priority, ctx.sampling_priority)
       else
         assert_nil(ctx.sampling_priority)
+      end
+    end
+  end
+
+  def test_origin
+    ctx = Datadog::Context.new
+
+    assert_nil(ctx.origin)
+
+    [nil, '', 'synthetics', 'origin'].each do |origin|
+      ctx.origin = origin
+      if origin
+        assert_equal(origin, ctx.origin)
+      else
+        assert_nil(ctx.origin)
       end
     end
   end

--- a/test/propagation/distributed_headers_test.rb
+++ b/test/propagation/distributed_headers_test.rb
@@ -110,24 +110,4 @@ class DistributedHeadersTest < Minitest::Test
       end
     end
   end
-
-  def test_origin
-    test_cases = {
-      { 'HTTP_X_DATADOG_ORIGIN' => '' } => nil,
-      { 'HTTP_X_DATADOG_ORIGIN' => 'synthetics' } => 'synthetics',
-      { 'HTTP_X_DATADOG_ORIGIN' => 'origin' } => 'origin',
-      # nil cases below are very important to test, they are valid real-world use cases
-      {} => nil,
-      { 'HTTP_X_DATADOG_ORIGN' => 'synthetics' } => nil
-    }
-
-    test_cases.each do |env, expected|
-      dh = Datadog::DistributedHeaders.new(env)
-      if expected
-        assert_equal(expected, dh.origin, "with #{env} origin should return #{expected}")
-      else
-        assert_nil(dh.origin, "with #{env} origin should return nil")
-      end
-    end
-  end
 end

--- a/test/propagation/distributed_headers_test.rb
+++ b/test/propagation/distributed_headers_test.rb
@@ -110,4 +110,24 @@ class DistributedHeadersTest < Minitest::Test
       end
     end
   end
+
+  def test_origin
+    test_cases = {
+      { 'HTTP_X_DATADOG_ORIGIN' => '' } => nil,
+      { 'HTTP_X_DATADOG_ORIGIN' => 'synthetics' } => 'synthetics',
+      { 'HTTP_X_DATADOG_ORIGIN' => 'origin' } => 'origin',
+      # nil cases below are very important to test, they are valid real-world use cases
+      {} => nil,
+      { 'HTTP_X_DATADOG_ORIGN' => 'synthetics' } => nil
+    }
+
+    test_cases.each do |env, expected|
+      dh = Datadog::DistributedHeaders.new(env)
+      if expected
+        assert_equal(expected, dh.origin, "with #{env} origin should return #{expected}")
+      else
+        assert_nil(dh.origin, "with #{env} origin should return nil")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds support for extracting, injecting, and propagating `X-Datadog-Origin` headers as a part of distributed tracing.

- `X-Datadog-Origin` header will be parsed and attached to the context as `context.origin`.
- `X-Datadog-Origin` header will be appended to any distributed tracing request from a context with `context.origin` set.
- `_dd.origin` tag will be set on the root trace of the context set to the value from `context.origin`.