### PR TITLE
Pin the Mongo::Address class to support MongoDB Ruby client version > 2.4

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -74,7 +74,7 @@ elsif Gem::Version.new('1.9.3') <= Gem::Version.new(RUBY_VERSION) \
       gem 'elasticsearch-transport'
       gem 'excon'
       gem 'hiredis'
-      gem 'mongo', '>= 2.8.0'
+      gem 'mongo', '< 2.5'
       gem 'mysql2', '0.3.21', platform: :ruby
       gem 'rack', '1.4.7'
       gem 'rack-cache', '1.7.1'
@@ -159,7 +159,7 @@ elsif Gem::Version.new('2.0.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'elasticsearch-transport'
       gem 'excon'
       gem 'hiredis'
-      gem 'mongo', '>= 2.8.0'
+      gem 'mongo', '< 2.5'
       gem 'mysql2', '0.3.21', platform: :ruby
       gem 'rack', '1.4.7'
       gem 'rack-cache', '1.7.1'
@@ -264,7 +264,7 @@ elsif Gem::Version.new('2.1.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'elasticsearch-transport'
       gem 'excon'
       gem 'hiredis'
-      gem 'mongo', '>= 2.8.0'
+      gem 'mongo', '< 2.5'
       gem 'mysql2', '0.3.21', platform: :ruby
       gem 'rack', '1.4.7'
       gem 'rack-cache', '1.7.1'

--- a/Appraisals
+++ b/Appraisals
@@ -74,7 +74,7 @@ elsif Gem::Version.new('1.9.3') <= Gem::Version.new(RUBY_VERSION) \
       gem 'elasticsearch-transport'
       gem 'excon'
       gem 'hiredis'
-      gem 'mongo', '< 2.5'
+      gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '0.3.21', platform: :ruby
       gem 'rack', '1.4.7'
       gem 'rack-cache', '1.7.1'
@@ -159,7 +159,7 @@ elsif Gem::Version.new('2.0.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'elasticsearch-transport'
       gem 'excon'
       gem 'hiredis'
-      gem 'mongo', '< 2.5'
+      gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '0.3.21', platform: :ruby
       gem 'rack', '1.4.7'
       gem 'rack-cache', '1.7.1'
@@ -264,7 +264,7 @@ elsif Gem::Version.new('2.1.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'elasticsearch-transport'
       gem 'excon'
       gem 'hiredis'
-      gem 'mongo', '< 2.5'
+      gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '0.3.21', platform: :ruby
       gem 'rack', '1.4.7'
       gem 'rack-cache', '1.7.1'
@@ -404,7 +404,7 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'graphql', '< 1.9.4'
       gem 'grpc'
       gem 'hiredis'
-      gem 'mongo', '< 2.5'
+      gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
       gem 'racecar', '>= 0.3.5'
       gem 'rack'
@@ -543,7 +543,7 @@ elsif Gem::Version.new('2.3.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'graphql'
       gem 'grpc'
       gem 'hiredis'
-      gem 'mongo', '< 2.5'
+      gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
       gem 'racecar', '>= 0.3.5'
       gem 'rack'
@@ -576,7 +576,7 @@ elsif Gem::Version.new('2.4.0') <= Gem::Version.new(RUBY_VERSION)
       gem 'graphql'
       gem 'grpc'
       gem 'hiredis'
-      gem 'mongo', '< 2.5'
+      gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
       gem 'racecar', '>= 0.3.5'
       gem 'rack'

--- a/lib/ddtrace/contrib/mongodb/instrumentation.rb
+++ b/lib/ddtrace/contrib/mongodb/instrumentation.rb
@@ -8,72 +8,58 @@ require 'ddtrace/contrib/mongodb/subscribers'
 module Datadog
   module Contrib
     module MongoDB
-      # Instrumentation for Mongo::Client
+      # Instrumentation for Mongo integration
       module Instrumentation
-        def self.included(base)
-          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
-            base.class_eval do
-              # Instance methods
-              include InstanceMethodsCompatibility
-              include CommonInstanceMethods
-              include ClientInstanceMethods if base == Mongo::Client
-            end
-          else
-            base.send(:prepend, CommonInstanceMethods)
-            base.send(:prepend, ClientInstanceMethods) if base == Mongo::Client
-          end
-        end
-
-        # Compatibility shim for Rubies not supporting `.prepend`
-        module InstanceMethodsCompatibility
+        # Instrumentation for Mongo::Client
+        module Client
           def self.included(base)
-            base.class_eval do
-              alias_method :initialize_without_datadog, :initialize
-              remove_method :initialize
+            base.send(:include, InstanceMethods)
+          end
+
+          # Instance methods for Mongo::Client
+          module InstanceMethods
+            def datadog_pin
+              # safe-navigation to avoid crashes during each query
+              return unless respond_to? :cluster
+              return unless cluster.respond_to? :addresses
+              return unless cluster.addresses.respond_to? :first
+              Datadog::Pin.get_from(cluster.addresses.first)
+            end
+
+            def datadog_pin=(pin)
+              # safe-navigation to avoid crashes during each query
+              return unless respond_to? :cluster
+              return unless cluster.respond_to? :addresses
+              return unless cluster.addresses.respond_to? :each
+              # attach the PIN to all cluster addresses. One of them is used
+              # when executing a Command and it is attached to the Monitoring
+              # Event instance.
+              cluster.addresses.each { |x| pin.onto(x) }
             end
           end
-
-          def initialize(*args, &block)
-            initialize_without_datadog(*args, &block)
-          end
         end
 
-        # CommonInstanceMethods - implementing instrumentation
-        module CommonInstanceMethods
-          def initialize(*args, &blk)
-            # attach the Pin instance
-            super(*args, &blk)
-            tracer = Datadog.configuration[:mongo][:tracer]
-            service = Datadog.configuration[:mongo][:service_name]
-            pin = Datadog::Pin.new(
-              service,
-              app: Datadog::Contrib::MongoDB::Ext::APP,
-              app_type: Datadog::Ext::AppTypes::DB,
-              tracer: tracer
-            )
-            pin.onto(self)
-          end
-        end
-
-        # ClientInstanceMethods - implementing instrumentation
-        module ClientInstanceMethods
-          def datadog_pin
-            # safe-navigation to avoid crashes during each query
-            return unless respond_to? :cluster
-            return unless cluster.respond_to? :addresses
-            return unless cluster.addresses.respond_to? :first
-            Datadog::Pin.get_from(cluster.addresses.first)
+        # Instrumentation for Mongo::Address
+        module Address
+          def self.included(base)
+            base.send(:include, InstanceMethods)
           end
 
-          def datadog_pin=(pin)
-            # safe-navigation to avoid crashes during each query
-            return unless respond_to? :cluster
-            return unless cluster.respond_to? :addresses
-            return unless cluster.addresses.respond_to? :each
-            # attach the PIN to all cluster addresses. One of them is used
-            # when executing a Command and it is attached to the Monitoring
-            # Event instance.
-            cluster.addresses.each { |x| pin.onto(x) }
+          # Instance methods for Mongo::Address
+          module InstanceMethods
+            def datadog_pin
+              @datadog_pin ||= begin
+                tracer = Datadog.configuration[:mongo][:tracer]
+                service = Datadog.configuration[:mongo][:service_name]
+
+                Datadog::Pin.new(
+                  service,
+                  app: Datadog::Contrib::MongoDB::Ext::APP,
+                  app_type: Datadog::Ext::AppTypes::DB,
+                  tracer: tracer
+                )
+              end
+            end
           end
         end
       end

--- a/lib/ddtrace/contrib/mongodb/patcher.rb
+++ b/lib/ddtrace/contrib/mongodb/patcher.rb
@@ -18,8 +18,8 @@ module Datadog
         def patch
           do_once(:mongo) do
             begin
-              ::Mongo::Client.send(:include, Instrumentation)
-              ::Mongo::Address.send(:include, Instrumentation)
+              ::Mongo::Address.send(:include, Instrumentation::Address)
+              ::Mongo::Client.send(:include, Instrumentation::Client)
               add_mongo_monitoring
             rescue StandardError => e
               Datadog::Tracer.log.error("Unable to apply MongoDB integration: #{e}")

--- a/lib/ddtrace/contrib/mongodb/patcher.rb
+++ b/lib/ddtrace/contrib/mongodb/patcher.rb
@@ -19,6 +19,7 @@ module Datadog
           do_once(:mongo) do
             begin
               ::Mongo::Client.send(:include, Instrumentation)
+              ::Mongo::Address.send(:include, Instrumentation)
               add_mongo_monitoring
             rescue StandardError => e
               Datadog::Tracer.log.error("Unable to apply MongoDB integration: #{e}")

--- a/spec/ddtrace/contrib/mongodb/client_spec.rb
+++ b/spec/ddtrace/contrib/mongodb/client_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'Mongo::Client instrumentation' do
   let(:spans) { tracer.writer.spans(:keep) }
   let(:span) { spans.first }
 
+  let(:mongo_gem_version) { Gem.loaded_specs['mongo'].version }
+
   def discard_spans!
     tracer.writer.spans
   end
@@ -96,7 +98,11 @@ RSpec.describe 'Mongo::Client instrumentation' do
         it_behaves_like 'a MongoDB trace'
 
         it 'has operation-specific properties' do
-          expect(span.resource).to eq("{\"operation\"=>\"insert\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"documents\"=>[{\"name\"=>\"?\"}]}")
+          if mongo_gem_version < Gem::Version.new('2.5')
+            expect(span.resource).to eq("{\"operation\"=>:insert, \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"documents\"=>[{:name=>\"?\"}], \"ordered\"=>\"?\"}")
+          else
+            expect(span.resource).to eq("{\"operation\"=>\"insert\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"documents\"=>[{\"name\"=>\"?\"}]}")
+          end
           expect(span.get_tag('mongodb.rows')).to eq('1')
         end
       end
@@ -108,7 +114,11 @@ RSpec.describe 'Mongo::Client instrumentation' do
         it_behaves_like 'a MongoDB trace'
 
         it 'has operation-specific properties' do
-          expect(span.resource).to eq("{\"operation\"=>\"insert\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"documents\"=>[{\"name\"=>\"?\", \"hobbies\"=>[\"?\"]}]}")
+          if mongo_gem_version < Gem::Version.new('2.5')
+            expect(span.resource).to eq("{\"operation\"=>:insert, \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"documents\"=>[{:name=>\"?\", :hobbies=>[\"?\"]}], \"ordered\"=>\"?\"}")
+          else
+            expect(span.resource).to eq("{\"operation\"=>\"insert\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"documents\"=>[{\"name\"=>\"?\", \"hobbies\"=>[\"?\"]}]}")
+          end
           expect(span.get_tag('mongodb.rows')).to eq('1')
         end
       end
@@ -130,7 +140,11 @@ RSpec.describe 'Mongo::Client instrumentation' do
         it_behaves_like 'a MongoDB trace'
 
         it 'has operation-specific properties' do
-          expect(span.resource).to eq("{\"operation\"=>\"insert\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"documents\"=>[{\"name\"=>\"?\", \"hobbies\"=>[\"?\"]}, \"?\"]}")
+          if mongo_gem_version < Gem::Version.new('2.5')
+            expect(span.resource).to eq("{\"operation\"=>:insert, \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"documents\"=>[{:name=>\"?\", :hobbies=>[\"?\"]}, \"?\"], \"ordered\"=>\"?\"}")
+          else
+            expect(span.resource).to eq("{\"operation\"=>\"insert\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"documents\"=>[{\"name\"=>\"?\", \"hobbies\"=>[\"?\"]}, \"?\"]}")
+          end
           expect(span.get_tag('mongodb.rows')).to eq('2')
         end
       end
@@ -153,7 +167,11 @@ RSpec.describe 'Mongo::Client instrumentation' do
       it_behaves_like 'a MongoDB trace'
 
       it 'has operation-specific properties' do
-        expect(span.resource).to eq("{\"operation\"=>\"find\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"filter\"=>{}, \"lsid\"=>{\"id\"=>\"?\"}}")
+        if mongo_gem_version < Gem::Version.new('2.5')
+          expect(span.resource).to eq("{\"operation\"=>\"find\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"filter\"=>{}}")
+        else
+          expect(span.resource).to eq("{\"operation\"=>\"find\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"filter\"=>{}, \"lsid\"=>{\"id\"=>\"?\"}}")
+        end
         expect(span.get_tag('mongodb.rows')).to be nil
       end
     end
@@ -174,7 +192,11 @@ RSpec.describe 'Mongo::Client instrumentation' do
       it_behaves_like 'a MongoDB trace'
 
       it 'has operation-specific properties' do
-        expect(span.resource).to eq("{\"operation\"=>\"find\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"filter\"=>{\"name\"=>\"?\"}, \"lsid\"=>{\"id\"=>\"?\"}}")
+        if mongo_gem_version < Gem::Version.new('2.5')
+          expect(span.resource).to eq("{\"operation\"=>\"find\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"filter\"=>{\"name\"=>\"?\"}}")
+        else
+          expect(span.resource).to eq("{\"operation\"=>\"find\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"filter\"=>{\"name\"=>\"?\"}, \"lsid\"=>{\"id\"=>\"?\"}}")
+        end
         expect(span.get_tag('mongodb.rows')).to be nil
       end
     end
@@ -199,7 +221,11 @@ RSpec.describe 'Mongo::Client instrumentation' do
       it_behaves_like 'a MongoDB trace'
 
       it 'has operation-specific properties' do
-        expect(span.resource).to eq("{\"operation\"=>\"update\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"updates\"=>[{\"q\"=>{\"name\"=>\"?\"}, \"u\"=>{\"$set\"=>{\"phone_number\"=>\"?\"}}, \"multi\"=>\"?\", \"upsert\"=>\"?\"}]}")
+        if mongo_gem_version < Gem::Version.new('2.5')
+          expect(span.resource).to eq("{\"operation\"=>:update, \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"updates\"=>[{\"q\"=>{\"name\"=>\"?\"}, \"u\"=>{\"$set\"=>{\"phone_number\"=>\"?\"}}, \"multi\"=>\"?\", \"upsert\"=>\"?\"}], \"ordered\"=>\"?\"}")
+        else
+          expect(span.resource).to eq("{\"operation\"=>\"update\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"updates\"=>[{\"q\"=>{\"name\"=>\"?\"}, \"u\"=>{\"$set\"=>{\"phone_number\"=>\"?\"}}, \"multi\"=>\"?\", \"upsert\"=>\"?\"}]}")
+        end
         expect(span.get_tag('mongodb.rows')).to eq('1')
       end
     end
@@ -232,7 +258,11 @@ RSpec.describe 'Mongo::Client instrumentation' do
       it_behaves_like 'a MongoDB trace'
 
       it 'has operation-specific properties' do
-        expect(span.resource).to eq("{\"operation\"=>\"update\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"updates\"=>[{\"q\"=>{}, \"u\"=>{\"$set\"=>{\"phone_number\"=>\"?\"}}, \"multi\"=>\"?\", \"upsert\"=>\"?\"}]}")
+        if mongo_gem_version < Gem::Version.new('2.5')
+          expect(span.resource).to eq("{\"operation\"=>:update, \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"updates\"=>[{\"q\"=>{}, \"u\"=>{\"$set\"=>{\"phone_number\"=>\"?\"}}, \"multi\"=>\"?\", \"upsert\"=>\"?\"}], \"ordered\"=>\"?\"}")
+        else
+          expect(span.resource).to eq("{\"operation\"=>\"update\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"updates\"=>[{\"q\"=>{}, \"u\"=>{\"$set\"=>{\"phone_number\"=>\"?\"}}, \"multi\"=>\"?\", \"upsert\"=>\"?\"}]}")
+        end
         expect(span.get_tag('mongodb.rows')).to eq('2')
       end
     end
@@ -257,7 +287,11 @@ RSpec.describe 'Mongo::Client instrumentation' do
       it_behaves_like 'a MongoDB trace'
 
       it 'has operation-specific properties' do
-        expect(span.resource).to eq("{\"operation\"=>\"delete\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"deletes\"=>[{\"q\"=>{\"name\"=>\"?\"}, \"limit\"=>\"?\"}]}")
+        if mongo_gem_version < Gem::Version.new('2.5')
+          expect(span.resource).to eq("{\"operation\"=>:delete, \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"deletes\"=>[{\"q\"=>{\"name\"=>\"?\"}, \"limit\"=>\"?\"}], \"ordered\"=>\"?\"}")
+        else
+          expect(span.resource).to eq("{\"operation\"=>\"delete\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"deletes\"=>[{\"q\"=>{\"name\"=>\"?\"}, \"limit\"=>\"?\"}]}")
+        end
         expect(span.get_tag('mongodb.rows')).to eq('1')
       end
     end
@@ -290,7 +324,11 @@ RSpec.describe 'Mongo::Client instrumentation' do
       it_behaves_like 'a MongoDB trace'
 
       it 'has operation-specific properties' do
-        expect(span.resource).to eq("{\"operation\"=>\"delete\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"deletes\"=>[{\"q\"=>{\"name\"=>\"?\"}, \"limit\"=>\"?\"}]}")
+        if mongo_gem_version < Gem::Version.new('2.5')
+          expect(span.resource).to eq("{\"operation\"=>:delete, \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"deletes\"=>[{\"q\"=>{\"name\"=>\"?\"}, \"limit\"=>\"?\"}], \"ordered\"=>\"?\"}")
+        else
+          expect(span.resource).to eq("{\"operation\"=>\"delete\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"deletes\"=>[{\"q\"=>{\"name\"=>\"?\"}, \"limit\"=>\"?\"}]}")
+        end
         expect(span.get_tag('mongodb.rows')).to eq('2')
       end
     end
@@ -303,7 +341,11 @@ RSpec.describe 'Mongo::Client instrumentation' do
       it_behaves_like 'a MongoDB trace'
 
       it 'has operation-specific properties' do
-        expect(span.resource).to eq("{\"operation\"=>\"dropDatabase\", \"database\"=>\"#{database}\", \"collection\"=>1, \"lsid\"=>{\"id\"=>\"?\"}}")
+        if mongo_gem_version < Gem::Version.new('2.5')
+          expect(span.resource).to eq("{\"operation\"=>:dropDatabase, \"database\"=>\"#{database}\", \"collection\"=>1}")
+        else
+          expect(span.resource).to eq("{\"operation\"=>\"dropDatabase\", \"database\"=>\"#{database}\", \"collection\"=>1, \"lsid\"=>{\"id\"=>\"?\"}}")
+        end
         expect(span.get_tag('mongodb.rows')).to be nil
       end
     end
@@ -314,7 +356,11 @@ RSpec.describe 'Mongo::Client instrumentation' do
       it_behaves_like 'a MongoDB trace'
 
       it 'has operation-specific properties' do
-        expect(span.resource).to eq("{\"operation\"=>\"drop\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"lsid\"=>{\"id\"=>\"?\"}}")
+        if mongo_gem_version < Gem::Version.new('2.5')
+          expect(span.resource).to eq("{\"operation\"=>:drop, \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\"}")
+        else
+          expect(span.resource).to eq("{\"operation\"=>\"drop\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"lsid\"=>{\"id\"=>\"?\"}}")
+        end
         expect(span.get_tag('mongodb.rows')).to be nil
         expect(span.status).to eq(1)
         expect(span.get_tag('error.msg')).to eq('ns not found (26)')
@@ -341,7 +387,6 @@ RSpec.describe 'Mongo::Client instrumentation' do
         let(:insert_span) { spans.first }
         let(:auth_span) { spans.last }
         let(:drop_database?) { false }
-        let(:mongo_gem_version) { Gem.loaded_specs['mongo'].version }
 
         before(:each) do
           begin

--- a/spec/ddtrace/contrib/mongodb/client_spec.rb
+++ b/spec/ddtrace/contrib/mongodb/client_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
         it_behaves_like 'a MongoDB trace'
 
         it 'has operation-specific properties' do
-          expect(span.resource).to eq("{\"operation\"=>:insert, \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"documents\"=>[{:name=>\"?\"}], \"ordered\"=>\"?\"}")
+          expect(span.resource).to eq("{\"operation\"=>\"insert\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"documents\"=>[{\"name\"=>\"?\"}]}")
           expect(span.get_tag('mongodb.rows')).to eq('1')
         end
       end
@@ -108,7 +108,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
         it_behaves_like 'a MongoDB trace'
 
         it 'has operation-specific properties' do
-          expect(span.resource).to eq("{\"operation\"=>:insert, \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"documents\"=>[{:name=>\"?\", :hobbies=>[\"?\"]}], \"ordered\"=>\"?\"}")
+          expect(span.resource).to eq("{\"operation\"=>\"insert\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"documents\"=>[{\"name\"=>\"?\", \"hobbies\"=>[\"?\"]}]}")
           expect(span.get_tag('mongodb.rows')).to eq('1')
         end
       end
@@ -130,7 +130,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
         it_behaves_like 'a MongoDB trace'
 
         it 'has operation-specific properties' do
-          expect(span.resource).to eq("{\"operation\"=>:insert, \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"documents\"=>[{:name=>\"?\", :hobbies=>[\"?\"]}, \"?\"], \"ordered\"=>\"?\"}")
+          expect(span.resource).to eq("{\"operation\"=>\"insert\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"documents\"=>[{\"name\"=>\"?\", \"hobbies\"=>[\"?\"]}, \"?\"]}")
           expect(span.get_tag('mongodb.rows')).to eq('2')
         end
       end
@@ -153,7 +153,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
       it_behaves_like 'a MongoDB trace'
 
       it 'has operation-specific properties' do
-        expect(span.resource).to eq("{\"operation\"=>\"find\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"filter\"=>{}}")
+        expect(span.resource).to eq("{\"operation\"=>\"find\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"filter\"=>{}, \"lsid\"=>{\"id\"=>\"?\"}}")
         expect(span.get_tag('mongodb.rows')).to be nil
       end
     end
@@ -174,7 +174,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
       it_behaves_like 'a MongoDB trace'
 
       it 'has operation-specific properties' do
-        expect(span.resource).to eq("{\"operation\"=>\"find\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"filter\"=>{\"name\"=>\"?\"}}")
+        expect(span.resource).to eq("{\"operation\"=>\"find\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"filter\"=>{\"name\"=>\"?\"}, \"lsid\"=>{\"id\"=>\"?\"}}")
         expect(span.get_tag('mongodb.rows')).to be nil
       end
     end
@@ -199,7 +199,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
       it_behaves_like 'a MongoDB trace'
 
       it 'has operation-specific properties' do
-        expect(span.resource).to eq("{\"operation\"=>:update, \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"updates\"=>[{\"q\"=>{\"name\"=>\"?\"}, \"u\"=>{\"$set\"=>{\"phone_number\"=>\"?\"}}, \"multi\"=>\"?\", \"upsert\"=>\"?\"}], \"ordered\"=>\"?\"}")
+        expect(span.resource).to eq("{\"operation\"=>\"update\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"updates\"=>[{\"q\"=>{\"name\"=>\"?\"}, \"u\"=>{\"$set\"=>{\"phone_number\"=>\"?\"}}, \"multi\"=>\"?\", \"upsert\"=>\"?\"}]}")
         expect(span.get_tag('mongodb.rows')).to eq('1')
       end
     end
@@ -232,7 +232,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
       it_behaves_like 'a MongoDB trace'
 
       it 'has operation-specific properties' do
-        expect(span.resource).to eq("{\"operation\"=>:update, \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"updates\"=>[{\"q\"=>{}, \"u\"=>{\"$set\"=>{\"phone_number\"=>\"?\"}}, \"multi\"=>\"?\", \"upsert\"=>\"?\"}], \"ordered\"=>\"?\"}")
+        expect(span.resource).to eq("{\"operation\"=>\"update\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"updates\"=>[{\"q\"=>{}, \"u\"=>{\"$set\"=>{\"phone_number\"=>\"?\"}}, \"multi\"=>\"?\", \"upsert\"=>\"?\"}]}")
         expect(span.get_tag('mongodb.rows')).to eq('2')
       end
     end
@@ -257,7 +257,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
       it_behaves_like 'a MongoDB trace'
 
       it 'has operation-specific properties' do
-        expect(span.resource).to eq("{\"operation\"=>:delete, \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"deletes\"=>[{\"q\"=>{\"name\"=>\"?\"}, \"limit\"=>\"?\"}], \"ordered\"=>\"?\"}")
+        expect(span.resource).to eq("{\"operation\"=>\"delete\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"deletes\"=>[{\"q\"=>{\"name\"=>\"?\"}, \"limit\"=>\"?\"}]}")
         expect(span.get_tag('mongodb.rows')).to eq('1')
       end
     end
@@ -290,7 +290,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
       it_behaves_like 'a MongoDB trace'
 
       it 'has operation-specific properties' do
-        expect(span.resource).to eq("{\"operation\"=>:delete, \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"deletes\"=>[{\"q\"=>{\"name\"=>\"?\"}, \"limit\"=>\"?\"}], \"ordered\"=>\"?\"}")
+        expect(span.resource).to eq("{\"operation\"=>\"delete\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"ordered\"=>\"?\", \"lsid\"=>{\"id\"=>\"?\"}, \"deletes\"=>[{\"q\"=>{\"name\"=>\"?\"}, \"limit\"=>\"?\"}]}")
         expect(span.get_tag('mongodb.rows')).to eq('2')
       end
     end
@@ -303,7 +303,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
       it_behaves_like 'a MongoDB trace'
 
       it 'has operation-specific properties' do
-        expect(span.resource).to eq("{\"operation\"=>:dropDatabase, \"database\"=>\"#{database}\", \"collection\"=>1}")
+        expect(span.resource).to eq("{\"operation\"=>\"dropDatabase\", \"database\"=>\"#{database}\", \"collection\"=>1, \"lsid\"=>{\"id\"=>\"?\"}}")
         expect(span.get_tag('mongodb.rows')).to be nil
       end
     end
@@ -314,7 +314,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
       it_behaves_like 'a MongoDB trace'
 
       it 'has operation-specific properties' do
-        expect(span.resource).to eq("{\"operation\"=>:drop, \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\"}")
+        expect(span.resource).to eq("{\"operation\"=>\"drop\", \"database\"=>\"#{database}\", \"collection\"=>\"#{collection}\", \"lsid\"=>{\"id\"=>\"?\"}}")
         expect(span.get_tag('mongodb.rows')).to be nil
         expect(span.status).to eq(1)
         expect(span.get_tag('error.msg')).to eq('ns not found (26)')
@@ -353,6 +353,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
         end
 
         it 'produces spans for command and authentication' do
+          # TODO: fix this spec. Not sure if newer MongoDB ruby client driver behaves as describe below
           # With LDAP/SASL, Mongo will run a "saslStart" command
           # after the original command starts but before it finishes.
           # Thus we should expect it to create an authentication span


### PR DESCRIPTION
Fixes: https://github.com/DataDog/dd-trace-rb/issues/729

In order to preserve backwards compatibility with older gem `mongo <= 2.4` clients and support the new `mongo > 2.4` clients we do the following:
* We pin the `Mongo::Address` class under any circumstance, so if client connections are re-created after the fork while using `mongo > 2.4` client version, those remain pined. See [here](https://docs.mongodb.com/ruby-driver/master/tutorials/ruby-driver-create-client/#usage-with-forking-servers) for further details on the MongoDB client connection issues under forking webservers.
* if the object that is being patched (`base`) is `Mongo::Client` class, then we patch it too. This is what keeps backwards compatibility with older clients.

