### PR TITLE
Add hostname reporting

### DIFF
--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -18,6 +18,10 @@ module Datadog
               default: -> { env_to_bool(Ext::Analytics::ENV_TRACE_ANALYTICS_ENABLED, nil) },
               lazy: true
 
+      option  :report_hostname,
+              default: -> { env_to_bool(Ext::NET::ENV_REPORT_HOSTNAME, false) },
+              lazy: true
+
       option  :runtime_metrics_enabled,
               default: -> { env_to_bool(Ext::Runtime::Metrics::ENV_ENABLED, false) },
               lazy: true

--- a/lib/ddtrace/ext/net.rb
+++ b/lib/ddtrace/ext/net.rb
@@ -1,6 +1,8 @@
 module Datadog
   module Ext
     module NET
+      ENV_REPORT_HOSTNAME = 'DD_TRACE_REPORT_HOSTNAME'.freeze
+      TAG_HOSTNAME = '_dd.hostname'.freeze
       TARGET_HOST = 'out.host'.freeze
       TARGET_PORT = 'out.port'.freeze
     end

--- a/lib/ddtrace/runtime/socket.rb
+++ b/lib/ddtrace/runtime/socket.rb
@@ -1,0 +1,14 @@
+require 'socket'
+
+module Datadog
+  module Runtime
+    # For runtime identity
+    module Socket
+      module_function
+
+      def hostname
+        ::Socket.gethostname
+      end
+    end
+  end
+end

--- a/spec/ddtrace/runtime/socket_spec.rb
+++ b/spec/ddtrace/runtime/socket_spec.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+
+require 'spec_helper'
+require 'ddtrace/runtime/socket'
+
+RSpec.describe Datadog::Runtime::Socket do
+  describe '::hostname' do
+    subject(:hostname) { described_class.hostname }
+    it { is_expected.to be_a_kind_of(String) }
+  end
+end


### PR DESCRIPTION
This pull request adds functionality for reporting the hostname as a tag on the root span of each trace.

It can be enabled by setting `DD_TRACE_REPORT_HOSTNAME=true` or `Datadog.configuration.report_hostname = true`. It is disabled by default.