### PR TITLE
MongoDB: add required credentails for plain auth

### DIFF
--- a/spec/ddtrace/contrib/mongodb/client_spec.rb
+++ b/spec/ddtrace/contrib/mongodb/client_spec.rb
@@ -430,7 +430,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
 
     describe 'with LDAP/SASL authentication' do
       let(:client_options) do
-        super().merge(auth_mech: :plain)
+        super().merge(auth_mech: :plain, user: 'plain_user', password: 'plain_pass')
       end
 
       context 'which fails' do
@@ -465,7 +465,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
             expect(insert_span.resource).to match(/"operation"\s*=>\s*:insert/)
             expect(insert_span.status).to eq(1)
             expect(insert_span.get_tag('error.type')).to eq('Mongo::Monitoring::Event::CommandFailed')
-            expect(insert_span.get_tag('error.msg')).to eq('User  is not authorized to access test.')
+            expect(insert_span.get_tag('error.msg')).to match(/.*is not authorized to access.*/)
           end
 
           expect(auth_span.name).to eq('mongo.cmd')


### PR DESCRIPTION
[mongo-ruby-driver](https://github.com/mongodb/mongo-ruby-driver) relased additional sanity checks to client authentication validation [on v2.11.0](https://github.com/mongodb/mongo-ruby-driver/pull/1496/files#diff-9b873200a76992a56a5c5fa0fd7914b2R889-R895).

This PR adds credential information that is now mandatory in our tests using `:plain` authentication.