### PR TITLE
Add additional health metrics

### DIFF
--- a/lib/ddtrace/context.rb
+++ b/lib/ddtrace/context.rb
@@ -1,4 +1,5 @@
 require 'thread'
+require 'ddtrace/diagnostics/health'
 
 module Datadog
   # \Context is used to keep track of a hierarchy of spans for the current
@@ -89,9 +90,17 @@ module Datadog
         # by default has 10000 spans, all of which belong to unfinished parts of a
         # larger trace. This is a catch-all to reduce global memory usage.
         if @max_length > 0 && @trace.length >= @max_length
-          Datadog::Tracer.log.debug("context full, ignoring span #{span.name}")
           # Detach the span from any context, it's being dropped and ignored.
           span.context = nil
+          Datadog::Tracer.log.debug("context full, ignoring span #{span.name}")
+
+          # If overflow has already occurred, don't send this metric.
+          # Prevents metrics spam if buffer repeatedly overflows for the same trace.
+          unless @overflow
+            Diagnostics::Health.metrics.error_context_overflow(1, tags: ["max_length:#{@max_length}"])
+            @overflow = true
+          end
+
           return
         end
         set_current_span(span)
@@ -111,12 +120,18 @@ module Datadog
         # on per-instrumentation code to retrieve handle parent/child relations.
         set_current_span(span.parent)
         return if span.tracer.nil?
-        return unless Datadog::Tracer.debug_logging
-        if span.parent.nil? && !check_finished_spans
-          opened_spans = @trace.length - @finished_spans
-          Datadog::Tracer.log.debug("root span #{span.name} closed but has #{opened_spans} unfinished spans:")
-          @trace.each do |s|
-            Datadog::Tracer.log.debug("unfinished span: #{s}") unless s.finished?
+        if span.parent.nil? && !all_spans_finished?
+          if Datadog::Tracer.debug_logging
+            opened_spans = @trace.length - @finished_spans
+            Datadog::Tracer.log.debug("root span #{span.name} closed but has #{opened_spans} unfinished spans:")
+          end
+
+          @trace.reject(&:finished?).group_by(&:name).each do |unfinished_span_name, unfinished_spans|
+            Datadog::Tracer.log.debug("unfinished span: #{unfinished_spans.first}") if Datadog::Tracer.debug_logging
+            Diagnostics::Health.metrics.error_unfinished_spans(
+              unfinished_spans.length,
+              tags: ["name:#{unfinished_span_name}"]
+            )
           end
         end
       end
@@ -126,7 +141,7 @@ module Datadog
     # is considered finished if all spans in this context are finished.
     def finished?
       @mutex.synchronize do
-        return check_finished_spans
+        return all_spans_finished?
       end
     end
 
@@ -153,7 +168,7 @@ module Datadog
         attach_origin if @origin
 
         # still return sampled attribute, even if context is not finished
-        return nil, sampled unless check_finished_spans()
+        return nil, sampled unless all_spans_finished?
 
         reset
         [trace, sampled]
@@ -180,6 +195,7 @@ module Datadog
       @finished_spans = 0
       @current_span = nil
       @current_root_span = nil
+      @overflow = false
     end
 
     def set_current_span(span)
@@ -195,7 +211,7 @@ module Datadog
 
     # Returns if the trace for the current Context is finished or not.
     # Low-level internal function, not thread-safe.
-    def check_finished_spans
+    def all_spans_finished?
       @finished_spans > 0 && @trace.length == @finished_spans
     end
 

--- a/lib/ddtrace/diagnostics/health.rb
+++ b/lib/ddtrace/diagnostics/health.rb
@@ -10,14 +10,18 @@ module Datadog
         count :api_errors, Ext::Diagnostics::Health::Metrics::METRIC_API_ERRORS
         count :api_requests, Ext::Diagnostics::Health::Metrics::METRIC_API_REQUESTS
         count :api_responses, Ext::Diagnostics::Health::Metrics::METRIC_API_RESPONSES
