### PR TITLE
[core] Stop sending service information

### DIFF
--- a/lib/ddtrace/contrib/active_model_serializers/patcher.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/patcher.rb
@@ -21,13 +21,6 @@ module Datadog
             begin
               # Subscribe to ActiveModelSerializers events
               Events.subscribe!
-
-              # Set service info
-              get_option(:tracer).set_service_info(
-                get_option(:service_name),
-                Ext::APP,
-                Datadog::Ext::AppTypes::WEB
-              )
             rescue StandardError => e
               Datadog::Tracer.log.error("Unable to apply ActiveModelSerializers integration: #{e}")
             end

--- a/lib/ddtrace/contrib/active_record/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_record/configuration/settings.rb
@@ -17,11 +17,7 @@ module Datadog
                   lazy: true
 
           option :orm_service_name
-          option :service_name, depends_on: [:tracer] do |value|
-            (value || Utils.adapter_name).tap do |service_name|
-              tracer.set_service_info(service_name, Ext::APP, Datadog::Ext::AppTypes::DB)
-            end
-          end
+          option :service_name
 
           option :tracer, default: Datadog.tracer do |value|
             value.tap do

--- a/lib/ddtrace/contrib/active_record/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_record/configuration/settings.rb
@@ -17,7 +17,9 @@ module Datadog
                   lazy: true
 
           option :orm_service_name
-          option :service_name
+          option :service_name,
+                 default: -> { Utils.adapter_name },
+                 lazy: true
 
           option :tracer, default: Datadog.tracer do |value|
             value.tap do

--- a/lib/ddtrace/contrib/dalli/patcher.rb
+++ b/lib/ddtrace/contrib/dalli/patcher.rb
@@ -21,13 +21,6 @@ module Datadog
             begin
               add_pin!
               ::Dalli::Server.send(:include, Instrumentation)
-
-              # TODO: When Dalli pin is removed, set service info.
-              # get_option(:tracer).set_service_info(
-              #   get_option(:service_name),
-              #   Ext::APP,
-              #   Datadog::Ext::AppTypes::CACHE
-              # )
             rescue StandardError => e
               Datadog::Tracer.log.error("Unable to apply Dalli integration: #{e}")
             end

--- a/lib/ddtrace/contrib/faraday/middleware.rb
+++ b/lib/ddtrace/contrib/faraday/middleware.rb
@@ -82,8 +82,6 @@ module Datadog
 
         def setup_service!
           return if options[:service_name] == datadog_configuration[:service_name]
-
-          Patcher.register_service(options[:service_name])
         end
       end
     end

--- a/lib/ddtrace/contrib/faraday/patcher.rb
+++ b/lib/ddtrace/contrib/faraday/patcher.rb
@@ -22,9 +22,6 @@ module Datadog
 
               add_pin!
               add_middleware!
-
-              # TODO: When Faraday pin is removed, set service info.
-              # register_service(get_option(:service_name))
             rescue StandardError => e
               Datadog::Tracer.log.error("Unable to apply Faraday integration: #{e}")
             end
@@ -43,14 +40,6 @@ module Datadog
 
         def add_middleware!
           ::Faraday::Middleware.register_middleware(ddtrace: Middleware)
-        end
-
-        def register_service(name)
-          get_option(:tracer).set_service_info(
-            name,
-            Ext::APP,
-            Datadog::Ext::AppTypes::WEB
-          )
         end
 
         def get_option(option)

--- a/lib/ddtrace/contrib/grape/patcher.rb
+++ b/lib/ddtrace/contrib/grape/patcher.rb
@@ -26,13 +26,6 @@ module Datadog
 
               add_pin!
 
-              # TODO: When Grape pin is removed, set service info.
-              # get_option(:tracer).set_service_info(
-              #   get_option(:service_name),
-              #   Ext::APP,
-              #   Datadog::Ext::AppTypes::WEB
-              # )
-
               # Subscribe to ActiveSupport events
               Datadog::Contrib::Grape::Endpoint.subscribe
             rescue StandardError => e

--- a/lib/ddtrace/contrib/graphql/configuration/settings.rb
+++ b/lib/ddtrace/contrib/graphql/configuration/settings.rb
@@ -17,10 +17,7 @@ module Datadog
                   lazy: true
 
           option :schemas
-          option :service_name, default: Ext::SERVICE_NAME, depends_on: [:tracer] do |value|
-            get_option(:tracer).set_service_info(value, Ext::APP, Datadog::Ext::AppTypes::WEB)
-            value
-          end
+          option :service_name, default: Ext::SERVICE_NAME
         end
       end
     end

--- a/lib/ddtrace/contrib/grpc/patcher.rb
+++ b/lib/ddtrace/contrib/grpc/patcher.rb
@@ -23,13 +23,6 @@ module Datadog
 
               add_pin!
 
-              # TODO: When GRPC pin is removed, set service info.
-              # get_option(:tracer).set_service_info(
-              #   get_option(:service_name),
-              #   Ext::APP,
-              #   Datadog::Ext::AppTypes::WEB
-              # )
-
               prepend_interceptor
             rescue StandardError => e
               Datadog::Tracer.log.error("Unable to apply gRPC integration: #{e}")

