### PR TITLE
Fix registration with modular sinatra applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased (stable)]
 
+### Fixed
+
+- Sinatra now also registers automatically for apps inheriting from `Sinatra::Base`
+
 ## [Unreleased (beta)]
 
 ## [0.21.2] - 2019-04-10
@@ -400,9 +404,9 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.12.1...v0.13.0
 - Hash quantization into core library (#410)
 - MongoDB integration to use Hash quantization library (#463)
 
-### Changed 
+### Changed
 
-- Hash quantization truncates arrays with nested objects (#463) 
+- Hash quantization truncates arrays with nested objects (#463)
 
 ## [0.13.0.beta1] - 2018-05-09
 

--- a/lib/ddtrace/contrib/sinatra/patcher.rb
+++ b/lib/ddtrace/contrib/sinatra/patcher.rb
@@ -25,7 +25,7 @@ module Datadog
         end
 
         def register_tracer
-          ::Sinatra.send(:register, Datadog::Contrib::Sinatra::Tracer)
+          ::Sinatra::Base.public_send(:register, Datadog::Contrib::Sinatra::Tracer)
         end
       end
     end

--- a/lib/ddtrace/contrib/sinatra/patcher.rb
+++ b/lib/ddtrace/contrib/sinatra/patcher.rb
@@ -25,7 +25,7 @@ module Datadog
         end
 
         def register_tracer
-          ::Sinatra::Base.public_send(:register, Datadog::Contrib::Sinatra::Tracer)
+          ::Sinatra::Base.register(Datadog::Contrib::Sinatra::Tracer)
         end
       end
     end

--- a/spec/ddtrace/contrib/sinatra/multi_app_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/multi_app_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
     end
 
     let(:app_one) do
-      Class.new(Sinatra::Application) do
+      Class.new(Sinatra::Base) do
         get '/endpoint' do
           '1'
         end
@@ -52,7 +52,7 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
     end
 
     let(:app_two) do
-      Class.new(Sinatra::Application) do
+      Class.new(Sinatra::Base) do
         get '/endpoint' do
           '2'
         end


### PR DESCRIPTION
### Problem to be solved

This (very reduced) example application will not generate any monitoring:
```
Datadog.configure do |c|
  c.use :sinatra
end

class MyApp < Sinatra::Base
  get 'hello_world' do
    [200, {}, ['Hello World!']]
  end
end
```

### Solution

According to Sinatra documentation `Sinatra.register` will only affect "classic" style sinatra applications (the ones without a class, that you define on the top-level).

To make datadog available for all kinds of sinatra applications (e.g. also modular style apps inheriting from Sinatra::Base) automatically, the Tracer needs to be registered on `Sinatra::Base`, which should still leave it available on "classic" style applications, since those inherit from `Sinatra::Base`.

See: http://sinatrarb.com/extensions.html

### Note/Disclaimer

Reading the sinatra documentation it is arguable, that we should not automatically register datadog with
`Sinatra::Base`, but leave it to the user to manually register it with all subclasses.

However, the [ddtrace docs](https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#sinatra) don't mention that I need to register something manually, so I assume it is intended to be automatic. Also the user is kind of "opting in" to using Datadog for sinatra by calling `c.use :sinatra`. I don't think there is a use case for only including ddtrace in one of two modular applications in the same code base...