### PR TITLE
Add configuration option DSL block syntax

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,7 +54,7 @@ namespace :spec do
 
   RSpec::Core::RakeTask.new(:contrib) do |t, args|
     # rubocop:disable Metrics/LineLength
-    t.pattern = 'spec/**/contrib/{analytics,configurable,integration,patchable,patcher,registerable,registry,configuration/*}_spec.rb'
+    t.pattern = 'spec/**/contrib/{analytics,configurable,extensions,integration,patchable,patcher,registerable,registry,configuration/*}_spec.rb'
     t.rspec_opts = args.to_a.join(' ')
   end
 

--- a/lib/ddtrace/configuration/option.rb
+++ b/lib/ddtrace/configuration/option.rb
@@ -24,8 +24,15 @@ module Datadog
       end
 
       def reset
-        @is_set = false
-        @value = nil
+        @value = if definition.resetter
+                   # Don't change @is_set to false; custom resetters are
+                   # responsible for changing @value back to a good state.
+                   # Setting @is_set = false would cause a default to be applied.
+                   @context.instance_exec(@value, &definition.resetter)
+                 else
+                   @is_set = false
+                   nil
+                 end
       end
     end
   end

--- a/lib/ddtrace/configuration/option.rb
+++ b/lib/ddtrace/configuration/option.rb
@@ -15,6 +15,7 @@ module Datadog
       def set(value)
         @value = @context.instance_exec(value, &definition.setter).tap do
           @is_set = true
+          @context.instance_exec(value, &definition.on_set) if definition.on_set
         end
       end
 

--- a/lib/ddtrace/configuration/option.rb
+++ b/lib/ddtrace/configuration/option.rb
@@ -20,7 +20,12 @@ module Datadog
       end
 
       def get
-        return definition.default_value unless @is_set
+        # Initialize to default value, if not set
+        unless @is_set
+          @value = definition.default_value
+          @is_set = true
+        end
+
         @value
       end
 

--- a/lib/ddtrace/configuration/option_definition.rb
+++ b/lib/ddtrace/configuration/option_definition.rb
@@ -9,6 +9,7 @@ module Datadog
         :depends_on,
         :lazy,
         :name,
+        :resetter,
         :setter
 
       def initialize(name, meta = {}, &block)
@@ -16,6 +17,7 @@ module Datadog
         @depends_on = meta[:depends_on] || []
         @lazy = meta[:lazy] || false
         @name = name.to_sym
+        @resetter = meta[:resetter]
         @setter = meta[:setter] || block || IDENTITY
       end
 
@@ -35,6 +37,7 @@ module Datadog
           @lazy = false
           @name = name.to_sym
           @setter = OptionDefinition::IDENTITY
+          @resetter = nil
 
           # If options were supplied, apply them.
           apply_options!(options)
@@ -51,18 +54,22 @@ module Datadog
           @default = block_given? ? block : value
         end
 
+        def helper(name, *_args, &block)
+          @helpers[name] = block
+        end
+
         # rubocop:disable Style/TrivialAccessors
         # (Rubocop erroneously thinks #lazy == #lazy= )
         def lazy(value)
           @lazy = value
         end
 
-        def setter(&block)
-          @setter = block
+        def resetter(&block)
+          @resetter = block
         end
 
-        def helper(name, *_args, &block)
-          @helpers[name] = block
+        def setter(&block)
+          @setter = block
         end
 
         # For applying options for OptionDefinition
@@ -72,6 +79,7 @@ module Datadog
           default(options[:default]) if options.key?(:default)
           depends_on(*options[:depends_on]) if options.key?(:depends_on)
           lazy(options[:lazy]) if options.key?(:lazy)
+          resetter(&options[:resetter]) if options.key?(:resetter)
           setter(&options[:setter]) if options.key?(:setter)
         end
 
@@ -84,6 +92,7 @@ module Datadog
             default: @default,
             depends_on: @depends_on,
             lazy: @lazy,
+            resetter: @resetter,
             setter: @setter
           }
         end

--- a/lib/ddtrace/configuration/option_definition.rb
+++ b/lib/ddtrace/configuration/option_definition.rb
@@ -70,7 +70,7 @@ module Datadog
 
         # rubocop:disable Style/TrivialAccessors
         # (Rubocop erroneously thinks #lazy == #lazy= )
-        def lazy(value)
+        def lazy(value = true)
           @lazy = value
         end
 

--- a/lib/ddtrace/configuration/option_definition.rb
+++ b/lib/ddtrace/configuration/option_definition.rb
@@ -8,6 +8,7 @@ module Datadog
 
       attr_reader \
         :default,
+        :delegate_to,
         :depends_on,
         :lazy,
         :name,
@@ -17,6 +18,7 @@ module Datadog
 
       def initialize(name, meta = {}, &block)
         @default = meta[:default]
+        @delegate_to = meta[:delegate_to]
         @depends_on = meta[:depends_on] || []
         @lazy = meta[:lazy] || false
         @name = name.to_sym
@@ -41,6 +43,7 @@ module Datadog
 
         def initialize(name, options = {})
           @default = nil
+          @delegate_to = nil
           @depends_on = []
           @helpers = {}
           @lazy = false
@@ -62,6 +65,10 @@ module Datadog
 
         def default(value = nil, &block)
           @default = block_given? ? block : value
+        end
+
+        def delegate_to(&block)
+          @delegate_to = block
         end
 
         def helper(name, *_args, &block)
@@ -91,6 +98,7 @@ module Datadog
           return if options.nil? || options.empty?
 
           default(options[:default]) if options.key?(:default)
+          delegate_to(&options[:delegate_to]) if options.key?(:delegate_to)
           depends_on(*options[:depends_on]) if options.key?(:depends_on)
           lazy(options[:lazy]) if options.key?(:lazy)
           on_set(&options[:on_set]) if options.key?(:on_set)
@@ -105,6 +113,7 @@ module Datadog
         def meta
           {
             default: @default,
+            delegate_to: @delegate_to,
             depends_on: @depends_on,
             lazy: @lazy,
             on_set: @on_set,

--- a/lib/ddtrace/configuration/option_definition.rb
+++ b/lib/ddtrace/configuration/option_definition.rb
@@ -9,6 +9,7 @@ module Datadog
         :depends_on,
         :lazy,
         :name,
+        :on_set,
         :resetter,
         :setter
 
@@ -17,6 +18,7 @@ module Datadog
         @depends_on = meta[:depends_on] || []
         @lazy = meta[:lazy] || false
         @name = name.to_sym
+        @on_set = meta[:on_set]
         @resetter = meta[:resetter]
         @setter = meta[:setter] || block || IDENTITY
       end
@@ -36,8 +38,9 @@ module Datadog
           @helpers = {}
           @lazy = false
           @name = name.to_sym
-          @setter = OptionDefinition::IDENTITY
+          @on_set = nil
           @resetter = nil
+          @setter = OptionDefinition::IDENTITY
 
           # If options were supplied, apply them.
           apply_options!(options)
@@ -64,6 +67,10 @@ module Datadog
           @lazy = value
         end
 
+        def on_set(&block)
+          @on_set = block
+        end
+
         def resetter(&block)
           @resetter = block
         end
@@ -79,6 +86,7 @@ module Datadog
           default(options[:default]) if options.key?(:default)
           depends_on(*options[:depends_on]) if options.key?(:depends_on)
           lazy(options[:lazy]) if options.key?(:lazy)
+          on_set(&options[:on_set]) if options.key?(:on_set)
           resetter(&options[:resetter]) if options.key?(:resetter)
           setter(&options[:setter]) if options.key?(:setter)
         end
@@ -92,6 +100,7 @@ module Datadog
             default: @default,
             depends_on: @depends_on,
             lazy: @lazy,
+            on_set: @on_set,
             resetter: @resetter,
             setter: @setter
           }