--- a/lib/ddtrace/contrib/racecar/patcher.rb
+++ b/lib/ddtrace/contrib/racecar/patcher.rb
@@ -21,14 +21,6 @@ module Datadog
             begin
               # Subscribe to Racecar events
               Events.subscribe!
-
-              # Set service info
-              configuration = Datadog.configuration[:racecar]
-              configuration[:tracer].set_service_info(
-                configuration[:service_name],
-                Ext::APP,
-                Datadog::Ext::AppTypes::WORKER
-              )
             rescue StandardError => e
               Datadog::Tracer.log.error("Unable to apply Racecar integration: #{e}")
             end

--- a/lib/ddtrace/contrib/rack/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rack/configuration/settings.rb
@@ -29,17 +29,9 @@ module Datadog
           option :quantize, default: {}
           option :request_queuing, default: false
 
-          option :service_name, default: Ext::SERVICE_NAME, depends_on: [:tracer] do |value|
-            get_option(:tracer).set_service_info(value, Ext::APP, Datadog::Ext::AppTypes::WEB)
-            value
-          end
+          option :service_name, default: Ext::SERVICE_NAME
 
-          option :web_service_name, default: Ext::WEBSERVER_SERVICE_NAME, depends_on: [:tracer, :request_queuing] do |value|
-            if get_option(:request_queuing)
-              get_option(:tracer).set_service_info(value, Ext::WEBSERVER_APP, Datadog::Ext::AppTypes::WEB)
-            end
-            value
-          end
+          option :web_service_name, default: Ext::WEBSERVER_SERVICE_NAME
         end
       end
     end

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -26,7 +26,6 @@ module Datadog
 
           activate_rack!(config)
           activate_active_record!(config)
-          set_service_info!(config)
 
           # By default, default service would be guessed from the script
           # being executed, but here we know better, get it from Rails config.
@@ -63,12 +62,6 @@ module Datadog
             service_name: config[:database_service],
             tracer: config[:tracer]
           )
-        end
-
-        def self.set_service_info!(config)
-          tracer = config[:tracer]
-          tracer.set_service_info(config[:controller_service], Ext::APP, Datadog::Ext::AppTypes::WEB)
-          tracer.set_service_info(config[:cache_service], Ext::APP, Datadog::Ext::AppTypes::CACHE)
         end
       end
     end

--- a/lib/ddtrace/contrib/rake/patcher.rb
+++ b/lib/ddtrace/contrib/rake/patcher.rb
@@ -21,13 +21,6 @@ module Datadog
             begin
               # Add instrumentation patch to Rake task
               ::Rake::Task.send(:include, Instrumentation)
-
-              # Set service info
-              get_option(:tracer).set_service_info(
-                get_option(:service_name),
-                Ext::APP,
-                Datadog::Ext::AppTypes::WORKER
-              )
             rescue StandardError => e
               Datadog::Tracer.log.error("Unable to apply Rake integration: #{e}")
             end

--- a/lib/ddtrace/contrib/rest_client/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rest_client/configuration/settings.rb
@@ -16,10 +16,7 @@ module Datadog
                   lazy: true
 
           option :distributed_tracing, default: true
-          option :service_name, default: Ext::SERVICE_NAME, depends_on: [:tracer] do |value|
-            get_option(:tracer).set_service_info(value, Ext::APP, Datadog::Ext::AppTypes::WEB)
-            value
-          end
+          option :service_name, default: Ext::SERVICE_NAME
         end
       end
     end

--- a/lib/ddtrace/contrib/shoryuken/tracer.rb
+++ b/lib/ddtrace/contrib/shoryuken/tracer.rb
@@ -8,7 +8,6 @@ module Datadog
         def initialize(options = {})
           @tracer = options[:tracer] || configuration[:tracer]
           @shoryuken_service = options[:service_name] || configuration[:service_name]
-          set_service_info(@shoryuken_service)
         end
 
         def call(worker_instance, queue, sqs_msg, body)
@@ -39,15 +38,6 @@ module Datadog
 
         def configuration
           Datadog.configuration[:shoryuken]
-        end
-
-        def set_service_info(service)
-          return if @tracer.nil? || @tracer.services[service]
-          @tracer.set_service_info(
-            service,
-            Ext::APP,
-            Datadog::Ext::AppTypes::WORKER
-          )
         end
       end
     end

--- a/lib/ddtrace/contrib/sidekiq/client_tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/client_tracer.rb
@@ -11,7 +11,6 @@ module Datadog
         def initialize(options = {})
           super
           @sidekiq_service = options[:client_service_name] || configuration[:client_service_name]
-          set_service_info(@sidekiq_service)
         end
 
         # Client middleware arguments are documented here:

--- a/lib/ddtrace/contrib/sidekiq/server_tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/server_tracer.rb
@@ -17,7 +17,6 @@ module Datadog
           resource = job_resource(job)
 
           service = service_from_worker_config(resource) || @sidekiq_service
-          set_service_info(service)
 
           @tracer.trace(Ext::SPAN_JOB, service: service, span_type: Datadog::Ext::AppTypes::WORKER) do |span|
             span.resource = resource

