### PR TITLE
Additional cleanup for Ruby 1.9 support

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,5 +1,9 @@
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
-  raise NotImplementedError, 'Ruby versions < 2.0.0 are not supported!'
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'ddtrace/version'
+
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new(Datadog::VERSION::MINIMUM_RUBY_VERSION)
+  raise NotImplementedError, "Ruby versions < #{Datadog::VERSION::MINIMUM_RUBY_VERSION} are not supported!"
 elsif Gem::Version.new('2.0.0') <= Gem::Version.new(RUBY_VERSION) \
       && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1.0')
   if RUBY_PLATFORM != 'java'

--- a/Rakefile
+++ b/Rakefile
@@ -189,8 +189,8 @@ end
 
 desc 'CI task; it runs all tests for current version of Ruby'
 task :ci do
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
-    raise NotImplementedError, 'Ruby versions < 2.0.0 are not supported!'
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new(Datadog::VERSION::MINIMUM_RUBY_VERSION)
+    raise NotImplementedError, "Ruby versions < #{Datadog::VERSION::MINIMUM_RUBY_VERSION} are not supported!"
   elsif Gem::Version.new('2.0.0') <= Gem::Version.new(RUBY_VERSION) \
         && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1.0')
     # Main library

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -7,7 +7,7 @@ require 'ddtrace/version'
 Gem::Specification.new do |spec|
   spec.name                  = 'ddtrace'
   spec.version               = Datadog::VERSION::STRING
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = ">= #{Datadog::VERSION::MINIMUM_RUBY_VERSION}"
   spec.authors               = ['Datadog, Inc.']
   spec.email                 = ['dev@datadoghq.com']
 

--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -19,7 +19,7 @@ This guide covers some of the common how-tos and technical reference material fo
 
 The trace library uses Docker Compose to create a Ruby environment to develop and test within, as well as containers for any dependencies that might be necessary for certain kinds of tests.
 
