### PR TITLE
Add integration configuration options

### DIFF
--- a/lib/ddtrace/configuration/options.rb
+++ b/lib/ddtrace/configuration/options.rb
@@ -60,7 +60,7 @@ module Datadog
           options[name].get
         end
 
-        def to_h
+        def options_hash
           options.each_with_object({}) do |(key, _), hash|
             hash[key] = get_option(key)
           end

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -59,6 +59,10 @@ module Datadog
         yield(self) if block_given?
       end
 
+      def to_h
+        options_hash
+      end
+
       def reset!
         reset_options!
       end

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -59,6 +59,10 @@ module Datadog
         yield(self) if block_given?
       end
 
+      def reset!
+        reset_options!
+      end
+
       def distributed_tracing
         # TODO: Move distributed tracing configuration to it's own Settings sub-class
         # DEV: We do this to fake `Datadog.configuration.distributed_tracing.propagation_inject_style`

--- a/lib/ddtrace/contrib/configuration/integration.rb
+++ b/lib/ddtrace/contrib/configuration/integration.rb
@@ -30,43 +30,45 @@ module Datadog
           elsif args.first == true
             enable!
           elsif args.any? || block_given?
-            add_configuration_callback(*args, &block)
+            if definition.defer?
+              add_apply_callback(*args, &block)
+            else
+              apply!(*args, &block)
+            end
           end
         end
 
-        # Add a configuration callback
-        def add_configuration_callback(*args, &block)
-          # Defer execution by wrapping in a proc
-          callback = proc do
-            Datadog.configuration.set(
-              definition.name,
-              *args,
-              &block
-            )
-          end
+        # Add a callback that applies configuration
+        # when the integration is activated.
+        def add_apply_callback(*args, &block)
+          callbacks << proc { apply!(*args, &block) }
+        end
 
-          # Add callback to collection
-          callbacks << callback
+        # Apply configuration to integration
+        def apply!(*args, &block)
+          Datadog.configuration.set(
+            definition.name,
+            *args,
+            &block
+          )
+        end
+
+        def activate!
+          Datadog.configuration.use(definition.name)
         end
 
         # Apply configuration and activate the integration
-        def activate!(*args, &block)
+        def apply_and_activate!(*args, &block)
           return unless enabled?
 
-          # Apply default settings to block first
-          if block_given?
-            Datadog.configuration.set(
-              definition.name,
-              *args,
-              &block
-            )
-          end
+          # First apply any supplied configuration to the integration
+          apply!(*args, &block)
 
           # Then apply all configuration callbacks
           callbacks.each(&:call)
 
           # Then activate the integration
-          Datadog.configuration.use(definition.name)
+          activate!
         end
 
         def reset

--- a/lib/ddtrace/contrib/configuration/integration.rb
+++ b/lib/ddtrace/contrib/configuration/integration.rb
@@ -1,0 +1,79 @@
+module Datadog
+  module Contrib
+    module Configuration
+      # Represents an instance of a configurable integration
+      class Integration
+        attr_reader \
+          :definition,
+          :callbacks
+
+        def initialize(definition)
+          @definition = definition
+          reset
+        end
+
+        def enable!
+          @enabled = true
+        end
+
+        def disable!
+          @enabled = false
+        end
+
+        def enabled?
+          @enabled == true
+        end
+
+        def configure(*args, &block)
+          if args.first == false
+            disable!
+          elsif args.first == true
+            enable!
+          elsif args.any? || block_given?
+            add_configuration_callback(*args, &block)
+          end
+        end
+
+        # Add a configuration callback
+        def add_configuration_callback(*args, &block)
+          # Defer execution by wrapping in a proc
+          callback = proc do
+            Datadog.configuration.set(
+              definition.name,
+              *args,
+              &block
+            )
+          end
+
+          # Add callback to collection
+          callbacks << callback
+        end
+
+        # Apply configuration and activate the integration
+        def activate!(*args, &block)
+          return unless enabled?
+
+          # Apply default settings to block first
+          if block_given?
+            Datadog.configuration.set(
+              definition.name,
+              *args,
+              &block
+            )
+          end
+
+          # Then apply all configuration callbacks
+          callbacks.each(&:call)
+
+          # Then activate the integration
+          Datadog.configuration.use(definition.name)
+        end
+
+        def reset
+          @enabled = definition.enabled?
+          @callbacks = []
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/configuration/integration_definition.rb
+++ b/lib/ddtrace/contrib/configuration/integration_definition.rb
@@ -7,10 +7,15 @@ module Datadog
           :default_configuration_name,
           :name
 
-        def initialize(name, meta = {}, &block)
+        def initialize(name, meta = {})
           @name = name.to_sym
           @enabled = meta.fetch(:enabled, true)
+          @defer = meta.fetch(:defer, false)
           @default_configuration_name = meta.fetch(:default_configuration_name, :default)
+        end
+
+        def defer?
+          @defer == true
         end
 
         def enabled?

--- a/lib/ddtrace/contrib/configuration/integration_definition.rb
+++ b/lib/ddtrace/contrib/configuration/integration_definition.rb
@@ -1,0 +1,22 @@
+module Datadog
+  module Contrib
+    module Configuration
+      # Represents a definition for an integration configuration
+      class IntegrationDefinition
+        attr_reader \
+          :default_configuration_name,
+          :name
+
+        def initialize(name, meta = {}, &block)
+          @name = name.to_sym
+          @enabled = meta.fetch(:enabled, true)
+          @default_configuration_name = meta.fetch(:default_configuration_name, :default)
+        end
+
+        def enabled?
+          @enabled == true
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/configuration/integration_definition.rb
+++ b/lib/ddtrace/contrib/configuration/integration_definition.rb
@@ -4,14 +4,14 @@ module Datadog
       # Represents a definition for an integration configuration
       class IntegrationDefinition
         attr_reader \
