### PR TITLE
[core] Remove runtime-id tag

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1778,7 +1778,6 @@ In addition, all metrics will include the following tags:
 | Name         | Description                                             |
 | ------------ | ------------------------------------------------------- |
 | `language`   | Programming language traced. (e.g. `ruby`)              |
-| `runtime-id` | Unique identifier of runtime environment (i.e. process) |
 | `service`    | List of services this metric is associated with.        |
 
 ### OpenTracing

--- a/lib/ddtrace/ext/metrics.rb
+++ b/lib/ddtrace/ext/metrics.rb
@@ -4,7 +4,6 @@ module Datadog
       TAG_LANG = 'language'.freeze
       TAG_LANG_INTERPRETER = 'language-interpreter'.freeze
       TAG_LANG_VERSION = 'language-version'.freeze
-      TAG_RUNTIME_ID = 'runtime-id'.freeze
       TAG_TRACER_VERSION = 'tracer-version'.freeze
     end
   end

--- a/lib/ddtrace/ext/runtime.rb
+++ b/lib/ddtrace/ext/runtime.rb
@@ -16,7 +16,6 @@ module Datadog
       TRACER_VERSION = Datadog::VERSION::STRING
 
       TAG_LANG = 'language'.freeze
-      TAG_RUNTIME_ID = 'runtime-id'.freeze
 
       # Metrics
       module Metrics

--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -117,9 +117,6 @@ module Datadog
         # and defaults are unfrozen for mutation in Statsd.
         DEFAULT.dup.tap do |options|
           options[:tags] = options[:tags].dup
-
-          # Add runtime ID dynamically because it might change during fork.
-          options[:tags] << "#{Ext::Metrics::TAG_RUNTIME_ID}:#{Runtime::Identity.id}".freeze
         end
       end
     end

--- a/lib/ddtrace/runtime/metrics.rb
+++ b/lib/ddtrace/runtime/metrics.rb
@@ -26,7 +26,6 @@ module Datadog
 
         # Tag span with language and runtime ID for association with metrics
         span.set_tag(Ext::Runtime::TAG_LANG, Runtime::Identity.lang)
-        span.set_tag(Ext::Runtime::TAG_RUNTIME_ID, Runtime::Identity.id)
       end
 
       # Associate service with runtime metrics

--- a/spec/ddtrace/contrib/rack/configuration_spec.rb
+++ b/spec/ddtrace/contrib/rack/configuration_spec.rb
@@ -79,7 +79,6 @@ RSpec.describe 'Rack integration configuration' do
         # Queue span gets tagged for runtime metrics because its a local root span.
         # TODO: It probably shouldn't get tagged like this in the future; it's not part of the runtime.
         expect(queue_span.get_tag(Datadog::Ext::Runtime::TAG_LANG)).to eq('ruby')
-        expect(queue_span.get_tag(Datadog::Ext::Runtime::TAG_RUNTIME_ID)).to eq(Datadog::Runtime::Identity.id)
 
         expect(rack_span.name).to eq('rack.request')
         expect(rack_span.span_type).to eq('web')
@@ -89,7 +88,6 @@ RSpec.describe 'Rack integration configuration' do
         expect(rack_span.get_tag('http.status_code')).to eq('200')
         expect(rack_span.get_tag('http.url')).to eq('/')
         expect(rack_span.get_tag(Datadog::Ext::Runtime::TAG_LANG)).to eq('ruby')
-        expect(rack_span.get_tag(Datadog::Ext::Runtime::TAG_RUNTIME_ID)).to eq(Datadog::Runtime::Identity.id)
         expect(rack_span.status).to eq(0)
 
         expect(queue_span.span_id).to eq(rack_span.parent_id)
@@ -110,7 +108,6 @@ RSpec.describe 'Rack integration configuration' do
         expect(span.get_tag('http.status_code')).to eq('200')
         expect(span.get_tag('http.url')).to eq('/')
         expect(span.get_tag(Datadog::Ext::Runtime::TAG_LANG)).to eq('ruby')
-        expect(span.get_tag(Datadog::Ext::Runtime::TAG_RUNTIME_ID)).to eq(Datadog::Runtime::Identity.id)
         expect(span.status).to eq(0)
 
         expect(span.parent_id).to eq(0)

