### PR TITLE
Add container tags to traces

### DIFF
--- a/lib/ddtrace/ext/transport.rb
+++ b/lib/ddtrace/ext/transport.rb
@@ -6,6 +6,7 @@ module Datadog
         DEFAULT_PORT = 8126
         ENV_DEFAULT_HOST = 'DD_AGENT_HOST'.freeze
         ENV_DEFAULT_PORT = 'DD_TRACE_AGENT_PORT'.freeze
+        HEADER_CONTAINER_ID = 'Datadog-Container-ID'.freeze
         HEADER_META_LANG = 'Datadog-Meta-Lang'.freeze
         HEADER_META_LANG_VERSION = 'Datadog-Meta-Lang-Version'.freeze
         HEADER_META_LANG_INTERPRETER = 'Datadog-Meta-Lang-Interpreter'.freeze

--- a/lib/ddtrace/ext/transport.rb
+++ b/lib/ddtrace/ext/transport.rb
@@ -1,0 +1,16 @@
+module Datadog
+  module Ext
+    module Transport
+      module HTTP
+        DEFAULT_HOST = '127.0.0.1'.freeze
+        DEFAULT_PORT = 8126
+        ENV_DEFAULT_HOST = 'DD_AGENT_HOST'.freeze
+        ENV_DEFAULT_PORT = 'DD_TRACE_AGENT_PORT'.freeze
+        HEADER_META_LANG = 'Datadog-Meta-Lang'.freeze
+        HEADER_META_LANG_VERSION = 'Datadog-Meta-Lang-Version'.freeze
+        HEADER_META_LANG_INTERPRETER = 'Datadog-Meta-Lang-Interpreter'.freeze
+        HEADER_META_TRACER_VERSION = 'Datadog-Meta-Tracer-Version'.freeze
+      end
+    end
+  end
+end

--- a/lib/ddtrace/runtime/cgroup.rb
+++ b/lib/ddtrace/runtime/cgroup.rb
@@ -18,9 +18,13 @@ module Datadog
       def descriptors(process = 'self')
         [].tap do |descriptors|
           begin
-            File.open("/proc/#{process}/cgroup").each do |line|
-              line = line.strip
-              descriptors << parse(line) unless line.empty?
+            filepath = "/proc/#{process}/cgroup"
+
+            if File.exist?(filepath)
+              File.open("/proc/#{process}/cgroup").each do |line|
+                line = line.strip
+                descriptors << parse(line) unless line.empty?
+              end
             end
           rescue StandardError => e
             Datadog::Tracer.log.error("Error while parsing cgroup. Cause: #{e.message} Location: #{e.backtrace.first}")

--- a/lib/ddtrace/runtime/cgroup.rb
+++ b/lib/ddtrace/runtime/cgroup.rb
@@ -1,0 +1,40 @@
+require 'ddtrace/ext/runtime'
+
+module Datadog
+  module Runtime
+    # For control groups
+    module Cgroup
+      LINE_REGEX = /^(\d+):([^:]*):(.+)$/
+
+      Descriptor = Struct.new(
+        :id,
+        :groups,
+        :path,
+        :controllers
+      )
+
+      module_function
+
+      def descriptors(process = 'self')
+        [].tap do |descriptors|
+          begin
+            File.open("/proc/#{process}/cgroup").each do |line|
+              line = line.strip
+              descriptors << parse(line) unless line.empty?
+            end
+          rescue StandardError => e
+            Datadog::Tracer.log.error("Error while parsing cgroup. Cause: #{e.message} Location: #{e.backtrace.first}")
+          end
+        end
+      end
+
+      def parse(line)
+        id, groups, path = line.scan(LINE_REGEX).first
+
+        Descriptor.new(id, groups, path).tap do |descriptor|
+          descriptor.controllers = groups.split(',') unless groups.nil?
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/runtime/container.rb
+++ b/lib/ddtrace/runtime/container.rb
@@ -49,6 +49,7 @@ module Datadog
                 platform = parts[0]
                 container_id = parts[-1][CONTAINER_REGEX]
                 task_uid = parts[-2][POD_REGEX]
+
                 # If container ID wasn't found, ignore.
                 # Path might describe a non-container environment.
                 next if container_id.nil?
@@ -56,6 +57,8 @@ module Datadog
                 descriptor.platform = platform
                 descriptor.container_id = container_id
                 descriptor.task_uid = task_uid
