### PR TITLE
Enable distributed tracing by default

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -76,7 +76,6 @@ namespace :spec do
     :sidekiq,
     :sinatra,
     :sucker_punch,
-    :rest_client,
     :shoryuken
   ].each do |contrib|
     RSpec::Core::RakeTask.new(contrib) do |t|

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -568,7 +568,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) | `false` |
+| `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) | `true` |
 | `error_handler` | A `Proc` that accepts a `response` parameter. If it evaluates to a *truthy* value, the trace span is marked as an error. By default only sets 5XX responses as errors. | `nil` |
 | `service_name` | Service name for Excon instrumentation. When provided to middleware for a specific connection, it applies only to that connection object. | `'excon'` |
 | `split_by_domain` | Uses the request domain as the service name when set to `true`. | `false` |
@@ -625,7 +625,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) | `false` |
+| `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) | `true` |
 | `error_handler` | A `Proc` that accepts a `response` parameter. If it evaluates to a *truthy* value, the trace span is marked as an error. By default only sets 5XX responses as errors. | `nil` |
 | `service_name` | Service name for Faraday instrumentation. When provided to middleware for a specific connection, it applies only to that connection object. | `'faraday'` |
 | `split_by_domain` | Uses the request domain as the service name when set to `true`. | `false` |
@@ -838,7 +838,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) | `false` |
+| `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) | `true` |
 | `service_name` | Service name used for `http` instrumentation | `'net/http'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 
@@ -899,7 +899,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | Key | Description | Default |
 | --- | ----------- | ------- |
 | `application` | Your Rack application. Required for `middleware_names`. | `nil` |
-| `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `false` |
+| `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `true` |
 | `event_sample_rate` | Rate which spans should be sampled for search and analytics. | `nil` |
 | `headers` | Hash of HTTP request or response headers to add as tags to the `rack.request`. Accepts `request` and `response` keys with Array values e.g. `['Last-Modified']`. Adds `http.request.headers.*` and `http.response.headers.*` tags respectively. | `{ response: ['Content-Type', 'X-Request-ID'] }` |
 | `middleware_names` | Enable this if you want to use the middleware classes as the resource names for `rack` spans. Requires `application` option to use. | `false` |
@@ -966,7 +966,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `cache_service` | Cache service name used when tracing cache activity | `'<app_name>-cache'` |
 | `controller_service` | Service name used when tracing a Rails action controller | `'<app_name>'` |
 | `database_service` | Database service name used when tracing database activity | `'<app_name>-<adapter_name>'` |
-| `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `false` |
+| `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `true` |
 | `exception_controller` | Class or Module which identifies a custom exception controller class. Tracer provides improved error behavior when it can identify custom exception controllers. By default, without this option, it 'guesses' what a custom exception controller looks like. Providing this option aids this identification. | `nil` |
 | `middleware` | Add the trace middleware to the Rails application. Set to `false` if you don't want the middleware to load. | `true` |
 | `middleware_names` | Enables any short-circuited middleware requests to display the middleware name as resource for the trace. | `false` |
@@ -1134,7 +1134,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) | `false` |
+| `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) | `true` |
 | `service_name` | Service name for `rest_client` instrumentation. | `'rest_client'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 
