### PR TITLE
Deprecate GRPC global pin in favor of configuration API

### DIFF
--- a/lib/ddtrace/contrib/grpc/datadog_interceptor/client.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor/client.rb
@@ -15,7 +15,7 @@ module Datadog
 
             options = {
               span_type: Datadog::Ext::HTTP::TYPE,
-              service: datadog_pin.service_name,
+              service: service_name,
               resource: format_resource(keywords[:method])
             }
 

--- a/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
@@ -14,7 +14,7 @@ module Datadog
           def trace(keywords)
             options = {
               span_type: Datadog::Ext::HTTP::TYPE,
-              service: datadog_pin.service_name,
+              service: service_name,
               resource: format_resource(keywords[:method])
             }
             metadata = keywords[:call].metadata

--- a/spec/ddtrace/contrib/grpc/datadog_interceptor/client_spec.rb
+++ b/spec/ddtrace/contrib/grpc/datadog_interceptor/client_spec.rb
@@ -4,13 +4,14 @@ require 'ddtrace'
 
 RSpec.describe 'tracing on the client connection' do
   subject(:client) { Datadog::Contrib::GRPC::DatadogInterceptor::Client.new }
+  let(:tracer) { get_test_tracer }
 
-  let(:span) { subject.datadog_pin.tracer.writer.spans.first }
+  let(:span) { tracer.writer.spans.first }
 
   before do
     Datadog.configure do |c|
       c.use :grpc,
-            tracer: get_test_tracer,
+            tracer: tracer,
             service_name: 'rspec'
     end
   end
@@ -35,11 +36,11 @@ RSpec.describe 'tracing on the client connection' do
 
     it 'replaces default service name' do
       default_client_interceptor.request_response(keywords) {}
-      span = default_client_interceptor.datadog_pin.tracer.writer.spans.first
+      span = tracer.writer.spans.first
       expect(span.service).to eq 'rspec'
 
       configured_client_interceptor.request_response(keywords) {}
-      span = configured_client_interceptor.datadog_pin.tracer.writer.spans.first
+      span = tracer.writer.spans.first
       expect(span.service).to eq 'cepsr'
     end
   end

--- a/spec/ddtrace/contrib/grpc/datadog_interceptor/server_spec.rb
+++ b/spec/ddtrace/contrib/grpc/datadog_interceptor/server_spec.rb
@@ -4,14 +4,15 @@ require 'ddtrace'
 
 RSpec.describe 'tracing on the server connection' do
   subject(:server) { Datadog::Contrib::GRPC::DatadogInterceptor::Server.new }
+  let(:tracer) { get_test_tracer }
 
   before do
     Datadog.configure do |c|
-      c.use :grpc, tracer: get_test_tracer, service_name: 'rspec'
+      c.use :grpc, tracer: tracer, service_name: 'rspec'
     end
   end
 
-  let(:span) { Datadog::Pin.get_from(::GRPC).tracer.writer.spans.first }
+  let(:span) { tracer.writer.spans.first }
 
   shared_examples 'span data contents' do
     specify { expect(span.name).to eq 'grpc.service' }

--- a/spec/ddtrace/contrib/grpc/integration_spec.rb
+++ b/spec/ddtrace/contrib/grpc/integration_spec.rb
@@ -5,13 +5,15 @@ require 'ddtrace'
 RSpec.describe 'gRPC integration test' do
   include GRPCHelper
 
+  let(:tracer) { get_test_tracer }
+
   let(:spans) do
-    Datadog::Pin.get_from(::GRPC).tracer.writer.spans
+    tracer.writer.spans
   end
 
   before do
     Datadog.configure do |c|
-      c.use :grpc, tracer: get_test_tracer, service_name: 'rspec'
+      c.use :grpc, tracer: tracer, service_name: 'rspec'
     end
   end
 

--- a/spec/ddtrace/contrib/grpc/interception_context_spec.rb
+++ b/spec/ddtrace/contrib/grpc/interception_context_spec.rb
@@ -4,13 +4,14 @@ require 'ddtrace'
 
 RSpec.describe GRPC::InterceptionContext do
   subject(:interception_context) { described_class.new }
+  let(:tracer) { get_test_tracer }
 
   describe '#intercept!' do
-    let(:span) { Datadog::Pin.get_from(::GRPC).tracer.writer.spans.first }
+    let(:span) { tracer.writer.spans.first }
 
     before do
       Datadog.configure do |c|
-        c.use :grpc, tracer: get_test_tracer, service_name: 'rspec'
+        c.use :grpc, tracer: tracer, service_name: 'rspec'
       end
 
       subject.intercept!(type, keywords) {}

