### PR TITLE
Change span types for HTTP, web, and some datastore integrations

### DIFF
--- a/lib/ddtrace/contrib/dalli/ext.rb
+++ b/lib/ddtrace/contrib/dalli/ext.rb
@@ -9,6 +9,7 @@ module Datadog
         QUANTIZE_MAX_CMD_LENGTH = 100
         SERVICE_NAME = 'memcached'.freeze
         SPAN_COMMAND = 'memcached.command'.freeze
+        SPAN_TYPE_COMMAND = 'memcached'.freeze
         TAG_COMMAND = 'memcached.command'.freeze
       end
     end

--- a/lib/ddtrace/contrib/dalli/instrumentation.rb
+++ b/lib/ddtrace/contrib/dalli/instrumentation.rb
@@ -1,6 +1,6 @@
-require 'ddtrace/ext/app_types'
 require 'ddtrace/ext/net'
 require 'ddtrace/contrib/analytics'
+require 'ddtrace/contrib/dalli/ext'
 require 'ddtrace/contrib/dalli/quantize'
 
 module Datadog
@@ -35,7 +35,7 @@ module Datadog
             tracer.trace(Datadog::Contrib::Dalli::Ext::SPAN_COMMAND) do |span|
               span.resource = op.to_s.upcase
               span.service = datadog_configuration[:service_name]
-              span.span_type = Datadog::Ext::AppTypes::CACHE
+              span.span_type = Datadog::Contrib::Dalli::Ext::SPAN_TYPE_COMMAND
 
               # Set analytics sample rate
               if Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])

--- a/lib/ddtrace/contrib/elasticsearch/ext.rb
+++ b/lib/ddtrace/contrib/elasticsearch/ext.rb
@@ -8,6 +8,7 @@ module Datadog
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_ELASTICSEARCH_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'elasticsearch'.freeze
         SPAN_QUERY = 'elasticsearch.query'.freeze
+        SPAN_TYPE_QUERY = 'elasticsearch'.freeze
         TAG_BODY = 'elasticsearch.body'.freeze
         TAG_METHOD = 'elasticsearch.method'.freeze
         TAG_PARAMS = 'elasticsearch.params'.freeze

--- a/lib/ddtrace/contrib/elasticsearch/patcher.rb
+++ b/lib/ddtrace/contrib/elasticsearch/patcher.rb
@@ -78,7 +78,7 @@ module Datadog
                   port = connection.host[:port] if connection
 
                   span.service = pin.service
-                  span.span_type = Datadog::Ext::AppTypes::DB
+                  span.span_type = Datadog::Contrib::Elasticsearch::Ext::SPAN_TYPE_QUERY
 
                   # load JSON for the following fields unless they're already strings
                   params = JSON.generate(params) if params && !params.is_a?(String)

--- a/lib/ddtrace/contrib/excon/middleware.rb
+++ b/lib/ddtrace/contrib/excon/middleware.rb
@@ -106,7 +106,7 @@ module Datadog
         def annotate!(span, datum)
           span.resource = datum[:method].to_s.upcase
           span.service = service_name(datum)
-          span.span_type = Datadog::Ext::HTTP::TYPE
+          span.span_type = Datadog::Ext::HTTP::TYPE_OUTBOUND
 
           # Set analytics sample rate
           if analytics_enabled?

--- a/lib/ddtrace/contrib/faraday/middleware.rb
+++ b/lib/ddtrace/contrib/faraday/middleware.rb
@@ -33,7 +33,7 @@ module Datadog
         def annotate!(span, env)
           span.resource = env[:method].to_s.upcase
           span.service = service_name(env)
-          span.span_type = Datadog::Ext::HTTP::TYPE
+          span.span_type = Datadog::Ext::HTTP::TYPE_OUTBOUND
 
           # Set analytics sample rate
           if analytics_enabled?

--- a/lib/ddtrace/contrib/grape/endpoint.rb
+++ b/lib/ddtrace/contrib/grape/endpoint.rb
@@ -41,7 +41,7 @@ module Datadog
             tracer.trace(
               Ext::SPAN_ENDPOINT_RUN,
               service: service_name,
-              span_type: Datadog::Ext::HTTP::TYPE
+              span_type: Datadog::Ext::HTTP::TYPE_INBOUND
             )
 
             Thread.current[KEY_RUN] = true
@@ -107,7 +107,7 @@ module Datadog
             tracer.trace(
               Ext::SPAN_ENDPOINT_RENDER,
               service: service_name,
-              span_type: Datadog::Ext::HTTP::TYPE
+              span_type: Datadog::Ext::HTTP::TEMPLATE
             )
 
             Thread.current[KEY_RENDER] = true
@@ -147,7 +147,7 @@ module Datadog
             span = tracer.trace(
               Ext::SPAN_ENDPOINT_RUN_FILTERS,
               service: service_name,
-              span_type: Datadog::Ext::HTTP::TYPE
+              span_type: Datadog::Ext::HTTP::TYPE_INBOUND
             )
 
             begin

--- a/lib/ddtrace/contrib/grpc/datadog_interceptor/client.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor/client.rb
@@ -15,7 +15,7 @@ module Datadog
             keywords[:metadata] ||= {}
 
             options = {
-              span_type: Datadog::Ext::HTTP::TYPE,
+              span_type: Datadog::Ext::HTTP::TYPE_OUTBOUND,
               service: service_name,
               resource: format_resource(keywords[:method])
             }

