### PR TITLE
RSpec matcher for Span error checking

### DIFF
--- a/spec/ddtrace/contrib/ethon/easy_patch_spec.rb
+++ b/spec/ddtrace/contrib/ethon/easy_patch_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Datadog::Contrib::Ethon::EasyPatch do
       end
 
       it 'has error set' do
-        expect(span.get_tag(Datadog::Ext::Errors::MSG)).to eq('Request has failed with HTTP error: 500')
+        expect(span).to have_error_message('Request has failed with HTTP error: 500')
       end
     end
 
@@ -131,7 +131,7 @@ RSpec.describe Datadog::Contrib::Ethon::EasyPatch do
       end
 
       it 'has no error set' do
-        expect(span.get_tag(Datadog::Ext::Errors::MSG)).to be_nil
+        expect(span).to_not have_error_message
       end
     end
 
@@ -148,7 +148,7 @@ RSpec.describe Datadog::Contrib::Ethon::EasyPatch do
       end
 
       it 'has error set' do
-        expect(span.get_tag(Datadog::Ext::Errors::MSG)).to eq('Request has failed: Timeout was reached')
+        expect(span).to have_error_message('Request has failed: Timeout was reached')
       end
     end
   end

--- a/spec/ddtrace/contrib/ethon/shared_examples.rb
+++ b/spec/ddtrace/contrib/ethon/shared_examples.rb
@@ -71,13 +71,13 @@ RSpec.shared_examples_for 'instrumented request' do
         end
 
         it 'has error set' do
-          expect(span.get_tag(Datadog::Ext::Errors::MSG)).to eq('Request has failed with HTTP error: 500')
+          expect(span).to have_error_message('Request has failed with HTTP error: 500')
         end
         it 'has no error stack' do
-          expect(span.get_tag(Datadog::Ext::Errors::STACK)).to be_nil
+          expect(span).to_not have_error_stack
         end
         it 'has no error type' do
-          expect(span.get_tag(Datadog::Ext::Errors::TYPE)).to be_nil
+          expect(span).to_not have_error_type
         end
       end
 
@@ -91,7 +91,7 @@ RSpec.shared_examples_for 'instrumented request' do
         end
 
         it 'has no error set' do
-          expect(span.get_tag(Datadog::Ext::Errors::MSG)).to be_nil
+          expect(span).to_not have_error_message
         end
       end
 
@@ -105,7 +105,7 @@ RSpec.shared_examples_for 'instrumented request' do
         end
 
         it 'has error set' do
-          expect(span.get_tag(Datadog::Ext::Errors::MSG)).to eq('Request has failed: Timeout was reached')
+          expect(span).to have_error_message('Request has failed: Timeout was reached')
         end
       end
     end

--- a/spec/ddtrace/contrib/ethon/typhoeus_integration_spec.rb
+++ b/spec/ddtrace/contrib/ethon/typhoeus_integration_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Datadog::Contrib::Ethon do
       end
 
       it 'has timeout set on GET request span' do
-        expect(span_get.get_tag(Datadog::Ext::Errors::MSG)).to eq('Request has failed: Timeout was reached')
+        expect(span_get).to have_error_message('Request has failed: Timeout was reached')
       end
 
       it 'has span hierarchy properly set up' do

--- a/spec/ddtrace/contrib/faraday/middleware_spec.rb
+++ b/spec/ddtrace/contrib/faraday/middleware_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Faraday middleware' do
       expect(request_span.get_tag(Datadog::Ext::NET::TARGET_HOST)).to eq('example.com')
       expect(request_span.get_tag(Datadog::Ext::NET::TARGET_PORT)).to eq('80')
       expect(request_span.span_type).to eq(Datadog::Ext::HTTP::TYPE_OUTBOUND)
-      expect(request_span.status).to_not eq(Datadog::Ext::Errors::STATUS)
+      expect(request_span).to_not have_error
     end
   end
 
@@ -86,16 +86,16 @@ RSpec.describe 'Faraday middleware' do
       expect(request_span.get_tag(Datadog::Ext::NET::TARGET_HOST)).to eq('example.com')
       expect(request_span.get_tag(Datadog::Ext::NET::TARGET_PORT)).to eq('80')
       expect(request_span.span_type).to eq(Datadog::Ext::HTTP::TYPE_OUTBOUND)
