### PR TITLE
Extract logging from Datadog::Tracer to Datadog::Logger

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1450,7 +1450,7 @@ Datadog.configure do |c|
   c.tracer log: Logger.new(f)                 # Overriding the default tracer
 end
 
-Datadog::Tracer.log.info { "this is typically called by tracing code" }
+Datadog::Logger.log.info { "this is typically called by tracing code" }
 ```
 
 ### Environment and tags

--- a/lib/ddtrace/buffer.rb
+++ b/lib/ddtrace/buffer.rb
@@ -83,7 +83,7 @@ module Datadog
       @buffer_accepted += 1
       @buffer_accepted_lengths += trace.length
     rescue StandardError => e
-      Datadog::Tracer.log.debug("Failed to measure queue accept. Cause: #{e.message} Source: #{e.backtrace.first}")
+      Datadog::Logger.log.debug("Failed to measure queue accept. Cause: #{e.message} Source: #{e.backtrace.first}")
     end
 
     def measure_drop(trace)
@@ -91,7 +91,7 @@ module Datadog
       @buffer_spans -= trace.length
       @buffer_accepted_lengths -= trace.length
     rescue StandardError => e
-      Datadog::Tracer.log.debug("Failed to measure queue drop. Cause: #{e.message} Source: #{e.backtrace.first}")
+      Datadog::Logger.log.debug("Failed to measure queue drop. Cause: #{e.message} Source: #{e.backtrace.first}")
     end
 
     def measure_pop(traces)
@@ -113,7 +113,7 @@ module Datadog
       @buffer_dropped = 0
       @buffer_spans = 0
     rescue StandardError => e
-      Datadog::Tracer.log.debug("Failed to measure queue. Cause: #{e.message} Source: #{e.backtrace.first}")
+      Datadog::Logger.log.debug("Failed to measure queue. Cause: #{e.message} Source: #{e.backtrace.first}")
     end
   end
 end

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -85,10 +85,10 @@ module Datadog
           tracer.tap do |t|
             unless options.nil?
               t.configure(options)
-              t.class.log = options[:log] if options[:log]
+              Datadog::Logger.log = options[:log] if options[:log]
               t.set_tags(options[:tags]) if options[:tags]
               t.set_tags(env: options[:env]) if options[:env]
-              t.class.debug_logging = options.fetch(:debug, false)
+              Datadog::Logger.debug_logging = options.fetch(:debug, false)
             end
           end
         end

--- a/lib/ddtrace/context.rb
+++ b/lib/ddtrace/context.rb
@@ -92,7 +92,7 @@ module Datadog
         if @max_length > 0 && @trace.length >= @max_length
           # Detach the span from any context, it's being dropped and ignored.
           span.context = nil
-          Datadog::Tracer.log.debug("context full, ignoring span #{span.name}")
+          Datadog::Logger.log.debug("context full, ignoring span #{span.name}")
 
           # If overflow has already occurred, don't send this metric.
           # Prevents metrics spam if buffer repeatedly overflows for the same trace.
@@ -121,13 +121,13 @@ module Datadog
         set_current_span(span.parent)
         return if span.tracer.nil?
         if span.parent.nil? && !all_spans_finished?
-          if Datadog::Tracer.debug_logging
+          if Datadog::Logger.debug_logging
             opened_spans = @trace.length - @finished_spans
-            Datadog::Tracer.log.debug("root span #{span.name} closed but has #{opened_spans} unfinished spans:")
+            Datadog::Logger.log.debug("root span #{span.name} closed but has #{opened_spans} unfinished spans:")
           end
 
           @trace.reject(&:finished?).group_by(&:name).each do |unfinished_span_name, unfinished_spans|
-            Datadog::Tracer.log.debug("unfinished span: #{unfinished_spans.first}") if Datadog::Tracer.debug_logging
+            Datadog::Logger.log.debug("unfinished span: #{unfinished_spans.first}") if Datadog::Logger.debug_logging
             Diagnostics::Health.metrics.error_unfinished_spans(
               unfinished_spans.length,
               tags: ["name:#{unfinished_span_name}"]

--- a/lib/ddtrace/contrib/action_pack/action_controller/instrumentation.rb
+++ b/lib/ddtrace/contrib/action_pack/action_controller/instrumentation.rb
@@ -23,7 +23,7 @@ module Datadog
             tracing_context = payload.fetch(:tracing_context)
             tracing_context[:dd_request_span] = span
           rescue StandardError => e
-            Datadog::Tracer.log.error(e.message)
+            Datadog::Logger.log.error(e.message)
           end
 
           def finish_processing(payload)
@@ -67,7 +67,7 @@ module Datadog
               span.finish
             end
           rescue StandardError => e
-            Datadog::Tracer.log.error(e.message)
+            Datadog::Logger.log.error(e.message)
           end
 
           def exception_controller?(payload)

--- a/lib/ddtrace/contrib/action_view/events/render_partial.rb
+++ b/lib/ddtrace/contrib/action_view/events/render_partial.rb
@@ -31,7 +31,7 @@ module Datadog
 
             record_exception(span, payload)
           rescue StandardError => e
-            Datadog::Tracer.log.debug(e.message)
+            Datadog::Logger.log.debug(e.message)
           end
         end
       end

--- a/lib/ddtrace/contrib/action_view/events/render_template.rb
+++ b/lib/ddtrace/contrib/action_view/events/render_template.rb
@@ -34,7 +34,7 @@ module Datadog
 
             record_exception(span, payload)
           rescue StandardError => e
-            Datadog::Tracer.log.debug(e.message)
+            Datadog::Logger.log.debug(e.message)
           end
         end
       end

--- a/lib/ddtrace/contrib/action_view/instrumentation/partial_renderer.rb
+++ b/lib/ddtrace/contrib/action_view/instrumentation/partial_renderer.rb
@@ -21,7 +21,7 @@ module Datadog
 
               datadog_render_partial(template)
             rescue StandardError => e
-              Datadog::Tracer.log.debug(e.message)
+              Datadog::Logger.log.debug(e.message)
             end
 
             # execute the original function anyway

--- a/lib/ddtrace/contrib/action_view/instrumentation/template_renderer.rb
+++ b/lib/ddtrace/contrib/action_view/instrumentation/template_renderer.rb
@@ -50,7 +50,7 @@ module Datadog
                       )
                     end
                   rescue StandardError => e
-                    Datadog::Tracer.log.debug(e.message)
+                    Datadog::Logger.log.debug(e.message)
                   end
 
                   # execute the original function anyway
@@ -99,7 +99,7 @@ module Datadog
 
                 datadog_render_template(template, layout_name)
               rescue StandardError => e
-                Datadog::Tracer.log.debug(e.message)
+                Datadog::Logger.log.debug(e.message)
               end
 
               # execute the original function anyway

--- a/lib/ddtrace/contrib/action_view/patcher.rb
+++ b/lib/ddtrace/contrib/action_view/patcher.rb
@@ -38,7 +38,7 @@ module Datadog
             ::ActionView::Rendering.send(:prepend, Instrumentation::TemplateRenderer::Rails30)
             ::ActionView::Partials::PartialRenderer.send(:prepend, Instrumentation::PartialRenderer::RailsLessThan4)
           else
-            Datadog::Tracer.log.debug('Expected Template/Partial classes not found; template rendering disabled')
+            Datadog::Logger.log.debug('Expected Template/Partial classes not found; template rendering disabled')
           end
         end
       end

--- a/lib/ddtrace/contrib/active_record/events/instantiation.rb
+++ b/lib/ddtrace/contrib/active_record/events/instantiation.rb
@@ -48,7 +48,7 @@ module Datadog
             span.set_tag(Ext::TAG_INSTANTIATION_CLASS_NAME, payload.fetch(:class_name))
             span.set_tag(Ext::TAG_INSTANTIATION_RECORD_COUNT, payload.fetch(:record_count))
           rescue StandardError => e
-            Datadog::Tracer.log.debug(e.message)
+            Datadog::Logger.log.debug(e.message)
           end
         end
       end

--- a/lib/ddtrace/contrib/active_record/events/sql.rb
+++ b/lib/ddtrace/contrib/active_record/events/sql.rb
@@ -55,7 +55,7 @@ module Datadog
             span.set_tag(Datadog::Ext::NET::TARGET_HOST, config[:host]) if config[:host]
             span.set_tag(Datadog::Ext::NET::TARGET_PORT, config[:port]) if config[:port]
           rescue StandardError => e
-            Datadog::Tracer.log.debug(e.message)
+            Datadog::Logger.log.debug(e.message)
           end
         end
       end

--- a/lib/ddtrace/contrib/active_support/cache/instrumentation.rb
+++ b/lib/ddtrace/contrib/active_support/cache/instrumentation.rb
@@ -31,7 +31,7 @@ module Datadog
             span.resource = payload.fetch(:action)
             tracing_context[:dd_cache_span] = span
           rescue StandardError => e
-            Datadog::Tracer.log.debug(e.message)
+            Datadog::Logger.log.debug(e.message)
           end
 
           def finish_trace_cache(payload)
@@ -56,7 +56,7 @@ module Datadog
               span.finish
             end
           rescue StandardError => e
-            Datadog::Tracer.log.debug(e.message)
+            Datadog::Logger.log.debug(e.message)
           end
 
           # Defines instrumentation for ActiveSupport cache reading

--- a/lib/ddtrace/contrib/active_support/notifications/subscription.rb
+++ b/lib/ddtrace/contrib/active_support/notifications/subscription.rb
@@ -114,7 +114,7 @@ module Datadog
             def run(span, name, id, payload)
               run!(span, name, id, payload)
             rescue StandardError => e
-              Datadog::Tracer.log.debug("ActiveSupport::Notifications handler for '#{name}' failed: #{e.message}")
+              Datadog::Logger.log.debug("ActiveSupport::Notifications handler for '#{name}' failed: #{e.message}")
             end
 
             def run!(*args)
@@ -139,7 +139,7 @@ module Datadog
                 begin
                   callback.call(event, key, *args)
                 rescue StandardError => e
-                  Datadog::Tracer.log.debug(
+                  Datadog::Logger.log.debug(
                     "ActiveSupport::Notifications '#{key}' callback for '#{event}' failed: #{e.message}"
                   )
                 end

--- a/lib/ddtrace/contrib/dalli/patcher.rb
+++ b/lib/ddtrace/contrib/dalli/patcher.rb
@@ -57,7 +57,7 @@ module Datadog
 
           def log_deprecation_warning(method_name)
             do_once(method_name) do
-              Datadog::Tracer.log.warn("#{method_name}:#{DEPRECATION_WARNING}")
+              Datadog::Logger.log.warn("#{method_name}:#{DEPRECATION_WARNING}")
             end
           end
         end

--- a/lib/ddtrace/contrib/dalli/quantize.rb
+++ b/lib/ddtrace/contrib/dalli/quantize.rb
@@ -13,7 +13,7 @@ module Datadog
           command = Utils.utf8_encode(command, binary: true, placeholder: placeholder)
           Utils.truncate(command, Ext::QUANTIZE_MAX_CMD_LENGTH)
         rescue => e
-          Tracer.log.debug("Error sanitizing Dalli operation: #{e}")
+          Logger.log.debug("Error sanitizing Dalli operation: #{e}")
           placeholder
         end
       end

--- a/lib/ddtrace/contrib/elasticsearch/patcher.rb
+++ b/lib/ddtrace/contrib/elasticsearch/patcher.rb
@@ -97,7 +97,7 @@ module Datadog
                   quantized_url = Datadog::Contrib::Elasticsearch::Quantize.format_url(url)
                   span.resource = "#{method} #{quantized_url}"
                 rescue StandardError => e
-                  Datadog::Tracer.log.error(e.message)
+                  Datadog::Logger.log.error(e.message)
                 ensure
                   # the call is still executed
                   response = perform_request_without_datadog(*args)

--- a/lib/ddtrace/contrib/excon/middleware.rb
+++ b/lib/ddtrace/contrib/excon/middleware.rb
@@ -30,7 +30,7 @@ module Datadog
               end
             end
           rescue StandardError => e
-            Datadog::Tracer.log.debug(e.message)
+            Datadog::Logger.log.debug(e.message)
           end
 
           @stack.request_call(datum)
@@ -137,7 +137,7 @@ module Datadog
             end
           end
         rescue StandardError => e
-          Datadog::Tracer.log.debug(e.message)
+          Datadog::Logger.log.debug(e.message)
         end
 
         def propagate!(span, datum)

--- a/lib/ddtrace/contrib/faraday/patcher.rb
+++ b/lib/ddtrace/contrib/faraday/patcher.rb
@@ -66,7 +66,7 @@ module Datadog
 
           def log_deprecation_warning(method_name)
             do_once(method_name) do
-              Datadog::Tracer.log.warn("#{method_name}:#{DEPRECATION_WARNING}")
+              Datadog::Logger.log.warn("#{method_name}:#{DEPRECATION_WARNING}")
             end
           end
         end

--- a/lib/ddtrace/contrib/grape/endpoint.rb
+++ b/lib/ddtrace/contrib/grape/endpoint.rb
@@ -46,7 +46,7 @@ module Datadog
 
             Thread.current[KEY_RUN] = true
           rescue StandardError => e
-            Datadog::Tracer.log.error(e.message)
+            Datadog::Logger.log.error(e.message)
           end
 
           def endpoint_run(name, start, finish, id, payload)
@@ -96,7 +96,7 @@ module Datadog
               span.finish(finish)
             end
           rescue StandardError => e
-            Datadog::Tracer.log.error(e.message)
+            Datadog::Logger.log.error(e.message)
           end
 
           def endpoint_start_render(*)
@@ -112,7 +112,7 @@ module Datadog
 
             Thread.current[KEY_RENDER] = true
           rescue StandardError => e
-            Datadog::Tracer.log.error(e.message)
+            Datadog::Logger.log.error(e.message)
           end
 
           def endpoint_render(name, start, finish, id, payload)
@@ -132,7 +132,7 @@ module Datadog
               span.finish(finish)
             end
           rescue StandardError => e
-            Datadog::Tracer.log.error(e.message)
+            Datadog::Logger.log.error(e.message)
           end
 
           def endpoint_run_filters(name, start, finish, id, payload)
@@ -164,7 +164,7 @@ module Datadog
               span.finish(finish)
             end
           rescue StandardError => e
-            Datadog::Tracer.log.error(e.message)
+            Datadog::Logger.log.error(e.message)
           end
 
           private

--- a/lib/ddtrace/contrib/grape/patcher.rb
+++ b/lib/ddtrace/contrib/grape/patcher.rb
@@ -63,7 +63,7 @@ module Datadog
 
           def log_deprecation_warning(method_name)
             do_once(method_name) do
-              Datadog::Tracer.log.warn("#{method_name}:#{DEPRECATION_WARNING}")
+              Datadog::Logger.log.warn("#{method_name}:#{DEPRECATION_WARNING}")
             end
           end
         end

--- a/lib/ddtrace/contrib/grpc/datadog_interceptor/client.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor/client.rb
@@ -40,7 +40,7 @@ module Datadog
             Datadog::GRPCPropagator
               .inject!(span.context, metadata)
           rescue StandardError => e
-            Datadog::Tracer.log.debug("GRPC client trace failed: #{e}")
+            Datadog::Logger.log.debug("GRPC client trace failed: #{e}")
           end
 
           def format_resource(proto_method)

--- a/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
@@ -35,7 +35,7 @@ module Datadog
             tracer.provider.context = Datadog::GRPCPropagator
                                       .extract(metadata)
           rescue StandardError => e
-            Datadog::Tracer.log.debug(
+            Datadog::Logger.log.debug(
               "unable to propagate GRPC metadata to context: #{e}"
             )
           end
@@ -49,7 +49,7 @@ module Datadog
             # Set analytics sample rate
             Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
           rescue StandardError => e
-            Datadog::Tracer.log.debug("GRPC client trace failed: #{e}")
+            Datadog::Logger.log.debug("GRPC client trace failed: #{e}")
           end
 
           def reserved_headers

--- a/lib/ddtrace/contrib/grpc/patcher.rb
+++ b/lib/ddtrace/contrib/grpc/patcher.rb
@@ -62,7 +62,7 @@ module Datadog
 
           def log_deprecation_warning(method_name)
             do_once(method_name) do
-              Datadog::Tracer.log.warn("#{method_name}:#{DEPRECATION_WARNING}")
+              Datadog::Logger.log.warn("#{method_name}:#{DEPRECATION_WARNING}")
             end
           end
         end

--- a/lib/ddtrace/contrib/http/instrumentation.rb
+++ b/lib/ddtrace/contrib/http/instrumentation.rb
@@ -46,7 +46,7 @@ module Datadog
                   Datadog::HTTPPropagator.inject!(span.context, req)
                 end
               rescue StandardError => e
-                Datadog::Tracer.log.error("error preparing span for http request: #{e}")
+                Datadog::Logger.log.error("error preparing span for http request: #{e}")
               ensure
                 response = super(req, body, &block)
               end

--- a/lib/ddtrace/contrib/mongodb/subscribers.rb
+++ b/lib/ddtrace/contrib/mongodb/subscribers.rb
@@ -50,7 +50,7 @@ module Datadog
           # the framework itself, so we set only the error and the message
           span.set_error(event)
         rescue StandardError => e
-          Datadog::Tracer.log.debug("error when handling MongoDB 'failed' event: #{e}")
+          Datadog::Logger.log.debug("error when handling MongoDB 'failed' event: #{e}")
         ensure
           # whatever happens, the Span must be removed from the local storage and
           # it must be finished to prevent any leak
@@ -66,7 +66,7 @@ module Datadog
           rows = event.reply.fetch('n', nil)
           span.set_tag(Ext::TAG_ROWS, rows) unless rows.nil?
         rescue StandardError => e
-          Datadog::Tracer.log.debug("error when handling MongoDB 'succeeded' event: #{e}")
+          Datadog::Logger.log.debug("error when handling MongoDB 'succeeded' event: #{e}")
         ensure
           # whatever happens, the Span must be removed from the local storage and
           # it must be finished to prevent any leak

--- a/lib/ddtrace/contrib/patchable.rb
+++ b/lib/ddtrace/contrib/patchable.rb
@@ -30,7 +30,7 @@ module Datadog
 
         def patch
           if !self.class.compatible? || patcher.nil?
-            Datadog::Tracer.log.warn("Unable to patch #{self.class.name}")
+            Datadog::Logger.log.warn("Unable to patch #{self.class.name}")
             return
           end
 

--- a/lib/ddtrace/contrib/patcher.rb
+++ b/lib/ddtrace/contrib/patcher.rb
@@ -32,7 +32,7 @@ module Datadog
               end
             rescue StandardError => e
               # Log the error
-              Datadog::Tracer.log.error("Failed to apply #{patch_name} patch. Cause: #{e} Location: #{e.backtrace.first}")
+              Datadog::Logger.log.error("Failed to apply #{patch_name} patch. Cause: #{e} Location: #{e.backtrace.first}")
 
               # Emit a metric
               tags = default_tags

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -218,7 +218,7 @@ module Datadog
                 if key == :datadog_rack_request_span \
                   && @datadog_span_warning \
                   && @datadog_deprecation_warnings
-                  Datadog::Tracer.log.warn(REQUEST_SPAN_DEPRECATION_WARNING)
+                  Datadog::Logger.log.warn(REQUEST_SPAN_DEPRECATION_WARNING)
                   @datadog_span_warning = true
                 end
                 super
@@ -228,7 +228,7 @@ module Datadog
                 if key == :datadog_rack_request_span \
                   && @datadog_span_warning \
                   && @datadog_deprecation_warnings
-                  Datadog::Tracer.log.warn(REQUEST_SPAN_DEPRECATION_WARNING)
+                  Datadog::Logger.log.warn(REQUEST_SPAN_DEPRECATION_WARNING)
                   @datadog_span_warning = true
                 end
                 super

--- a/lib/ddtrace/contrib/rack/patcher.rb
+++ b/lib/ddtrace/contrib/rack/patcher.rb
@@ -38,7 +38,7 @@ module Datadog
           # context of middleware patching outside a Rails server process (eg. a
           # process that doesn't serve HTTP requests but has Rails environment
           # loaded such as a Resque master process)
-          Tracer.log.debug("Error patching middleware stack: #{e}")
+          Logger.log.debug("Error patching middleware stack: #{e}")
         end
 
         def retain_middleware_name(middleware)
@@ -90,7 +90,7 @@ module Datadog
             if get_option(:application)
               MiddlewareNamePatcher.patch
             else
-              Datadog::Tracer.log.warn(%(
+              Datadog::Logger.log.warn(%(
               Rack :middleware_names requires you to also pass :application.
               Middleware names have NOT been patched; please provide :application.
               e.g. use: :rack, middleware_names: true, application: my_rack_app).freeze)

--- a/lib/ddtrace/contrib/rack/request_queue.rb
+++ b/lib/ddtrace/contrib/rack/request_queue.rb
@@ -30,7 +30,7 @@ module Datadog
         rescue StandardError => e
           # in case of an Exception we don't create a
           # `request.queuing` span
-          Datadog::Tracer.log.debug("[rack] unable to parse request queue headers: #{e}")
+          Datadog::Logger.log.debug("[rack] unable to parse request queue headers: #{e}")
           nil
         end
       end

--- a/lib/ddtrace/contrib/rake/instrumentation.rb
+++ b/lib/ddtrace/contrib/rake/instrumentation.rb
@@ -47,14 +47,14 @@ module Datadog
             span.set_tag(Ext::TAG_TASK_ARG_NAMES, arg_names)
             span.set_tag(Ext::TAG_INVOKE_ARGS, quantize_args(args)) unless args.nil?
           rescue StandardError => e
-            Datadog::Tracer.log.debug("Error while tracing Rake invoke: #{e.message}")
+            Datadog::Logger.log.debug("Error while tracing Rake invoke: #{e.message}")
           end
 
           def annotate_execute!(span, args)
             span.resource = name
             span.set_tag(Ext::TAG_EXECUTE_ARGS, quantize_args(args.to_hash)) unless args.nil?
           rescue StandardError => e
-            Datadog::Tracer.log.debug("Error while tracing Rake execute: #{e.message}")
+            Datadog::Logger.log.debug("Error while tracing Rake execute: #{e.message}")
           end
 
           def quantize_args(args)

--- a/lib/ddtrace/contrib/redis/quantize.rb
+++ b/lib/ddtrace/contrib/redis/quantize.rb
@@ -15,7 +15,7 @@ module Datadog
           str = Utils.utf8_encode(str, binary: true, placeholder: PLACEHOLDER)
           Utils.truncate(str, VALUE_MAX_LEN, TOO_LONG_MARK)
         rescue => e
-          Datadog::Tracer.log.debug("non formattable Redis arg #{str}: #{e}")
+          Datadog::Logger.log.debug("non formattable Redis arg #{str}: #{e}")
           PLACEHOLDER
         end
 

--- a/lib/ddtrace/contrib/sinatra/tracer.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer.rb
@@ -68,7 +68,7 @@ module Datadog
             span = Sinatra::Env.datadog_span(env)
 
             unless span
-              Datadog::Tracer.log.error('missing request span in :after hook')
+              Datadog::Logger.log.error('missing request span in :after hook')
               return
             end
 

--- a/lib/ddtrace/ext/forced_tracing.rb
+++ b/lib/ddtrace/ext/forced_tracing.rb
@@ -12,7 +12,7 @@ module Datadog
 
         # Only log each deprecation warning once (safeguard against log spam)
         unless @deprecation_warning_shown
-          Datadog::Tracer.log.warn(
+          Datadog::Logger.log.warn(
             'forced tracing: Datadog::Ext::ForcedTracing has been renamed to Datadog::Ext::ManualTracing'
           )
           @deprecation_warning_shown = true

--- a/lib/ddtrace/logger.rb
+++ b/lib/ddtrace/logger.rb
@@ -7,6 +7,48 @@ module Datadog
   # - progname defaults to ddtrace to clearly identify Datadog dd-trace-rb related messages
   # - adds last caller stack-trace info to know where the message comes from
   class Logger < ::Logger
+    # Global, memoized, lazy initialized instance of a logger that is used within the the Datadog
+    # namespace. This logger outputs to +STDOUT+ by default, and is considered thread-safe.
+    class << self
+      def log
+        unless defined? @logger
+          @logger = Datadog::Logger.new(STDOUT)
+          @logger.level = Logger::WARN
+        end
+        @logger
+      end
+
+      # Override the default logger with a custom one.
+      def log=(logger)
+        return unless logger
+        return unless logger.respond_to? :methods
+        return unless logger.respond_to? :error
+        if logger.respond_to? :methods
+          unimplemented = new(STDOUT).methods - logger.methods
+          unless unimplemented.empty?
+            logger.error("logger #{logger} does not implement #{unimplemented}")
+            return
+          end
+        end
+        @logger = logger
+      end
+
+      # Activate the debug mode providing more information related to tracer usage
+      # Default to Warn level unless using custom logger
+      def debug_logging=(value)
+        if value
+          log.level = Logger::DEBUG
+        elsif log.is_a?(Datadog::Logger)
+          log.level = Logger::WARN
+        end
+      end
+
+      # Return if the debug mode is activated or not
+      def debug_logging
+        log.level == Logger::DEBUG
+      end
+    end
+
     def initialize(*args, &block)
       super
       self.progname = LOG_PREFIX

--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -62,7 +62,7 @@ module Datadog
 
       statsd.count(stat, value, metric_options(options))
     rescue StandardError => e
-      Datadog::Tracer.log.error("Failed to send count stat. Cause: #{e.message} Source: #{e.backtrace.first}")
+      Datadog::Logger.log.error("Failed to send count stat. Cause: #{e.message} Source: #{e.backtrace.first}")
     end
 
     def distribution(stat, value = nil, options = nil, &block)
@@ -72,7 +72,7 @@ module Datadog
 
       statsd.distribution(stat, value, metric_options(options))
     rescue StandardError => e
-      Datadog::Tracer.log.error("Failed to send distribution stat. Cause: #{e.message} Source: #{e.backtrace.first}")
+      Datadog::Logger.log.error("Failed to send distribution stat. Cause: #{e.message} Source: #{e.backtrace.first}")
     end
 
     def increment(stat, options = nil)
@@ -81,7 +81,7 @@ module Datadog
 
       statsd.increment(stat, metric_options(options))
     rescue StandardError => e
-      Datadog::Tracer.log.error("Failed to send increment stat. Cause: #{e.message} Source: #{e.backtrace.first}")
+      Datadog::Logger.log.error("Failed to send increment stat. Cause: #{e.message} Source: #{e.backtrace.first}")
     end
 
     def gauge(stat, value = nil, options = nil, &block)
@@ -91,7 +91,7 @@ module Datadog
 
       statsd.gauge(stat, value, metric_options(options))
     rescue StandardError => e
-      Datadog::Tracer.log.error("Failed to send gauge stat. Cause: #{e.message} Source: #{e.backtrace.first}")
+      Datadog::Logger.log.error("Failed to send gauge stat. Cause: #{e.message} Source: #{e.backtrace.first}")
     end
 
     def time(stat, options = nil)
@@ -107,7 +107,7 @@ module Datadog
           distribution(stat, ((finished - start) * 1000), options)
         end
       rescue StandardError => e
-        Datadog::Tracer.log.error("Failed to send time stat. Cause: #{e.message} Source: #{e.backtrace.first}")
+        Datadog::Logger.log.error("Failed to send time stat. Cause: #{e.message} Source: #{e.backtrace.first}")
       end
     end
 

--- a/lib/ddtrace/monkey.rb
+++ b/lib/ddtrace/monkey.rb
@@ -48,7 +48,7 @@ module Datadog
     end
 
     def log_deprecation_warning(method)
-      Datadog::Tracer.log.warn("#{method}:#{DEPRECATION_WARNING}")
+      Datadog::Logger.log.warn("#{method}:#{DEPRECATION_WARNING}")
     end
 
     class << self

--- a/lib/ddtrace/pin.rb
+++ b/lib/ddtrace/pin.rb
@@ -107,7 +107,7 @@ module Datadog
     def log_deprecation_warning(method_name)
       # Only log each deprecation warning once (safeguard against log spam)
       do_once(method_name) do
-        Datadog::Tracer.log.warn("#{method_name}:#{DEPRECATION_WARNING}")
+        Datadog::Logger.log.warn("#{method_name}:#{DEPRECATION_WARNING}")
       end
     end
   end

--- a/lib/ddtrace/pipeline.rb
+++ b/lib/ddtrace/pipeline.rb
@@ -34,7 +34,7 @@ module Datadog
 
       result || []
     rescue => e
-      Datadog::Tracer.log.debug(
+      Datadog::Logger.log.debug(
         "trace dropped entirely due to `Pipeline.before_flush` error: #{e}"
       )
 

--- a/lib/ddtrace/propagation/http_propagator.rb
+++ b/lib/ddtrace/propagation/http_propagator.rb
@@ -19,7 +19,7 @@ module Datadog
     def self.inject!(context, env)
       # Prevent propagation from being attempted if context provided is nil.
       if context.nil?
-        ::Datadog::Tracer.log.debug('Cannot inject context into env to propagate over HTTP: context is nil.'.freeze)
+        ::Datadog::Logger.log.debug('Cannot inject context into env to propagate over HTTP: context is nil.'.freeze)
         return
       end
 
@@ -58,7 +58,7 @@ module Datadog
             # Return an empty/new context if we have a mismatch in values extracted
             msg = "#{context.trace_id} != #{extracted_context.trace_id} && " \
                   "#{context.span_id} != #{extracted_context.span_id}"
-            ::Datadog::Tracer.log.debug("Cannot extract context from HTTP: extracted contexts differ, #{msg}".freeze)
+            ::Datadog::Logger.log.debug("Cannot extract context from HTTP: extracted contexts differ, #{msg}".freeze)
             # DEV: This will return from `self.extract` not this `each` block
             return ::Datadog::Context.new
           end

--- a/lib/ddtrace/runtime/cgroup.rb
+++ b/lib/ddtrace/runtime/cgroup.rb
@@ -27,7 +27,7 @@ module Datadog
               end
             end
           rescue StandardError => e
-            Datadog::Tracer.log.error("Error while parsing cgroup. Cause: #{e.message} Location: #{e.backtrace.first}")
+            Datadog::Logger.log.error("Error while parsing cgroup. Cause: #{e.message} Location: #{e.backtrace.first}")
           end
         end
       end

--- a/lib/ddtrace/runtime/container.rb
+++ b/lib/ddtrace/runtime/container.rb
@@ -61,7 +61,7 @@ module Datadog
                 break
               end
             rescue StandardError => e
-              Datadog::Tracer.log.error(
+              Datadog::Logger.log.error(
                 "Error while parsing container info. Cause: #{e.message} Location: #{e.backtrace.first}"
               )
             end

--- a/lib/ddtrace/runtime/metrics.rb
+++ b/lib/ddtrace/runtime/metrics.rb
@@ -63,7 +63,7 @@ module Datadog
       def try_flush
         yield
       rescue StandardError => e
-        Datadog::Tracer.log.error("Error while sending runtime metric. Cause: #{e.message}")
+        Datadog::Logger.log.error("Error while sending runtime metric. Cause: #{e.message}")
       end
 
       def default_metric_options

--- a/lib/ddtrace/sampler.rb
+++ b/lib/ddtrace/sampler.rb
@@ -48,7 +48,7 @@ module Datadog
     #   sampled.
     def initialize(sample_rate = 1.0)
       unless sample_rate > 0.0 && sample_rate <= 1.0
-        Datadog::Tracer.log.error('sample rate is not between 0 and 1, disabling the sampler')
+        Datadog::Logger.log.error('sample rate is not between 0 and 1, disabling the sampler')
         sample_rate = 1.0
       end
 

--- a/lib/ddtrace/sampling/rule.rb
+++ b/lib/ddtrace/sampling/rule.rb
@@ -28,7 +28,7 @@ module Datadog
       def match?(span)
         @matcher.match?(span)
       rescue => e
-        Datadog::Tracer.log.error("Matcher failed. Cause: #{e.message} Source: #{e.backtrace.first}")
+        Datadog::Logger.log.error("Matcher failed. Cause: #{e.message} Source: #{e.backtrace.first}")
         nil
       end
 

--- a/lib/ddtrace/sampling/rule_sampler.rb
+++ b/lib/ddtrace/sampling/rule_sampler.rb
@@ -95,7 +95,7 @@ module Datadog
           set_limiter_metrics(span, rate_limiter.effective_rate)
         end
       rescue StandardError => e
-        Datadog::Tracer.log.error("Rule sampling failed. Cause: #{e.message} Source: #{e.backtrace.first}")
+        Datadog::Logger.log.error("Rule sampling failed. Cause: #{e.message} Source: #{e.backtrace.first}")
         yield(span)
       end
 

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -82,7 +82,7 @@ module Datadog
     def set_tag(key, value = nil)
       @meta[key] = value.to_s
     rescue StandardError => e
-      Datadog::Tracer.log.debug("Unable to set the tag #{key}, ignoring it. Caused by: #{e}")
+      Datadog::Logger.log.debug("Unable to set the tag #{key}, ignoring it. Caused by: #{e}")
     end
 
     # This method removes a tag for the given key.
@@ -102,7 +102,7 @@ module Datadog
       value = Float(value)
       @metrics[key] = value
     rescue StandardError => e
-      Datadog::Tracer.log.debug("Unable to set the metric #{key}, ignoring it. Caused by: #{e}")
+      Datadog::Logger.log.debug("Unable to set the metric #{key}, ignoring it. Caused by: #{e}")
     end
 
     # This method removes a metric for the given key. It acts like {#remove_tag}.
@@ -154,7 +154,7 @@ module Datadog
         @context.close_span(self)
         @tracer.record(self)
       rescue StandardError => e
-        Datadog::Tracer.log.debug("error recording finished trace: #{e}")
+        Datadog::Logger.log.debug("error recording finished trace: #{e}")
         Diagnostics::Health.metrics.error_span_finish(1, tags: ["error:#{e.class.name}"])
       end
       self

--- a/lib/ddtrace/sync_writer.rb
+++ b/lib/ddtrace/sync_writer.rb
@@ -24,7 +24,7 @@ module Datadog
     def write(trace, services = nil)
       unless services.nil?
         Datadog::Patcher.do_once('SyncWriter#write') do
-          Datadog::Tracer.log.warn(%(
+          Datadog::Logger.log.warn(%(
             write: Writing services has been deprecated and no longer need to be provided.
             write(traces, services) can be updted to write(traces)
           ))
@@ -35,7 +35,7 @@ module Datadog
         proc { flush_trace(trace) }
       )
     rescue => e
-      Tracer.log.debug(e)
+      Logger.log.debug(e)
     end
 
     private

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -28,50 +28,10 @@ module Datadog
     ALLOWED_SPAN_OPTIONS = [:service, :resource, :span_type].freeze
     DEFAULT_ON_ERROR = proc { |span, error| span.set_error(error) unless span.nil? }
 
-    # Global, memoized, lazy initialized instance of a logger that is used within the the Datadog
-    # namespace. This logger outputs to +STDOUT+ by default, and is considered thread-safe.
-    def self.log
-      unless defined? @logger
-        @logger = Datadog::Logger.new(STDOUT)
-        @logger.level = Logger::WARN
-      end
-      @logger
-    end
-
-    # Override the default logger with a custom one.
-    def self.log=(logger)
-      return unless logger
-      return unless logger.respond_to? :methods
-      return unless logger.respond_to? :error
-      if logger.respond_to? :methods
-        unimplemented = Logger.new(STDOUT).methods - logger.methods
-        unless unimplemented.empty?
-          logger.error("logger #{logger} does not implement #{unimplemented}")
-          return
-        end
-      end
-      @logger = logger
-    end
-
-    # Activate the debug mode providing more information related to tracer usage
-    # Default to Warn level unless using custom logger
-    def self.debug_logging=(value)
-      if value
-        log.level = Logger::DEBUG
-      elsif log.is_a?(Datadog::Logger)
-        log.level = Logger::WARN
-      end
-    end
-
-    # Return if the debug mode is activated or not
-    def self.debug_logging
-      log.level == Logger::DEBUG
-    end
-
     def services
       # Only log each deprecation warning once (safeguard against log spam)
       Datadog::Patcher.do_once('Tracer#set_service_info') do
-        Datadog::Tracer.log.warn('services: Usage of Tracer.services has been deprecated')
+        Datadog::Logger.log.warn('services: Usage of Tracer.services has been deprecated')
       end
 
       {}
@@ -164,7 +124,7 @@ module Datadog
     def set_service_info(service, app, app_type)
       # Only log each deprecation warning once (safeguard against log spam)
       Datadog::Patcher.do_once('Tracer#set_service_info') do
-        Datadog::Tracer.log.warn(%(
+        Datadog::Logger.log.warn(%(
           set_service_info: Usage of set_service_info has been deprecated,
           service information no longer needs to be reported to the trace agent.
         ))
@@ -179,7 +139,7 @@ module Datadog
       begin
         @default_service = File.basename($PROGRAM_NAME, '.*')
       rescue StandardError => e
-        Datadog::Tracer.log.error("unable to guess default service: #{e}")
+        Datadog::Logger.log.error("unable to guess default service: #{e}")
         @default_service = 'ruby'.freeze
       end
       @default_service
@@ -302,7 +262,7 @@ module Datadog
             span = start_span(name, options)
           # rubocop:disable Lint/UselessAssignment
           rescue StandardError => e
-            Datadog::Tracer.log.debug('Failed to start span: #{e}')
+            Datadog::Logger.log.debug('Failed to start span: #{e}')
           ensure
             return_value = yield(span)
           end
@@ -372,11 +332,11 @@ module Datadog
     def write(trace)
       return if @writer.nil? || !@enabled
 
-      if Datadog::Tracer.debug_logging
-        Datadog::Tracer.log.debug("Writing #{trace.length} spans (enabled: #{@enabled})")
+      if Datadog::Logger.debug_logging
+        Datadog::Logger.log.debug("Writing #{trace.length} spans (enabled: #{@enabled})")
         str = String.new('')
         PP.pp(trace, str)
-        Datadog::Tracer.log.debug(str)
+        Datadog::Logger.log.debug(str)
       end
 
       @writer.write(trace)

--- a/lib/ddtrace/transport/http/client.rb
+++ b/lib/ddtrace/transport/http/client.rb
@@ -41,9 +41,9 @@ module Datadog
 
           # Log error
           if stats.consecutive_errors > 0
-            Datadog::Tracer.log.debug(message)
+            Datadog::Logger.log.debug(message)
           else
-            Datadog::Tracer.log.error(message)
+            Datadog::Logger.log.error(message)
           end
 
           # Update statistics

--- a/lib/ddtrace/utils.rb
+++ b/lib/ddtrace/utils.rb
@@ -57,7 +57,7 @@ module Datadog
         str.encode(::Encoding::UTF_8)
       end
     rescue => e
-      Tracer.log.debug("Error encoding string in UTF-8: #{e}")
+      Logger.log.debug("Error encoding string in UTF-8: #{e}")
 
       options.fetch(:placeholder, STRING_PLACEHOLDER)
     end

--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -55,7 +55,7 @@ module Datadog
           # ensures that the thread will not die because of an exception.
           # TODO[manu]: findout the reason and reschedule the send if it's not
           # a fatal exception
-          Datadog::Tracer.log.error(
+          Datadog::Logger.log.error(
             "Error during traces flush: dropped #{traces.length} items. Cause: #{e} Location: #{e.backtrace.first}"
           )
         end
@@ -64,7 +64,7 @@ module Datadog
       def callback_runtime_metrics
         @runtime_metrics_task.call unless @runtime_metrics_task.nil?
       rescue StandardError => e
-        Datadog::Tracer.log.error(
+        Datadog::Logger.log.error(
           "Error during runtime metrics flush. Cause: #{e} Location: #{e.backtrace.first}"
         )
       end
@@ -74,7 +74,7 @@ module Datadog
         @mutex.synchronize do
           return if @run
           @run = true
-          Tracer.log.debug("Starting thread in the process: #{Process.pid}")
+          Logger.log.debug("Starting thread in the process: #{Process.pid}")
           @worker = Thread.new { perform }
         end
       end

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -104,7 +104,7 @@ module Datadog
     def write(trace, services = nil)
       unless services.nil?
         Datadog::Patcher.do_once('Writer#write') do
-          Datadog::Tracer.log.warn(%(
+          Datadog::Logger.log.warn(%(
             write: Writing services has been deprecated and no longer need to be provided.
             write(traces, services) can be updated to write(traces)
           ))

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Datadog::Configuration::Settings do
 
   describe '#tracer' do
     let(:tracer) { Datadog::Tracer.new }
-    let(:debug_state) { tracer.class.debug_logging }
+    let(:debug_state) { Datadog::Logger.debug_logging }
     let(:custom_log) { Logger.new(STDOUT) }
 
     context 'given some settings' do
       before(:each) do
-        @original_log = tracer.class.log
+        @original_log = Datadog::Logger.log
 
         settings.tracer(
           enabled: false,
@@ -29,14 +29,14 @@ RSpec.describe Datadog::Configuration::Settings do
       end
 
       after(:each) do
-        tracer.class.debug_logging = debug_state
-        tracer.class.log = @original_log
+        Datadog::Logger.debug_logging = debug_state
+        Datadog::Logger.log = @original_log
       end
 
       it 'applies settings correctly' do
         expect(tracer.enabled).to be false
         expect(debug_state).to be false
-        expect(Datadog::Tracer.log).to eq(custom_log)
+        expect(Datadog::Logger.log).to eq(custom_log)
         expect(tracer.writer.transport.current_api.adapter.hostname).to eq('tracer.host.com')
         expect(tracer.writer.transport.current_api.adapter.port).to eq(1234)
         expect(tracer.tags[:env]).to eq(:config_test)

--- a/spec/ddtrace/context_spec.rb
+++ b/spec/ddtrace/context_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Datadog::Context do
 
         let(:options) { { max_length: max_length } }
         let(:max_length) { 1 }
-        before { allow(Datadog::Tracer.log).to receive(:debug) }
+        before { allow(Datadog::Logger.log).to receive(:debug) }
 
         RSpec::Matchers.define :a_context_overflow_error do
           match { |actual| actual.include?('context full') }
@@ -88,7 +88,7 @@ RSpec.describe Datadog::Context do
 
           it 'sends overflow metric' do
             expect(overflow_span).to have_received(:context=).with(nil)
-            expect(Datadog::Tracer.log).to have_received(:debug)
+            expect(Datadog::Logger.log).to have_received(:debug)
               .with(a_context_overflow_error)
             expect(health_metrics).to have_received(:error_context_overflow)
               .with(1, tags: ["max_length:#{max_length}"])
@@ -102,7 +102,7 @@ RSpec.describe Datadog::Context do
           end
 
           it 'sends overflow metric only once' do
-            expect(Datadog::Tracer.log).to have_received(:debug)
+            expect(Datadog::Logger.log).to have_received(:debug)
               .with(a_context_overflow_error)
               .twice
             expect(health_metrics).to have_received(:error_context_overflow)
@@ -121,7 +121,7 @@ RSpec.describe Datadog::Context do
           end
 
           it 'sends overflow metric once per reset' do
-            expect(Datadog::Tracer.log).to have_received(:debug)
+            expect(Datadog::Logger.log).to have_received(:debug)
               .with(a_context_overflow_error)
               .twice
             expect(health_metrics).to have_received(:error_context_overflow)
@@ -185,17 +185,17 @@ RSpec.describe Datadog::Context do
 
         context 'when tracer debug logging is on' do
           before do
-            allow(Datadog::Tracer).to receive(:debug_logging).and_return(true)
-            allow(Datadog::Tracer.log).to receive(:debug)
+            allow(Datadog::Logger).to receive(:debug_logging).and_return(true)
+            allow(Datadog::Logger.log).to receive(:debug)
             context.add_span(unfinished_span)
             close_span
           end
 
           it 'logs debug messages' do
-            expect(Datadog::Tracer.log).to have_received(:debug)
+            expect(Datadog::Logger.log).to have_received(:debug)
               .with(an_unfinished_spans_error('root.span', 1))
 
-            expect(Datadog::Tracer.log).to have_received(:debug)
+            expect(Datadog::Logger.log).to have_received(:debug)
               .with(an_unfinished_span_error).once
           end
         end

--- a/spec/ddtrace/contrib/patcher_spec.rb
+++ b/spec/ddtrace/contrib/patcher_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Datadog::Contrib::Patcher do
 
         context 'when patcher .patch raises an error' do
           before do
-            allow(Datadog::Tracer.log).to receive(:error)
+            allow(Datadog::Logger.log).to receive(:error)
           end
 
           context 'and .target_version is not defined' do
@@ -84,7 +84,7 @@ RSpec.describe Datadog::Contrib::Patcher do
 
             it 'handles the error' do
               expect { patch }.to_not raise_error
-              expect(Datadog::Tracer.log).to have_received(:error)
+              expect(Datadog::Logger.log).to have_received(:error)
                 .with(a_patch_error(patcher.name))
               expect(health_metrics).to have_received(:error_instrumentation_patch)
                 .with(1, tags: array_including('patcher:TestPatcher', 'error:StandardError'))
@@ -108,7 +108,7 @@ RSpec.describe Datadog::Contrib::Patcher do
 
             it 'handles the error' do
               expect { patch }.to_not raise_error
-              expect(Datadog::Tracer.log).to have_received(:error)
+              expect(Datadog::Logger.log).to have_received(:error)
                 .with(a_patch_error(patcher.name))
               expect(health_metrics).to have_received(:error_instrumentation_patch)
                 .with(1, tags: array_including('patcher:TestPatcher', 'error:StandardError', 'target_version:1.0'))
@@ -255,7 +255,7 @@ RSpec.describe Datadog::Contrib::Patcher do
 
         context 'when patcher .patch raises an error' do
           before do
-            allow(Datadog::Tracer.log).to receive(:error)
+            allow(Datadog::Logger.log).to receive(:error)
           end
 
           context 'and .target_version is not defined' do
@@ -271,7 +271,7 @@ RSpec.describe Datadog::Contrib::Patcher do
 
             it 'handles the error' do
               expect { patch }.to_not raise_error
-              expect(Datadog::Tracer.log).to have_received(:error)
+              expect(Datadog::Logger.log).to have_received(:error)
                 .with(a_patch_error(patcher.name))
               expect(health_metrics).to have_received(:error_instrumentation_patch)
                 .with(1, tags: array_including('patcher:TestPatcher', 'error:StandardError'))
@@ -295,7 +295,7 @@ RSpec.describe Datadog::Contrib::Patcher do
 
             it 'handles the error' do
               expect { patch }.to_not raise_error
-              expect(Datadog::Tracer.log).to have_received(:error)
+              expect(Datadog::Logger.log).to have_received(:error)
                 .with(a_patch_error(patcher.name))
               expect(health_metrics).to have_received(:error_instrumentation_patch)
                 .with(1, tags: array_including('patcher:TestPatcher', 'error:StandardError', 'target_version:1.0'))

--- a/spec/ddtrace/contrib/rack/middleware_spec.rb
+++ b/spec/ddtrace/contrib/rack/middleware_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Datadog::Contrib::Rack::TraceMiddleware do
     end
 
     describe 'deprecation warnings' do
-      before(:each) { allow(Datadog::Tracer.log).to receive(:warn) }
+      before(:each) { allow(Datadog::Logger.log).to receive(:warn) }
 
       # Expect this for backwards compatibility
       context 'backwards compatibility' do
@@ -55,7 +55,7 @@ RSpec.describe Datadog::Contrib::Rack::TraceMiddleware do
         end
 
         it do
-          expect(Datadog::Tracer.log).to_not have_received(:warn)
+          expect(Datadog::Logger.log).to_not have_received(:warn)
             .with(/:datadog_rack_request_span/)
         end
       end
@@ -67,7 +67,7 @@ RSpec.describe Datadog::Contrib::Rack::TraceMiddleware do
         end
 
         it do
-          expect(Datadog::Tracer.log).to_not have_received(:warn)
+          expect(Datadog::Logger.log).to_not have_received(:warn)
             .with(/:datadog_rack_request_span/)
         end
       end

--- a/spec/ddtrace/metrics_spec.rb
+++ b/spec/ddtrace/metrics_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Datadog::Metrics do
 
   shared_examples_for 'missing value arg' do
     it 'logs an error without raising' do
-      expect(Datadog::Tracer.log).to receive(:error)
+      expect(Datadog::Logger.log).to receive(:error)
       expect { subject }.to_not raise_error
     end
   end
@@ -272,7 +272,7 @@ RSpec.describe Datadog::Metrics do
       context 'which raises an error' do
         before(:each) do
           expect(statsd).to receive(:count).and_raise(StandardError)
-          expect(Datadog::Tracer.log).to receive(:error)
+          expect(Datadog::Logger.log).to receive(:error)
         end
 
         it { expect { count }.to_not raise_error }
@@ -343,7 +343,7 @@ RSpec.describe Datadog::Metrics do
       context 'which raises an error' do
         before(:each) do
           expect(statsd).to receive(:distribution).and_raise(StandardError)
-          expect(Datadog::Tracer.log).to receive(:error)
+          expect(Datadog::Logger.log).to receive(:error)
         end
 
         it { expect { distribution }.to_not raise_error }
@@ -414,7 +414,7 @@ RSpec.describe Datadog::Metrics do
       context 'which raises an error' do
         before(:each) do
           expect(statsd).to receive(:gauge).and_raise(StandardError)
-          expect(Datadog::Tracer.log).to receive(:error)
+          expect(Datadog::Logger.log).to receive(:error)
         end
 
         it { expect { gauge }.to_not raise_error }
@@ -485,7 +485,7 @@ RSpec.describe Datadog::Metrics do
       context 'which raises an error' do
         before(:each) do
           expect(statsd).to receive(:increment).and_raise(StandardError)
-          expect(Datadog::Tracer.log).to receive(:error)
+          expect(Datadog::Logger.log).to receive(:error)
         end
 
         it { expect { increment }.to_not raise_error }
@@ -553,7 +553,7 @@ RSpec.describe Datadog::Metrics do
       context 'which raises an error' do
         before(:each) do
           expect(statsd).to receive(:distribution).and_raise(StandardError)
-          expect(Datadog::Tracer.log).to receive(:error)
+          expect(Datadog::Logger.log).to receive(:error)
         end
 
         it { expect { time }.to_not raise_error }

--- a/spec/ddtrace/propagation/propagation_integration_spec.rb
+++ b/spec/ddtrace/propagation/propagation_integration_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe 'Context propagation' do
       it 'does not raise an error or propagate the trace' do
         on_size_exceeded do |span|
           # Verify warning message is produced.
-          allow(Datadog::Tracer.log).to receive(:debug)
+          allow(Datadog::Logger.log).to receive(:debug)
           expect { Datadog::HTTPPropagator.inject!(span.context, env) }.to_not raise_error
-          expect(Datadog::Tracer.log).to have_received(:debug).with(/Cannot inject context/)
+          expect(Datadog::Logger.log).to have_received(:debug).with(/Cannot inject context/)
 
           # The context has reached its max size and cannot be propagated.
           # Check headers aren't present.

--- a/spec/ddtrace/runtime/cgroup_spec.rb
+++ b/spec/ddtrace/runtime/cgroup_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Datadog::Runtime::Cgroup do
           .with('/proc/self/cgroup')
           .and_return(false)
 
-        expect(Datadog::Tracer.log).to_not receive(:error)
+        expect(Datadog::Logger.log).to_not receive(:error)
       end
 
       it do
@@ -34,7 +34,7 @@ RSpec.describe Datadog::Runtime::Cgroup do
             .with('/proc/self/cgroup')
             .and_raise(error)
 
-          expect(Datadog::Tracer.log).to receive(:error) do |msg|
+          expect(Datadog::Logger.log).to receive(:error) do |msg|
             expect(msg).to match(/Error while parsing cgroup./)
           end
         end

--- a/spec/ddtrace/runtime/metrics_spec.rb
+++ b/spec/ddtrace/runtime/metrics_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Datadog::Runtime::Metrics do
       end
 
       context 'when an error is thrown' do
-        before(:each) { allow(Datadog::Tracer.log).to receive(:error) }
+        before(:each) { allow(Datadog::Logger.log).to receive(:error) }
 
         it do
           allow(metric).to receive(:available?)
@@ -68,7 +68,7 @@ RSpec.describe Datadog::Runtime::Metrics do
 
           flush
 
-          expect(Datadog::Tracer.log).to have_received(:error)
+          expect(Datadog::Logger.log).to have_received(:error)
             .with(/Error while sending runtime metric./)
             .at_least(:once)
         end

--- a/spec/ddtrace/sampler_spec.rb
+++ b/spec/ddtrace/sampler_spec.rb
@@ -13,8 +13,8 @@ end
 RSpec.describe Datadog::AllSampler do
   subject(:sampler) { described_class.new }
 
-  before(:each) { Datadog::Tracer.log.level = Logger::FATAL }
-  after(:each) { Datadog::Tracer.log.level = Logger::WARN }
+  before(:each) { Datadog::Logger.log.level = Logger::FATAL }
+  after(:each) { Datadog::Logger.log.level = Logger::WARN }
 
   describe '#sample!' do
     let(:spans) do
@@ -39,8 +39,8 @@ end
 RSpec.describe Datadog::RateSampler do
   subject(:sampler) { described_class.new(sample_rate) }
 
-  before(:each) { Datadog::Tracer.log.level = Logger::FATAL }
-  after(:each) { Datadog::Tracer.log.level = Logger::WARN }
+  before(:each) { Datadog::Logger.log.level = Logger::FATAL }
+  after(:each) { Datadog::Logger.log.level = Logger::WARN }
 
   describe '#initialize' do
     context 'given a sample rate' do
@@ -231,8 +231,8 @@ RSpec.describe Datadog::PrioritySampler do
 
   let(:sample_rate_tag_value) { nil }
 
-  before(:each) { Datadog::Tracer.log.level = Logger::FATAL }
-  after(:each) { Datadog::Tracer.log.level = Logger::WARN }
+  before(:each) { Datadog::Logger.log.level = Logger::FATAL }
+  after(:each) { Datadog::Logger.log.level = Logger::WARN }
 
   describe '#sample!' do
     subject(:sample) { sampler.sample!(span) }

--- a/spec/ddtrace/sampling/rule_spec.rb
+++ b/spec/ddtrace/sampling/rule_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Datadog::Sampling::Rule do
       before do
         allow(matcher).to receive(:match?).and_raise(error)
 
-        expect(Datadog::Tracer.log).to receive(:error)
+        expect(Datadog::Logger.log).to receive(:error)
           .with(a_string_including("Matcher failed. Cause: #{error}"))
       end
 

--- a/spec/ddtrace/span_spec.rb
+++ b/spec/ddtrace/span_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Datadog::Span do
       end
 
       before do
-        allow(Datadog::Tracer.log).to receive(:debug)
+        allow(Datadog::Logger.log).to receive(:debug)
         allow(context).to receive(:close_span)
           .with(span)
           .and_raise(error)
@@ -30,7 +30,7 @@ RSpec.describe Datadog::Span do
       end
 
       it 'logs a debug message' do
-        expect(Datadog::Tracer.log).to have_received(:debug)
+        expect(Datadog::Logger.log).to have_received(:debug)
           .with(a_record_finish_error(error))
       end
 

--- a/spec/ddtrace/transport/http/client_spec.rb
+++ b/spec/ddtrace/transport/http/client_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Datadog::Transport::HTTP::Client do
 
         before do
           allow(handler).to receive(:response).and_raise(error_class)
-          allow(Datadog::Tracer).to receive(:log).and_return(logger)
+          allow(Datadog::Logger).to receive(:log).and_return(logger)
           allow(logger).to receive(:debug)
           allow(logger).to receive(:error)
         end

--- a/spec/ddtrace/workers_spec.rb
+++ b/spec/ddtrace/workers_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Datadog::Workers::AsyncTransport do
     describe 'when raising errors' do
       it 'does not re-raise' do
         buf = StringIO.new
-        Datadog::Tracer.log = Datadog::Logger.new(buf)
+        Datadog::Logger.log = Datadog::Logger.new(buf)
         task = proc { raise StandardError }
         worker = Datadog::Workers::AsyncTransport.new(
           transport: nil,

--- a/spec/support/http_helpers.rb
+++ b/spec/support/http_helpers.rb
@@ -33,7 +33,7 @@ module HttpHelpers
         res = Net::HTTP.get_response(uri)
         return true if res.code == '200'
       rescue StandardError => e
-        Datadog::Tracer.log.error("Failed waiting for http server #{e.message}") if attempts_left < 5
+        Datadog::Logger.log.error("Failed waiting for http server #{e.message}") if attempts_left < 5
       end
     end
   end

--- a/spec/support/log_helpers.rb
+++ b/spec/support/log_helpers.rb
@@ -14,12 +14,12 @@ module LogHelpers
   end
 
   def without_errors
-    level = Datadog::Tracer.log.level
-    Datadog::Tracer.log.level = Logger::FATAL
+    level = Datadog::Logger.log.level
+    Datadog::Logger.log.level = Logger::FATAL
     begin
       yield
     ensure
-      Datadog::Tracer.log.level = level
+      Datadog::Logger.log.level = level
     end
   end
 
@@ -27,13 +27,13 @@ module LogHelpers
     let(:log_buffer) { StringIO.new }
 
     before(:each) do
-      @default_logger = Datadog::Tracer.log
-      Datadog::Tracer.log = Datadog::Logger.new(log_buffer)
-      Datadog::Tracer.log.level = ::Logger::WARN
+      @default_logger = Datadog::Logger.log
+      Datadog::Logger.log = Datadog::Logger.new(log_buffer)
+      Datadog::Logger.log.level = ::Logger::WARN
     end
 
     after(:each) do
-      Datadog::Tracer.log = @default_logger
+      Datadog::Logger.log = @default_logger
     end
 
     # Checks buffer to see if it contains lines that match all patterns.

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -187,19 +187,19 @@ class ContextTest < Minitest::Test
   def test_log_unfinished_spans
     tracer = get_test_tracer
 
-    default_log = Datadog::Tracer.log
-    default_level = Datadog::Tracer.log.level
+    default_log = Datadog::Logger.log
+    default_level = Datadog::Logger.log.level
 
     buf = StringIO.new
 
-    Datadog::Tracer.log = Datadog::Logger.new(buf)
-    Datadog::Tracer.log.level = ::Logger::DEBUG
+    Datadog::Logger.log = Datadog::Logger.new(buf)
+    Datadog::Logger.log.level = ::Logger::DEBUG
 
-    assert_equal(true, Datadog::Tracer.log.debug?)
-    assert_equal(true, Datadog::Tracer.log.info?)
-    assert_equal(true, Datadog::Tracer.log.warn?)
-    assert_equal(true, Datadog::Tracer.log.error?)
-    assert_equal(true, Datadog::Tracer.log.fatal?)
+    assert_equal(true, Datadog::Logger.log.debug?)
+    assert_equal(true, Datadog::Logger.log.info?)
+    assert_equal(true, Datadog::Logger.log.warn?)
+    assert_equal(true, Datadog::Logger.log.error?)
+    assert_equal(true, Datadog::Logger.log.fatal?)
 
     root = Datadog::Span.new(tracer, 'parent')
     child1 = Datadog::Span.new(tracer, 'child_1', trace_id: root.trace_id, parent_id: root.span_id)
@@ -239,8 +239,8 @@ class ContextTest < Minitest::Test
       i += 1
     end
 
-    Datadog::Tracer.log = default_log
-    Datadog::Tracer.log.level = default_level
+    Datadog::Logger.log = default_log
+    Datadog::Logger.log.level = default_level
   end
 
   def test_thread_safe

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -4,39 +4,39 @@ require 'helper'
 require 'ddtrace/span'
 
 class LoggerTest < Minitest::Test
-  DEFAULT_LOG = Datadog::Tracer.log
+  DEFAULT_LOG = Datadog::Logger.log
 
   def setup
     @buf = StringIO.new
-    Datadog::Tracer.log = Datadog::Logger.new(@buf)
-    Datadog::Tracer.log.level = ::Logger::WARN
+    Datadog::Logger.log = Datadog::Logger.new(@buf)
+    Datadog::Logger.log.level = ::Logger::WARN
   end
 
   def teardown
-    Datadog::Tracer.log = DEFAULT_LOG
+    Datadog::Logger.log = DEFAULT_LOG
   end
 
   def test_tracer_logger
     # a logger must be available by default
-    assert Datadog::Tracer.log
-    Datadog::Tracer.log.debug('a logger is here!')
-    Datadog::Tracer.log.info() { 'flash info' } # &block syntax
+    assert Datadog::Logger.log
+    Datadog::Logger.log.debug('a logger is here!')
+    Datadog::Logger.log.info() { 'flash info' } # &block syntax
   end
 
   def test_tracer_default_debug_mode
-    logger = Datadog::Tracer.log
+    logger = Datadog::Logger.log
     assert_equal(logger.level, Logger::WARN)
   end
 
   def test_tracer_set_debug_mode
-    logger = Datadog::Tracer.log
+    logger = Datadog::Logger.log
 
     # enable the debug mode
-    Datadog::Tracer.debug_logging = true
+    Datadog::Logger.debug_logging = true
     assert_equal(logger.level, Logger::DEBUG)
 
     # revert to production mode
-    Datadog::Tracer.debug_logging = false
+    Datadog::Logger.debug_logging = false
     assert_equal(logger.level, Logger::WARN)
   end
 
@@ -45,25 +45,25 @@ class LoggerTest < Minitest::Test
     custom_buf = StringIO.new
     custom_logger = Logger.new(custom_buf)
     custom_logger.level = ::Logger::INFO
-    Datadog::Tracer.log = custom_logger
+    Datadog::Logger.log = custom_logger
 
-    Datadog::Tracer.debug_logging = false
+    Datadog::Logger.debug_logging = false
     assert_equal(custom_logger.level, ::Logger::INFO)
   end
 
   def test_tracer_logger_override
-    assert_equal(false, Datadog::Tracer.log.debug?)
-    assert_equal(false, Datadog::Tracer.log.info?)
-    assert_equal(true, Datadog::Tracer.log.warn?)
-    assert_equal(true, Datadog::Tracer.log.error?)
-    assert_equal(true, Datadog::Tracer.log.fatal?)
+    assert_equal(false, Datadog::Logger.log.debug?)
+    assert_equal(false, Datadog::Logger.log.info?)
+    assert_equal(true, Datadog::Logger.log.warn?)
+    assert_equal(true, Datadog::Logger.log.error?)
+    assert_equal(true, Datadog::Logger.log.fatal?)
 
-    Datadog::Tracer.log.debug('never to be seen')
-    Datadog::Tracer.log.warn('careful here')
-    Datadog::Tracer.log.error() { 'this does not work' }
-    Datadog::Tracer.log.error('foo') { 'neither does this' }
-    Datadog::Tracer.log.progname = 'bar'
-    Datadog::Tracer.log.add(Logger::WARN, 'add some warning')
+    Datadog::Logger.log.debug('never to be seen')
+    Datadog::Logger.log.warn('careful here')
+    Datadog::Logger.log.error() { 'this does not work' }
+    Datadog::Logger.log.error('foo') { 'neither does this' }
+    Datadog::Logger.log.progname = 'bar'
+    Datadog::Logger.log.add(Logger::WARN, 'add some warning')
 
     lines = @buf.string.lines
 
@@ -92,16 +92,16 @@ class LoggerTest < Minitest::Test
   end
 
   def test_tracer_logger_override_debug
-    Datadog::Tracer.log.level = ::Logger::DEBUG
+    Datadog::Logger.log.level = ::Logger::DEBUG
 
-    assert_equal(true, Datadog::Tracer.log.debug?)
-    assert_equal(true, Datadog::Tracer.log.info?)
-    assert_equal(true, Datadog::Tracer.log.warn?)
-    assert_equal(true, Datadog::Tracer.log.error?)
-    assert_equal(true, Datadog::Tracer.log.fatal?)
+    assert_equal(true, Datadog::Logger.log.debug?)
+    assert_equal(true, Datadog::Logger.log.info?)
+    assert_equal(true, Datadog::Logger.log.warn?)
+    assert_equal(true, Datadog::Logger.log.error?)
+    assert_equal(true, Datadog::Logger.log.fatal?)
 
-    Datadog::Tracer.log.debug('detailed things')
-    Datadog::Tracer.log.info() { 'more detailed info' }
+    Datadog::Logger.log.debug('detailed things')
+    Datadog::Logger.log.info() { 'more detailed info' }
 
     lines = @buf.string.lines
 
@@ -130,12 +130,12 @@ class LoggerTest < Minitest::Test
 
     buf_log = Datadog::Logger.new(buf)
 
-    Datadog::Tracer.log = buf_log
-    Datadog::Tracer.log.level = ::Logger::DEBUG
+    Datadog::Logger.log = buf_log
+    Datadog::Logger.log.level = ::Logger::DEBUG
 
-    Datadog::Tracer.log = nil
-    assert_equal(buf_log, Datadog::Tracer.log)
-    Datadog::Tracer.log = "this won't work"
-    assert_equal(buf_log, Datadog::Tracer.log)
+    Datadog::Logger.log = nil
+    assert_equal(buf_log, Datadog::Logger.log)
+    Datadog::Logger.log = "this won't work"
+    assert_equal(buf_log, Datadog::Logger.log)
   end
 end

--- a/test/monkey_test.rb
+++ b/test/monkey_test.rb
@@ -3,20 +3,20 @@ require 'minitest/autorun'
 require 'ddtrace'
 
 class MonkeyTest < Minitest::Test
-  DEFAULT_LOG = Datadog::Tracer.log
+  DEFAULT_LOG = Datadog::Logger.log
 
   def setup
     @buf = StringIO.new
-    Datadog::Tracer.log = Datadog::Logger.new(@buf)
-    Datadog::Tracer.log.level = ::Logger::WARN
+    Datadog::Logger.log = Datadog::Logger.new(@buf)
+    Datadog::Logger.log.level = ::Logger::WARN
   end
 
   def teardown
-    Datadog::Tracer.log = DEFAULT_LOG
+    Datadog::Logger.log = DEFAULT_LOG
   end
 
   def assert_warning_issued(method)
-    assert_equal(true, Datadog::Tracer.log.warn?)
+    assert_equal(true, Datadog::Logger.log.warn?)
     lines = @buf.string.lines
     assert_equal(6, lines.length, 'there should be 1 log messages (with 6 lines)') if lines.respond_to? :length
 


### PR DESCRIPTION
The logging functions in the `Tracer` class are global-level and totally independent of the other functions within the tracer. Given this, and tracer doesn't need to be responsible for logging, let's extract logging from `Tracer` to our existing `Datadog::Logger`.

Major benefit of doing so is that there are many components that depend on logging functions, but do not need the `Tracer` itself. Often times doing `require 'ddtrace/tracer` to get these functions results in a circular reference. Extracting this dependency prevents this kind of error from happening.