### PR TITLE
Add TraceWriter and RuntimeMetrics workers

### DIFF
--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -24,7 +24,7 @@ module Datadog
     end
 
     def runtime_metrics
-      tracer.writer.runtime_metrics
+      configuration.runtime_metrics
     end
   end
 end

--- a/lib/ddtrace/environment.rb
+++ b/lib/ddtrace/environment.rb
@@ -19,5 +19,7 @@ module Datadog
         end
       end
     end
+
+    extend Helpers
   end
 end

--- a/lib/ddtrace/event.rb
+++ b/lib/ddtrace/event.rb
@@ -1,0 +1,52 @@
+require 'ddtrace/logger'
+
+module Datadog
+  # A simple pub-sub event model for components to exchange messages through.
+  class Event
+    attr_reader \
+      :name,
+      :subscriptions
+
+    def initialize(name)
+      @name = name
+      @subscriptions = {}
+      @mutex = Mutex.new
+    end
+
+    def subscribe(key, &block)
+      raise ArgumentError, 'Must give a block to subscribe!' unless block
+
+      @mutex.synchronize do
+        subscriptions[key] = block
+      end
+    end
+
+    def unsubscribe(key)
+      @mutex.synchronize do
+        subscriptions.delete(key)
+      end
+    end
+
+    def unsubscribe_all!
+      @mutex.synchronize do
+        subscriptions.clear
+      end
+
+      true
+    end
+
+    def publish(*args)
+      @mutex.synchronize do
+        subscriptions.each do |key, block|
+          begin
+            block.call(*args)
+          rescue StandardError => e
+            Datadog::Logger.log.debug("Error while handling '#{key}' for '#{name}' event: #{e.message}")
+          end
+        end
+
+        true
+      end
+    end
+  end
+end

--- a/lib/ddtrace/sync_writer.rb
+++ b/lib/ddtrace/sync_writer.rb
@@ -4,6 +4,7 @@ require 'ddtrace/runtime/metrics'
 
 module Datadog
   # SyncWriter flushes both services and traces synchronously
+  # DEV: To be replaced by Datadog::Workers::TraceWriter.
   class SyncWriter
     attr_reader \
       :priority_sampler,

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -362,10 +362,12 @@ module Datadog
       # but neither are configured. Verify the sampler isn't already a
       # priority sampler too, so we don't wrap one with another.
       if options.key?(:writer)
-        if writer.priority_sampler.nil?
-          deactivate_priority_sampling!(sampler)
-        else
-          activate_priority_sampling!(writer.priority_sampler)
+        if writer.respond_to?(:priority_sampler)
+          if writer.priority_sampler.nil?
+            deactivate_priority_sampling!(sampler)
+          else
+            activate_priority_sampling!(writer.priority_sampler)
+          end
         end
       elsif priority_sampling != false && !@sampler.is_a?(PrioritySampler)
         writer_options[:priority_sampler] = activate_priority_sampling!(@sampler)

--- a/lib/ddtrace/worker.rb
+++ b/lib/ddtrace/worker.rb
@@ -1,0 +1,20 @@
+module Datadog
+  # Base class for work tasks
+  class Worker
+    attr_reader \
+      :task
+
+    def initialize(&block)
+      @task = block
+    end
+
+    def perform(*args)
+      task.call(*args) unless task.nil?
+    end
+
+    protected
+
+    attr_writer \
+      :task
+  end
+end

--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -1,6 +1,7 @@
 require 'time'
 
 require 'ddtrace/workers/trace_writer'
+require 'ddtrace/workers/runtime_metrics'
 
 require 'ddtrace/buffer'
 require 'ddtrace/runtime/metrics'

--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -1,5 +1,7 @@
 require 'time'
 
+require 'ddtrace/workers/trace_writer'
+
 require 'ddtrace/buffer'
 require 'ddtrace/runtime/metrics'
 

--- a/lib/ddtrace/workers/async.rb
+++ b/lib/ddtrace/workers/async.rb
@@ -1,0 +1,163 @@
+require 'ddtrace/logger'
+
+module Datadog
+  module Workers
+    module Async
+      # Adds threading behavior to workers
+      # to run tasks asynchronously.
+      # rubocop:disable Metrics/ModuleLength
+      module Thread
+        FORK_POLICY_STOP = :stop
+        FORK_POLICY_RESTART = :restart
+        SHUTDOWN_TIMEOUT = 1
+
+        def self.included(base)
+          base.send(:prepend, PrependedMethods)
+        end
+
+        # Methods that must be prepended
+        module PrependedMethods
+          def perform(*args)
+            start { self.result = super(*args) } if unstarted?
+          end
+        end
+
+        attr_reader \
+          :error,
+          :result
+
+        attr_writer \
+          :fork_policy
+
+        def join(timeout = nil)
+          return true unless running?
+          !worker.join(timeout).nil?
+        end
+
+        def terminate
+          return false unless running?
+          @run_async = false
+          worker.terminate
+          true
+        end
+
+        def run_async?
+          @run_async = false unless instance_variable_defined?(:@run_async)
+          @run_async == true
+        end
+
+        def unstarted?
+          worker.nil? || forked?
+        end
+
+        def running?
+          !worker.nil? && worker.alive?
+        end
+
+        def error?
+          @error = nil unless instance_variable_defined?(:@error)
+          !@error.nil?
+        end
+
+        def completed?
+          !worker.nil? && worker.status == false && !error?
+        end
+
+        def failed?
+          !worker.nil? && worker.status == false && error?
+        end
+
+        def forked?
+          !pid.nil? && pid != Process.pid
+        end
+
+        def fork_policy
+          @fork_policy ||= FORK_POLICY_STOP
+        end
+
+        protected
+
+        attr_writer \
+          :result
+
+        def mutex
+          @mutex ||= Mutex.new
+        end
+
+        def after_fork
+          # Do nothing by default
+        end
+
+        private
+
+        attr_reader \
+          :pid
+
+        def mutex_after_fork
+          @mutex_after_fork ||= Mutex.new
+        end
+
+        def worker
+          @worker ||= nil
+        end
+
+        def start(&block)
+          mutex.synchronize do
+            return if running?
+            if forked?
+              case fork_policy
+              when FORK_POLICY_STOP
+                stop_fork
+              when FORK_POLICY_RESTART
+                restart_after_fork(&block)
+              end
+            elsif !run_async?
+              start_worker(&block)
+            end
+          end
+        end
+
+        def start_worker
+          @run_async = true
+          @pid = Process.pid
+          @error = nil
+          Logger.log.debug("Starting thread in the process: #{Process.pid}")
+
+          @worker = ::Thread.new do
+            begin
+              yield
+            rescue StandardError => e
+              @error = e
+              Logger.log.debug("Worker thread error. Cause #{e.message} Location: #{e.backtrace.first}")
+            end
+          end
+        end
+
+        def stop_fork
+          mutex_after_fork.synchronize do
+            if forked?
+              # Trigger callback to allow workers to reset themselves accordingly
+              after_fork
+
+              # Reset and turn off
+              @pid = Process.pid
+              @run_async = false
+            end
+          end
+        end
+
+        def restart_after_fork(&block)
+          mutex_after_fork.synchronize do
+            if forked?
+              # Trigger callback to allow workers to reset themselves accordingly
+              after_fork
+
+              # Start worker
+              start_worker(&block)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/workers/loop.rb
+++ b/lib/ddtrace/workers/loop.rb
@@ -1,0 +1,105 @@
+module Datadog
+  module Workers
+    # Adds looping behavior to workers, with a sleep
+    # interval between each loop.
+    module IntervalLoop
+      BACK_OFF_RATIO = 1.2
+      BACK_OFF_MAX = 5
+      DEFAULT_INTERVAL = 1
+
+      def self.included(base)
+        base.send(:prepend, PrependedMethods)
+      end
+
+      # Methods that must be prepended
+      module PrependedMethods
+        def perform(*args)
+          perform_loop { super(*args) }
+        end
+      end
+
+      def stop_loop
+        mutex.synchronize do
+          return false unless run_loop?
+          @run_loop = false
+          shutdown.signal
+        end
+
+        true
+      end
+
+      def work_pending?
+        run_loop?
+      end
+
+      def run_loop?
+        @run_loop = false unless instance_variable_defined?(:@run_loop)
+        @run_loop == true
+      end
+
+      def loop_default_interval
+        @loop_default_interval ||= DEFAULT_INTERVAL
+      end
+
+      def loop_back_off_ratio
+        @loop_back_off_ratio ||= BACK_OFF_RATIO
+      end
+
+      def loop_back_off_max
+        @loop_back_off_max ||= BACK_OFF_MAX
+      end
+
+      def loop_wait_time
+        @loop_wait_time ||= loop_default_interval
+      end
+
+      def loop_back_off?
+        false
+      end
+
+      def loop_back_off!(amount = nil)
+        @loop_wait_time = amount || [loop_wait_time * BACK_OFF_RATIO, BACK_OFF_MAX].min
+      end
+
+      protected
+
+      attr_writer \
+        :loop_back_off_max,
+        :loop_back_off_ratio,
+        :loop_default_interval
+
+      def mutex
+        @mutex ||= Mutex.new
+      end
+
+      private
+
+      def perform_loop
+        @run_loop = true
+
+        loop do
+          if work_pending?
+            # Run the task
+            yield
+
+            # Reset the wait interval
+            loop_back_off!(loop_default_interval)
+          elsif loop_back_off?
+            # Back off the wait interval a bit
+            loop_back_off!
+          end
+
+          # Wait for an interval, unless shutdown has been signaled.
+          mutex.synchronize do
+            return unless run_loop? || work_pending?
+            shutdown.wait(mutex, loop_wait_time) if run_loop?
+          end
+        end
+      end
+
+      def shutdown
+        @shutdown ||= ConditionVariable.new
+      end
+    end
+  end
+end