--- a/lib/ddtrace/contrib/sidekiq/tracing.rb
+++ b/lib/ddtrace/contrib/sidekiq/tracing.rb
@@ -22,16 +22,6 @@ module Datadog
             job['class']
           end
         end
-
-        def set_service_info(service)
-          # Ensure the tracer knows about this service.
-          return if @tracer.services[service]
-          @tracer.set_service_info(
-            service,
-            Ext::APP,
-            Datadog::Ext::AppTypes::WORKER
-          )
-        end
       end
     end
   end

--- a/lib/ddtrace/contrib/sinatra/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sinatra/configuration/settings.rb
@@ -24,10 +24,7 @@ module Datadog
           option :headers, default: DEFAULT_HEADERS
           option :resource_script_names, default: false
 
-          option :service_name, default: Ext::SERVICE_NAME, depends_on: [:tracer] do |value|
-            get_option(:tracer).set_service_info(value, Ext::APP, Datadog::Ext::AppTypes::WEB)
-            value
-          end
+          option :service_name, default: Ext::SERVICE_NAME
         end
       end
     end

--- a/lib/ddtrace/encoding.rb
+++ b/lib/ddtrace/encoding.rb
@@ -21,11 +21,6 @@ module Datadog
         encode(to_send)
       end
 
-      # Encodes services hash
-      def encode_services(services)
-        encode(services)
-      end
-
       # Defines the underlying format used during traces or services encoding.
       # This method must be implemented and should only be used by the internal functions.
       def encode(_)

--- a/lib/ddtrace/pin.rb
+++ b/lib/ddtrace/pin.rb
@@ -57,8 +57,6 @@ module Datadog
     end
 
     def service_name=(name)
-      tracer.set_service_info(name, app, app_type) if name && app && app_type
-
       @service_name = name
     end
 

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -162,6 +162,8 @@ module Datadog
     # Set the information about the given service. A valid example is:
     #
     #   tracer.set_service_info('web-application', 'rails', 'web')
+    #
+    # set_service_info is deprecated, no service information needs to be tracked
     def set_service_info(service, app, app_type)
       @services[service] = {
         'app' => app,

--- a/lib/ddtrace/transport.rb
+++ b/lib/ddtrace/transport.rb
@@ -11,7 +11,7 @@ module Datadog
   # rubocop:disable Metrics/ClassLength
   class HTTPTransport
     attr_accessor :hostname, :port
-    attr_reader :traces_endpoint, :services_endpoint
+    attr_reader :traces_endpoint
 
     DEFAULT_AGENT_HOST = '127.0.0.1'.freeze
     DEFAULT_TRACE_AGENT_PORT = '8126'.freeze
@@ -27,21 +27,18 @@ module Datadog
       V4 = 'v0.4'.freeze => {
         version: V4,
         traces_endpoint: '/v0.4/traces'.freeze,
-        services_endpoint: '/v0.4/services'.freeze,
         encoder: Encoding::MsgpackEncoder,
         fallback: 'v0.3'.freeze
       }.freeze,
       V3 = 'v0.3'.freeze => {
         version: V3,
         traces_endpoint: '/v0.3/traces'.freeze,
-        services_endpoint: '/v0.3/services'.freeze,
         encoder: Encoding::MsgpackEncoder,
         fallback: 'v0.2'.freeze
       }.freeze,
       V2 = 'v0.2'.freeze => {
         version: V2,
         traces_endpoint: '/v0.2/traces'.freeze,
-        services_endpoint: '/v0.2/services'.freeze,
         encoder: Encoding::JSONEncoder
       }.freeze
     }.freeze
@@ -78,10 +75,7 @@ module Datadog
     def send(endpoint, data)
       case endpoint
       when :services
-        payload = @encoder.encode_services(data)
-        status_code = post(@api[:services_endpoint], payload) do |response|
-          process_callback(:services, response)
-        end
+        return nil
       when :traces
         count = data.length
         payload = @encoder.encode_traces(data)

--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -16,7 +16,6 @@ module Datadog
       SHUTDOWN_TIMEOUT = 1
 
       attr_reader \
-        :service_buffer,
         :trace_buffer
 
       def initialize(options = {})
@@ -24,7 +23,6 @@ module Datadog
 
         # Callbacks
         @trace_task = options[:on_trace]
-        @service_task = options[:on_service]
         @runtime_metrics_task = options[:on_runtime_metrics]
 
         # Intervals
@@ -35,7 +33,6 @@ module Datadog
         # Buffers
         buffer_size = options.fetch(:buffer_size, 100)
         @trace_buffer = TraceBuffer.new(buffer_size)
-        @service_buffer = TraceBuffer.new(buffer_size)
 
         # Threading
         @shutdown = ConditionVariable.new
@@ -60,21 +57,6 @@ module Datadog
         end
       end
 
-      # Callback function that process traces and executes the +send_services()+ method.
-      def callback_services
-        return true if @service_buffer.empty?
-
-        begin
-          services = @service_buffer.pop()
-          @service_task.call(services[0], @transport) unless @service_task.nil?
-        rescue StandardError => e
-          # ensures that the thread will not die because of an exception.
-          # TODO[manu]: findout the reason and reschedule the send if it's not
-          # a fatal exception
-          Datadog::Tracer.log.error("Error during services flush: dropped #{services.length} items. Cause: #{e}")
-        end
-      end
-
       def callback_runtime_metrics
         @runtime_metrics_task.call unless @runtime_metrics_task.nil?
       rescue StandardError => e