--- a/lib/ddtrace/configuration/option_definition.rb
+++ b/lib/ddtrace/configuration/option_definition.rb
@@ -1,3 +1,5 @@
+require 'ddtrace/configuration/option'
+
 module Datadog
   module Configuration
     # Represents a definition for an integration configuration option
@@ -25,6 +27,11 @@ module Datadog
 
       def default_value
         lazy ? @default.call : @default
+      end
+
+      # Creates a new Option, bound to the context provided.
+      def build(context)
+        Option.new(self, context)
       end
 
       # Acts as DSL for building OptionDefinitions

--- a/lib/ddtrace/configuration/option_definition.rb
+++ b/lib/ddtrace/configuration/option_definition.rb
@@ -22,6 +22,72 @@ module Datadog
       def default_value
         lazy ? @default.call : @default
       end
+
+      # Acts as DSL for building OptionDefinitions
+      class Builder
+        attr_reader \
+          :helpers
+
+        def initialize(name, options = {})
+          @default = nil
+          @depends_on = []
+          @helpers = {}
+          @lazy = false
+          @name = name.to_sym
+          @setter = OptionDefinition::IDENTITY
+
+          # If options were supplied, apply them.
+          apply_options!(options)
+
+          # Apply block if given.
+          yield(self) if block_given?
+        end
+
+        def depends_on(*values)
+          @depends_on = values.flatten
+        end
+
+        def default(value = nil, &block)
+          @default = block_given? ? block : value
+        end
+
+        # rubocop:disable Style/TrivialAccessors
+        # (Rubocop erroneously thinks #lazy == #lazy= )
+        def lazy(value)
+          @lazy = value
+        end
+
+        def setter(&block)
+          @setter = block
+        end
+
+        def helper(name, *_args, &block)
+          @helpers[name] = block
+        end
+
+        # For applying options for OptionDefinition
+        def apply_options!(options = {})
+          return if options.nil? || options.empty?
+
+          default(options[:default]) if options.key?(:default)
+          depends_on(*options[:depends_on]) if options.key?(:depends_on)
+          lazy(options[:lazy]) if options.key?(:lazy)
+          setter(&options[:setter]) if options.key?(:setter)
+        end
+
+        def to_definition
+          OptionDefinition.new(@name, meta)
+        end
+
+        def meta
+          {
+            default: @default,
+            depends_on: @depends_on,
+            lazy: @lazy,
+            setter: @setter
+          }
+        end
+      end
     end
   end
 end

--- a/lib/ddtrace/configuration/options.rb
+++ b/lib/ddtrace/configuration/options.rb
@@ -1,4 +1,3 @@
-require 'ddtrace/configuration/option'
 require 'ddtrace/configuration/option_set'
 require 'ddtrace/configuration/option_definition'
 require 'ddtrace/configuration/option_definition_set'
@@ -90,7 +89,7 @@ module Datadog
         def add_option(name)
           assert_valid_option!(name)
           definition = self.class.options[name]
-          Option.new(definition, self).tap do |option|
+          definition.build(self).tap do |option|
             options[name] = option
           end
         end

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -16,35 +16,42 @@ module Datadog
       #
       # Configuration options
       #
-      option  :analytics_enabled,
-              default: -> { env_to_bool(Ext::Analytics::ENV_TRACE_ANALYTICS_ENABLED, nil) },
-              lazy: true
+      option :analytics_enabled do |o|
+        o.default { env_to_bool(Ext::Analytics::ENV_TRACE_ANALYTICS_ENABLED, nil) }
+        o.lazy true
+      end
 
-      option  :report_hostname,
-              default: -> { env_to_bool(Ext::NET::ENV_REPORT_HOSTNAME, false) },
-              lazy: true
+      option :report_hostname do |o|
+        o.default { env_to_bool(Ext::NET::ENV_REPORT_HOSTNAME, false) }
+        o.lazy true
+      end
 
-      option  :runtime_metrics_enabled,
-              default: -> { env_to_bool(Ext::Runtime::Metrics::ENV_ENABLED, false) },
-              lazy: true
+      option :runtime_metrics_enabled do |o|
+        o.default { env_to_bool(Ext::Runtime::Metrics::ENV_ENABLED, false) }
+        o.lazy true
+      end
 
-      # Look for all headers by default
-      option  :propagation_extract_style,
-              default: lambda {
-                env_to_list(Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV,
-                            [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG,
-                             Ext::DistributedTracing::PROPAGATION_STYLE_B3,
-                             Ext::DistributedTracing::PROPAGATION_STYLE_B3_SINGLE_HEADER])
-              },
-              lazy: true
+      option :propagation_extract_style do |o|
+        o.default do
+          # Look for all headers by default
+          env_to_list(Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV,
+                      [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG,
+                       Ext::DistributedTracing::PROPAGATION_STYLE_B3,
+                       Ext::DistributedTracing::PROPAGATION_STYLE_B3_SINGLE_HEADER])
+        end
 
-      # Only inject Datadog headers by default
-      option  :propagation_inject_style,
-              default: lambda {
-                env_to_list(Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV,
-                            [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG])
-              },
-              lazy: true
+        o.lazy true
+      end
+
+      option :propagation_inject_style do |o|
+        o.default do
+          # Only inject Datadog headers by default
+          env_to_list(Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV,
+                      [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG])
+        end
+
+        o.lazy true
+      end
 
       option :tracer do |o|
         o.default Tracer.new

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -54,7 +54,8 @@ module Datadog
       end
 
       option :tracer do |o|
-        o.default Tracer.new
+        o.default { Tracer.new }
+        o.lazy
 
         # Backwards compatibility for configuring tracer e.g. `c.tracer debug: true`
         o.helper :tracer do |options = nil|

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -54,8 +54,14 @@ module Datadog
       end
 
       option :tracer do |o|
-        o.default { Tracer.new }
-        o.lazy
+        o.default Tracer.new
+
+        # On reset, shut down the old tracer,
+        # then instantiate a new one.
+        o.resetter do |tracer|
+          tracer.shutdown!
+          Tracer.new
+        end
 
         # Backwards compatibility for configuring tracer e.g. `c.tracer debug: true`
         o.helper :tracer do |options = nil|

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -18,17 +18,17 @@ module Datadog
       #
       option :analytics_enabled do |o|
         o.default { env_to_bool(Ext::Analytics::ENV_TRACE_ANALYTICS_ENABLED, nil) }
-        o.lazy true
+        o.lazy
       end
 
       option :report_hostname do |o|
         o.default { env_to_bool(Ext::NET::ENV_REPORT_HOSTNAME, false) }
-        o.lazy true
+        o.lazy
       end
 
       option :runtime_metrics_enabled do |o|
         o.default { env_to_bool(Ext::Runtime::Metrics::ENV_ENABLED, false) }
-        o.lazy true
+        o.lazy
       end
 
       option :propagation_extract_style do |o|
@@ -40,7 +40,7 @@ module Datadog
                        Ext::DistributedTracing::PROPAGATION_STYLE_B3_SINGLE_HEADER])
         end
 
-        o.lazy true
+        o.lazy
       end
 
       option :propagation_inject_style do |o|
@@ -50,7 +50,7 @@ module Datadog
                       [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG])
         end
 