--- a/lib/ddtrace/workers/polling.rb
+++ b/lib/ddtrace/workers/polling.rb
@@ -1,0 +1,48 @@
+require 'ddtrace/workers/async'
+require 'ddtrace/workers/loop'
+
+module Datadog
+  module Workers
+    # Adds polling (async looping) behavior to workers
+    module Polling
+      SHUTDOWN_TIMEOUT = 1
+
+      def self.included(base)
+        base.send(:include, Workers::IntervalLoop)
+        base.send(:include, Workers::Async::Thread)
+        base.send(:prepend, PrependedMethods)
+      end
+
+      # Methods that must be prepended
+      module PrependedMethods
+        def perform(*args)
+          super if enabled?
+        end
+      end
+
+      def stop(force_stop = false, timeout = SHUTDOWN_TIMEOUT)
+        if running?
+          # Attempt graceful stop and wait
+          stop_loop
+          graceful = join(timeout)
+
+          # If timeout and force stop...
+          !graceful && force_stop ? terminate : graceful
+        else
+          false
+        end
+      end
+
+      def enabled?
+        @enabled = true unless instance_variable_defined?(:@enabled)
+        @enabled
+      end
+
+      # Allow worker to be started
+      def enabled=(value)
+        # Coerce to boolean
+        @enabled = (value == true)
+      end
+    end
+  end
+end

--- a/lib/ddtrace/workers/queue.rb
+++ b/lib/ddtrace/workers/queue.rb
@@ -1,0 +1,39 @@
+module Datadog
+  module Workers
+    # Adds queue behavior to workers, with a buffer
+    # to which items can be queued then dequeued.
+    module Queue
+      def self.included(base)
+        base.send(:prepend, PrependedMethods)
+      end
+
+      # Methods that must be prepended
+      module PrependedMethods
+        def perform(*args)
+          super(*dequeue) if work_pending?
+        end
+      end
+
+      def buffer
+        @buffer ||= []
+      end
+
+      def enqueue(*args)
+        buffer.push(args)
+      end
+
+      def dequeue
+        buffer.shift
+      end
+
+      def work_pending?
+        !buffer.empty?
+      end
+
+      protected
+
+      attr_writer \
+        :buffer
+    end
+  end
+end

--- a/lib/ddtrace/workers/runtime_metrics.rb
+++ b/lib/ddtrace/workers/runtime_metrics.rb
@@ -1,0 +1,58 @@
+require 'forwardable'
+
+require 'ddtrace/environment'
+require 'ddtrace/runtime/metrics'
+
+require 'ddtrace/worker'
+require 'ddtrace/workers/polling'
+
+module Datadog
+  module Workers
+    # Emits runtime metrics asynchronously on a timed loop
+    class RuntimeMetrics < Worker
+      extend Forwardable
+      include Workers::Polling
+
+      attr_reader \
+        :metrics
+
+      def initialize(options = {})
+        @metrics = options.fetch(:metrics, Runtime::Metrics.new)
+
+        # Workers::Async::Thread settings
+        self.fork_policy = options.fetch(:fork_policy, Workers::Async::Thread::FORK_POLICY_STOP)
+
+        # Workers::IntervalLoop settings
+        self.interval = options[:interval] if options.key?(:interval)
+        self.back_off_ratio = options[:back_off_ratio] if options.key?(:back_off_ratio)
+        self.back_off_max = options[:back_off_max] if options.key?(:back_off_max)
+
+        self.enabled = options.fetch(
+          :enabled,
+          Datadog::Environment.env_to_bool(Ext::Runtime::Metrics::ENV_ENABLED, false)
+        )
+      end
+
+      def perform
+        metrics.flush
+        true
+      end
+
+      def enabled=(value)
+        old_state = enabled?
+        super
+        new_state = enabled?
+
+        # Auto-start/stop worker if state changed.
+        if old_state != new_state
+          new_state ? perform : stop
+        end
+      end
+
+      def_delegators \
+        :metrics,
+        :associate_with_span,
+        :register_service
+    end
+  end
+end

--- a/lib/ddtrace/workers/trace_writer.rb
+++ b/lib/ddtrace/workers/trace_writer.rb
@@ -1,0 +1,199 @@
+require 'ddtrace/logger'
+require 'ddtrace/transport/http'
+
+require 'ddtrace/event'
+require 'ddtrace/worker'
+require 'ddtrace/workers/polling'
+require 'ddtrace/workers/queue'
+
+module Datadog
+  module Workers
+    # Writes traces to transport synchronously
+    class TraceWriter < Worker
+      attr_reader \
+        :transport
+
+      def initialize(options = {})
+        transport_options = options.fetch(:transport_options, {})
+
+        if transport_options.is_a?(Proc)
+          transport_options = { on_build: transport_options }
+        end
+
+        transport_options[:hostname] = options[:hostname] if options.key?(:hostname)
+        transport_options[:port] = options[:port] if options.key?(:port)
+
+        @transport = options.fetch(:transport) do
+          Transport::HTTP.default(transport_options)
+        end
+      end
+
+      def perform(traces)
+        write_traces(traces)
+      end
+
+      def write(trace)
+        write_traces([trace])
+      end
+
+      def write_traces(traces)
+        traces = process_traces(traces)
+        flush_traces(traces)
+      rescue StandardError => e
+        Datadog::Logger.log.error(
+          "Error while writing traces: dropped #{traces.length} items. Cause: #{e} Location: #{e.backtrace.first}"
+        )
+      end
+
+      def process_traces(traces)
+        # Run traces through the processing pipeline
+        traces = Pipeline.process!(traces)
+
+        # Inject hostname if configured to do so
+        inject_hostname!(traces) if Datadog.configuration.report_hostname
+
+        traces
+      end
+
+      def flush_traces(traces)
+        transport.send_traces(traces).tap do |response|
+          flush_completed.publish(response)
+        end
+      end
+
+      def inject_hostname!(traces)
+        traces.each do |trace|
+          next if trace.first.nil?
+
+          hostname = Datadog::Runtime::Socket.hostname
+          unless hostname.nil? || hostname.empty?
+            trace.first.set_tag(Ext::NET::TAG_HOSTNAME, hostname)
+          end
+        end
+      end
+
+      def flush_completed
+        @flush_completed ||= FlushCompleted.new
+      end
+
+      # Flush completed event for worker
+      class FlushCompleted < Event
+        def initialize
+          super(:flush_completed)
+        end
+
+        def publish(response)
+          super(response)
+        end
+      end
+    end
+
+    # Writes traces to transport asynchronously,
+    # using a thread & buffer.
+    class AsyncTraceWriter < TraceWriter
+      include Workers::Queue
+      include Workers::Polling
+
+      DEFAULT_BUFFER_MAX_SIZE = 1000
+      FORK_POLICY_ASYNC = :async
+      FORK_POLICY_SYNC = :sync
+
+      attr_writer \
+        :async
+
+      def initialize(options = {})
+        # Workers::TraceWriter settings
+        super
+
+        # Workers::Polling settings
+        self.enabled = options.fetch(:enabled, true)
+
+        # Workers::Async::Thread settings
+        @async = true
+        self.fork_policy = options.fetch(:fork_policy, FORK_POLICY_ASYNC)
+
+        # Workers::IntervalLoop settings
+        self.loop_default_interval = options[:interval] if options.key?(:interval)
+        self.loop_back_off_ratio = options[:back_off_ratio] if options.key?(:back_off_ratio)
+        self.loop_back_off_max = options[:back_off_max] if options.key?(:back_off_max)
+
+        # Workers::Queue settings
+        @buffer_size = options.fetch(:buffer_size, DEFAULT_BUFFER_MAX_SIZE)
+        self.buffer = TraceBuffer.new(@buffer_size)
+      end
+
+      # NOTE: #perform is wrapped by other modules:
+      #       Polling --> Async --> IntervalLoop --> AsyncTraceWriter --> TraceWriter
+      def perform(traces)
+        super(traces).tap do |response|
+          loop_back_off! if response.server_error?
+        end
+      end
+
+      def stop(*args)
+        buffer.close if running?
+        super
+      end
+
+      def enqueue(trace)
+        buffer.push(trace)
+      end
+
+      def dequeue
+        # Wrap results in Array because they are
+        # splatted as args against TraceWriter#perform.
+        [buffer.pop]
+      end
+
+      def work_pending?
+        !buffer.empty?
+      end
+
+      def async?
+        @async == true
+      end
+
+      def fork_policy=(policy)
+        # Translate to Workers::Async::Thread policy
+        thread_fork_policy = case policy
+                             when Workers::Async::Thread::FORK_POLICY_STOP
+                               policy
+                             when FORK_POLICY_SYNC
+                               # Stop the async thread because the writer
+                               # will bypass and run synchronously.
+                               Workers::Async::Thread::FORK_POLICY_STOP
+                             else
+                               Workers::Async::Thread::FORK_POLICY_RESTART
+                             end
+
+        # Update thread fork policy
+        super(thread_fork_policy)
+
+        # Update local policy
+        @writer_fork_policy = policy
+      end
+
+      def after_fork
+        # In multiprocess environments, forks will share the same buffer until its written to.
+        # A.K.A. copy-on-write. We don't want forks to write traces generated from another process.
+        # Instead, we reset it after the fork. (Make sure any enqueue operations happen after this.)
+        self.buffer = TraceBuffer.new(@buffer_size)
+
+        # Switch to synchronous mode if configured to do so.
+        # In some cases synchronous writing is preferred because the fork will be short lived.
+        @async = false if @writer_fork_policy == FORK_POLICY_SYNC
+      end
+
+      def write(trace)
+        # Start worker thread. If the process has forked, it will trigger #after_fork to
+        # reconfigure the worker accordingly.
+        # NOTE: It's important we do this before queuing or it will drop the current trace,
+        #       because #after_fork resets the buffer.
+        perform
+
+        # Queue the trace if running asynchronously, otherwise short-circuit and write it directly.
+        async? ? enqueue(trace) : write_traces([trace])
+      end
+    end
+  end
+end

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -68,9 +68,7 @@ module Datadog
     # stops worker for spans.
     def stop
       return if worker.nil?
