### PR TITLE
Quantize Redis AUTH command

### DIFF
--- a/lib/ddtrace/contrib/redis/quantize.rb
+++ b/lib/ddtrace/contrib/redis/quantize.rb
@@ -20,8 +20,14 @@ module Datadog
         end
 
         def format_command_args(command_args)
+          return 'AUTH ?' if auth_command?(command_args)
           cmd = command_args.map { |x| format_arg(x) }.join(' ')
           Utils.truncate(cmd, CMD_MAX_LEN, TOO_LONG_MARK)
+        end
+
+        def auth_command?(command_args)
+          return false unless command_args.is_a?(Array) && !command_args.empty?
+          command_args.first.to_sym == :auth
         end
       end
     end

--- a/spec/ddtrace/contrib/redis/method_replaced_spec.rb
+++ b/spec/ddtrace/contrib/redis/method_replaced_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe 'Redis replace method test' do
   it do
     expect(call_without_datadog_method).to_not be nil
     expect(redis).to receive(:call).once.and_call_original
-    redis.call(['ping', 'hello world'])
+    redis.call('ping', 'hello world')
   end
 end

--- a/spec/ddtrace/contrib/redis/miniapp_spec.rb
+++ b/spec/ddtrace/contrib/redis/miniapp_spec.rb
@@ -6,6 +6,8 @@ require 'hiredis'
 require 'ddtrace'
 
 RSpec.describe 'Redis mini app test' do
+  before(:each) { skip unless ENV['TEST_DATADOG_INTEGRATION'] }
+
   let(:tracer) { get_test_tracer }
 
   def all_spans


### PR DESCRIPTION
The Redis integration is not properly quantizing `AUTH` commands. This pull request applies quantization for `AUTH` commands.