### PR TITLE
Rack: Accept generic X-Request-Start header

### DIFF
--- a/lib/ddtrace/contrib/rack/request_queue.rb
+++ b/lib/ddtrace/contrib/rack/request_queue.rb
@@ -13,9 +13,7 @@ module Datadog
           return unless header
 
           # nginx header is in the format "t=1512379167.574"
-          # TODO: this should be generic enough to work with any
-          # frontend web server or load balancer
-          time_string = header.split('t=')[1]
+          time_string = header.to_s.sub('t=', '')
           return if time_string.nil?
 
           # Return nil if the time is clearly invalid

--- a/lib/ddtrace/contrib/rack/request_queue.rb
+++ b/lib/ddtrace/contrib/rack/request_queue.rb
@@ -12,7 +12,7 @@ module Datadog
           header = env[REQUEST_START] || env[QUEUE_START]
           return unless header
 
-          # nginx header is milliseconds in the format "t=1512379167.574"
+          # nginx header is seconds in the format "t=1512379167.574"
           # apache header is microseconds in the format "t=1570633834463123"
           # heorku header is milliseconds in the format "1570634024294"
           time_string = header.to_s.delete('^0-9')

--- a/lib/ddtrace/contrib/rack/request_queue.rb
+++ b/lib/ddtrace/contrib/rack/request_queue.rb
@@ -15,7 +15,7 @@ module Datadog
           # nginx header is milliseconds in the format "t=1512379167.574"
           # apache header is microseconds in the format "t=1570633834463123"
           # heorku header is milliseconds in the format "1570634024294"
-          time_string = header.to_s.gsub(/t=|\./, '')
+          time_string = header.to_s.delete('^0-9')
           return if time_string.nil?
 
           # Return nil if the time is clearly invalid

--- a/lib/ddtrace/contrib/rack/request_queue.rb
+++ b/lib/ddtrace/contrib/rack/request_queue.rb
@@ -12,12 +12,14 @@ module Datadog
           header = env[REQUEST_START] || env[QUEUE_START]
           return unless header
 
-          # nginx header is in the format "t=1512379167.574"
-          time_string = header.to_s.sub('t=', '')
+          # nginx header is milliseconds in the format "t=1512379167.574"
+          # apache header is microseconds in the format "t=1570633834463123"
+          # heorku header is milliseconds in the format "1570634024294"
+          time_string = header.to_s.gsub(/t=|\./, '')
           return if time_string.nil?
 
           # Return nil if the time is clearly invalid
-          time_value = time_string.to_f
+          time_value = "#{time_string[0, 10]}.#{time_string[10, 13]}".to_f
           return if time_value.zero?
 
           # return the request_start only if it's lesser than

--- a/lib/ddtrace/contrib/rack/request_queue.rb
+++ b/lib/ddtrace/contrib/rack/request_queue.rb
@@ -15,7 +15,7 @@ module Datadog
 
           # nginx header is seconds in the format "t=1512379167.574"
           # apache header is microseconds in the format "t=1570633834463123"
-          # heorku header is milliseconds in the format "1570634024294"
+          # heroku header is milliseconds in the format "1570634024294"
           time_string = header.to_s.delete('^0-9')
           return if time_string.nil?
 

--- a/lib/ddtrace/contrib/rack/request_queue.rb
+++ b/lib/ddtrace/contrib/rack/request_queue.rb
@@ -5,6 +5,7 @@ module Datadog
       module QueueTime
         REQUEST_START = 'HTTP_X_REQUEST_START'.freeze
         QUEUE_START = 'HTTP_X_QUEUE_START'.freeze
+        MINIMUM_ACCEPTABLE_TIME_VALUE = 1_000_000_000.freeze
 
         module_function
 
@@ -19,8 +20,8 @@ module Datadog
           return if time_string.nil?
 
           # Return nil if the time is clearly invalid
-          time_value = "#{time_string[0, 10]}.#{time_string[10, 13]}".to_f
-          return if time_value.zero?
+          time_value = "#{time_string[0, 10]}.#{time_string[10, 6]}".to_f
+          return if time_value.zero? || time_value < MINIMUM_ACCEPTABLE_TIME_VALUE
 
           # return the request_start only if it's lesser than
           # current time, to avoid significant clock skew

--- a/lib/ddtrace/contrib/rack/request_queue.rb
+++ b/lib/ddtrace/contrib/rack/request_queue.rb
@@ -5,7 +5,7 @@ module Datadog
       module QueueTime
         REQUEST_START = 'HTTP_X_REQUEST_START'.freeze
         QUEUE_START = 'HTTP_X_QUEUE_START'.freeze
