### PR TITLE
Remove default rate limit from RuleSampler

### DIFF
--- a/lib/ddtrace/sampling/rule_sampler.rb
+++ b/lib/ddtrace/sampling/rule_sampler.rb
@@ -37,7 +37,7 @@ module Datadog
                         elsif rate_limit
                           Datadog::Sampling::TokenBucket.new(rate_limit)
                         else
-                          Datadog::Sampling::TokenBucket.new(100)
+                          Datadog::Sampling::UnlimitedLimiter.new
                         end
 
         @default_sampler = if default_sampler

--- a/spec/ddtrace/sampling/rule_sampler_spec.rb
+++ b/spec/ddtrace/sampling/rule_sampler_spec.rb
@@ -20,6 +20,25 @@ RSpec.describe Datadog::Sampling::RuleSampler do
     allow(rate_limiter).to receive(:allow?).with(1).and_return(allow?)
   end
 
+  context '#initialize' do
+    subject(:rule_sampler) { described_class.new(rules) }
+
+    it { expect(subject.rate_limiter).to be_a(Datadog::Sampling::UnlimitedLimiter) }
+    it { expect(subject.default_sampler).to be_a(Datadog::AllSampler) }
+
+    context 'with rate_limit' do
+      subject(:rule_sampler) { described_class.new(rules, rate_limit: 1.0) }
+
+      it { expect(subject.rate_limiter).to be_a(Datadog::Sampling::TokenBucket) }
+    end
+
+    context 'with default_sample_rate' do
+      subject(:rule_sampler) { described_class.new(rules, default_sample_rate: 1.0) }
+
+      it { expect(subject.default_sampler).to be_a(Datadog::RateSampler) }
+    end
+  end
+
   shared_context 'matching rule' do
     let(:rules) { [rule] }
     let(:rule) { instance_double(Datadog::Sampling::Rule) }


### PR DESCRIPTION
Our initial design had our `RuleSampler` limited to 100 request/sec by default.
We've since changed our decision remove any limits by default.