-          :default_configuration_name,
-          :name
+          :name,
+          :default
 
         def initialize(name, meta = {})
           @name = name.to_sym
           @enabled = meta.fetch(:enabled, true)
           @defer = meta.fetch(:defer, false)
-          @default_configuration_name = meta.fetch(:default_configuration_name, :default)
+          @default = block if block_given?
         end
 
         def defer?

--- a/lib/ddtrace/contrib/configuration/integration_definition.rb
+++ b/lib/ddtrace/contrib/configuration/integration_definition.rb
@@ -7,7 +7,7 @@ module Datadog
           :name,
           :default
 
-        def initialize(name, meta = {})
+        def initialize(name, meta = {}, &block)
           @name = name.to_sym
           @enabled = meta.fetch(:enabled, true)
           @defer = meta.fetch(:defer, false)

--- a/lib/ddtrace/contrib/configuration/integration_definition_set.rb
+++ b/lib/ddtrace/contrib/configuration/integration_definition_set.rb
@@ -1,0 +1,9 @@
+module Datadog
+  module Contrib
+    module Configuration
+      # Represents a set of integration definitions
+      class IntegrationDefinitionSet < Hash
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/configuration/integration_set.rb
+++ b/lib/ddtrace/contrib/configuration/integration_set.rb
@@ -1,0 +1,9 @@
+module Datadog
+  module Contrib
+    module Configuration
+      # Represents a set of integration configurations
+      class IntegrationSet < Hash
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/configuration/integrations.rb
+++ b/lib/ddtrace/contrib/configuration/integrations.rb
@@ -50,15 +50,15 @@ module Datadog
 
         # Instance behavior for a configuration object with options
         module InstanceMethods
+          def integrations
+            @integrations ||= IntegrationSet.new
+          end
+
           # Applies configuration and activates an integration
-          # TODO: Implement #use/#set/#[] from Extensions instead
+          # TODO: Merge behavior with #use/#set/#[] from Extensions instead
           def apply_and_activate!(name, *args, &block)
             integration = get_integration(name)
             integration.apply_and_activate!(*args, &block)
-          end
-
-          def integrations
-            @integrations ||= IntegrationSet.new
           end
 
           def configure_integration(name, *args, &block)

--- a/lib/ddtrace/contrib/configuration/integrations.rb
+++ b/lib/ddtrace/contrib/configuration/integrations.rb
@@ -24,9 +24,9 @@ module Datadog
 
           protected
 
-          def integration(name, meta = {})
+          def integration(name, meta = {}, &block)
             assert_valid_integration!(name)
-            integrations[name] = IntegrationDefinition.new(name, meta).tap do
+            integrations[name] = IntegrationDefinition.new(name, meta, &block).tap do
               define_integration_accessors(name)
             end
           end
@@ -86,7 +86,7 @@ module Datadog
           def add_integration(name)
             assert_valid_integration!(name)
             definition = self.class.integrations[name]
-            Integration.new(definition).tap do |integration|
+            Integration.new(definition, self).tap do |integration|
               integrations[name] = integration
             end
           end

--- a/lib/ddtrace/contrib/configuration/integrations.rb
+++ b/lib/ddtrace/contrib/configuration/integrations.rb
@@ -1,0 +1,106 @@
+require 'ddtrace/contrib/configuration/integration'
+require 'ddtrace/contrib/configuration/integration_set'
+require 'ddtrace/contrib/configuration/integration_definition'
+require 'ddtrace/contrib/configuration/integration_definition_set'
+
+module Datadog
+  module Contrib
+    module Configuration
+      # Behavior for a configuration object that contains integration settings
+      module Integrations
+        def self.included(base)
+          base.send(:extend, ClassMethods)
+          base.send(:include, InstanceMethods)
+        end
+
+        # Class behavior for a configuration object that contains integration settings
+        module ClassMethods
+          def integrations
+            @integrations ||= begin
+              # Allows for class inheritance of integration definitions
+              superclass <= Integrations ? superclass.integrations.dup : IntegrationDefinitionSet.new
+            end
+          end
+
+          protected
+
+          def integration(name)
+            assert_valid_integration!(name)
+            integrations[name] = IntegrationDefinition.new(name).tap do
+              define_integration_accessors(name)
+            end
+          end
+
+          private
+
+          def assert_valid_integration!(name)
+            unless Datadog.registry[name]
+              raise(InvalidIntegrationDefinitionError, "Registry doesn't define the integration: #{name}")
+            end
+          end
+
+          def define_integration_accessors(name)
+            integration_name = name
+
+            define_method(integration_name) do |*args, &block|
+              configure_integration(integration_name, *args, &block)
+            end
+          end
+        end
+
+        # Instance behavior for a configuration object with options
+        module InstanceMethods
+          # Applies configuration and activates an integration
+          # TODO: Implement #use/#set/#[] from Extensions instead
+          def activate!(name, *args, &block)
+            integration = get_integration(name)
+            integration.activate!(*args, &block)
+          end
+
+          def integrations
+            @integrations ||= IntegrationSet.new
+          end
+
+          def configure_integration(name, *args, &block)
+            integration = get_integration(name)
+            integration.configure(*args, &block)
+          end
+
+          def get_integration(name)
+            add_integration(name) unless integrations.key?(name)
+            integrations[name]
+          end
+
+          def integrations_hash
+            integrations.each_with_object({}) do |(key, _), hash|
+              hash[key] = get_integration(key)
+            end
+          end
+
+          def reset_integrations!
+            integrations.values.each(&:reset)
+          end
+
+          private
+
+          def add_integration(name)
+            assert_valid_integration!(name)
+            definition = self.class.integrations[name]
+            Integration.new(definition).tap do |integration|
+              integrations[name] = integration
+            end
+          end
+
+          def assert_valid_integration!(name)
+            unless self.class.integrations.key?(name)
+              raise(InvalidIntegrationError, "#{self.class.name} doesn't use the integration: #{name}")
+            end
+          end
+        end
+
+        InvalidIntegrationDefinitionError = Class.new(StandardError)
+        InvalidIntegrationError = Class.new(StandardError)
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/configuration/integrations.rb
+++ b/lib/ddtrace/contrib/configuration/integrations.rb
@@ -24,9 +24,9 @@ module Datadog
 
           protected
 