@@ -91,13 +73,12 @@ module Datadog
         end
       end
 
-      # Closes all available queues and waits for the trace and service buffer to flush
+      # Closes all available queues and waits for the trace buffer to flush
       def stop
         @mutex.synchronize do
           return unless @run
 
           @trace_buffer.close
-          @service_buffer.close
           @run = false
           @shutdown.signal
         end
@@ -117,12 +98,6 @@ module Datadog
         @trace_buffer.push(trace)
       end
 
-      # Enqueue an item in the service internal buffer. This operation is thread-safe.
-      def enqueue_service(service)
-        return if service == {} # no use to send this, not worth it
-        @service_buffer.push(service)
-      end
-
       private
 
       alias flush_data callback_traces
@@ -131,11 +106,10 @@ module Datadog
         loop do
           @back_off = flush_data ? @flush_interval : [@back_off * BACK_OFF_RATIO, BACK_OFF_MAX].min
 
-          callback_services
           callback_runtime_metrics
 
           @mutex.synchronize do
-            return if !@run && @trace_buffer.empty? && @service_buffer.empty?
+            return if !@run && @trace_buffer.empty?
             @shutdown.wait(@mutex, @back_off) if @run # do not wait when shutting down
           end
         end

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -84,7 +84,16 @@ module Datadog
     end
 
     # enqueue the trace for submission to the API
-    def write(trace, services)
+    def write(trace, services = nil)
+      unless services.nil?
+        Datadog::Patcher.do_once('Writer#write') do
+          Datadog::Tracer.log.warn(%(
+            write: Writing services has been deprecated and no longer need to be provided.
+            write(traces, services) can be updted to write(traces)
+          ))
+        end
+      end
+
       # In multiprocess environments, the main process initializes the +Writer+ instance and if
       # the process forks (i.e. a web server like Unicorn or Puma with multiple workers) the new
       # processes will share the same +Writer+ until the first write (COW). Because of that,

--- a/spec/ddtrace/contrib/active_record/tracer_spec.rb
+++ b/spec/ddtrace/contrib/active_record/tracer_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe 'ActiveRecord instrumentation' do
 
     let(:spans) { tracer.writer.spans }
     let(:span) { spans.first }
-    let(:services) { tracer.writer.services }
 
     it_behaves_like 'analytics for integration' do
       let(:analytics_enabled_var) { Datadog::Contrib::ActiveRecord::Ext::ENV_ANALYTICS_ENABLED }
@@ -42,8 +41,6 @@ RSpec.describe 'ActiveRecord instrumentation' do
     it 'calls the instrumentation when is used standalone' do
       # expect service and trace is sent
       expect(spans.size).to eq(1)
-      expect(services).to_not be_empty
-      expect(services['mysql2']).to eq('app' => 'active_record', 'app_type' => 'db')
 
       expect(span.service).to eq('mysql2')
       expect(span.name).to eq('mysql2.query')

--- a/spec/ddtrace/contrib/redis/redis_spec.rb
+++ b/spec/ddtrace/contrib/redis/redis_spec.rb
@@ -193,28 +193,6 @@ RSpec.describe 'Redis test' do
         it_behaves_like 'a span with common tags'
       end
     end
-
-    context 'service name' do
-      let(:services) { tracer.writer.services }
-      let(:service_name) { 'redis-test' }
-
-      before(:each) do
-        redis.set 'FOO', 'bar'
-        tracer.writer.services # empty queue
-        Datadog.configure(
-          client,
-          service_name: service_name,
-          tracer: tracer,
-          app_type: Datadog::Ext::AppTypes::CACHE
-        )
-        redis.set 'FOO', 'bar'
-      end
-
-      it do
-        expect(services).to have(1).items
-        expect(services[service_name]).to eq('app' => 'redis', 'app_type' => 'cache')
-      end
-    end
   end
 
   it_behaves_like 'a Redis driver', :ruby

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -44,9 +44,6 @@ RSpec.describe 'Tracer integration tests' do
     end
 
     def agent_receives_span_step2
-      # Deprecated, does nothing
-      tracer.set_service_info('my.service', 'rails', 'web')
-
       create_trace
 
       # Timeout after 3 seconds, waiting for 1 flush
@@ -90,9 +87,6 @@ RSpec.describe 'Tracer integration tests' do
     include_context 'agent-based test'
 
     before(:each) do
-      # Deprecated, does nothing
-      tracer.set_service_info('my.service', 'rails', 'web')
-
       tracer.trace('my.short.op') do |span|
         @span = span
         span.service = 'my.service'
@@ -118,9 +112,6 @@ RSpec.describe 'Tracer integration tests' do
     include_context 'agent-based test'
 
     before(:each) do
-      # Deprecated, does nothing
-      tracer.set_service_info('my.service', 'rails', 'web')
-
       tracer.trace('my.short.op') do |span|
         span.service = 'my.service'
       end

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe 'Tracer integration tests' do
     end
 
     def agent_receives_span_step2
