### PR TITLE
Use original return values for rake methods

### DIFF
--- a/lib/ddtrace/contrib/rake/instrumentation.rb
+++ b/lib/ddtrace/contrib/rake/instrumentation.rb
@@ -16,9 +16,11 @@ module Datadog
             return super unless enabled?
 
             tracer.trace(Ext::SPAN_INVOKE, span_options) do |span|
-              super
+              result = super
               annotate_invoke!(span, args)
             end
+
+            result
           ensure
             shutdown_tracer!
           end
@@ -27,9 +29,11 @@ module Datadog
             return super unless enabled?
 
             tracer.trace(Ext::SPAN_EXECUTE, span_options) do |span|
-              super
+              result = super
               annotate_execute!(span, args)
             end
+
+            result
           ensure
             shutdown_tracer!
           end

--- a/lib/ddtrace/contrib/rake/instrumentation.rb
+++ b/lib/ddtrace/contrib/rake/instrumentation.rb
@@ -15,6 +15,7 @@ module Datadog
           def invoke(*args)
             return super unless enabled?
 
+            result = nil
             tracer.trace(Ext::SPAN_INVOKE, span_options) do |span|
               result = super
               annotate_invoke!(span, args)
@@ -28,6 +29,7 @@ module Datadog
           def execute(args = nil)
             return super unless enabled?
 
+            result = nil
             tracer.trace(Ext::SPAN_EXECUTE, span_options) do |span|
               result = super
               annotate_execute!(span, args)

--- a/lib/ddtrace/contrib/rake/instrumentation.rb
+++ b/lib/ddtrace/contrib/rake/instrumentation.rb
@@ -15,13 +15,9 @@ module Datadog
           def invoke(*args)
             return super unless enabled?
 
-            result = nil
             tracer.trace(Ext::SPAN_INVOKE, span_options) do |span|
-              result = super
-              annotate_invoke!(span, args)
+              super.tap { annotate_invoke!(span, args) }
             end
-
-            result
           ensure
             shutdown_tracer!
           end
@@ -29,13 +25,9 @@ module Datadog
           def execute(args = nil)
             return super unless enabled?
 
-            result = nil
             tracer.trace(Ext::SPAN_EXECUTE, span_options) do |span|
-              result = super
-              annotate_execute!(span, args)
+              super.tap { annotate_execute!(span, args) }
             end
-
-            result
           ensure
             shutdown_tracer!
           end

--- a/spec/ddtrace/contrib/rake/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/rake/instrumentation_spec.rb
@@ -131,6 +131,11 @@ RSpec.describe Datadog::Contrib::Rake::Instrumentation do
 
       before(:each) { define_task! }
 
+      it 'returns task return value' do
+        allow(spy).to receive(:call)
+        expect(task.invoke(*args)).to contain_exactly(task_body)
+      end
+
       context 'without args' do
         it_behaves_like 'a single task execution' do
           describe '\'rake.invoke\' span tags' do


### PR DESCRIPTION
## Problem

The [Rake instrumentation](https://github.com/DataDog/dd-trace-rb/blob/v0.22.0/lib/ddtrace/contrib/rake/instrumentation.rb#L26-L35) causes the results of `#invoke` and `#execute` to be swallowed. This means, when calling one Rake task from another Rake task, the former will now always return `nil`. For example, given the following rake tasks:

```ruby
namespace :some do
  task :task do
    raise 'I am sad.' unless Rake::Task['some:other_task'].execute == 'I am happy!'
    puts 'Yaaay!'
  end

  task :other_task do
    'I am happy!'
  end
end
```

Running `rake some:task` will fail with the "I am sad." message.

## Impact

There are some instances, where it is helpful to run certain Rake tasks within others. For example, running ActiveRecord's built-in `db` tasks as part of a larger purpose-built task that sets up an environment.

In general, this does not appear to be a common use-case. However, in cases where it's needed, the only alternative would be to use exceptions for control-flow, which is an anti-pattern that should be avoided.

## Solution

Simply assign the results of `super` in these two methods to a local variable, and return that at the end of the wrapper's execution. This causes `rake some:task` to print "Yaaay!" and not error, for the above example.