-          def integration(name)
+          def integration(name, meta = {})
             assert_valid_integration!(name)
-            integrations[name] = IntegrationDefinition.new(name).tap do
+            integrations[name] = IntegrationDefinition.new(name, meta).tap do
               define_integration_accessors(name)
             end
           end
@@ -52,9 +52,9 @@ module Datadog
         module InstanceMethods
           # Applies configuration and activates an integration
           # TODO: Implement #use/#set/#[] from Extensions instead
-          def activate!(name, *args, &block)
+          def apply_and_activate!(name, *args, &block)
             integration = get_integration(name)
-            integration.activate!(*args, &block)
+            integration.apply_and_activate!(*args, &block)
           end
 
           def integrations

--- a/lib/ddtrace/contrib/configuration/settings.rb
+++ b/lib/ddtrace/contrib/configuration/settings.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/environment'
 require 'ddtrace/configuration/options'
+require 'ddtrace/contrib/configuration/integrations'
 
 module Datadog
   module Contrib
@@ -8,6 +9,7 @@ module Datadog
       class Settings
         extend Datadog::Environment::Helpers
         include Datadog::Configuration::Options
+        include Integrations
 
         option :service_name
         option :tracer,
@@ -37,11 +39,12 @@ module Datadog
         end
 
         def to_h
-          options_hash
+          integrations_hash.merge(options_hash)
         end
 
         def reset!
           reset_options!
+          reset_integrations!
         end
       end
     end

--- a/lib/ddtrace/contrib/configuration/settings.rb
+++ b/lib/ddtrace/contrib/configuration/settings.rb
@@ -35,6 +35,14 @@ module Datadog
         def []=(name, value)
           respond_to?("#{name}=") ? send("#{name}=", value) : set_option(name, value)
         end
+
+        def to_h
+          options_hash
+        end
+
+        def reset!
+          reset_options!
+        end
       end
     end
   end

--- a/lib/ddtrace/contrib/excon/middleware.rb
+++ b/lib/ddtrace/contrib/excon/middleware.rb
@@ -17,7 +17,7 @@ module Datadog
 
         def initialize(stack, options = {})
           super(stack)
-          @options = Datadog.configuration[:excon].to_h.merge(options)
+          @options = Datadog.configuration[:excon].options_hash.merge(options)
         end
 
         def request_call(datum)

--- a/lib/ddtrace/contrib/extensions.rb
+++ b/lib/ddtrace/contrib/extensions.rb
@@ -34,7 +34,7 @@ module Datadog
             integration.configuration(configuration_name) unless integration.nil?
           end
 
-          def use(integration_name, options = {}, &block)
+          def set(integration_name, options = {}, &block)
             integration = fetch_integration(integration_name)
 
             unless integration.nil?
@@ -42,7 +42,12 @@ module Datadog
               filtered_options = options.reject { |k, _v| k == :describes }
               integration.configure(configuration_name, filtered_options, &block)
             end
+          end
 
+          def use(integration_name, options = {}, &block)
+            set(integration_name, options, &block)
+
+            integration = fetch_integration(integration_name)
             integration.patch if integration.respond_to?(:patch)
           end
 

--- a/lib/ddtrace/contrib/faraday/middleware.rb
+++ b/lib/ddtrace/contrib/faraday/middleware.rb
@@ -14,7 +14,7 @@ module Datadog
 
         def initialize(app, options = {})
           super(app)
-          @options = datadog_configuration.to_h.merge(options)
+          @options = datadog_configuration.options_hash.merge(options)
           setup_service!
         end
 

--- a/spec/ddtrace/configuration/options_spec.rb
+++ b/spec/ddtrace/configuration/options_spec.rb
@@ -101,8 +101,8 @@ RSpec.describe Datadog::Configuration::Options do
         end
       end
 
-      describe '#to_h' do
-        subject(:hash) { options_object.to_h }
+      describe '#options_hash' do
+        subject(:hash) { options_object.options_hash }
 
         context 'when no options are defined' do
           it { is_expected.to eq({}) }

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -6,6 +6,21 @@ RSpec.describe Datadog::Configuration::Settings do
   subject(:configuration) { described_class.new(registry: registry) }
   let(:registry) { Datadog::Contrib::Registry.new }
 
+  describe '#to_h' do
+    subject(:hash) { configuration.to_h }
+    let(:options_hash) { double('options hash') }
+
+    before do
+      allow(configuration).to receive(:options_hash)
+        .and_return(options_hash)
+    end
+
+    it do
+      is_expected.to be(options_hash)
+      expect(configuration).to have_received(:options_hash)
+    end
+  end
+
   describe '#reset!' do
     subject(:reset!) { configuration.reset! }
 

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -3,9 +3,23 @@ require 'spec_helper'
 require 'ddtrace/configuration/settings'
 
 RSpec.describe Datadog::Configuration::Settings do
-  let(:configuration) { described_class.new(registry: registry) }
+  subject(:configuration) { described_class.new(registry: registry) }
   let(:registry) { Datadog::Contrib::Registry.new }
 
+  describe '#reset!' do
+    subject(:reset!) { configuration.reset! }
+
+    before do
+      allow(configuration).to receive(:reset_options!)
+      reset!
+    end
+
+    it 'resets the options' do
+      expect(configuration).to have_received(:reset_options!)
+    end
+  end
+
+  # TODO: Extract integration behavior to `contrib`
   describe '#use' do
     subject(:result) { configuration.use(name, options) }
     let(:name) { :example }