--- a/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
@@ -14,7 +14,7 @@ module Datadog
         class Server < Base
           def trace(keywords)
             options = {
-              span_type: Datadog::Ext::HTTP::TYPE,
+              span_type: Datadog::Ext::HTTP::TYPE_INBOUND,
               service: service_name,
               resource: format_resource(keywords[:method])
             }

--- a/lib/ddtrace/contrib/http/instrumentation.rb
+++ b/lib/ddtrace/contrib/http/instrumentation.rb
@@ -63,7 +63,7 @@ module Datadog
             pin.tracer.trace(Ext::SPAN_REQUEST) do |span|
               begin
                 span.service = pin.service
-                span.span_type = Datadog::Ext::HTTP::TYPE
+                span.span_type = Datadog::Ext::HTTP::TYPE_OUTBOUND
                 span.resource = req.method
 
                 if pin.tracer.enabled && !Datadog::Contrib::HTTP.should_skip_distributed_tracing?(pin)

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -34,6 +34,7 @@ module Datadog
 
           tracer.trace(
             Ext::SPAN_HTTP_SERVER_QUEUE,
+            span_type: Datadog::Ext::HTTP::TYPE_PROXY,
             start_time: request_start,
             service: configuration[:web_service_name]
           )
@@ -57,7 +58,7 @@ module Datadog
           trace_options = {
             service: configuration[:service_name],
             resource: nil,
-            span_type: Datadog::Ext::HTTP::TYPE
+            span_type: Datadog::Ext::HTTP::TYPE_INBOUND
           }
 
           # start a new request span and attach it to the current Rack environment;

--- a/lib/ddtrace/contrib/rails/action_controller.rb
+++ b/lib/ddtrace/contrib/rails/action_controller.rb
@@ -21,7 +21,7 @@ module Datadog
           # trace the execution
           tracer = Datadog.configuration[:rails][:tracer]
           service = Datadog.configuration[:rails][:controller_service]
-          type = Datadog::Ext::HTTP::TYPE
+          type = Datadog::Ext::HTTP::TYPE_INBOUND
           span = tracer.trace(Ext::SPAN_ACTION_CONTROLLER, service: service, span_type: type)
 
           # attach the current span to the tracing context

--- a/lib/ddtrace/contrib/rest_client/request_patch.rb
+++ b/lib/ddtrace/contrib/rest_client/request_patch.rb
@@ -60,7 +60,7 @@ module Datadog
           def datadog_trace_request(uri)
             span = datadog_configuration[:tracer].trace(Ext::SPAN_REQUEST,
                                                         service: datadog_configuration[:service_name],
-                                                        span_type: Datadog::Ext::AppTypes::WEB)
+                                                        span_type: Datadog::Ext::HTTP::TYPE_OUTBOUND)
 
             datadog_tag_request(uri, span)
 

--- a/lib/ddtrace/contrib/sinatra/tracer_middleware.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer_middleware.rb
@@ -23,7 +23,7 @@ module Datadog
           tracer.trace(
             Ext::SPAN_REQUEST,
             service: configuration[:service_name],
-            span_type: Datadog::Ext::HTTP::TYPE
+            span_type: Datadog::Ext::HTTP::TYPE_INBOUND
           ) do |span|
             Sinatra::Env.set_datadog_span(env, span)
 

--- a/lib/ddtrace/ext/http.rb
+++ b/lib/ddtrace/ext/http.rb
@@ -6,7 +6,9 @@ module Datadog
       METHOD = 'http.method'.freeze
       STATUS_CODE = 'http.status_code'.freeze
       TEMPLATE = 'template'.freeze
-      TYPE = 'http'.freeze
+      TYPE_INBOUND = 'web'.freeze
+      TYPE_OUTBOUND = 'http'.freeze
+      TYPE_PROXY = 'proxy'.freeze
       URL = 'http.url'.freeze
 
       # General header functionality

--- a/spec/ddtrace/contrib/dalli/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/dalli/instrumentation_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe 'Dalli instrumentation' do
       expect(all_spans.size).to eq(1)
       expect(span.service).to eq('memcached')
       expect(span.name).to eq('memcached.command')
+      expect(span.span_type).to eq('memcached')
       expect(span.resource).to eq('SET')
       expect(span.get_tag('memcached.command')).to eq('set abc 123 0 0')
       expect(span.get_tag('out.host')).to eq(test_host)

--- a/spec/ddtrace/contrib/elasticsearch/patcher_spec.rb
+++ b/spec/ddtrace/contrib/elasticsearch/patcher_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe Datadog::Contrib::Elasticsearch::Patcher do
       it { expect(span.name).to eq('elasticsearch.query') }
       it { expect(span.service).to eq('elasticsearch') }
       it { expect(span.resource).to eq('GET _cluster/health') }
+      it { expect(span.span_type).to eq('elasticsearch') }
       it { expect(span.parent_id).not_to be_nil }
       it { expect(span.trace_id).not_to be_nil }
     end
