### PR TITLE
[core] Rename Ext::ForcedTracing to Ext::ManualTracing

### DIFF
--- a/lib/ddtrace/ext/forced_tracing.rb
+++ b/lib/ddtrace/ext/forced_tracing.rb
@@ -1,14 +1,25 @@
 require 'ddtrace/ext/manual_tracing'
-require 'ddtrace/patcher'
+require 'ddtrace/tracer'
 
 module Datadog
   module Ext
     # Defines constants for forced tracing
     module ForcedTracing
-      TAG_KEEP = 'manual.keep'.freeze
-      TAG_DROP = 'manual.drop'.freeze
+      @deprecation_warning_shown = false
 
-      deprecate_constant :TAG_KEEP, :TAG_DROP
+      def self.const_missing(name)
+        super unless Ext::ManualTracing.const_defined?(name)
+
+        # Only log each deprecation warning once (safeguard against log spam)
+        unless @deprecation_warning_shown
+          Datadog::Tracer.log.warn(
+            'forced tracing: Datadog::Ext::ForcedTracing has been renamed to Datadog::Ext::ManualTracing'
+          )
+          @deprecation_warning_shown = true
+        end
+
+        Ext::ManualTracing.const_get(name)
+      end
     end
   end
 end

--- a/lib/ddtrace/ext/forced_tracing.rb
+++ b/lib/ddtrace/ext/forced_tracing.rb
@@ -1,9 +1,14 @@
+require 'ddtrace/ext/manual_tracing'
+require 'ddtrace/patcher'
+
 module Datadog
   module Ext
     # Defines constants for forced tracing
     module ForcedTracing
-      TAG_KEEP = 'manual.drop'.freeze
-      TAG_DROP = 'manual.keep'.freeze
+      TAG_KEEP = 'manual.keep'.freeze
+      TAG_DROP = 'manual.drop'.freeze
+
+      deprecate_constant :TAG_KEEP, :TAG_DROP
     end
   end
 end

--- a/lib/ddtrace/ext/manual_tracing.rb
+++ b/lib/ddtrace/ext/manual_tracing.rb
@@ -1,0 +1,9 @@
+module Datadog
+  module Ext
+    # Defines constants for manual tracing
+    module ManualTracing
+      TAG_KEEP = 'manual.keep'.freeze
+      TAG_DROP = 'manual.drop'.freeze
+    end
+  end
+end

--- a/lib/ddtrace/forced_tracing.rb
+++ b/lib/ddtrace/forced_tracing.rb
@@ -1,4 +1,4 @@
-require 'ddtrace/ext/forced_tracing'
+require 'ddtrace/ext/manual_tracing'
 require 'ddtrace/ext/priority'
 
 module Datadog
@@ -49,9 +49,9 @@ module Datadog
           # Configure sampling priority if they give us a forced tracing tag
           # DEV: Do not set if the value they give us is explicitly "false"
           case key
-          when Ext::ForcedTracing::TAG_KEEP
+          when Ext::ManualTracing::TAG_KEEP
             ForcedTracing.keep(self) unless value == false
-          when Ext::ForcedTracing::TAG_DROP
+          when Ext::ManualTracing::TAG_DROP
             ForcedTracing.drop(self) unless value == false
           else
             # Otherwise, set the tag normally.

--- a/spec/ddtrace/span_spec.rb
+++ b/spec/ddtrace/span_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'ddtrace/ext/forced_tracing'
 require 'ddtrace/span'
 
 RSpec.describe Datadog::Span do
@@ -31,88 +32,63 @@ RSpec.describe Datadog::Span do
       end
     end
 
-    context 'given Datadog::Ext::ForcedTracing::TAG_KEEP' do
-      let(:key) { Datadog::Ext::ForcedTracing::TAG_KEEP }
+    shared_examples 'setting sampling priority tag' do |key, expected_value|
+      context "given #{key}" do
+        let(:key) { key }
 
-      context 'with nil value' do
-        # This could be `nil`, or any other value, as long as it isn't "false"
-        let(:value) { nil }
+        context 'with nil value' do
+          # This could be `nil`, or any other value, as long as it isn't "false"
+          let(:value) { nil }
 
-        it 'sets the correct sampling priority' do
-          expect(context.sampling_priority).to eq(Datadog::Ext::Priority::USER_KEEP)
+          it 'sets the correct sampling priority' do
+            expect(context.sampling_priority).to eq(expected_value)
+          end
+
+          it 'does not set a tag' do
+            expect(span.get_tag(key)).to be nil
+          end
         end
 
