### PR TITLE
Fix parameter validation for rate limiter

### DIFF
--- a/spec/ddtrace/sampling/rate_limiter_spec.rb
+++ b/spec/ddtrace/sampling/rate_limiter_spec.rb
@@ -78,6 +78,18 @@ RSpec.describe Datadog::Sampling::TokenBucket do
         end
       end
     end
+
+    context 'with negative rate' do
+      let(:rate) { -1 }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with zero rate' do
+      let(:rate) { 0 }
+
+      it { is_expected.to eq(false) }
+    end
   end
 
   describe '#effective_rate' do
@@ -105,6 +117,18 @@ RSpec.describe Datadog::Sampling::TokenBucket do
         let(:size) { max_tokens + 1 }
         it { is_expected.to eq(0.0) }
       end
+    end
+
+    context 'with negative rate' do
+      let(:rate) { -1 }
+
+      it { is_expected.to eq(1.0) }
+    end
+
+    context 'with zero rate' do
+      let(:rate) { 0 }
+
+      it { is_expected.to eq(0.0) }
     end
   end
 end


### PR DESCRIPTION
We started getting this warning in CI after #854 has been merged:
[`(ddtrace/sampling/rate_limiter.rb:34:in 'initialize') rate is not between 0 and 1, setting limiter to 100% as a fallback`](https://circleci.com/api/v1.1/project/github/DataDog/dd-trace-rb/45561/output/104/0?file=true&allocation-id=5de586008de98c5287eaaac7-0-build%2F6BDF3114).

This happens because our rate limiter implementation class, `TokenBucket`, was performing a ratio validation (number between 0 and 1) instead of a rate/sec validation.

This PR address this issue. `TokenBucket` now supports unlimited mode as well, to allow for graceful handling of all possible values for the `rate` parameter.