-      @worker.stop
-      @worker = nil
-      true
+      @worker.stop.tap { @worker = nil }
     end
 
     # flush spans to the trace-agent, handles spans only

--- a/spec/ddtrace/event_spec.rb
+++ b/spec/ddtrace/event_spec.rb
@@ -1,0 +1,137 @@
+require 'spec_helper'
+
+require 'ddtrace'
+require 'ddtrace/event'
+
+RSpec.describe Datadog::Event do
+  subject(:event) { described_class.new(name) }
+  let(:name) { :test_event }
+
+  describe '#initialize' do
+    it do
+      is_expected.to have_attributes(
+        name: name,
+        subscriptions: kind_of(Hash)
+      )
+    end
+  end
+
+  describe '#subscribe' do
+    subject(:subscribe) { event.subscribe(key, &block) }
+    let(:key) { :test_subscription }
+
+    context 'when given a key and block' do
+      let(:block) { proc {} }
+
+      it 'adds a new subscription' do
+        expect { subscribe }.to change { event.subscriptions[key] }
+          .from(nil)
+          .to(block)
+      end
+
+      context 'whose key already exists' do
+        let(:old_block) { proc {} }
+        before { event.subscribe(key, &old_block) }
+
+        it 'replaces the original subscription' do
+          expect { subscribe }.to change { event.subscriptions[key] }
+            .from(old_block)
+            .to(block)
+        end
+      end
+    end
+
+    context 'when not given a block' do
+      let(:block) { nil }
+      it { expect { subscribe }.to raise_error(ArgumentError) }
+    end
+  end
+
+  describe '#unsubscribe' do
+    subject(:unsubscribe) { event.unsubscribe(key) }
+    let(:key) { :test_subscription }
+
+    context 'when no subscription has been made' do
+      it { is_expected.to be nil }
+    end
+
+    context 'after a subscription has been made' do
+      let(:block) { proc {} }
+      before { event.subscribe(key, &block) }
+
+      it 'removes the subscription' do
+        expect { unsubscribe }.to change { event.subscriptions[key] }
+          .from(block)
+          .to(nil)
+
+        is_expected.to be block
+      end
+    end
+  end
+
+  describe '#unsubscribe_all!' do
+    subject(:unsubscribe_all!) { event.unsubscribe_all! }
+
+    context 'after multiple subscriptions have been made' do
+      before { 2.times { |i| event.subscribe(i, &proc {}) } }
+
+      it 'removes all the subscriptions' do
+        expect { unsubscribe_all! }.to change { event.subscriptions.empty? }
+          .from(false)
+          .to(true)
+
+        is_expected.to be true
+      end
+    end
+  end
+
+  describe '#publish' do
+    subject(:publish) { event.publish(*args) }
+    let(:args) { [:a, :b] }
+
+    context 'when there are no subscribers' do
+      it { expect { publish }.to_not raise_error }
+      it { is_expected.to be true }
+    end
+
+    context 'when there are multiple subscribers' do
+      let(:subscriptions) do
+        {
+          first: proc { |*_args| },
+          second: proc { |*_args| }
+        }
+      end
+
+      before do
+        subscriptions.each do |key, block|
+          allow(block).to receive(:call)
+          event.subscribe(key, &block)
+        end
+      end
+
+      it 'calls both subscribers' do
+        publish
+
+        subscriptions.values.each do |block|
+          expect(block).to have_received(:call).with(*args).ordered
+        end
+      end
+
+      context 'and the first raises an error' do
+        let(:error) { StandardError.new('Failure!') }
+
+        before do
+          allow(subscriptions[:first]).to receive(:call).and_raise(error)
+          allow(Datadog::Logger.log).to receive(:debug)
+        end
+
+        it 'logs an error and continues to the next' do
+          publish
+
+          expect(Datadog::Logger.log).to have_received(:debug).with(/Error while handling 'first'/).once
+          expect(subscriptions[:second]).to have_received(:call).with(*args)
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/worker_spec.rb
+++ b/spec/ddtrace/worker_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+require 'ddtrace/worker'
+
+RSpec.describe Datadog::Worker do
+  subject(:worker) { described_class.new(&block) }
+  let(:block) { proc {} }
+
+  describe '#initialize' do
+    context 'given a block' do
+      it { is_expected.to have_attributes(task: block) }
+    end
+  end
+
+  describe '#perform' do
+    subject(:perform) { worker.perform(*args) }
+    let(:args) { [:a, :b] }
+
+    context 'when no task has been set' do
+      let(:block) { nil }
+      it { is_expected.to be nil }
+      it { expect { perform }.to_not raise_error }
+    end
+
+    context 'when a task has been set' do
+      let(:result) { double('result') }
+
+      before { allow(block).to receive(:call).and_return(result) }
+
+      it 'calls the task and returns its result' do
+        is_expected.to be result
+        expect(block).to have_received(:call).with(*args)
+      end
+    end
+  end
+end

