### PR TITLE
Add Rails component configuration

### DIFF
--- a/lib/ddtrace/contrib/rails/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rails/configuration/settings.rb
@@ -6,6 +6,17 @@ module Datadog
       module Configuration
         # Custom settings for the Rails integration
         class Settings < Contrib::Configuration::Settings
+          COMPONENTS = [
+            :active_record,
+            :action_view,
+            :action_pack,
+            :active_support,
+            :rack
+          ].freeze
+
+          # Define each component as an integration
+          COMPONENTS.each { |name| integration(name) }
+
           option  :analytics_enabled,
                   default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) },
                   lazy: true do |value|
@@ -58,10 +69,7 @@ module Datadog
 
           option :tracer, default: Datadog.tracer do |value|
             value.tap do
-              Datadog.configuration[:active_record][:tracer] = value
-              Datadog.configuration[:active_support][:tracer] = value
-              Datadog.configuration[:action_pack][:tracer] = value
-              Datadog.configuration[:action_view][:tracer] = value
+              COMPONENTS.each { |name| Datadog.configuration[name][:tracer] = value }
             end
           end
         end

--- a/lib/ddtrace/contrib/rails/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rails/configuration/settings.rb
@@ -15,7 +15,7 @@ module Datadog
           ].freeze
 
           # Define each component as an integration
-          COMPONENTS.each { |name| integration(name) }
+          COMPONENTS.each { |name| integration name, defer: true }
 
           option  :analytics_enabled,
                   default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) },

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -37,62 +37,57 @@ module Datadog
           # We set defaults here instead of in the patcher because we need to wait
           # for the Rails application to be fully initialized.
           Datadog.configuration[:rails].tap do |config|
-            config[:service_name] ||= Utils.app_name
-            config[:database_service] ||= "#{config[:service_name]}-#{Contrib::ActiveRecord::Utils.adapter_name}"
-            config[:controller_service] ||= config[:service_name]
-            config[:cache_service] ||= "#{config[:service_name]}-cache"
+            config.service_name ||= Utils.app_name
+            config.database_service ||= "#{config.service_name}-#{Contrib::ActiveRecord::Utils.adapter_name}"
+            config.controller_service ||= config.service_name
+            config.cache_service ||= "#{config.service_name}-cache"
           end
         end
 
         def self.activate_rack!(config)
-          Datadog.configuration.use(
-            :rack,
-            tracer: config[:tracer],
-            application: ::Rails.application,
-            service_name: config[:service_name],
-            middleware_names: config[:middleware_names],
-            distributed_tracing: config[:distributed_tracing]
-          )
+          config.activate!(:rack) do |rack|
+            rack.tracer = config.tracer
+            rack.application = ::Rails.application
+            rack.service_name = config.service_name
+            rack.middleware_names = config.middleware_names
+            rack.distributed_tracing = config.distributed_tracing
+          end
         end
 
         def self.activate_active_support!(config)
           return unless defined?(::ActiveSupport)
 
-          Datadog.configuration.use(
-            :active_support,
-            cache_service: config[:cache_service],
-            tracer: config[:tracer]
-          )
+          config.activate!(:active_support) do |active_support|
+            active_support.cache_service = config.cache_service
+            active_support.tracer = config.tracer
+          end
         end
 
         def self.activate_action_pack!(config)
           return unless defined?(::ActionPack)
 
-          Datadog.configuration.use(
-            :action_pack,
-            service_name: config[:service_name],
-            tracer: config[:tracer]
-          )
+          config.activate!(:action_pack) do |action_pack|
+            action_pack.service_name = config.service_name
+            action_pack.tracer = config.tracer
+          end
         end
 
         def self.activate_action_view!(config)
           return unless defined?(::ActionView)
 
-          Datadog.configuration.use(
-            :action_view,
-            service_name: config[:service_name],
-            tracer: config[:tracer]
-          )
+          config.activate!(:action_view) do |action_view|
+            action_view.service_name = config.service_name
+            action_view.tracer = config.tracer
+          end
         end
 
         def self.activate_active_record!(config)
           return unless defined?(::ActiveRecord)
 
-          Datadog.configuration.use(
-            :active_record,
-            service_name: config[:database_service],
-            tracer: config[:tracer]
-          )
+          config.activate!(:active_record) do |active_record|
+            active_record.service_name = config.database_service
+            active_record.tracer = config.tracer
+          end
         end
       end
     end

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -22,11 +22,11 @@ module Datadog
         def self.setup
           config = config_with_defaults
 
