### PR TITLE
Change HTTP #after_request span hook scope

### DIFF
--- a/lib/ddtrace/contrib/http/instrumentation.rb
+++ b/lib/ddtrace/contrib/http/instrumentation.rb
@@ -87,7 +87,7 @@ module Datadog
 
               # Invoke hook, if set.
               unless Contrib::HTTP::Instrumentation.after_request.nil?
-                instance_exec(span, req, response, &Contrib::HTTP::Instrumentation.after_request)
+                Contrib::HTTP::Instrumentation.after_request.call(span, self, req, response)
               end
 
               response


### PR DESCRIPTION
Following on the #after_request hook introduced in #716, this PR changes the signature slightly, to add `http` as an argument, and the invocation from `instance_exec` to `call`.

An `after_request` span hook would now look like this:

```
Datadog::Contrib::HTTP::Instrumentation.after_request do |span, http, request, response|
  # As an example, you can use this hook to modify the error on the HTTP span.
  case response.code.to_i
  when 400...599
    if response.class.body_permitted? && !response.body.nil?
      span.set_error([response.class, response.body[0...4095]])
    end
  end
end
```

Where:

 - `span` is a `Datadog::Span` after an HTTP request, and being fully annotated.
 - `http` is a `Net::HTTP` object which performed the request.
 - `request` is the corresponding `Net::HTTP` request object. (e.g. `Net::HTTP::Get`)
 - `response` is the corresponding `Net::HTTP` response object. (e.g. `Net::HTTPNotFound`)

This change was made so that when configured in a configuration file, variables outside the span hook would be accessible to grant greater flexibility, whereas with `instance_exec` they were previously not. The `http` arg was added to compensate for the loss of this previous scope.