+        count :error_context_overflow, Ext::Diagnostics::Health::Metrics::METRIC_ERROR_CONTEXT_OVERFLOW
+        count :error_span_finish, Ext::Diagnostics::Health::Metrics::METRIC_ERROR_SPAN_FINISH
+        count :error_unfinished_spans, Ext::Diagnostics::Health::Metrics::METRIC_ERROR_UNFINISHED_SPANS
         count :queue_accepted, Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_ACCEPTED
         count :queue_accepted_lengths, Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_ACCEPTED_LENGTHS
         count :queue_dropped, Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_DROPPED
+        count :traces_filtered, Ext::Diagnostics::Health::Metrics::METRIC_TRACES_FILTERED
+        count :writer_cpu_time, Ext::Diagnostics::Health::Metrics::METRIC_WRITER_CPU_TIME
         gauge :queue_length, Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_LENGTH
         gauge :queue_max_length, Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_MAX_LENGTH
         gauge :queue_spans, Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_SPANS
-        count :traces_filtered, Ext::Diagnostics::Health::Metrics::METRIC_TRACES_FILTERED
-        count :writer_cpu_time, Ext::Diagnostics::Health::Metrics::METRIC_WRITER_CPU_TIME
+        gauge :sampling_service_cache_length, Ext::Diagnostics::Health::Metrics::METRIC_SAMPLING_SERVICE_CACHE_LENGTH
       end
 
       module_function

--- a/lib/ddtrace/ext/diagnostics.rb
+++ b/lib/ddtrace/ext/diagnostics.rb
@@ -10,12 +10,16 @@ module Datadog
           METRIC_API_ERRORS = 'datadog.tracer.api.errors'.freeze
           METRIC_API_REQUESTS = 'datadog.tracer.api.requests'.freeze
           METRIC_API_RESPONSES = 'datadog.tracer.api.responses'.freeze
+          METRIC_ERROR_CONTEXT_OVERFLOW = 'datadog.tracer.error.context_overflow'.freeze
+          METRIC_ERROR_SPAN_FINISH = 'datadog.tracer.error.span_finish'.freeze
+          METRIC_ERROR_UNFINISHED_SPANS = 'datadog.tracer.error.unfinished_spans'.freeze
           METRIC_QUEUE_ACCEPTED = 'datadog.tracer.queue.accepted'.freeze
           METRIC_QUEUE_ACCEPTED_LENGTHS = 'datadog.tracer.queue.accepted_lengths'.freeze
           METRIC_QUEUE_DROPPED = 'datadog.tracer.queue.dropped'.freeze
           METRIC_QUEUE_LENGTH = 'datadog.tracer.queue.length'.freeze
           METRIC_QUEUE_MAX_LENGTH = 'datadog.tracer.queue.max_length'.freeze
           METRIC_QUEUE_SPANS = 'datadog.tracer.queue.spans'.freeze
+          METRIC_SAMPLING_SERVICE_CACHE_LENGTH = 'datadog.tracer.sampling.service_cache_length'.freeze
           METRIC_TRACES_FILTERED = 'datadog.tracer.traces.filtered'.freeze
           METRIC_WRITER_CPU_TIME = 'datadog.tracer.writer.cpu_time'.freeze
         end

--- a/lib/ddtrace/sampler.rb
+++ b/lib/ddtrace/sampler.rb
@@ -1,6 +1,7 @@
 require 'forwardable'
 
 require 'ddtrace/ext/priority'
+require 'ddtrace/diagnostics/health'
 
 module Datadog
   # \Sampler performs client-side trace sampling.
@@ -146,6 +147,10 @@ module Datadog
       end
     end
 
+    def length
+      @samplers.length
+    end
+
     private
 
     def set_rate(key, rate)
@@ -169,6 +174,9 @@ module Datadog
 
       # Update each service rate
       update_all(rate_by_service)
