### PR TITLE
Add #after_request hook to HTTP integration

### DIFF
--- a/lib/ddtrace/contrib/http/instrumentation.rb
+++ b/lib/ddtrace/contrib/http/instrumentation.rb
@@ -39,8 +39,6 @@ module Datadog
 
         # InstanceMethods - implementing instrumentation
         module InstanceMethods
-          # rubocop:disable Metrics/MethodLength
-          # rubocop:disable Metrics/AbcSize
           def request(req, body = nil, &block) # :yield: +response+
             pin = datadog_pin
             return super(req, body, &block) unless pin && pin.tracer
@@ -55,16 +53,7 @@ module Datadog
               begin
                 span.service = pin.service
                 span.span_type = Datadog::Ext::HTTP::TYPE
-
                 span.resource = req.method
-                # Using the method as a resource, as URL/path can trigger
-                # a possibly infinite number of resources.
-
-                # Set analytics sample rate
-                Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
-
-                span.set_tag(Datadog::Ext::HTTP::URL, req.path)
-                span.set_tag(Datadog::Ext::HTTP::METHOD, req.method)
 
                 if pin.tracer.enabled && !Datadog::Contrib::HTTP.should_skip_distributed_tracing?(pin)
                   req.add_field(Datadog::Ext::DistributedTracing::HTTP_HEADER_TRACE_ID, span.trace_id)
@@ -81,23 +70,35 @@ module Datadog
               ensure
                 response = super(req, body, &block)
               end
-              span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, response.code)
-              if req.respond_to?(:uri) && req.uri
-                span.set_tag(Datadog::Ext::NET::TARGET_HOST, req.uri.host)
-                span.set_tag(Datadog::Ext::NET::TARGET_PORT, req.uri.port.to_s)
-              else
-                span.set_tag(Datadog::Ext::NET::TARGET_HOST, @address)
-                span.set_tag(Datadog::Ext::NET::TARGET_PORT, @port.to_s)
-              end
 
-              case response.code.to_i / 100
-              when 4
-                span.set_error(response)
-              when 5
-                span.set_error(response)
+              # Add additional tags to the span.
+              annotate_span!(span, req, response)
+
               end
 
               response
+            end
+          end
+
+          def annotate_span!(span, request, response)
+            span.set_tag(Datadog::Ext::HTTP::URL, request.path)
+            span.set_tag(Datadog::Ext::HTTP::METHOD, request.method)
+            span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, response.code)
+
+            if request.respond_to?(:uri) && request.uri
+              span.set_tag(Datadog::Ext::NET::TARGET_HOST, request.uri.host)
+              span.set_tag(Datadog::Ext::NET::TARGET_PORT, request.uri.port.to_s)
+            else
+              span.set_tag(Datadog::Ext::NET::TARGET_HOST, @address)
+              span.set_tag(Datadog::Ext::NET::TARGET_PORT, @port.to_s)
+            end
+
+            # Set analytics sample rate
+            Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
+
+            case response.code.to_i
+            when 400...599
+              span.set_error(response)
             end
           end
 


### PR DESCRIPTION
To aid customization of HTTP instrumentation, this pull request adds a configurable hook which can be defined and invoked after each HTTP request.

In practice, one can add the following anywhere to their Datadog configuration:

```ruby
Datadog::Contrib::HTTP::Instrumentation.after_request do |span, request, response|
  # As an example, you can use this hook to modify the error on the HTTP span.
  case response.code.to_i
  when 400...599
    if response.class.body_permitted? && !response.body.nil?
      span.set_error([response.class, response.body[0...4095]])
    end
  end
end
```

We anticipate this feature will eventually be replaced by span hooks when those are available.