### PR TITLE
Move rack tracing to BodyProxy to support async responses

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentracing', '>= 0.4.1'
 
   # Development dependencies
+  spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake', '>= 10.5'
   spec.add_development_dependency 'rubocop', '= 0.49.1' if RUBY_VERSION >= '2.1.0'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Finishing the trace spans in an `ensure` doesn't handle streaming or async responses, which return a `body` that responds to `each` but continue to do work after the middlewares are completed. Using a `::Rack::BodyProxy` ensures that the trace spans are finished when the response body is finished writing (and is closed) instead.