### PR TITLE
Bump to version 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Release notes: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.20.0
 
 Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.19.1...v0.20.0
 
+This release will log deprecation warnings for any usage of `Datadog::Pin`.
+These changes are backwards compatible, but all integration configuration should be moved away from `Pin` and to the configuration API instead.
+
 ### Added
 
 - Propagate synthetics origin header (#699)
@@ -21,6 +24,16 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.19.1...v0.20.0
 ### Fixes
 
 - Fix Rack http_server.queue spans missing from distributed traces (#709)
+
+### Refactored
+
+- Refactor MongoDB to use instrumentation module (#704)
+- Refactor HTTP to use instrumentation module (#703)
+- Deprecate GRPC global pin in favor of configuration API (#702)
+- Deprecate Grape pin in favor of configuration API (#700)
+- Deprecate Faraday pin in favor of configuration API (#696)
+- Deprecate Dalli pin in favor of configuration API (#693)
+
 
 ## [0.19.1] - 2019-02-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -711,8 +711,9 @@ Release notes: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.3.1
 
 Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 
-[Unreleased (stable)]: https://github.com/DataDog/dd-trace-rb/compare/v0.19.1...master
-[Unreleased (beta)]: https://github.com/DataDog/dd-trace-rb/compare/v0.19.1...0.20-dev
+[Unreleased (stable)]: https://github.com/DataDog/dd-trace-rb/compare/v0.20.0...master
+[Unreleased (beta)]: https://github.com/DataDog/dd-trace-rb/compare/v0.20.0...0.21-dev
+[0.20.0]: https://github.com/DataDog/dd-trace-rb/compare/v0.19.1...v0.20.0
 [0.19.1]: https://github.com/DataDog/dd-trace-rb/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/DataDog/dd-trace-rb/compare/v0.18.3...v0.19.0
 [0.18.3]: https://github.com/DataDog/dd-trace-rb/compare/v0.18.2...v0.18.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ These changes are backwards compatible, but all integration configuration should
 - Deprecate Faraday pin in favor of configuration API (#696)
 - Deprecate Dalli pin in favor of configuration API (#693)
 
-
 ## [0.19.1] - 2019-02-07
 
 Release notes: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.19.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.19.1...v0.20.0
 
 - Enable distributed tracing by default (#701)
 
+### Fixes
+
+- Fix Rack http_server.queue spans missing from distributed traces (#709)
+
 ## [0.19.1] - 2019-02-07
 
 Release notes: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.19.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ## [Unreleased (beta)]
 
+## [0.20.0] - 2019-03-07
+
+Release notes: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.20.0
+
+Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.19.1...v0.20.0
+
+### Added
+
+- Propagate synthetics origin header (#699)
+
+### Changed
+
+- Enable distributed tracing by default (#701)
+
 ## [0.19.1] - 2019-02-07
 
 Release notes: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.19.1

--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -1,8 +1,8 @@
 module Datadog
   module VERSION
     MAJOR = 0
-    MINOR = 19
-    PATCH = 1
+    MINOR = 20
+    PATCH = 0
     PRE = nil
 
     STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.')


### PR DESCRIPTION
## [0.20.0] - 2019-03-07

Release notes: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.20.0

Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.19.1...v0.20.0

This release will log deprecation warnings for any usage of `Datadog::Pin`.
These changes are backwards compatible, but all integration configuration should be moved away from `Pin` and to the configuration API instead.

### Added

- Propagate synthetics origin header (#699)

### Changed

- Enable distributed tracing by default (#701)

### Fixes

- Fix Rack http_server.queue spans missing from distributed traces (#709)

### Refactored

- Refactor MongoDB to use instrumentation module (#704)
- Refactor HTTP to use instrumentation module (#703)
- Deprecate GRPC global pin in favor of configuration API (#702)
- Deprecate Grape pin in favor of configuration API (#700)
- Deprecate Faraday pin in favor of configuration API (#696)
- Deprecate Dalli pin in favor of configuration API (#693)