-        MINIMUM_ACCEPTABLE_TIME_VALUE = 1_000_000_000.freeze
+        MINIMUM_ACCEPTABLE_TIME_VALUE = 1_000_000_000
 
         module_function
 

--- a/spec/ddtrace/contrib/rack/queue_time_spec.rb
+++ b/spec/ddtrace/contrib/rack/queue_time_spec.rb
@@ -9,26 +9,64 @@ RSpec.describe Datadog::Contrib::Rack::QueueTime do
     subject(:request_start) { described_class.get_request_start(env) }
 
     context 'given a Rack env with' do
-      context described_class::REQUEST_START do
-        let(:env) { { described_class::REQUEST_START => "t=#{value}" } }
-        let(:value) { 1512379167.574 }
-        it { expect(request_start.to_f).to eq(value) }
-
-        context 'but does not start with t=' do
-          let(:env) { { described_class::REQUEST_START => value } }
+      context 'milliseconds' do
+        context described_class::REQUEST_START do
+          let(:env) { { described_class::REQUEST_START => "t=#{value}" } }
+          let(:value) { 1512379167.574 }
           it { expect(request_start.to_f).to eq(value) }
+
+          context 'but does not start with t=' do
+            let(:env) { { described_class::REQUEST_START => value } }
+            it { expect(request_start.to_f).to eq(value) }
+          end
+
+          context 'without decimal places' do
+            let(:env) { { described_class::REQUEST_START => value } }
+            let(:value) { 1512379167574 }
+            it { expect(request_start.to_f).to eq(1512379167.574) }
+          end
+
+          context 'but a malformed value' do
+            let(:value) { 'foobar' }
+            it { is_expected.to be nil }
+          end
         end
 
-        context 'but a malformed value' do
-          let(:value) { 'foobar' }
-          it { is_expected.to be nil }
+        context described_class::QUEUE_START do
+          let(:env) { { described_class::QUEUE_START => "t=#{value}" } }
+          let(:value) { 1512379167.574 }
+          it { expect(request_start.to_f).to eq(value) }
         end
       end
 
-      context described_class::QUEUE_START do
-        let(:env) { { described_class::QUEUE_START => "t=#{value}" } }
-        let(:value) { 1512379167.574 }
-        it { expect(request_start.to_f).to eq(value) }
+      context 'microseconds' do
+        context described_class::REQUEST_START do
+          let(:env) { { described_class::REQUEST_START => "t=#{value}" } }
+          let(:value) { 1570633834.463123 }
+          it { expect(request_start.to_f).to eq(value) }
+
+          context 'but does not start with t=' do
+            let(:env) { { described_class::REQUEST_START => value } }
+            it { expect(request_start.to_f).to eq(value) }
+          end
+
+          context 'without decimal places' do
+            let(:env) { { described_class::REQUEST_START => value } }
+            let(:value) { 1570633834463123 }
+            it { expect(request_start.to_f).to eq(1570633834.463123) }
+          end
+
+          context 'but a malformed value' do
+            let(:value) { 'foobar' }
+            it { is_expected.to be nil }
+          end
+        end
+
+        context described_class::QUEUE_START do
+          let(:env) { { described_class::QUEUE_START => "t=#{value}" } }
+          let(:value) { 1570633834.463123 }
+          it { expect(request_start.to_f).to eq(value) }
+        end
       end
 
       context 'nothing' do

--- a/spec/ddtrace/contrib/rack/queue_time_spec.rb
+++ b/spec/ddtrace/contrib/rack/queue_time_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe Datadog::Contrib::Rack::QueueTime do
         let(:value) { 1512379167.574 }
         it { expect(request_start.to_f).to eq(value) }
 
+        context 'but does not start with t=' do
+          let(:env) { { described_class::REQUEST_START => value } }
+          it { expect(request_start.to_f).to eq(value) }
+        end
+
         context 'but a malformed value' do
           let(:value) { 'foobar' }
           it { is_expected.to be nil }

--- a/spec/ddtrace/contrib/rack/queue_time_spec.rb
+++ b/spec/ddtrace/contrib/rack/queue_time_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe Datadog::Contrib::Rack::QueueTime do
             let(:value) { 'foobar' }
             it { is_expected.to be nil }
           end
+
+          context 'before the start of the acceptable time range' do
+            let(:value) { 999_999_999.000 }
+            it { is_expected.to be nil }
+          end
         end
 
         context described_class::QUEUE_START do


### PR DESCRIPTION
This patch makes the `t=` portion of the X-Request-Start header optional so that the request queuing time can be supported on platforms like Heroku.