### PR TITLE
Fix analytics tag specs breaking when global state lingers

### DIFF
--- a/spec/ddtrace/contrib/delayed_job/plugin_spec.rb
+++ b/spec/ddtrace/contrib/delayed_job/plugin_spec.rb
@@ -34,7 +34,12 @@ RSpec.describe Datadog::Contrib::DelayedJob::Plugin, :delayed_job_active_record 
     Delayed::Worker.delay_jobs = false
   end
 
-  after(:each) { Datadog.registry[:delayed_job].reset_configuration! }
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:delayed_job].reset_configuration!
+    example.run
+    Datadog.registry[:delayed_job].reset_configuration!
+  end
 
   describe 'instrumenting worker execution' do
     let(:worker) { double(:worker, name: 'worker') }

--- a/spec/ddtrace/contrib/racecar/patcher_spec.rb
+++ b/spec/ddtrace/contrib/racecar/patcher_spec.rb
@@ -19,7 +19,12 @@ RSpec.describe 'Racecar patcher' do
     end
   end
 
-  after(:each) { Datadog.registry[:racecar].reset_configuration! }
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:racecar].reset_configuration!
+    example.run
+    Datadog.registry[:racecar].reset_configuration!
+  end
 
   describe 'for single message processing' do
     let(:topic) { 'dd_trace_test_dummy' }

--- a/spec/ddtrace/contrib/rack/configuration_spec.rb
+++ b/spec/ddtrace/contrib/rack/configuration_spec.rb
@@ -21,7 +21,12 @@ RSpec.describe 'Rack integration configuration' do
     end
   end
 
-  after(:each) { Datadog.registry[:rack].reset_configuration! }
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:rack].reset_configuration!
+    example.run
+    Datadog.registry[:rack].reset_configuration!
+  end
 
   shared_context 'an incoming HTTP request' do
     subject(:response) { get '/' }

--- a/spec/ddtrace/contrib/rake/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/rake/instrumentation_spec.rb
@@ -25,8 +25,10 @@ RSpec.describe Datadog::Contrib::Rake::Instrumentation do
     end
   end
 
-  after(:each) do
-    # Reset configuration to defaults
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:rake].reset_configuration!
+    example.run
     Datadog.registry[:rake].reset_configuration!
 
     # We don't want instrumentation enabled during the rest of the test suite...

--- a/spec/ddtrace/contrib/resque/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/resque/instrumentation_spec.rb
@@ -28,7 +28,12 @@ RSpec.describe 'Resque instrumentation' do
     end
   end
 
-  after(:each) { Datadog.registry[:resque].reset_configuration! }
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:resque].reset_configuration!
+    example.run
+    Datadog.registry[:resque].reset_configuration!
+  end
 
   shared_examples 'job execution tracing' do
     context 'that succeeds' do

--- a/spec/ddtrace/contrib/shoryuken/tracer_spec.rb
+++ b/spec/ddtrace/contrib/shoryuken/tracer_spec.rb
@@ -20,7 +20,12 @@ RSpec.describe Datadog::Contrib::Shoryuken::Tracer do
     end
   end
 
-  after { Datadog.registry[:shoryuken].reset_configuration! }
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:shoryuken].reset_configuration!
+    example.run
+    Datadog.registry[:shoryuken].reset_configuration!
+  end
 
   shared_context 'Shoryuken::Worker' do
     let(:worker_class) do


### PR DESCRIPTION
Some of our tests leave global state after they complete in the form of configuration. This lingering configuration can break some other tests, and was breaking analytics tag tests when run in a particular order after other tests.

This pull request performs resets "around" examples, so as to make sure they begin with clean state, and do not leave global configuration state after they complete.