### PR TITLE
Dalli multiplexing

### DIFF
--- a/lib/ddtrace/contrib/dalli/instrumentation.rb
+++ b/lib/ddtrace/contrib/dalli/instrumentation.rb
@@ -58,7 +58,7 @@ module Datadog
           end
 
           def datadog_configuration
-            Datadog.configuration[:dalli]
+            Datadog.configuration[:dalli, "#{hostname}:#{port}"] || Datadog.configuration[:dalli]
           end
         end
       end


### PR DESCRIPTION
This pull request adds multiplexing to Dalli instrumentation. Users can define configuration using the hostname port combo of the server to apply specific instrumentation settings:

```ruby
Datadog.configure do |c|
  c.use :dalli, describes: 'localhost:1234', service_name: 'local-cache'
end
```

Then any Dalli client that sends to this hostname/port combo will have the trace settings applied, in this case commands sent to `'localhost:1234'` will be tagged as the `local-cache` service. Commands that don't match this exactly will use default settings instead.