-To start a development environment, choose a target Ruby version (e.g. between `1.9` and `2.4`) then run the following:
+To start a development environment, choose a target Ruby version then run the following:
 
 ```
 # In the root directory of the project...

--- a/lib/ddtrace/contrib/dalli/instrumentation.rb
+++ b/lib/ddtrace/contrib/dalli/instrumentation.rb
@@ -9,28 +9,11 @@ module Datadog
       # Instruments every interaction with the memcached server
       module Instrumentation
         def self.included(base)
-          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
-            base.class_eval do
-              alias_method :request_without_datadog, :request
-              remove_method :request
-              include InstanceMethods
-            end
-          else
-            base.send(:prepend, InstanceMethods)
-          end
-        end
-
-        # Compatibility shim for Rubies not supporting `.prepend`
-        module InstanceMethodsCompatibility
-          def request(*args, &block)
-            request_without_datadog(*args, &block)
-          end
+          base.send(:prepend, InstanceMethods)
         end
 
         # InstanceMethods - implementing instrumentation
         module InstanceMethods
-          include InstanceMethodsCompatibility unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')
-
           def request(op, *args)
             tracer.trace(Datadog::Contrib::Dalli::Ext::SPAN_COMMAND) do |span|
               span.resource = op.to_s.upcase

--- a/lib/ddtrace/contrib/ethon/integration.rb
+++ b/lib/ddtrace/contrib/ethon/integration.rb
@@ -18,10 +18,6 @@ module Datadog
           super && defined?(::Ethon::Easy)
         end
 
-        def self.compatible?
-          super && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')
-        end
-
         def default_configuration
           Configuration::Settings.new
         end

--- a/lib/ddtrace/contrib/grape/instrumentation.rb
+++ b/lib/ddtrace/contrib/grape/instrumentation.rb
@@ -4,48 +4,8 @@ module Datadog
       # Instrumentation for Grape::Endpoint
       module Instrumentation
         def self.included(base)
-          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
-            base.class_eval do
-              # Class methods
-              singleton_class.send(:include, ClassMethodsCompatibility)
-              singleton_class.send(:include, ClassMethods)
-
-              # Instance methods
-              include InstanceMethodsCompatibility
-              include InstanceMethods
-            end
-          else
-            base.singleton_class.send(:prepend, ClassMethods)
-            base.send(:prepend, InstanceMethods)
-          end
-        end
-
-        # Compatibility shim for Rubies not supporting `.prepend`
-        module ClassMethodsCompatibility
-          def self.included(base)
-            base.class_eval do
-              alias_method :generate_api_method_without_datadog, :generate_api_method
-              remove_method :generate_api_method
-            end
-          end
-
-          def generate_api_method(*args, &block)
-            generate_api_method_without_datadog(*args, &block)
-          end
-        end
-
-        # Compatibility shim for Rubies not supporting `.prepend`
-        module InstanceMethodsCompatibility
-          def self.included(base)
-            base.class_eval do
-              alias_method :run_without_datadog, :run
-              remove_method :run
-            end
-          end
-
-          def run(*args, &block)
-            run_without_datadog(*args, &block)
-          end
+          base.singleton_class.send(:prepend, ClassMethods)
+          base.send(:prepend, InstanceMethods)
         end
 
         # ClassMethods - implementing instrumentation

--- a/lib/ddtrace/contrib/grpc/integration.rb
+++ b/lib/ddtrace/contrib/grpc/integration.rb
@@ -20,9 +20,7 @@ module Datadog
         end
 
         def self.compatible?
-          super \
-            && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0') \
-            && version >= Gem::Version.new('0.10.0')
+          super && version >= Gem::Version.new('0.10.0')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/http/instrumentation.rb
+++ b/lib/ddtrace/contrib/http/instrumentation.rb
@@ -12,15 +12,7 @@ module Datadog
       # Instrumentation for Net::HTTP
       module Instrumentation
         def self.included(base)
-          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
-            base.class_eval do
-              # Instance methods
-              include InstanceMethodsCompatibility
-              include InstanceMethods
-            end
-          else
-            base.send(:prepend, InstanceMethods)
-          end
+          base.send(:prepend, InstanceMethods)
         end
 
         # Span hook invoked after request is completed.
@@ -31,20 +23,6 @@ module Datadog
           else
             # Get hook
             @after_request ||= nil
-          end
-        end
-
-        # Compatibility shim for Rubies not supporting `.prepend`
-        module InstanceMethodsCompatibility
-          def self.included(base)
-            base.class_eval do
-              alias_method :request_without_datadog, :request
-              remove_method :request
-            end
-          end
-
-          def request(*args, &block)
-            request_without_datadog(*args, &block)
           end
         end
 

--- a/lib/ddtrace/contrib/mysql2/instrumentation.rb
+++ b/lib/ddtrace/contrib/mysql2/instrumentation.rb
@@ -10,29 +10,7 @@ module Datadog
       # Mysql2::Client patch module
       module Instrumentation
         def self.included(base)
-          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
-            base.class_eval do
-              # Instance methods
-              include InstanceMethodsCompatibility
-              include InstanceMethods
-            end
-          else
-            base.send(:prepend, InstanceMethods)
-          end
-        end
-
-        # Mysql2::Client patch 1.9.3 instance methods
-        module InstanceMethodsCompatibility
-          def self.included(base)
-            base.class_eval do
-              alias_method :query_without_datadog, :query
-              remove_method :query
-            end
-          end
-
-          def query(*args, &block)
-            query_without_datadog(*args, &block)
-          end
+          base.send(:prepend, InstanceMethods)
         end
 
         # Mysql2::Client patch instance methods

--- a/lib/ddtrace/contrib/patchable.rb
+++ b/lib/ddtrace/contrib/patchable.rb
@@ -18,7 +18,7 @@ module Datadog
         end
 
         def compatible?
-          Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0') && present?
+          Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(VERSION::MINIMUM_RUBY_VERSION) && present?
         end
       end
 

--- a/lib/ddtrace/contrib/rake/integration.rb
+++ b/lib/ddtrace/contrib/rake/integration.rb
@@ -19,10 +19,6 @@ module Datadog
           super && defined?(::Rake)
         end
 
-        def self.compatible?
-          super && RUBY_VERSION >= '2.0.0'
-        end
-
         def default_configuration
           Configuration::Settings.new
         end

--- a/lib/ddtrace/contrib/rest_client/integration.rb
+++ b/lib/ddtrace/contrib/rest_client/integration.rb
@@ -18,10 +18,6 @@ module Datadog
           super && defined?(::RestClient::Request)
         end
 
-        def self.compatible?
-          super && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('1.9.3')
-        end
-
         def default_configuration
           Configuration::Settings.new
         end

--- a/lib/ddtrace/contrib/rest_client/request_patch.rb
+++ b/lib/ddtrace/contrib/rest_client/request_patch.rb
@@ -9,28 +9,11 @@ module Datadog
       # RestClient RequestPatch
       module RequestPatch
         def self.included(base)
-          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
-            base.class_eval do
-              alias_method :execute_without_datadog, :execute
-              remove_method :execute
-              include InstanceMethods
-            end
-          else
-            base.send(:prepend, InstanceMethods)
-          end
-        end
-
-        # Compatibility shim for Rubies not supporting `.prepend`
-        module InstanceMethodsCompatibility
-          def execute(&block)
-            execute_without_datadog(&block)
-          end
+          base.send(:prepend, InstanceMethods)
         end
 
         # InstanceMethods - implementing instrumentation
         module InstanceMethods
-          include InstanceMethodsCompatibility unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')
-
           def execute(&block)
             uri = URI.parse(url)
 

--- a/lib/ddtrace/contrib/sequel/integration.rb
+++ b/lib/ddtrace/contrib/sequel/integration.rb
@@ -19,10 +19,6 @@ module Datadog
           super && defined?(::Sequel)
         end
 
-        def self.compatible?
-          super && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')
-        end
-
         def default_configuration
           Configuration::Settings.new
         end

--- a/lib/ddtrace/ext/runtime.rb
+++ b/lib/ddtrace/ext/runtime.rb
@@ -5,13 +5,7 @@ module Datadog
     module Runtime
       # Identity
       LANG = 'ruby'.freeze
-      LANG_INTERPRETER = begin
-        if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('1.9')
-          (RUBY_ENGINE + '-' + RUBY_PLATFORM)
-        else
-          ('ruby-' + RUBY_PLATFORM)
-        end
-      end.freeze
+      LANG_INTERPRETER = (RUBY_ENGINE + '-' + RUBY_PLATFORM).freeze
       LANG_VERSION = RUBY_VERSION
       TRACER_VERSION = Datadog::VERSION::STRING
 

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -243,7 +243,7 @@ module Datadog
 
     private
 
-    if defined?(JRUBY_VERSION) || Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
+    if defined?(JRUBY_VERSION) || Gem::Version.new(RUBY_VERSION) < Gem::Version.new(VERSION::MINIMUM_RUBY_VERSION)
       def now_allocations
         0
       end

--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -6,5 +6,7 @@ module Datadog
     PRE = nil
 
     STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.')
+
+    MINIMUM_RUBY_VERSION = '2.0.0'.freeze
   end
 end

--- a/spec/ddtrace/contrib/patchable_spec.rb
+++ b/spec/ddtrace/contrib/patchable_spec.rb
@@ -36,13 +36,12 @@ RSpec.describe Datadog::Contrib::Patchable do
 
       describe '#compatible?' do
         subject(:compatible) { patchable_class.compatible? }
-        let(:expected_compatibility) { Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0') ? true : false }
 
         context 'when version' do
           context 'is defined' do
             let(:version) { double('version') }
             before(:each) { allow(patchable_class).to receive(:version).and_return(version) }
-            it { is_expected.to be expected_compatibility }
+            it { is_expected.to be true }
           end
 
           context 'is not defined' do


### PR DESCRIPTION
I noticed many occurrences of `base.class_eval`, which we primarily used for Ruby 1.X support.

This PR removes all code paths for Ruby 1.X support.

During this cleanup, I noticed it was not exactly easy to track down all occurrences of explicit Ruby version checks, and I had to resort to very broad regular expressions to the results I need.
In order to improve this for the future I extract a constant containing the minimum version of Ruby we support, and this is one part specially I'd like some feedback on:
Not having this shared constant makes future Ruby version deprecation much harder, but I'm not 100% happy with how the final result looks like.
I added that constant to `version.rb`, as that allowed us to use it from our `gemspec`, `rake`, and `Appraisals`. This makes the full namespaced constant look a little bit off to me: `Datadog::VERSION::MINIMUM_RUBY_VERSION`.
Again feedback is greatly appreciated.