### PR TITLE
Fix synthetics-derived contexts being ignored

### DIFF
--- a/lib/ddtrace/distributed_tracing/headers/datadog.rb
+++ b/lib/ddtrace/distributed_tracing/headers/datadog.rb
@@ -28,7 +28,7 @@ module Datadog
           # Return early if this propagation is not valid
           # DEV: To be valid we need to have a trace id and a parent id or when it is a synthetics trace, just the trace id
           # DEV: `DistributedHeaders#id` will not return 0
-          return unless (trace_id && parent_id) || (origin == 'synthetics' && trace_id)
+          return unless (trace_id && parent_id) || (origin && origin.include?('synthetics') && trace_id)
 
           # Return new context
           ::Datadog::Context.new(trace_id: trace_id,

--- a/lib/ddtrace/distributed_tracing/headers/datadog.rb
+++ b/lib/ddtrace/distributed_tracing/headers/datadog.rb
@@ -28,7 +28,7 @@ module Datadog
           # Return early if this propagation is not valid
           # DEV: To be valid we need to have a trace id and a parent id or when it is a synthetics trace, just the trace id
           # DEV: `DistributedHeaders#id` will not return 0
-          return unless (trace_id && parent_id) || (origin && origin.include?('synthetics') && trace_id)
+          return unless (trace_id && parent_id) || (origin && trace_id)
 
           # Return new context
           ::Datadog::Context.new(trace_id: trace_id,

--- a/lib/ddtrace/distributed_tracing/headers/headers.rb
+++ b/lib/ddtrace/distributed_tracing/headers/headers.rb
@@ -13,6 +13,8 @@ module Datadog
           @env = env
         end
 
+        # TODO: Don't assume Rack format.
+        #       Make distributed tracing headers apathetic.
         def header(name)
           rack_header = "http-#{name}".upcase!.tr('-', '_')
 

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -231,8 +231,8 @@ module Datadog
         @sampler.sample!(span)
         span.set_tag('system.pid', Process.pid)
 
-        if ctx
-          span.trace_id = ctx.trace_id unless ctx.trace_id.nil?
+        if ctx && ctx.trace_id
+          span.trace_id = ctx.trace_id
           span.parent_id = ctx.span_id unless ctx.span_id.nil?
         end
       else

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -230,9 +230,10 @@ module Datadog
         # root span
         @sampler.sample!(span)
         span.set_tag('system.pid', Process.pid)
-        if ctx && ctx.trace_id && ctx.span_id
-          span.trace_id = ctx.trace_id
-          span.parent_id = ctx.span_id
+
+        if ctx
+          span.trace_id = ctx.trace_id unless ctx.trace_id.nil?
+          span.parent_id = ctx.span_id unless ctx.span_id.nil?
         end
       else
         # child span

--- a/spec/ddtrace/distributed_tracing/headers/datadog_spec.rb
+++ b/spec/ddtrace/distributed_tracing/headers/datadog_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Datadog::DistributedTracing::Headers::Datadog do
     let(:env) { {} }
 
     context 'with empty env' do
-      it { is_expected.to be_nil }
+      it { is_expected.to be nil }
     end
 
     context 'with trace_id and span_id' do
@@ -95,8 +95,8 @@ RSpec.describe Datadog::DistributedTracing::Headers::Datadog do
 
       it { expect(context.trace_id).to eq(10000) }
       it { expect(context.span_id).to eq(20000) }
-      it { expect(context.sampling_priority).to be_nil }
-      it { expect(context.origin).to be_nil }
+      it { expect(context.sampling_priority).to be nil }
+      it { expect(context.origin).to be nil }
 
       context 'with sampling priority' do
         let(:env) do
@@ -108,7 +108,7 @@ RSpec.describe Datadog::DistributedTracing::Headers::Datadog do
         it { expect(context.trace_id).to eq(10000) }
         it { expect(context.span_id).to eq(20000) }
         it { expect(context.sampling_priority).to eq(1) }
-        it { expect(context.origin).to be_nil }
+        it { expect(context.origin).to be nil }
 
         context 'with origin' do
           let(:env) do
@@ -134,29 +134,29 @@ RSpec.describe Datadog::DistributedTracing::Headers::Datadog do
 
         it { expect(context.trace_id).to eq(10000) }
         it { expect(context.span_id).to eq(20000) }
-        it { expect(context.sampling_priority).to be_nil }
+        it { expect(context.sampling_priority).to be nil }
         it { expect(context.origin).to eq('synthetics') }
       end
     end
 
     context 'with span_id' do
       let(:env) { { env_header(Datadog::Ext::DistributedTracing::HTTP_HEADER_PARENT_ID) => '10000' } }
-      it { is_expected.to be_nil }
+      it { is_expected.to be nil }
     end
 
     context 'with origin' do
       let(:env) { { env_header(Datadog::Ext::DistributedTracing::HTTP_HEADER_ORIGIN) => 'synthetics' } }
-      it { is_expected.to be_nil }
+      it { is_expected.to be nil }
     end
 
     context 'with sampling priority' do
       let(:env) { { env_header(Datadog::Ext::DistributedTracing::HTTP_HEADER_SAMPLING_PRIORITY) => '1' } }
-      it { is_expected.to be_nil }
+      it { is_expected.to be nil }
     end
 
     context 'with trace_id' do
       let(:env) { { env_header(Datadog::Ext::DistributedTracing::HTTP_HEADER_TRACE_ID) => '10000' } }
-      it { is_expected.to be_nil }
+      it { is_expected.to be nil }
 
       context 'with synthetics origin' do
         let(:env) do
@@ -165,8 +165,8 @@ RSpec.describe Datadog::DistributedTracing::Headers::Datadog do
         end
 
         it { expect(context.trace_id).to eq(10000) }
-        it { expect(context.span_id).to be_nil }
-        it { expect(context.sampling_priority).to be_nil }
+        it { expect(context.span_id).to be nil }
+        it { expect(context.sampling_priority).to be nil }
         it { expect(context.origin).to eq('synthetics') }
       end
 
@@ -176,7 +176,10 @@ RSpec.describe Datadog::DistributedTracing::Headers::Datadog do
             env_header(Datadog::Ext::DistributedTracing::HTTP_HEADER_ORIGIN) => 'custom-origin' }
         end
 
-        it { is_expected.to be_nil }
+        it { expect(context.trace_id).to eq(10000) }
+        it { expect(context.span_id).to be nil }
+        it { expect(context.sampling_priority).to be nil }
+        it { expect(context.origin).to eq('custom-origin') }
       end
     end
   end

--- a/spec/ddtrace/tracer_integration_spec.rb
+++ b/spec/ddtrace/tracer_integration_spec.rb
@@ -76,4 +76,53 @@ RSpec.describe Datadog::Tracer do
       it { expect(@child_root_span).to be child_span }
     end
   end
+
+  context 'with synthetics' do
+    context 'which applies the context from distributed tracing headers' do
+      let(:trace_id) { 3238677264721744442 }
+      let(:parent_id) { 0 }
+      let(:sampling_priority) { 1 }
+      let(:origin) { 'synthetics' }
+
+      let(:distributed_tracing_headers) do
+        {
+          rack_header(Datadog::Ext::DistributedTracing::HTTP_HEADER_TRACE_ID) => trace_id.to_s,
+          rack_header(Datadog::Ext::DistributedTracing::HTTP_HEADER_PARENT_ID) => parent_id.to_s,
+          rack_header(Datadog::Ext::DistributedTracing::HTTP_HEADER_SAMPLING_PRIORITY) => sampling_priority.to_s,
+          rack_header(Datadog::Ext::DistributedTracing::HTTP_HEADER_ORIGIN) => origin
+        }
+      end
+
+      def rack_header(header)
+        "http-#{header}".upcase!.tr('-', '_')
+      end
+
+      let(:synthetics_context) { Datadog::HTTPPropagator.extract(distributed_tracing_headers) }
+
+      before do
+        tracer.provider.context = synthetics_context
+      end
+
+      describe 'when used to trace the local application' do
+        before do
+          tracer.trace('local.operation') do |local_span|
+            @local_span = local_span
+            @local_context = tracer.call_context
+          end
+        end
+
+        it 'produces a well-formed trace' do
+          expect(spans).to have(1).item
+          expect(spans.first).to be(@local_span)
+
+          spans.first.tap do |local_span|
+            expect(local_span.trace_id).to eq(trace_id)
+            expect(local_span.parent_id).to eq(parent_id)
+            expect(origin_tag(local_span)).to eq(origin)
+            expect(sampling_priority_metric(local_span)).to eq(sampling_priority)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/ddtrace/tracer_integration_spec.rb
+++ b/spec/ddtrace/tracer_integration_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Datadog::Tracer do
         tracer.provider.context = synthetics_context
       end
 
-      describe 'when used to trace the local application' do
+      shared_examples_for 'a synthetics-sourced trace' do
         before do
           tracer.trace('local.operation') do |local_span|
             @local_span = local_span
@@ -111,7 +111,7 @@ RSpec.describe Datadog::Tracer do
           end
         end
 
-        it 'produces a well-formed trace' do
+        it 'that is well-formed' do
           expect(spans).to have(1).item
           expect(spans.first).to be(@local_span)
 
@@ -122,6 +122,16 @@ RSpec.describe Datadog::Tracer do
             expect(sampling_priority_metric(local_span)).to eq(sampling_priority)
           end
         end
+      end
+
+      context 'for a synthetics request' do
+        let(:origin) { 'synthetics' }
+        it_behaves_like 'a synthetics-sourced trace'
+      end
+
+      context 'for a synthetics browser request' do
+        let(:origin) { 'synthetics-browser' }
+        it_behaves_like 'a synthetics-sourced trace'
       end
     end
   end


### PR DESCRIPTION
The following does not produce a distributed trace with the designated trace ID:

```
curl -H "x-datadog-trace-id: 3238677264721744442" -H "x-datadog-parent-id: 0" -H "x-datadog-sampling-priority: 1" -H "x-datadog-origin: synthetics" localhost:3000
```

When synthetics traces are submitted via HTTP headers, they often are missing `parent_id` or have a value of `0`, which is not a valid span ID, and thus the context's `parent_id` becomes `nil`.

When the tracer encounters `parent_id = nil`, it assumes the context is malformed and ignores its trace ID and parent ID, opting to use the ones generated from the local span instead. Ultimately this causes synthetics traces to go missing, because the trace IDs don't match what's sent by synthetics.

This pull request ensures that the trace ID from synthetics is respected, regardless of what parent ID is, so that the resulting traces receive the correct trace ID.