### PR TITLE
Fix GraphQL 1.9.4 breaking Ruby 2.2 build

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -401,7 +401,7 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'elasticsearch-transport'
       gem 'excon'
       gem 'grape'
-      gem 'graphql'
+      gem 'graphql', '< 1.9.4'
       gem 'grpc'
       gem 'hiredis'
       gem 'mongo', '< 2.5'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,7 @@
 version: '3.2'
 services:
   tracer-1.9:
-    build:
-      context: ./.circleci/images/primary
-      dockerfile: Dockerfile-1.9.3
+    image: datadog/docker-library:ddtrace_rb_1_9_3
     command: /bin/bash
     depends_on:
       - ddagent
@@ -31,9 +29,7 @@ services:
       - bundle-1.9:/usr/local/bundle
       - gemfiles-1.9:/app/gemfiles
   tracer-2.0:
-    build:
-      context: ./.circleci/images/primary
-      dockerfile: Dockerfile-2.0.0
+    image: datadog/docker-library:ddtrace_rb_2_0_0
     command: /bin/bash
     depends_on:
       - ddagent
@@ -61,9 +57,7 @@ services:
       - bundle-2.0:/usr/local/bundle
       - gemfiles-2.0:/app/gemfiles
   tracer-2.1:
-    build:
-      context: ./.circleci/images/primary
-      dockerfile: Dockerfile-2.1.10
+    image: datadog/docker-library:ddtrace_rb_2_1_10
     command: /bin/bash
     depends_on:
       - ddagent
@@ -91,9 +85,7 @@ services:
       - bundle-2.1:/usr/local/bundle
       - gemfiles-2.1:/app/gemfiles
   tracer-2.2:
-    build:
-      context: ./.circleci/images/primary
-      dockerfile: Dockerfile-2.2.10
+    image: datadog/docker-library:ddtrace_rb_2_2_10
     command: /bin/bash
     depends_on:
       - ddagent
@@ -121,9 +113,7 @@ services:
       - bundle-2.2:/usr/local/bundle
       - gemfiles-2.2:/app/gemfiles
   tracer-2.3:
-    build:
-      context: ./.circleci/images/primary
-      dockerfile: Dockerfile-2.3.7
+    image: datadog/docker-library:ddtrace_rb_2_3_7
     command: /bin/bash
     depends_on:
       - ddagent
@@ -151,9 +141,7 @@ services:
       - bundle-2.3:/usr/local/bundle
       - gemfiles-2.3:/app/gemfiles
   tracer-2.4:
-    build:
-      context: ./.circleci/images/primary
-      dockerfile: Dockerfile-2.4.4
+    image: datadog/docker-library:ddtrace_rb_2_4_4
     command: /bin/bash
     depends_on:
       - ddagent

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -27,8 +27,14 @@ RSpec.describe Datadog::Tracer do
         it 'tracks the number of allocations made in the span' do
           skip 'Not supported for Ruby < 2.0' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
 
+          # Create and discard first trace.
+          # When warming up, it might have more allocations than subsequent traces.
           tracer.trace(name) {}
-          tracer.trace(name) { 'hello' }
+          writer.spans
+
+          # Then create traces to compare
+          tracer.trace(name) {}
+          tracer.trace(name) { Object.new }
 
           first, second = writer.spans
 


### PR DESCRIPTION
As reported in https://github.com/rmosolgo/graphql-ruby/issues/2235, GraphQL 1.9.4 introduced a safe navigation operator which is incompatible with Ruby 2.2.

This pull request fixes the version for GraphQL to < 1.9.4 for Ruby 2.2.