### PR TITLE
Add :accessors to configuration option

### DIFF
--- a/lib/ddtrace/configuration/options.rb
+++ b/lib/ddtrace/configuration/options.rb
@@ -60,7 +60,7 @@ module Datadog
           options[name].get
         end
 
-        def to_h
+        def options_hash
           options.each_with_object({}) do |(key, _), hash|
             hash[key] = get_option(key)
           end

--- a/lib/ddtrace/configuration/options.rb
+++ b/lib/ddtrace/configuration/options.rb
@@ -24,8 +24,10 @@ module Datadog
         protected
 
         def option(name, meta = {}, &block)
+          accessors = meta.key?(:accessors) ? meta.delete(:accessors) : true
+
           options[name] = OptionDefinition.new(name, meta, &block).tap do
-            define_option_accessors(name)
+            define_option_accessors(name) if accessors
           end
         end
 

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -59,6 +59,10 @@ module Datadog
         yield(self) if block_given?
       end
 
+      def to_h
+        options_hash
+      end
+
       def reset!
         reset_options!
       end

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -44,7 +44,7 @@ module Datadog
               },
               lazy: true
 
-      option :tracer, default: Tracer.new
+      option :tracer, default: Tracer.new, accessors: false
 
       def initialize(options = {})
         configure(options)
@@ -81,7 +81,6 @@ module Datadog
       end
 
       # Backwards compatibility for configuring tracer e.g. `c.tracer debug: true`
-      remove_method :tracer
       def tracer(options = nil)
         tracer = options && options.key?(:instance) ? set_option(:tracer, options[:instance]) : get_option(:tracer)
 
@@ -94,6 +93,10 @@ module Datadog
             t.class.debug_logging = options.fetch(:debug, false)
           end
         end
+      end
+
+      def tracer=(value)
+        set_option(:tracer, value)
       end
     end
   end

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -59,6 +59,10 @@ module Datadog
         yield(self) if block_given?
       end
 
+      def reset!
+        reset_options!
+      end
+
       def distributed_tracing
         # TODO: Move distributed tracing configuration to it's own Settings sub-class
         # DEV: We do this to fake `Datadog.configuration.distributed_tracing.propagation_inject_style`

--- a/lib/ddtrace/contrib/configuration/settings.rb
+++ b/lib/ddtrace/contrib/configuration/settings.rb
@@ -35,6 +35,14 @@ module Datadog
         def []=(name, value)
           respond_to?("#{name}=") ? send("#{name}=", value) : set_option(name, value)
         end
+
+        def to_h
+          options_hash
+        end
+
+        def reset!
+          reset_options!
+        end
       end
     end
   end

--- a/lib/ddtrace/contrib/excon/middleware.rb
+++ b/lib/ddtrace/contrib/excon/middleware.rb
@@ -17,7 +17,7 @@ module Datadog
 
         def initialize(stack, options = {})
           super(stack)
-          @options = Datadog.configuration[:excon].to_h.merge(options)
+          @options = Datadog.configuration[:excon].options_hash.merge(options)
         end
 
         def request_call(datum)

--- a/lib/ddtrace/contrib/faraday/middleware.rb
+++ b/lib/ddtrace/contrib/faraday/middleware.rb
@@ -14,7 +14,7 @@ module Datadog
 
         def initialize(app, options = {})
           super(app)
-          @options = datadog_configuration.to_h.merge(options)
+          @options = datadog_configuration.options_hash.merge(options)
           setup_service!
         end
 

--- a/spec/ddtrace/configuration/options_spec.rb
+++ b/spec/ddtrace/configuration/options_spec.rb
@@ -101,8 +101,8 @@ RSpec.describe Datadog::Configuration::Options do
         end
       end
 
-      describe '#to_h' do
-        subject(:hash) { options_object.to_h }
+      describe '#options_hash' do
+        subject(:hash) { options_object.options_hash }
 
         context 'when no options are defined' do
           it { is_expected.to eq({}) }