@@ -80,6 +81,7 @@ RSpec.describe Datadog::Contrib::Elasticsearch::Patcher do
       it { expect(span.name).to eq('elasticsearch.query') }
       it { expect(span.service).to eq('elasticsearch') }
       it { expect(span.resource).to eq('GET _cluster/health') }
+      it { expect(span.span_type).to eq('elasticsearch') }
       it { expect(span.parent_id).not_to be_nil }
       it { expect(span.trace_id).not_to be_nil }
     end
@@ -120,6 +122,7 @@ RSpec.describe Datadog::Contrib::Elasticsearch::Patcher do
 
       it { expect(span.name).to eq('elasticsearch.query') }
       it { expect(span.service).to eq('elasticsearch') }
+      it { expect(span.span_type).to eq('elasticsearch') }
       it { expect(span.resource).to eq('PUT some_index/type/?') }
 
       it { expect(span.parent_id).not_to be_nil }

--- a/spec/ddtrace/contrib/excon/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/excon/instrumentation_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Datadog::Contrib::Excon::Middleware do
       expect(request_span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/success')
       expect(request_span.get_tag(Datadog::Ext::NET::TARGET_HOST)).to eq('example.com')
       expect(request_span.get_tag(Datadog::Ext::NET::TARGET_PORT)).to eq('80')
-      expect(request_span.span_type).to eq(Datadog::Ext::HTTP::TYPE)
+      expect(request_span.span_type).to eq(Datadog::Ext::HTTP::TYPE_OUTBOUND)
       expect(request_span.status).to_not eq(Datadog::Ext::Errors::STATUS)
     end
   end
@@ -112,7 +112,7 @@ RSpec.describe Datadog::Contrib::Excon::Middleware do
       expect(request_span.get_tag(Datadog::Ext::HTTP::STATUS_CODE)).to eq('500')
       expect(request_span.get_tag(Datadog::Ext::NET::TARGET_HOST)).to eq('example.com')
       expect(request_span.get_tag(Datadog::Ext::NET::TARGET_PORT)).to eq('80')
-      expect(request_span.span_type).to eq(Datadog::Ext::HTTP::TYPE)
+      expect(request_span.span_type).to eq(Datadog::Ext::HTTP::TYPE_OUTBOUND)
       expect(request_span.status).to eq(Datadog::Ext::Errors::STATUS)
       expect(request_span.get_tag(Datadog::Ext::Errors::TYPE)).to eq('Error 500')
       expect(request_span.get_tag(Datadog::Ext::Errors::MSG)).to eq('Boom!')

--- a/spec/ddtrace/contrib/faraday/middleware_spec.rb
+++ b/spec/ddtrace/contrib/faraday/middleware_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Faraday middleware' do
       expect(request_span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/success')
       expect(request_span.get_tag(Datadog::Ext::NET::TARGET_HOST)).to eq('example.com')
       expect(request_span.get_tag(Datadog::Ext::NET::TARGET_PORT)).to eq('80')
-      expect(request_span.span_type).to eq(Datadog::Ext::HTTP::TYPE)
+      expect(request_span.span_type).to eq(Datadog::Ext::HTTP::TYPE_OUTBOUND)
       expect(request_span.status).to_not eq(Datadog::Ext::Errors::STATUS)
     end
   end
@@ -85,7 +85,7 @@ RSpec.describe 'Faraday middleware' do
       expect(request_span.get_tag(Datadog::Ext::HTTP::STATUS_CODE)).to eq('500')
       expect(request_span.get_tag(Datadog::Ext::NET::TARGET_HOST)).to eq('example.com')
       expect(request_span.get_tag(Datadog::Ext::NET::TARGET_PORT)).to eq('80')
-      expect(request_span.span_type).to eq(Datadog::Ext::HTTP::TYPE)
+      expect(request_span.span_type).to eq(Datadog::Ext::HTTP::TYPE_OUTBOUND)
       expect(request_span.status).to eq(Datadog::Ext::Errors::STATUS)
       expect(request_span.get_tag(Datadog::Ext::Errors::TYPE)).to eq('Error 500')
       expect(request_span.get_tag(Datadog::Ext::Errors::MSG)).to eq('Boom!')

--- a/spec/ddtrace/contrib/grpc/datadog_interceptor/server_spec.rb
+++ b/spec/ddtrace/contrib/grpc/datadog_interceptor/server_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'tracing on the server connection' do
 
   shared_examples 'span data contents' do
     specify { expect(span.name).to eq 'grpc.service' }
-    specify { expect(span.span_type).to eq 'http' }
+    specify { expect(span.span_type).to eq 'web' }
     specify { expect(span.service).to eq 'rspec' }
     specify { expect(span.resource).to eq 'my.server.endpoint' }
     specify { expect(span.get_tag('error.stack')).to be_nil }

--- a/spec/ddtrace/contrib/grpc/interception_context_spec.rb
+++ b/spec/ddtrace/contrib/grpc/interception_context_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe GRPC::InterceptionContext do
     context 'when intercepting on the server' do
       shared_examples 'span data contents' do
         specify { expect(span.name).to eq 'grpc.service' }
-        specify { expect(span.span_type).to eq 'http' }
+        specify { expect(span.span_type).to eq 'web' }
         specify { expect(span.service).to eq 'rspec' }
         specify { expect(span.resource).to eq 'my.server.endpoint' }
         specify { expect(span.get_tag('error.stack')).to be_nil }

--- a/spec/ddtrace/contrib/rack/configuration_spec.rb
+++ b/spec/ddtrace/contrib/rack/configuration_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe 'Rack integration configuration' do
         expect(spans).to have(2).items
 
         expect(queue_span.name).to eq('http_server.queue')
+        expect(queue_span.span_type).to eq('proxy')
         expect(queue_span.service).to eq(Datadog.configuration[:rack][:web_service_name])
         expect(queue_span.start_time.to_i).to eq(queue_time)
         # Queue span gets tagged for runtime metrics because its a local root span.
@@ -81,7 +82,7 @@ RSpec.describe 'Rack integration configuration' do
         expect(queue_span.get_tag(Datadog::Ext::Runtime::TAG_RUNTIME_ID)).to eq(Datadog::Runtime::Identity.id)
 
         expect(rack_span.name).to eq('rack.request')
-        expect(rack_span.span_type).to eq('http')
+        expect(rack_span.span_type).to eq('web')
         expect(rack_span.service).to eq(Datadog.configuration[:rack][:service_name])
         expect(rack_span.resource).to eq('GET 200')
         expect(rack_span.get_tag('http.method')).to eq('GET')
@@ -102,7 +103,7 @@ RSpec.describe 'Rack integration configuration' do
 
         expect(span).to_not be nil
         expect(span.name).to eq('rack.request')
-        expect(span.span_type).to eq('http')
+        expect(span.span_type).to eq('web')
         expect(span.service).to eq(Datadog.configuration[:rack][:service_name])
         expect(span.resource).to eq('GET 200')
         expect(span.get_tag('http.method')).to eq('GET')

--- a/spec/ddtrace/contrib/rack/integration_spec.rb
+++ b/spec/ddtrace/contrib/rack/integration_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Rack integration tests' do
 
         it do
           expect(span.name).to eq('rack.request')
-          expect(span.span_type).to eq('http')
+          expect(span.span_type).to eq('web')
           expect(span.service).to eq('rack')
           expect(span.resource).to eq('GET 404')
           expect(span.get_tag('http.method')).to eq('GET')
@@ -86,7 +86,7 @@ RSpec.describe 'Rack integration tests' do
 
           it do
             expect(span.name).to eq('rack.request')
-            expect(span.span_type).to eq('http')
+            expect(span.span_type).to eq('web')
             expect(span.service).to eq('rack')
             expect(span.resource).to eq('GET 200')
             expect(span.get_tag('http.method')).to eq('GET')
@@ -103,7 +103,7 @@ RSpec.describe 'Rack integration tests' do
 
           it do
             expect(span.name).to eq('rack.request')
-            expect(span.span_type).to eq('http')
+            expect(span.span_type).to eq('web')
             expect(span.service).to eq('rack')
             expect(span.resource).to eq('GET 200')
             expect(span.get_tag('http.method')).to eq('GET')
@@ -125,7 +125,7 @@ RSpec.describe 'Rack integration tests' do
 
             it do
               expect(span.name).to eq('rack.request')
-              expect(span.span_type).to eq('http')
+              expect(span.span_type).to eq('web')
               expect(span.service).to eq('rack')
               expect(span.resource).to eq('GET 200')
               expect(span.get_tag('http.method')).to eq('GET')
@@ -145,7 +145,7 @@ RSpec.describe 'Rack integration tests' do
 
             it do
               expect(span.name).to eq('rack.request')
-              expect(span.span_type).to eq('http')
+              expect(span.span_type).to eq('web')
               expect(span.service).to eq('rack')
               expect(span.resource).to eq('GET 200')
               expect(span.get_tag('http.method')).to eq('GET')
@@ -166,7 +166,7 @@ RSpec.describe 'Rack integration tests' do
 
           it do
             expect(span.name).to eq('rack.request')
-            expect(span.span_type).to eq('http')
+            expect(span.span_type).to eq('web')
             expect(span.service).to eq('rack')
             expect(span.resource).to eq('GET 200')
             expect(span.get_tag('http.method')).to eq('GET')
@@ -191,7 +191,7 @@ RSpec.describe 'Rack integration tests' do
 
           it do
             expect(span.name).to eq('rack.request')
-            expect(span.span_type).to eq('http')
+            expect(span.span_type).to eq('web')
             expect(span.service).to eq('custom-rack')
             expect(span.resource).to eq('GET 200')
             expect(span.get_tag('http.method')).to eq('GET')
@@ -212,7 +212,7 @@ RSpec.describe 'Rack integration tests' do
 
           it do
             expect(span.name).to eq('rack.request')
-            expect(span.span_type).to eq('http')
+            expect(span.span_type).to eq('web')
             expect(span.service).to eq('rack')
             expect(span.resource).to eq('POST 200')
             expect(span.get_tag('http.method')).to eq('POST')
@@ -245,7 +245,7 @@ RSpec.describe 'Rack integration tests' do
 
         it do
           expect(span.name).to eq('rack.request')
-          expect(span.span_type).to eq('http')
+          expect(span.span_type).to eq('web')
           expect(span.service).to eq('rack')
           expect(span.resource).to eq('GET 400')
           expect(span.get_tag('http.method')).to eq('GET')
@@ -277,7 +277,7 @@ RSpec.describe 'Rack integration tests' do
 
         it do
           expect(span.name).to eq('rack.request')
-          expect(span.span_type).to eq('http')
+          expect(span.span_type).to eq('web')
           expect(span.service).to eq('rack')
           expect(span.resource).to eq('GET 500')
           expect(span.get_tag('http.method')).to eq('GET')
@@ -311,7 +311,7 @@ RSpec.describe 'Rack integration tests' do
 
           it do
             expect(span.name).to eq('rack.request')
-            expect(span.span_type).to eq('http')
+            expect(span.span_type).to eq('web')
             expect(span.service).to eq('rack')
             expect(span.resource).to eq('GET')
             expect(span.get_tag('http.method')).to eq('GET')
@@ -346,7 +346,7 @@ RSpec.describe 'Rack integration tests' do
 
           it do
             expect(span.name).to eq('rack.request')
-            expect(span.span_type).to eq('http')
+            expect(span.span_type).to eq('web')
             expect(span.service).to eq('rack')
             expect(span.resource).to eq('GET')
             expect(span.get_tag('http.method')).to eq('GET')
@@ -396,7 +396,7 @@ RSpec.describe 'Rack integration tests' do
 
             it do
               expect(span.name).to eq('rack.request')
-              expect(span.span_type).to eq('http')
+              expect(span.span_type).to eq('web')
               expect(span.service).to eq('rack')
               expect(span.resource).to eq('GET /app/')
               expect(span.get_tag('http.method')).to eq('GET_V2')
@@ -438,7 +438,7 @@ RSpec.describe 'Rack integration tests' do
 
             it do
               expect(span.name).to eq('rack.request')
-              expect(span.span_type).to eq('http')
+              expect(span.span_type).to eq('web')
               expect(span.service).to eq('rack')
               expect(span.resource).to eq('GET 500')
               expect(span.get_tag('http.method')).to eq('GET')
@@ -473,7 +473,7 @@ RSpec.describe 'Rack integration tests' do
 
             it do
               expect(span.name).to eq('rack.request')
-              expect(span.span_type).to eq('http')
+              expect(span.span_type).to eq('web')
               expect(span.service).to eq('rack')
               expect(span.resource).to eq('GET 500')
               expect(span.get_tag('http.method')).to eq('GET')
@@ -596,7 +596,7 @@ RSpec.describe 'Rack integration tests' do
 
             it do
               expect(span.name).to eq('rack.request')
-              expect(span.span_type).to eq('http')
+              expect(span.span_type).to eq('web')
               expect(span.service).to eq('rack')
               expect(span.resource).to eq('GET 200')
               expect(span.get_tag('http.method')).to eq('GET')

--- a/spec/ddtrace/contrib/rails/middleware_spec.rb
+++ b/spec/ddtrace/contrib/rails/middleware_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'Rails request' do
 
         it do
           expect(span.name).to eq('rack.request')
-          expect(span.span_type).to eq('http')
+          expect(span.span_type).to eq('web')
           expect(span.resource).to eq('TestController#index')
           expect(span.get_tag('http.url')).to eq('/')
           expect(span.get_tag('http.method')).to eq('GET')
@@ -179,7 +179,7 @@ RSpec.describe 'Rails request' do
 
         it do
           expect(span.name).to eq('rack.request')
-          expect(span.span_type).to eq('http')
+          expect(span.span_type).to eq('web')
           expect(span.resource).to eq('TestController#index')
           expect(span.get_tag('http.url')).to eq('/')
           expect(span.get_tag('http.method')).to eq('GET')
@@ -240,7 +240,7 @@ RSpec.describe 'Rails request' do
 
         it do
           expect(span.name).to eq('rack.request')
-          expect(span.span_type).to eq('http')
+          expect(span.span_type).to eq('web')
           expect(span.resource).to eq('TestController#index')
 
           expect(span.get_tag('http.url')).to eq('/') if Rails.version >= '3.2'
@@ -287,7 +287,7 @@ RSpec.describe 'Rails request' do
 
             it do
               expect(span.name).to eq('rack.request')
-              expect(span.span_type).to eq('http')
+              expect(span.span_type).to eq('web')
               expect(span.resource).to eq('TestController#index')
               expect(span.get_tag('http.url')).to eq('/')
               expect(span.get_tag('http.method')).to eq('GET')

--- a/spec/ddtrace/contrib/rest_client/request_patch_spec.rb
+++ b/spec/ddtrace/contrib/rest_client/request_patch_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Datadog::Contrib::RestClient::RequestPatch do
           end
 
           it 'is http type' do
-            expect(span.span_type).to eq('web')
+            expect(span.span_type).to eq('http')
           end
 
           it 'is named correctly' do
@@ -177,7 +177,7 @@ RSpec.describe Datadog::Contrib::RestClient::RequestPatch do
             end
 
             it 'is http type' do
-              expect(span.span_type).to eq('web')
+              expect(span.span_type).to eq('http')
             end
 
             it 'is named correctly' do

--- a/spec/ddtrace/contrib/sinatra/activerecord_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/activerecord_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'Sinatra instrumentation with ActiveRecord' do
       expect(sinatra_span.resource).to eq('POST /')
       expect(sinatra_span.get_tag(Datadog::Ext::HTTP::METHOD)).to eq('POST')
       expect(sinatra_span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/')
-      expect(sinatra_span.span_type).to eq(Datadog::Ext::HTTP::TYPE)
+      expect(sinatra_span.span_type).to eq(Datadog::Ext::HTTP::TYPE_INBOUND)
       expect(sinatra_span.status).to eq(0)
       expect(sinatra_span.parent).to be nil
     end

--- a/spec/ddtrace/contrib/sinatra/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/tracer_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Sinatra instrumentation' do
           expect(span.get_tag(Datadog::Ext::HTTP::METHOD)).to eq('GET')
           expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/')
           expect(span.get_tag('http.response.headers.content_type')).to eq('text/html;charset=utf-8')
-          expect(span.span_type).to eq(Datadog::Ext::HTTP::TYPE)
+          expect(span.span_type).to eq(Datadog::Ext::HTTP::TYPE_INBOUND)
           expect(span.status).to eq(0)
           expect(span.parent).to be nil
         end

--- a/test/contrib/grape/rack_integration_test.rb
+++ b/test/contrib/grape/rack_integration_test.rb
@@ -15,21 +15,21 @@ class TracedRackAPITest < BaseRackAPITest
     rack = spans[2]
 
     assert_equal(render.name, 'grape.endpoint_render')
-    assert_equal(render.span_type, 'http')
+    assert_equal(render.span_type, 'template')
     assert_equal(render.service, 'grape')
     assert_equal(render.resource, 'grape.endpoint_render')
     assert_equal(render.status, 0)
     assert_equal(render.parent, run)
 
     assert_equal(run.name, 'grape.endpoint_run')
-    assert_equal(run.span_type, 'http')
+    assert_equal(run.span_type, 'web')
     assert_equal(run.service, 'grape')
     assert_equal(run.resource, 'RackTestingAPI#success')
     assert_equal(run.status, 0)
     assert_equal(run.parent, rack)
 
     assert_equal(rack.name, 'rack.request')
-    assert_equal(rack.span_type, 'http')
+    assert_equal(rack.span_type, 'web')
     assert_equal(rack.service, 'rack')
     assert_equal(rack.resource, 'RackTestingAPI#success')
     assert_equal(rack.status, 0)
@@ -50,7 +50,7 @@ class TracedRackAPITest < BaseRackAPITest
     rack = spans[2]
 
     assert_equal(render.name, 'grape.endpoint_render')
-    assert_equal(render.span_type, 'http')
+    assert_equal(render.span_type, 'template')
     assert_equal(render.service, 'grape')
     assert_equal(render.resource, 'grape.endpoint_render')
     assert_equal(render.status, 1)
@@ -60,14 +60,14 @@ class TracedRackAPITest < BaseRackAPITest
     assert_equal(render.parent, run)
 
     assert_equal(run.name, 'grape.endpoint_run')
-    assert_equal(run.span_type, 'http')
+    assert_equal(run.span_type, 'web')
     assert_equal(run.service, 'grape')
     assert_equal(run.resource, 'RackTestingAPI#hard_failure')
     assert_equal(run.status, 1)
     assert_equal(run.parent, rack)
 
     assert_equal(rack.name, 'rack.request')
-    assert_equal(rack.span_type, 'http')
+    assert_equal(rack.span_type, 'web')
     assert_equal(rack.service, 'rack')
     assert_equal(rack.resource, 'RackTestingAPI#hard_failure')
     assert_equal(rack.status, 1)
@@ -83,7 +83,7 @@ class TracedRackAPITest < BaseRackAPITest
     rack = spans[0]
 
     assert_equal(rack.name, 'rack.request')
-    assert_equal(rack.span_type, 'http')
+    assert_equal(rack.span_type, 'web')
     assert_equal(rack.service, 'rack')
     assert_equal(rack.resource, 'GET 404')
     assert_equal(rack.status, 0)

--- a/test/contrib/grape/request_test.rb
+++ b/test/contrib/grape/request_test.rb
@@ -14,14 +14,14 @@ class TracedAPITest < BaseAPITest
     run = spans[1]
 
     assert_equal(render.name, 'grape.endpoint_render')
-    assert_equal(render.span_type, 'http')
+    assert_equal(render.span_type, 'template')
     assert_equal(render.service, 'grape')
     assert_equal(render.resource, 'grape.endpoint_render')
     assert_equal(render.status, 0)
     assert_equal(render.parent, run)
 
     assert_equal(run.name, 'grape.endpoint_run')
-    assert_equal(run.span_type, 'http')
+    assert_equal(run.span_type, 'web')
     assert_equal(run.service, 'grape')
     assert_equal(run.resource, 'TestingAPI#success')
     assert_equal(run.status, 0)
@@ -40,7 +40,7 @@ class TracedAPITest < BaseAPITest
     run = spans[1]
 
     assert_equal(render.name, 'grape.endpoint_render')
-    assert_equal(render.span_type, 'http')
+    assert_equal(render.span_type, 'template')
     assert_equal(render.service, 'grape')
     assert_equal(render.resource, 'grape.endpoint_render')
     assert_equal(render.status, 1)
@@ -50,7 +50,7 @@ class TracedAPITest < BaseAPITest
     assert_equal(render.parent, run)
 
     assert_equal(run.name, 'grape.endpoint_run')
-    assert_equal(run.span_type, 'http')
+    assert_equal(run.span_type, 'web')
     assert_equal(run.service, 'grape')
     assert_equal(run.resource, 'TestingAPI#hard_failure')
     assert_equal(run.status, 1)
@@ -72,7 +72,7 @@ class TracedAPITest < BaseAPITest
     render, run, before, after = spans
 
     assert_equal(before.name, 'grape.endpoint_run_filters')
-    assert_equal(before.span_type, 'http')
+    assert_equal(before.span_type, 'web')
     assert_equal(before.service, 'grape')
     assert_equal(before.resource, 'grape.endpoint_run_filters')
     assert_equal(before.status, 0)
@@ -80,14 +80,14 @@ class TracedAPITest < BaseAPITest
     assert(before.to_hash[:duration] > 0.01)
 
     assert_equal(render.name, 'grape.endpoint_render')
-    assert_equal(render.span_type, 'http')
+    assert_equal(render.span_type, 'template')
     assert_equal(render.service, 'grape')
     assert_equal(render.resource, 'grape.endpoint_render')
     assert_equal(render.status, 0)
     assert_equal(render.parent, run)
 
     assert_equal(after.name, 'grape.endpoint_run_filters')
-    assert_equal(after.span_type, 'http')
+    assert_equal(after.span_type, 'web')
     assert_equal(after.service, 'grape')
     assert_equal(after.resource, 'grape.endpoint_run_filters')
     assert_equal(after.status, 0)
@@ -95,7 +95,7 @@ class TracedAPITest < BaseAPITest
     assert(after.to_hash[:duration] > 0.01)
 
     assert_equal('grape.endpoint_run', run.name)
-    assert_equal('http', run.span_type)
+    assert_equal('web', run.span_type)
     assert_equal('grape', run.service)
     assert_equal('TestingAPI#before_after', run.resource)
     assert_equal(0, run.status)
@@ -114,7 +114,7 @@ class TracedAPITest < BaseAPITest
     run, before = spans
 
     assert_equal(before.name, 'grape.endpoint_run_filters')
-    assert_equal(before.span_type, 'http')
+    assert_equal(before.span_type, 'web')
     assert_equal(before.service, 'grape')
     assert_equal(before.resource, 'grape.endpoint_run_filters')
     assert_equal(before.status, 1)
@@ -124,7 +124,7 @@ class TracedAPITest < BaseAPITest
     assert_equal(before.parent, run)
 
     assert_equal(run.name, 'grape.endpoint_run')
-    assert_equal(run.span_type, 'http')
+    assert_equal(run.span_type, 'web')
     assert_equal(run.service, 'grape')
     assert_equal(run.resource, 'TestingAPI#before')
     assert_equal(run.status, 1)

--- a/test/contrib/rails/controller_test.rb
+++ b/test/contrib/rails/controller_test.rb
@@ -23,7 +23,7 @@ class TracingControllerTest < ActionController::TestCase
 
     span = spans[0]
     assert_equal(span.name, 'rails.action_controller')
-    assert_equal(span.span_type, 'http')
+    assert_equal(span.span_type, 'web')
     assert_equal(span.resource, 'TracingController#index')
     assert_equal(span.get_tag('rails.route.action'), 'index')
     assert_equal(span.get_tag('rails.route.controller'), 'TracingController')
@@ -258,7 +258,7 @@ class TracingControllerTest < ActionController::TestCase
 
     brother_span, parent_span, controller_span, = spans
     assert_equal('rails.action_controller', controller_span.name)
-    assert_equal('http', controller_span.span_type)
+    assert_equal('web', controller_span.span_type)
     assert_equal('TracingController#index', controller_span.resource)
     assert_equal('index', controller_span.get_tag('rails.route.action'))
     assert_equal('TracingController', controller_span.get_tag('rails.route.controller'))

--- a/test/contrib/rails/errors_test.rb
+++ b/test/contrib/rails/errors_test.rb
@@ -24,7 +24,7 @@ class TracingControllerTest < ActionController::TestCase
     span = spans[0]
     assert_equal(span.name, 'rails.action_controller')
     assert_equal(span.status, 1)
-    assert_equal(span.span_type, 'http')
+    assert_equal(span.span_type, 'web')
     assert_equal(span.resource, 'TracingController#error')
     assert_equal(span.get_tag('rails.route.action'), 'error')
     assert_equal(span.get_tag('rails.route.controller'), 'TracingController')
@@ -42,7 +42,7 @@ class TracingControllerTest < ActionController::TestCase
 
     span = spans[0]
     assert_equal(span.name, 'rails.action_controller')
-    assert_equal(span.span_type, 'http')
+    assert_equal(span.span_type, 'web')
     assert_equal(span.resource, 'TracingController#not_found')
     assert_equal(span.get_tag('rails.route.action'), 'not_found')
     assert_equal(span.get_tag('rails.route.controller'), 'TracingController')
@@ -66,7 +66,7 @@ class TracingControllerTest < ActionController::TestCase
 
     assert_equal(span_request.name, 'rails.action_controller')
     assert_equal(span_request.status, 1)
-    assert_equal(span_request.span_type, 'http')
+    assert_equal(span_request.span_type, 'web')
     assert_equal(span_request.resource, 'TracingController#missing_template')
     assert_equal(span_request.get_tag('rails.route.action'), 'missing_template')
     assert_equal(span_request.get_tag('rails.route.controller'), 'TracingController')
@@ -102,7 +102,7 @@ class TracingControllerTest < ActionController::TestCase
 
     assert_equal(span_request.name, 'rails.action_controller')
     assert_equal(span_request.status, 1)
-    assert_equal(span_request.span_type, 'http')
+    assert_equal(span_request.span_type, 'web')
     assert_equal(span_request.resource, 'TracingController#missing_partial')
     assert_equal(span_request.get_tag('rails.route.action'), 'missing_partial')
     assert_equal(span_request.get_tag('rails.route.controller'), 'TracingController')
@@ -139,7 +139,7 @@ class TracingControllerTest < ActionController::TestCase
 
     assert_equal(span_request.name, 'rails.action_controller')
     assert_equal(span_request.status, 1)
-    assert_equal(span_request.span_type, 'http')
+    assert_equal(span_request.span_type, 'web')
     assert_equal(span_request.resource, 'TracingController#error_template')
     assert_equal(span_request.get_tag('rails.route.action'), 'error_template')
     assert_equal(span_request.get_tag('rails.route.controller'), 'TracingController')
@@ -175,7 +175,7 @@ class TracingControllerTest < ActionController::TestCase
 
     assert_equal(span_request.name, 'rails.action_controller')
     assert_equal(span_request.status, 1)
-    assert_equal(span_request.span_type, 'http')
+    assert_equal(span_request.span_type, 'web')
     assert_equal(span_request.resource, 'TracingController#error_partial')
     assert_equal(span_request.get_tag('rails.route.action'), 'error_partial')
     assert_equal(span_request.get_tag('rails.route.controller'), 'TracingController')

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -44,14 +44,14 @@ class FullStackTest < ActionDispatch::IntegrationTest
     end
 
     assert_equal(request_span.name, 'rack.request')
-    assert_equal(request_span.span_type, 'http')
+    assert_equal(request_span.span_type, 'web')
     assert_equal(request_span.resource, 'TracingController#full')
     assert_equal(request_span.get_tag('http.url'), '/full')
     assert_equal(request_span.get_tag('http.method'), 'GET')
     assert_equal(request_span.get_tag('http.status_code'), '200')
 
     assert_equal(controller_span.name, 'rails.action_controller')
-    assert_equal(controller_span.span_type, 'http')
+    assert_equal(controller_span.span_type, 'web')
     assert_equal(controller_span.resource, 'TracingController#full')
     assert_equal(controller_span.get_tag('rails.route.action'), 'full')
     assert_equal(controller_span.get_tag('rails.route.controller'), 'TracingController')
@@ -105,7 +105,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     refute_nil(controller_span.get_tag('error.stack')) # error stack is in rack span
 
     assert_equal('rack.request', request_span.name)
-    assert_equal(request_span.span_type, 'http')
+    assert_equal(request_span.span_type, 'web')
     assert_equal(request_span.resource, 'TracingController#error')
     assert_equal(request_span.get_tag('http.url'), '/error')
     assert_equal(request_span.get_tag('http.method'), 'GET')
@@ -133,7 +133,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_nil(controller_span.get_tag('error.stack'))
 
     assert_equal('rack.request', request_span.name)
-    assert_equal(request_span.span_type, 'http')
+    assert_equal(request_span.span_type, 'web')
     assert_equal(request_span.resource, 'TracingController#soft_error')
     assert_equal(request_span.get_tag('http.url'), '/soft_error')
     assert_equal(request_span.get_tag('http.method'), 'GET')
@@ -159,7 +159,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     refute_nil(controller_span.get_tag('error.stack')) # error stack is in rack span
 
     assert_equal('rack.request', request_span.name)
-    assert_equal(request_span.span_type, 'http')
+    assert_equal(request_span.span_type, 'web')
     assert_equal(request_span.resource, 'TracingController#sub_error')
     assert_equal(request_span.get_tag('http.url'), '/sub_error')
     assert_equal(request_span.get_tag('http.method'), 'GET')
@@ -213,7 +213,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     request_span = spans[0]
 
     assert_equal('rack.request', request_span.name)
-    assert_equal(request_span.span_type, 'http')
+    assert_equal(request_span.span_type, 'web')
     assert_equal(request_span.resource, 'GET 404')
     assert_equal(request_span.get_tag('http.url'), '/not_existing')
     assert_equal(request_span.get_tag('http.method'), 'GET')


### PR DESCRIPTION
To make the use of `span.type` a bit more consistent, this pull request changes the span types for many integrations:

 - Spans that measure web proxies (e.g. Nginx front end server) have type `proxy`
 - Spans that measure inbound HTTP behavior have type `web`
 - Spans that measure outbound HTTP behavior have type `http`
 - Spans that measure SQL database calls have type `sql`
 - Spans that measure calls to other datastores have specific types (like `redis`, `elasticsearch`, `mongodb`, etc.)

This should yield nicer looking "Total Time Spent by Type" graphs in the service view.