--- a/spec/ddtrace/workers/async_spec.rb
+++ b/spec/ddtrace/workers/async_spec.rb
@@ -1,0 +1,427 @@
+require 'spec_helper'
+
+require 'ddtrace/worker'
+require 'ddtrace/workers/async'
+
+RSpec.describe Datadog::Workers::Async::Thread do
+  context 'when included into a worker' do
+    subject(:worker) { worker_class.new(&task) }
+
+    let(:worker_class) do
+      Class.new(Datadog::Worker) { include Datadog::Workers::Async::Thread }
+    end
+
+    let(:task) { proc { |*args| worker_spy.perform(*args) } }
+    let(:worker_spy) { double('worker spy') }
+
+    before { allow(worker_spy).to receive(:perform) }
+
+    shared_context 'perform and wait' do
+      let(:perform) { worker.perform(*args) }
+      let(:args) { [:foo, :bar] }
+      let(:perform_complete) { ConditionVariable.new }
+      let(:perform_result) { double('perform result') }
+      let(:perform_task) { proc { |*_args| } }
+
+      before do
+        allow(worker_spy).to receive(:perform) do |*actual_args|
+          perform_task.call(*actual_args)
+          perform_complete.signal
+          perform_result
+        end
+
+        perform
+
+        # Block until #perform gives signal or timeout is reached.
+        Mutex.new.tap do |mutex|
+          mutex.synchronize do
+            perform_complete.wait(mutex, 0.1)
+            sleep(0.1) # Give a little extra time to collect the thread.
+          end
+        end
+      end
+    end
+
+    shared_context 'perform and wait with error' do
+      include_context 'perform and wait' do
+        let(:error) { error_class.new }
+        let(:error_class) { stub_const('TestError', Class.new(StandardError)) }
+        let(:perform_task) do
+          proc do |*_actual_args|
+            raise error
+          end
+        end
+      end
+    end
+
+    describe '#perform' do
+      subject(:perform) { worker.perform(*args) }
+      let(:args) { [:foo, :bar] }
+
+      context 'given arguments' do
+        include_context 'perform and wait' do
+          let(:perform_task) do
+            proc do |*actual_args|
+              expect(actual_args).to eq args
+            end
+          end
+        end
+
+        it 'performs the task async' do
+          # expect(worker.result).to eq(perform_result)
+          expect(worker).to have_attributes(
+            result: perform_result,
+            error?: false,
+            error: nil,
+            completed?: true,
+            unstarted?: false,
+            run_async?: true
+          )
+        end
+      end
+    end
+
+    describe '#error?' do
+      subject(:error?) { worker.error? }
+
+      context 'by default' do
+        it { is_expected.to be false }
+      end
+
+      context 'when #perform raises an error' do
+        include_context 'perform and wait with error'
+        it { is_expected.to be true }
+      end
+    end
+
+    describe '#error' do
+      subject(:error) { worker.error }
+
+      context 'by default' do
+        it { is_expected.to be nil }
+      end
+
+      context 'when #perform raises an error' do
+        include_context 'perform and wait with error'
+        it { is_expected.to be error }
+      end
+    end
+
+    describe '#result' do
+      subject(:result) { worker.result }
+
+      context 'by default' do
+        it { is_expected.to be nil }
+      end
+
+      context 'after #perform completes' do
+        include_context 'perform and wait'
+        it { is_expected.to be perform_result }
+      end
+    end
+
+    describe '#fork_policy' do
+      subject(:fork_policy) { worker.fork_policy }
+
+      context 'by default' do
+        it { is_expected.to be described_class::FORK_POLICY_STOP }
+      end
+
+      context 'when set' do
+        let(:policy) { double('policy') }
+
+        it do
+          expect { worker.fork_policy = policy }
+            .to change { worker.fork_policy }
+            .from(described_class::FORK_POLICY_STOP)
+            .to(policy)
+        end
+      end
+    end
+
+    describe '#fork_policy=' do
+      subject(:set_fork_policy) { worker.fork_policy = policy }
+      let(:policy) { double('policy') }
+
+      it do
+        expect { set_fork_policy }
+          .to change { worker.fork_policy }
+          .from(described_class::FORK_POLICY_STOP)
+          .to(policy)
+      end
+    end
+
+    describe '#join' do
+      subject(:join) { worker.join }
+      let(:thread) { worker.send(:worker) }
+
+      context 'when not started' do
+        it { is_expected.to be true }
+      end
+
+      context 'when started' do
+        let(:task) { proc { sleep(1) } }
+        let(:join_result) { double('join result') }
+
+        before { worker.perform }
+
+        context 'given no arguments' do
+          before do
+            expect(thread).to receive(:join)
+              .with(nil)
+              .and_return(join_result)
+          end
+
+          it { is_expected.to be true }
+        end
+
+        context 'given a timeout' do
+          subject(:join) { worker.join(timeout) }
+          let(:timeout) { rand }
+
+          context 'which is not reached' do
+            before do
+              expect(thread).to receive(:join)
+                .with(timeout)
+                .and_return(join_result)
+            end
+
+            it { is_expected.to be true }
+          end
+
+          context 'which is reached' do
+            before do
+              expect(thread).to receive(:join)
+                .with(timeout)
+                .and_return(nil)
+            end
+
+            it { is_expected.to be false }
+          end
+        end
+      end
+    end
+
+    describe '#terminate' do
+      subject(:terminate) { worker.terminate }
+
+      context 'when not started' do
+        it { is_expected.to be false }
+      end
+
+      context 'when started' do
+        let(:task) { proc { sleep(1) } }
+        let(:join_result) { double('join result') }
+
+        before do
+          worker.perform
+          expect(worker.send(:worker)).to receive(:terminate)
+            .and_call_original
+        end
+
+        it do
+          is_expected.to be true
+          expect(worker.run_async?).to be false
+        end
+      end
+    end
+
+    describe '#run_async?' do
+      subject(:run_async?) { worker.run_async? }
+
+      context 'by default' do
+        it { is_expected.to be false }
+      end
+
+      context 'when started' do
+        before { worker.perform }
+        after { worker.terminate }
+        it { is_expected.to be true }
+      end
+    end
+
+    describe '#unstarted?' do
+      subject(:unstarted?) { worker.unstarted? }
+
+      context 'by default' do
+        it { is_expected.to be true }
+      end
+
+      context 'when started' do
+        before { worker.perform }
+        after { worker.terminate }
+        it { is_expected.to be false }
+      end
+    end
+
+    describe '#running?' do
+      subject(:running?) { worker.running? }
+
+      context 'by default' do
+        it { is_expected.to be false }
+      end
+
+      context 'when started' do
+        before { worker.perform }
+        after { worker.terminate }
+        it { is_expected.to be true }
+      end
+    end
+
+    describe '#completed?' do
+      subject(:completed?) { worker.completed? }
+
+      context 'by default' do
+        it { is_expected.to be false }
+      end
+
+      context 'when running' do
+        let(:task) { proc { sleep(1) } }
+
+        before { worker.perform }
+        after { worker.terminate }
+
+        it do
+          expect(worker.running?).to be true
+          is_expected.to be false
+        end
+      end
+
+      context 'when completed successfully' do
+        include_context 'perform and wait'
+        it { is_expected.to be true }
+      end
+
+      context 'when failed' do
+        include_context 'perform and wait with error'
+        it { is_expected.to be false }
+      end
+    end
+
+    describe '#failed?' do
+      subject(:failed?) { worker.failed? }
+
+      context 'by default' do
+        it { is_expected.to be false }
+      end
+
+      context 'when running' do
+        let(:task) { proc { sleep(1) } }
+
+        before { worker.perform }
+        after { worker.terminate }
+
+        it do
+          expect(worker.running?).to be true
+          is_expected.to be false
+        end
+      end
+
+      context 'when completed successfully' do
+        include_context 'perform and wait'
+        it { is_expected.to be false }
+      end
+
+      context 'when failed' do
+        include_context 'perform and wait with error'
+
+        it do
+          is_expected.to be true
+          expect(worker.error?).to be true
+        end
+      end
+    end
+
+    describe '#forked?' do
+      subject(:forked?) { worker.forked? }
+
+      context 'by default' do
+        it { is_expected.to be false }
+      end
+
+      context 'when started but not forked' do
+        let(:task) { proc { sleep(1) } }
+
+        before { worker.perform }
+        after { worker.terminate }
+
+        it do
+          expect(worker.running?).to be true
+          is_expected.to be false
+        end
+      end
+
+      context 'when started then forked' do
+        let(:task) { proc { sleep(1) } }
+
+        before { worker.perform }
+        after { worker.terminate }
+
+        it do
+          expect(worker.running?).to be true
+          expect(worker.forked?).to be false
+
+          expect_in_fork do
+            expect(worker.forked?).to be true
+          end
+        end
+      end
+    end
+
+    describe 'integration tests' do
+      describe 'forking' do
+        context 'when the process forks' do
+          context 'with FORK_POLICY_STOP fork policy' do
+            before { worker.fork_policy = described_class::FORK_POLICY_STOP }
+
+            it 'does not restart the worker' do
+              worker.perform
+
+              expect_in_fork do
+                expect(worker.running?).to be false
+
+                # Capture the flush
+                @performed = false
+                allow(worker_spy).to receive(:perform) do
+                  @performed = true
+                end
+
+                # Attempt restart of worker & verify it stops.
+                expect { worker.perform }.to change { worker.run_async? }
+                  .from(true)
+                  .to(false)
+              end
+            end
+          end
+
+          context 'with FORK_POLICY_RESTART fork policy' do
+            before { worker.fork_policy = described_class::FORK_POLICY_RESTART }
+
+            it 'restarts the worker' do
+              # Start worker
+              worker.perform
+
+              expect_in_fork do
+                expect(worker.running?).to be false
+
+                # Capture the flush
+                @performed = false
+                allow(worker_spy).to receive(:perform) do
+                  @performed = true
+                end
+
+                # Restart worker & wait
+                worker.perform
+                try_wait_until { @performed }
+
+                # Verify state of the worker
+                expect(worker.failed?).to be false
+                expect(worker_spy).to have_received(:perform).at_least(:once)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/workers/loop_spec.rb
+++ b/spec/ddtrace/workers/loop_spec.rb
@@ -1,0 +1,226 @@
+require 'spec_helper'
+
+require 'ddtrace/worker'
+require 'ddtrace/workers/loop'
+
+RSpec.describe Datadog::Workers::IntervalLoop do
+  context 'when included into a worker' do
+    subject(:worker) { worker_class.new(&task) }
+
+    let(:worker_class) do
+      Class.new(Datadog::Worker) { include Datadog::Workers::IntervalLoop }
+    end
+
+    let(:task) { proc { |*args| worker_spy.perform(*args) } }
+    let(:worker_spy) { double('worker spy') }
+
+    before { allow(worker_spy).to receive(:perform) }
+
+    # Stub conditional wait so tests run faster
+    before { allow(worker.send(:shutdown)).to receive(:wait) }
+
+    shared_context 'loop limit' do
+      let(:perform_limit) { 2 }
+
+      before do
+        @perform_invocations ||= 0
+
+        allow(worker_spy).to receive(:perform) do |*actual_args|
+          expect(actual_args).to eq args
+
+          # Abort loop if limit reached
+          @perform_invocations += 1
+          worker.stop_loop if @perform_invocations >= perform_limit
+        end
+      end
+    end
+
+    shared_context 'perform loop in thread' do
+      before do
+        # Start the loop in a thread, give it time to warm up.
+        @thread = Thread.new { worker.perform }
+        sleep(0.1)
+      end
+
+      after { @thread.kill }
+    end
+
+    describe '#perform' do
+      subject(:perform) { worker.perform(*args) }
+      let(:args) { [:foo, :bar] }
+
+      context 'given arguments' do
+        include_context 'loop limit'
+
+        it 'performs the loop' do
+          perform
+          expect(@perform_invocations).to eq(perform_limit)
+        end
+      end
+    end
+
+    describe '#stop_loop' do
+      subject(:stop_loop) { worker.stop_loop }
+
+      context 'when the worker is not running' do
+        before { worker.stop_loop }
+        it { is_expected.to be false }
+      end
+
+      context 'when the worker is running' do
+        include_context 'perform loop in thread'
+
+        it { is_expected.to be true }
+
+        it do
+          expect { stop_loop }.to change { worker.run_loop? }
+            .from(true)
+            .to(false)
+        end
+
+        it do
+          expect { stop_loop }.to change { worker.work_pending? }
+            .from(true)
+            .to(false)
+        end
+      end
+    end
+
+    describe '#work_pending?' do
+      subject(:work_pending?) { worker.work_pending? }
+
+      context 'when the worker is not running' do
+        it { is_expected.to be false }
+      end
+
+      context 'when the worker is running' do
+        include_context 'perform loop in thread'
+        it { is_expected.to be true }
+      end
+    end
+
+    describe '#run_loop?' do
+      subject(:run_loop?) { worker.run_loop? }
+
+      context 'when worker is not running' do
+        it { is_expected.to be false }
+      end
+
+      context 'when worker is running' do
+        include_context 'perform loop in thread'
+        it { is_expected.to be true }
+      end
+    end
+
+    describe '#loop_default_interval' do
+      subject(:loop_default_interval) { worker.loop_default_interval }
+
+      context 'default' do
+        it { is_expected.to eq(described_class::DEFAULT_INTERVAL) }
+      end
+
+      context 'when set' do
+        let(:value) { rand }
+
+        it do
+          expect { worker.send(:loop_default_interval=, value) }
+            .to change { worker.loop_default_interval }
+            .from(described_class::DEFAULT_INTERVAL)
+            .to(value)
+        end
+      end
+    end
+
+    describe '#loop_back_off_ratio' do
+      subject(:loop_back_off_ratio) { worker.loop_back_off_ratio }
+
+      context 'default' do
+        it { is_expected.to eq(described_class::BACK_OFF_RATIO) }
+      end
+
+      context 'when set' do
+        let(:value) { rand }
+
+        it do
+          expect { worker.send(:loop_back_off_ratio=, value) }
+            .to change { worker.loop_back_off_ratio }
+            .from(described_class::BACK_OFF_RATIO)
+            .to(value)
+        end
+      end
+    end
+
+    describe '#loop_back_off_max' do
+      subject(:loop_back_off_max) { worker.loop_back_off_max }
+
+      context 'default' do
+        it { is_expected.to eq(described_class::BACK_OFF_MAX) }
+      end
+
+      context 'when set' do
+        let(:value) { rand }
+
+        it do
+          expect { worker.send(:loop_back_off_max=, value) }
+            .to change { worker.loop_back_off_max }
+            .from(described_class::BACK_OFF_MAX)
+            .to(value)
+        end
+      end
+    end
+
+    describe '#loop_wait_time' do
+      subject(:loop_wait_time) { worker.loop_wait_time }
+
+      context 'default' do
+        it { is_expected.to eq(described_class::DEFAULT_INTERVAL) }
+      end
+
+      context 'when set' do
+        let(:value) { rand }
+
+        it do
+          expect { worker.send(:loop_default_interval=, value) }
+            .to change { worker.loop_default_interval }
+            .from(described_class::DEFAULT_INTERVAL)
+            .to(value)
+        end
+      end
+    end
+
+    describe '#loop_back_off?' do
+      subject(:loop_back_off?) { worker.loop_back_off? }
+      it { is_expected.to be false }
+    end
+
+    describe '#loop_back_off!' do
+      subject(:loop_back_off!) { worker.loop_back_off! }
+
+      context 'given no arguments' do
+        it do
+          expect { loop_back_off! }
+            .to change { worker.loop_wait_time }
+            .from(described_class::DEFAULT_INTERVAL)
+            .to(described_class::BACK_OFF_RATIO)
+
+          expect { worker.loop_back_off! }
+            .to change { worker.loop_wait_time }
+            .from(described_class::BACK_OFF_RATIO)
+            .to(described_class::BACK_OFF_RATIO * described_class::BACK_OFF_RATIO)
+        end
+      end
+
+      context 'given an amount to back off' do
+        subject(:loop_back_off!) { worker.loop_back_off!(value) }
+        let(:value) { rand }
+
+        it do
+          expect { loop_back_off! }
+            .to change { worker.loop_wait_time }
+            .from(described_class::DEFAULT_INTERVAL)
+            .to(value)
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/workers/polling_spec.rb
+++ b/spec/ddtrace/workers/polling_spec.rb
@@ -1,0 +1,181 @@
+require 'spec_helper'
+
+require 'ddtrace/worker'
+require 'ddtrace/workers/polling'
+
+RSpec.describe Datadog::Workers::Polling do
+  context 'when included into a worker' do
+    subject(:worker) { worker_class.new }
+
+    let(:worker_class) do
+      Class.new(Datadog::Worker) { include Datadog::Workers::Polling }
+    end
+
+    describe '#perform' do
+      subject(:perform) { worker.perform }
+      after { worker.stop(true, 0) }
+
+      let(:worker) { worker_class.new(&task) }
+      let(:task) { proc { |*args| worker_spy.perform(*args) } }
+      let(:worker_spy) { double('worker spy') }
+
+      before { allow(worker_spy).to receive(:perform) }
+
+      context 'by default' do
+        it do
+          perform
+          try_wait_until { worker.running? && worker.run_loop? }
+          expect(worker_spy).to have_received(:perform).at_least(:once)
+        end
+      end
+
+      context 'when #enabled? is true' do
+        before { allow(worker).to receive(:enabled?).and_return(true) }
+
+        it do
+          perform
+          try_wait_until { worker.running? && worker.run_loop? }
+          expect(worker_spy).to have_received(:perform).at_least(:once)
+        end
+      end
+
+      context 'when #enabled? is false' do
+        before { allow(worker).to receive(:enabled?).and_return(false) }
+
+        it do
+          perform
+          expect(worker_spy).to_not have_received(:perform)
+        end
+      end
+    end
+
+    describe '#stop' do
+      subject(:stop) { worker.stop }
+
+      shared_context 'graceful stop' do
+        before do
+          allow(worker).to receive(:join)
+            .with(described_class::SHUTDOWN_TIMEOUT)
+            .and_return(true)
+        end
+      end
+
+      context 'when the worker has not been started' do
+        before do
+          allow(worker).to receive(:join)
+            .with(described_class::SHUTDOWN_TIMEOUT)
+            .and_return(true)
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the worker has been started' do
+        include_context 'graceful stop'
+
+        before do
+          worker.perform
+          try_wait_until { worker.running? && worker.run_loop? }
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context 'called multiple times with graceful stop' do
+        include_context 'graceful stop'
+
+        before do
+          worker.perform
+          try_wait_until { worker.running? && worker.run_loop? }
+        end
+
+        it do
+          expect(worker.stop).to be true
+          try_wait_until { !worker.running? }
+          expect(worker.stop).to be false
+        end
+      end
+
+      context 'given force_stop: true' do
+        subject(:stop) { worker.stop(true) }
+
+        context 'and the worker does not gracefully stop' do
+          before do
+            # Make it ignore graceful stops
+            allow(worker).to receive(:stop_loop).and_return(false)
+            allow(worker).to receive(:join).and_return(nil)
+          end
+
+          context 'after the worker has been started' do
+            before { worker.perform }
+
+            it do
+              is_expected.to be true
+
+              # Give thread time to be terminated
+              try_wait_until { !worker.running? }
+
+              expect(worker.run_async?).to be false
+              expect(worker.running?).to be false
+            end
+          end
+        end
+      end
+    end
+
+    describe '#enabled?' do
+      subject(:enabled?) { worker.enabled? }
+
+      before { allow(worker).to receive(:perform) }
+
+      context 'by default' do
+        it { is_expected.to be true }
+      end
+
+      context 'when enabled= is set to false' do
+        it do
+          expect { worker.enabled = false }
+            .to change { worker.enabled? }
+            .from(true)
+            .to(false)
+        end
+      end
+    end
+
+    describe '#enabled=' do
+      subject(:set_enabled_value) { worker.enabled = value }
+
+      context 'and given true' do
+        let(:value) { true }
+
+        it do
+          expect { set_enabled_value }
+            .to_not change { worker.enabled? }
+            .from(true)
+        end
+      end
+
+      context 'and given false' do
+        let(:value) { false }
+
+        it do
+          expect { set_enabled_value }
+            .to change { worker.enabled? }
+            .from(true)
+            .to(false)
+        end
+      end
+
+      context 'and given nil' do
+        let(:value) { nil }
+
+        it 'does nothing' do
+          expect { set_enabled_value }
+            .to change { worker.enabled? }
+            .from(true)
+            .to(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/workers/queue_spec.rb
+++ b/spec/ddtrace/workers/queue_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+require 'ddtrace/worker'
+require 'ddtrace/workers/queue'
+
+RSpec.describe Datadog::Workers::Queue do
+  context 'when included into a worker' do
+    subject(:worker) { worker_class.new(&task) }
+
+    let(:worker_class) do
+      Class.new(Datadog::Worker) { include Datadog::Workers::Queue }
+    end
+
+    let(:task) { proc { |*args| worker_spy.perform(*args) } }
+    let(:worker_spy) { double('worker spy') }
+
+    describe '#perform' do
+      subject(:perform) { worker.perform }
+
+      context 'when no work is queued' do
+        it 'does not perform the task' do
+          expect(worker_spy).to_not receive(:perform)
+          perform
+        end
+      end
+
+      context 'when work is queued' do
+        let(:args) { [:foo, :bar] }
+        before { worker.enqueue(*args) }
+
+        it 'performs the task with arguments provided' do
+        end
+      end
+    end
+
+    describe '#buffer' do
+      subject(:buffer) { worker.buffer }
+      it { is_expected.to be_a_kind_of(Array) }
+      it { is_expected.to be_empty }
+    end
+
+    describe '#enqueue' do
+      subject(:enqueue) { worker.enqueue(*args) }
+      let(:args) { [:foo, :bar] }
+
+      it do
+        expect { enqueue }.to change { worker.buffer }
+          .from([])
+          .to([args])
+      end
+    end
+
+    describe '#dequeue' do
+      subject(:dequeue) { worker.dequeue }
+
+      context 'when nothing is queued' do
+        it { is_expected.to be nil }
+      end
+
+      context 'when args are queued' do
+        let(:args) { [:foo, :bar] }
+        before { worker.enqueue(*args) }
+
+        it do
+          expect { dequeue }.to change { worker.buffer }
+            .from([args])
+            .to([])
+
+          is_expected.to eq args
+        end
+      end
+    end
+
+    describe '#work_pending?' do
+      subject(:work_pending?) { worker.work_pending? }
+
+      context 'when the buffer is empty' do
+        it { is_expected.to be false }
+      end
+
+      context 'when the buffer is not empty' do
+        before { worker.enqueue(*args) }
+        let(:args) { [:foo, :bar] }
+        it { is_expected.to be true }
+      end
+    end
+  end
+end

--- a/spec/ddtrace/workers/runtime_metrics_spec.rb
+++ b/spec/ddtrace/workers/runtime_metrics_spec.rb
@@ -1,0 +1,267 @@
+require 'spec_helper'
+
+require 'ddtrace'
+require 'ddtrace/workers/runtime_metrics'
+
+RSpec.describe Datadog::Workers::RuntimeMetrics do
+  subject(:worker) { described_class.new(options) }
+  let(:metrics) { instance_double(Datadog::Runtime::Metrics) }
+  let(:options) { { metrics: metrics, enabled: true } }
+
+  before { allow(metrics).to receive(:flush) }
+  after { worker.stop(true, 0) }
+
+  describe '#initialize' do
+    it { expect(worker).to be_a_kind_of(Datadog::Workers::Polling) }
+
+    context 'by default' do
+      subject(:worker) { described_class.new }
+      it { expect(worker.enabled?).to be false }
+    end
+
+    context 'when :enabled is given' do
+      let(:options) { super().merge(enabled: true) }
+      it { expect(worker.enabled?).to be true }
+    end
+
+    context 'when :enabled is not given' do
+      before { options.delete(:enabled) }
+
+      context "and #{Datadog::Ext::Runtime::Metrics::ENV_ENABLED} is not set" do
+        before do
+          expect(Datadog::Environment).to receive(:env_to_bool)
+            .with(Datadog::Ext::Runtime::Metrics::ENV_ENABLED, false)
+            .and_return(false)
+        end
+
+        it { expect(worker.enabled?).to be false }
+      end
+
+      context "and #{Datadog::Ext::Runtime::Metrics::ENV_ENABLED} is set" do
+        before do
+          expect(Datadog::Environment).to receive(:env_to_bool)
+            .with(Datadog::Ext::Runtime::Metrics::ENV_ENABLED, false)
+            .and_return(true)
+        end
+
+        it { expect(worker.enabled?).to be true }
+      end
+    end
+  end
+
+  describe '#perform' do
+    subject(:perform) { worker.perform }
+    after { worker.stop(true, 0) }
+
+    context 'when #enabled? is true' do
+      before { allow(worker).to receive(:enabled?).and_return(true) }
+
+      it 'starts a worker thread' do
+        perform
+        expect(worker).to have_attributes(
+          metrics: metrics,
+          run_async?: true,
+          running?: true,
+          unstarted?: false,
+          forked?: false,
+          fork_policy: Datadog::Workers::Async::Thread::FORK_POLICY_STOP,
+          result: nil
+        )
+      end
+    end
+  end
+
+  describe '#enabled=' do
+    subject(:set_enabled_value) { worker.enabled = value }
+    after { worker.stop(true, 0) }
+
+    context 'when not running' do
+      before do
+        worker.enabled = false
+        allow(worker).to receive(:perform)
+        allow(worker).to receive(:stop)
+      end
+
+      context 'and given true' do
+        let(:value) { true }
+
+        it 'starts the worker' do
+          expect { set_enabled_value }
+            .to change { worker.enabled? }
+            .from(false)
+            .to(true)
+
+          expect(worker).to have_received(:perform)
+          expect(worker).to_not have_received(:stop)
+        end
+      end
+
+      context 'and given false' do
+        let(:value) { false }
+
+        it 'does nothing' do
+          expect { set_enabled_value }
+            .to_not change { worker.enabled? }
+            .from(false)
+
+          expect(worker).to_not have_received(:perform)
+          expect(worker).to_not have_received(:stop)
+        end
+      end
+
+      context 'and given nil' do
+        let(:value) { nil }
+
+        it 'does nothing' do
+          expect { set_enabled_value }
+            .to_not change { worker.enabled? }
+            .from(false)
+
+          expect(worker).to_not have_received(:perform)
+          expect(worker).to_not have_received(:stop)
+        end
+      end
+    end
+
+    context 'when already running' do
+      before do
+        worker.enabled = true
+        allow(worker).to receive(:perform)
+        allow(worker).to receive(:stop)
+      end
+
+      context 'and given true' do
+        let(:value) { true }
+
+        it 'does nothing' do
+          expect { set_enabled_value }
+            .to_not change { worker.enabled? }
+            .from(true)
+
+          expect(worker).to_not have_received(:perform)
+          expect(worker).to_not have_received(:stop)
+        end
+      end
+
+      context 'and given false' do
+        let(:value) { false }
+
+        it 'stops the worker' do
+          expect { set_enabled_value }
+            .to change { worker.enabled? }
+            .from(true)
+            .to(false)
+
+          expect(worker).to_not have_received(:perform)
+          expect(worker).to have_received(:stop)
+        end
+      end
+
+      context 'and given nil' do
+        let(:value) { nil }
+
+        it 'stops the worker' do
+          expect { set_enabled_value }
+            .to change { worker.enabled? }
+            .from(true)
+            .to(false)
+
+          expect(worker).to_not have_received(:perform)
+          expect(worker).to have_received(:stop)
+        end
+      end
+    end
+  end
+
+  describe 'forwarded methods' do
+    describe '#associate_with_span' do
+      subject(:associate_with_span) { worker.associate_with_span(span) }
+      let(:span) { instance_double(Datadog::Span) }
+
+      before { allow(worker.metrics).to receive(:associate_with_span) }
+
+      it 'forwards to #metrics' do
+        associate_with_span
+        expect(worker.metrics).to have_received(:associate_with_span)
+          .with(span)
+      end
+    end
+
+    describe '#register_service' do
+      subject(:register_service) { worker.register_service(service) }
+      let(:service) { double('service') }
+
+      before { allow(worker.metrics).to receive(:register_service) }
+
+      it 'forwards to #metrics' do
+        register_service
+        expect(worker.metrics).to have_received(:register_service)
+          .with(service)
+      end
+    end
+  end
+
+  describe 'integration tests' do
+    let(:options) do
+      {
+        metrics: metrics,
+        fork_policy: fork_policy,
+        enabled: true
+      }
+    end
+
+    describe 'forking' do
+      context 'when the process forks' do
+        before { allow(metrics).to receive(:flush) }
+        after { worker.stop }
+
+        context 'with FORK_POLICY_STOP fork policy' do
+          let(:fork_policy) { Datadog::Workers::Async::Thread::FORK_POLICY_STOP }
+
+          it 'does not produce metrics' do
+            # Start worker in main process
+            worker.perform
+
+            expect_in_fork do
+              # Capture the flush
+              @flushed = false
+              allow(metrics).to receive(:flush) do
+                @flushed = true
+              end
+
+              # Attempt restart of worker & verify it stops.
+              expect { worker.perform }.to change { worker.run_async? }
+                .from(true)
+                .to(false)
+            end
+          end
+        end
+
+        context 'with FORK_POLICY_RESTART fork policy' do
+          let(:fork_policy) { Datadog::Workers::Async::Thread::FORK_POLICY_RESTART }
+
+          it 'continues producing metrics' do
+            # Start worker
+            worker.perform
+
+            expect_in_fork do
+              # Capture the flush
+              @flushed = false
+              allow(metrics).to receive(:flush) do
+                @flushed = true
+              end
+
+              # Restart worker & wait
+              worker.perform
+              try_wait_until(attempts: 30) { @flushed }
+
+              # Verify state of the worker
+              expect(worker.error?).to be false
+              expect(metrics).to have_received(:flush).at_least(:once)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/workers/trace_writer_spec.rb
+++ b/spec/ddtrace/workers/trace_writer_spec.rb
@@ -1,0 +1,676 @@
+require 'spec_helper'
+
+require 'ddtrace'
+require 'ddtrace/workers/trace_writer'
+
+RSpec.describe Datadog::Workers::TraceWriter do
+  subject(:writer) { described_class.new(options) }
+  let(:options) { {} }
+
+  describe '#initialize' do
+    context 'given :transport' do
+      let(:options) { { transport: transport } }
+      let(:transport) { instance_double(Datadog::Transport::HTTP::Client) }
+      it { expect(writer.transport).to be transport }
+    end
+
+    context 'given :transport_options' do
+      let(:options) { { transport_options: transport_options } }
+
+      context 'that is a Hash' do
+        let(:transport_options) { {} }
+        let(:transport) { instance_double(Datadog::Transport::HTTP::Client) }
+
+        before do
+          expect(Datadog::Transport::HTTP).to receive(:default)
+            .with(transport_options)
+            .and_return(transport)
+        end
+
+        it { expect(writer.transport).to be transport }
+      end
+
+      context 'that is a Proc' do
+        let(:transport_options) { proc {} }
+        let(:transport) { instance_double(Datadog::Transport::HTTP::Client) }
+
+        before do
+          expect(Datadog::Transport::HTTP).to receive(:default)
+            .with(on_build: kind_of(Proc))
+            .and_return(transport)
+        end
+
+        it { expect(writer.transport).to be transport }
+      end
+    end
+
+    context 'given :hostname' do
+      let(:options) { { hostname: hostname } }
+      let(:hostname) { double('hostname') }
+      let(:transport) { instance_double(Datadog::Transport::HTTP::Client) }
+
+      before do
+        expect(Datadog::Transport::HTTP).to receive(:default)
+          .with(hostname: hostname)
+          .and_return(transport)
+      end
+
+      it { expect(writer.transport).to be transport }
+    end
+
+    context 'given :port' do
+      let(:options) { { port: port } }
+      let(:port) { double('port') }
+      let(:transport) { instance_double(Datadog::Transport::HTTP::Client) }
+
+      before do
+        expect(Datadog::Transport::HTTP).to receive(:default)
+          .with(port: port)
+          .and_return(transport)
+      end
+
+      it { expect(writer.transport).to be transport }
+    end
+  end
+
+  describe '#write' do
+    subject(:write) { writer.write(trace) }
+    let(:trace) { double('trace') }
+    let(:response) { instance_double(Datadog::Transport::Response) }
+
+    before do
+      expect(writer).to receive(:write_traces)
+        .with([trace])
+        .and_return(response)
+    end
+
+    it { is_expected.to be response }
+  end
+
+  describe '#perform' do
+    subject(:perform) { writer.perform(traces) }
+    let(:traces) { double('traces') }
+    let(:response) { instance_double(Datadog::Transport::Response) }
+
+    before do
+      expect(writer).to receive(:write_traces)
+        .with(traces)
+        .and_return(response)
+    end
+
+    it { is_expected.to be response }
+  end
+
+  describe '#write_traces' do
+    subject(:write_traces) { writer.write_traces(traces) }
+    let(:traces) { double('traces') }
+    let(:processed_traces) { double('processed traces') }
+    let(:response) { instance_double(Datadog::Transport::Response) }
+
+    before do
+      expect(writer).to receive(:process_traces)
+        .with(traces)
+        .and_return(processed_traces)
+
+      expect(writer).to receive(:flush_traces)
+        .with(processed_traces)
+        .and_return(response)
+    end
+
+    it { is_expected.to be response }
+  end
+
+  describe '#process_traces' do
+    subject(:process_traces) { writer.process_traces(traces) }
+    let(:traces) { double('traces') }
+    let(:processed_traces) { double('processed traces') }
+
+    before do
+      expect(Datadog::Pipeline).to receive(:process!)
+        .with(traces)
+        .and_return(processed_traces)
+    end
+
+    context 'when \'report_hostname\'' do
+      context 'is enabled' do
+        before do
+          allow(Datadog.configuration).to receive(:report_hostname)
+            .and_return(true)
+
+          expect(writer).to receive(:inject_hostname!)
+            .with(processed_traces)
+        end
+
+        it { is_expected.to be(processed_traces) }
+      end
+
+      context 'is not enabled' do
+        before do
+          allow(Datadog.configuration).to receive(:report_hostname)
+            .and_return(false)
+        end
+
+        it { is_expected.to be(processed_traces) }
+      end
+    end
+  end
+
+  describe '#flush_traces' do
+    subject(:flush_traces) { writer.flush_traces(traces) }
+    let(:traces) { double('traces') }
+    let(:response) { instance_double(Datadog::Transport::Response) }
+
+    before do
+      expect(writer.transport).to receive(:send_traces)
+        .with(traces)
+        .and_return(response)
+
+      expect(writer.flush_completed).to receive(:publish)
+        .with(response)
+    end
+
+    it { is_expected.to be(response) }
+  end
+
+  describe '#inject_hostname!' do
+    subject(:inject_hostname!) { writer.inject_hostname!(traces) }
+    let(:traces) { get_test_traces(2) }
+
+    context 'when hostname' do
+      before do
+        allow(Datadog::Runtime::Socket).to receive(:hostname)
+          .and_return(hostname)
+      end
+
+      context 'is available' do
+        let(:hostname) { 'localhost' }
+
+        it 'sets the hostname on the first span of each trace' do
+          inject_hostname!
+
+          traces.each do |trace|
+            expect(trace.first.get_tag(Datadog::Ext::NET::TAG_HOSTNAME)).to eq(hostname)
+          end
+        end
+      end
+
+      context 'is not available' do
+        let(:hostname) { nil }
+
+        it 'hoes not set the hostname on any of the traces' do
+          inject_hostname!
+
+          traces.each do |trace|
+            expect(trace.first.get_tag(Datadog::Ext::NET::TAG_HOSTNAME)).to be nil
+          end
+        end
+      end
+    end
+  end
+
+  describe '#flush_completed' do
+    subject(:flush_completed) { writer.flush_completed }
+    it { is_expected.to be_a_kind_of(described_class::FlushCompleted) }
+  end
+
+  describe described_class::FlushCompleted do
+    subject(:event) { described_class.new }
+
+    describe '#name' do
+      subject(:name) { event.name }
+      it { is_expected.to be :flush_completed }
+    end
+  end
+end
+
+RSpec.describe Datadog::Workers::AsyncTraceWriter do
+  subject(:writer) { described_class.new(options) }
+  let(:options) { {} }
+
+  it { expect(writer).to be_a_kind_of(Datadog::Workers::Queue) }
+  it { expect(writer).to be_a_kind_of(Datadog::Workers::Polling) }
+
+  describe '#initialize' do
+    context 'defaults' do
+      it do
+        is_expected.to have_attributes(
+          enabled?: true,
+          fork_policy: Datadog::Workers::Async::Thread::FORK_POLICY_RESTART,
+          buffer: kind_of(Datadog::TraceBuffer)
+        )
+      end
+    end
+
+    context 'given :enabled' do
+      let(:options) { { enabled: enabled } }
+
+      context 'as false' do
+        let(:enabled) { false }
+        it { expect(writer.enabled?).to be false }
+      end
+
+      context 'as true' do
+        let(:enabled) { true }
+        it { expect(writer.enabled?).to be true }
+      end
+
+      context 'as nil' do
+        let(:enabled) { nil }
+        it { expect(writer.enabled?).to be false }
+      end
+    end
+
+    context 'given :fork_policy' do
+      let(:options) { { fork_policy: fork_policy } }
+
+      context "as #{Datadog::Workers::Async::Thread::FORK_POLICY_STOP}" do
+        let(:fork_policy) { Datadog::Workers::Async::Thread::FORK_POLICY_STOP }
+        it { expect(writer.fork_policy).to be Datadog::Workers::Async::Thread::FORK_POLICY_STOP }
+      end
+
+      context "as #{described_class::FORK_POLICY_ASYNC}" do
+        let(:fork_policy) { described_class::FORK_POLICY_ASYNC }
+        it { expect(writer.fork_policy).to be Datadog::Workers::Async::Thread::FORK_POLICY_RESTART }
+      end
+
+      context "as #{described_class::FORK_POLICY_SYNC}" do
+        let(:fork_policy) { described_class::FORK_POLICY_SYNC }
+        it { expect(writer.fork_policy).to be Datadog::Workers::Async::Thread::FORK_POLICY_STOP }
+      end
+    end
+
+    context 'given :interval' do
+      let(:options) { { interval: interval } }
+      let(:interval) { double('interval') }
+      it { expect(writer.loop_default_interval).to be interval }
+    end
+
+    context 'given :back_off_ratio' do
+      let(:options) { { back_off_ratio: back_off_ratio } }
+      let(:back_off_ratio) { double('back_off_ratio') }
+      it { expect(writer.loop_back_off_ratio).to be back_off_ratio }
+    end
+
+    context 'given :back_off_max' do
+      let(:options) { { back_off_max: back_off_max } }
+      let(:back_off_max) { double('back_off_max') }
+      it { expect(writer.loop_back_off_max).to be back_off_max }
+    end
+
+    context 'given :buffer_size' do
+      let(:options) { { buffer_size: buffer_size } }
+      let(:buffer_size) { double('buffer_size') }
+      let(:buffer) { instance_double(Datadog::TraceBuffer) }
+
+      before do
+        expect(Datadog::TraceBuffer).to receive(:new)
+          .with(buffer_size)
+          .and_return(buffer)
+      end
+
+      it { expect(writer.buffer).to be buffer }
+    end
+  end
+
+  describe '#perform' do
+    subject(:perform) { writer.perform }
+    after { writer.stop }
+
+    it 'starts a worker thread' do
+      is_expected.to be_a_kind_of(Thread)
+      expect(writer).to have_attributes(
+        run_async?: true,
+        running?: true,
+        unstarted?: false,
+        forked?: false,
+        fork_policy: :restart,
+        result: nil
+      )
+    end
+  end
+
+  describe '#write' do
+    subject(:write) { writer.write(trace) }
+    let(:trace) { double('trace') }
+
+    context 'when in async mode' do
+      before { allow(writer).to receive(:async?).and_return true }
+
+      context 'and given a trace' do
+        before do
+          allow(writer.buffer).to receive(:push)
+          write
+        end
+
+        it { expect(writer.buffer).to have_received(:push).with(trace) }
+      end
+    end
+
+    context 'when not in async mode' do
+      before { allow(writer).to receive(:async?).and_return false }
+
+      context 'and given a trace' do
+        before do
+          allow(writer).to receive(:write_traces)
+          write
+        end
+
+        it { expect(writer).to have_received(:write_traces).with([trace]) }
+      end
+    end
+  end
+
+  describe '#enqueue' do
+    subject(:enqueue) { writer.enqueue(trace) }
+    let(:trace) { double('trace') }
+
+    before do
+      allow(writer.buffer).to receive(:push)
+      enqueue
+    end
+
+    it { expect(writer.buffer).to have_received(:push).with(trace) }
+  end
+
+  describe '#dequeue' do
+    subject(:dequeue) { writer.dequeue }
+    let(:traces) { double('traces') }
+
+    before do
+      allow(writer.buffer).to receive(:pop)
+        .and_return(traces)
+    end
+
+    it { is_expected.to eq([traces]) }
+  end
+
+  describe '#stop' do
+    subject(:stop) { writer.stop }
+
+    shared_context 'shuts down the worker' do
+      before do
+        expect(writer.buffer).to receive(:close)
+        allow(writer).to receive(:join)
+          .with(described_class::SHUTDOWN_TIMEOUT)
+          .and_return(true)
+      end
+    end
+
+    context 'when the worker has not been started' do
+      before do
+        expect(writer.buffer).to_not receive(:close)
+        allow(writer).to receive(:join)
+          .with(described_class::SHUTDOWN_TIMEOUT)
+          .and_return(true)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the worker has been started' do
+      include_context 'shuts down the worker'
+
+      before do
+        writer.perform
+        try_wait_until { writer.running? && writer.run_loop? }
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'called multiple times with graceful stop' do
+      include_context 'shuts down the worker'
+
+      before do
+        writer.perform
+        try_wait_until { writer.running? && writer.run_loop? }
+      end
+
+      it do
+        expect(writer.stop).to be true
+        try_wait_until { !writer.running? }
+        expect(writer.stop).to be false
+      end
+    end
+
+    context 'given force_stop: true' do
+      subject(:stop) { writer.stop(true) }
+
+      context 'and the worker does not gracefully stop' do
+        before do
+          # Make it ignore graceful stops
+          expect(writer.buffer).to receive(:close)
+          allow(writer).to receive(:stop_loop).and_return(false)
+          allow(writer).to receive(:join).and_return(nil)
+        end
+
+        context 'after the worker has been started' do
+          before { writer.perform }
+
+          it do
+            is_expected.to be true
+
+            # Give thread time to be terminated
+            try_wait_until { !writer.running? }
+
+            expect(writer.run_async?).to be false
+            expect(writer.running?).to be false
+          end
+        end
+      end
+    end
+  end
+
+  describe '#work_pending?' do
+    subject(:work_pending?) { writer.work_pending? }
+
+    context 'when the buffer is empty' do
+      it { is_expected.to be false }
+    end
+
+    context 'when the buffer is not empty' do
+      let(:trace) { get_test_traces(1).first }
+      before { writer.enqueue(trace) }
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#async=' do
+    subject(:set_async) { writer.async = value }
+
+    context 'given true' do
+      let(:value) { true }
+
+      it do
+        is_expected.to be true
+        expect(writer.async?).to be true
+      end
+    end
+
+    context 'given false' do
+      let(:value) { false }
+
+      it do
+        is_expected.to be false
+        expect(writer.async?).to be false
+      end
+    end
+  end
+
+  describe '#async?' do
+    subject(:async?) { writer.async? }
+
+    context 'by default' do
+      it { is_expected.to be true }
+    end
+
+    context 'when set to false' do
+      before { writer.async = false }
+
+      it do
+        is_expected.to be false
+      end
+    end
+
+    context 'when set to truthy' do
+      before { writer.async = 1 }
+
+      it do
+        is_expected.to be false
+      end
+    end
+  end
+
+  describe '#fork_policy=' do
+    subject(:set_fork_policy) { writer.fork_policy = value }
+
+    context 'given FORK_POLICY_ASYNC' do
+      let(:value) { described_class::FORK_POLICY_ASYNC }
+
+      it do
+        is_expected.to be value
+        expect(writer.fork_policy).to eq(Datadog::Workers::Async::Thread::FORK_POLICY_RESTART)
+      end
+    end
+
+    context 'given FORK_POLICY_SYNC' do
+      let(:value) { described_class::FORK_POLICY_SYNC }
+
+      it do
+        is_expected.to be value
+        expect(writer.fork_policy).to eq(Datadog::Workers::Async::Thread::FORK_POLICY_STOP)
+      end
+    end
+  end
+
+  describe '#after_fork' do
+    subject(:after_fork) { writer.after_fork }
+
+    it { expect { after_fork }.to(change { writer.buffer }) }
+
+    context 'when fork_policy is' do
+      before { writer.fork_policy = fork_policy }
+
+      context 'FORK_POLICY_ASYNC' do
+        let(:fork_policy) { described_class::FORK_POLICY_ASYNC }
+
+        it do
+          expect { after_fork }.to_not(change { writer.async? })
+        end
+      end
+
+      context 'FORK_POLICY_SYNC' do
+        let(:fork_policy) { described_class::FORK_POLICY_SYNC }
+
+        it do
+          expect { after_fork }.to change { writer.async? }.from(true).to(false)
+        end
+      end
+    end
+  end
+
+  describe '#write' do
+    subject(:write) { writer.write(trace) }
+    let(:trace) { double('trace') }
+
+    context 'when #async?' do
+      before { expect(writer.async?).to be true }
+
+      context 'is true' do
+        it 'starts a worker thread & queues the trace' do
+          expect(writer.buffer).to receive(:push)
+            .with(trace)
+
+          expect { write }.to change { writer.running? }
+            .from(false)
+            .to(true)
+        end
+      end
+
+      context 'is false' do
+        before { allow(writer).to receive(:async?).and_return(false) }
+
+        it 'writes the trace synchronously' do
+          expect(writer.buffer).to_not receive(:push)
+          expect(writer).to receive(:write_traces)
+            .with([trace])
+          write
+        end
+      end
+    end
+  end
+
+  describe 'integration tests' do
+    let(:options) { { transport: transport, fork_policy: fork_policy } }
+    let(:transport) { Datadog::Transport::HTTP.default { |t| t.adapter :test, output } }
+    let(:output) { [] }
+
+    describe 'forking' do
+      context 'when the process forks and a trace is written' do
+        let(:traces) { get_test_traces(3) }
+
+        before do
+          allow(writer).to receive(:after_fork)
+            .and_call_original
+          allow(writer.transport).to receive(:send_traces)
+            .and_call_original
+        end
+
+        after { writer.stop }
+
+        context 'with :sync fork policy' do
+          let(:fork_policy) { :sync }
+
+          it 'does not drop any traces' do
+            # Start writer in main process
+            writer.perform
+
+            expect_in_fork do
+              traces.each do |trace|
+                expect(writer.write(trace)).to be_a_kind_of(Datadog::Transport::HTTP::Response)
+              end
+
+              expect(writer).to have_received(:after_fork).once
+
+              traces.each do |trace|
+                expect(writer.transport).to have_received(:send_traces)
+                  .with([trace])
+              end
+
+              expect(writer.buffer).to be_empty
+            end
+          end
+        end
+
+        context 'with :async fork policy' do
+          let(:fork_policy) { :async }
+          let(:flushed_traces) { [] }
+
+          it 'does not drop any traces' do
+            # Start writer in main process
+            writer.perform
+
+            expect_in_fork do
+              # Queue up traces, wait for worker to process them.
+              traces.each { |trace| writer.write(trace) }
+              try_wait_until(attempts: 30) { !writer.work_pending? }
+
+              # Verify state of the writer
+              expect(writer).to have_received(:after_fork).once
+              expect(writer.buffer).to be_empty
+              expect(writer.error?).to be false
+
+              expect(writer.transport).to have_received(:send_traces).at_most(traces.length).times do |traces|
+                flushed_traces.concat(traces)
+              end
+
+              expect(flushed_traces).to_not be_empty
+              expect(flushed_traces).to have(traces.length).items
+              expect(flushed_traces).to include(*traces)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -1,4 +1,25 @@
 module SynchronizationHelpers
+  def expect_in_fork
+    read, write = IO.pipe
+
+    pid = fork do
+      read.close
+
+      yield
+
+      Marshal.dump(true, write)
+    end
+
+    # Wait for fork to finish, retrieve its output
+    write.close
+    result = read.read
+    Process.wait(pid)
+
+    # Expect fork and assertions to have completed successfully.
+    # rubocop:disable Security/MarshalLoad
+    expect(Marshal.load(result)).to be true
+  end
+
   def try_wait_until(options = {})
     attempts = options.fetch(:attempts, 10)
     backoff = options.fetch(:backoff, 0.1)


### PR DESCRIPTION
As we have introduced new features to the tracing library, the responsibilities of the `Writer`, `SyncWriter`, `AsyncWorker` have grown and have consequently become more complex. Some current issues include:

 - Divergence between the `Writer` and `SyncWriter`, which duplicate flush logic in a way that's produced a few bugs.
 - `Writer` has become responsible for writing runtime metrics, but is done synchronously with trace writing.
 - `Writer` acts as a middleman for a lot of configuration for `AsyncWorker` and the `Transport` which makes it possess a great deal more about these components that it should.
 - `AsyncWorker` has a high degree of coupling with `Writer` and cannot be effectively/cleanly re-used for runtime metrics.

This pull request seeks to effectively rewrite these components and introduce their successors, to address many of the above issues. These new components include the:
 - `Event`: A minimalistic pub-sub pattern
 - `Worker`: A minimalistic task pattern
 - `Async::Thread`, `IntervalLoop` and `Queue`: Module extensions to `Worker`
 - `TraceWriter` and `AsyncTraceWriter`: Worker implementations for trace writing

Some of the benefits of these include:

 - Eliminates the `SyncWriter` by having one common definition for trace flushing behavior, then having `AsyncTraceWriter` decorated upon that. `AsyncTraceWriter` can optionally automatically switch to synchronous writing when forked (addresses the need for `SyncWriter` in integrations like Resque.)
 - Breaks the worker behaviors into smaller, composable behaviors (e.g. `Async`, `Queue`, `IntervalLoop`, etc) which should be easier to test and re-use, which will...
 - ...allow us to extract and introduce a runtime metrics worker. These changes make building & maintaining the runtime metrics worker easier because it shares many components with the `AsyncTraceWriter`.
 - Puts us in a better position to fix a bug with priority sampling rate updates, by breaking a circular dependency between the `Writer` and the `Tracer`, by implementing a pub-sub pattern with `Event`.
 - Finally (as a subjective opinion) makes domain logic for components like the `Writer` and `Worker` much easier to read and understand, because more generic behaviors (such as thread management) are extracted leaving a much smaller, denser concentration of the domain logic.

When everything is complete, we should be able to swap in the `TraceWriter` for the `Writer` within `Tracer` and everything should just work :tm:! The original `Writer` and its components will remain untouched and available for backwards compatibility.