-          activate_rack!(config)
-          activate_active_support!(config)
-          activate_action_pack!(config)
-          activate_action_view!(config)
-          activate_active_record!(config)
+          config.apply_and_activate!(:rack)
+          config.apply_and_activate!(:active_support) if defined?(::ActiveSupport)
+          config.apply_and_activate!(:action_pack) if defined?(::ActionPack)
+          config.apply_and_activate!(:action_view) if defined?(::ActionView)
+          config.apply_and_activate!(:active_record) if defined?(::ActiveRecord)
 
           # By default, default service would be guessed from the script
           # being executed, but here we know better, get it from Rails config.
@@ -41,52 +41,6 @@ module Datadog
             config.database_service ||= "#{config.service_name}-#{Contrib::ActiveRecord::Utils.adapter_name}"
             config.controller_service ||= config.service_name
             config.cache_service ||= "#{config.service_name}-cache"
-          end
-        end
-
-        def self.activate_rack!(config)
-          config.apply_and_activate!(:rack) do |rack|
-            rack.tracer = config.tracer
-            rack.application = ::Rails.application
-            rack.service_name = config.service_name
-            rack.middleware_names = config.middleware_names
-            rack.distributed_tracing = config.distributed_tracing
-          end
-        end
-
-        def self.activate_active_support!(config)
-          return unless defined?(::ActiveSupport)
-
-          config.apply_and_activate!(:active_support) do |active_support|
-            active_support.cache_service = config.cache_service
-            active_support.tracer = config.tracer
-          end
-        end
-
-        def self.activate_action_pack!(config)
-          return unless defined?(::ActionPack)
-
-          config.apply_and_activate!(:action_pack) do |action_pack|
-            action_pack.service_name = config.service_name
-            action_pack.tracer = config.tracer
-          end
-        end
-
-        def self.activate_action_view!(config)
-          return unless defined?(::ActionView)
-
-          config.apply_and_activate!(:action_view) do |action_view|
-            action_view.service_name = config.service_name
-            action_view.tracer = config.tracer
-          end
-        end
-
-        def self.activate_active_record!(config)
-          return unless defined?(::ActiveRecord)
-
-          config.apply_and_activate!(:active_record) do |active_record|
-            active_record.service_name = config.database_service
-            active_record.tracer = config.tracer
           end
         end
       end

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -45,7 +45,7 @@ module Datadog
         end
 
         def self.activate_rack!(config)
-          config.activate!(:rack) do |rack|
+          config.apply_and_activate!(:rack) do |rack|
             rack.tracer = config.tracer
             rack.application = ::Rails.application
             rack.service_name = config.service_name
@@ -57,7 +57,7 @@ module Datadog
         def self.activate_active_support!(config)
           return unless defined?(::ActiveSupport)
 
-          config.activate!(:active_support) do |active_support|
+          config.apply_and_activate!(:active_support) do |active_support|
             active_support.cache_service = config.cache_service
             active_support.tracer = config.tracer
           end
@@ -66,7 +66,7 @@ module Datadog
         def self.activate_action_pack!(config)
           return unless defined?(::ActionPack)
 
-          config.activate!(:action_pack) do |action_pack|
+          config.apply_and_activate!(:action_pack) do |action_pack|
             action_pack.service_name = config.service_name
             action_pack.tracer = config.tracer
           end
@@ -75,7 +75,7 @@ module Datadog
         def self.activate_action_view!(config)
           return unless defined?(::ActionView)
 
-          config.activate!(:action_view) do |action_view|
+          config.apply_and_activate!(:action_view) do |action_view|
             action_view.service_name = config.service_name
             action_view.tracer = config.tracer
           end
@@ -84,7 +84,7 @@ module Datadog
         def self.activate_active_record!(config)
           return unless defined?(::ActiveRecord)
 
-          config.activate!(:active_record) do |active_record|
+          config.apply_and_activate!(:active_record) do |active_record|
             active_record.service_name = config.database_service
             active_record.tracer = config.tracer
           end