--- a/spec/ddtrace/contrib/active_record/tracer_spec.rb
+++ b/spec/ddtrace/contrib/active_record/tracer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'ActiveRecord instrumentation' do
     Article.count
 
     # Reset options (that might linger from other tests)
-    Datadog.configuration[:active_record].reset_options!
+    Datadog.configuration[:active_record].reset!
 
     Datadog.configure do |c|
       c.use :active_record, configuration_options

--- a/spec/ddtrace/contrib/analytics_examples.rb
+++ b/spec/ddtrace/contrib/analytics_examples.rb
@@ -3,9 +3,9 @@ require 'ddtrace/ext/analytics'
 RSpec.shared_examples_for 'analytics for integration' do |options = { ignore_global_flag: true }|
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog.configuration.reset_options!
+    Datadog.configuration.reset!
     example.run
-    Datadog.configuration.reset_options!
+    Datadog.configuration.reset!
   end
 
   context 'when not configured' do

--- a/spec/ddtrace/contrib/configuration/integration_definition_set_spec.rb
+++ b/spec/ddtrace/contrib/configuration/integration_definition_set_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+require 'ddtrace'
+
+RSpec.describe Datadog::Contrib::Configuration::IntegrationDefinitionSet do
+  subject(:set) { described_class.new }
+
+  it { is_expected.to be_a_kind_of(Hash) }
+end

--- a/spec/ddtrace/contrib/configuration/integration_definition_spec.rb
+++ b/spec/ddtrace/contrib/configuration/integration_definition_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+require 'ddtrace'
+
+RSpec.describe Datadog::Contrib::Configuration::IntegrationDefinition do
+  subject(:definition) { described_class.new(name, meta, &block) }
+
+  let(:name) { :foobar }
+  let(:meta) { {} }
+  let(:block) { nil }
+
+  describe '#default' do
+    subject(:default) { definition.default }
+
+    context 'when not initialized with a block' do
+      it { is_expected.to be nil }
+    end
+
+    context 'when initialized with a block' do
+      let(:block) { proc {} }
+      it { is_expected.to be block }
+    end
+  end
+
+  describe '#name' do
+    subject(:result) { definition.name }
+
+    context 'when given a String' do
+      let(:name) { 'foobar' }
+      it { is_expected.to be name.to_sym }
+    end
+
+    context 'when given a Symbol' do
+      let(:name) { :foobar }
+      it { is_expected.to be name }
+    end
+  end
+
+  describe '#defer?' do
+    subject(:defer) { definition.defer? }
+
+    context 'when initialized with nothing' do
+      it { is_expected.to be false }
+    end
+
+    context 'when initialized with true' do
+      let(:meta) { { defer: true } }
+      it { is_expected.to be true }
+    end
+
+    context 'when initialized with false' do
+      let(:meta) { { defer: false } }
+      it { is_expected.to be false }
+    end
+
+    context 'when initialized with nil' do
+      let(:meta) { { defer: nil } }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#enabled?' do
+    subject(:enabled) { definition.enabled? }
+
+    context 'when initialized with nothing' do
+      it { is_expected.to be true }
+    end
+
+    context 'when initialized with true' do
+      let(:meta) { { enabled: true } }
+      it { is_expected.to be true }
+    end
+
+    context 'when initialized with false' do
+      let(:meta) { { enabled: false } }
+      it { is_expected.to be false }
+    end
+
+    context 'when initialized with nil' do
+      let(:meta) { { enabled: nil } }
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/spec/ddtrace/contrib/configuration/integration_set_spec.rb
+++ b/spec/ddtrace/contrib/configuration/integration_set_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+require 'ddtrace'
+
+RSpec.describe Datadog::Contrib::Configuration::IntegrationSet do
+  subject(:set) { described_class.new }
+
+  it { is_expected.to be_a_kind_of(Hash) }
+end

