### PR TITLE
Detect aws-sdk-core as well as the monolithic aws-sdk gem

### DIFF
--- a/lib/ddtrace/contrib/aws/integration.rb
+++ b/lib/ddtrace/contrib/aws/integration.rb
@@ -14,10 +14,8 @@ module Datadog
         def self.version
           if Gem.loaded_specs['aws-sdk']
             Gem.loaded_specs['aws-sdk'].version
-          elsif Gem.loaded_specs['aws-sdk-core'] 
+          elsif Gem.loaded_specs['aws-sdk-core']
             Gem.loaded_specs['aws-sdk-core'].version
-          else
-            nil
           end
         end
 

--- a/lib/ddtrace/contrib/aws/integration.rb
+++ b/lib/ddtrace/contrib/aws/integration.rb
@@ -12,7 +12,13 @@ module Datadog
         register_as :aws, auto_patch: true
 
         def self.version
-          Gem.loaded_specs['aws-sdk'] && Gem.loaded_specs['aws-sdk'].version
+          if Gem.loaded_specs['aws-sdk']
+            Gem.loaded_specs['aws-sdk'].version
+          elsif Gem.loaded_specs['aws-sdk-core'] 
+            Gem.loaded_specs['aws-sdk-core'].version
+          else
+            nil
+          end
         end
 
         def self.present?


### PR DESCRIPTION
See https://github.com/DataDog/dd-trace-rb/issues/707

This PR introduces @alksl's workaround from the issue above to detect both monolithic and modular versions of the aws-sdk* gem family. This is important as AWS themselves encourage the more modular approach going forward.

Versions between the "monolithic" and "modular" gems are kept consistent (see [aws-sdk-core](https://rubygems.org/gems/aws-sdk-core/versions/) and [aws-sdk](https://rubygems.org/gems/aws-sdk/versions/)) so there shouldn't be any problems with collision.