-        o.lazy true
+        o.lazy
       end
 
       option :tracer do |o|

--- a/lib/ddtrace/contrib/action_pack/configuration/settings.rb
+++ b/lib/ddtrace/contrib/action_pack/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :controller_service

--- a/lib/ddtrace/contrib/action_pack/configuration/settings.rb
+++ b/lib/ddtrace/contrib/action_pack/configuration/settings.rb
@@ -7,16 +7,18 @@ module Datadog
       module Configuration
         # Custom settings for the ActionPack integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :controller_service
-          option :exception_controller, default: nil
+          option :exception_controller
           option :service_name, default: Ext::SERVICE_NAME
         end
       end

--- a/lib/ddtrace/contrib/action_view/configuration/settings.rb
+++ b/lib/ddtrace/contrib/action_view/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the ActionView integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :service_name, default: Ext::SERVICE_NAME
           option :template_base_path, default: 'views/'

--- a/lib/ddtrace/contrib/action_view/configuration/settings.rb
+++ b/lib/ddtrace/contrib/action_view/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/active_model_serializers/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/configuration/settings.rb
@@ -16,11 +16,14 @@ module Datadog
                   lazy: true
 
           option :service_name, default: Ext::SERVICE_NAME
-          option :tracer, default: Datadog.tracer do |value|
-            (value || Datadog.tracer).tap do |v|
-              # Make sure to update tracers of all subscriptions
-              Events.subscriptions.each do |subscription|
-                subscription.tracer = v
+          option :tracer do |o|
+            o.default Datadog.tracer
+            o.setter do |value|
+              (value || Datadog.tracer).tap do |v|
+                # Make sure to update tracers of all subscriptions
+                Events.subscriptions.each do |subscription|
+                  subscription.tracer = v
+                end
               end
             end
           end

--- a/lib/ddtrace/contrib/active_model_serializers/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the ActiveModelSerializers integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :service_name, default: Ext::SERVICE_NAME
           option :tracer do |o|

--- a/lib/ddtrace/contrib/active_model_serializers/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/configuration/settings.rb
@@ -18,16 +18,6 @@ module Datadog
           end
 
           option :service_name, default: Ext::SERVICE_NAME
-          option :tracer do |o|
-            o.default Datadog.tracer
-            o.setter { |value| value || Datadog.tracer }
-            o.on_set do |value|
-              # Make sure to update tracers of all subscriptions
-              Events.subscriptions.each do |subscription|
-                subscription.tracer = value
-              end
-            end
-          end
         end
       end
     end

--- a/lib/ddtrace/contrib/active_model_serializers/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/configuration/settings.rb
@@ -18,12 +18,11 @@ module Datadog
           option :service_name, default: Ext::SERVICE_NAME
           option :tracer do |o|
             o.default Datadog.tracer
-            o.setter do |value|
-              (value || Datadog.tracer).tap do |v|
-                # Make sure to update tracers of all subscriptions
-                Events.subscriptions.each do |subscription|
-                  subscription.tracer = v
-                end
+            o.setter { |value| value || Datadog.tracer }
+            o.on_set do |value|
+              # Make sure to update tracers of all subscriptions
+              Events.subscriptions.each do |subscription|
+                subscription.tracer = value
               end
             end
           end

--- a/lib/ddtrace/contrib/active_model_serializers/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/active_model_serializers/event.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/event.rb
@@ -21,7 +21,7 @@ module Datadog
           end
 
           def tracer
-            configuration[:tracer]
+            -> { configuration[:tracer] }
           end
 
           def configuration

--- a/lib/ddtrace/contrib/active_record/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_record/configuration/settings.rb
@@ -10,18 +10,18 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :orm_service_name
           option :service_name do |o|
             o.default { Utils.adapter_name }
-            o.lazy true
+            o.lazy
           end
 
           option :tracer do |o|

--- a/lib/ddtrace/contrib/active_record/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_record/configuration/settings.rb
@@ -23,11 +23,9 @@ module Datadog
 
           option :tracer do |o|
             o.default Datadog.tracer
-            o.setter do |value|
-              value.tap do
-                Events.subscriptions.each do |subscription|
-                  subscription.tracer = value
-                end
+            o.on_set do |value|
+              Events.subscriptions.each do |subscription|
+                subscription.tracer = value
               end
             end
           end

--- a/lib/ddtrace/contrib/active_record/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_record/configuration/settings.rb
@@ -21,10 +21,13 @@ module Datadog
                  default: -> { Utils.adapter_name },
                  lazy: true
 
-          option :tracer, default: Datadog.tracer do |value|
-            value.tap do
-              Events.subscriptions.each do |subscription|
-                subscription.tracer = value
+          option :tracer do |o|
+            o.default Datadog.tracer
+            o.setter do |value|
+              value.tap do
+                Events.subscriptions.each do |subscription|
+                  subscription.tracer = value
+                end
               end
             end
           end

--- a/lib/ddtrace/contrib/active_record/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_record/configuration/settings.rb
@@ -23,15 +23,6 @@ module Datadog
             o.default { Utils.adapter_name }
             o.lazy
           end
-
-          option :tracer do |o|
-            o.default Datadog.tracer
-            o.on_set do |value|
-              Events.subscriptions.each do |subscription|
-                subscription.tracer = value
-              end
-            end
-          end
         end
       end
     end

--- a/lib/ddtrace/contrib/active_record/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_record/configuration/settings.rb
@@ -8,18 +8,21 @@ module Datadog
       module Configuration
         # Custom settings for the ActiveRecord integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :orm_service_name
-          option :service_name,
-                 default: -> { Utils.adapter_name },
-                 lazy: true
+          option :service_name do |o|
+            o.default { Utils.adapter_name }
+            o.lazy true
+          end
 
           option :tracer do |o|
             o.default Datadog.tracer

--- a/lib/ddtrace/contrib/active_record/event.rb
+++ b/lib/ddtrace/contrib/active_record/event.rb
@@ -17,7 +17,7 @@ module Datadog
           end
 
           def tracer
-            configuration[:tracer]
+            -> { configuration[:tracer] }
           end
 
           def configuration

--- a/lib/ddtrace/contrib/active_support/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_support/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :cache_service, default: Ext::SERVICE_CACHE

--- a/lib/ddtrace/contrib/active_support/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_support/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the ActiveSupport integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :cache_service, default: Ext::SERVICE_CACHE
         end

--- a/lib/ddtrace/contrib/active_support/notifications/subscriber.rb
+++ b/lib/ddtrace/contrib/active_support/notifications/subscriber.rb
@@ -41,7 +41,7 @@ module Datadog
             end
 
             # Creates a subscription and immediately activates it.
-            def subscribe(pattern, span_name, options = {}, tracer = Datadog.tracer, &block)
+            def subscribe(pattern, span_name, options = {}, tracer = -> { Datadog.tracer }, &block)
               subscription(span_name, options, tracer, &block).tap do |subscription|
                 subscription.subscribe(pattern)
               end
@@ -49,7 +49,7 @@ module Datadog
 
             # Creates a subscription without activating it.
             # Subscription is added to the inheriting class' list of subscriptions.
-            def subscription(span_name, options = {}, tracer = Datadog.tracer, &block)
+            def subscription(span_name, options = {}, tracer = -> { Datadog.tracer }, &block)
               Subscription.new(tracer, span_name, options, &block).tap do |subscription|
                 subscriptions << subscription
               end

--- a/lib/ddtrace/contrib/active_support/notifications/subscription.rb
+++ b/lib/ddtrace/contrib/active_support/notifications/subscription.rb
@@ -5,7 +5,6 @@ module Datadog
         # An ActiveSupport::Notification subscription that wraps events with tracing.
         class Subscription
           attr_accessor \
