### PR TITLE
Add Unix socket transport adapter

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1754,6 +1754,21 @@ Datadog.configure do |c|
 end
 ```
 
+#### Using the Unix socket adapter
+
+The `UnixSocket` adapter submits traces using `Net::HTTP` over Unix socket.
+
+To use, first configure your trace agent to listen by Unix socket, then configure the tracer with:
+
+```ruby
+Datadog.configure do |c|
+  c.tracer transport_options: proc { |t|
+    # Provide filepath to trace agent Unix socket
+    t.adapter :unix, '/tmp/ddagent/trace.sock'
+  }
+end
+```
+
 #### Using the transport test adapter
 
 The `Test` adapter is a no-op transport that can optionally buffer requests. For use in test suites or other non-production environments.

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -4,8 +4,9 @@ require 'ddtrace/ext/runtime'
 require 'ddtrace/transport/http/builder'
 require 'ddtrace/transport/http/api'
 
-require 'ddtrace/transport/http/adapters/test'
 require 'ddtrace/transport/http/adapters/net'
+require 'ddtrace/transport/http/adapters/test'
+require 'ddtrace/transport/http/adapters/unix_socket'
 
 module Datadog
   module Transport
@@ -76,8 +77,9 @@ module Datadog
       end
 
       # Add adapters to registry
-      Builder::REGISTRY.set(Adapters::Test, :test)
       Builder::REGISTRY.set(Adapters::Net, :net_http)
+      Builder::REGISTRY.set(Adapters::Test, :test)
+      Builder::REGISTRY.set(Adapters::UnixSocket, :unix)
     end
   end
 end

--- a/lib/ddtrace/transport/http/adapters/unix_socket.rb
+++ b/lib/ddtrace/transport/http/adapters/unix_socket.rb
@@ -1,0 +1,64 @@
+require 'net/http'
+require 'ddtrace/transport/http/adapters/net'
+
+module Datadog
+  module Transport
+    module HTTP
+      module Adapters
+        # Adapter for Unix sockets
+        class UnixSocket < Adapters::Net
+          DEFAULT_TIMEOUT = 1
+
+          attr_reader \
+            :filepath,
+            :timeout
+
+          def initialize(filepath, options = {})
+            @filepath = filepath
+            @timeout = options.fetch(:timeout, DEFAULT_TIMEOUT)
+          end
+
+          def open
+            # Open connection
+            connection = HTTP.new(
+              filepath,
+              read_timeout: timeout,
+              continue_timeout: timeout
+            )
+
+            connection.start do |http|
+              yield(http)
+            end
+          end
+
+          # Re-implements Net:HTTP with underlying Unix socket
+          class HTTP < ::Net::HTTP
+            DEFAULT_TIMEOUT = 1
+
+            attr_reader \
+              :filepath,
+              :unix_socket
+
+            def initialize(filepath, options = {})
+              super('localhost', 80)
+              @filepath = filepath
+              @read_timeout = options.fetch(:read_timeout, DEFAULT_TIMEOUT)
+              @continue_timeout = options.fetch(:continue_timeout, DEFAULT_TIMEOUT)
+              @debug_output = options[:debug_output] if options.key?(:debug_output)
+            end
+
+            def connect
+              @unix_socket = UNIXSocket.open(filepath)
+              @socket = ::Net::BufferedIO.new(@unix_socket).tap do |socket|
+                socket.read_timeout = @read_timeout
+                socket.continue_timeout = @continue_timeout
+                socket.debug_output = @debug_output
+              end
+              on_connect
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/transport/http/adapters/unix_socket_integration_spec.rb
+++ b/spec/ddtrace/transport/http/adapters/unix_socket_integration_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+require 'stringio'
+require 'thread'
+require 'webrick'
+
+require 'ddtrace/transport/http'
+require 'ddtrace/transport/http/adapters/unix_socket'
+
+RSpec.describe 'Adapters::UnixSocket integration tests' do
+  before { skip unless ENV['TEST_DATADOG_INTEGRATION'] }
+
+  subject(:adapter) { Datadog::Transport::HTTP::Adapters::UnixSocket.new(filepath, options) }
+
+  let(:filepath) { '/tmp/ddtrace_unix_test.sock' }
+  let(:options) { { timeout: timeout } }
+  let(:timeout) { 2 }
+
+  shared_context 'Unix socket server' do
+    # Server
+    let(:server) { UNIXServer.new(filepath) }
+    let(:messages) { [] }
+
+    # HTTP
+    let(:http) { WEBrick::HTTPServer.new(Logger: log, AccessLog: access_log) }
+    let(:log) { WEBrick::Log.new(log_buffer) }
+    let(:log_buffer) { StringIO.new }
+    let(:access_log) { [[log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]] }
+    let(:server_proc) do
+      proc do |req, res|
+        messages << req
+        res.body = '{}'
+      end
+    end
+
+    def cleanup_socket
+      File.delete(filepath) if File.exist?(filepath)
+    end
+
+    before do
+      cleanup_socket
+      server
+      http.mount_proc('/', &server_proc)
+
+      @http_server_thread = Thread.start do
+        http.start
+      end
+
+      @unix_server_thread = Thread.start do
+        begin
+          sock = server.accept
+          http.run(sock)
+        rescue => e
+          puts "UNIX server error!: #{e}"
+        end
+      end
+    end
+
+    after do
+      http.shutdown
+      cleanup_socket
+    end
+  end
+
+  describe 'when sending traces through Unix socket client' do
+    include_context 'Unix socket server'
+
+    let(:client) do
+      Datadog::Transport::HTTP.default do |t|
+        t.adapter adapter
+      end
+    end
+
+    let(:traces) { get_test_traces(2) }
+
+    it 'sends traces successfully' do
+      client.send_traces(traces)
+
+      expect(messages).to have(1).items
+      messages.first.tap do |http_request|
+        expect(http_request.header).to include(
+          'datadog-meta-lang' => [Datadog::Ext::Runtime::LANG],
+          'datadog-meta-lang-version' => [Datadog::Ext::Runtime::LANG_VERSION],
+          'datadog-meta-lang-interpreter' => [Datadog::Ext::Runtime::LANG_INTERPRETER],
+          'datadog-meta-tracer-version' => [Datadog::Ext::Runtime::TRACER_VERSION],
+          'content-type' => ['application/msgpack'],
+          'x-datadog-trace-count' => [traces.length.to_s]
+        )
+
+        expect(http_request.header['content-length'].first.to_i).to be > 0
+      end
+    end
+  end
+end

--- a/spec/ddtrace/transport/http/adapters/unix_socket_spec.rb
+++ b/spec/ddtrace/transport/http/adapters/unix_socket_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper'
+
+require 'ddtrace/transport/http/adapters/unix_socket'
+
+RSpec.describe Datadog::Transport::HTTP::Adapters::UnixSocket do
+  subject(:adapter) { described_class.new(filepath, options) }
+
+  let(:filepath) { double('filepath') }
+  let(:timeout) { double('timeout') }
+  let(:options) { { timeout: timeout } }
+
+  shared_context 'HTTP connection stub' do
+    let(:http_connection) { instance_double(described_class::HTTP) }
+
+    before do
+      allow(described_class::HTTP).to receive(:new)
+        .with(
+          adapter.filepath,
+          read_timeout: timeout,
+          continue_timeout: timeout
+        )
+        .and_return(http_connection)
+
+      allow(http_connection).to receive(:start) do |&block|
+        block.call(http_connection)
+      end
+    end
+  end
+
+  describe '#initialize' do
+    context 'given no options' do
+      let(:options) { {} }
+
+      it do
+        is_expected.to have_attributes(
+          filepath: filepath,
+          timeout: described_class::DEFAULT_TIMEOUT
+        )
+      end
+    end
+
+    context 'given a timeout option' do
+      let(:options) { { timeout: timeout } }
+      let(:timeout) { double('timeout') }
+      it { is_expected.to have_attributes(timeout: timeout) }
+    end
+  end
+
+  describe '#open' do
+    include_context 'HTTP connection stub'
+
+    it 'opens and yields a Net::HTTP connection' do
+      expect { |b| adapter.open(&b) }.to yield_with_args(http_connection)
+    end
+  end
+end
+
+RSpec.describe Datadog::Transport::HTTP::Adapters::UnixSocket::HTTP do
+  subject(:unix_http) { described_class.new(filepath, options) }
+  let(:filepath) { double('filepath') }
+  let(:options) { {} }
+
+  describe '#initialize' do
+    context 'given no options' do
+      let(:options) { {} }
+
+      it do
+        is_expected.to have_attributes(
+          filepath: filepath,
+          read_timeout: described_class::DEFAULT_TIMEOUT,
+          continue_timeout: described_class::DEFAULT_TIMEOUT
+        )
+      end
+    end
+
+    context 'given a read timeout option' do
+      let(:options) { { read_timeout: read_timeout } }
+      let(:read_timeout) { double('read_timeout') }
+      it { is_expected.to have_attributes(read_timeout: read_timeout) }
+    end
+
+    context 'given a continue timeout option' do
+      let(:options) { { continue_timeout: continue_timeout } }
+      let(:continue_timeout) { double('continue_timeout') }
+      it { is_expected.to have_attributes(continue_timeout: continue_timeout) }
+    end
+  end
+
+  describe '#connect' do
+    subject(:connect) { unix_http.connect }
+    let(:unix_socket) { instance_double(::UNIXSocket) }
+    let(:net_io) { instance_double(::Net::BufferedIO) }
+
+    before do
+      allow(::UNIXSocket).to receive(:open)
+        .with(filepath)
+        .and_return(unix_socket)
+
+      allow(::Net::BufferedIO).to receive(:new)
+        .with(unix_socket)
+        .and_return(net_io)
+
+      allow(net_io).to receive(:read_timeout=)
+      allow(net_io).to receive(:continue_timeout=)
+      allow(net_io).to receive(:debug_output=)
+    end
+
+    it 'opens a Unix socket' do
+      expect { connect }.to change { unix_http.unix_socket }.from(nil).to(unix_socket)
+      expect(net_io).to have_received(:read_timeout=).with(unix_http.read_timeout)
+      expect(net_io).to have_received(:continue_timeout=).with(unix_http.continue_timeout)
+    end
+  end
+end


### PR DESCRIPTION
As an extension to the new HTTP transport introduced in https://github.com/DataDog/dd-trace-rb/pull/628, this pull request adds Unix socket adapter support for the transport layer that sends trace data from the library to the agent.

```ruby
Datadog.configure do |c|
  c.tracer transport_options: proc { |t|
    # Provide filepath to trace agent Unix socket
    t.adapter :unix, '/tmp/ddagent/trace.sock'
  }
end
```

As it is dependent on changes from #628, we should wait for that to be merged to `0.25-dev` before merging this pull request.