--- a/spec/ddtrace/configuration/options_spec.rb
+++ b/spec/ddtrace/configuration/options_spec.rb
@@ -49,6 +49,19 @@ RSpec.describe Datadog::Configuration::Options do
           expect(options_class.new).to respond_to(name)
           expect(options_class.new).to respond_to("#{name}=")
         end
+
+        context 'when given :accessors' do
+          context 'as false' do
+            let(:meta) { { accessors: false } }
+
+            it 'creates an option definition without accessors' do
+              is_expected.to be_a_kind_of(Datadog::Configuration::OptionDefinition)
+              expect(options_class.options).to include(name)
+              expect(options_class.new).to_not respond_to(name)
+              expect(options_class.new).to_not respond_to("#{name}=")
+            end
+          end
+        end
       end
     end
 

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -6,6 +6,21 @@ RSpec.describe Datadog::Configuration::Settings do
   subject(:configuration) { described_class.new(registry: registry) }
   let(:registry) { Datadog::Contrib::Registry.new }
 
+  describe '#to_h' do
+    subject(:hash) { configuration.to_h }
+    let(:options_hash) { double('options hash') }
+
+    before do
+      allow(configuration).to receive(:options_hash)
+        .and_return(options_hash)
+    end
+
+    it do
+      is_expected.to be(options_hash)
+      expect(configuration).to have_received(:options_hash)
+    end
+  end
+
   describe '#reset!' do
     subject(:reset!) { configuration.reset! }
 

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -3,9 +3,23 @@ require 'spec_helper'
 require 'ddtrace/configuration/settings'
 
 RSpec.describe Datadog::Configuration::Settings do
-  let(:configuration) { described_class.new(registry: registry) }
+  subject(:configuration) { described_class.new(registry: registry) }
   let(:registry) { Datadog::Contrib::Registry.new }
 
+  describe '#reset!' do
+    subject(:reset!) { configuration.reset! }
+
+    before do
+      allow(configuration).to receive(:reset_options!)
+      reset!
+    end
+
+    it 'resets the options' do
+      expect(configuration).to have_received(:reset_options!)
+    end
+  end
+
+  # TODO: Extract integration behavior to `contrib`
   describe '#use' do
     subject(:result) { configuration.use(name, options) }
     let(:name) { :example }

--- a/spec/ddtrace/contrib/active_record/tracer_spec.rb
+++ b/spec/ddtrace/contrib/active_record/tracer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'ActiveRecord instrumentation' do
     Article.count
 
     # Reset options (that might linger from other tests)
-    Datadog.configuration[:active_record].reset_options!
+    Datadog.configuration[:active_record].reset!
 
     Datadog.configure do |c|
       c.use :active_record, configuration_options

--- a/spec/ddtrace/contrib/analytics_examples.rb
+++ b/spec/ddtrace/contrib/analytics_examples.rb
@@ -3,9 +3,9 @@ require 'ddtrace/ext/analytics'
 RSpec.shared_examples_for 'analytics for integration' do |options = { ignore_global_flag: true }|
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog.configuration.reset_options!
+    Datadog.configuration.reset!
     example.run
-    Datadog.configuration.reset_options!
+    Datadog.configuration.reset!
   end
 
   context 'when not configured' do

--- a/spec/ddtrace/contrib/configuration/settings_spec.rb
+++ b/spec/ddtrace/contrib/configuration/settings_spec.rb
@@ -7,6 +7,34 @@ RSpec.describe Datadog::Contrib::Configuration::Settings do
 
   it { is_expected.to be_a_kind_of(Datadog::Configuration::Options) }
 
+  describe '#to_h' do
+    subject(:hash) { settings.to_h }
+    let(:options_hash) { double('options hash') }
+
+    before do
+      allow(settings).to receive(:options_hash)
+        .and_return(options_hash)
+    end
+
+    it do
+      is_expected.to be(options_hash)
+      expect(settings).to have_received(:options_hash)
+    end
+  end
+
+  describe '#reset!' do
+    subject(:reset!) { settings.reset! }
+
+    before do
+      allow(settings).to receive(:reset_options!)
+      reset!
+    end
+
+    it 'resets the options' do
+      expect(settings).to have_received(:reset_options!)
+    end
+  end
+
   describe '#options' do
     subject(:options) { settings.options }
 