--- a/spec/ddtrace/contrib/rails/configuration_spec.rb
+++ b/spec/ddtrace/contrib/rails/configuration_spec.rb
@@ -1,0 +1,246 @@
+require 'ddtrace/contrib/rails/rails_helper'
+
+RSpec.describe 'Rails configuration' do
+  include_context 'Rails test application'
+
+  let(:routes) { { '/' => 'test#index' } }
+  let(:controllers) { [controller] }
+
+  let(:controller) do
+    stub_const('TestController', Class.new(ActionController::Base) do
+      def index
+        head :ok
+      end
+    end)
+  end
+
+  let(:tracer) { get_test_tracer }
+
+  before do
+    allow(Datadog.configuration).to receive(:use).and_call_original
+    allow(Datadog.configuration).to receive(:set).and_call_original
+  end
+
+  around do |example|
+    targets = [:rails] + Datadog::Contrib::Rails::Configuration::Settings::COMPONENTS
+
+    # Reset before and after each example; don't allow global state to linger.
+    targets.each { |t| Datadog.registry[t].reset_configuration! }
+    example.run
+    targets.each { |t| Datadog.registry[t].reset_configuration! }
+  end
+
+  describe 'for ActiveRecord' do
+    let(:rails_config) { Datadog.configuration[:rails] }
+    let(:active_record_config) { Datadog.configuration[:active_record] }
+
+    context 'by default' do
+      before do
+        Datadog.configure do |c|
+          c.use :rails
+        end
+      end
+
+      it 'is activated with default settings' do
+        # Load the app
+        app
+
+        expect(Datadog.configuration).to have_received(:use)
+          .with(:active_record, *any_args)
+
+        # Assert default settings
+        expect(active_record_config.service_name).to eq(rails_config.database_service)
+        expect(active_record_config.tracer).to eq(rails_config.tracer)
+      end
+    end
+
+    context 'when set to false' do
+      before do
+        Datadog.configure do |c|
+          c.use :rails do |rails|
+            rails.active_record false
+          end
+        end
+      end
+
+      it 'prevents ActiveRecord from being configured or patched' do
+        # Load the app
+        app
+
+        expect(Datadog.configuration).to_not have_received(:use)
+          .with(:active_record, *any_args)
+
+        expect(Datadog.configuration).to_not have_received(:set)
+          .with(:active_record, *any_args)
+      end
+    end
+
+    context 'when set to true' do
+      before do
+        Datadog.configure do |c|
+          c.use :rails do |rails|
+            rails.active_record true
+          end
+        end
+      end
+
+      it 'activates ActiveRecord instrumentation with default settings' do
+        # Load the app
+        app
+
+        expect(Datadog.configuration).to have_received(:use)
+          .with(:active_record, *any_args)
+
+        # Assert default settings
+        expect(active_record_config.service_name).to eq(rails_config.database_service)
+        expect(active_record_config.tracer).to eq(rails_config.tracer)
+      end
+    end
+
+    context 'when given options' do
+      let(:options) { { service_name: service_name } }
+      let(:service_name) { double('ActiveRecord service name') }
+
+      before do
+        Datadog.configure do |c|
+          c.use :rails do |rails|
+            rails.active_record options
+          end
+        end
+      end
+
+      it 'activates ActiveRecord instrumentation with given settings' do
+        # Load the app
+        app
+
+        expect(Datadog.configuration).to have_received(:use)
+          .with(:active_record, *any_args)
+
+        # Applies the default settings with options as overrides
+        expect(active_record_config.service_name).to eq(service_name)
+        expect(active_record_config.tracer).to eq(rails_config.tracer)
+      end
+    end
+
+    context 'when given a block' do
+      let(:service_name) { double('ActiveRecord service name') }
+
+      context 'with simple settings' do
+        before do
+          Datadog.configure do |c|
+            c.use :rails do |rails|
+              rails.active_record do |active_record|
+                active_record.service_name = service_name
+              end
+            end
+          end
+        end
+
+        it 'activates ActiveRecord instrumentation with default settings' do
+          # Load the app
+          app
+
+          expect(Datadog.configuration).to have_received(:use)
+            .with(:active_record, *any_args)
+
+          # Applies the default settings with block as override
+          expect(active_record_config.service_name).to eq(service_name)
+          expect(active_record_config.tracer).to eq(rails_config.tracer)
+        end
+      end
+
+      context 'that depends on Rails settings already being available' do
+        before do
+          Datadog.configure do |c|
+            c.use :rails do |rails|
+              rails.active_record do |active_record|
+                active_record.service_name = "#{rails.service_name}-#{service_name}"
+              end
+            end
+          end
+        end
+
+        it 'activates ActiveRecord instrumentation with given settings' do
+          # Load the app
+          app
+
+          expect(Datadog.configuration).to have_received(:use)
+            .with(:active_record, *any_args)
+
+          # Applies the default settings with block as override
+          expect(active_record_config.service_name).to eq("#{rails_config.service_name}-#{service_name}")
+          expect(active_record_config.tracer).to eq(rails_config.tracer)
+        end
+      end
+    end
+
+    context 'when given multiple blocks that describe different databases' do
+      let(:primary_service_name) { double('ActiveRecord primary service name') }
+      let(:secondary_service_name) { double('ActiveRecord secondary service name') }
+
+      before do
+        # Stub ActiveRecord::Base, to pretend its been configured
+        allow(ActiveRecord::Base).to receive(:configurations).and_return(
+          'test' => {
+            'adapter' => 'sqlite3',
+            'pool' => 5,
+            'timeout' => 5000,
+            'database' => ':memory:'
+          },
+          'primary' => {
+            'adapter' => 'sqlite3',
+            'pool' => 5,
+            'timeout' => 5000,
+            'database' => ':memory_b:'
+          },
+          'secondary' => {
+            'adapter' => 'sqlite3',
+            'pool' => 5,
+            'timeout' => 5000,
+            'database' => ':memory_c:'
+          }
+        )
+
+        Datadog.configure do |c|
+          c.use :rails do |rails|
+            rails.tracer = tracer
+
+            rails.active_record describes: :primary do |primary|
+              puts "\nPrimary: #{primary.object_id}\n"
+              primary.service_name = primary_service_name
+            end
+
+            rails.active_record describes: :secondary do |secondary|
+              puts "\nSecondary: #{secondary.object_id}\n"
+              secondary.service_name = secondary_service_name
+            end
+          end
+        end
+      end
+
+      it 'activates ActiveRecord instrumentation for each database with given settings' do
+        # Load the app
+        app
+
+        expect(Datadog.configuration).to have_received(:use)
+          .with(:active_record, *any_args)
+
+        # Applies the default settings to default config
+        expect(active_record_config.service_name).to eq(rails_config.database_service)
+        expect(active_record_config.tracer).to be(tracer)
+
+        # Applies the default settings with overrides to primary DB
+        Datadog.configuration[:active_record, :primary].tap do |primary|
+          expect(primary.service_name).to eq(primary_service_name)
+          expect(primary.tracer).to be(tracer)
+        end
+
+        # Applies the default settings with overrides to secondary DB
+        Datadog.configuration[:active_record, :secondary].tap do |secondary|
+          expect(secondary.service_name).to eq(secondary_service_name)
+          expect(secondary.tracer).to be(tracer)
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/rails/support/rails5.rb
+++ b/spec/ddtrace/contrib/rails/support/rails5.rb
@@ -34,6 +34,8 @@ RSpec.shared_context 'Rails 5 base application' do
       config.eager_load = false
       config.consider_all_requests_local = true
       config.middleware.delete ActionDispatch::DebugExceptions