--- a/spec/ddtrace/contrib/configuration/integration_spec.rb
+++ b/spec/ddtrace/contrib/configuration/integration_spec.rb
@@ -1,0 +1,472 @@
+require 'spec_helper'
+
+require 'ddtrace'
+
+RSpec.describe Datadog::Contrib::Configuration::Integration do
+  subject(:integration) { described_class.new(definition, context) }
+
+  let(:context) { double('configuration object') }
+  let(:definition) do
+    instance_double(
+      Datadog::Contrib::Configuration::IntegrationDefinition,
+      name: definition_name,
+      default: definition_default,
+      defer?: definition_defer?,
+      enabled?: definition_enabled?
+    )
+  end
+
+  let(:definition_name) { double('name') }
+  let(:definition_default) { proc {} }
+  let(:definition_defer?) { false }
+  let(:definition_enabled?) { true }
+
+  describe '#initialize' do
+    it { expect(integration.definition).to be(definition) }
+    it { expect(integration.callbacks).to eq([]) }
+  end
+
+  describe '#enable!' do
+    subject(:enable!) { integration.enable! }
+
+    context 'when enabled by default' do
+      let(:definition_enabled?) { true }
+      before { enable! }
+      it { expect(integration.enabled?).to be(true) }
+    end
+
+    context 'when disabled by default' do
+      let(:definition_enabled?) { false }
+      it { expect { enable! }.to change { integration.enabled? }.from(false).to(true) }
+    end
+  end
+
+  describe '#disable!' do
+    subject(:disable!) { integration.disable! }
+
+    context 'when enabled by default' do
+      let(:definition_enabled?) { true }
+      it { expect { disable! }.to change { integration.enabled? }.from(true).to(false) }
+    end
+
+    context 'when disabled by default' do
+      let(:definition_enabled?) { false }
+      before { disable! }
+      it { expect(integration.enabled?).to be(false) }
+    end
+  end
+
+  describe '#enabled?' do
+    subject(:enabled?) { integration.enabled? }
+
+    context 'when enabled by default' do
+      let(:definition_enabled?) { true }
+      it { is_expected.to be true }
+    end
+
+    context 'when disabled by default' do
+      let(:definition_enabled?) { false }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#defaults_applied?' do
+    subject(:defaults_applied?) { integration.defaults_applied? }
+
+    context 'before defaults are applied' do
+      it { is_expected.to be false }
+    end
+
+    context 'when defaults are applied' do
+      before { allow(Datadog.configuration).to receive(:set) }
+
+      it do
+        expect { integration.apply_defaults! }
+          .to change { integration.defaults_applied? }
+          .from(false)
+          .to(true)
+      end
+    end
+  end
+
+  describe '#configure' do
+    subject(:configure) { integration.configure(*args, &block) }
+    let(:args) { [] }
+    let(:block) { nil }
+
+    before { allow(Datadog.configuration).to receive(:set) }
+
+    context 'when given nothing' do
+      before { expect(Datadog.configuration).to_not receive(:set) }
+      it { expect { configure }.to_not(change { integration.enabled? }) }
+      it { expect { configure }.to_not(change { integration.callbacks }) }
+    end
+
+    context 'when given false' do
+      let(:args) { [false] }
+      let(:definition_enabled?) { true }
+      it { expect { configure }.to change { integration.enabled? }.from(true).to(false) }
+    end
+
+    context 'when given true' do
+      let(:args) { [true] }
+      let(:definition_enabled?) { false }
+      it { expect { configure }.to change { integration.enabled? }.from(false).to(true) }
+    end
+
+    context 'when given a Hash' do
+      let(:args) { [hash] }
+      let(:hash) { { foo: :bar } }
+
+      context 'and :defer is enabled by default' do
+        let(:definition_defer?) { true }
+        it { expect { configure }.to change { integration.callbacks }.from([]).to(array_including(kind_of(Proc))) }
+      end
+
+      context 'and :defer is disabled by default' do
+        let(:definition_defer?) { false }
+
+        context 'with defaults' do
+          context 'that have not been applied' do
+            before { configure }
+
+            it 'applies the defaults before applying configuration' do
+              expect(Datadog.configuration).to have_received(:set)
+                .with(definition_name)
+                .ordered
+              expect(Datadog.configuration).to have_received(:set)
+                .with(definition_name, hash)
+                .ordered
+            end
+          end
+
+          context 'that have already been applied' do
+            before do
+              integration.apply_defaults!
+              configure
+            end
+
+            it 'applies the configuration without applying defaults twice' do
+              expect(Datadog.configuration).to have_received(:set)
+                .with(definition_name)
+                .once
+                .ordered
+              expect(Datadog.configuration).to have_received(:set)
+                .with(definition_name, hash)
+                .ordered
+            end
+          end
+        end
+      end
+    end
+
+    context 'when given a block' do
+      let(:block) { proc {} }
+
+      context 'and :defer is enabled by default' do
+        let(:definition_defer?) { true }
+        it { expect { configure }.to change { integration.callbacks }.from([]).to(array_including(kind_of(Proc))) }
+      end
+
+      context 'and :defer is disabled by default' do
+        let(:definition_defer?) { false }
+
+        context 'with defaults' do
+          let(:definition_default) { proc { defaults } }
+          before { allow(context).to receive(:defaults) }
+
+          context 'that have not been applied' do
+            it 'applies the defaults before applying configuration' do
+              expect(Datadog.configuration).to receive(:set) do |name, &b|
+                @default_set ||= false
+
+                expect(name).to be(definition_name)
+
+                if @default_set
+                  expect(b).to be(block)
+                else
+                  # Verify args
+                  expect(b).to_not be(block)
+
+                  # Verify default block behavior
+                  b.call
+                  expect(context).to have_received(:defaults)
+
+                  @default_set = true
+                end
+              end
+
+              configure
+            end
+          end
+
+          context 'that have already been applied' do
+            it 'applies the configuration without applying defaults twice' do
+              integration.apply_defaults!
+
+              expect(Datadog.configuration).to receive(:set) do |name, &b|
+                expect(name).to be(definition_name)
+                expect(b).to be(block)
+              end
+
+              configure
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe '#add_callback' do
+    subject(:add_callback) { integration.add_callback(*args, &block) }
+    let(:args) { [{ foo: :bar }] }
+    let(:block) { proc {} }
+
+    it do
+      expect { add_callback }
+        .to change { integration.callbacks }
+        .from([])
+        .to(array_including(kind_of(Proc)))
+    end
+
+    describe 'adds a callback' do
+      subject(:callback) { integration.callbacks.first }
+
+      before { add_callback }
+
+      it 'that sets configuration with the arguments provided when invoked' do
+        expect(Datadog.configuration).to receive(:set) do |name, *a, &b|
+          expect(name).to be(definition_name)
+          expect(a).to eq(args)
+          expect(b).to be(block)
+        end
+
+        callback.call
+      end
+    end
+  end
+
+  describe '#apply!' do
+    subject(:apply!) { integration.apply!(*args, &block) }
+    let(:args) { [{ foo: :bar }] }
+    let(:block) { proc {} }
+
+    it 'sets configuration with the arguments provided when invoked' do
+      expect(Datadog.configuration).to receive(:set) do |name, *a, &b|
+        expect(name).to be(definition_name)
+        expect(a).to eq(args)
+        expect(b).to be(block)
+      end
+
+      apply!
+    end
+  end
+
+  describe '#apply_defaults!' do
+    subject(:apply_defaults!) { integration.apply_defaults! }
+    let(:definition_default) { proc { |*args| defaults(*args) } }
+
+    before do
+      allow(Datadog.configuration).to receive(:set)
+      allow(context).to receive(:defaults)
+    end
+
+    it { expect { apply_defaults! }.to change { integration.defaults_applied? }.from(false).to(true) }
+    it 'sets configuration with defaults' do
+      expect(Datadog.configuration).to receive(:set) do |name, *_args, &block|
+        # Verify args
+        expect(name).to be(definition_name)
+        expect(block).to be_a_kind_of(Proc)
+
+        # Verify behavior default block
+        block_args = [double('arg')]
+        block.call(*block_args)
+        expect(context).to have_received(:defaults)
+          .with(*block_args)
+      end
+
+      apply_defaults!
+    end
+  end
+
+  describe '#apply_callbacks!' do
+    subject(:apply_callbacks!) { integration.apply_callbacks! }
+
+    context 'when there are callbacks' do
+      let(:first_callback_args) { { foo: :bar } }
+      let(:second_callback_args) { { bar: :baz } }
+
+      before do
+        integration.add_callback(first_callback_args)
+        integration.add_callback(second_callback_args)
+        allow(Datadog.configuration).to receive(:set)
+        apply_callbacks!
+      end
+
+      it 'invokes each callback in FIFO order' do
+        expect(Datadog.configuration).to have_received(:set)
+          .with(definition_name, first_callback_args)
+          .ordered
+
+        expect(Datadog.configuration).to have_received(:set)
+          .with(definition_name, second_callback_args)
+          .ordered
+      end
+    end
+  end
+
+  describe '#apply_and_activate!' do
+    subject(:apply_and_activate!) { integration.apply_and_activate!(*args, &block) }
+    let(:args) { [{ foo: :bar }] }
+    let(:block) { proc {} }
+
+    let(:definition_defer?) { true }
+    let(:callback_args) { [{ bar: :baz }] }
+    let(:callback_block) { proc {} }
+
+    before do
+      # Add a callback to test with
+      integration.configure(*callback_args, &callback_block)
+    end
+
+    context 'when disabled' do
+      before { integration.disable! }
+
+      it do
+        expect(Datadog.configuration).to_not receive(:use)
+        expect(Datadog.configuration).to_not receive(:set)
+        apply_and_activate!
+      end
+    end
+
+    context 'when enabled' do
+      before { integration.enable! }
+
+      context 'and defaults' do
+        let(:definition_default) { proc { defaults } }
+
+        before do
+          allow(Datadog.configuration).to receive(:use)
+          allow(Datadog.configuration).to receive(:set)
+          allow(context).to receive(:defaults)
+        end
+
+        context 'have already been applied' do
+          before { integration.apply_defaults! }
+
+          it do
+            expect(Datadog.configuration).to receive(:set) do |name, *a, &b|
+              @count ||= 0
+
+              expect(name).to eq(definition_name)
+
+              case @count
+              when 0
+                # First the callbacks
+                expect(a).to eq(callback_args)
+                expect(b).to be(callback_block)
+              when 1
+                # Then the overrides
+                expect(a).to eq(args)
+                expect(b).to be(block)
+              else
+                raise '#set called more than twice! Expected only twice'
+              end
+
+              @count += 1
+            end.twice.ordered
+
+            # Finally the activation
+            expect(Datadog.configuration).to receive(:use)
+              .with(definition_name)
+              .ordered
+
+            apply_and_activate!
+          end
+        end
+
+        context 'have not been applied' do
+          it do
+            # First the defaults
+            expect(Datadog.configuration).to receive(:set)
+              .with(definition_name)
+              .ordered
+
+            # Then the callbacks
+            expect(Datadog.configuration).to receive(:set)
+              .with(definition_name, *callback_args)
+              .ordered
+
+            # Then the overrides
+            expect(Datadog.configuration).to receive(:set)
+              .with(definition_name, *args)
+              .ordered
+
+            # Finally the activation
+            expect(Datadog.configuration).to receive(:use)
+              .with(definition_name)
+              .ordered
+
+            apply_and_activate!
+          end
+        end
+      end
+    end
+  end
+
+  describe '#activate!' do
+    subject(:activate!) { integration.activate! }
+
+    before { allow(Datadog.configuration).to receive(:use) }
+
+    context 'when enabled' do
+      before { integration.enable! }
+
+      it do
+        activate!
+        expect(Datadog.configuration).to have_received(:use)
+          .with(definition_name)
+      end
+    end
+
+    context 'when disabled' do
+      before { integration.disable! }
+
+      it do
+        activate!
+        expect(Datadog.configuration).to_not have_received(:use)
+      end
+    end
+  end
+
+  describe '#reset' do
+    subject(:reset) { integration.reset }
+
+    context 'after the integration has been configured and activated' do
+      let(:definition_enabled?) { false }
+      let(:definition_defer?) { true }
+
+      before(:each) do
+        allow(Datadog.configuration).to receive(:set)
+        allow(Datadog.configuration).to receive(:use)
+
+        # Apply state changes
+        integration.configure(foo: :bar)
+        integration.apply_and_activate!
+
+        # Verify state has been set
+        expect(integration.callbacks).to have(1).items
+        expect(integration.defaults_applied?).to be true
+        expect(integration.enabled?).to be true
+
+        integration.reset
+      end
+
+      it 'resets values' do
+        expect(integration.callbacks).to be_empty
+        expect(integration.defaults_applied?).to be false
+        expect(integration.enabled?).to be false
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/configuration/integrations_spec.rb
+++ b/spec/ddtrace/contrib/configuration/integrations_spec.rb
@@ -1,0 +1,201 @@
+require 'spec_helper'
+
+require 'ddtrace'
+
+RSpec.describe Datadog::Contrib::Configuration::Integrations do
+  describe 'implemented' do
+    subject(:integrations_class) do
+      Class.new.tap do |klass|
+        klass.send(:include, described_class)
+      end
+    end
+
+    let(:integration_name) { :foo }
+
+    shared_context 'registered integration' do
+      let(:registered_integration) { instance_double(Datadog::Contrib::Integration) }
+
+      before do
+        allow(Datadog.registry).to receive(:[])
+          .with(integration_name)
+          .and_return(registered_integration)
+      end
+    end
+
+    shared_context 'defined integration' do
+      include_context 'registered integration'
+
+      let(:integration_definition) { instance_double(Datadog::Contrib::Configuration::IntegrationDefinition) }
+      let(:meta) { {} }
+      let(:block) { proc {} }
+
+      before do
+        allow(Datadog::Contrib::Configuration::IntegrationDefinition).to receive(:new) do |name, m = {}, &b|
+          expect(name).to eq(integration_name)
+          expect(m).to eq(meta)
+          expect(b).to be(block)
+
+          integration_definition
+        end
+
+        integrations_class.send(:integration, integration_name, meta, &block)
+      end
+    end
+
+    describe 'class behavior' do
+      describe '#integrations' do
+        subject(:integrations) { integrations_class.integrations }
+
+        context 'for a class directly implementing Integrations' do
+          it { is_expected.to be_a_kind_of(Datadog::Contrib::Configuration::IntegrationDefinitionSet) }
+        end
+
+        context 'on class inheriting from a class implementing Integrations' do
+          let(:parent_class) do
+            Class.new.tap do |klass|
+              klass.send(:include, described_class)
+            end
+          end
+          let(:integrations_class) { Class.new(parent_class) }
+
+          context 'which defines some integrations' do
+            include_context 'registered integration'
+
+            before { parent_class.send(:integration, integration_name) }
+
+            it { is_expected.to be_a_kind_of(Datadog::Contrib::Configuration::IntegrationDefinitionSet) }
+            it { is_expected.to_not be(parent_class.integrations) }
+            it { is_expected.to include(integration_name) }
+          end
+        end
+      end
+
+      describe '#integration' do
+        subject(:integration) { integrations_class.send(:integration, integration_name, meta, &block) }
+
+        let(:meta) { {} }
+        let(:block) { proc {} }
+
+        context 'when the integration is registered' do
+          include_context 'registered integration'
+
+          it 'creates an integration definition' do
+            is_expected.to be_a_kind_of(Datadog::Contrib::Configuration::IntegrationDefinition)
+            expect(integrations_class.integrations).to include(integration_name)
+            expect(integrations_class.new).to respond_to(integration_name)
+          end
+        end
+      end
+    end
+
+    describe 'instance behavior' do
+      subject(:integrations_context) { integrations_class.new }
+
+      shared_context 'configurable integration' do
+        include_context 'defined integration'
+
+        let(:integration) { instance_double(Datadog::Contrib::Configuration::Integration) }
+
+        before do
+          allow(Datadog::Contrib::Configuration::Integration).to receive(:new)
+            .with(integration_definition, integrations_context)
+            .and_return(integration)
+        end
+      end
+
+      describe '#integrations' do
+        subject(:integrations) { integrations_context.integrations }
+        it { is_expected.to be_a_kind_of(Datadog::Contrib::Configuration::IntegrationSet) }
+      end
+
+      describe '#apply_and_activate!' do
+        subject(:apply_and_activate!) { integrations_context.apply_and_activate!(integration_name, *args, &block) }
+        let(:args) { [{ bar: :baz }] }
+        let(:block) { proc {} }
+
+        context 'when the integration is defined' do
+          include_context 'configurable integration'
+
+          it 'applies and activates the integration' do
+            expect(integration).to receive(:apply_and_activate!) do |*a, &b|
+              expect(a).to eq(args)
+              expect(b).to be(block)
+            end
+
+            apply_and_activate!
+          end
+        end
+
+        context 'when the integration is not defined' do
+          it { expect { apply_and_activate! }.to raise_error(described_class::InvalidIntegrationError) }
+        end
+      end
+
+      describe '#configure_integration' do
+        subject(:configure_integration) { integrations_context.configure_integration(integration_name, *args, &block) }
+        let(:args) { [{ bar: :baz }] }
+        let(:block) { proc {} }
+
+        context 'when the integration is defined' do
+          include_context 'configurable integration'
+
+          it 'configures the integration' do
+            expect(integration).to receive(:configure) do |*a, &b|
+              expect(a).to eq(args)
+              expect(b).to be(block)
+            end
+
+            configure_integration
+          end
+        end
+
+        context 'when the integration is not defined' do
+          it { expect { configure_integration }.to raise_error(described_class::InvalidIntegrationError) }
+        end
+      end
+
+      describe '#get_integration' do
+        subject(:get_integration) { integrations_context.get_integration(integration_name) }
+
+        context 'when the integration is defined' do
+          include_context 'configurable integration'
+
+          it { is_expected.to be(integration) }
+        end
+
+        context 'when the integration is not defined' do
+          it { expect { get_integration }.to raise_error(described_class::InvalidIntegrationError) }
+        end
+      end
+
+      describe '#integrations_hash' do
+        subject(:integrations_hash) { integrations_context.integrations_hash }
+
+        context 'when no integrations are defined' do
+          it { is_expected.to eq({}) }
+        end
+
+        context 'when integrations are configured' do
+          include_context 'configurable integration'
+          before { integrations_context.get_integration(integration_name) }
+          it { is_expected.to eq(foo: integration) }
+        end
+      end
+
+      describe '#reset_integrations!' do
+        subject(:reset_integrations!) { integrations_context.reset_integrations! }
+
+        context 'when an integration is configured' do
+          include_context 'configurable integration'
+
+          before { integrations_context.get_integration(integration_name) }
+
+          it 'resets the integration to its default value' do
+            expect(integration).to receive(:reset)
+            reset_integrations!
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/configuration/settings_spec.rb
+++ b/spec/ddtrace/contrib/configuration/settings_spec.rb
@@ -9,16 +9,21 @@ RSpec.describe Datadog::Contrib::Configuration::Settings do
 
   describe '#to_h' do
     subject(:hash) { settings.to_h }
