### PR TITLE
Add warning log if an integration is incompatible

### DIFF
--- a/lib/ddtrace/contrib/patchable.rb
+++ b/lib/ddtrace/contrib/patchable.rb
@@ -29,7 +29,11 @@ module Datadog
         end
 
         def patch
-          return if !self.class.compatible? || patcher.nil?
+          if !self.class.compatible? || patcher.nil?
+            Datadog::Tracer.log.warn("Unable to patch #{self.class.name}")
+            return
+          end
+
           patcher.patch
         end
       end

--- a/spec/ddtrace/contrib/patchable_spec.rb
+++ b/spec/ddtrace/contrib/patchable_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 require 'ddtrace'
 
 RSpec.describe Datadog::Contrib::Patchable do
+  include_context 'tracer logging'
+
   describe 'implemented' do
     subject(:patchable_class) do
       Class.new.tap do |klass|
@@ -62,6 +64,12 @@ RSpec.describe Datadog::Contrib::Patchable do
         subject(:patch) { patchable_object.patch }
 
         context 'when the patchable object' do
+          let(:unpatched_warnings) do
+            [
+              /.*Unable to patch*/
+            ]
+          end
+
           context 'is compatible' do
             before(:each) { allow(patchable_class).to receive(:compatible?).and_return(true) }
 
@@ -78,6 +86,7 @@ RSpec.describe Datadog::Contrib::Patchable do
             context 'and the patcher is nil' do
               it 'does not applies the patch' do
                 is_expected.to be nil
+                expect(log_buffer).to contain_line_with(*unpatched_warnings)
               end
             end
           end
@@ -85,6 +94,7 @@ RSpec.describe Datadog::Contrib::Patchable do
           context 'is not compatible' do
             it 'does not applies the patch' do
               is_expected.to be nil
+              expect(log_buffer).to contain_line_with(*unpatched_warnings)
             end
           end
         end


### PR DESCRIPTION
Addresses https://github.com/DataDog/dd-trace-rb/issues/457 . If an integration fails to get patched due to an incompatibility (generally a version issue) there is no indication of this and the tracing will just fail silently.  

- Per discussion of remediation options in the open issue, this PR adds a conditional `WARN` log on the `patch` method if the integration is incompatible. I used `class.name` here to refer to the integration but if there is a more appropriate way to do so please let me know.

- Also updates `patchable_spec.rb` to reflect new logging behavior using the conventions seen elsewhere in the spec.

Thanks for taking a look! Let me know if there's any feedback, happy to address anything or open to ideas if there's a better way to approach this!