### PR TITLE
Fix Rails template layout name

### DIFF
--- a/lib/ddtrace/contrib/action_view/event.rb
+++ b/lib/ddtrace/contrib/action_view/event.rb
@@ -1,0 +1,39 @@
+require 'ddtrace/contrib/active_support/notifications/event'
+
+module Datadog
+  module Contrib
+    module ActionView
+      # Defines basic behavior for an ActionView event.
+      module Event
+        def self.included(base)
+          base.send(:include, ActiveSupport::Notifications::Event)
+          base.send(:extend, ClassMethods)
+        end
+
+        # Class methods for ActionView events.
+        module ClassMethods
+          def span_options
+            { service: configuration[:service_name] }
+          end
+
+          def tracer
+            -> { configuration[:tracer] }
+          end
+
+          def configuration
+            Datadog.configuration[:action_view]
+          end
+
+          def record_exception(span, payload)
+            if payload [:exception_object]
+              span.set_error(payload[:exception_object])
+            elsif payload[:exception]
+              # Fallback for ActiveSupport < 5.0
+              span.set_error(payload[:exception])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/action_view/events.rb
+++ b/lib/ddtrace/contrib/action_view/events.rb
@@ -1,0 +1,30 @@
+require 'ddtrace/contrib/action_view/events/render_partial'
+require 'ddtrace/contrib/action_view/events/render_template'
+
+module Datadog
+  module Contrib
+    module ActionView
+      # Defines collection of instrumented ActionView events
+      module Events
+        ALL = [
+          Events::RenderPartial,
+          Events::RenderTemplate
+        ].freeze
+
+        module_function
+
+        def all
+          self::ALL
+        end
+
+        def subscriptions
+          all.collect(&:subscriptions).collect(&:to_a).flatten
+        end
+
+        def subscribe!
+          all.each(&:subscribe!)
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/action_view/events/render_partial.rb
+++ b/lib/ddtrace/contrib/action_view/events/render_partial.rb
@@ -1,0 +1,40 @@
+require 'ddtrace/ext/net'
+require 'ddtrace/contrib/analytics'
+require 'ddtrace/contrib/action_view/ext'
+require 'ddtrace/contrib/action_view/event'
+
+module Datadog
+  module Contrib
+    module ActionView
+      module Events
+        # Defines instrumentation for render_partial.action_view event
+        module RenderPartial
+          include ActionView::Event
+
+          EVENT_NAME = 'render_partial.action_view'.freeze
+
+          module_function
+
+          def event_name
+            self::EVENT_NAME
+          end
+
+          def span_name
+            Ext::SPAN_RENDER_PARTIAL
+          end
+
+          def process(span, _event, _id, payload)
+            span.span_type = Datadog::Ext::HTTP::TEMPLATE
+
+            template_name = Utils.normalize_template_name(payload[:identifier])
+            span.set_tag(Ext::TAG_TEMPLATE_NAME, template_name) if template_name
+
+            record_exception(span, payload)
+          rescue StandardError => e
+            Datadog::Tracer.log.debug(e.message)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/action_view/events/render_template.rb
+++ b/lib/ddtrace/contrib/action_view/events/render_template.rb
@@ -1,0 +1,43 @@
+require 'ddtrace/ext/net'
+require 'ddtrace/contrib/analytics'
+require 'ddtrace/contrib/action_view/ext'
+require 'ddtrace/contrib/action_view/event'
+
+module Datadog
+  module Contrib
+    module ActionView
+      module Events
+        # Defines instrumentation for render_template.action_view event
+        module RenderTemplate
+          include ActionView::Event
+
+          EVENT_NAME = 'render_template.action_view'.freeze
+
+          module_function
+
+          def event_name
+            self::EVENT_NAME
+          end
+
+          def span_name
+            Ext::SPAN_RENDER_TEMPLATE
+          end
+
+          def process(span, _event, _id, payload)
+            span.span_type = Datadog::Ext::HTTP::TEMPLATE
+
+            template_name = Utils.normalize_template_name(payload[:identifier])
+            span.set_tag(Ext::TAG_TEMPLATE_NAME, template_name) if template_name
+
+            layout = payload[:layout]
+            span.set_tag(Ext::TAG_LAYOUT, layout) if layout
+
+            record_exception(span, payload)
+          rescue StandardError => e
+            Datadog::Tracer.log.debug(e.message)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/action_view/instrumentation/partial_renderer.rb
+++ b/lib/ddtrace/contrib/action_view/instrumentation/partial_renderer.rb
@@ -4,7 +4,7 @@ module Datadog
   module Contrib
     module ActionView
       module Instrumentation