-            :tracer,
             :span_name,
             :options
 
@@ -16,6 +15,10 @@ module Datadog
             @options = options
             @handler = Handler.new(&block)
             @callbacks = Callbacks.new
+          end
+
+          def tracer
+            @tracer.is_a?(Proc) ? @tracer.call : @tracer
           end
 
           # ActiveSupport 3.x calls this

--- a/lib/ddtrace/contrib/aws/configuration/settings.rb
+++ b/lib/ddtrace/contrib/aws/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the AWS integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :service_name, default: Ext::SERVICE_NAME
         end

--- a/lib/ddtrace/contrib/aws/configuration/settings.rb
+++ b/lib/ddtrace/contrib/aws/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/configuration/settings.rb
+++ b/lib/ddtrace/contrib/configuration/settings.rb
@@ -7,12 +7,12 @@ module Datadog
       class Settings
         include Datadog::Configuration::Base
 
-        option :service_name
-        option :tracer,
-               default: -> { Datadog.tracer },
-               lazy: true
         option :analytics_enabled, default: false
         option :analytics_sample_rate, default: 1.0
+        option :service_name
+        option :tracer do |o|
+          o.delegate_to { Datadog.tracer }
+        end
 
         def configure(options = {})
           self.class.options.dependency_order.each do |name|

--- a/lib/ddtrace/contrib/dalli/configuration/settings.rb
+++ b/lib/ddtrace/contrib/dalli/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the Dalli integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :service_name, default: Ext::SERVICE_NAME
         end

--- a/lib/ddtrace/contrib/dalli/configuration/settings.rb
+++ b/lib/ddtrace/contrib/dalli/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/delayed_job/configuration/settings.rb
+++ b/lib/ddtrace/contrib/delayed_job/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the DelayedJob integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :service_name, default: Ext::SERVICE_NAME
         end

--- a/lib/ddtrace/contrib/delayed_job/configuration/settings.rb
+++ b/lib/ddtrace/contrib/delayed_job/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/elasticsearch/configuration/settings.rb
+++ b/lib/ddtrace/contrib/elasticsearch/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :quantize, default: {}

--- a/lib/ddtrace/contrib/elasticsearch/configuration/settings.rb
+++ b/lib/ddtrace/contrib/elasticsearch/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the Elasticsearch integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :quantize, default: {}
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/ethon/configuration/settings.rb
+++ b/lib/ddtrace/contrib/ethon/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :distributed_tracing, default: true

--- a/lib/ddtrace/contrib/ethon/configuration/settings.rb
+++ b/lib/ddtrace/contrib/ethon/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the Ethon integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :distributed_tracing, default: true
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/excon/configuration/settings.rb
+++ b/lib/ddtrace/contrib/excon/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :distributed_tracing, default: true

--- a/lib/ddtrace/contrib/excon/configuration/settings.rb
+++ b/lib/ddtrace/contrib/excon/configuration/settings.rb
@@ -7,16 +7,18 @@ module Datadog
       module Configuration
         # Custom settings for the Excon integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :distributed_tracing, default: true
-          option :error_handler, default: nil
+          option :error_handler
           option :service_name, default: Ext::SERVICE_NAME
           option :split_by_domain, default: false
         end

--- a/lib/ddtrace/contrib/faraday/configuration/settings.rb
+++ b/lib/ddtrace/contrib/faraday/configuration/settings.rb
@@ -14,12 +14,12 @@ module Datadog
 
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :distributed_tracing, default: true

--- a/lib/ddtrace/contrib/faraday/configuration/settings.rb
+++ b/lib/ddtrace/contrib/faraday/configuration/settings.rb
@@ -12,13 +12,15 @@ module Datadog
             Datadog::Ext::HTTP::ERROR_RANGE.cover?(env[:status])
           end
 
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :distributed_tracing, default: true
           option :error_handler, default: DEFAULT_ERROR_HANDLER

--- a/lib/ddtrace/contrib/grape/configuration/settings.rb
+++ b/lib/ddtrace/contrib/grape/configuration/settings.rb
@@ -8,13 +8,15 @@ module Datadog
       module Configuration
         # Custom settings for the Grape integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :enabled, default: true
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/grape/configuration/settings.rb
+++ b/lib/ddtrace/contrib/grape/configuration/settings.rb
@@ -10,12 +10,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :enabled, default: true

--- a/lib/ddtrace/contrib/graphql/configuration/settings.rb
+++ b/lib/ddtrace/contrib/graphql/configuration/settings.rb
@@ -10,12 +10,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :schemas

--- a/lib/ddtrace/contrib/graphql/configuration/settings.rb
+++ b/lib/ddtrace/contrib/graphql/configuration/settings.rb
@@ -8,13 +8,15 @@ module Datadog
       module Configuration
         # Custom settings for the GraphQL integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :schemas
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/grpc/configuration/settings.rb
+++ b/lib/ddtrace/contrib/grpc/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the gRPC integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :service_name, default: Ext::SERVICE_NAME
         end

--- a/lib/ddtrace/contrib/grpc/configuration/settings.rb
+++ b/lib/ddtrace/contrib/grpc/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/http/configuration/settings.rb
+++ b/lib/ddtrace/contrib/http/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the HTTP integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :distributed_tracing, default: true
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/http/configuration/settings.rb
+++ b/lib/ddtrace/contrib/http/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :distributed_tracing, default: true

--- a/lib/ddtrace/contrib/mongodb/configuration/settings.rb
+++ b/lib/ddtrace/contrib/mongodb/configuration/settings.rb
@@ -9,13 +9,15 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           DEFAULT_QUANTIZE = { show: [:collection, :database, :operation] }.freeze
 
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :quantize, default: DEFAULT_QUANTIZE
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/mongodb/configuration/settings.rb
+++ b/lib/ddtrace/contrib/mongodb/configuration/settings.rb
@@ -11,12 +11,12 @@ module Datadog
 
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :quantize, default: DEFAULT_QUANTIZE

--- a/lib/ddtrace/contrib/mysql2/configuration/settings.rb
+++ b/lib/ddtrace/contrib/mysql2/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the Mysql2 integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :service_name, default: Ext::SERVICE_NAME
         end

--- a/lib/ddtrace/contrib/mysql2/configuration/settings.rb
+++ b/lib/ddtrace/contrib/mysql2/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/racecar/configuration/settings.rb
+++ b/lib/ddtrace/contrib/racecar/configuration/settings.rb
@@ -16,11 +16,14 @@ module Datadog
                   lazy: true
 
           option :service_name, default: Ext::SERVICE_NAME
-          option :tracer, default: Datadog.tracer do |value|
-            (value || Datadog.tracer).tap do |v|
-              # Make sure to update tracers of all subscriptions
-              Events.subscriptions.each do |subscription|
-                subscription.tracer = v
+          option :tracer do |o|
+            o.default Datadog.tracer
+            o.setter do |value|
+              (value || Datadog.tracer).tap do |v|
+                # Make sure to update tracers of all subscriptions
+                Events.subscriptions.each do |subscription|
+                  subscription.tracer = v
+                end
               end
             end
           end

--- a/lib/ddtrace/contrib/racecar/configuration/settings.rb
+++ b/lib/ddtrace/contrib/racecar/configuration/settings.rb
@@ -18,16 +18,6 @@ module Datadog
           end
 
           option :service_name, default: Ext::SERVICE_NAME