-      expect(request_span.status).to eq(Datadog::Ext::Errors::STATUS)
-      expect(request_span.get_tag(Datadog::Ext::Errors::TYPE)).to eq('Error 500')
-      expect(request_span.get_tag(Datadog::Ext::Errors::MSG)).to eq('Boom!')
+      expect(request_span).to have_error
+      expect(request_span).to have_error_type('Error 500')
+      expect(request_span).to have_error_message('Boom!')
     end
   end
 
   context 'when there is a client error' do
     subject!(:response) { client.get('/not_found') }
 
-    it { expect(request_span.status).to_not eq(Datadog::Ext::Errors::STATUS) }
+    it { expect(request_span).to_not have_error }
   end
 
   context 'when there is custom error handling' do
@@ -103,7 +103,7 @@ RSpec.describe 'Faraday middleware' do
 
     let(:middleware_options) { { error_handler: custom_handler } }
     let(:custom_handler) { ->(env) { (400...600).cover?(env[:status]) } }
-    it { expect(request_span.status).to eq(Datadog::Ext::Errors::STATUS) }
+    it { expect(request_span).to have_error }
   end
 
   context 'when split by domain' do

--- a/spec/ddtrace/contrib/racecar/patcher_spec.rb
+++ b/spec/ddtrace/contrib/racecar/patcher_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Racecar patcher' do
           expect(span.get_tag('kafka.partition')).to eq(partition.to_s)
           expect(span.get_tag('kafka.offset')).to eq(offset.to_s)
           expect(span.get_tag('kafka.first_offset')).to be nil
-          expect(span.status).to_not eq(Datadog::Ext::Errors::STATUS)
+          expect(span).to_not have_error
         end
       end
     end
@@ -86,7 +86,7 @@ RSpec.describe 'Racecar patcher' do
           expect(span.get_tag('kafka.partition')).to eq(partition.to_s)
           expect(span.get_tag('kafka.offset')).to eq(offset.to_s)
           expect(span.get_tag('kafka.first_offset')).to be nil
-          expect(span.status).to eq(Datadog::Ext::Errors::STATUS)
+          expect(span).to have_error
         end
       end
     end
@@ -133,7 +133,7 @@ RSpec.describe 'Racecar patcher' do
           expect(span.get_tag('kafka.offset')).to be nil
           expect(span.get_tag('kafka.first_offset')).to eq(offset.to_s)
           expect(span.get_tag('kafka.message_count')).to eq(message_count.to_s)
-          expect(span.status).to_not eq(Datadog::Ext::Errors::STATUS)
+          expect(span).to_not have_error
         end
       end
     end
@@ -161,7 +161,7 @@ RSpec.describe 'Racecar patcher' do
           expect(span.get_tag('kafka.offset')).to be nil
           expect(span.get_tag('kafka.first_offset')).to eq(offset.to_s)
           expect(span.get_tag('kafka.message_count')).to eq(message_count.to_s)
-          expect(span.status).to eq(Datadog::Ext::Errors::STATUS)
+          expect(span).to have_error
         end
       end
     end

--- a/spec/ddtrace/contrib/rails/middleware_spec.rb
+++ b/spec/ddtrace/contrib/rails/middleware_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe 'Rails request' do
           expect(span.get_tag('http.status_code')).to eq('500')
           expect(span.get_tag('error.type')).to eq('NotImplementedError')
           expect(span.get_tag('error.msg')).to eq('NotImplementedError')
-          expect(span.status).to eq(Datadog::Ext::Errors::STATUS)
+          expect(span).to have_error
           expect(span.get_tag('error.stack')).to_not be nil
         end
       end
@@ -188,13 +188,13 @@ RSpec.describe 'Rails request' do
           if Rails.version >= '3.2'
             expect(span.get_tag('error.type')).to be nil
             expect(span.get_tag('error.msg')).to be nil