+
+      # Emit metric for service cache size
+      Diagnostics::Health.metrics.sampling_service_cache_length(length)
     end
 
     private

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -6,6 +6,7 @@ require 'ddtrace/ext/errors'
 require 'ddtrace/ext/priority'
 require 'ddtrace/analytics'
 require 'ddtrace/forced_tracing'
+require 'ddtrace/diagnostics/health'
 
 module Datadog
   # Represents a logical unit of work in the system. Each trace consists of one or more spans.
@@ -154,6 +155,7 @@ module Datadog
         @tracer.record(self)
       rescue StandardError => e
         Datadog::Tracer.log.debug("error recording finished trace: #{e}")
+        Diagnostics::Health.metrics.error_span_finish(1, tags: ["error:#{e.class.name}"])
       end
       self
     end

--- a/spec/ddtrace/context_spec.rb
+++ b/spec/ddtrace/context_spec.rb
@@ -7,6 +7,232 @@ RSpec.describe Datadog::Context do
   let(:options) { {} }
   let(:tracer) { get_test_tracer }
 
+  describe '#initialize' do
+    context 'with defaults' do
+      it do
+        is_expected.to have_attributes(
+          max_length: described_class::DEFAULT_MAX_LENGTH,
+          trace_id: nil,
+          span_id: nil,
+          sampled?: false,
+          sampling_priority: nil,
+          origin: nil
+        )
+      end
+    end
+
+    context 'given a' do
+      [
+        :max_length,
+        :trace_id,
+        :span_id,
+        :sampling_priority,
+        :origin
+      ].each do |option_name|
+        context ":#{option_name} option" do
+          let(:options) { { option_name => option_value } }
+          let(:option_value) { double(option_name.to_s) }
+          it { expect(context.send(option_name)).to eq(option_value) }
+        end
+      end
+    end
+
+    context 'given a :sampled option' do
+      let(:options) { { sampled: sampled } }
+      let(:sampled) { double('sampled') }
+      it { expect(context.sampled?).to eq(sampled) }
+    end
+  end
+
+  describe '#add_span' do
+    subject(:add_span) { context.add_span(span) }
+
+    let(:span) { new_span }
+
+    def new_span
+      instance_double(
+        Datadog::Span,
+        name: double('name'),
+        trace_id: double('trace ID'),
+        span_id: double('span ID'),
+        sampled: double('sampled')
+      ).tap do |span|
+        allow(span).to receive(:context=)
+      end
+    end
+
+    context 'given a span' do
+      context 'that causes an overflow' do
+        include_context 'health metrics'
+
+        let(:existing_span) { new_span }
+        let(:overflow_span) { new_span }
+
+        let(:options) { { max_length: max_length } }
+        let(:max_length) { 1 }
+        before { allow(Datadog::Tracer.log).to receive(:debug) }
+
+        RSpec::Matchers.define :a_context_overflow_error do
+          match { |actual| actual.include?('context full') }
+        end
+
+        context 'once' do
+          before do
+            context.add_span(existing_span)
+            context.add_span(overflow_span)
+          end
+
+          it 'doesn\'t add the span to the context' do
+            expect(context.current_span).to be existing_span
+          end
+
+          it 'sends overflow metric' do
+            expect(overflow_span).to have_received(:context=).with(nil)
+            expect(Datadog::Tracer.log).to have_received(:debug)
+              .with(a_context_overflow_error)
+            expect(health_metrics).to have_received(:error_context_overflow)
+              .with(1, tags: ["max_length:#{max_length}"])
+          end
+        end
+
+        context 'twice' do
+          before do
+            context.add_span(existing_span)
+            2.times { context.add_span(overflow_span) }
+          end
+
+          it 'sends overflow metric only once' do
+            expect(Datadog::Tracer.log).to have_received(:debug)
+              .with(a_context_overflow_error)
+              .twice
+            expect(health_metrics).to have_received(:error_context_overflow)
+              .with(1, tags: ["max_length:#{max_length}"])
+              .once
+          end
+        end
+
+        context 'twice after previously overflowing and resetting' do
+          before do
+            context.add_span(existing_span)
+            context.add_span(overflow_span)
+            context.send(:reset)
+            context.add_span(existing_span)
+            context.add_span(overflow_span)
+          end
+
+          it 'sends overflow metric once per reset' do
+            expect(Datadog::Tracer.log).to have_received(:debug)
+              .with(a_context_overflow_error)
+              .twice
+            expect(health_metrics).to have_received(:error_context_overflow)
+              .with(1, tags: ["max_length:#{max_length}"])
+              .twice
+          end
+        end
+      end
+    end
+  end
+
+  describe '#close_span' do
+    subject(:close_span) { context.close_span(span) }
+
+    let(:span) { new_span }
+
+    def new_span(name = nil)
+      instance_double(
+        Datadog::Span,
+        name: name || double('name'),
+        trace_id: double('trace ID'),
+        span_id: double('span ID'),
+        parent: double('parent ID'),
+        sampled: double('sampled'),
+        tracer: instance_double(Datadog::Tracer),
+        finished?: false
+      ).tap do |span|
+        allow(span).to receive(:context=)
+      end
+    end
+
+    before { context.add_span(span) }
+
+    context 'given a root span' do
+      let(:span) do
+        new_span('root.span').tap do |span|
+          allow(span).to receive(:parent).and_return(nil)
+          allow(span).to receive(:finished?).and_return(true)
+        end
+      end
+
+      context 'when the context has unfinished spans' do
+        include_context 'health metrics'
+
+        def new_unfinished_span(name = nil)
+          new_span(name || 'unfinished.span').tap do |span|
+            allow(span).to receive(:parent).and_return(span)
+            allow(span).to receive(:finished?).and_return(false)
+          end
+        end
+
+        let(:unfinished_span) { new_unfinished_span }
+
+        RSpec::Matchers.define :an_unfinished_spans_error do |name, count|
+          match { |actual| actual.include?("root span #{name} closed but has #{count} unfinished spans:") }
+        end
+
+        RSpec::Matchers.define :an_unfinished_span_error do
+          match { |actual| actual.include?('unfinished span:') }
+        end
+
+        context 'when tracer debug logging is on' do
+          before do
+            allow(Datadog::Tracer).to receive(:debug_logging).and_return(true)
+            allow(Datadog::Tracer.log).to receive(:debug)
+            context.add_span(unfinished_span)
+            close_span
+          end
+
+          it 'logs debug messages' do
+            expect(Datadog::Tracer.log).to have_received(:debug)
+              .with(an_unfinished_spans_error('root.span', 1))
+
+            expect(Datadog::Tracer.log).to have_received(:debug)
+              .with(an_unfinished_span_error).once
+          end
+        end
+
+        context 'of one type' do
+          before do
+            context.add_span(unfinished_span)
+            close_span
+          end
+
+          it 'sends an unfinished span error metric' do
+            expect(health_metrics).to have_received(:error_unfinished_spans)
+              .with(1, tags: ['name:unfinished.span']).once
+          end
+        end
+
+        context 'of multiple types' do
+          before do
+            context.add_span(new_unfinished_span('unfinished.span.one'))
+            context.add_span(new_unfinished_span('unfinished.span.one'))
+            context.add_span(new_unfinished_span('unfinished.span.two'))
+            context.add_span(new_unfinished_span('unfinished.span.two'))
+            close_span
+          end
+
+          it 'sends unfinished span error metrics per kind of unfinished span' do
+            expect(health_metrics).to have_received(:error_unfinished_spans)
+              .with(2, tags: ['name:unfinished.span.one']).once
+
+            expect(health_metrics).to have_received(:error_unfinished_spans)
+              .with(2, tags: ['name:unfinished.span.two']).once
+          end
+        end
+      end
+    end
+  end
+
   describe '#current_root_span' do
     subject(:current_root_span) { context.current_root_span }
 