--- a/spec/ddtrace/contrib/http/patcher_spec.rb
+++ b/spec/ddtrace/contrib/http/patcher_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'net/http patcher' do
 
     stub_request(:any, host)
 
-    Datadog.configuration[:http].reset_options!
+    Datadog.configuration[:http].reset!
     Datadog.configure do |c|
       c.use :http, tracer: tracer
     end

--- a/spec/ddtrace/contrib/rake/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/rake/instrumentation_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Datadog::Contrib::Rake::Instrumentation do
     skip('Rake integration incompatible.') unless Datadog::Contrib::Rake::Integration.compatible?
 
     # Reset options (that might linger from other tests)
-    Datadog.configuration[:rake].reset_options!
+    Datadog.configuration[:rake].reset!
 
     # Patch Rake
     Datadog.configure do |c|

--- a/spec/ddtrace/contrib/sequel/configuration_spec.rb
+++ b/spec/ddtrace/contrib/sequel/configuration_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Sequel configuration' do
     end
 
     describe 'when configured' do
-      after(:each) { Datadog.configuration[:sequel].reset_options! }
+      after(:each) { Datadog.configuration[:sequel].reset! }
 
       context 'only with defaults' do
         # Expect it to be the normalized adapter name.

--- a/spec/ddtrace/propagation/http_propagator_spec.rb
+++ b/spec/ddtrace/propagation/http_propagator_spec.rb
@@ -6,9 +6,9 @@ require 'ddtrace/propagation/http_propagator'
 RSpec.describe Datadog::HTTPPropagator do
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog.configuration.reset_options!
+    Datadog.configuration.reset!
     example.run
-    Datadog.configuration.reset_options!
+    Datadog.configuration.reset!
   end
 
   let(:tracer) { get_test_tracer }

--- a/test/contrib/grape/rack_app.rb
+++ b/test/contrib/grape/rack_app.rb
@@ -50,7 +50,7 @@ class BaseRackAPITest < MiniTest::Test
   def teardown
     super
     # reset the configuration
-    Datadog.configuration[:rack].reset_options!
-    Datadog.configuration[:grape].reset_options!
+    Datadog.configuration[:rack].reset!
+    Datadog.configuration[:grape].reset!
   end
 end

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -13,7 +13,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     # this prevents the overhead to reinitialize the Rails application
     # and the Rack stack
     @tracer = get_test_tracer
-    Datadog.configuration[:rails].reset_options!
+    Datadog.configuration[:rails].reset!
     Datadog.configuration[:rails][:tracer] = @tracer
     Datadog.configuration[:rails][:database_service] = get_adapter_name
     Datadog::Contrib::Rails::Framework.setup

--- a/test/contrib/rails/tracer_test.rb
+++ b/test/contrib/rails/tracer_test.rb
@@ -7,7 +7,7 @@ class TracerTest < ActionDispatch::IntegrationTest
     # don't pollute the global tracer
     @tracer = get_test_tracer
     @config = Datadog.configuration[:rails]
-    Datadog.configuration[:rails].reset_options!
+    Datadog.configuration[:rails].reset!
     @config[:tracer] = @tracer
   end
 


### PR DESCRIPTION
Based on https://github.com/DataDog/dd-trace-rb/pull/808 as a pre-requisite.

Currently, when defining an option with `option :foo`, it automatically adds accessor methods `#foo` and `#foo=`. This is a good default for most simple values, but has limitations when the usage of the option in question is intended to be more sophisticated, e.g. `config.tracer host: `localhost`, port: 8126`.

This pull request adds the `accessors` option, which allows accessors to be skipped, so that they can be customized.

```ruby
option :foo, accessors: false

def foo
  # Custom behavior
end

def foo=(value)
  # Custom behavior
end
```