### PR TITLE
Move buffer size and flush interval defaults into constants

### DIFF
--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -391,8 +391,8 @@ module Datadog
       transport_options = options.fetch(:transport_options, {})
 
       # Compile writer options
-      rebuild_writer = false
-      writer_options = {}
+      writer_options = options.fetch(:writer_options, {})
+      rebuild_writer = !writer_options.empty?
 
       # Re-build the sampler and writer if priority sampling is enabled,
       # but neither are configured. Verify the sampler isn't already a

--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -10,6 +10,8 @@ module Datadog
     # will perform a task at regular intervals. The thread can be stopped
     # with the +stop()+ method and can start with the +start()+ method.
     class AsyncTransport
+      DEFAULT_BUFFER_MAX_SIZE = 100
+      DEFAULT_FLUSH_INTERVAL = 1
       DEFAULT_TIMEOUT = 5
       BACK_OFF_RATIO = 1.2
       BACK_OFF_MAX = 5
@@ -26,12 +28,12 @@ module Datadog
         @runtime_metrics_task = options[:on_runtime_metrics]
 
         # Intervals
-        interval = options.fetch(:interval, 1)
+        interval = options.fetch(:interval, DEFAULT_FLUSH_INTERVAL)
         @flush_interval = interval
         @back_off = interval
 
         # Buffers
-        buffer_size = options.fetch(:buffer_size, 100)
+        buffer_size = options.fetch(:buffer_size, DEFAULT_BUFFER_MAX_SIZE)
         @trace_buffer = TraceBuffer.new(buffer_size)
 
         # Threading

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -18,8 +18,8 @@ module Datadog
 
     def initialize(options = {})
       # writer and transport parameters
-      @buff_size = options.fetch(:buffer_size, 100)
-      @flush_interval = options.fetch(:flush_interval, 1)
+      @buff_size = options.fetch(:buffer_size, Workers::AsyncTransport::DEFAULT_BUFFER_MAX_SIZE)
+      @flush_interval = options.fetch(:flush_interval, Workers::AsyncTransport::DEFAULT_FLUSH_INTERVAL)
       transport_options = options.fetch(:transport_options, {})
 
       # priority sampling

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+require 'ddtrace'
 require 'ddtrace/configuration/settings'
 
 RSpec.describe Datadog::Configuration::Settings do
@@ -22,6 +23,7 @@ RSpec.describe Datadog::Configuration::Settings do
           port: 1234,
           env: :config_test,
           tags: { foo: :bar },
+          writer_options: { buffer_size: 1234 },
           instance: tracer
         )
       end
@@ -39,6 +41,14 @@ RSpec.describe Datadog::Configuration::Settings do
         expect(tracer.writer.transport.current_api.adapter.port).to eq(1234)
         expect(tracer.tags[:env]).to eq(:config_test)
         expect(tracer.tags[:foo]).to eq(:bar)
+      end
+    end
+
+    context 'given :writer_options' do
+      before { settings.tracer(writer_options: { buffer_size: 1234 }) }
+
+      it 'applies settings correctly' do
+        expect(settings.tracer.writer.instance_variable_get(:@buff_size)).to eq(1234)
       end
     end
 


### PR DESCRIPTION
This pull request moves some default values into constants, and makes the writer configurable from `Datadog.tracer.configure` (in order to change buffer size.)