### PR TITLE
Deprecate support for Ruby 1.9

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -78,8 +78,8 @@ For contributing, checkout the [contribution guidelines][contribution docs] and 
 
 | Type  | Documentation              | Version | Support type |
 | ----- | -------------------------- | -----   | ------------ |
-| MRI   | https://www.ruby-lang.org/ | 1.9.1   | Experimental |
-|       |                            | 1.9.3   | Full         |
+| MRI   | https://www.ruby-lang.org/ | 1.9.1   | Deprecated   |
+|       |                            | 1.9.3   | Deprecated   |
 |       |                            | 2.0     | Full         |
 |       |                            | 2.1     | Full         |
 |       |                            | 2.2     | Full         |
@@ -104,6 +104,8 @@ For contributing, checkout the [contribution guidelines][contribution docs] and 
 *Full* support indicates all tracer features are available.
 
 *Experimental* indicates most features should be available, but unverified.
+
+*Deprecated* indicates support will be removed in a future release.
 
 ## Installation
 

--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -6,16 +6,24 @@ module Datadog
   module Configuration
     attr_writer :configuration
 
+    RUBY_19_DEPRECATION_WARNING = %(
+      Support for Ruby versions < 2.0 in dd-trace-rb is DEPRECATED.
+      Last version to support Ruby < 2.0 will be 0.26.x, which will only receive critical bugfixes to existing features.
+      Support for Ruby versions < 2.0 will be REMOVED with version 0.27.0.).freeze
+
     def configuration
       @configuration ||= Settings.new
     end
 
     def configure(target = configuration, opts = {})
       if target.is_a?(Settings)
-        yield(target)
+        yield(target) if block_given?
       else
         PinSetup.new(target, opts).call
       end
+
+      # Raise Ruby 1.9 deprecation warning, if necessary.
+      raise_ruby_19_deprecation_warning!
     end
 
     # Helper methods
@@ -25,6 +33,17 @@ module Datadog
 
     def runtime_metrics
       tracer.writer.runtime_metrics
+    end
+
+    # TODO: Remove with version 0.27.0
+    def raise_ruby_19_deprecation_warning!
+      return unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
+
+      require 'ddtrace/patcher'
+
+      Datadog::Patcher.do_once(:ruby_19_deprecation_warning) do
+        Datadog::Tracer.log.warn(RUBY_19_DEPRECATION_WARNING)
+      end
     end
   end
 end

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+
+require 'ddtrace/configuration/settings'
+
+RSpec.describe Datadog::Configuration::Settings do
+  let(:configuration) { described_class.new(registry: registry) }
+  let(:registry) { Datadog::Contrib::Registry.new }
+
+  describe '#use' do
+    subject(:result) { configuration.use(name, options) }
+    let(:name) { :example }
+    let(:integration) { double('integration') }
+    let(:options) { {} }
+
+    before(:each) do
+      registry.add(name, integration)
+    end
+
+    context 'for a generic integration' do
+      before(:each) do
+        expect(integration).to receive(:configure).with(:default, options).and_return([])
+        expect(integration).to receive(:patch).and_return(true)
+      end
+
+      it { expect { result }.to_not raise_error }
+    end
+
+    context 'for an integration that includes Datadog::Contrib::Integration' do
+      let(:patcher_module) do
+        stub_const('Patcher', Module.new do
+          include Datadog::Contrib::Patcher
+
+          def self.patch
+            true
+          end
+        end)
+      end
+
+      let(:integration_class) do
+        patcher_module
+
+        Class.new do
+          include Datadog::Contrib::Integration
+
+          def self.version
+            Gem::Version.new('0.1')
+          end
+
+          def patcher
+            Patcher
+          end
+        end
+      end
+
+      let(:integration) do
+        integration_class.new(name)
+      end
+
+      context 'which is provided only a name' do
+        it do
+          expect(integration).to receive(:configure).with(:default, {})
+          configuration.use(name)
+        end
+      end
+
+      context 'which is provided a block' do
+        it do
+          expect(integration).to receive(:configure).with(:default, {}).and_call_original
+          expect { |b| configuration.use(name, options, &b) }.to yield_with_args(
+            a_kind_of(Datadog::Contrib::Configuration::Settings)
+          )
+        end
+      end
+    end
+  end
+
+  describe '#tracer' do
+    let(:tracer) { Datadog::Tracer.new }
+    let(:debug_state) { tracer.class.debug_logging }
+    let(:custom_log) { Logger.new(STDOUT) }
+
+    context 'given some settings' do
+      before(:each) do
+        @original_log = tracer.class.log
+
+        configuration.tracer(
+          enabled: false,
+          debug: !debug_state,
+          log: custom_log,
+          hostname: 'tracer.host.com',
+          port: 1234,
+          env: :config_test,
+          tags: { foo: :bar },
+          instance: tracer
+        )
+      end
+
+      after(:each) do
+        tracer.class.debug_logging = debug_state
+        tracer.class.log = @original_log
+      end
+
+      it 'applies settings correctly' do
+        expect(tracer.enabled).to be false
+        expect(debug_state).to be false
+        expect(Datadog::Tracer.log).to eq(custom_log)
+        expect(tracer.writer.transport.current_api.adapter.hostname).to eq('tracer.host.com')
+        expect(tracer.writer.transport.current_api.adapter.port).to eq(1234)
+        expect(tracer.tags[:env]).to eq(:config_test)
+        expect(tracer.tags[:foo]).to eq(:bar)
+      end
+    end
+
+    it 'acts on the default tracer' do
+      previous_state = Datadog.tracer.enabled
+      configuration.tracer(enabled: !previous_state)
+      expect(Datadog.tracer.enabled).to eq(!previous_state)
+      configuration.tracer(enabled: previous_state)
+      expect(Datadog.tracer.enabled).to eq(previous_state)
+    end
+  end
+
+  describe '#[]' do
+    context 'when the integration doesn\'t exist' do
+      it do
+        expect { configuration[:foobar] }.to raise_error(
+          Datadog::Contrib::Extensions::Configuration::Settings::InvalidIntegrationError
+        )
+      end
+    end
+  end
+end

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -1,131 +1,43 @@
 require 'spec_helper'
 
