### PR TITLE
:warning: Avoid deprecation warnings on Rails 6

### DIFF
--- a/lib/ddtrace/contrib/rails/utils.rb
+++ b/lib/ddtrace/contrib/rails/utils.rb
@@ -26,7 +26,9 @@ module Datadog
         end
 
         def self.app_name
-          if ::Rails::VERSION::MAJOR >= 4
+          if ::Rails::VERSION::MAJOR >= 6
+            ::Rails.application.class.module_parent_name.underscore
+          elsif ::Rails::VERSION::MAJOR >= 4
             ::Rails.application.class.parent_name.underscore
           else
             ::Rails.application.class.to_s.underscore


### PR DESCRIPTION
`parent_name` will be renamed `module_parent_name` in Rails 6.1, so it displays deprecation warnings on Rails 6.0.

refs: https://github.com/rails/rails/pull/34051