--- a/spec/ddtrace/debug/health_spec.rb
+++ b/spec/ddtrace/debug/health_spec.rb
@@ -26,12 +26,17 @@ RSpec.describe Datadog::Diagnostics::Health::Metrics do
   it_behaves_like 'a health metric', :count, :api_errors, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_API_ERRORS
   it_behaves_like 'a health metric', :count, :api_requests, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_API_REQUESTS
   it_behaves_like 'a health metric', :count, :api_responses, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_API_RESPONSES
+  it_behaves_like 'a health metric', :count, :error_context_overflow, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_ERROR_CONTEXT_OVERFLOW
+  it_behaves_like 'a health metric', :count, :error_span_finish, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_ERROR_SPAN_FINISH
+  it_behaves_like 'a health metric', :count, :error_unfinished_spans, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_ERROR_UNFINISHED_SPANS
   it_behaves_like 'a health metric', :count, :queue_accepted, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_ACCEPTED
   it_behaves_like 'a health metric', :count, :queue_accepted_lengths, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_ACCEPTED_LENGTHS
   it_behaves_like 'a health metric', :count, :queue_dropped, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_DROPPED
+  it_behaves_like 'a health metric', :count, :traces_filtered, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_TRACES_FILTERED
+  it_behaves_like 'a health metric', :count, :writer_cpu_time, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_WRITER_CPU_TIME
+
   it_behaves_like 'a health metric', :gauge, :queue_length, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_LENGTH
   it_behaves_like 'a health metric', :gauge, :queue_max_length, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_MAX_LENGTH
   it_behaves_like 'a health metric', :gauge, :queue_spans, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_SPANS