--- a/spec/ddtrace/runtime/metrics_spec.rb
+++ b/spec/ddtrace/runtime/metrics_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Datadog::Runtime::Metrics do
 
       context 'when no services have been registered' do
         it do
-          is_expected.to have(2).items
+          is_expected.to have(1).items
 
           is_expected.to include('language:ruby')
         end
@@ -138,7 +138,7 @@ RSpec.describe Datadog::Runtime::Metrics do
         before(:each) { services.each { |service| runtime_metrics.register_service(service) } }
 
         it do
-          is_expected.to have(4).items
+          is_expected.to have(3).items
 
           is_expected.to include('language:ruby')
           is_expected.to include(*services.collect { |service| "service:#{service}" })

--- a/spec/ddtrace/runtime/metrics_spec.rb
+++ b/spec/ddtrace/runtime/metrics_spec.rb
@@ -16,9 +16,6 @@ RSpec.describe Datadog::Runtime::Metrics do
       expect(span).to receive(:set_tag)
         .with(Datadog::Ext::Runtime::TAG_LANG, Datadog::Runtime::Identity.lang)
 
-      expect(span).to receive(:set_tag)
-        .with(Datadog::Ext::Runtime::TAG_RUNTIME_ID, Datadog::Runtime::Identity.id)
-
       associate_with_span
     end
 
@@ -133,7 +130,6 @@ RSpec.describe Datadog::Runtime::Metrics do
           is_expected.to have(2).items
 
           is_expected.to include('language:ruby')
-          is_expected.to include("runtime-id:#{Datadog::Runtime::Identity.id}")
         end
       end
 
@@ -145,7 +141,6 @@ RSpec.describe Datadog::Runtime::Metrics do
           is_expected.to have(4).items
 
           is_expected.to include('language:ruby')
-          is_expected.to include("runtime-id:#{Datadog::Runtime::Identity.id}")
           is_expected.to include(*services.collect { |service| "service:#{service}" })
         end
       end

--- a/spec/ddtrace/tracer_integration_spec.rb
+++ b/spec/ddtrace/tracer_integration_spec.rb
@@ -21,10 +21,6 @@ RSpec.describe Datadog::Tracer do
     span.get_tag(Datadog::Ext::Runtime::TAG_LANG)
   end
 
-  def runtime_id_tag(span)
-    span.get_tag(Datadog::Ext::Runtime::TAG_RUNTIME_ID)
-  end
-
   describe '#active_root_span' do
     subject(:active_root_span) { tracer.active_root_span }
 
@@ -67,7 +63,6 @@ RSpec.describe Datadog::Tracer do
       it { expect(sampling_priority_metric(parent_span)).to eq(1) }
       it { expect(origin_tag(parent_span)).to eq('synthetics') }
       it { expect(lang_tag(parent_span)).to eq('ruby') }
-      it { expect(runtime_id_tag(parent_span)).to eq(Datadog::Runtime::Identity.id) }
       it { expect(child_span.name).to eq(child_span_name) }
       it { expect(child_span.finished?).to be(true) }
       it { expect(child_span.trace_id).to eq(parent_span.trace_id) }
@@ -75,7 +70,6 @@ RSpec.describe Datadog::Tracer do
       it { expect(sampling_priority_metric(child_span)).to eq(1) }
       it { expect(origin_tag(child_span)).to eq('synthetics') }
       it { expect(lang_tag(child_span)).to eq('ruby') }
-      it { expect(runtime_id_tag(child_span)).to eq(Datadog::Runtime::Identity.id) }
       # This is expected to be child_span because when propagated, we don't
       # propagate the root span, only its ID. Therefore the span reference
       # should be the first span on the other end of the distributed trace.

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -185,7 +185,7 @@ class TracerTest < Minitest::Test
     assert_equal('special-service', span.service)
     assert_equal('extra-resource', span.resource)
     assert_equal('my-type', span.span_type)
-    assert_equal(7, span.meta.length)
+    assert_equal(6, span.meta.length)
     assert_equal('test', span.get_tag('env'))
     assert_equal('cool', span.get_tag('temp'))
     assert_equal('value1', span.get_tag('tag1'))


### PR DESCRIPTION
We no longer need to tag runtime metrics with `runtime-id` tag.

This PR removes all references of `runtime-id`.