+      # Deprecated, does nothing
       tracer.set_service_info('my.service', 'rails', 'web')
 
       create_trace
@@ -51,14 +52,11 @@ RSpec.describe 'Tracer integration tests' do
       # Timeout after 3 seconds, waiting for 1 flush
       wait_for_flush(:traces_flushed)
 
-      # Timeout after 3 seconds, waiting for 1 flush
-      wait_for_flush(:services_flushed)
-
       stats = tracer.writer.stats
       expect(stats[:traces_flushed]).to eq(1)
-      expect(stats[:services_flushed]).to eq(1)
-      # Number of successes can be 1 or 2 because services count as one flush too
-      expect(stats[:transport][:success]).to be >= 1
+      expect(stats[:services_flushed]).to be_nil
+      # Number of successes will only be 1 since we do not flush services
+      expect(stats[:transport][:success]).to eq(1)
       expect(stats[:transport][:client_error]).to eq(0)
       expect(stats[:transport][:server_error]).to eq(0)
       expect(stats[:transport][:internal_error]).to eq(0)
@@ -74,7 +72,7 @@ RSpec.describe 'Tracer integration tests' do
 
       stats = tracer.writer.stats
       expect(stats[:traces_flushed]).to eq(2)
-      expect(stats[:services_flushed]).to eq(1)
+      expect(stats[:services_flushed]).to be_nil
       expect(stats[:transport][:success]).to be > previous_success
       expect(stats[:transport][:client_error]).to eq(0)
       expect(stats[:transport][:server_error]).to eq(0)
@@ -92,6 +90,7 @@ RSpec.describe 'Tracer integration tests' do
     include_context 'agent-based test'
 
     before(:each) do
+      # Deprecated, does nothing
       tracer.set_service_info('my.service', 'rails', 'web')
 
       tracer.trace('my.short.op') do |span|
@@ -108,7 +107,7 @@ RSpec.describe 'Tracer integration tests' do
       expect(@first_shutdown).to be true
       expect(@span.finished?).to be true
       expect(stats[:traces_flushed]).to eq(1)
-      expect(stats[:services_flushed]).to eq(1)
+      expect(stats[:services_flushed]).to be_nil
       expect(stats[:transport][:client_error]).to eq(0)
       expect(stats[:transport][:server_error]).to eq(0)
       expect(stats[:transport][:internal_error]).to eq(0)
@@ -119,6 +118,7 @@ RSpec.describe 'Tracer integration tests' do
     include_context 'agent-based test'
 
     before(:each) do
+      # Deprecated, does nothing
       tracer.set_service_info('my.service', 'rails', 'web')
 
       tracer.trace('my.short.op') do |span|
@@ -140,7 +140,7 @@ RSpec.describe 'Tracer integration tests' do
     it do
       expect(@shutdown_results.count(true)).to eq(1)
       expect(stats[:traces_flushed]).to eq(1)
-      expect(stats[:services_flushed]).to eq(1)
+      expect(stats[:services_flushed]).to be_nil
       expect(stats[:transport][:client_error]).to eq(0)
       expect(stats[:transport][:server_error]).to eq(0)
       expect(stats[:transport][:internal_error]).to eq(0)

--- a/spec/ddtrace/pin_spec.rb
+++ b/spec/ddtrace/pin_spec.rb
@@ -24,13 +24,6 @@ RSpec.describe Datadog::Pin do
     context 'when given sufficient info' do
       let(:options) { { app: 'test-app', app_type: 'test-type', tracer: tracer } }
       let(:tracer) { get_test_tracer }
-
-      it 'sets the service info' do
-        expect(tracer.services.key?(service_name)).to be true
-        expect(tracer.services[service_name]).to eq(
-          'app' => 'test-app', 'app_type' => 'test-type'
-        )
-      end
     end
 
     context 'when given insufficient info' do

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -131,4 +131,21 @@ RSpec.describe Datadog::Tracer do
       end
     end
   end
+
+  describe '#set_service_info' do
+    include_context 'tracer logging'
+
+    before(:each) do
+      # Call multiple times to assert we only log once
+      tracer.set_service_info('service-A', 'app-A', 'app_type-A')
+      tracer.set_service_info('service-B', 'app-B', 'app_type-B')
+      tracer.set_service_info('service-C', 'app-C', 'app_type-C')
+      tracer.set_service_info('service-D', 'app-D', 'app_type-D')
+    end
+
+    it 'generates a single deprecation warnings' do
+      expect(log_buffer.length).to be > 1
+      expect(log_buffer).to contain_line_with('Usage of set_service_info has been deprecated')
+    end
+  end
 end

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -135,6 +135,11 @@ RSpec.describe Datadog::Tracer do
   describe '#set_service_info' do
     include_context 'tracer logging'
 
+    # Ensure we have a clean `@done_once` before and after each test
+    # so we can properly test the behavior here, and we don't pollute other tests
+    before(:each) { Datadog::Patcher.instance_variable_set(:@done_once, nil) }
+    after(:each) { Datadog::Patcher.instance_variable_set(:@done_once, nil) }
+
     before(:each) do
       # Call multiple times to assert we only log once
       tracer.set_service_info('service-A', 'app-A', 'app_type-A')