-  it_behaves_like 'a health metric', :count, :traces_filtered, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_TRACES_FILTERED
-  it_behaves_like 'a health metric', :count, :writer_cpu_time, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_WRITER_CPU_TIME
+  it_behaves_like 'a health metric', :gauge, :sampling_service_cache_length, Datadog::Ext::Diagnostics::Health::Metrics::METRIC_SAMPLING_SERVICE_CACHE_LENGTH
 end

--- a/spec/ddtrace/sampler_spec.rb
+++ b/spec/ddtrace/sampler_spec.rb
@@ -115,6 +115,113 @@ RSpec.describe Datadog::RateSampler do
 end
 
 RSpec.describe Datadog::RateByServiceSampler do
+  subject(:sampler) { described_class.new }
+
+  describe '#initialize' do
+    context 'with defaults' do
+      it { expect(sampler.default_key).to eq(described_class::DEFAULT_KEY) }
+      it { expect(sampler.length).to eq 1 }
+      it { expect(sampler.default_sampler.sample_rate).to eq 1.0 }
+    end
+
+    context 'given a default rate' do
+      subject(:sampler) { described_class.new(default_rate) }
+      let(:default_rate) { 0.1 }
+      it { expect(sampler.default_sampler.sample_rate).to eq default_rate }
+    end
+  end
+
+  describe '#resolve' do
+    subject(:resolve) { sampler.resolve(span) }
+    let(:span) { instance_double(Datadog::Span, service: service_name) }
+    let(:service_name) { 'my-service' }
+
+    context 'when the sampler is not configured with an :env option' do
+      it { is_expected.to eq("service:#{service_name},env:") }
+    end
+
+    context 'when the sampler is configured with an :env option' do
+      let(:sampler) { described_class.new(1.0, env: env) }
+
+      context 'that is a String' do
+        let(:env) { 'my-env' }
+        it { is_expected.to eq("service:#{service_name},env:#{env}") }
+      end
+
+      context 'that is a Proc' do
+        let(:env) { proc { 'my-env' } }
+        it { is_expected.to eq("service:#{service_name},env:my-env") }
+      end
+    end
+  end
+
+  describe '#update' do
+    subject(:update) { sampler.update(rate_by_service) }
+    let(:samplers) { sampler.instance_variable_get(:@samplers) }
+
+    include_context 'health metrics'
+
+    context 'when new rates' do
+      context 'describe a new bucket' do
+        let(:new_key) { 'service:new-service,env:my-env' }
+        let(:new_rate) { 0.5 }
+        let(:rate_by_service) { { new_key => new_rate } }
+
+        before { update }
+
+        it 'adds a new sampler' do
+          expect(samplers).to include(
+            described_class::DEFAULT_KEY => kind_of(Datadog::RateSampler),
+            new_key => kind_of(Datadog::RateSampler)
+          )
+
+          expect(samplers[new_key].sample_rate).to eq(new_rate)
+        end
+      end
+
+      context 'describe an existing bucket' do
+        let(:existing_key) { 'service:existing-service,env:my-env' }
+        let(:new_rate) { 0.5 }
+        let(:rate_by_service) { { existing_key => new_rate } }
+
+        before do
+          sampler.update(existing_key => 1.0)
+          update
+        end
+
+        it 'updates the existing sampler' do
+          expect(samplers).to include(
+            described_class::DEFAULT_KEY => kind_of(Datadog::RateSampler),
+            existing_key => kind_of(Datadog::RateSampler)
+          )
+
+          expect(samplers[existing_key].sample_rate).to eq(new_rate)
+
+          # Expect metrics twice; one for setup, one for test.
+          expect(health_metrics).to have_received(:sampling_service_cache_length).with(2).twice
+        end
+      end
+
+      context 'omit an existing bucket' do
+        let(:old_key) { 'service:old-service,env:my-env' }
+        let(:rate_by_service) { {} }
+
+        before do
+          sampler.update(old_key => 1.0)
+          update
+        end
+
+        it 'updates the existing sampler' do
+          expect(samplers).to include(
+            described_class::DEFAULT_KEY => kind_of(Datadog::RateSampler)
+          )
+
+          expect(samplers.keys).to_not include(old_key)
+          expect(health_metrics).to have_received(:sampling_service_cache_length).with(1)
+        end
+      end
+    end
+  end
 end
 
 RSpec.describe Datadog::PrioritySampler do

