### PR TITLE
Fix SyncWriter raising NoMethodError for #runtime_metrics

### DIFF
--- a/lib/ddtrace/sync_writer.rb
+++ b/lib/ddtrace/sync_writer.rb
@@ -1,12 +1,21 @@
+require 'ddtrace/runtime/metrics'
+
 module Datadog
   # SyncWriter flushes both services and traces synchronously
   class SyncWriter
-    attr_reader :transport
+    attr_reader \
+      :runtime_metrics,
+      :transport
 
     def initialize(options = {})
       @transport = options.fetch(:transport) do
         transport_options = options.fetch(:transport_options, {})
         HTTPTransport.new(transport_options)
+      end
+
+      # Runtime metrics
+      @runtime_metrics = options.fetch(:runtime_metrics) do
+        Runtime::Metrics.new
       end
     end
 

--- a/spec/ddtrace/sync_writer_spec.rb
+++ b/spec/ddtrace/sync_writer_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+require 'ddtrace'
+require 'ddtrace/sync_writer'
+
+RSpec.describe Datadog::SyncWriter do
+  subject(:sync_writer) { described_class.new }
+
+  describe '#runtime_metrics' do
+    subject(:runtime_metrics) { sync_writer.runtime_metrics }
+    it { is_expected.to be_a_kind_of(Datadog::Runtime::Metrics) }
+  end
+end


### PR DESCRIPTION
Users using 0.22.0+ and `SyncWriter` might see `undefined method 'runtime_metrics' for #<Datadog::SyncWriter:0x0000000004dfa2b0>`. When runtime metrics was introduced with 0.22.0, it overlooked use of `SyncWriter`.

This pull request prevents this `NoMethodError` and permits normal operation of tracing. It however, does not add support for runtime metrics with `SyncWriter`, something that will be evaluated in the future.