### PR TITLE
[resque] Rewrite Resque integration

### DIFF
--- a/lib/ddtrace/contrib/resque/enqueue.rb
+++ b/lib/ddtrace/contrib/resque/enqueue.rb
@@ -1,0 +1,24 @@
+module Datadog
+  module Contrib
+    module Resque
+      module Enqueue
+        def enqueue_to(queue_name, klass, *args)
+          pin = Datadog::Pin.get_from(::Resque)
+          return super(queue_name, klass, *args) unless pin && pin.enabled?
+
+          # DEV: Do not set a service name
+          #   Otherwise these spans will be grouped together with
+          #   the other "resque" spans and be considered for the
+          #   top level operation name
+          pin.tracer.trace(Ext::SPAN_ENQUEUE) do |span|
+            span.resource = klass.name
+            span.set_tag(Ext::TAG_QUEUE, queue_name)
+            span.set_tag(Ext::TAG_CLASS, klass.name)
+
+            return super(queue_name, klass, *args)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/resque/ext.rb
+++ b/lib/ddtrace/contrib/resque/ext.rb
@@ -8,6 +8,14 @@ module Datadog
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_RESQUE_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'resque'.freeze
         SPAN_JOB = 'resque.job'.freeze
+        SPAN_JOB_PERFORM = 'resque.job.perform'.freeze
+        SPAN_ENQUEUE = 'resque.enqueue'.freeze
+        SPAN_JOB_AFTER_HOOK = 'resque.job.after_hook'.freeze
+        SPAN_JOB_FAILURE_HOOK = 'resque.job.failure_hook'.freeze
+        SPAN_JOB_AROUND_HOOK = 'resque.job.around_hook'.freeze
+        SPAN_JOB_BEFORE_HOOK = 'resque.job.before_hook'.freeze
+        TAG_QUEUE = 'resque.queue'.freeze
+        TAG_CLASS = 'resque.class'.freeze
       end
     end
   end

--- a/lib/ddtrace/contrib/resque/job.rb
+++ b/lib/ddtrace/contrib/resque/job.rb
@@ -1,0 +1,57 @@
+require 'ddtrace/contrib/resque/utils'
+require 'resque/plugin'
+
+module Datadog
+  module Contrib
+    module Resque
+      module Job
+        def perform
+          pin = Datadog::Pin.get_from(::Resque)
+          return super unless pin && pin.enabled?
+
+          return super unless has_payload_class? && !payload_class.class_variable_defined?(:@@__datadog_patched)
+
+          job = self
+          payload_class.class_eval do
+            @@__datadog_patched = true
+
+            singleton_class.class_eval do
+
+              prepend(
+                Module.new do
+                  job.before_hooks.each do |hook_name|
+                    define_method(hook_name, Utils.hook_wrapper(hook_name, Ext::SPAN_JOB_BEFORE_HOOK))
+                  end
+
+                  job.after_hooks.each do |hook_name|
+                    define_method(hook_name, Utils.hook_wrapper(hook_name, Ext::SPAN_JOB_AFTER_HOOK))
+                  end
+
+                  job.failure_hooks.each do |hook_name|
+                    define_method(hook_name, Utils.hook_wrapper(hook_name, Ext::SPAN_JOB_FAILURE_HOOK))
+                  end
+
+                  job.around_hooks.each do |hook_name|
+                    define_method(hook_name) do |*args, &block|
+                      pin = Datadog::Pin.get_from(::Resque)
+                      return super(*args) unless pin && pin.enabled?
+
+                      pin.tracer.trace(Ext::SPAN_JOB_AROUND_HOOK, service: pin.service_name) do |span|
+                        span.resource = "#{self.name}.#{hook_name}"
+                        return super(*args, &block)
+                      end
+                    end
+                  end
+
+                  define_method(:perform, Utils.hook_wrapper('perform', Ext::SPAN_JOB_PERFORM))
+                end
+              )
+            end
+          end
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/resque/utils.rb
+++ b/lib/ddtrace/contrib/resque/utils.rb
@@ -1,0 +1,19 @@
+module Datadog
+  module Contrib
+    module Resque
+      module Utils
+        def self.hook_wrapper(hook_name, span_name)
+          Proc.new do |*args|
+            pin = Datadog::Pin.get_from(::Resque)
+            return super(*args) unless pin && pin.enabled?
+
+            pin.tracer.trace(span_name, service: pin.service_name) do |span|
+              span.resource = "#{self.name}.#{hook_name}"
+              return super(*args)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/resque/worker.rb
+++ b/lib/ddtrace/contrib/resque/worker.rb
@@ -1,0 +1,61 @@
+require 'ddtrace/contrib/analytics'
+require 'resque'
+
+module Datadog
+  module Contrib
+    module Resque
+      module Worker
+        def report_failed_job(job, exception)
+          pin = Datadog::Pin.get_from(::Resque)
+          return super(job, exception) unless pin && pin.enabled?
+
+          span = pin.tracer.active_span
+          return super(job, exception) unless span
+
+          span.set_error(exception)
+          super(job, exception)
+        end
+
+        def perform(job)
+          pin = Datadog::Pin.get_from(::Resque)
+          return super(job) unless pin && pin.enabled?
+
+          datadog_configuration = Datadog.configuration[:resque]
+          return super(job) unless datadog_configuration
+
+          # Clear out any existing context since we forked
+          # DEV: Otherwise we would inherit from any existing context in the parent process
+          pin.tracer.provider.context = nil if fork_per_job?
+
+          pin.tracer.trace(Ext::SPAN_JOB, service: pin.service_name) do |span|
+            begin
+              span.resource = job.payload_class_name
+              span.span_type = Datadog::Ext::AppTypes::WORKER
+              span.set_tag(Ext::TAG_QUEUE, job.queue)
+              span.set_tag(Ext::TAG_CLASS, job.payload_class_name)
+
+              # Set analytics sample rate
+              if Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])
+                Contrib::Analytics.set_sample_rate(span, datadog_configuration[:analytics_sample_rate])
+              end
+            rescue StandardError => e
+              Datadog::Tracer.log.error("Failed to setup Resque task span: #{e}")
+            end
+
+            begin
+              return super(job)
+            ensure
+              yield job if block_given?
+            end
+          end
+        ensure
+          # Manually shutdown the tracer and wait for final flush if we were forked
+          if fork_per_job?
+            pin.tracer.shutdown!
+            pin.tracer.writer.worker.join
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
While looking into an issue with Resque I took a little time to rethink how we are instrumenting Resque.

With this I was able to add more visibility, like `before_perform`/`after_perform` hooks, and tracing the call for `Resque.enqueue_to`.

This also no longer requires you to manually specify which jobs to trace (`c.use :resque, workers: []`)