### PR TITLE
adds jruby to compatibility check

### DIFF
--- a/lib/ddtrace/contrib/patchable.rb
+++ b/lib/ddtrace/contrib/patchable.rb
@@ -1,3 +1,5 @@
+require 'ddtrace/runtime'
+
 module Datadog
   module Contrib
     # Base provides features that are shared across all integrations
@@ -18,7 +20,7 @@ module Datadog
         end
 
         def compatible?
-          (RUBY_VERSION >= '1.9.3' || (defined?(JRUBY_VERSION) && JRUBY_VERSION >= '9.1.5')) && present?
+          Datadog::Runtime.supported? && present?
         end
       end
 

--- a/lib/ddtrace/contrib/patchable.rb
+++ b/lib/ddtrace/contrib/patchable.rb
@@ -18,7 +18,7 @@ module Datadog
         end
 
         def compatible?
-          RUBY_VERSION >= '1.9.3' && present?
+          (RUBY_VERSION >= '1.9.3' || (defined?(JRUBY_VERSION) && JRUBY_VERSION >= '9.1.5')) && present?
         end
       end
 

--- a/lib/ddtrace/runtime.rb
+++ b/lib/ddtrace/runtime.rb
@@ -1,0 +1,10 @@
+module Datadog
+  # Namespace for ddtrace OpenTracing implementation
+  module Runtime
+    module_function
+
+    def supported?
+      RUBY_VERSION >= '1.9.3' || (defined?(JRUBY_VERSION) && JRUBY_VERSION >= '9.1.5')
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses issue 743 https://github.com/DataDog/dd-trace-rb/issues/743 , where integrations are not enabled due to users running `JRuby`

Some Integrations don't define a specific `compatible?` check, falling back to `Contrib::Integration` `compatible?`. This method just does a simple check of the Ruby version. However there is currently experimental support for `JRuby 9.1.5` and higher according to our docs, so adding this option to `compatible?` in the same way it's done for determining whether to collect runtime metrics here: https://github.com/DataDog/dd-trace-rb/blob/67bc4744079b8103d4fbfa95771e67a0267217f1/lib/ddtrace/span.rb#L241

Happy to add a spec here as well if we feel it's useful, or any feedback welcome if this approach isn't appropriate