@@ -1254,7 +1254,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `false` |
+| `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `true` |
 | `headers` | Hash of HTTP request or response headers to add as tags to the `sinatra.request`. Accepts `request` and `response` keys with Array values e.g. `['Last-Modified']`. Adds `http.request.headers.*` and `http.response.headers.*` tags respectively. | `{ response: ['Content-Type', 'X-Request-ID'] }` |
 | `resource_script_names` | Prepend resource names with script name | `false` |
 | `service_name` | Service name used for `sinatra` instrumentation | `'sinatra'` |

--- a/lib/ddtrace/contrib/excon/configuration/settings.rb
+++ b/lib/ddtrace/contrib/excon/configuration/settings.rb
@@ -7,7 +7,7 @@ module Datadog
       module Configuration
         # Custom settings for the Excon integration
         class Settings < Contrib::Configuration::Settings
-          option :distributed_tracing, default: false
+          option :distributed_tracing, default: true
           option :error_handler, default: nil
           option :service_name, default: Ext::SERVICE_NAME
           option :split_by_domain, default: false

--- a/lib/ddtrace/contrib/faraday/configuration/settings.rb
+++ b/lib/ddtrace/contrib/faraday/configuration/settings.rb
@@ -12,7 +12,7 @@ module Datadog
             Datadog::Ext::HTTP::ERROR_RANGE.cover?(env[:status])
           end
 
-          option :distributed_tracing, default: false
+          option :distributed_tracing, default: true
           option :error_handler, default: DEFAULT_ERROR_HANDLER
           option :service_name, default: Ext::SERVICE_NAME
           option :split_by_domain, default: false

--- a/lib/ddtrace/contrib/http/configuration/settings.rb
+++ b/lib/ddtrace/contrib/http/configuration/settings.rb
@@ -7,7 +7,7 @@ module Datadog
       module Configuration
         # Custom settings for the HTTP integration
         class Settings < Contrib::Configuration::Settings
-          option :distributed_tracing, default: false
+          option :distributed_tracing, default: true
           option :service_name, default: Ext::SERVICE_NAME
         end
       end

--- a/lib/ddtrace/contrib/rack/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rack/configuration/settings.rb
@@ -15,7 +15,7 @@ module Datadog
           }.freeze
 
           option :application
-          option :distributed_tracing, default: false
+          option :distributed_tracing, default: true
           option :headers, default: DEFAULT_HEADERS
           option :middleware_names, default: false
           option :quantize, default: {}

--- a/lib/ddtrace/contrib/rails/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rails/configuration/settings.rb
@@ -14,7 +14,7 @@ module Datadog
               Datadog.configuration[:active_record][:service_name] = value
             end
           end
-          option :distributed_tracing, default: false
+          option :distributed_tracing, default: true
           option :exception_controller, default: nil
           option :middleware, default: true
           option :middleware_names, default: false

--- a/lib/ddtrace/contrib/rest_client/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rest_client/configuration/settings.rb
@@ -7,7 +7,7 @@ module Datadog
       module Configuration
         # Custom settings for the RestClient integration
         class Settings < Contrib::Configuration::Settings
-          option :distributed_tracing, default: false
+          option :distributed_tracing, default: true
           option :service_name, default: Ext::SERVICE_NAME, depends_on: [:tracer] do |value|
             get_option(:tracer).set_service_info(value, Ext::APP, Datadog::Ext::AppTypes::WEB)
             value

--- a/lib/ddtrace/contrib/sinatra/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sinatra/configuration/settings.rb
@@ -12,7 +12,7 @@ module Datadog
             response: %w[Content-Type X-Request-ID]
           }.freeze
 
-          option :distributed_tracing, default: false
+          option :distributed_tracing, default: true
           option :headers, default: DEFAULT_HEADERS
           option :resource_script_names, default: false
 

--- a/spec/ddtrace/contrib/excon/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/excon/instrumentation_spec.rb
@@ -185,7 +185,6 @@ RSpec.describe Datadog::Contrib::Excon::Middleware do
         .and_wrap_original do |m, *args|
           m.call(*args).tap do |datum|
             # Assert request headers
-            span = datum[:datadog_span]
             headers = datum[:headers]
             expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_HEADER_TRACE_ID)
             expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_HEADER_PARENT_ID)

--- a/spec/ddtrace/contrib/excon/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/excon/instrumentation_spec.rb
@@ -158,11 +158,11 @@ RSpec.describe Datadog::Contrib::Excon::Middleware do
         .and_wrap_original do |m, *args|
           m.call(*args).tap do |datum|
             # Assert request headers
+            span = datum[:datadog_span]
             headers = datum[:headers]
             expect(headers).to include(Datadog::Ext::DistributedTracing::HTTP_HEADER_TRACE_ID => span.trace_id.to_s)
             expect(headers).to include(Datadog::Ext::DistributedTracing::HTTP_HEADER_PARENT_ID => span.span_id.to_s)
-            expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_SAMPLING_PRIORITY)
-            expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_ORIGIN)
+            expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_HEADER_SAMPLING_PRIORITY)
           end
         end
 
@@ -187,10 +187,9 @@ RSpec.describe Datadog::Contrib::Excon::Middleware do
             # Assert request headers
             span = datum[:datadog_span]
             headers = datum[:headers]
-            expect(headers).to include(Datadog::Ext::DistributedTracing::HTTP_HEADER_TRACE_ID => span.trace_id.to_s)
-            expect(headers).to include(Datadog::Ext::DistributedTracing::HTTP_HEADER_PARENT_ID => span.span_id.to_s)
-            expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_SAMPLING_PRIORITY)
-            expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_ORIGIN)
+            expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_HEADER_TRACE_ID)
+            expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_HEADER_PARENT_ID)
+            expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_HEADER_SAMPLING_PRIORITY)
           end
         end
 
@@ -216,7 +215,6 @@ RSpec.describe Datadog::Contrib::Excon::Middleware do
               expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_HEADER_TRACE_ID)
               expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_HEADER_PARENT_ID)
               expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_HEADER_SAMPLING_PRIORITY)
-              expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_HEADER_ORIGIN)
             end
           end
 

--- a/spec/ddtrace/contrib/faraday/middleware_spec.rb
+++ b/spec/ddtrace/contrib/faraday/middleware_spec.rb
@@ -115,20 +115,8 @@ RSpec.describe 'Faraday middleware' do
     let(:headers) { response.env.request_headers }
 
     it do
-      expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_HEADER_TRACE_ID)
-      expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_HEADER_PARENT_ID)
-    end
-  end
-
-  context 'when distributed tracing is enabled' do
-    subject(:response) { client.get('/success') }
-
-    let(:middleware_options) { { distributed_tracing: true } }
-    let(:headers) { response.env.request_headers }
-
-    it do
-      expect(headers[Datadog::Ext::DistributedTracing::HTTP_HEADER_TRACE_ID]).to eq(request_span.trace_id.to_s)
-      expect(headers[Datadog::Ext::DistributedTracing::HTTP_HEADER_PARENT_ID]).to eq(request_span.span_id.to_s)
+      expect(headers).to include(Datadog::Ext::DistributedTracing::HTTP_HEADER_TRACE_ID => request_span.trace_id.to_s)
+      expect(headers).to include(Datadog::Ext::DistributedTracing::HTTP_HEADER_PARENT_ID => request_span.span_id.to_s)
     end
 
     context 'but the tracer is disabled' do
@@ -138,6 +126,18 @@ RSpec.describe 'Faraday middleware' do
         expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_HEADER_PARENT_ID)
         expect(request_span).to be nil
       end
+    end
+  end
+
+  context 'when distributed tracing is disabled' do
+    subject(:response) { client.get('/success') }
+
+    let(:middleware_options) { { distributed_tracing: false } }
+    let(:headers) { response.env.request_headers }
+
+    it do
+      expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_HEADER_TRACE_ID)
+      expect(headers).to_not include(Datadog::Ext::DistributedTracing::HTTP_HEADER_PARENT_ID)
     end
   end
 

--- a/spec/ddtrace/contrib/http/request_spec.rb
+++ b/spec/ddtrace/contrib/http/request_spec.rb
@@ -168,10 +168,7 @@ RSpec.describe 'net/http requests' do
       })
     end
 
-    context 'when enabled' do
-      before(:each) { Datadog.configure { |c| c.use :http, distributed_tracing: true } }
-      after(:each) { Datadog.configure { |c| c.use :http, distributed_tracing: false } }
-
+    context 'by default' do
       context 'and the tracer is enabled' do
         before(:each) do
           tracer.configure(enabled: true)
@@ -224,6 +221,9 @@ RSpec.describe 'net/http requests' do
       before(:each) do
         Datadog.configure { |c| c.use :http, distributed_tracing: false }
         client.get(path)
+      end
+      after(:each) do
+        Datadog.configure { |c| c.use :http, distributed_tracing: true }
       end
 
       let(:span) { spans.last }

--- a/spec/ddtrace/contrib/rack/distributed_spec.rb
+++ b/spec/ddtrace/contrib/rack/distributed_spec.rb
@@ -76,9 +76,7 @@ RSpec.describe 'Rack integration distributed tracing' do
     end
   end
 
-  context 'when enabled' do
-    let(:rack_options) { super().merge(distributed_tracing: true) }
-
+  context 'by default' do
     context 'and a request is received' do
       include_context 'an incoming HTTP request'
 

--- a/spec/ddtrace/contrib/rest_client/request_patch_spec.rb
+++ b/spec/ddtrace/contrib/rest_client/request_patch_spec.rb
@@ -178,8 +178,8 @@ RSpec.describe Datadog::Contrib::RestClient::RequestPatch do
       end
     end
 
-    context 'distributed tracing enabled' do
-      let(:rest_client_options) { { distributed_tracing: true } }
+    context 'distributed tracing default' do
+      # let(:rest_client_options) { { distributed_tracing: true } }
 
       it_behaves_like 'instrumented request'
 
@@ -212,6 +212,44 @@ RSpec.describe Datadog::Contrib::RestClient::RequestPatch do
 
           expect(a_request(:get, url).with(headers: { 'X-Datadog-Sampling-Priority' => sampling_priority.to_s }))
             .to have_been_made
+        end
+      end
+    end
+
+    context 'distributed tracing disabled' do
+      let(:rest_client_options) { { distributed_tracing: false } }
+
+      it_behaves_like 'instrumented request'
+
+      shared_examples_for 'does not propagate distributed headers' do
+        let(:span) { tracer.writer.spans.first }
+
+        it 'does not propagate the headers' do
+          request
+
+          distributed_tracing_headers = { 'X-Datadog-Parent-Id' => span.span_id.to_s,
+                                          'X-Datadog-Trace-Id' => span.trace_id.to_s }
+
+          expect(a_request(:get, url).with(headers: distributed_tracing_headers)).to_not have_been_made
+        end
+      end
+
+      it_behaves_like 'does not propagate distributed headers'
+
+      context 'with sampling priority' do
+        let(:sampling_priority) { 0.2 }
+
+        before do
+          tracer.provider.context.sampling_priority = sampling_priority
+        end
+
+        it_behaves_like 'does not propagate distributed headers'
+
+        it 'does not propagate sampling priority headers' do
+          RestClient.get(url)
+
+          expect(a_request(:get, url).with(headers: { 'X-Datadog-Sampling-Priority' => sampling_priority.to_s }))
+            .to_not have_been_made
         end
       end
     end

--- a/spec/ddtrace/contrib/rest_client/request_patch_spec.rb
+++ b/spec/ddtrace/contrib/rest_client/request_patch_spec.rb
@@ -179,8 +179,6 @@ RSpec.describe Datadog::Contrib::RestClient::RequestPatch do
     end
 
     context 'distributed tracing default' do
-      # let(:rest_client_options) { { distributed_tracing: true } }
-
       it_behaves_like 'instrumented request'
 
       shared_examples_for 'propagating distributed headers' do

--- a/spec/ddtrace/contrib/sinatra/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/tracer_spec.rb
@@ -294,9 +294,7 @@ RSpec.describe 'Sinatra instrumentation' do
       end
     end
 
-    context 'with distributed tracing' do
-      let(:options) { super().merge(distributed_tracing: true) }
-
+    context 'with distributed tracing default' do
       context 'and a simple request is made' do
         include_context 'app with simple route'
 
@@ -319,6 +317,36 @@ RSpec.describe 'Sinatra instrumentation' do
             expect(span.trace_id).to eq(1)
             expect(span.parent_id).to eq(2)
             expect(span.get_metric(Datadog::Ext::DistributedTracing::SAMPLING_PRIORITY_KEY)).to eq(2.0)
+          end
+        end
+      end
+    end
+
+    context 'with distributed tracing disabled' do
+      let(:options) { super().merge(distributed_tracing: false) }
+
+      context 'and a simple request is made' do
+        include_context 'app with simple route'
+
+        subject(:response) { get '/', query_string, headers }
+        let(:query_string) { {} }
+        let(:headers) { {} }
+
+        context 'without distributed tracing headers' do
+          let(:headers) do
+            {
+              'HTTP_X_DATADOG_TRACE_ID' => '1',
+              'HTTP_X_DATADOG_PARENT_ID' => '2',
+              'HTTP_X_DATADOG_SAMPLING_PRIORITY' => Datadog::Ext::Priority::USER_KEEP.to_s
+            }
+          end
+
+          it do
+            is_expected.to be_ok
+            expect(spans).to have(1).items
+            expect(span.trace_id).to_not eq(1)
+            expect(span.parent_id).to_not eq(2)
+            expect(span.get_metric(Datadog::Ext::DistributedTracing::SAMPLING_PRIORITY_KEY)).to_not eq(2.0)
           end
         end
       end


### PR DESCRIPTION
This PR updates all integrations which allow enabling distributed tracing to have it enabled by default.