-require 'ddtrace'
+require 'ddtrace/patcher'
+require 'ddtrace/configuration'
 
-RSpec.describe Datadog::Configuration::Settings do
-  let(:configuration) { described_class.new(registry: registry) }
-  let(:registry) { Datadog::Contrib::Registry.new }
+RSpec.describe Datadog::Configuration do
+  context 'when extended by a class' do
+    subject(:test_class) { stub_const('TestClass', Class.new { extend Datadog::Configuration }) }
 
-  describe '#use' do
-    subject(:result) { configuration.use(name, options) }
-    let(:name) { :example }
-    let(:integration) { double('integration') }
-    let(:options) { {} }
+    describe '#configure' do
+      subject(:configure) { test_class.configure }
 
-    before(:each) do
-      registry.add(name, integration)
-    end
-
-    context 'for a generic integration' do
-      before(:each) do
-        expect(integration).to receive(:configure).with(:default, options).and_return([])
-        expect(integration).to receive(:patch).and_return(true)
-      end
-
-      it { expect { result }.to_not raise_error }
-    end
-
-    context 'for an integration that includes Datadog::Contrib::Integration' do
-      let(:patcher_module) do
-        stub_const('Patcher', Module.new do
-          include Datadog::Contrib::Patcher
-
-          def self.patch
-            true
-          end
-        end)
-      end
-
-      let(:integration_class) do
-        patcher_module
-
-        Class.new do
-          include Datadog::Contrib::Integration
-
-          def self.version
-            Gem::Version.new('0.1')
-          end
-
-          def patcher
-            Patcher
+      context 'deprecation warning for Ruby 1.9' do
+        before do
+          # Reset deprecation warning
+          if Datadog::Patcher.instance_variable_defined?(:@done_once) \
+             && !Datadog::Patcher.instance_variable_get(:@done_once).nil?
+            Datadog::Patcher.instance_variable_get(:@done_once).delete(:ruby_19_deprecation_warning)
           end
         end
-      end
 
-      let(:integration) do
-        integration_class.new(name)
-      end
+        if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
+          context 'is raised' do
+            it do
+              expect(Datadog::Tracer.log).to receive(:warn)
+                .with(described_class::RUBY_19_DEPRECATION_WARNING)
 
-      context 'which is provided only a name' do
-        it do
-          expect(integration).to receive(:configure).with(:default, {})
-          configuration.use(name)
+              configure
+            end
+          end
+        else
+          context 'is not raised' do
+            it do
+              expect(Datadog::Tracer.log).to_not receive(:warn)
+                .with(described_class::RUBY_19_DEPRECATION_WARNING)
+
+              configure
+            end
+          end
         end