--- a/spec/support/health_metric_helpers.rb
+++ b/spec/support/health_metric_helpers.rb
@@ -1,4 +1,5 @@
 require 'support/metric_helpers'
+require 'ddtrace'
 require 'ddtrace/ext/diagnostics'
 
 module HealthMetricHelpers
@@ -11,16 +12,26 @@ module HealthMetricHelpers
       api_errors: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_API_ERRORS },
       api_requests: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_API_REQUESTS },
       api_responses: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_API_RESPONSES },
+      error_context_overflow: {
+        type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_ERROR_CONTEXT_OVERFLOW
+      },
+      error_span_finish: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_ERROR_SPAN_FINISH },
+      error_unfinished_spans: {
+        type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_ERROR_UNFINISHED_SPANS
+      },
       queue_accepted: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_ACCEPTED },
       queue_accepted_lengths: {
         type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_ACCEPTED_LENGTHS
       },
       queue_dropped: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_DROPPED },
+      traces_filtered: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_TRACES_FILTERED },
+      writer_cpu_time: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_WRITER_CPU_TIME },
       queue_length: { type: :gauge, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_LENGTH },
       queue_max_length: { type: :gauge, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_MAX_LENGTH },
       queue_spans: { type: :gauge, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_SPANS },
-      traces_filtered: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_TRACES_FILTERED },
-      writer_cpu_time: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_WRITER_CPU_TIME }
+      sampling_service_cache_length: {
+        type: :gauge, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_SAMPLING_SERVICE_CACHE_LENGTH
+      }
     }.freeze
 
     let(:health_metrics) { Datadog::Diagnostics::Health.metrics }


### PR DESCRIPTION
To improve visibility into how the tracer performs, this pull request adds additional health metrics to monitor for some kinds of errors and other measurements.