### PR TITLE
Support for Redis array arguments

### DIFF
--- a/lib/ddtrace/contrib/redis/quantize.rb
+++ b/lib/ddtrace/contrib/redis/quantize.rb
@@ -20,7 +20,9 @@ module Datadog
         end
 
         def format_command_args(command_args)
+          command_args = resolve_command_args(command_args)
           return 'AUTH ?' if auth_command?(command_args)
+
           cmd = command_args.map { |x| format_arg(x) }.join(' ')
           Utils.truncate(cmd, CMD_MAX_LEN, TOO_LONG_MARK)
         end
@@ -29,6 +31,16 @@ module Datadog
           return false unless command_args.is_a?(Array) && !command_args.empty?
           command_args.first.to_sym == :auth
         end
+
+        # Unwraps command array when Redis is called with the following syntax:
+        #   redis.call([:cmd, 'arg1', ...])
+        def resolve_command_args(command_args)
+          return command_args.first if command_args.is_a?(Array) && command_args.first.is_a?(Array)
+
+          command_args
+        end
+
+        private_class_method :auth_command?, :resolve_command_args
       end
     end
   end

--- a/spec/ddtrace/contrib/redis/quantize_spec.rb
+++ b/spec/ddtrace/contrib/redis/quantize_spec.rb
@@ -74,5 +74,10 @@ RSpec.describe Datadog::Contrib::Redis::Quantize do
         it { expect(output[496..499]).to eq('X...') }
       end
     end
+
+    context 'given a nested array' do
+      let(:args) { [[:set, 'KEY', 'VALUE']] }
+      it { is_expected.to eq('SET KEY VALUE') }
+    end
   end
 end

--- a/spec/ddtrace/contrib/redis/redis_spec.rb
+++ b/spec/ddtrace/contrib/redis/redis_spec.rb
@@ -108,6 +108,23 @@ RSpec.describe 'Redis test' do
       end
     end
 
+    context 'arguments wrapped in array' do
+      before(:each) do
+        expect(redis.call([:set, 'FOO', 'bar'])).to eq('OK')
+      end
+
+      it { expect(all_spans).to have(1).item }
+
+      describe 'span' do
+        subject(:span) { all_spans[-1] }
+
+        it do
+          expect(span.resource).to eq('SET FOO bar')
+          expect(span.get_tag('redis.raw_command')).to eq('SET FOO bar')
+        end
+      end
+    end
+
     context 'pipeline' do
       before(:each) do
         redis.pipelined do


### PR DESCRIPTION
Fixes #796

Add support for calling `redis#call` with arguments wrapped inside an array:
```ruby
require 'redis'
redis = Redis.new
redis.call([:cmd, 'arg1', ...])
```

This is a [supported call convention by `redis-rb`](https://github.com/redis/redis-rb/blob/v4.1.2/lib/redis/connection/command_helper.rb#L11-L16).