### PR TITLE
Add example of where current span comes from

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1402,6 +1402,9 @@ When not using [distributed tracing](#distributed-tracing), you may change the p
 If you change the priority, we recommend you do it as soon as possible, when the root span has just been created.
 
 ```ruby
+# First, grab the active span
+span = Datadog.tracer.active_span
+
 # Indicate to reject the trace
 span.context.sampling_priority = Datadog::Ext::Priority::USER_REJECT
 


### PR DESCRIPTION
Had a user reach out in the community channel, confused about where the span comes from in the example code. 

Hopefully this clarifies that you'd grab it from the current context. 