-        it 'does not set a tag' do
-          expect(span.get_tag(Datadog::Ext::ForcedTracing::TAG_KEEP)).to be nil
-        end
-      end
+        context 'with true value' do
+          # We only check for `== false`, but test with `true` to be sure it works
+          let(:value) { true }
 
-      context 'with true value' do
-        # We only check for `== false`, but test with `true` to be sure it works
-        let(:value) { true }
+          it 'sets the correct sampling priority' do
+            expect(context.sampling_priority).to eq(expected_value)
+          end
 
-        it 'sets the correct sampling priority' do
-          expect(context.sampling_priority).to eq(Datadog::Ext::Priority::USER_KEEP)
-        end
-
-        it 'does not set a tag' do
-          expect(span.get_tag(Datadog::Ext::ForcedTracing::TAG_KEEP)).to be nil
-        end
-      end
-
-      context 'with false value' do
-        let(:value) { false }
-
-        it 'does not set the sampling priority' do
-          expect(context.sampling_priority).to_not eq(Datadog::Ext::Priority::USER_KEEP)
+          it 'does not set a tag' do
+            expect(span.get_tag(key)).to be nil
+          end
         end
 
-        it 'does not set a tag' do
-          expect(span.get_tag(Datadog::Ext::ForcedTracing::TAG_KEEP)).to be nil
-        end
-      end
-    end
+        context 'with false value' do
+          let(:value) { false }
 
-    context 'given Datadog::Ext::ForcedTracing::TAG_DROP' do
-      let(:key) { Datadog::Ext::ForcedTracing::TAG_DROP }
+          it 'does not set the sampling priority' do
+            expect(context.sampling_priority).to_not eq(expected_value)
+          end
 
-      context 'with nil value' do
-        # This could be `nil`, or any other value, as long as it isn't "false"
-        let(:value) { nil }
-
-        it 'sets the correct sampling priority' do
-          expect(context.sampling_priority).to eq(Datadog::Ext::Priority::USER_REJECT)
-        end
-
-        it 'does not set a tag' do
-          expect(span.get_tag(Datadog::Ext::ForcedTracing::TAG_DROP)).to be nil
-        end
-      end
-
-      context 'with true value' do
-        # We only check for `== false`, but test with `true` to be sure it works
-        let(:value) { true }
-
-        it 'sets the correct sampling priority' do
-          expect(context.sampling_priority).to eq(Datadog::Ext::Priority::USER_REJECT)
-        end
-
-        it 'does not set a tag' do
-          expect(span.get_tag(Datadog::Ext::ForcedTracing::TAG_DROP)).to be nil
-        end
-      end
-
-      context 'with false value' do
-        let(:value) { false }
-
-        it 'does not set the sampling priority' do
-          expect(context.sampling_priority).to_not eq(Datadog::Ext::Priority::USER_REJECT)
-        end
-
-        it 'does not set a tag' do
-          expect(span.get_tag(Datadog::Ext::ForcedTracing::TAG_DROP)).to be nil
+          it 'does not set a tag' do
+            expect(span.get_tag(key)).to be nil
+          end
         end
       end
     end
+
+    # TODO: Remove when ForcedTracing is fully deprecated
+    it_behaves_like('setting sampling priority tag',
+                    Datadog::Ext::ForcedTracing::TAG_KEEP,
+                    Datadog::Ext::Priority::USER_KEEP)
+    it_behaves_like('setting sampling priority tag',
+                    Datadog::Ext::ForcedTracing::TAG_DROP,
+                    Datadog::Ext::Priority::USER_REJECT)
+
+    it_behaves_like('setting sampling priority tag',
+                    Datadog::Ext::ManualTracing::TAG_KEEP,
+                    Datadog::Ext::Priority::USER_KEEP)
+    it_behaves_like('setting sampling priority tag',
+                    Datadog::Ext::ManualTracing::TAG_DROP,
+                    Datadog::Ext::Priority::USER_REJECT)
   end
 end


### PR DESCRIPTION
This PR renames `Datadog::Ext::ForcedTracing` to `Datadog::Ext::ManualTracing`.

As well, we noticed that we had `TAG_KEEP = 'manual.drop'` and `TAG_DROP = 'manual.keep'`, so that is fixed as well.