### PR TITLE
Add at_exit hook for Tracer shutdown

### DIFF
--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -19,6 +19,11 @@ module Datadog
   # Load and extend Contrib by default
   require 'ddtrace/contrib/extensions'
   extend Contrib::Extensions
+
+  # Add shutdown hook:
+  # Ensures the tracer has an opportunity to flush traces
+  # and cleanup before terminating the process.
+  at_exit { Datadog.tracer.shutdown! }
 end
 
 require 'ddtrace/contrib/action_pack/integration'

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -89,8 +89,9 @@ module Datadog
     #   tracer.shutdown!
     #
     def shutdown!
-      return if !@enabled || @writer.worker.nil?
-      @writer.worker.stop
+      return unless @enabled
+
+      @writer.stop unless @writer.nil?
     end
 
     # Return the current active \Context for this traced execution. This method is

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -61,7 +61,7 @@ module Datadog
         interval: @flush_interval
       )
 
-      @worker.start()
+      @worker.start
     end
 
     # stops worker for spans.
@@ -69,6 +69,7 @@ module Datadog
       return if worker.nil?
       @worker.stop
       @worker = nil
+      true
     end
 
     # flush spans to the trace-agent, handles spans only

--- a/spec/ddtrace/contrib/resque/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/resque/instrumentation_spec.rb
@@ -113,6 +113,9 @@ RSpec.describe 'Resque instrumentation' do
           expect(tracer.active_span.parent_id).to eq(0)
         end
 
+        # On completion of the fork, `Datadog.tracer.shutdown!` will be invoked.
+        expect(tracer.writer).to receive(:stop)
+
         tracer.trace('main.process') do
           perform_job(job_class)
         end


### PR DESCRIPTION
When traced Ruby processes are terminated, they may not permit the worker an opportunity to flush existing traces. This pull request adds an `at_exit` hook that calls `shutdown!` on the Tracer, so it can be cleaned up in a more graceful fashion.