### PR TITLE
Add configuration #settings option

### DIFF
--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -31,26 +31,28 @@ module Datadog
         o.lazy
       end
 
-      option :propagation_extract_style do |o|
-        o.default do
-          # Look for all headers by default
-          env_to_list(Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV,
-                      [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG,
-                       Ext::DistributedTracing::PROPAGATION_STYLE_B3,
-                       Ext::DistributedTracing::PROPAGATION_STYLE_B3_SINGLE_HEADER])
+      settings :distributed_tracing do
+        option :propagation_extract_style do |o|
+          o.default do
+            # Look for all headers by default
+            env_to_list(Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV,
+                        [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG,
+                         Ext::DistributedTracing::PROPAGATION_STYLE_B3,
+                         Ext::DistributedTracing::PROPAGATION_STYLE_B3_SINGLE_HEADER])
+          end
+
+          o.lazy
         end
 
-        o.lazy
-      end
+        option :propagation_inject_style do |o|
+          o.default do
+            # Only inject Datadog headers by default
+            env_to_list(Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV,
+                        [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG])
+          end
 
-      option :propagation_inject_style do |o|
-        o.default do
-          # Only inject Datadog headers by default
-          env_to_list(Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV,
-                      [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG])
+          o.lazy
         end
-
-        o.lazy
       end
 
       option :tracer do |o|
@@ -77,12 +79,6 @@ module Datadog
             end
           end
         end
-      end
-
-      def distributed_tracing
-        # TODO: Move distributed tracing configuration to it's own Settings sub-class
-        # DEV: We do this to fake `Datadog.configuration.distributed_tracing.propagation_inject_style`
-        self
       end
 
       def runtime_metrics(options = nil)

--- a/lib/ddtrace/propagation/http_propagator.rb
+++ b/lib/ddtrace/propagation/http_propagator.rb
@@ -24,7 +24,7 @@ module Datadog
       end
 
       # Inject all configured propagation styles
-      ::Datadog.configuration.propagation_inject_style.each do |style|
+      ::Datadog.configuration.distributed_tracing.propagation_inject_style.each do |style|
         propagator = PROPAGATION_STYLES[style]
         propagator.inject!(context, env) unless propagator.nil?
       end
@@ -36,7 +36,7 @@ module Datadog
       context = nil
       dd_context = nil
 
-      ::Datadog.configuration.propagation_extract_style.each do |style|
+      ::Datadog.configuration.distributed_tracing.propagation_extract_style.each do |style|
         propagator = PROPAGATION_STYLES[style]
         next if propagator.nil?
 

--- a/spec/ddtrace/configuration/base_spec.rb
+++ b/spec/ddtrace/configuration/base_spec.rb
@@ -10,6 +10,27 @@ RSpec.describe Datadog::Configuration::Base do
       end
     end
 
+    describe 'class behavior' do
+      describe '#settings' do
+        subject(:settings) { base_class.send(:settings, name, &block) }
+
+        context 'given a name and block' do
+          let(:name) { :debug }
+          let(:block) { proc { option :enabled } }
+
+          it 'adds a settings option' do
+            settings
+
+            base_class.options[name].tap do |option|
+              expect(option).to be_a_kind_of(Datadog::Configuration::OptionDefinition)
+              expect(option.default_value).to be_a_kind_of(described_class)
+              expect(option.default_value.option_defined?(:enabled)).to be true
+            end
+          end
+        end
+      end
+    end
+
     describe 'instance behavior' do
       subject(:base_object) { base_class.new }
 


### PR DESCRIPTION
Based on #808 and #830.

This pull request adds a `settings` helper to configuration objects, allowing them to define sub-groupings of settings:

```ruby
settings :debug do
  option :logging, default: false

  settings :metrics do
    option :enabled, default: false
    option :client, default Datadog::Metrics.new
  end
end

# Usage
config.debug.logging = true
config.debug.metrics.enabled = true
```