-    let(:options_hash) { double('options hash') }
+    let(:options_hash) { { option: true } }
+    let(:integrations_hash) { { integration: true } }
 
     before do
       allow(settings).to receive(:options_hash)
         .and_return(options_hash)
+
+      allow(settings).to receive(:integrations_hash)
+        .and_return(integrations_hash)
     end
 
     it do
-      is_expected.to be(options_hash)
+      is_expected.to eq(integrations_hash.merge(options_hash))
       expect(settings).to have_received(:options_hash)
+      expect(settings).to have_received(:integrations_hash)
     end
   end
 
@@ -27,11 +32,13 @@ RSpec.describe Datadog::Contrib::Configuration::Settings do
 
     before do
       allow(settings).to receive(:reset_options!)
+      allow(settings).to receive(:reset_integrations!)
       reset!
     end
 
     it 'resets the options' do
       expect(settings).to have_received(:reset_options!)
+      expect(settings).to have_received(:reset_integrations!)
     end
   end
 

--- a/spec/ddtrace/contrib/configuration/settings_spec.rb
+++ b/spec/ddtrace/contrib/configuration/settings_spec.rb
@@ -7,6 +7,34 @@ RSpec.describe Datadog::Contrib::Configuration::Settings do
 
   it { is_expected.to be_a_kind_of(Datadog::Configuration::Options) }
 
