### PR TITLE
Update CI to use Bundler 1.17.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,11 @@ ruby_containers: &ruby_containers
     environment:
       - BUNDLE_GEMFILE=/app/Gemfile
   - &container-2_3
-    image: datadog/docker-library:ddtrace_rb_2_3_7
+    image: datadog/docker-library:ddtrace_rb_2_3_8
     environment:
       - BUNDLE_GEMFILE=/app/Gemfile
   - &container-2_4
-    image: datadog/docker-library:ddtrace_rb_2_4_4
+    image: datadog/docker-library:ddtrace_rb_2_4_6
     environment:
       - BUNDLE_GEMFILE=/app/Gemfile
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,27 +5,27 @@ job_defaults: &job_defaults
 
 ruby_containers: &ruby_containers
   - &container-1_9
-    image: datadog/docker-library:ddtrace_rb_1_9_3
+    image: palazzem/docker-library:ddtrace_rb_1_9_3
     environment:
       - BUNDLE_GEMFILE=/app/Gemfile
   - &container-2_0
-    image: datadog/docker-library:ddtrace_rb_2_0_0
+    image: palazzem/docker-library:ddtrace_rb_2_0_0
     environment:
       - BUNDLE_GEMFILE=/app/Gemfile
   - &container-2_1
-    image: datadog/docker-library:ddtrace_rb_2_1_10
+    image: palazzem/docker-library:ddtrace_rb_2_1_10
     environment:
       - BUNDLE_GEMFILE=/app/Gemfile
   - &container-2_2
-    image: datadog/docker-library:ddtrace_rb_2_2_10
+    image: palazzem/docker-library:ddtrace_rb_2_2_10
     environment:
       - BUNDLE_GEMFILE=/app/Gemfile
   - &container-2_3
-    image: datadog/docker-library:ddtrace_rb_2_3_8
+    image: palazzem/docker-library:ddtrace_rb_2_3_8
     environment:
       - BUNDLE_GEMFILE=/app/Gemfile
   - &container-2_4
-    image: datadog/docker-library:ddtrace_rb_2_4_6
+    image: palazzem/docker-library:ddtrace_rb_2_4_6
     environment:
       - BUNDLE_GEMFILE=/app/Gemfile
 

--- a/.circleci/images/primary/Dockerfile-1.9.3
+++ b/.circleci/images/primary/Dockerfile-1.9.3
@@ -1,6 +1,10 @@
 # Last version: https://github.com/docker-library/ruby/blob/90c4e3be58d565007c518d311d4bd05086a1638c/1.9/Dockerfile
 FROM ruby:1.9.3
 
+# Add Jessie repos
+# Fixes https://superuser.com/questions/1423486/issue-with-fetching-http-deb-debian-org-debian-dists-jessie-updates-inrelease
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
   && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
@@ -59,8 +63,8 @@ RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cac
   && dockerize --version
 
 # Install RubyGems
-RUN gem update --system
-RUN gem install bundler
+RUN gem update --system 2.7.9
+RUN gem install bundler -v '1.17.3'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/.circleci/images/primary/Dockerfile-2.0.0
+++ b/.circleci/images/primary/Dockerfile-2.0.0
@@ -1,6 +1,10 @@
 # Last version: https://github.com/docker-library/ruby/blob/c387c6c3a2505060514e31c247cb37d22c944e55/2.0/Dockerfile
 FROM ruby:2.0.0
 
+# Add Jessie repos
+# Fixes https://superuser.com/questions/1423486/issue-with-fetching-http-deb-debian-org-debian-dists-jessie-updates-inrelease
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
   && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
@@ -59,8 +63,8 @@ RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cac
   && dockerize --version
 
 # Install RubyGems
-RUN gem update --system
-RUN gem install bundler
+RUN gem update --system 2.7.9
+RUN gem install bundler -v '1.17.3'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/.circleci/images/primary/Dockerfile-2.1.10
+++ b/.circleci/images/primary/Dockerfile-2.1.10
@@ -1,6 +1,10 @@
 # Last version: https://github.com/docker-library/ruby/blob/99def14400fcd612782367830836dfcbc10c8c50/2.1/Dockerfile
 FROM ruby:2.1.10
 
+# Add Jessie repos
+# Fixes https://superuser.com/questions/1423486/issue-with-fetching-http-deb-debian-org-debian-dists-jessie-updates-inrelease
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
   && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
@@ -59,8 +63,8 @@ RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cac
   && dockerize --version
 
 # Install RubyGems
-RUN gem update --system
-RUN gem install bundler
+RUN gem update --system 2.7.9
+RUN gem install bundler -v '1.17.3'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/.circleci/images/primary/Dockerfile-2.2.10
+++ b/.circleci/images/primary/Dockerfile-2.2.10
@@ -1,6 +1,10 @@
 # Last version: https://github.com/docker-library/ruby/blob/395cce4eba52917eb9a40c72d50703a1ce9e1acd/2.2/jessie/Dockerfile
 FROM ruby:2.2.10
 
+# Add Jessie repos
+# Fixes https://superuser.com/questions/1423486/issue-with-fetching-http-deb-debian-org-debian-dists-jessie-updates-inrelease
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
   && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