-            expect(span.status).to_not eq(Datadog::Ext::Errors::STATUS)
+            expect(span).to_not have_error
             expect(span.get_tag('error.stack')).to be nil
           else
             # Rails 3.0 raises errors for 404 routing errors
             expect(span.get_tag('error.type')).to eq('ActionController::RoutingError')
             expect(span.get_tag('error.msg')).to eq('/missing_route')
-            expect(span.status).to eq(Datadog::Ext::Errors::STATUS)
+            expect(span).to have_error
             expect(span.get_tag('error.stack')).to_not be nil
           end
         end
@@ -249,7 +249,7 @@ RSpec.describe 'Rails request' do
           expect(span.get_tag('http.status_code')).to eq('500')
           expect(span.get_tag('error.type')).to eq('CustomError')
           expect(span.get_tag('error.msg')).to eq('Custom error message!')
-          expect(span.status).to eq(Datadog::Ext::Errors::STATUS)
+          expect(span).to have_error
           expect(span.get_tag('error.stack')).to_not be nil
         end
       end
@@ -294,7 +294,7 @@ RSpec.describe 'Rails request' do
               expect(span.get_tag('http.status_code')).to eq('404')
               expect(span.get_tag('error.type')).to be nil
               expect(span.get_tag('error.msg')).to be nil
-              expect(span.status).to_not eq(Datadog::Ext::Errors::STATUS)
+              expect(span).to_not have_error
               expect(span.get_tag('error.stack')).to be nil
             end
           end

--- a/spec/ddtrace/contrib/resque/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/resque/instrumentation_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Resque instrumentation' do
         expect(span.resource).to eq(job_class.name)
         expect(span.span_type).to eq(Datadog::Ext::AppTypes::WORKER)
         expect(span.service).to eq('resque')
-        expect(span.status).to_not eq(Datadog::Ext::Errors::STATUS)
+        expect(span).to_not have_error
       end
 
       it_behaves_like 'analytics for integration' do
@@ -78,9 +78,9 @@ RSpec.describe 'Resque instrumentation' do
         expect(span.resource).to eq(job_class.name)
         expect(span.span_type).to eq(Datadog::Ext::AppTypes::WORKER)
         expect(span.service).to eq('resque')
-        expect(span.get_tag(Datadog::Ext::Errors::MSG)).to eq(error_message)
-        expect(span.status).to eq(Datadog::Ext::Errors::STATUS)
-        expect(span.get_tag(Datadog::Ext::Errors::TYPE)).to eq(error_class_name)
+        expect(span).to have_error_message(error_message)
+        expect(span).to have_error
+        expect(span).to have_error_type(error_class_name)
       end
     end
   end

--- a/spec/ddtrace/contrib/rest_client/request_patch_spec.rb
+++ b/spec/ddtrace/contrib/rest_client/request_patch_spec.rb
@@ -104,13 +104,13 @@ RSpec.describe Datadog::Contrib::RestClient::RequestPatch do
           end
 
           it 'has error set' do
-            expect(span.get_tag(Datadog::Ext::Errors::MSG)).to eq('500 Internal Server Error')
+            expect(span).to have_error_message('500 Internal Server Error')
           end
           it 'has error stack' do
             expect(span.get_tag(Datadog::Ext::Errors::STACK)).not_to be_nil
           end
           it 'has error set' do
-            expect(span.get_tag(Datadog::Ext::Errors::TYPE)).to eq('RestClient::InternalServerError')
+            expect(span).to have_error_type('RestClient::InternalServerError')
           end
         end
 
@@ -126,7 +126,7 @@ RSpec.describe Datadog::Contrib::RestClient::RequestPatch do
           end
 
           it 'error is not set' do
-            expect(span.get_tag(Datadog::Ext::Errors::MSG)).to be_nil
+            expect(span).to_not have_error_message
           end
         end
       end

--- a/spec/ddtrace/contrib/sinatra/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/tracer_spec.rb
@@ -242,8 +242,8 @@ RSpec.describe 'Sinatra instrumentation' do
         it do
           is_expected.to be_bad_request
           expect(spans).to have(1).items
-          expect(span.get_tag(Datadog::Ext::Errors::TYPE)).to be nil
-          expect(span.get_tag(Datadog::Ext::Errors::MSG)).to be nil
+          expect(span).to_not have_error_type
+          expect(span).to_not have_error_message
           expect(span.status).to eq(0)
         end
       end
