### PR TITLE
Ignore interpreter warnings from external libraries

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -58,4 +58,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
   spec.add_development_dependency 'pry', '~> 0.10.4'
   spec.add_development_dependency 'pry-stack_explorer', '~> 0.4.9.2'
+  spec.add_development_dependency 'warning' if RUBY_VERSION >= '2.5.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,14 @@ require 'support/http_helpers'
 require 'support/metric_helpers'
 require 'support/container_helpers'
 
+begin
+  # Ignore interpreter warnings from external libraries
+  require 'warning'
+  Warning.ignore([:method_redefined, :not_reached, :unused_var], %r{.*/gems/[^/]*/lib/})
+rescue LoadError
+  puts 'warning suppressing gem not available, external library warnings will be displayed'
+end
+
 WebMock.allow_net_connect!
 WebMock.disable!
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,6 +7,14 @@ require 'ddtrace/encoding'
 require 'ddtrace/tracer'
 require 'ddtrace/span'
 
+begin
+  # Ignore interpreter warnings from external libraries
+  require 'warning'
+  Warning.ignore([:method_redefined, :not_reached, :unused_var], %r{.*/gems/[^/]*/lib/})
+rescue LoadError
+  puts 'warning suppressing gem not available, external library warnings will be displayed'
+end
+
 WebMock.allow_net_connect!
 WebMock.disable!
 


### PR DESCRIPTION
Our [test runs](https://circleci.com/gh/DataDog/dd-trace-rb/36787) are filled with interpreter errors from external libraries:
```
gems/grape-1.2.4/lib/grape/api.rb:57: warning: method redefined; discarding old inherited
gems/grape-1.2.4/lib/grape/api.rb:39: warning: previous definition of inherited was here
gems/sequel-5.24.0/lib/sequel/dataset/query.rb:84: warning: statement not reached
gems/webmock-2.3.2/lib/webmock/util/json.rb:27: warning: assigned but unused variable - pos
```

These warnings are not actionable by us, and I don't foresee us making any decisions based on information from these warnings.

This PR suppresses these four types of warnings: `:method_redefined, :not_reached, :unused_var`.

Any new warnings types introduced by Ruby in the future will be displayed.

Notably, I kept these two types of warnings: `instance variable @namespace_description not initialized` and `last argument was passed as a single Hash, although a splat keyword arguments here`.
They happen frequently, but I believe they _could_ indicate that we are not configuring a gem correctly:
```
gems/grape-1.2.4/lib/grape/dsl/routing.rb:166: warning: instance variable @namespace_description not initialized
  gems/grape-1.2.4/lib/grape/formatter.rb:16: warning: in `formatters': the last argument was passed as a single Hash
gems/grape-1.2.4/lib/grape/formatter.rb:21: warning: although a splat keyword arguments here
```