### PR TITLE
Refactor Datadog::Metrics constants

### DIFF
--- a/lib/ddtrace/ext/metrics.rb
+++ b/lib/ddtrace/ext/metrics.rb
@@ -1,6 +1,11 @@
 module Datadog
   module Ext
     module Metrics
+      DEFAULT_HOST = '127.0.0.1'.freeze
+      DEFAULT_PORT = 8125
+      ENV_DEFAULT_HOST = 'DD_AGENT_HOST'.freeze
+      ENV_DEFAULT_PORT = 'DD_METRIC_AGENT_PORT'.freeze
+
       TAG_LANG = 'language'.freeze
       TAG_LANG_INTERPRETER = 'language-interpreter'.freeze
       TAG_LANG_VERSION = 'language-version'.freeze


### PR DESCRIPTION
This pull request moves some constants for `Datadog::Metrics` to the `Ext::Metrics` module, and fills in some missing unit tests for `Datadog::Metrics`.