@@ -262,8 +262,8 @@ RSpec.describe 'Sinatra instrumentation' do
         it do
           is_expected.to be_server_error
           expect(spans).to have(1).items
-          expect(span.get_tag(Datadog::Ext::Errors::TYPE)).to be nil
-          expect(span.get_tag(Datadog::Ext::Errors::MSG)).to be nil
+          expect(span).to_not have_error_type
+          expect(span).to_not have_error_message
           expect(span.status).to eq(1)
         end
       end
@@ -282,8 +282,8 @@ RSpec.describe 'Sinatra instrumentation' do
         it do
           is_expected.to be_server_error
           expect(spans).to have(1).items
-          expect(span.get_tag(Datadog::Ext::Errors::TYPE)).to eq('StandardError')
-          expect(span.get_tag(Datadog::Ext::Errors::MSG)).to eq('something bad')
+          expect(span).to have_error_type('StandardError')
+          expect(span).to have_error_message('something bad')
           expect(span.status).to eq(1)
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,30 +9,30 @@ require 'ddtrace/encoding'
 require 'ddtrace/tracer'
 require 'ddtrace/span'
 
-# require 'support/test_access_patch'
-require 'support/faux_writer'
-require 'support/faux_transport'
-require 'support/spy_transport'
-require 'support/tracer_helpers'
-# require 'support/rails_active_record_helpers'
 require 'support/configuration_helpers'
-require 'support/synchronization_helpers'
-require 'support/log_helpers'
-require 'support/http_helpers'
-require 'support/metric_helpers'
 require 'support/container_helpers'
+require 'support/faux_transport'
+require 'support/faux_writer'
+require 'support/http_helpers'
+require 'support/log_helpers'
+require 'support/metric_helpers'
+require 'support/span_helpers'
+require 'support/spy_transport'
+require 'support/synchronization_helpers'
+require 'support/tracer_helpers'
 
 WebMock.allow_net_connect!
 WebMock.disable!
 
 RSpec.configure do |config|
-  config.include TracerHelpers
-  config.include HttpHelpers
   config.include ConfigurationHelpers
-  config.include SynchronizationHelpers
+  config.include ContainerHelpers
+  config.include HttpHelpers
   config.include LogHelpers
   config.include MetricHelpers
-  config.include ContainerHelpers
+  config.include SpanHelpers
+  config.include SynchronizationHelpers
+  config.include TracerHelpers
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/span_helpers.rb
+++ b/spec/support/span_helpers.rb
@@ -1,0 +1,39 @@
+module SpanHelpers
+  RSpec::Matchers.define :have_error do
+    match do |span|
+      @actual = span.status
+      values_match? Datadog::Ext::Errors::STATUS, @actual
+    end
+
+    def description_of(actual)
+      "Span with status #{super}"
+    end
+  end
+
+  def self.define_have_error_tag(tag_name, tag)
+    RSpec::Matchers.define "have_error_#{tag_name}" do |*args|
+      match do |span|
+        expected = args.first
+
+        @tag_name = tag_name
+        @actual = span.get_tag(tag)
+
+        if args.empty? && @actual.nil?
+          # This condition enables the negative matcher:
+          # expect(foo).to_not have_error_tag
+          return false
+        end
+
+        values_match? expected, @actual
+      end
+
+      def description_of(actual) # rubocop:disable Lint/NestedMethodDefinition
+        "Span with error #{@tag_name} #{super}"
+      end
+    end
+  end
+
+  define_have_error_tag(:message, Datadog::Ext::Errors::MSG)
+  define_have_error_tag(:stack, Datadog::Ext::Errors::STACK)
+  define_have_error_tag(:type, Datadog::Ext::Errors::TYPE)
+end


### PR DESCRIPTION
Encapsulates error checking for `Span` instances:
```ruby
expect(span).to have_error
expect(span).to have_error_type('Error 500')
expect(span).to have_error_message('Boom!')
```

The matchers also work when negated:
```ruby
expect(span).to_not have_error
expect(span).to_not have_error_type
expect(span).to_not have_error_message
```