-          option :tracer do |o|
-            o.default Datadog.tracer
-            o.setter { |value| value || Datadog.tracer }
-            o.on_set do |value|
-              # Make sure to update tracers of all subscriptions
-              Events.subscriptions.each do |subscription|
-                subscription.tracer = value
-              end
-            end
-          end
         end
       end
     end

--- a/lib/ddtrace/contrib/racecar/configuration/settings.rb
+++ b/lib/ddtrace/contrib/racecar/configuration/settings.rb
@@ -18,12 +18,11 @@ module Datadog
           option :service_name, default: Ext::SERVICE_NAME
           option :tracer do |o|
             o.default Datadog.tracer
-            o.setter do |value|
-              (value || Datadog.tracer).tap do |v|
-                # Make sure to update tracers of all subscriptions
-                Events.subscriptions.each do |subscription|
-                  subscription.tracer = v
-                end
+            o.setter { |value| value || Datadog.tracer }
+            o.on_set do |value|
+              # Make sure to update tracers of all subscriptions
+              Events.subscriptions.each do |subscription|
+                subscription.tracer = value
               end
             end
           end

--- a/lib/ddtrace/contrib/racecar/configuration/settings.rb
+++ b/lib/ddtrace/contrib/racecar/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/racecar/configuration/settings.rb
+++ b/lib/ddtrace/contrib/racecar/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the Racecar integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :service_name, default: Ext::SERVICE_NAME
           option :tracer do |o|

--- a/lib/ddtrace/contrib/racecar/event.rb
+++ b/lib/ddtrace/contrib/racecar/event.rb
@@ -26,7 +26,7 @@ module Datadog
           end
 
           def tracer
-            configuration[:tracer]
+            -> { configuration[:tracer] }
           end
 
           def configuration

--- a/lib/ddtrace/contrib/rack/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rack/configuration/settings.rb
@@ -14,13 +14,15 @@ module Datadog
             ]
           }.freeze
 
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :application
           option :distributed_tracing, default: true

--- a/lib/ddtrace/contrib/rack/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rack/configuration/settings.rb
@@ -16,12 +16,12 @@ module Datadog
 
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :application

--- a/lib/ddtrace/contrib/rails/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rails/configuration/settings.rb
@@ -9,60 +9,48 @@ module Datadog
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
             o.lazy true
-            o.setter do |value|
-              value.tap do
-                # Update ActionPack analytics too
-                Datadog.configuration[:action_pack][:analytics_enabled] = value
-              end
+            o.on_set do |value|
+              # Update ActionPack analytics too
+              Datadog.configuration[:action_pack][:analytics_enabled] = value
             end
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
             o.lazy true
-            o.setter do |value|
-              value.tap do
-                # Update ActionPack analytics too
-                Datadog.configuration[:action_pack][:analytics_sample_rate] = value
-              end
+            o.on_set do |value|
+              # Update ActionPack analytics too
+              Datadog.configuration[:action_pack][:analytics_sample_rate] = value
             end
           end
 
           option :cache_service do |o|
-            o.setter do |value|
-              value.tap do
-                # Update ActiveSupport service name too
-                Datadog.configuration[:active_support][:cache_service] = value
-              end
+            o.on_set do |value|
+              # Update ActiveSupport service name too
+              Datadog.configuration[:active_support][:cache_service] = value
             end
           end
 
           option :controller_service do |o|
-            o.setter do |value|
-              value.tap do
-                # Update ActionPack service name too
-                Datadog.configuration[:action_pack][:controller_service] = value
-              end
+            o.on_set do |value|
+              # Update ActionPack service name too
+              Datadog.configuration[:action_pack][:controller_service] = value
             end
           end
 
           option :database_service do |o|
             o.depends_on :service_name
-            o.setter do |value|
-              value.tap do
-                # Update ActiveRecord service name too
-                Datadog.configuration[:active_record][:service_name] = value
-              end
+            o.on_set do |value|
+              # Update ActiveRecord service name too
+              Datadog.configuration[:active_record][:service_name] = value
             end
           end
 
           option :distributed_tracing, default: true
           option :exception_controller do |o|
-            o.setter do |value|
-              value.tap do
-                # Update ActionPack exception controller too
-                Datadog.configuration[:action_pack][:exception_controller] = value
-              end
+            o.on_set do |value|
+              # Update ActionPack exception controller too
+              Datadog.configuration[:action_pack][:exception_controller] = value
             end
           end
 
@@ -70,21 +58,19 @@ module Datadog
           option :middleware_names, default: false
           option :template_base_path do |o|
             o.default 'views/'
-            o.setter do |value|
+            o.on_set do |value|
               # Update ActionView template base path too
-              value.tap { Datadog.configuration[:action_view][:template_base_path] = value }
+              Datadog.configuration[:action_view][:template_base_path] = value
             end
           end
 
           option :tracer do |o|
             o.default Datadog.tracer
-            o.setter do |value|
-              value.tap do
-                Datadog.configuration[:active_record][:tracer] = value
-                Datadog.configuration[:active_support][:tracer] = value
-                Datadog.configuration[:action_pack][:tracer] = value
-                Datadog.configuration[:action_view][:tracer] = value
-              end
+            o.on_set do |value|
+              Datadog.configuration[:active_record][:tracer] = value
+              Datadog.configuration[:active_support][:tracer] = value
+              Datadog.configuration[:action_pack][:tracer] = value
+              Datadog.configuration[:action_view][:tracer] = value
             end
           end
         end

--- a/lib/ddtrace/contrib/rails/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rails/configuration/settings.rb
@@ -65,7 +65,7 @@ module Datadog
           end
 
           option :tracer do |o|
-            o.default Datadog.tracer
+            o.delegate_to { Datadog.tracer }
             o.on_set do |value|
               Datadog.configuration[:active_record][:tracer] = value
               Datadog.configuration[:active_support][:tracer] = value

--- a/lib/ddtrace/contrib/rails/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rails/configuration/settings.rb
@@ -8,7 +8,7 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
-            o.lazy true
+            o.lazy
             o.on_set do |value|
               # Update ActionPack analytics too
               Datadog.configuration[:action_pack][:analytics_enabled] = value
@@ -17,7 +17,7 @@ module Datadog
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
             o.on_set do |value|
               # Update ActionPack analytics too
               Datadog.configuration[:action_pack][:analytics_sample_rate] = value

--- a/lib/ddtrace/contrib/rails/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rails/configuration/settings.rb
@@ -6,62 +6,85 @@ module Datadog
       module Configuration
         # Custom settings for the Rails integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) },
-                  lazy: true do |value|
-            value.tap do
-              # Update ActionPack analytics too
-              Datadog.configuration[:action_pack][:analytics_enabled] = value
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
+            o.lazy true
+            o.setter do |value|
+              value.tap do
+                # Update ActionPack analytics too
+                Datadog.configuration[:action_pack][:analytics_enabled] = value
+              end
             end
           end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true do |value|
-            value.tap do
-              # Update ActionPack analytics too
-              Datadog.configuration[:action_pack][:analytics_sample_rate] = value
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+            o.setter do |value|
+              value.tap do
+                # Update ActionPack analytics too
+                Datadog.configuration[:action_pack][:analytics_sample_rate] = value
+              end
             end
           end
 
-          option :cache_service do |value|
-            value.tap do
-              # Update ActiveSupport service name too
-              Datadog.configuration[:active_support][:cache_service] = value
+          option :cache_service do |o|
+            o.setter do |value|
+              value.tap do
+                # Update ActiveSupport service name too
+                Datadog.configuration[:active_support][:cache_service] = value
+              end
             end
           end