--- a/spec/ddtrace/contrib/grpc/patcher_spec.rb
+++ b/spec/ddtrace/contrib/grpc/patcher_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+
+require 'grpc'
+require 'ddtrace'
+require 'ddtrace/contrib/grpc/patcher'
+
+RSpec.describe 'GRPC instrumentation' do
+  include_context 'tracer logging'
+
+  let(:tracer) { get_test_tracer }
+  let(:configuration_options) { { tracer: tracer } }
+
+  # Enable the test tracer
+  before(:each) do
+    Datadog.configure do |c|
+      c.use :grpc, configuration_options
+    end
+  end
+
+  def reset_deprecation_warnings!(pin)
+    if pin.instance_variable_defined?(:@done_once)
+      pin.instance_variable_get(:@done_once).delete('#datadog_pin')
+      pin.instance_variable_get(:@done_once).delete('#datadog_pin=')
+    end
+  end
+
+  let(:deprecation_warnings) do
+    [
+      /.*#datadog_pin.*/,
+      /.*Use of Datadog::Pin with GRPC is DEPRECATED.*/
+    ]
+  end
+
+  it 'does not generate deprecation warnings' do
+    expect(log_buffer.length).to eq(0)
+    expect(log_buffer).to_not contain_line_with(*deprecation_warnings)
+    expect(log_buffer).to_not contain_line_with(*deprecation_warnings)
+  end
+
+  context 'when pin is referenced by' do
+    describe 'Datadog::Pin.get_from' do
+      subject(:pin) { Datadog::Pin.get_from(GRPC) }
+      before(:each) { pin }
+      after(:each) { reset_deprecation_warnings!(pin) }
+
+      it { expect(log_buffer).to contain_line_with(*deprecation_warnings).once }
+
+      context 'twice' do
+        before(:each) { Datadog::Pin.get_from(GRPC) }
+        it { expect(log_buffer).to contain_line_with(*deprecation_warnings).once }
+      end
+
+      context 'and then calls' do
+        # Make sure 'service_name' passes through to underlying configuration
+        describe '#service_name=' do
+          let(:original_service_name) { Datadog.configuration[:grpc][:service_name] }
+          let(:new_service_name) { 'new_service' }
+          after(:each) { pin.service_name = original_service_name }
+
+          it 'updates the configuration service name' do
+            expect { pin.service_name = new_service_name }
+              .to change { Datadog.configuration[:grpc][:service_name] }
+              .from(original_service_name).to(new_service_name)
+          end
+        end
+
+        # Make sure 'tracer' passes through to underlying configuration
+        describe 'tracer=' do
+          let(:new_tracer) { double('tracer') }
+          after(:each) { pin.tracer = tracer }
+
+          it 'updates the configuration service name' do
+            expect { pin.tracer = new_tracer }
+              .to change { Datadog.configuration[:grpc][:tracer] }
+              .from(tracer).to(new_tracer)
+          end
+        end
+      end
+    end
+
+    describe '#datadog_pin' do
+      subject(:pin) { GRPC.datadog_pin }
+      before(:each) { pin }
+      after(:each) { reset_deprecation_warnings!(pin) }
+      it { expect(log_buffer).to contain_line_with(*deprecation_warnings).once }
+
+      context 'twice' do
+        it { expect(log_buffer).to contain_line_with(*deprecation_warnings).once }
+      end
+    end
+
+    describe '#datadog_pin=' do
+      before(:each) do
+        # Store original pin first
+        original_pin
+
+        # Set new pin
+        GRPC.datadog_pin = new_pin
+      end
+      let(:original_pin) do
+        # We know this to create deprecation warnings...
+        # Retrieve the pin and reset the buffer
+        GRPC.datadog_pin.tap do
+          log_buffer.truncate(0)
+          log_buffer.rewind
+        end
+      end
+      let(:new_pin) { Datadog::Pin.new('new_service') }
+
+      after(:each) do
+        # Restore original pin
+        GRPC.datadog_pin = original_pin
+        reset_deprecation_warnings!(original_pin)
+      end
+
+      it { expect(log_buffer).to contain_line_with(*deprecation_warnings).once }
+    end
+  end
+end


### PR DESCRIPTION
GRPC uses `Datadog::Pin` to drive configuration, for global settings and individual interceptors.

This pull requests changes the integration to use the configuration API instead of the global pin, and deprecates the use of `GRPC.datadog_pin` as a means to drive configuration, and now raises warnings when it is accessed this way. Instead, when the pin is accessed and configured, it will apply the appropriate configuration via the configuration API.

It will still continue to use `Datadog::Pin` objects when trace settings are configured for an individual interceptor, so this part of the API will remain the same.

Changes here should be backwards compatible; any users using the global pin directly should receive a warning to upgrade while still preserving existing functionality. Users who use the pin attached to interceptors should not see a change in behavior there.