-        # Instrumentation for partial rendering
+        # Legacy instrumentation for partial rendering for Rails < 4
         module PartialRenderer
           def render(*args, &block)
             datadog_tracer.trace(
@@ -54,21 +54,13 @@ module Datadog
             self.active_datadog_span = nil
           end
 
-          # Rails < 6 partial rendering
-          module RailsLessThan6
+          # Rails < 4 partial rendering
+          # ActiveSupport events are used instead for Rails >= 4
+          module RailsLessThan4
             include PartialRenderer
 
             def datadog_template(*args)
               @template
-            end
-          end
-
-          # Rails >= 6 partial rendering
-          module Rails6Plus
-            include PartialRenderer
-
-            def datadog_template(*args)
-              args[1]
             end
           end
         end

--- a/lib/ddtrace/contrib/action_view/instrumentation/template_renderer.rb
+++ b/lib/ddtrace/contrib/action_view/instrumentation/template_renderer.rb
@@ -4,9 +4,9 @@ module Datadog
   module Contrib
     module ActionView
       module Instrumentation
-        # Instrumentation for template rendering
+        # Legacy instrumentation for template rendering for Rails < 4
         module TemplateRenderer
-          # Rails < 3.1 template rendering
+          # Legacy Rails < 3.1 template rendering
           module Rails30
             # rubocop:disable Metrics/MethodLength
             def self.prepended(base)
@@ -82,7 +82,7 @@ module Datadog
             end
           end
 
-          # Shared code for Rails >= 3.1 template rendering
+          # Legacy shared code for Rails >= 3.1 template rendering
           module Rails31Plus
             def render(*args, &block)
               datadog_tracer.trace(
@@ -143,20 +143,12 @@ module Datadog
             end
           end
 
-          # Rails >= 3.1 && < 6 template rendering
-          module Rails31To5
+          # Rails >= 3.1, < 4 template rendering
+          # ActiveSupport events are used instead for Rails >= 4
+          module RailsLessThan4
             include Rails31Plus
 
             def datadog_parse_args(template, layout_name, *args)
-              [template, layout_name]
-            end
-          end
-
-          # Rails >= 6 template rendering
-          module Rails6Plus
-            include Rails31Plus
-
-            def datadog_parse_args(view, template, layout_name, *args)
               [template, layout_name]
             end
           end

--- a/lib/ddtrace/contrib/action_view/patcher.rb
+++ b/lib/ddtrace/contrib/action_view/patcher.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/ext/http'
 require 'ddtrace/contrib/patcher'
+require 'ddtrace/contrib/action_view/events'
 require 'ddtrace/contrib/action_view/ext'
 require 'ddtrace/contrib/action_view/instrumentation/partial_renderer'
 require 'ddtrace/contrib/action_view/instrumentation/template_renderer'
@@ -30,18 +31,19 @@ module Datadog
 
         def patch_renderer
           do_once(:patch_renderer) do
-            if defined?(::ActionView::TemplateRenderer) && defined?(::ActionView::PartialRenderer)
-              if Integration.version < Gem::Version.new('6.0.0')
-                ::ActionView::TemplateRenderer.send(:prepend, Instrumentation::TemplateRenderer::Rails31To5)
-                ::ActionView::PartialRenderer.send(:prepend, Instrumentation::PartialRenderer::RailsLessThan6)
-              else
-                ::ActionView::TemplateRenderer.send(:prepend, Instrumentation::TemplateRenderer::Rails6Plus)
-                ::ActionView::PartialRenderer.send(:prepend, Instrumentation::PartialRenderer::Rails6Plus)
-              end
+            if Integration.version >= Gem::Version.new('4.0.0')
+              Events.subscribe!
+            elsif defined?(::ActionView::TemplateRenderer) && defined?(::ActionView::PartialRenderer)
+              # Rails < 4 compatibility:
+              #  Rendering events are not nested in this version, creating
+              #  render_partial spans outside of the parent render_template span.
+              #  We fall back to manual patching instead.
+              ::ActionView::TemplateRenderer.send(:prepend, Instrumentation::TemplateRenderer::RailsLessThan4)
+              ::ActionView::PartialRenderer.send(:prepend, Instrumentation::PartialRenderer::RailsLessThan4)
             elsif defined?(::ActionView::Rendering) && defined?(::ActionView::Partials::PartialRenderer)
               # NOTE: Rails < 3.1 compatibility: different classes are used
               ::ActionView::Rendering.send(:prepend, Instrumentation::TemplateRenderer::Rails30)
-              ::ActionView::Partials::PartialRenderer.send(:prepend, Instrumentation::PartialRenderer::RailsLessThan6)
+              ::ActionView::Partials::PartialRenderer.send(:prepend, Instrumentation::PartialRenderer::RailsLessThan4)
             else
               Datadog::Tracer.log.debug('Expected Template/Partial classes not found; template rendering disabled')
             end

--- a/test/contrib/rails/errors_test.rb
+++ b/test/contrib/rails/errors_test.rb
@@ -54,6 +54,8 @@ class TracingControllerTest < ActionController::TestCase
   end
 
   test 'missing rendering should close the template Span' do
+    skip 'Recent versions use events, and cannot suffer from this issue' if Rails.version >= '4.0.0'
+
     # this route raises an exception, but the notification `render_template.action_view`
     # is not fired, causing unfinished spans; this test protects from regressions
     assert_raises ::ActionView::MissingTemplate do
@@ -84,6 +86,8 @@ class TracingControllerTest < ActionController::TestCase
   end
 
   test 'missing partial rendering should close the template Span' do
+    skip 'Recent versions use events, and cannot suffer from this issue' if Rails.version >= '4.0.0'
+
     # this route raises an exception, but the notification `render_partial.action_view`
     # is not fired, causing unfinished spans; this test protects from regressions
     assert_raises ::ActionView::Template::Error do

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -58,6 +58,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
 
     assert_equal(render_span.name, 'rails.render_template')
     assert_equal(render_span.span_type, 'template')
+    assert_equal(render_span.service, Datadog.configuration[:rails][:service_name])
     assert_equal(render_span.resource, 'rails.render_template')
     assert_equal(render_span.get_tag('rails.template_name'), 'tracing/full.html.erb')
 


### PR DESCRIPTION
Fixes #857 

This PR fixes the retrieval of the `layout` property for the `ActionView` integration.

The approach I took was to use the `ActiveSupport` events that are published during template rendering.
These events have existed for all versions of Rails we support, but only since Rails 4.0 they exist in a useful state.

Before Rails 4.0, we only received one event at the end of the instrumentation, there were no separate "before" and "after" events. This prevent us from properly nesting `render_partial` spans inside their respective `render_template` span.

The reason our test suite did not capture this bug is because we explicitly set the `layout 'application'` in our controller during testing, while most users don't actually set it in their applications. A test case was added to prevent future regressions.

In sum, this PR implements `ActionView` integration through `ActiveSupport` events for Rails >= 4.0, and falls back to the existing patcher for Rails 3.X.