### PR TITLE
Improve labeling of Sidekiq traces when using Delayed Extensions

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -446,6 +446,7 @@ elsif Gem::Version.new('2.3.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'dalli'
       gem 'delayed_job'
       gem 'delayed_job_active_record'
+      gem 'ruby-prof', '< 1.0'
       gem 'elasticsearch-transport'
       gem 'excon'
       gem 'grape'

--- a/lib/ddtrace/contrib/sidekiq/tracing.rb
+++ b/lib/ddtrace/contrib/sidekiq/tracing.rb
@@ -18,6 +18,8 @@ module Datadog
         def job_resource(job)
           if job['wrapped']
             job['wrapped']
+          elsif job['class'] == 'Sidekiq::Extensions::DelayedClass'
+            YAML.load(job['args'].first)[0..1].join('.') rescue job['class'] # rubocop:disable Security/YAMLLoad
           else
             job['class']
           end

--- a/test/contrib/sidekiq/client_tracer_test.rb
+++ b/test/contrib/sidekiq/client_tracer_test.rb
@@ -7,6 +7,10 @@ class ClientTracerTest < TracerTestBase
     def perform(); end
   end
 
+  class DelayableClass
+    def self.do_work; end
+  end
+
   def setup
     super
 
@@ -20,6 +24,7 @@ class ClientTracerTest < TracerTestBase
     end
 
     Sidekiq::Testing.server_middleware.clear
+    Sidekiq::Extensions.enable_delay!
   end
 
   def test_empty
@@ -55,5 +60,10 @@ class ClientTracerTest < TracerTestBase
     assert_equal('default', span.get_tag('sidekiq.job.queue'))
     assert_equal(0, span.status)
     assert_nil(span.parent)
+  end
+
+  def test_delayed_extensions
+    DelayableClass.delay.do_work
+    assert_equal('ClientTracerTest::DelayableClass.do_work', @writer.spans.first.resource)
   end
 end

--- a/test/contrib/sidekiq/server_tracer_test.rb
+++ b/test/contrib/sidekiq/server_tracer_test.rb
@@ -27,6 +27,10 @@ class ServerTracerTest < TracerTestBase
     def perform(); end
   end
 
+  class DelayableClass
+    def self.do_work; end
+  end
+
   def setup
     super
 
@@ -34,6 +38,7 @@ class ServerTracerTest < TracerTestBase
       chain.add(Datadog::Contrib::Sidekiq::ServerTracer,
                 tracer: @tracer, enabled: true)
     end
+    Sidekiq::Extensions.enable_delay!
   end
 
   def test_empty
@@ -93,5 +98,10 @@ class ServerTracerTest < TracerTestBase
     assert_equal('default', custom.get_tag('sidekiq.job.queue'))
     assert_equal(0, custom.status)
     assert_nil(custom.parent)
+  end
+
+  def test_delayed_extensions
+    DelayableClass.delay.do_work
+    assert_equal('ServerTracerTest::DelayableClass.do_work', @writer.spans.first.resource)
   end
 end


### PR DESCRIPTION
We rely heavily on [Sidekiq's delayed extensions](https://github.com/mperham/sidekiq/wiki/Delayed-extensions) to background any non-request work without needing to define lots of trivial worker classes.

As a result, practically all of the traces for our sidekiq service in Datadog are lumped under a single label:

![](https://cl.ly/e45636ba612e/Screen%20Shot%202019-08-22%20at%209.45.11%20PM.png)

We have been running with this small patch to improve the labeling and now get much more granular traces:

![](https://cl.ly/4e4fa95f6393/Screen%20Shot%202019-08-23%20at%203.54.44%20PM.png)

The patch is based on [similar code in Sidekiq's job class](https://github.com/mperham/sidekiq/blob/148afbf0779b246d82a95fa1b6b984c67ebf6229/lib/sidekiq/api.rb#L346-L349). I'd have used that helper directly except that this middleware only has access to the job payload and not a job object.

Open to better (or just more efficient) ways of accomplishing this, as well as any other feedback.