### PR TITLE
Add analytics global flag

### DIFF
--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -5,11 +5,24 @@ require_relative 'configuration/pin_setup'
 module Datadog
   # Configuration provides a unique access point for configurations
   class Configuration
+    ENV_TRACE_ANALYTICS_ENABLED = 'DD_TRACE_ANALYTICS_ENABLED'.freeze
     InvalidIntegrationError = Class.new(StandardError)
+
+    attr_writer :analytics_enabled
 
     def initialize(options = {})
       @registry = options.fetch(:registry) { Datadog.registry }
       @wrapped_registry = {}
+      @analytics_enabled = nil
+    end
+
+    def analytics_enabled
+      @analytics_enabled || begin
+        if ENV.key?(ENV_TRACE_ANALYTICS_ENABLED)
+          value = ENV[ENV_TRACE_ANALYTICS_ENABLED]
+          value.to_s.downcase == 'true'
+        end
+      end
     end
 
     def [](integration_name, configuration_name = :default)

--- a/lib/ddtrace/contrib/analytics.rb
+++ b/lib/ddtrace/contrib/analytics.rb
@@ -9,9 +9,7 @@ module Datadog
       # Checks whether analytics should be enabled.
       # `flag` is a truthy/falsey value that represents a setting on the integration.
       def enabled?(flag = nil)
-        # TODO: Check global flag here.
-        # (global_flag && flag != false) || flag == true
-        flag == true
+        (Datadog.configuration.analytics_enabled && flag != false) || flag == true
       end
 
       def set_sample_rate(span, sample_rate)

--- a/spec/ddtrace/contrib/rack/configuration_spec.rb
+++ b/spec/ddtrace/contrib/rack/configuration_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Rack integration configuration' do
     end
   end
 
-  it_behaves_like 'analytics for integration' do
+  it_behaves_like 'analytics for integration', ignore_global_flag: false do
     include_context 'an incoming HTTP request'
     before { is_expected.to be_ok }
     let(:analytics_enabled_var) { Datadog::Contrib::Rack::Ext::ENV_ANALYTICS_ENABLED }

--- a/spec/ddtrace/contrib/rails/analytics_spec.rb
+++ b/spec/ddtrace/contrib/rails/analytics_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Rails trace analytics' do
       end
     end
 
-    it_behaves_like 'analytics for integration' do
+    it_behaves_like 'analytics for integration', ignore_global_flag: false do
       before { expect { result }.to_not raise_error }
       let(:analytics_enabled_var) { Datadog::Contrib::Rails::Ext::ENV_ANALYTICS_ENABLED }
       let(:analytics_sample_rate_var) { Datadog::Contrib::Rails::Ext::ENV_ANALYTICS_SAMPLE_RATE }

--- a/spec/ddtrace/contrib/sinatra/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/tracer_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Sinatra instrumentation' do
           expect(span.parent).to be nil
         end
 
-        it_behaves_like 'analytics for integration' do
+        it_behaves_like 'analytics for integration', ignore_global_flag: false do
           before { is_expected.to be_ok }
           let(:analytics_enabled_var) { Datadog::Contrib::Sinatra::Ext::ENV_ANALYTICS_ENABLED }
           let(:analytics_sample_rate_var) { Datadog::Contrib::Sinatra::Ext::ENV_ANALYTICS_SAMPLE_RATE }


### PR DESCRIPTION
This pull request adds the `Datadog.configuration.analytics_enabled` setting and `DD_TRACE_ANALYTICS_ENABLED` environment variable to globally enable and disable trace analytics.

If `true`, only integrations that aren't explicitly configured to `false` will activate analytics. If `false`, only integrations that have been explicitly configured with `true` will activate analytics. If unset (left as `nil`), only integrations that have been explicitly configured with `true` will activate analytics.

Basically this means the global flag can be used to turn on certain integrations which default as `nil` (e.g. Rack, Racecar, etc), but will not activate others (such as Excon, Sequel, etc.) Those other integrations will require explicit configuration to activate analytics. By default, all analytics are off.