-          option :controller_service do |value|
-            value.tap do
-              # Update ActionPack service name too
-              Datadog.configuration[:action_pack][:controller_service] = value
+
+          option :controller_service do |o|
+            o.setter do |value|
+              value.tap do
+                # Update ActionPack service name too
+                Datadog.configuration[:action_pack][:controller_service] = value
+              end
             end
           end
-          option :database_service, depends_on: [:service_name] do |value|
-            value.tap do
-              # Update ActiveRecord service name too
-              Datadog.configuration[:active_record][:service_name] = value
+
+          option :database_service do |o|
+            o.depends_on :service_name
+            o.setter do |value|
+              value.tap do
+                # Update ActiveRecord service name too
+                Datadog.configuration[:active_record][:service_name] = value
+              end
             end
           end
+
           option :distributed_tracing, default: true
-          option :exception_controller, default: nil do |value|
-            value.tap do
-              # Update ActionPack exception controller too
-              Datadog.configuration[:action_pack][:exception_controller] = value
+          option :exception_controller do |o|
+            o.setter do |value|
+              value.tap do
+                # Update ActionPack exception controller too
+                Datadog.configuration[:action_pack][:exception_controller] = value
+              end
             end
           end
+
           option :middleware, default: true
           option :middleware_names, default: false
-          option :template_base_path, default: 'views/' do |value|
-            # Update ActionView template base path too
-            value.tap { Datadog.configuration[:action_view][:template_base_path] = value }
+          option :template_base_path do |o|
+            o.default 'views/'
+            o.setter do |value|
+              # Update ActionView template base path too
+              value.tap { Datadog.configuration[:action_view][:template_base_path] = value }
+            end
           end
 
-          option :tracer, default: Datadog.tracer do |value|
-            value.tap do
-              Datadog.configuration[:active_record][:tracer] = value
-              Datadog.configuration[:active_support][:tracer] = value
-              Datadog.configuration[:action_pack][:tracer] = value
-              Datadog.configuration[:action_view][:tracer] = value
+          option :tracer do |o|
+            o.default Datadog.tracer
+            o.setter do |value|
+              value.tap do
+                Datadog.configuration[:active_record][:tracer] = value
+                Datadog.configuration[:active_support][:tracer] = value
+                Datadog.configuration[:action_pack][:tracer] = value
+                Datadog.configuration[:action_view][:tracer] = value
+              end
             end
           end
         end

--- a/lib/ddtrace/contrib/rake/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rake/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :enabled, default: true

--- a/lib/ddtrace/contrib/rake/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rake/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the Rake integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :enabled, default: true
           option :quantize, default: {}

--- a/lib/ddtrace/contrib/redis/configuration/settings.rb
+++ b/lib/ddtrace/contrib/redis/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the Redis integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :service_name, default: Ext::SERVICE_NAME
         end

--- a/lib/ddtrace/contrib/redis/configuration/settings.rb
+++ b/lib/ddtrace/contrib/redis/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/resque/configuration/settings.rb
+++ b/lib/ddtrace/contrib/resque/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the Resque integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :service_name, default: Ext::SERVICE_NAME
           option :workers, default: []

--- a/lib/ddtrace/contrib/resque/configuration/settings.rb
+++ b/lib/ddtrace/contrib/resque/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/rest_client/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rest_client/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the RestClient integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :distributed_tracing, default: true
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/rest_client/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rest_client/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :distributed_tracing, default: true

--- a/lib/ddtrace/contrib/sequel/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sequel/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
         end
       end

--- a/lib/ddtrace/contrib/sequel/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sequel/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the Sequel integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
         end
       end
     end

--- a/lib/ddtrace/contrib/shoryuken/configuration/settings.rb
+++ b/lib/ddtrace/contrib/shoryuken/configuration/settings.rb
@@ -6,13 +6,15 @@ module Datadog
       module Configuration
         # Default settings for the Shoryuken integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :service_name, default: Ext::SERVICE_NAME
         end

--- a/lib/ddtrace/contrib/shoryuken/configuration/settings.rb
+++ b/lib/ddtrace/contrib/shoryuken/configuration/settings.rb
@@ -8,12 +8,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/sidekiq/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sidekiq/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the Sidekiq integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :service_name, default: Ext::SERVICE_NAME
           option :client_service_name, default: Ext::CLIENT_SERVICE_NAME

--- a/lib/ddtrace/contrib/sidekiq/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sidekiq/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/sinatra/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sinatra/configuration/settings.rb
@@ -14,12 +14,12 @@ module Datadog
 
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :distributed_tracing, default: true

--- a/lib/ddtrace/contrib/sinatra/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sinatra/configuration/settings.rb
@@ -12,13 +12,15 @@ module Datadog
             response: %w[Content-Type X-Request-ID]
           }.freeze
 
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :distributed_tracing, default: true
           option :headers, default: DEFAULT_HEADERS

--- a/lib/ddtrace/contrib/sucker_punch/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sucker_punch/configuration/settings.rb
@@ -9,12 +9,12 @@ module Datadog
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
-            o.lazy true
+            o.lazy
           end
 
           option :analytics_sample_rate do |o|
             o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy true
+            o.lazy
           end
 
           option :service_name, default: Ext::SERVICE_NAME

--- a/lib/ddtrace/contrib/sucker_punch/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sucker_punch/configuration/settings.rb
@@ -7,13 +7,15 @@ module Datadog
       module Configuration
         # Custom settings for the SuckerPunch integration
         class Settings < Contrib::Configuration::Settings
-          option  :analytics_enabled,
-                  default: -> { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) },
-                  lazy: true
+          option :analytics_enabled do |o|
+            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }
+            o.lazy true
+          end
 
-          option  :analytics_sample_rate,
-                  default: -> { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) },
-                  lazy: true
+          option :analytics_sample_rate do |o|
+            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
+            o.lazy true
+          end
 
           option :service_name, default: Ext::SERVICE_NAME
         end

--- a/spec/ddtrace/configuration/option_definition_spec.rb
+++ b/spec/ddtrace/configuration/option_definition_spec.rb
@@ -264,9 +264,16 @@ RSpec.describe Datadog::Configuration::OptionDefinition::Builder do
   end
 
   describe '#lazy' do
-    subject(:lazy) { builder.lazy(value) }
-    let(:value) { true }
-    it { is_expected.to be value }
+    context 'given no arguments' do
+      subject(:lazy) { builder.lazy }
+      it { is_expected.to be true }
+    end
+
+    context 'given a value' do
+      subject(:lazy) { builder.lazy(value) }
+      let(:value) { double('value') }
+      it { is_expected.to be value }
+    end
   end
 
   describe '#on_set' do

--- a/spec/ddtrace/configuration/option_definition_spec.rb
+++ b/spec/ddtrace/configuration/option_definition_spec.rb
@@ -129,6 +129,20 @@ RSpec.describe Datadog::Configuration::OptionDefinition do
       it { is_expected.to be default }
     end
   end
+
+  describe '#build' do
+    subject(:build) { definition.build(context) }
+    let(:context) { double('context') }
+    let(:option) { instance_double(Datadog::Configuration::Option) }
+
+    before do
+      expect(Datadog::Configuration::Option).to receive(:new)
+        .with(definition, context)
+        .and_return(option)
+    end
+
+    it { is_expected.to be option }
+  end
 end
 
 RSpec.describe Datadog::Configuration::OptionDefinition::Builder do

