### PR TITLE
Move span resource name to method

### DIFF
--- a/lib/ddtrace/contrib/faraday/middleware.rb
+++ b/lib/ddtrace/contrib/faraday/middleware.rb
@@ -71,7 +71,7 @@ module Datadog
 
           options[:service_name]
         end
-        
+
         def resource_name(env)
           env[:method].to_s.upcase
         end


### PR DESCRIPTION
Name span resource via method, similar to the service_name method.