+  describe '#to_h' do
+    subject(:hash) { settings.to_h }
+    let(:options_hash) { double('options hash') }
+
+    before do
+      allow(settings).to receive(:options_hash)
+        .and_return(options_hash)
+    end
+
+    it do
+      is_expected.to be(options_hash)
+      expect(settings).to have_received(:options_hash)
+    end
+  end
+
+  describe '#reset!' do
+    subject(:reset!) { settings.reset! }
+
+    before do
+      allow(settings).to receive(:reset_options!)
+      reset!
+    end
+
+    it 'resets the options' do
+      expect(settings).to have_received(:reset_options!)
+    end
+  end
+
   describe '#options' do
     subject(:options) { settings.options }
 

--- a/spec/ddtrace/contrib/http/patcher_spec.rb
+++ b/spec/ddtrace/contrib/http/patcher_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'net/http patcher' do
 
     stub_request(:any, host)
 
-    Datadog.configuration[:http].reset_options!
+    Datadog.configuration[:http].reset!
     Datadog.configure do |c|
       c.use :http, tracer: tracer
     end

--- a/spec/ddtrace/contrib/rake/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/rake/instrumentation_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Datadog::Contrib::Rake::Instrumentation do
     skip('Rake integration incompatible.') unless Datadog::Contrib::Rake::Integration.compatible?
 
     # Reset options (that might linger from other tests)
