### PR TITLE
Address warning on Rule spec

### DIFF
--- a/spec/ddtrace/sampling/rule_spec.rb
+++ b/spec/ddtrace/sampling/rule_spec.rb
@@ -32,8 +32,13 @@ RSpec.describe Datadog::Sampling::Rule do
     end
 
     context 'when matcher errs' do
+      let(:error) { StandardError }
+
       before do
-        allow(matcher).to receive(:match?).and_raise(StandardError)
+        allow(matcher).to receive(:match?).and_raise(error)
+
+        expect(Datadog::Tracer.log).to receive(:error)
+          .with(a_string_including("Matcher failed. Cause: #{error}"))
       end
 
       it { is_expected.to be nil }


### PR DESCRIPTION
One of our tests for the rule sampler tests whether everything still works when a rule matcher fails.
That test outputs a log message that wasn't caught properly in the test environment.

This PR addresses that, creating an assertion on calls to `Datadog::Tracer.log` for that test.