### PR TITLE
Fix integration tracers initializing too early

### DIFF
--- a/lib/ddtrace/contrib/configuration/settings.rb
+++ b/lib/ddtrace/contrib/configuration/settings.rb
@@ -10,7 +10,9 @@ module Datadog
         include Datadog::Configuration::Options
 
         option :service_name
-        option :tracer, default: Datadog.tracer
+        option :tracer,
+               default: -> { Datadog.tracer },
+               lazy: true
         option :analytics_enabled, default: false
         option :analytics_sample_rate, default: 1.0
 


### PR DESCRIPTION
When configuring Datadog with OpenTracing, typically the `Datadog.tracer` gets swapped for the OpenTracing instance of `Datadog::Tracer`.

Given the original code for defining a `tracer` option for integrations, it was initializing its own reference to `Datadog::Tracer` at load time, instead of at run time. This means when OpenTracing was configured, the integrations were using the old instance created at load time, and a 2nd tracer was being used just for OpenTracing. This could manifest some strange behavior, and cause the Datadog tracer to appear misconfigured.

The interim solution is to lazy initialize `tracer` for integrations. It's only a short term fix though, given if you reassign the Datadog global tracer after configuring the integrations, you'll end up with the same issue. Thus with this change its recommended that integrations are only configured after the global tracer has been. e.g.

```
require 'ddtrace'
require 'ddtrace/opentracer'

# Activate and configure open tracing
OpenTracing.global_tracer = Datadog::OpenTracer::Tracer.new
Datadog.tracer.default_service = 'service_name'

# Then configure integration settings
Datadog.configure do |c|
  c.tracer env: "dev"
  c.use :rails
end
```