### PR TITLE
Fix custom log level manipulation and isolate logger unit tests

### DIFF
--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -53,10 +53,11 @@ module Datadog
     end
 
     # Activate the debug mode providing more information related to tracer usage
+    # Default to Warn level unless using custom logger
     def self.debug_logging=(value)
       if value
         log.level = Logger::DEBUG
-      elsif log.is_a(Datadog::Logger)
+      elsif log.is_a?(Datadog::Logger)
         log.level = Logger::WARN
       end
     end

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -54,7 +54,11 @@ module Datadog
 
     # Activate the debug mode providing more information related to tracer usage
     def self.debug_logging=(value)
-      log.level = value ? Logger::DEBUG : Logger::WARN
+      if value
+        log.level = Logger::DEBUG
+      elsif log.is_a(Datadog::Logger)
+        log.level = Logger::WARN
+      end
     end
 
     # Return if the debug mode is activated or not

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -4,6 +4,18 @@ require 'helper'
 require 'ddtrace/span'
 
 class LoggerTest < Minitest::Test
+  DEFAULT_LOG = Datadog::Tracer.log
+
+  def setup
+    @buf = StringIO.new
+    Datadog::Tracer.log = Datadog::Logger.new(@buf)
+    Datadog::Tracer.log.level = ::Logger::WARN
+  end
+
+  def teardown
+    Datadog::Tracer.log = DEFAULT_LOG
+  end
+
   def test_tracer_logger
     # a logger must be available by default
     assert Datadog::Tracer.log
@@ -29,29 +41,17 @@ class LoggerTest < Minitest::Test
   end
 
   def test_tracer_set_debug_custom_noop
-    default_log = Datadog::Tracer.log
-
     # custom logger
-    buf = StringIO.new
-    custom_logger = Logger.new(buf)
+    custom_buf = StringIO.new
+    custom_logger = Logger.new(custom_buf)
     custom_logger.level = ::Logger::INFO
     Datadog::Tracer.log = custom_logger
 
     Datadog::Tracer.debug_logging = false
     assert_equal(custom_logger.level, ::Logger::INFO)
+  end
 
-    Datadog::Tracer.log = default_log
-  end  
-
-  # rubocop:disable Metrics/MethodLength
   def test_tracer_logger_override
-    default_log = Datadog::Tracer.log
-
-    buf = StringIO.new
-
-    Datadog::Tracer.log = Datadog::Logger.new(buf)
-    Datadog::Tracer.log.level = ::Logger::WARN
-
     assert_equal(false, Datadog::Tracer.log.debug?)
     assert_equal(false, Datadog::Tracer.log.info?)
     assert_equal(true, Datadog::Tracer.log.warn?)
@@ -65,7 +65,7 @@ class LoggerTest < Minitest::Test
     Datadog::Tracer.log.progname = 'bar'
     Datadog::Tracer.log.add(Logger::WARN, 'add some warning')
 
-    lines = buf.string.lines
+    lines = @buf.string.lines
 
     assert_equal(4, lines.length, 'there should be 4 log messages') if lines.respond_to? :length
     # Test below iterates on lines, this is required for Ruby 1.9 backward compatibility.
@@ -89,16 +89,9 @@ class LoggerTest < Minitest::Test
       end
       i += 1
     end
-
-    Datadog::Tracer.log = default_log
   end
 
   def test_tracer_logger_override_debug
-    default_log = Datadog::Tracer.log
-
-    buf = StringIO.new
-
-    Datadog::Tracer.log = Datadog::Logger.new(buf)
     Datadog::Tracer.log.level = ::Logger::DEBUG
 
     assert_equal(true, Datadog::Tracer.log.debug?)
@@ -110,7 +103,7 @@ class LoggerTest < Minitest::Test
     Datadog::Tracer.log.debug('detailed things')
     Datadog::Tracer.log.info() { 'more detailed info' }
 
-    lines = buf.string.lines
+    lines = @buf.string.lines
 
     # Test below iterates on lines, this is required for Ruby 1.9 backward compatibility.
     assert_equal(2, lines.length, 'there should be 2 log messages') if lines.respond_to? :length
@@ -130,13 +123,9 @@ class LoggerTest < Minitest::Test
       end
       i += 1
     end
-
-    Datadog::Tracer.log = default_log
   end
 
   def test_tracer_logger_override_refuse
-    default_log = Datadog::Tracer.log
-
     buf = StringIO.new
 
     buf_log = Datadog::Logger.new(buf)
@@ -148,7 +137,5 @@ class LoggerTest < Minitest::Test
     assert_equal(buf_log, Datadog::Tracer.log)
     Datadog::Tracer.log = "this won't work"
     assert_equal(buf_log, Datadog::Tracer.log)
-
-    Datadog::Tracer.log = default_log
   end
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -28,6 +28,21 @@ class LoggerTest < Minitest::Test
     assert_equal(logger.level, Logger::WARN)
   end
 
+  def test_tracer_set_debug_custom_noop
+    default_log = Datadog::Tracer.log
+
+    # custom logger
+    buf = StringIO.new
+    custom_logger = Logger.new(buf)
+    custom_logger.level = ::Logger::INFO
+    Datadog::Tracer.log = custom_logger
+
+    Datadog::Tracer.debug_logging = false
+    assert_equal(custom_logger.level, ::Logger::INFO)
+
+    Datadog::Tracer.log = default_log
+  end  
+
   # rubocop:disable Metrics/MethodLength
   def test_tracer_logger_override
     default_log = Datadog::Tracer.log


### PR DESCRIPTION
Addressing https://github.com/DataDog/dd-trace-rb/issues/681  , a custom logger's log level can be unintentionally changed by Tracer configuration, which I was able to recreate locally.

- Per suggestion this PR adds a check in `self.debug_logging` assignment for whether the custom logger is an instance of the `Datadog::Logger` class and is a noop if debug logging is not enabled
- Adds a unit test in `test/logger_test.rb` for new behavior.
- While I was in there I noticed the logger unit tests could be isolated a bit more, as failed assertions would cause some of the teardown code at the end of each unit test to not get called.  Following some of the conventions used in other tests, this PR also adds setup and teardown helpers for `logger_test.rb`.

Thanks for taking a look! Happy to address any feedback or anything else you think might be relevant here.