--- a/spec/ddtrace/transport_spec.rb
+++ b/spec/ddtrace/transport_spec.rb
@@ -154,7 +154,6 @@ RSpec.describe Datadog::HTTPTransport do
       end
     end
 
-
     # Sending of services is deprecated and just returns `nil`
     context 'services' do
       subject(:code) { transport.send(:services, services) }

--- a/spec/ddtrace/transport_spec.rb
+++ b/spec/ddtrace/transport_spec.rb
@@ -154,34 +154,13 @@ RSpec.describe Datadog::HTTPTransport do
       end
     end
 
+
+    # Sending of services is deprecated and just returns `nil`
     context 'services' do
       subject(:code) { transport.send(:services, services) }
       let(:services) { get_test_services }
 
-      it_behaves_like 'an encoded transport'
-
-      context 'when the agent returns a 404' do
-        before(:each) do
-          original_post = transport.method(:post)
-          call_count = 0
-          allow(transport).to receive(:post) do |url, *rest|
-            if call_count > 0
-              original_post.call(url, *rest)
-            else
-              call_count += 1
-              404
-            end
-          end
-        end
-
-        it 'appropriately downgrades the API' do
-          expect(transport.instance_variable_get(:@api)[:version]).to eq(described_class::V3)
-          code = transport.send(:services, services)
-          # HTTPTransport should downgrade the encoder and API level
-          expect(transport.instance_variable_get(:@api)[:version]).to eq(described_class::V2)
-          expect(transport.success?(code)).to be true
-        end
-      end
+      it { expect(code).to be_nil }
     end
 
     context 'admin' do

--- a/spec/ddtrace/workers_integration_spec.rb
+++ b/spec/ddtrace/workers_integration_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Datadog::Workers::AsyncTransport integration tests' do
   let(:writer) do
     Datadog::Writer.new.tap do |w|
       # write some stuff to trigger a #start
-      w.write([], {})
+      w.write([])
       # now stop the writer and replace worker with ours, if we don't do
       # this the old worker will still be used.
       w.stop
@@ -169,8 +169,6 @@ RSpec.describe 'Datadog::Workers::AsyncTransport integration tests' do
     # Test that services are correctly flushed, with two of them
     context 'for two services' do
       before(:each) do
-        tracer.set_service_info('my.service', 'rails', 'web')
-        tracer.set_service_info('my.other.service', 'golang', 'api')
         tracer.start_span('my.op').finish
       end
 

--- a/spec/ddtrace/workers_integration_spec.rb
+++ b/spec/ddtrace/workers_integration_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'Datadog::Workers::AsyncTransport integration tests' do
 
       it 'flushes the trace correctly' do
         expect(stats[:traces_flushed]).to be >= 1
-        expect(stats[:services_flushed]).to eq(0)
+        expect(stats[:services_flushed]).to be_nil
 
         # Sanity checks
         expect(dump[200]).to_not be nil
@@ -165,7 +165,6 @@ RSpec.describe 'Datadog::Workers::AsyncTransport integration tests' do
 
   describe 'when setting service info' do
     let(:dumped_services) { dump[200][:services] }
-    let(:service_payload) { JSON.parse(dumped_services[0]) }
 
     # Test that services are correctly flushed, with two of them
     context 'for two services' do
@@ -173,28 +172,18 @@ RSpec.describe 'Datadog::Workers::AsyncTransport integration tests' do
         tracer.set_service_info('my.service', 'rails', 'web')
         tracer.set_service_info('my.other.service', 'golang', 'api')
         tracer.start_span('my.op').finish
-
-        wait_for_flush { writer.stats[:services_flushed] >= 1 }
       end
 
       it 'flushes the services correctly' do
-        expect(stats[:services_flushed]).to eq(1)
+        expect(stats[:services_flushed]).to be_nil
 
         # Sanity checks
         expect(dump[200]).to_not be nil
         expect(dump[500]).to_not be nil
         expect(dump[500]).to eq({})
-        expect(dumped_services).to_not be nil
 
-        # Unmarshalling data
-        expect(dumped_services).to have(1).items
-        expect(dumped_services[0]).to be_a_kind_of(String)
-        expect(service_payload).to be_a_kind_of(Hash)
-
-        expect(service_payload).to eq(
-          'my.service' => { 'app' => 'rails', 'app_type' => 'web' },
-          'my.other.service' => { 'app' => 'golang', 'app_type' => 'api' }
-        )
+        # No services information was sent
+        expect(dumped_services).to be_nil
       end
     end
   end
@@ -208,7 +197,6 @@ RSpec.describe 'Datadog::Workers::AsyncTransport integration tests' do
 
       # Enqueue some work for a final flush
       worker.enqueue_trace(get_test_traces(1))
-      worker.enqueue_service(get_test_services)
 
       # Interrupt back off and flush everything immediately
       @shutdown_beg = Time.now
@@ -234,7 +222,7 @@ RSpec.describe 'Datadog::Workers::AsyncTransport integration tests' do
 
       it do
         expect(trace_task).to have_received(:call).once