+      config.active_record.sqlite3.represent_boolean_as_integer = true
+
       instance_eval(&during_init)
 
       if ENV['USE_SIDEKIQ']


### PR DESCRIPTION
This PR depends on #809.

As a follow-up to #450 and #764, this pull request adds block style configuration for Rails components available, to make configuration more expressive and customizable.

Some new configuration examples include:

```ruby
# Customize ActiveRecord with block
Datadog.configure do |c|
  c.use :rails do |rails|
    rails.service_name = 'my-app'

    rails.active_record do |active_record|
      active_record.service_name = "#{rails.service_name}-postgres"
    end
  end
end

# Customize different ActiveRecord databases with block
Datadog.configure do |c|
  c.use :rails do |rails|
    rails.service_name = 'my-app'

    rails.active_record describes: :primary_db do |active_record|
      active_record.service_name = "#{rails.service_name}-primary-db"
    end

    rails.active_record describes: :secondary_db do |active_record|
      active_record.service_name = "#{rails.service_name}-secondary-db"
    end
  end
end

# Deactivate ActiveRecord
Datadog.configure do |c|
  c.use :rails do |rails|
    rails.active_record false
  end
end
```

The Rails configuration now allows all its sub-integrations (`rack, active_record, action_view, action_pack, active_support`) and their constituent options to configured in this manner.
