### PR TITLE
[Docs] Update lograge configuration to ensure full ID precision

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1776,8 +1776,9 @@ config.lograge.custom_options = lambda do |event|
   {
     # Adds IDs as tags to log output
     :dd => {
-      :trace_id => correlation.trace_id,
-      :span_id => correlation.span_id
+      # To preserve precision during JSON serialization, use strings for large numbers
+      :trace_id => correlation.trace_id.to_s,
+      :span_id => correlation.span_id.to_s
     },
     :ddsource => ["ruby"],
     :params => event.payload[:params].reject { |k| %w(controller action).include? k }


### PR DESCRIPTION
`trace_id` and `span_id` are 63-bit unsigned integers.
When transporting these values in a `lograge` configuration hash, it is possible that this has will be converted into a JSON object, which might cause loss of precision when parsing these large integers.

This PR adds instructions to the `GettingStarted.md` guide on how to avoid this issue.