-        expect(service_task).to have_received(:call).once
+        expect(service_task).to_not have_received(:call)
         expect(@shutdown_end - @shutdown_beg).to be < Datadog::Workers::AsyncTransport::SHUTDOWN_TIMEOUT
       end
     end

--- a/spec/ddtrace/workers_spec.rb
+++ b/spec/ddtrace/workers_spec.rb
@@ -11,18 +11,15 @@ RSpec.describe Datadog::Workers::AsyncTransport do
           transport: nil,
           buffer_size: 100,
           on_trace: task,
-          on_service: task,
           interval: 0.5
         )
 
         worker.enqueue_trace(get_test_traces(1))
-        worker.enqueue_service(get_test_services)
 
         expect { worker.callback_traces }.to_not raise_error
-        expect { worker.callback_services }.to_not raise_error
 
         lines = buf.string.lines
-        expect(lines.count).to eq 2
+        expect(lines.count).to eq 1
       end
     end
   end

--- a/spec/support/faux_writer.rb
+++ b/spec/support/faux_writer.rb
@@ -11,14 +11,12 @@ class FauxWriter < Datadog::Writer
 
     # easy access to registered components
     @spans = []
-    @services = {}
   end
 
-  def write(trace, services)
+  def write(trace)
     @mutex.synchronize do
-      super(trace, services)
+      super(trace)
       @spans << trace
-      @services = @services.merge(services) unless services.empty?
     end
   end
 
@@ -53,14 +51,6 @@ class FauxWriter < Datadog::Writer
       spans = @spans[0]
       @spans = @spans[1..@spans.size]
       spans
-    end
-  end
-
-  def services
-    @mutex.synchronize do
-      services = @services
-      @services = {}
-      services
     end
   end
 end

--- a/spec/support/spy_transport.rb
+++ b/spec/support/spy_transport.rb
@@ -15,8 +15,6 @@ class SpyTransport < Datadog::HTTPTransport
 
   def send(endpoint, data)
     data = case endpoint
-           when :services
-             @helper_encoder.encode_services(data)
            when :traces
              @helper_encoder.encode_traces(data)
            end

--- a/spec/support/test_access_patch.rb
+++ b/spec/support/test_access_patch.rb
@@ -21,7 +21,6 @@ module Datadog
   end
   class HTTPTransport
     remove_method :traces_endpoint
-    remove_method :services_endpoint
-    attr_accessor :traces_endpoint, :services_endpoint, :encoder, :headers
+    attr_accessor :traces_endpoint, :encoder, :headers
   end
 end

--- a/test/contrib/rails/tracer_test.rb
+++ b/test/contrib/rails/tracer_test.rb
@@ -25,89 +25,9 @@ class TracerTest < ActionDispatch::IntegrationTest
     assert Datadog.configuration[:rails][:tracer]
   end
 
-  test 'a default service and database should be properly set' do
-    services = Datadog.configuration[:rails][:tracer].services
+  test 'a default database should be properly set' do
     Datadog::Contrib::Rails::Framework.setup
     adapter_name = get_adapter_name
     refute_equal(adapter_name, 'defaultdb')
-    assert_equal(
-      {
-        app_name => {
-          'app' => 'rails', 'app_type' => 'web'
-        },
-        "#{app_name}-#{adapter_name}" => {
-          'app' => 'active_record', 'app_type' => 'db'
-        },
-        "#{app_name}-cache" => {
-          'app' => 'rails', 'app_type' => 'cache'
-        }
-      },
-      services
-    )
-  end
-
-  test 'database service can be changed by user' do
-    update_config(:database_service, 'customer-db')
-    tracer = Datadog.configuration[:rails][:tracer]
-
-    assert_equal(
-      {
-        app_name => {
-          'app' => 'rails', 'app_type' => 'web'
-        },
-        'customer-db' => {
-          'app' => 'active_record', 'app_type' => 'db'
-        },
-        "#{app_name}-cache" => {
-          'app' => 'rails', 'app_type' => 'cache'
-        }
-      },
-      tracer.services
-    )
-  end
-
-  test 'application service can be changed by user' do
-    tracer = Datadog.configuration[:rails][:tracer]
-    update_config(:controller_service, 'my-custom-app')
-    adapter_name = get_adapter_name()
-
-    assert_equal(
-      {
-        app_name => {
-          'app' => 'rack', 'app_type' => 'web'
-        },
-        'my-custom-app' => {
-          'app' => 'rails', 'app_type' => 'web'
-        },
-        "#{app_name}-#{adapter_name}" => {
-          'app' => 'active_record', 'app_type' => 'db'
-        },
-        "#{app_name}-cache" => {
-          'app' => 'rails', 'app_type' => 'cache'
-        }
-      },
-      tracer.services
-    )
-  end
-
-  test 'cache service can be changed by user' do
-    update_config(:cache_service, 'service-cache')
-    tracer = Datadog.configuration[:rails][:tracer]
-    adapter_name = get_adapter_name()
-
-    assert_equal(
-      {
-        app_name => {
-          'app' => 'rails', 'app_type' => 'web'
-        },
-        "#{app_name}-#{adapter_name}" => {
-          'app' => 'active_record', 'app_type' => 'db'
-        },
-        'service-cache' => {
-          'app' => 'rails', 'app_type' => 'cache'
-        }
-      },
-      tracer.services
-    )
   end
 end