-    Datadog.configuration[:rake].reset_options!
+    Datadog.configuration[:rake].reset!
 
     # Patch Rake
     Datadog.configure do |c|

--- a/spec/ddtrace/contrib/sequel/configuration_spec.rb
+++ b/spec/ddtrace/contrib/sequel/configuration_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Sequel configuration' do
     end
 
     describe 'when configured' do
-      after(:each) { Datadog.configuration[:sequel].reset_options! }
+      after(:each) { Datadog.configuration[:sequel].reset! }
 
       context 'only with defaults' do
         # Expect it to be the normalized adapter name.

--- a/spec/ddtrace/propagation/http_propagator_spec.rb
+++ b/spec/ddtrace/propagation/http_propagator_spec.rb
@@ -6,9 +6,9 @@ require 'ddtrace/propagation/http_propagator'
 RSpec.describe Datadog::HTTPPropagator do
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog.configuration.reset_options!
+    Datadog.configuration.reset!
     example.run
-    Datadog.configuration.reset_options!
+    Datadog.configuration.reset!
   end
 
   let(:tracer) { get_test_tracer }

--- a/test/contrib/grape/rack_app.rb
+++ b/test/contrib/grape/rack_app.rb
@@ -50,7 +50,7 @@ class BaseRackAPITest < MiniTest::Test
   def teardown
     super
     # reset the configuration
-    Datadog.configuration[:rack].reset_options!
-    Datadog.configuration[:grape].reset_options!
+    Datadog.configuration[:rack].reset!
+    Datadog.configuration[:grape].reset!
   end
 end

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -13,7 +13,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     # this prevents the overhead to reinitialize the Rails application
     # and the Rack stack
     @tracer = get_test_tracer
-    Datadog.configuration[:rails].reset_options!
+    Datadog.configuration[:rails].reset!
     Datadog.configuration[:rails][:tracer] = @tracer
     Datadog.configuration[:rails][:database_service] = get_adapter_name
     Datadog::Contrib::Rails::Framework.setup

--- a/test/contrib/rails/tracer_test.rb
+++ b/test/contrib/rails/tracer_test.rb
@@ -7,7 +7,7 @@ class TracerTest < ActionDispatch::IntegrationTest
     # don't pollute the global tracer
     @tracer = get_test_tracer
     @config = Datadog.configuration[:rails]
-    Datadog.configuration[:rails].reset_options!
+    Datadog.configuration[:rails].reset!
     @config[:tracer] = @tracer
   end
 


### PR DESCRIPTION
This PR is dependent on the changes from #808.

It introduces integration configuration options, whose purpose is to allow configuration for an integration to be captured in a settings object, and applied at a later time.

The principal use of these new settings are for meta-integrations, whose instrumentation is composed of other integrations (e.g. the Rails integration activates Rack, ActiveRecord and other instrumentation.) It will enable these meta-integrations to avoid collisions with other configurations, control how/when its sub integrations are activated, and make it possible for users to customize their behavior.

See #810, as an example of this being leveraged.