### PR TITLE
Skip pre-release CI step for external contributors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,6 +545,14 @@ jobs:
     docker:
       - *container-2_5
     steps:
+      - run:
+          name: Check if this commit author has publishing credentials
+          command: |
+            if [[ -z "${AWS_ACCESS_KEY_ID}" ]]
+            then
+              echo 'No AWS credentials, skipping publish of pre-release build.'
+              circleci task halt
+            fi
       - checkout
       - run:
           command: |


### PR DESCRIPTION
We publish pre-release builds of our CI builds for authors that are part of the @DataDog organization.

This currently causes an issue for external contributors, as our CI pipeline fails while running the `deploy prerelease Gem` step.

This PR skips that step if the commit author does not have enough access to publish a pre-release build.

That CI step will be considered successful by CircleCI, allowing external contributors to have a green ✅ on their PRs.