+
+                break
               end
             rescue StandardError => e
               Datadog::Tracer.log.error(

--- a/lib/ddtrace/runtime/container.rb
+++ b/lib/ddtrace/runtime/container.rb
@@ -1,0 +1,70 @@
+require 'ddtrace/ext/runtime'
+require 'ddtrace/runtime/cgroup'
+
+module Datadog
+  module Runtime
+    # For container environments
+    module Container
+      UUID_PATTERN = '[0-9a-f]{8}[-_]?[0-9a-f]{4}[-_]?[0-9a-f]{4}[-_]?[0-9a-f]{4}[-_]?[0-9a-f]{12}'.freeze
+      CONTAINER_PATTERN = '[0-9a-f]{64}'.freeze
+
+      POD_REGEX = /(pod)?(#{UUID_PATTERN})(?:.slice)?$/
+      CONTAINER_REGEX = /(#{UUID_PATTERN}|#{CONTAINER_PATTERN})(?:.scope)?$/
+
+      Descriptor = Struct.new(
+        :platform,
+        :container_id,
+        :task_uid
+      )
+
+      module_function
+
+      def platform
+        descriptor.platform
+      end
+
+      def container_id
+        descriptor.container_id
+      end
+
+      def task_uid
+        descriptor.task_uid
+      end
+
+      def descriptor
+        @descriptor ||= begin
+          Descriptor.new.tap do |descriptor|
+            begin
+              Cgroup.descriptors.each do |cgroup_descriptor|
+                # Parse container data from cgroup descriptor
+                path = cgroup_descriptor.path
+                next if path.nil?
+
+                # Split path into parts
+                parts = path.split('/')
+                parts.shift # Remove leading empty part
+                next if parts.length < 2
+
+                # Read info from path
+                platform = parts[0]
+                container_id = parts[-1][CONTAINER_REGEX]
+                task_uid = parts[-2][POD_REGEX]
+                # If container ID wasn't found, ignore.
+                # Path might describe a non-container environment.
+                next if container_id.nil?
+
+                descriptor.platform = platform
+                descriptor.container_id = container_id
+                descriptor.task_uid = task_uid
+              end
+            rescue StandardError => e
+              Datadog::Tracer.log.error(
+                "Error while parsing container info. Cause: #{e.message} Location: #{e.backtrace.first}"
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -15,13 +15,6 @@ module Datadog
   module Transport
     # Namespace for HTTP transport components
     module HTTP
-      DEFAULT_HEADERS = {
-        Datadog::Ext::Transport::HTTP::HEADER_META_LANG => Datadog::Ext::Runtime::LANG,
-        Datadog::Ext::Transport::HTTP::HEADER_META_LANG_VERSION => Datadog::Ext::Runtime::LANG_VERSION,
-        Datadog::Ext::Transport::HTTP::HEADER_META_LANG_INTERPRETER => Datadog::Ext::Runtime::LANG_INTERPRETER,
-        Datadog::Ext::Transport::HTTP::HEADER_META_TRACER_VERSION => Datadog::Ext::Runtime::TRACER_VERSION
-      }.freeze
-
       module_function
 
       # Builds a new Transport::HTTP::Client
@@ -34,14 +27,7 @@ module Datadog
       def default(options = {})
         new do |transport|
           transport.adapter :net_http, default_hostname, default_port
-
-          transport.headers DEFAULT_HEADERS
-
-          # Add container ID to default headers, if present.
-          container_id = Datadog::Runtime::Container.container_id
-          unless container_id.nil?
-            transport.headers Datadog::Ext::Transport::HTTP::HEADER_CONTAINER_ID => container_id
-          end
+          transport.headers default_headers
 
           apis = API.defaults
 
@@ -70,6 +56,21 @@ module Datadog
 
           # Call block to apply any customization, if provided.
           yield(transport) if block_given?
+        end
+      end
+
+      def default_headers
+        {
+          Datadog::Ext::Transport::HTTP::HEADER_META_LANG => Datadog::Ext::Runtime::LANG,
+          Datadog::Ext::Transport::HTTP::HEADER_META_LANG_VERSION => Datadog::Ext::Runtime::LANG_VERSION,
+          Datadog::Ext::Transport::HTTP::HEADER_META_LANG_INTERPRETER => Datadog::Ext::Runtime::LANG_INTERPRETER,
+          Datadog::Ext::Transport::HTTP::HEADER_META_TRACER_VERSION => Datadog::Ext::Runtime::TRACER_VERSION
+        }.tap do |headers|
+          # Add container ID, if present.
+          container_id = Datadog::Runtime::Container.container_id
+          unless container_id.nil?
+            headers[Datadog::Ext::Transport::HTTP::HEADER_CONTAINER_ID] = container_id
+          end
         end
       end
 

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -16,7 +16,6 @@ module Datadog
     # Namespace for HTTP transport components
     module HTTP
       DEFAULT_HEADERS = {
-        Datadog::Ext::Transport::HTTP::HEADER_CONTAINER_ID => Datadog::Runtime::Container.container_id,
         Datadog::Ext::Transport::HTTP::HEADER_META_LANG => Datadog::Ext::Runtime::LANG,
         Datadog::Ext::Transport::HTTP::HEADER_META_LANG_VERSION => Datadog::Ext::Runtime::LANG_VERSION,
         Datadog::Ext::Transport::HTTP::HEADER_META_LANG_INTERPRETER => Datadog::Ext::Runtime::LANG_INTERPRETER,
@@ -37,6 +36,12 @@ module Datadog
           transport.adapter :net_http, default_hostname, default_port
 
           transport.headers DEFAULT_HEADERS
+
+          # Add container ID to default headers, if present.
+          container_id = Datadog::Runtime::Container.container_id
+          unless container_id.nil?
+            transport.headers Datadog::Ext::Transport::HTTP::HEADER_CONTAINER_ID => container_id
+          end
 
           apis = API.defaults
 

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/version'
 require 'ddtrace/ext/runtime'
+require 'ddtrace/ext/transport'
 
 require 'ddtrace/transport/http/builder'
 require 'ddtrace/transport/http/api'
@@ -12,13 +13,11 @@ module Datadog
   module Transport
     # Namespace for HTTP transport components
     module HTTP
-      DEFAULT_AGENT_HOST = '127.0.0.1'.freeze
-      DEFAULT_TRACE_AGENT_PORT = 8126
       DEFAULT_HEADERS = {
-        'Datadog-Meta-Lang'.freeze => Datadog::Ext::Runtime::LANG,
-        'Datadog-Meta-Lang-Version'.freeze => Datadog::Ext::Runtime::LANG_VERSION,
-        'Datadog-Meta-Lang-Interpreter'.freeze => Datadog::Ext::Runtime::LANG_INTERPRETER,
-        'Datadog-Meta-Tracer-Version'.freeze => Datadog::Ext::Runtime::TRACER_VERSION
+        Datadog::Ext::Transport::HTTP::HEADER_META_LANG => Datadog::Ext::Runtime::LANG,
+        Datadog::Ext::Transport::HTTP::HEADER_META_LANG_VERSION => Datadog::Ext::Runtime::LANG_VERSION,
+        Datadog::Ext::Transport::HTTP::HEADER_META_LANG_INTERPRETER => Datadog::Ext::Runtime::LANG_INTERPRETER,
+        Datadog::Ext::Transport::HTTP::HEADER_META_TRACER_VERSION => Datadog::Ext::Runtime::TRACER_VERSION
       }.freeze
 
       module_function
@@ -32,9 +31,7 @@ module Datadog
       # Pass a block to override any settings.
       def default(options = {})
         new do |transport|
-          transport.adapter :net_http,
-                            ENV.fetch('DD_AGENT_HOST', DEFAULT_AGENT_HOST),
-                            ENV.fetch('DD_TRACE_AGENT_PORT', DEFAULT_TRACE_AGENT_PORT)
+          transport.adapter :net_http, default_hostname, default_port
 
           transport.headers DEFAULT_HEADERS
 
@@ -69,11 +66,11 @@ module Datadog
       end
 
       def default_hostname
-        ENV.fetch('DD_AGENT_HOST', DEFAULT_AGENT_HOST)
+        ENV.fetch(Datadog::Ext::Transport::HTTP::ENV_DEFAULT_HOST, Datadog::Ext::Transport::HTTP::DEFAULT_HOST)
       end
 
       def default_port
-        ENV.fetch('DD_TRACE_AGENT_PORT', DEFAULT_TRACE_AGENT_PORT)
+        ENV.fetch(Datadog::Ext::Transport::HTTP::ENV_DEFAULT_PORT, Datadog::Ext::Transport::HTTP::DEFAULT_PORT).to_i
       end
 
       # Add adapters to registry

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -2,6 +2,8 @@ require 'ddtrace/version'
 require 'ddtrace/ext/runtime'
 require 'ddtrace/ext/transport'
 
+require 'ddtrace/runtime/container'
+
 require 'ddtrace/transport/http/builder'
 require 'ddtrace/transport/http/api'
 
@@ -14,6 +16,7 @@ module Datadog
     # Namespace for HTTP transport components
     module HTTP
       DEFAULT_HEADERS = {
+        Datadog::Ext::Transport::HTTP::HEADER_CONTAINER_ID => Datadog::Runtime::Container.container_id,
         Datadog::Ext::Transport::HTTP::HEADER_META_LANG => Datadog::Ext::Runtime::LANG,
         Datadog::Ext::Transport::HTTP::HEADER_META_LANG_VERSION => Datadog::Ext::Runtime::LANG_VERSION,
         Datadog::Ext::Transport::HTTP::HEADER_META_LANG_INTERPRETER => Datadog::Ext::Runtime::LANG_INTERPRETER,

--- a/spec/ddtrace/runtime/cgroup_spec.rb
+++ b/spec/ddtrace/runtime/cgroup_spec.rb
@@ -1,0 +1,186 @@
+# encoding: utf-8
+
+require 'spec_helper'
+require 'ddtrace/runtime/cgroup'
+
+# rubocop:disable Metrics/LineLength
+RSpec.describe Datadog::Runtime::Cgroup do
+  describe '::descriptors' do
+    subject(:descriptors) { described_class.descriptors }
+
+    context 'given a \'/proc/self/cgroup\' file' do
+      context 'in a non-containerized environment' do
+        include_context 'non-containerized environment'
+
+        it do
+          is_expected.to be_a_kind_of(Array)
+          is_expected.to have(13).items
+          is_expected.to include(be_a_kind_of(described_class::Descriptor))
+        end
+      end
+
+      context 'in a Docker environment' do
+        include_context 'Docker environment'
+
+        it do
+          is_expected.to be_a_kind_of(Array)
+          is_expected.to have(13).items
+          is_expected.to include(be_a_kind_of(described_class::Descriptor))
+        end
+      end
+
+      context 'in a Kubernetes environment' do
+        include_context 'Kubernetes environment'
+
+        it do
+          is_expected.to be_a_kind_of(Array)
+          is_expected.to have(11).items
+          is_expected.to include(be_a_kind_of(described_class::Descriptor))
+        end
+      end
+
+      context 'in an ECS environment' do
+        include_context 'ECS environment'
+
+        it do
+          is_expected.to be_a_kind_of(Array)
+          is_expected.to have(9).items
+          is_expected.to include(be_a_kind_of(described_class::Descriptor))
+        end
+      end
+
+      context 'in a Fargate environment' do
+        include_context 'Fargate environment'
+
+        it do
+          is_expected.to be_a_kind_of(Array)
+          is_expected.to have(11).items
+          is_expected.to include(be_a_kind_of(described_class::Descriptor))
+        end
+      end
+    end
+  end
+
+  describe '::parse' do
+    subject(:parse) { described_class.parse(line) }
+
+    context 'given a line' do
+      context 'that is blank' do
+        let(:line) { '' }
+        it { is_expected.to be_a_kind_of(described_class::Descriptor) }
+        it do
+          is_expected.to have_attributes(
+            id: nil,
+            groups: nil,
+            path: nil,
+            controllers: nil
+          )
+        end
+      end
+
+      context 'with an empty path' do
+        let(:line) { '12:freezer:/' }
+        it { is_expected.to be_a_kind_of(described_class::Descriptor) }
+        it do
+          is_expected.to have_attributes(
+            id: '12',
+            groups: 'freezer',
+            path: '/',
+            controllers: ['freezer']
+          )
+        end
+      end
+
+      context 'with \'.slice\'' do
+        let(:line) { '11:memory:/user.slice' }
+        it { is_expected.to be_a_kind_of(described_class::Descriptor) }
+        it do
+          is_expected.to have_attributes(
+            id: '11',
+            groups: 'memory',
+            path: '/user.slice',
+            controllers: ['memory']
+          )
+        end
+      end
+
+      context 'with no group' do
+        let(:line) { '0::/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service' }
+        it { is_expected.to be_a_kind_of(described_class::Descriptor) }
+        it do
+          is_expected.to have_attributes(
+            id: '0',
+            groups: '',
+            path: '/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service',
+            controllers: []
+          )
+        end
+      end
+
+      context 'with \'@\'' do
+        let(:line) { '1:name=systemd:/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service' }
+        it { is_expected.to be_a_kind_of(described_class::Descriptor) }
+        it do
+          is_expected.to have_attributes(
+            id: '1',
+            groups: 'name=systemd',
+            path: '/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service',
+            controllers: ['name=systemd']
+          )
+        end
+      end
+
+      context 'in Docker format' do
+        let(:line) { '13:name=systemd:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860' }
+        it { is_expected.to be_a_kind_of(described_class::Descriptor) }
+        it do
+          is_expected.to have_attributes(
+            id: '13',
+            groups: 'name=systemd',
+            path: '/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860',
+            controllers: ['name=systemd']
+          )
+        end
+      end
+
+      context 'in Kubernetes format' do
+        let(:line) { '1:name=systemd:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1' }
+        it { is_expected.to be_a_kind_of(described_class::Descriptor) }
+        it do
+          is_expected.to have_attributes(
+            id: '1',
+            groups: 'name=systemd',
+            path: '/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1',
+            controllers: ['name=systemd']
+          )
+        end
+      end
+
+      context 'in ECS format' do
+        let(:line) { '1:blkio:/ecs/haissam-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce' }
+        it { is_expected.to be_a_kind_of(described_class::Descriptor) }
+        it do
+          is_expected.to have_attributes(
+            id: '1',
+            groups: 'blkio',
+            path: '/ecs/haissam-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce',
+            controllers: ['blkio']
+          )
+        end
+      end
+
+      context 'in Fargate format' do
+        let(:line) { '1:name=systemd:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da' }
+        it { is_expected.to be_a_kind_of(described_class::Descriptor) }
+        it do
+          is_expected.to have_attributes(
+            id: '1',
+            groups: 'name=systemd',
+            path: '/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da',
+            controllers: ['name=systemd']
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/runtime/container_spec.rb
+++ b/spec/ddtrace/runtime/container_spec.rb
@@ -4,15 +4,15 @@ require 'spec_helper'
 require 'ddtrace/runtime/container'
 
 RSpec.describe Datadog::Runtime::Container do
-  around do |example|
-    # Reset descriptor since it's cached.
-    Datadog::Runtime::Container.instance_variable_set(:@descriptor, nil)
-    example.run
-    Datadog::Runtime::Container.instance_variable_set(:@descriptor, nil)
-  end
-
   describe '::descriptor' do
     subject(:descriptor) { described_class.descriptor }
+
+    around do |example|
+      # Reset descriptor since it's cached.
+      Datadog::Runtime::Container.instance_variable_set(:@descriptor, nil)
+      example.run
+      Datadog::Runtime::Container.instance_variable_set(:@descriptor, nil)
+    end
 
     context 'when not in a containerized environment' do
       include_context 'non-containerized environment'

--- a/spec/ddtrace/runtime/container_spec.rb
+++ b/spec/ddtrace/runtime/container_spec.rb
@@ -1,0 +1,82 @@
+# encoding: utf-8
+
+require 'spec_helper'
+require 'ddtrace/runtime/container'
+
+RSpec.describe Datadog::Runtime::Container do
+  around do |example|
+    # Reset descriptor since it's cached.
+    Datadog::Runtime::Container.instance_variable_set(:@descriptor, nil)
+    example.run
+    Datadog::Runtime::Container.instance_variable_set(:@descriptor, nil)
+  end
+
+  describe '::descriptor' do
+    subject(:descriptor) { described_class.descriptor }
+
+    context 'when not in a containerized environment' do
+      include_context 'non-containerized environment'
+
+      it do
+        is_expected.to be_a_kind_of(described_class::Descriptor)
+        is_expected.to have_attributes(
+          platform: nil,
+          container_id: nil,
+          task_uid: nil
+        )
+      end
+    end
+
+    context 'when in a Docker environment' do
+      include_context 'Docker environment'
+
+      it do
+        is_expected.to be_a_kind_of(described_class::Descriptor)
+        is_expected.to have_attributes(
+          platform: 'docker',
+          container_id: container_id,
+          task_uid: nil
+        )
+      end
+    end
+
+    context 'when in a Kubernetes environment' do
+      include_context 'Kubernetes environment'
+
+      it do
+        is_expected.to be_a_kind_of(described_class::Descriptor)
+        is_expected.to have_attributes(
+          platform: 'kubepods',
+          container_id: container_id,
+          task_uid: pod_id
+        )
+      end
+    end
+
+    context 'when in a ECS environment' do
+      include_context 'ECS environment'
+
+      it do
+        is_expected.to be_a_kind_of(described_class::Descriptor)
+        is_expected.to have_attributes(
+          platform: 'ecs',
+          container_id: container_id,
+          task_uid: task_arn
+        )
+      end
+    end
+
+    context 'when in a Fargate environment' do
+      include_context 'Fargate environment'
+
+      it do
+        is_expected.to be_a_kind_of(described_class::Descriptor)
+        is_expected.to have_attributes(
+          platform: 'ecs',
+          container_id: container_id,
+          task_uid: task_arn
+        )
+      end
+    end
+  end
+end

--- a/spec/ddtrace/transport/http/adapters/net_integration_spec.rb
+++ b/spec/ddtrace/transport/http/adapters/net_integration_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe 'Adapters::Net integration tests' do
       expect(messages).to have(1).items
       messages.first.tap do |http_request|
         expect(http_request.header).to include(
+          'datadog-container-id' => [Datadog::Runtime::Container.container_id],
           'datadog-meta-lang' => [Datadog::Ext::Runtime::LANG],
           'datadog-meta-lang-version' => [Datadog::Ext::Runtime::LANG_VERSION],
           'datadog-meta-lang-interpreter' => [Datadog::Ext::Runtime::LANG_INTERPRETER],

--- a/spec/ddtrace/transport/http/adapters/net_integration_spec.rb
+++ b/spec/ddtrace/transport/http/adapters/net_integration_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe 'Adapters::Net integration tests' do
       expect(messages).to have(1).items
       messages.first.tap do |http_request|
         expect(http_request.header).to include(
-          'datadog-container-id' => [Datadog::Runtime::Container.container_id],
           'datadog-meta-lang' => [Datadog::Ext::Runtime::LANG],
           'datadog-meta-lang-version' => [Datadog::Ext::Runtime::LANG_VERSION],
           'datadog-meta-lang-interpreter' => [Datadog::Ext::Runtime::LANG_INTERPRETER],
@@ -62,6 +61,12 @@ RSpec.describe 'Adapters::Net integration tests' do
           'content-type' => ['application/msgpack'],
           'x-datadog-trace-count' => [traces.length.to_s]
         )
+
+        unless Datadog::Runtime::Container.container_id.nil?
+          expect(http_request.header).to include(
+            'datadog-container-id' => [Datadog::Runtime::Container.container_id]
+          )
+        end
 
         expect(http_request.header['content-length'].first.to_i).to be > 0
       end

--- a/spec/ddtrace/transport/http/adapters/unix_socket_integration_spec.rb
+++ b/spec/ddtrace/transport/http/adapters/unix_socket_integration_spec.rb
@@ -79,7 +79,6 @@ RSpec.describe 'Adapters::UnixSocket integration tests' do
       expect(messages).to have(1).items
       messages.first.tap do |http_request|
         expect(http_request.header).to include(
-          'datadog-container-id' => [Datadog::Runtime::Container.container_id],
           'datadog-meta-lang' => [Datadog::Ext::Runtime::LANG],
           'datadog-meta-lang-version' => [Datadog::Ext::Runtime::LANG_VERSION],
           'datadog-meta-lang-interpreter' => [Datadog::Ext::Runtime::LANG_INTERPRETER],
@@ -87,6 +86,12 @@ RSpec.describe 'Adapters::UnixSocket integration tests' do
           'content-type' => ['application/msgpack'],
           'x-datadog-trace-count' => [traces.length.to_s]
         )
+
+        unless Datadog::Runtime::Container.container_id.nil?
+          expect(http_request.header).to include(
+            'datadog-container-id' => [Datadog::Runtime::Container.container_id]
+          )
+        end
 
         expect(http_request.header['content-length'].first.to_i).to be > 0
       end

--- a/spec/ddtrace/transport/http/adapters/unix_socket_integration_spec.rb
+++ b/spec/ddtrace/transport/http/adapters/unix_socket_integration_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe 'Adapters::UnixSocket integration tests' do
       expect(messages).to have(1).items
       messages.first.tap do |http_request|
         expect(http_request.header).to include(
+          'datadog-container-id' => [Datadog::Runtime::Container.container_id],
           'datadog-meta-lang' => [Datadog::Ext::Runtime::LANG],
           'datadog-meta-lang-version' => [Datadog::Ext::Runtime::LANG_VERSION],
           'datadog-meta-lang-interpreter' => [Datadog::Ext::Runtime::LANG_INTERPRETER],

--- a/spec/ddtrace/transport/http_spec.rb
+++ b/spec/ddtrace/transport/http_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe Datadog::Transport::HTTP do
       default.apis.each do |_key, api|
         expect(api).to be_a_kind_of(Datadog::Transport::HTTP::API::Instance)
         expect(api.adapter).to be_a_kind_of(Datadog::Transport::HTTP::Adapters::Net)
-        expect(api.adapter.hostname).to eq(ENV.fetch('DD_AGENT_HOST', described_class::DEFAULT_AGENT_HOST))
-        expect(api.adapter.port).to eq(ENV.fetch('DD_TRACE_AGENT_PORT', described_class::DEFAULT_TRACE_AGENT_PORT))
+        expect(api.adapter.hostname).to eq(described_class.default_hostname)
+        expect(api.adapter.port).to eq(described_class.default_port)
         expect(api.headers).to eq(described_class::DEFAULT_HEADERS)
       end
     end
@@ -70,8 +70,8 @@ RSpec.describe Datadog::Transport::HTTP do
           default.apis.each do |_key, api|
             expect(api).to be_a_kind_of(Datadog::Transport::HTTP::API::Instance)
             expect(api.adapter).to be_a_kind_of(Datadog::Transport::HTTP::Adapters::Net)
-            expect(api.adapter.hostname).to eq(ENV.fetch('DD_AGENT_HOST', described_class::DEFAULT_AGENT_HOST))
-            expect(api.adapter.port).to eq(ENV.fetch('DD_TRACE_AGENT_PORT', described_class::DEFAULT_TRACE_AGENT_PORT))
+            expect(api.adapter.hostname).to eq(described_class.default_hostname)
+            expect(api.adapter.port).to eq(described_class.default_port)
             expect(api.headers).to eq(described_class::DEFAULT_HEADERS)
           end
         end
@@ -123,6 +123,62 @@ RSpec.describe Datadog::Transport::HTTP do
         expect { |b| described_class.default(&b) }.to yield_with_args(
           kind_of(Datadog::Transport::HTTP::Builder)
         )
+      end
+    end
+  end
+
+  describe '.default_hostname' do
+    subject(:default_hostname) { described_class.default_hostname }
+
+    context 'when environment variable is' do
+      context 'set' do
+        let(:value) { 'my-hostname' }
+
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::Transport::HTTP::ENV_DEFAULT_HOST => value) do
+            example.run
+          end
+        end
+
+        it { is_expected.to eq(value) }
+      end
+
+      context 'not set' do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::Transport::HTTP::ENV_DEFAULT_HOST => nil) do
+            example.run
+          end
+        end
+
+        it { is_expected.to eq(Datadog::Ext::Transport::HTTP::DEFAULT_HOST) }
+      end
+    end
+  end
+
+  describe '.default_port' do
+    subject(:default_port) { described_class.default_port }
+
+    context 'when environment variable is' do
+      context 'set' do
+        let(:value) { '1234' }
+
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::Transport::HTTP::ENV_DEFAULT_PORT => value) do
+            example.run
+          end
+        end
+
+        it { is_expected.to eq(value.to_i) }
+      end
+
+      context 'not set' do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::Transport::HTTP::ENV_DEFAULT_PORT => nil) do
+            example.run
+          end
+        end
+
+        it { is_expected.to eq(Datadog::Ext::Transport::HTTP::DEFAULT_PORT) }
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ require 'support/synchronization_helpers'
 require 'support/log_helpers'
 require 'support/http_helpers'
 require 'support/metric_helpers'
+require 'support/container_helpers'
 
 WebMock.allow_net_connect!
 WebMock.disable!
@@ -31,6 +32,7 @@ RSpec.configure do |config|
   config.include SynchronizationHelpers
   config.include LogHelpers
   config.include MetricHelpers
+  config.include ContainerHelpers
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/container_helpers.rb
+++ b/spec/support/container_helpers.rb
@@ -1,0 +1,123 @@
+require 'stringio'
+
+# rubocop:disable Metrics/ModuleLength
+module ContainerHelpers
+  shared_context 'cgroup file' do
+    let(:cgroup_file) { StringIO.new }
+
+    before do
+      allow(File).to receive(:open).and_call_original
+      allow(File).to receive(:open)
+        .with('/proc/self/cgroup')
+        .and_return(cgroup_file)
+    end
+  end
+
+  shared_context 'non-containerized environment' do
+    include_context 'cgroup file'
+
+    before do
+      cgroup_file.puts '12:hugetlb:/'
+      cgroup_file.puts '11:devices:/user.slice'
+      cgroup_file.puts '10:pids:/user.slice/user-1000.slice/user@1000.service'
+      cgroup_file.puts '9:memory:/user.slice'
+      cgroup_file.puts '8:cpuset:/'
+      cgroup_file.puts '7:rdma:/'
+      cgroup_file.puts '6:freezer:/'
+      cgroup_file.puts '5:perf_event:/'
+      cgroup_file.puts '4:cpu,cpuacct:/user.slice'
+      cgroup_file.puts '3:blkio:/user.slice'
+      cgroup_file.puts '2:net_cls,net_prio:/'
+      cgroup_file.puts '1:name=systemd:/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service'
+      cgroup_file.puts '0::/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service'
+      cgroup_file.rewind
+    end
+  end
+
+  shared_context 'Docker environment' do
+    include_context 'cgroup file'
+
+    let(:container_id) { '3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860' }
+
+    before do
+      cgroup_file.puts "13:name=systemd:/docker/#{container_id}"
+      cgroup_file.puts "12:pids:/docker/#{container_id}"
+      cgroup_file.puts "11:hugetlb:/docker/#{container_id}"
+      cgroup_file.puts "10:net_prio:/docker/#{container_id}"
+      cgroup_file.puts "9:perf_event:/docker/#{container_id}"
+      cgroup_file.puts "8:net_cls:/docker/#{container_id}"
+      cgroup_file.puts "7:freezer:/docker/#{container_id}"
+      cgroup_file.puts "6:devices:/docker/#{container_id}"
+      cgroup_file.puts "5:memory:/docker/#{container_id}"
+      cgroup_file.puts "4:blkio:/docker/#{container_id}"
+      cgroup_file.puts "3:cpuacct:/docker/#{container_id}"
+      cgroup_file.puts "2:cpu:/docker/#{container_id}"
+      cgroup_file.puts "1:cpuset:/docker/#{container_id}"
+      cgroup_file.rewind
+    end
+  end
+
+  shared_context 'Kubernetes environment' do
+    include_context 'cgroup file'
+
+    let(:container_id) { '3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1' }
+    let(:pod_id) { 'pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a' }
+
+    before do
+      cgroup_file.puts "11:perf_event:/kubepods/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "10:pids:/kubepods/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "9:memory:/kubepods/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "8:cpu,cpuacct:/kubepods/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "7:blkio:/kubepods/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "6:cpuset:/kubepods/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "5:devices:/kubepods/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "4:freezer:/kubepods/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "3:net_cls,net_prio:/kubepods/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "2:hugetlb:/kubepods/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "1:name=systemd:/kubepods/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.rewind
+    end
+  end
+
+  shared_context 'ECS environment' do
+    include_context 'cgroup file'
+
+    let(:container_id) { '38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce' }
+    let(:task_arn) { '5a0d5ceddf6c44c1928d367a815d890f' }
+
+    before do
+      cgroup_file.puts "9:perf_event:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "8:memory:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "7:hugetlb:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "6:freezer:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "5:devices:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "4:cpuset:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "3:cpuacct:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "2:cpu:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "1:blkio:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.rewind
+    end
+  end
+
+  shared_context 'Fargate environment' do
+    include_context 'cgroup file'
+
+    let(:container_id) { '432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da' }
+    let(:task_arn) { '55091c13-b8cf-4801-b527-f4601742204d' }
+
+    before do
+      cgroup_file.puts "11:hugetlb:/ecs/#{task_arn}/#{container_id}"
+      cgroup_file.puts "10:pids:/ecs/#{task_arn}/#{container_id}"
+      cgroup_file.puts "9:cpuset:/ecs/#{task_arn}/#{container_id}"
+      cgroup_file.puts "8:net_cls,net_prio:/ecs/#{task_arn}/#{container_id}"
+      cgroup_file.puts "7:cpu,cpuacct:/ecs/#{task_arn}/#{container_id}"
+      cgroup_file.puts "6:perf_event:/ecs/#{task_arn}/#{container_id}"
+      cgroup_file.puts "5:freezer:/ecs/#{task_arn}/#{container_id}"
+      cgroup_file.puts "4:devices:/ecs/#{task_arn}/#{container_id}"
+      cgroup_file.puts "3:blkio:/ecs/#{task_arn}/#{container_id}"
+      cgroup_file.puts "2:memory:/ecs/#{task_arn}/#{container_id}"
+      cgroup_file.puts "1:name=systemd:/ecs/#{task_arn}/#{container_id}"
+      cgroup_file.rewind
+    end
+  end
+end


### PR DESCRIPTION
To make it easier to correlate traces with infrastructure, this pull request adds container info tags to traces, if available.

TODO:

- [X] Module for reading container info from environment
- [x] Add container info as header to transport request