### PR TITLE
Ensure release loads the same files as  development

### DIFF
--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -1,5 +1,12 @@
 require 'thread'
 
+# During development, we load `ddtrace` by through `ddtrace.gemspec`,
+# which in turn eager loads 'ddtrace/version'.
+#
+# Users load this gem by requiring this file.
+# We need to ensure that any files loaded in our gemspec are also loaded here.
+require 'ddtrace/version'
+
 require 'ddtrace/pin'
 require 'ddtrace/tracer'
 require 'ddtrace/error'


### PR DESCRIPTION
During development, we load `ddtrace` by through `ddtrace.gemspec`, which in turn eager loads 'ddtrace/version'.

Users load this gem by requiring `lib/ddtrace.rb`.
We need to ensure that any files loaded in our gemspec are also loaded there.

This fixed the following issue:
```
NameError: uninitialized constant Datadog::Span::VERSION
from .../lib/ddtrace/span.rb:246:in `<class:Span>'
```

This issue was introduced in https://github.com/DataDog/dd-trace-rb/pull/819, which is still unreleased.