### PR TITLE
[opentracing] Mark datadog_span.status = 1 when set_tag('error', true)

### DIFF
--- a/lib/ddtrace/opentracer/span.rb
+++ b/lib/ddtrace/opentracer/span.rb
@@ -29,6 +29,14 @@ module Datadog
       # @param value [String, Numeric, Boolean] the value of the tag. If it's not
       # a String, Numeric, or Boolean it will be encoded with to_s
       def set_tag(key, value)
+        # Special cases to convert opentracing tags to datadog tags
+        case key
+        when "error"
+          # Opentracing supports and `error: <bool>` tag, we need to convert to span status
+          # DEV: Do not return, we want to still set the `error` tag as they requested
+          datadog_span.status = value ? Datadog::Ext::Errors::STATUS : 0
+        end
+
         tap { datadog_span.set_tag(key, value) }
       end
 

--- a/lib/ddtrace/opentracer/span.rb
+++ b/lib/ddtrace/opentracer/span.rb
@@ -31,7 +31,7 @@ module Datadog
       def set_tag(key, value)
         # Special cases to convert opentracing tags to datadog tags
         case key
-        when "error"
+        when 'error'
           # Opentracing supports and `error: <bool>` tag, we need to convert to span status
           # DEV: Do not return, we want to still set the `error` tag as they requested
           datadog_span.status = value ? Datadog::Ext::Errors::STATUS : 0

--- a/spec/ddtrace/opentracer/span_spec.rb
+++ b/spec/ddtrace/opentracer/span_spec.rb
@@ -26,10 +26,35 @@ if Datadog::OpenTracer.supported?
 
     describe '#set_tag' do
       subject(:result) { span.set_tag(key, value) }
-      let(:key) { 'account_id' }
-      let(:value) { '1234' }
-      before(:each) { expect(datadog_span).to receive(:set_tag).with(key, value) }
-      it { is_expected.to be(span) }
+
+      context 'when given arbitrary tag key and value' do
+        let(:key) { 'account_id' }
+        let(:value) { '1234' }
+
+        before(:each) { expect(datadog_span).to receive(:set_tag).with(key, value) }
+
+        it { is_expected.to be(span) }
+      end
+
+      context 'when given an error tag of true' do
+        let(:key) { 'error' }
+        let(:value) { true }
+
+        before(:each) { expect(datadog_span).to receive(:set_tag).with(key, value) }
+        before(:each) { expect(datadog_span).to receive(:'status=').with(Datadog::Ext::Errors::STATUS) }
+
+        it { is_expected.to be(span) }
+      end
+
+      context 'when given an error tag of false' do
+        let(:key) { 'error' }
+        let(:value) { false }
+
+        before(:each) { expect(datadog_span).to receive(:set_tag).with(key, value) }
+        before(:each) { expect(datadog_span).to receive(:'status=').with(0) }
+
+        it { is_expected.to be(span) }
+      end
     end
 
     describe '#set_baggage_item' do


### PR DESCRIPTION
Opentracing supports setting a tag `error` as a boolean. We were not doing anything with this tag, this code updates the opentracing span `set_tag` to look for `error` and translate that into setting the `datadog_span.status` property.

We also continue to set the tag as they requested, since that is what they'd expect.