--- a/spec/ddtrace/configuration/option_definition_spec.rb
+++ b/spec/ddtrace/configuration/option_definition_spec.rb
@@ -84,6 +84,20 @@ RSpec.describe Datadog::Configuration::OptionDefinition do
     end
   end
 
+  describe '#resetter' do
+    subject(:resetter) { definition.resetter }
+
+    context 'when given a value' do
+      let(:meta) { { resetter: resetter_value } }
+      let(:resetter_value) { double('resetter') }
+      it { is_expected.to be resetter_value }
+    end
+
+    context 'when not initialized' do
+      it { is_expected.to be nil }
+    end
+  end
+
   describe '#default_value' do
     subject(:result) { definition.default_value }
     let(:meta) { { default: default } }
@@ -129,6 +143,7 @@ RSpec.describe Datadog::Configuration::OptionDefinition::Builder do
               depends_on: [],
               lazy: false,
               name: name,
+              resetter: nil,
               setter: Datadog::Configuration::OptionDefinition::IDENTITY
             )
           end
@@ -225,6 +240,12 @@ RSpec.describe Datadog::Configuration::OptionDefinition::Builder do
     it { is_expected.to be value }
   end
 
+  describe '#resetter' do
+    subject(:resetter) { builder.resetter(&block) }
+    let(:block) { proc {} }
+    it { is_expected.to be block }
+  end
+
   describe '#setter' do
     subject(:setter) { builder.setter(&block) }
     let(:block) { proc {} }
@@ -265,6 +286,19 @@ RSpec.describe Datadog::Configuration::OptionDefinition::Builder do
       end
     end
 
+    context 'given :resetter' do
+      let(:options) { { resetter: value } }
+      let(:value) { proc {} }
+
+      it do
+        expect(builder).to receive(:resetter) do |&block|
+          expect(block).to be value
+        end
+
+        apply_options!
+      end
+    end
+
     context 'given :setter' do
       let(:options) { { setter: value } }
       let(:value) { proc {} }
@@ -301,6 +335,7 @@ RSpec.describe Datadog::Configuration::OptionDefinition::Builder do
         :default,
         :depends_on,
         :lazy,
+        :resetter,
         :setter
       )
     end

--- a/spec/ddtrace/configuration/option_definition_spec.rb
+++ b/spec/ddtrace/configuration/option_definition_spec.rb
@@ -65,6 +65,20 @@ RSpec.describe Datadog::Configuration::OptionDefinition do
     end
   end
 
+  describe '#on_set' do
+    subject(:on_set) { definition.on_set }
+
+    context 'when given a value' do
+      let(:meta) { { on_set: on_set_value } }
+      let(:on_set_value) { double('on_set') }
+      it { is_expected.to be on_set_value }
+    end
+
+    context 'when not initialized' do
+      it { is_expected.to be nil }
+    end
+  end
+
   describe '#setter' do
     subject(:setter) { definition.setter }
 
@@ -143,6 +157,7 @@ RSpec.describe Datadog::Configuration::OptionDefinition::Builder do
               depends_on: [],
               lazy: false,
               name: name,
+              on_set: nil,
               resetter: nil,
               setter: Datadog::Configuration::OptionDefinition::IDENTITY
             )
@@ -240,6 +255,12 @@ RSpec.describe Datadog::Configuration::OptionDefinition::Builder do
     it { is_expected.to be value }
   end
 
+  describe '#on_set' do
+    subject(:on_set) { builder.on_set(&block) }
+    let(:block) { proc {} }
+    it { is_expected.to be block }
+  end
+
   describe '#resetter' do
     subject(:resetter) { builder.resetter(&block) }
     let(:block) { proc {} }
@@ -282,6 +303,19 @@ RSpec.describe Datadog::Configuration::OptionDefinition::Builder do
 
       it do
         expect(builder).to receive(:lazy).with(value)
+        apply_options!
+      end
+    end
+
+    context 'given :on_set' do
+      let(:options) { { on_set: value } }
+      let(:value) { proc {} }
+
+      it do
+        expect(builder).to receive(:on_set) do |&block|
+          expect(block).to be value
+        end
+
         apply_options!
       end
     end
@@ -335,6 +369,7 @@ RSpec.describe Datadog::Configuration::OptionDefinition::Builder do
         :default,
         :depends_on,
         :lazy,
+        :on_set,
         :resetter,
         :setter
       )

--- a/spec/ddtrace/configuration/option_spec.rb
+++ b/spec/ddtrace/configuration/option_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Datadog::Configuration::Option do
     instance_double(
       Datadog::Configuration::OptionDefinition,
       default_value: default_value,
+      resetter: nil,
       setter: setter
     )
   end
@@ -57,15 +58,39 @@ RSpec.describe Datadog::Configuration::Option do
       let(:value) { double('value') }
 
       before(:each) do
+        allow(definition).to receive(:resetter).and_return nil
         allow(context).to receive(:instance_exec).with(value, &setter)
         allow(context).to receive(:instance_exec).with(default_value, &setter).and_return(default_value)
         option.set(value)
       end
 
-      context 'causes #get' do
-        subject(:get) { option.get }
-        before(:each) { reset }
-        it { is_expected.to be(default_value) }
+      context 'and no resetter is defined' do
+        context 'then #get is invoked' do
+          subject(:get) { option.get }
+          before(:each) { reset }
+          it { is_expected.to be(default_value) }
+        end
+      end
+
+      context 'and a resetter is defined' do
+        let(:resetter) { proc { resetter_value } }
+        let(:resetter_value) { double('resetter_value') }
+
+        before do
+          allow(definition).to receive(:resetter).and_return(resetter)
+
+          expect(context).to receive(:instance_exec) do |*args, &block|
+            expect(args.first).to be(setter_value)
+            expect(block).to be resetter
+            resetter.call
+          end
+        end
+
+        context 'then #get is invoked' do
+          subject(:get) { option.get }
+          before(:each) { reset }
+          it { is_expected.to be(resetter_value) }
+        end
       end
     end
   end

--- a/spec/ddtrace/configuration/option_spec.rb
+++ b/spec/ddtrace/configuration/option_spec.rb
@@ -61,6 +61,19 @@ RSpec.describe Datadog::Configuration::Option do
     context 'when #set' do
       context 'hasn\'t been called' do
         it { is_expected.to be(default_value) }
+
+        context 'and #get is called twice' do
+          before do
+            expect(definition).to receive(:default_value)
+              .once
+              .and_return(default_value)
+          end
+
+          it 'keeps and re-uses the same default object' do
+            is_expected.to be default_value
+            expect(option.get).to be default_value
+          end
+        end
       end
 
       context 'has been called' do

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -3,77 +3,7 @@ require 'spec_helper'
 require 'ddtrace/configuration/settings'
 
 RSpec.describe Datadog::Configuration::Settings do
