### PR TITLE
Add contribution and development guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing
+
+Community contributions to the Datadog tracing library for Ruby are welcome! See below for some basic guidelines.
+
+## Want to request a new feature?
+
+Many great ideas for new features come from the community, and we'd be happy to consider yours!
+
+To share your request, you can [open a Github issue](https://github.com/DataDog/dd-trace-rb/issues/new) with the details about what you'd like to see. At a minimum, please provide:
+
+ - The goal of the new feature
+ - A description of how it might be used or behave
+ - Links to any important resources (e.g. Github repos, websites, screenshots, specifications, diagrams)
+
+Additionally, if you can, include:
+
+ - A description of how it could be accomplished
+ - Code snippets that might demonstrate its use or implementation
+ - Screenshots or mockups that visually demonstrate the feature
+ - Links to similar features that would serve as a good comparison
+ - (Any other details that would be useful for implementing this feature!)
+
+Feature requests will be reviewed, discussed, and then added to [our Community project](https://github.com/DataDog/dd-trace-rb/projects/2).
+
+## Found a bug?
+
+For any urgent matters (such as outages) or issues concerning the Datadog service or UI, contact our support team via https://docs.datadoghq.com/help/ for direct, faster assistance.
+
+You may submit bug reports concerning the Datadog tracing library for Ruby by [opening a Github issue](https://github.com/DataDog/dd-trace-rb/issues/new). At a minimum, please provide:
+
+ - A description of the problem
+ - Steps to reproduce
+ - Expected behavior
+ - Actual behavior
+ - Errors (with stack traces) or warnings received
+ - Any details you can share about your configuration including:
+    - Ruby version & platform
+    - `ddtrace` version
+    - Versions of any other relevant gems (or a `Gemfile.lock` if available)
+    - Any configuration settings for the trace library (e.g. `initializers/datadog.rb`)
+
+If at all possible, also provide:
+
+ - Logs (from the tracer/application/agent) or other diagnostics
+ - Screenshots, links, or other visual aids that are publicly accessible
+ - Code sample or test that reproduces the problem
+ - An explanation of what causes the bug and/or how it can be fixed
+
+Reports that include rich detail are better, and ones with code that reproduce the bug are best. Bug requests are triaged, reviewed, and added to [our Community project](https://github.com/DataDog/dd-trace-rb/projects/2).
+
+## Have a patch?
+
+We welcome code contributions to the library, which you can [submit as a pull request](https://github.com/DataDog/dd-trace-rb/pull/new/master). To create a pull request:
+
+1. **Fork the repository** from https://github.com/DataDog/dd-trace-rb
+2. **Make any changes** for your patch.
+3. **Write tests** that demonstrate how the feature works or how the bug is fixed.
+4. **Update any documentation** such as `docs/GettingStarted.md`, especially for new features.
+5. **Submit the pull request** from your fork back to https://github.com/DataDog/dd-trace-rb. Bugs should merge back to `master`, and new features should merge back to the latest `dev` branch (e.g. `0.24-dev`).
+
+The pull request will be run through our CI pipeline, and a project member will review the changes with you. At a minimum, to be accepted and merged, pull requests must:
+
+ - Have a stated goal and detailed description of the changes made
+ - Include thorough test coverage and documentation, where applicable
+ - Pass all tests and code quality checks (linting/coverage/benchmarks) on CI
+ - Receive at least one approval from a project member with push permissions
+
+We also recommend that you share in your description:
+
+ - Any motivations or intent for the contribution
+ - Links to any issues/pull requests it might be related to
+ - Links to any webpages or other external resources that might be related to the change
+ - Screenshots, code samples, or other visual aids that demonstrate the changes or how they are implemented
+ - Benchmarks if the feature is anticipated to have performance implications
+ - Any limitations, constraints or risks that are important to consider
+
+Pull requests will be reviewed and added to [our Community project](https://github.com/DataDog/dd-trace-rb/projects/2).
+
+For more information on common topics such as debugging locally, or how to write new integrations, check out [our development guide](https://github.com/DataDog/dd-trace-rb/docs/DevelopmentGuide.md). If at any point you have a question or need assistance with your pull request, feel free to mention a project member! We're always happy to help contributors with their pull requests.
+
+## Final word
+
+Many thanks to all of our contributors, and looking forward to seeing you on Github! :tada:
+
+ - Datadog Ruby APM Team

--- a/README.md
+++ b/README.md
@@ -13,41 +13,11 @@ For installation, configuration, and details about using the API, check out our 
 
 For descriptions of terminology used in APM, take a look at the [official documentation][visualization docs].
 
+For contributing, checkout the [contribution guidelines][contribution docs] and [development guide][development docs].
+
 [setup docs]: https://docs.datadoghq.com/tracing/setup/ruby/
 [api docs]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md
 [gem docs]: http://gems.datadoghq.com/trace/docs/
 [visualization docs]: https://docs.datadoghq.com/tracing/visualization/
-
-## Development
-
-### Testing
-
-Configure your environment through:
-
-    $ bundle install
-    $ appraisal install
-
-You can launch tests using the following Rake commands:
-
-    $ rake test:main                                      # tracer tests
-    $ appraisal rails<version>-<database> rake test:rails # tests Rails matrix
-    $ appraisal contrib rake test:redis                   # tests Redis integration
-    ...
-
-Run ``rake --tasks`` for the list of available Rake tasks.
-Run ``appraisal list`` for the list of available appraisals.
-
-The test suite requires many backing services (PostgreSQL, MySQL, Redis, ...) and we're using
-``docker`` and ``docker-compose`` to start these services in the CI.
-To launch properly the test matrix, please [install docker][2] and [docker-compose][3] using
-the instructions provided by your platform. Then launch them through:
-
-    $ docker-compose up -d
-
-We also enforce the Ruby [community-driven style guide][1] through Rubocop. Simply launch:
-
-    $ rake rubocop
-
-[1]: https://github.com/bbatsov/ruby-style-guide
-[2]: https://www.docker.com/products/docker
-[3]: https://www.docker.com/products/docker-compose
+[contribution docs]: https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md
+[development docs]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md

--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -1,0 +1,132 @@
+# Developing
+
+This guide covers some of the common how-tos and technical reference material for developing changes within the trace library.
+
+## Table of Contents
+
+ - [Setting up](#setting-up)
+ - [Testing](#testing)
+     - [Writing tests](#writing-tests)
+     - [Running tests](#running-tests)
+     - [Checking code quality](#checking-code-quality)
+ - [Appendix](#appendix)
+     - [Writing new integrations](#writing-new-integrations)
+
+## Setting up
+
+*NOTE: To test locally, you must have `Docker` and `Docker Compose` installed. See the [Docker documentation](https://docs.docker.com/compose/install/) for details.*
+
+The trace library uses Docker Compose to create a Ruby environment to develop and test within, as well as containers for any dependencies that might be necessary for certain kinds of tests.
+
+To start a development environment, choose a target Ruby version (e.g. between `1.9` and `2.4`) then run the following:
+
+```
+# In the root directory of the project...
+cd ~/dd-trace-rb
+
+# Create and start a Ruby 2.3 test environment with its dependencies
+docker-compose run --rm tracer-2.3 /bin/bash
+
+# Then inside the container (e.g. `root@2a73c6d8673e:/app`)...
+# Install the library dependencies
+bundle install
+
+# Install build targets
+appraisal install
+```
+
+Then within this container you can [run tests](#running-tests), or [run code quality checks](#checking-code-quality).
+
+## Testing
+
+The test suite uses both [Minitest](https://github.com/seattlerb/minitest) and [RSpec](https://rspec.info/) tests to verify the correctness of both the core trace library and its integrations.
+
+Minitest is deprecated in favor of RSpec; all new tests should be written in RSpec, and only existing minitests should be updated.
+
+### Writing tests
+
+New tests should be written as RSpec tests in the `spec/ddtrace` folder. Test files should generally mirror the structure of `lib`.
+
+All changes should be covered by a corresponding RSpec tests. Unit tests are preferred, and integration tests are accepted where appropriate (e.g. acceptance tests, verifying compatibility with datastores, etc) but should be kept to a minimum.
+
+**Considerations for CI**
+
+All tests should run in CI. When adding new `spec.rb` files, you may need to add a test task to ensure your test file is run in CI.
+
+ - Ensure that there is a corresponding Rake task defined in `Rakefile` under the the `spec` namespace, whose pattern matches your test file.
+ - Verify the Rake task is configured to run for the appropriate Ruby runtimes in the `ci` Rake task.
+
+### Running tests
+
+Simplest way to run tests is to run `bundle exec rake ci`, which will run the entire test suite, just as CI does.
+
+**For the core library**
+
+Run the tests for the core library with:
+
+```
+# Run Minitest
+$ bundle exec rake test:main
+# Run RSpec
+$ bundle exec rake spec:main
+```
+
+**For integrations**
+
+Integrations which interact with dependencies not listed in the `ddtrace` gemspec will need to load these dependencies to run their tests.
+
+To do so, load the dependencies using [Appraisal](https://github.com/thoughtbot/appraisal). You can see a list of available appraisals with `bundle exec appraisal list`, or examine the `Appraisals` file.
+
+Then to run tests, prefix the test commain with the appraisal. For example:
+
+```
+# Runs tests for Rails 3.2 + Postgres
+$ bundle exec appraisal rails32-postgres spec:rails
+# Runs tests for Redis
+$ bundle exec appraisal contrib rake spec:redis
+```
+
+**Passing arguments to tests**
+
+When running RSpec tests, you may pass additional args as parameters to the Rake task. For example:
+
+```
+# Runs Redis tests with seed 1234
+$ bundle exec appraisal contrib rake spec:redis'[--seed,1234]'
+```
+
+This can be useful for replicating conditions from CI or isolating certain tests.
+
+### Checking code quality
+
+**Linting**
+
+The trace library uses Rubocop to enforce [code style](https://github.com/bbatsov/ruby-style-guide) and quality. To check, run:
+
+```
+$ bundle exec rake rubocop
+```
+
+## Appendix
+
+### Writing new integrations
+
+Integrations are extensions to the trace library that add support for external dependencies (gems); they typically add auto-instrumentation to popular gems and frameworks. You will find many of our integrations in the `contrib` folder.
+
+Some general guidelines for adding new integrations:
+
+ - An integration can either be added directly to `dd-trace-rb`, or developed as its own gem that depends on `ddtrace`.
+ - Integrations should implement the configuration API for easy, consistent implementation. (See existing integrations as examples of this.)
+ - All new integrations require documentation, unit/integration tests written in RSpec, and passing CI builds.
+ - It's highly encouraged to share screenshots or other demos of how the new integration looks and works.
+
+To get started quickly, it's perfectly fine to copy-paste an existing integration to use as a template, then modify it to match your needs. This is usually the fastest, easiest way to bootstrap a new integration and makes the time-to-first-trace often very quick, usually less than an hour if it's a simple implementation.
+
+Once you have it working in your application, you can [add unit tests](#writing-tests), [run them locally](#running-tests), and [check for code quality](#checking-code-quality) using Docker Compose.
+
+Then [open a pull request](https://github.com/DataDog/dd-trace-rb/CONTRIBUTING.md#have-a-patch) and be sure to add the following to the description:
+
+ - [Documentation](https://github.com/DataDog/dd-trace-rb/docs/GettingStarted.md) for the integration, including versions supported.
+ - Links to the repository/website of the library being integrated
+ - Screenshots showing a sample trace
+ - Any additional code snippets, sample apps, benchmarks, or other resources that demonstrate its implementation are a huge plus!

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -11,9 +11,13 @@ For details about contributing, check out the [development guide][development do
 
 For descriptions of terminology used in APM, take a look at the [official documentation][visualization docs].
 
+For contributing, checkout the [contribution guidelines][contribution docs] and [development guide][development docs].
+
 [setup docs]: https://docs.datadoghq.com/tracing/setup/ruby/
 [development docs]: https://github.com/DataDog/dd-trace-rb/blob/master/README.md#development
 [visualization docs]: https://docs.datadoghq.com/tracing/visualization/
+[contribution docs]: https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md
+[development docs]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
 
 ## Table of Contents
 


### PR DESCRIPTION
We'd like to make it easier for our contributors to make contributions, by giving them some guidelines and resources that add clarity to the process.

This pull request adds two documents:

1. `CONTRIBUTING.md` which describes the process and criteria for submitting contributions.
2. `DevelopmentGuide.md` which describes how-to topics such as writing/running tests, adding new integrations etc...