--- a/test/contrib/sidekiq/server_tracer_test.rb
+++ b/test/contrib/sidekiq/server_tracer_test.rb
@@ -42,9 +42,6 @@ class ServerTracerTest < TracerTestBase
     spans = @writer.spans()
     assert_equal(1, spans.length)
 
-    services = @writer.services()
-    assert_equal(1, services.length)
-
     span = spans[0]
     assert_equal('sidekiq', span.service)
     assert_equal('ServerTracerTest::EmptyWorker', span.resource)
@@ -64,9 +61,6 @@ class ServerTracerTest < TracerTestBase
     spans = @writer.spans()
     assert_equal(1, spans.length)
 
-    services = @writer.services()
-    assert_equal(1, services.length)
-
     span = spans[0]
     assert_equal('sidekiq', span.service)
     assert_equal('ServerTracerTest::ErrorWorker', span.resource)
@@ -84,9 +78,6 @@ class ServerTracerTest < TracerTestBase
 
     spans = @writer.spans()
     assert_equal(2, spans.length)
-
-    services = @writer.services()
-    assert_equal(2, services.length)
 
     custom, empty = spans
 

--- a/test/contrib/sidekiq/tracer_configure_test.rb
+++ b/test/contrib/sidekiq/tracer_configure_test.rb
@@ -13,13 +13,6 @@ class TracerTest < TracerTestBase
       chain.add(Datadog::Contrib::Sidekiq::ServerTracer, tracer: @tracer)
     end
     EmptyWorker.perform_async()
-
-    assert_equal(
-      @writer.services,
-      'sidekiq' => {
-        'app' => 'sidekiq', 'app_type' => 'worker'
-      }
-    )
   end
 
   def test_configuration_custom
@@ -33,12 +26,5 @@ class TracerTest < TracerTestBase
       )
     end
     EmptyWorker.perform_async()
-
-    assert_equal(
-      @tracer.services,
-      'my-sidekiq' => {
-        'app' => 'sidekiq', 'app_type' => 'worker'
-      }
-    )
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -121,14 +121,12 @@ class FauxWriter < Datadog::Writer
 
     # easy access to registered components
     @spans = []
-    @services = {}
   end
 
-  def write(trace, services)
+  def write(trace)
     @mutex.synchronize do
-      super(trace, services)
+      super(trace)
       @spans << trace
-      @services = @services.merge(services) unless services.empty?
     end
   end
 
@@ -165,14 +163,6 @@ class FauxWriter < Datadog::Writer
       spans
     end
   end
-
-  def services
-    @mutex.synchronize do
-      services = @services
-      @services = {}
-      services
-    end
-  end
 end
 
 # FauxTransport is a dummy HTTPTransport that doesn't send data to an agent.
@@ -196,8 +186,6 @@ class SpyTransport < Datadog::HTTPTransport
 
   def send(endpoint, data)
     data = case endpoint
-           when :services
-             @helper_encoder.encode_services(data)
            when :traces
              @helper_encoder.encode_traces(data)
            end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -234,8 +234,7 @@ end
 module Datadog
   class HTTPTransport
     remove_method :traces_endpoint
-    remove_method :services_endpoint
-    attr_accessor :traces_endpoint, :services_endpoint, :encoder, :headers
+    attr_accessor :traces_endpoint, :encoder, :headers
   end
 end
 

--- a/test/sync_writer_test.rb
+++ b/test/sync_writer_test.rb
@@ -12,11 +12,9 @@ module Datadog
 
     def test_sync_write
       trace = get_test_traces(1).first
-      services = get_test_services
 
-      @sync_writer.write(trace, services)
+      @sync_writer.write(trace)
       assert_includes(@transport.calls, [:traces, [trace]])
-      assert_includes(@transport.calls, [:services, services])
     end
 
     def test_sync_write_filtering
@@ -27,8 +25,8 @@ module Datadog
         Pipeline::SpanFilter.new { |span| span.name == 'span_1' }
       )
 
-      @sync_writer.write(trace1, {})
-      @sync_writer.write(trace2, {})
+      @sync_writer.write(trace1)
+      @sync_writer.write(trace2)
 
       refute_includes(@transport.calls, [:traces, [trace1]])
       assert_includes(@transport.calls, [:traces, [trace2]])

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -120,12 +120,6 @@ class TracerTest < Minitest::Test
     assert_nil(span.end_time)
   end
 
-  def test_set_service_info
-    tracer = get_test_tracer
-    tracer.set_service_info('rest-api', 'rails', 'web')
-    assert_equal(tracer.services['rest-api'], 'app' => 'rails', 'app_type' => 'web')
-  end
-
   def test_set_tags
     tracer = get_test_tracer
     tracer.set_tags('env' => 'test', 'component' => 'core')


### PR DESCRIPTION
We no longer need to make calls to `/services` so these unnecessary calls can be removed from the tracer.

**Reviewers:** The changes I made should all be internal and cause no breaking changes to user's code, but would love feedback specifically in this area, if you notice something removed that could be a problem, let me know.