@@ -59,8 +63,8 @@ RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cac
   && dockerize --version
 
 # Install RubyGems
-RUN gem update --system
-RUN gem install bundler
+RUN gem update --system 2.7.9
+RUN gem install bundler -v '1.17.3'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/.circleci/images/primary/Dockerfile-2.3.8
+++ b/.circleci/images/primary/Dockerfile-2.3.8
@@ -64,7 +64,9 @@ RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Install RubyGems
 RUN gem update --system
-RUN gem install bundler
+# Ruby 2.3 can support Bundler 2+
+# But hold back to < 2 for now, because some dependencies require it.
+RUN gem install bundler -v '1.17.3'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/.circleci/images/primary/Dockerfile-2.3.8
+++ b/.circleci/images/primary/Dockerfile-2.3.8
@@ -1,5 +1,5 @@
-# Current version: https://github.com/docker-library/ruby/blob/699a04311386ecc98ca242fc9bdee17fb4008863/2.4/stretch/Dockerfile
-FROM ruby:2.4.4
+# Current version: https://github.com/docker-library/ruby/blob/31f66490fdb837ddcc5896e3275f2188f2b7b6dd/2.3/stretch/Dockerfile
+FROM ruby:2.3.8
 
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \

--- a/.circleci/images/primary/Dockerfile-2.4.6
+++ b/.circleci/images/primary/Dockerfile-2.4.6
@@ -1,5 +1,5 @@
-# Current version: https://github.com/docker-library/ruby/blob/699a04311386ecc98ca242fc9bdee17fb4008863/2.3/stretch/Dockerfile
-FROM ruby:2.3.7
+# Current version: https://github.com/docker-library/ruby/blob/802421922ef50cfa05c89a3c619992acf4329986/2.4/jessie/Dockerfile
+FROM ruby:2.4.6
 
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
       - bundle-2.2:/usr/local/bundle
       - gemfiles-2.2:/app/gemfiles
   tracer-2.3:
-    image: datadog/docker-library:ddtrace_rb_2_3_7
+    image: datadog/docker-library:ddtrace_rb_2_3_8
     command: /bin/bash
     depends_on:
       - ddagent
@@ -141,7 +141,7 @@ services:
       - bundle-2.3:/usr/local/bundle
       - gemfiles-2.3:/app/gemfiles
   tracer-2.4:
-    image: datadog/docker-library:ddtrace_rb_2_4_4
+    image: datadog/docker-library:ddtrace_rb_2_4_6
     command: /bin/bash
     depends_on:
       - ddagent

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.2'
 services:
   tracer-1.9:
-    image: datadog/docker-library:ddtrace_rb_1_9_3
+    image: palazzem/docker-library:ddtrace_rb_1_9_3
     command: /bin/bash
     depends_on:
       - ddagent
@@ -29,7 +29,7 @@ services:
       - bundle-1.9:/usr/local/bundle
       - gemfiles-1.9:/app/gemfiles
   tracer-2.0:
-    image: datadog/docker-library:ddtrace_rb_2_0_0
+    image: palazzem/docker-library:ddtrace_rb_2_0_0
     command: /bin/bash
     depends_on:
       - ddagent
@@ -57,7 +57,7 @@ services:
       - bundle-2.0:/usr/local/bundle
       - gemfiles-2.0:/app/gemfiles
   tracer-2.1:
-    image: datadog/docker-library:ddtrace_rb_2_1_10
+    image: palazzem/docker-library:ddtrace_rb_2_1_10
     command: /bin/bash
     depends_on:
       - ddagent
@@ -85,7 +85,7 @@ services:
       - bundle-2.1:/usr/local/bundle
       - gemfiles-2.1:/app/gemfiles
   tracer-2.2:
-    image: datadog/docker-library:ddtrace_rb_2_2_10
+    image: palazzem/docker-library:ddtrace_rb_2_2_10
     command: /bin/bash
     depends_on:
       - ddagent
@@ -113,7 +113,7 @@ services:
       - bundle-2.2:/usr/local/bundle
       - gemfiles-2.2:/app/gemfiles
   tracer-2.3:
-    image: datadog/docker-library:ddtrace_rb_2_3_8
+    image: palazzem/docker-library:ddtrace_rb_2_3_8
     command: /bin/bash
     depends_on:
       - ddagent
@@ -141,7 +141,7 @@ services:
       - bundle-2.3:/usr/local/bundle
       - gemfiles-2.3:/app/gemfiles
   tracer-2.4:
-    image: datadog/docker-library:ddtrace_rb_2_4_6
+    image: palazzem/docker-library:ddtrace_rb_2_4_6
     command: /bin/bash
     depends_on:
       - ddagent


### PR DESCRIPTION
Bundler is incorrectly resolving the correct versions of gems to be compatible with the version of Ruby it is trying to install them for. This results in failed builds, claiming a gem version requires a particular version of Ruby, even though an older version of the same gem would support the current version of Ruby.

This became an issue with https://github.com/DataDog/dd-trace-rb/pull/762 when it started resolving gem dependencies incorrectly.

For this PR to work, we will need to update the Docker images on Docker Hub accordingly. (Blocked on that change.)