### PR TITLE
Increase default buffer size

### DIFF
--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -10,7 +10,7 @@ module Datadog
     # will perform a task at regular intervals. The thread can be stopped
     # with the +stop()+ method and can start with the +start()+ method.
     class AsyncTransport
-      DEFAULT_BUFFER_MAX_SIZE = 100
+      DEFAULT_BUFFER_MAX_SIZE = 1000
       DEFAULT_FLUSH_INTERVAL = 1
       DEFAULT_TIMEOUT = 5
       BACK_OFF_RATIO = 1.2


### PR DESCRIPTION
Our default buffer size is currently 100, which can overflow with high throughput applications causing traces to drop. Increasing this limit to 1000 will allow more traces to come through before the safety limit drops traces.