-  subject(:configuration) { described_class.new(registry: registry) }
-  let(:registry) { Datadog::Contrib::Registry.new }
-
-  # TODO: Extract integration behavior to `contrib`
-  describe '#use' do
-    subject(:result) { configuration.use(name, options) }
-    let(:name) { :example }
-    let(:integration) { double('integration') }
-    let(:options) { {} }
-
-    before(:each) do
-      registry.add(name, integration)
-    end
-
-    context 'for a generic integration' do
-      before(:each) do
-        expect(integration).to receive(:configure).with(:default, options).and_return([])
-        expect(integration).to receive(:patch).and_return(true)
-      end
-
-      it { expect { result }.to_not raise_error }
-    end
-
-    context 'for an integration that includes Datadog::Contrib::Integration' do
-      let(:patcher_module) do
-        stub_const('Patcher', Module.new do
-          include Datadog::Contrib::Patcher
-
-          def self.patch
-            true
-          end
-        end)
-      end
-
-      let(:integration_class) do
-        patcher_module
-
-        Class.new do
-          include Datadog::Contrib::Integration
-
-          def self.version
-            Gem::Version.new('0.1')
-          end
-
-          def patcher
-            Patcher
-          end
-        end
-      end
-
-      let(:integration) do
-        integration_class.new(name)
-      end
-
-      context 'which is provided only a name' do
-        it do
-          expect(integration).to receive(:configure).with(:default, {})
-          configuration.use(name)
-        end
-      end
-
-      context 'which is provided a block' do
-        it do
-          expect(integration).to receive(:configure).with(:default, {}).and_call_original
-          expect { |b| configuration.use(name, options, &b) }.to yield_with_args(
-            a_kind_of(Datadog::Contrib::Configuration::Settings)
-          )
-        end
-      end
-    end
-  end
+  subject(:settings) { described_class.new }
 
   describe '#tracer' do
     let(:tracer) { Datadog::Tracer.new }
@@ -84,7 +14,7 @@ RSpec.describe Datadog::Configuration::Settings do
       before(:each) do
         @original_log = tracer.class.log
 
-        configuration.tracer(
+        settings.tracer(
           enabled: false,
           debug: !debug_state,
           log: custom_log,
@@ -112,22 +42,12 @@ RSpec.describe Datadog::Configuration::Settings do
       end
     end
 
-    it 'acts on the default tracer' do
-      previous_state = Datadog.tracer.enabled
-      configuration.tracer(enabled: !previous_state)
-      expect(Datadog.tracer.enabled).to eq(!previous_state)
-      configuration.tracer(enabled: previous_state)
-      expect(Datadog.tracer.enabled).to eq(previous_state)
-    end
-  end
-
-  describe '#[]' do
-    context 'when the integration doesn\'t exist' do
-      it do
-        expect { configuration[:foobar] }.to raise_error(
-          Datadog::Contrib::Extensions::Configuration::Settings::InvalidIntegrationError
-        )
-      end
+    it 'acts on the tracer option' do
+      previous_state = settings.tracer.enabled
+      settings.tracer(enabled: !previous_state)
+      expect(settings.tracer.enabled).to eq(!previous_state)
+      settings.tracer(enabled: previous_state)
+      expect(settings.tracer.enabled).to eq(previous_state)
     end
   end
 end

--- a/spec/ddtrace/contrib/configuration/settings_spec.rb
+++ b/spec/ddtrace/contrib/configuration/settings_spec.rb
@@ -5,35 +5,7 @@ require 'ddtrace'
 RSpec.describe Datadog::Contrib::Configuration::Settings do
   subject(:settings) { described_class.new }
 
-  it { is_expected.to be_a_kind_of(Datadog::Configuration::Options) }
-
-  describe '#to_h' do
-    subject(:hash) { settings.to_h }
-    let(:options_hash) { double('options hash') }
-
-    before do
-      allow(settings).to receive(:options_hash)
-        .and_return(options_hash)
-    end
-
-    it do
-      is_expected.to be(options_hash)
-      expect(settings).to have_received(:options_hash)
-    end
-  end
-
-  describe '#reset!' do
-    subject(:reset!) { settings.reset! }
-
-    before do
-      allow(settings).to receive(:reset_options!)
-      reset!
-    end
-
-    it 'resets the options' do
-      expect(settings).to have_received(:reset_options!)
-    end
-  end
+  it { is_expected.to be_a_kind_of(Datadog::Configuration::Base) }
 
   describe '#options' do
     subject(:options) { settings.options }

--- a/spec/ddtrace/contrib/extensions_spec.rb
+++ b/spec/ddtrace/contrib/extensions_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+require 'ddtrace'
+require 'ddtrace/contrib/extensions'
+
+RSpec.describe Datadog::Contrib::Extensions do
+  context 'for' do
+    describe Datadog::Configuration::Settings do
+      subject(:settings) { described_class.new(registry: registry) }
+      let(:registry) { Datadog::Contrib::Registry.new }
+
+      describe '#[]' do
+        context 'when the integration doesn\'t exist' do
+          it do
+            expect { settings[:foobar] }.to raise_error(
+              Datadog::Contrib::Extensions::Configuration::Settings::InvalidIntegrationError
+            )
+          end
+        end
+      end
+
+      describe '#use' do
+        subject(:result) { settings.use(name, options) }
+        let(:name) { :example }
+        let(:integration) { double('integration') }
+        let(:options) { {} }
+
+        before(:each) do
+          registry.add(name, integration)
+        end
+
+        context 'for a generic integration' do
+          before(:each) do
+            expect(integration).to receive(:configure).with(:default, options).and_return([])
+            expect(integration).to receive(:patch).and_return(true)
+          end
+
+          it { expect { result }.to_not raise_error }
+        end
+
+        context 'for an integration that includes Datadog::Contrib::Integration' do
+          let(:patcher_module) do
+            stub_const('Patcher', Module.new do
+              include Datadog::Contrib::Patcher
+
+              def self.patch
+                true
+              end
+            end)
+          end
+
+          let(:integration_class) do
+            patcher_module
+
+            Class.new do
+              include Datadog::Contrib::Integration
+
+              def self.version
+                Gem::Version.new('0.1')
+              end
+
+              def patcher
+                Patcher
+              end
+            end
+          end
+
+          let(:integration) do
+            integration_class.new(name)
+          end
+
+          context 'which is provided only a name' do
+            it do
+              expect(integration).to receive(:configure).with(:default, {})
+              settings.use(name)
+            end
+          end
+
+          context 'which is provided a block' do
+            it do
+              expect(integration).to receive(:configure).with(:default, {}).and_call_original
+              expect { |b| settings.use(name, options, &b) }.to yield_with_args(
+                a_kind_of(Datadog::Contrib::Configuration::Settings)
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/contrib/sidekiq/tracer_test_base.rb
+++ b/test/contrib/sidekiq/tracer_test_base.rb
@@ -10,8 +10,8 @@ class TracerTestBase < Minitest::Test
   REDIS_PORT = ENV.fetch('TEST_REDIS_PORT', 6379)
 
   def setup
-    @writer = FauxWriter.new()
-    @tracer = Datadog::Tracer.new(writer: @writer)
+    @tracer = get_test_tracer
+    @writer = @tracer.writer
 
     redis_url = "redis://#{REDIS_HOST}:#{REDIS_PORT}"
 


### PR DESCRIPTION
Based on #808. Replaces #829.

To facilitate more robust configurations and features for configuration options, this pull request adds a DSL block syntax for option definitions. For example:

This:

```ruby
option :tracer, default: Datadog::Tracer.new

remove_method :tracer
def tracer(options = nil)
  # Custom helper code here
end
```

Becomes this:

```ruby
option :tracer do |o|
  o.default Datadog::Tracer.new
  o.helper :tracer do |options = nil|
    # Custom helper code here
  end
end
```

In addition to some cleaner syntax, this feature grants additional benefits:

 - Customization and disabling of helpers (e.g. `o.helper :foo, false`)
 - Permit passing blocks to configuration options (currently not possible)
 - More extensible kinds of options (e.g. integrations)

There is one breaking change which requires all option definitions using blocks to be wrapped, i.e. `option(:foo) { |value|  value }` becomes `option(:foo) { |o| o.setter { |value|  value } }`; all affected code has been updated in this PR though.