### PR TITLE
[core] Only require trace id for distributed tracing headers

### DIFF
--- a/lib/ddtrace/propagation/distributed_headers.rb
+++ b/lib/ddtrace/propagation/distributed_headers.rb
@@ -11,10 +11,11 @@ module Datadog
     end
 
     def valid?
-      # We just need a valid trace id. Parent id, sampling priority, and origin are all optional
-      # DEV: No parent id means that our trace will be the parent, but we use a specific trace id
-      #      this is the case for Synthetics requests, they send `X-Datadog-Parent-Id: 0`
-      trace_id
+      # Synthetics sends us `X-Datadog-Parent-Id: 0` which normally we would want
+      # to filter out, but is ok in this context since there is no parent from Synthetics
+      return true if origin == 'synthetics' && trace_id
+
+      trace_id && parent_id
     end
 
     def trace_id

--- a/lib/ddtrace/propagation/distributed_headers.rb
+++ b/lib/ddtrace/propagation/distributed_headers.rb
@@ -11,8 +11,10 @@ module Datadog
     end
 
     def valid?
-      # Sampling priority and origin are optional.
-      trace_id && parent_id
+      # We just need a valid trace id. Parent id, sampling priority, and origin are all optional
+      # DEV: No parent id means that our trace will be the parent, but we use a specific trace id
+      #      this is the case for Synthetics requests, they send `X-Datadog-Parent-Id: 0`
+      trace_id
     end
 
     def trace_id

--- a/test/propagation/distributed_headers_test.rb
+++ b/test/propagation/distributed_headers_test.rb
@@ -21,17 +21,18 @@ class DistributedHeadersTest < Minitest::Test
         'HTTP_X_DATADOG_PARENT_ID' => '456',
         'HTTP_X_DATADOG_SAMPLING_PRIORITY' => '0' } => false,
       { 'HTTP_X_DATADOG_TRACE_ID' => '123',
-        'HTTP_X_DATADOG_PARENT_ID' => 'b',
-        'HTTP_X_DATADOG_SAMPLING_PRIORITY' => '0' } => false,
-      { 'HTTP_X_DATADOG_TRACE_ID' => '123',
         'HTTP_X_DATADOG_PARENT_ID' => '456',
         'HTTP_X_DATADOG_SAMPLING_PRIORITY' => 'ooops' } =>  true, # corner case, 0 is valid for a sampling priority
       { 'HTTP_X_DATADOG_TRACE_ID' => '0',
         'HTTP_X_DATADOG_PARENT_ID' => '0' } => false,
       { 'HTTP_X_DATADOG_TRACE_TYPO' => '123',
         'HTTP_X_DATADOG_PARENT_ID' => '456' } => false,
+      # Parent id is not required
       { 'HTTP_X_DATADOG_TRACE_ID' => '123',
-        'HTTP_X_DATADOG_PARENT_TYPO' => '456' } => false
+        'HTTP_X_DATADOG_PARENT_ID' => 'b',
+        'HTTP_X_DATADOG_SAMPLING_PRIORITY' => '0' } => true,
+      { 'HTTP_X_DATADOG_TRACE_ID' => '123',
+        'HTTP_X_DATADOG_PARENT_TYPO' => '456' } => true
     }
 
     test_cases.each do |env, expected|
@@ -70,6 +71,8 @@ class DistributedHeadersTest < Minitest::Test
     test_cases = {
       { 'HTTP_X_DATADOG_PARENT_ID' => '123' } => 123,
       { 'HTTP_X_DATADOG_PARENT_ID' => '0' } => nil,
+      { 'HTTP_X_DATADOG_PARENT_ID' => 'a' } => nil,
+      { 'HTTP_X_DATADOG_PARENT_ID' => '' } => nil,
       { 'HTTP_X_DATADOG_PARENT_ID' => '-1' } => 18446744073709551615,
       { 'HTTP_X_DATADOG_PARENT_ID' => '-8809075535603237910' } => 9637668538106313706,
       { 'HTTP_X_DATADOG_PARENT_ID' => 'ooops' } => nil,

--- a/test/propagation/distributed_headers_test.rb
+++ b/test/propagation/distributed_headers_test.rb
@@ -35,7 +35,7 @@ class DistributedHeadersTest < Minitest::Test
       # Parent id is not required when origin is synthetics
       { 'HTTP_X_DATADOG_TRACE_ID' => '123',
         'HTTP_X_DATADOG_PARENT_ID' => '0',
-        'HTTP_X_DATADOG_ORIGIN' => 'synthetics'}
+        'HTTP_X_DATADOG_ORIGIN' => 'synthetics' } => true
     }
 
     test_cases.each do |env, expected|

--- a/test/propagation/distributed_headers_test.rb
+++ b/test/propagation/distributed_headers_test.rb
@@ -27,12 +27,15 @@ class DistributedHeadersTest < Minitest::Test
         'HTTP_X_DATADOG_PARENT_ID' => '0' } => false,
       { 'HTTP_X_DATADOG_TRACE_TYPO' => '123',
         'HTTP_X_DATADOG_PARENT_ID' => '456' } => false,
-      # Parent id is not required
       { 'HTTP_X_DATADOG_TRACE_ID' => '123',
         'HTTP_X_DATADOG_PARENT_ID' => 'b',
-        'HTTP_X_DATADOG_SAMPLING_PRIORITY' => '0' } => true,
+        'HTTP_X_DATADOG_SAMPLING_PRIORITY' => '0' } => false,
       { 'HTTP_X_DATADOG_TRACE_ID' => '123',
-        'HTTP_X_DATADOG_PARENT_TYPO' => '456' } => true
+        'HTTP_X_DATADOG_PARENT_TYPO' => '456' } => false,
+      # Parent id is not required when origin is synthetics
+      { 'HTTP_X_DATADOG_TRACE_ID' => '123',
+        'HTTP_X_DATADOG_PARENT_ID' => '0',
+        'HTTP_X_DATADOG_ORIGIN' => 'synthetics'}
     }
 
     test_cases.each do |env, expected|

--- a/test/propagation/distributed_headers_test.rb
+++ b/test/propagation/distributed_headers_test.rb
@@ -4,7 +4,7 @@ require 'ddtrace/span'
 require 'ddtrace/propagation/distributed_headers'
 
 class DistributedHeadersTest < Minitest::Test
-  def test_valid_without_sampling_priority
+  def test_valid_without_sampling_priority # rubocop:disable Metrics/MethodLength
     test_cases = {
       { 'HTTP_X_DATADOG_TRACE_ID' => '123',
         'HTTP_X_DATADOG_PARENT_ID' => '456' } => true,
@@ -33,6 +33,9 @@ class DistributedHeadersTest < Minitest::Test
       { 'HTTP_X_DATADOG_TRACE_ID' => '123',
         'HTTP_X_DATADOG_PARENT_TYPO' => '456' } => false,
       # Parent id is not required when origin is synthetics
+      { 'HTTP_X_DATADOG_TRACE_ID' => '123',
+        'HTTP_X_DATADOG_PARENT_ID' => '0',
+        'HTTP_X_DATADOG_ORIGIN' => 'not-synthetics' } => false,
       { 'HTTP_X_DATADOG_TRACE_ID' => '123',
         'HTTP_X_DATADOG_PARENT_ID' => '0',
         'HTTP_X_DATADOG_ORIGIN' => 'synthetics' } => true


### PR DESCRIPTION
When testing the new synthetics integration we noticed that sending `X-Datadog-Parent-Id: 0` causes us to ignore all distributed tracing headers.