### PR TITLE
[core] Support building an error from an HTTP Response

### DIFF
--- a/lib/ddtrace/error.rb
+++ b/lib/ddtrace/error.rb
@@ -1,3 +1,5 @@
+require 'net/http'
+
 # Datadog global namespace
 module Datadog
   # Error is a value-object responsible for sanitizing/encapsulating error data
@@ -9,9 +11,19 @@ module Datadog
       when Error then value
       when Array then new(*value)
       when Exception then new(value.class, value.message, value.backtrace)
+      when Net::HTTPResponse then build_from_http_response(value)
       when ContainsMessage then new(value.class, value.message)
       else BlankError
       end
+    end
+
+    def self.build_from_http_response(response)
+      message = response.message
+      if response.class.body_permitted? && !response.body.nil?
+        message = response.body[0...4095]
+      end
+
+      new(response.class, message)
     end
 
     def initialize(type = nil, message = nil, backtrace = nil)

--- a/spec/ddtrace/contrib/http/request_spec.rb
+++ b/spec/ddtrace/contrib/http/request_spec.rb
@@ -51,7 +51,10 @@ RSpec.describe 'net/http requests' do
     end
 
     context 'that returns 404' do
-      before(:each) { stub_request(:get, "#{uri}#{path}").to_return(status: 404) }
+      before(:each) do
+        stub_request(:get, "#{uri}#{path}")
+          .to_return(status: 404, body: '{"status": 404}')
+      end
       let(:span) { spans.first }
 
       it 'generates a well-formed trace' do
@@ -67,6 +70,7 @@ RSpec.describe 'net/http requests' do
         expect(span.get_tag('out.port')).to eq(port.to_s)
         expect(span.status).to eq(1)
         expect(span.get_tag('error.type')).to eq('Net::HTTPNotFound')
+        expect(span.get_tag('error.msg')).to eq('{"status": 404}')
       end
     end
   end


### PR DESCRIPTION
In this PR we have added the ability to build an error from a `Net::HTTPResponse`.