-      end
-
-      context 'which is provided a block' do
-        it do
-          expect(integration).to receive(:configure).with(:default, {}).and_call_original
-          expect { |b| configuration.use(name, options, &b) }.to yield_with_args(
-            a_kind_of(Datadog::Contrib::Configuration::Settings)
-          )
-        end
-      end
-    end
-  end
-
-  describe '#tracer' do
-    let(:tracer) { Datadog::Tracer.new }
-    let(:debug_state) { tracer.class.debug_logging }
-    let(:custom_log) { Logger.new(STDOUT) }
-
-    context 'given some settings' do
-      before(:each) do
-        @original_log = tracer.class.log
-
-        configuration.tracer(
-          enabled: false,
-          debug: !debug_state,
-          log: custom_log,
-          hostname: 'tracer.host.com',
-          port: 1234,
-          env: :config_test,
-          tags: { foo: :bar },
-          instance: tracer
-        )
-      end
-
-      after(:each) do
-        tracer.class.debug_logging = debug_state
-        tracer.class.log = @original_log
-      end
-
-      it 'applies settings correctly' do
-        expect(tracer.enabled).to be false
-        expect(debug_state).to be false
-        expect(Datadog::Tracer.log).to eq(custom_log)
-        expect(tracer.writer.transport.current_api.adapter.hostname).to eq('tracer.host.com')
-        expect(tracer.writer.transport.current_api.adapter.port).to eq(1234)
-        expect(tracer.tags[:env]).to eq(:config_test)
-        expect(tracer.tags[:foo]).to eq(:bar)
-      end
-    end
-
-    it 'acts on the default tracer' do
-      previous_state = Datadog.tracer.enabled
-      configuration.tracer(enabled: !previous_state)
-      expect(Datadog.tracer.enabled).to eq(!previous_state)
-      configuration.tracer(enabled: previous_state)
-      expect(Datadog.tracer.enabled).to eq(previous_state)
-    end
-  end
-
-  describe '#[]' do
-    context 'when the integration doesn\'t exist' do
-      it do
-        expect { configuration[:foobar] }.to raise_error(
-          Datadog::Contrib::Extensions::Configuration::Settings::InvalidIntegrationError
-        )
       end
     end
   end

--- a/spec/ddtrace/contrib/dalli/patcher_spec.rb
+++ b/spec/ddtrace/contrib/dalli/patcher_spec.rb
@@ -32,8 +32,6 @@ RSpec.describe 'Dalli instrumentation' do
   end
 
   it 'does not generate deprecation warnings' do
-    expect(log_buffer.length).to eq(0)
-    expect(log_buffer).to_not contain_line_with(*deprecation_warnings)
     expect(log_buffer).to_not contain_line_with(*deprecation_warnings)
   end
 

--- a/spec/ddtrace/contrib/faraday/patcher_spec.rb
+++ b/spec/ddtrace/contrib/faraday/patcher_spec.rb
@@ -32,8 +32,6 @@ RSpec.describe 'Faraday instrumentation' do
   end
 
   it 'does not generate deprecation warnings' do
-    expect(log_buffer.length).to eq(0)
-    expect(log_buffer).to_not contain_line_with(*deprecation_warnings)
     expect(log_buffer).to_not contain_line_with(*deprecation_warnings)
   end
 

--- a/spec/ddtrace/contrib/grpc/patcher_spec.rb
+++ b/spec/ddtrace/contrib/grpc/patcher_spec.rb
@@ -32,8 +32,6 @@ RSpec.describe 'GRPC instrumentation' do
   end
 
   it 'does not generate deprecation warnings' do
-    expect(log_buffer.length).to eq(0)
-    expect(log_buffer).to_not contain_line_with(*deprecation_warnings)
     expect(log_buffer).to_not contain_line_with(*deprecation_warnings)
   end
 


### PR DESCRIPTION
As a first step to dropping support for Ruby 1.9, this pull request adds a deprecation warning that fires only once when users invoke `Datadog.configure`.

The plan is to:

 - 0.25.0: Deprecate and warn of use of Ruby 1.9
 - 0.26.0: Last version to support Ruby 1.9. Will only backport and release critical bugfixes via `0.26-stable` maintenance branch.
 - 0.27.0: Drop Ruby 1.9 support. Bump Ruby version requirement in gempsec to 2.0.
