### PR TITLE
Add resource for Rails template spans

### DIFF
--- a/lib/ddtrace/contrib/action_view/events/render_partial.rb
+++ b/lib/ddtrace/contrib/action_view/events/render_partial.rb
@@ -26,8 +26,10 @@ module Datadog
           def process(span, _event, _id, payload)
             span.span_type = Datadog::Ext::HTTP::TEMPLATE
 
-            template_name = Utils.normalize_template_name(payload[:identifier])
-            span.set_tag(Ext::TAG_TEMPLATE_NAME, template_name) if template_name
+            if (template_name = Utils.normalize_template_name(payload[:identifier]))
+              span.resource = template_name
+              span.set_tag(Ext::TAG_TEMPLATE_NAME, template_name)
+            end
 
             record_exception(span, payload)
           rescue StandardError => e

--- a/lib/ddtrace/contrib/action_view/events/render_template.rb
+++ b/lib/ddtrace/contrib/action_view/events/render_template.rb
@@ -26,8 +26,10 @@ module Datadog
           def process(span, _event, _id, payload)
             span.span_type = Datadog::Ext::HTTP::TEMPLATE
 
-            template_name = Utils.normalize_template_name(payload[:identifier])
-            span.set_tag(Ext::TAG_TEMPLATE_NAME, template_name) if template_name
+            if (template_name = Utils.normalize_template_name(payload[:identifier]))
+              span.resource = template_name
+              span.set_tag(Ext::TAG_TEMPLATE_NAME, template_name)
+            end
 
             layout = payload[:layout]
             span.set_tag(Ext::TAG_LAYOUT, layout) if layout

--- a/lib/ddtrace/contrib/action_view/instrumentation/partial_renderer.rb
+++ b/lib/ddtrace/contrib/action_view/instrumentation/partial_renderer.rb
@@ -32,6 +32,7 @@ module Datadog
             template_name = Utils.normalize_template_name(template.try('identifier'))
 
             if template_name
+              active_datadog_span.resource = template_name
               active_datadog_span.set_tag(
                 Ext::TAG_TEMPLATE_NAME,
                 template_name

--- a/lib/ddtrace/contrib/action_view/instrumentation/template_renderer.rb
+++ b/lib/ddtrace/contrib/action_view/instrumentation/template_renderer.rb
@@ -37,6 +37,7 @@ module Datadog
                     template_name = Utils.normalize_template_name(template_name)
 
                     if template_name
+                      active_datadog_span.resource = template_name
                       active_datadog_span.set_tag(
                         Ext::TAG_TEMPLATE_NAME,
                         template_name
@@ -113,6 +114,7 @@ module Datadog
               layout = layout_name.try(:[], 'virtual_path') # Proc can be called without parameters since Rails 6
 
               if template_name
+                active_datadog_span.resource = template_name
                 active_datadog_span.set_tag(
                   Ext::TAG_TEMPLATE_NAME,
                   template_name

--- a/test/contrib/rails/controller_test.rb
+++ b/test/contrib/rails/controller_test.rb
@@ -52,7 +52,7 @@ class TracingControllerTest < ActionController::TestCase
     span = spans[1]
     assert_equal(span.name, 'rails.render_template')
     assert_equal(span.span_type, 'template')
-    assert_equal(span.resource, 'rails.render_template')
+    assert_equal(span.resource, 'tracing/index.html.erb')
     assert_equal(span.get_tag('rails.template_name'), 'tracing/index.html.erb') if Rails.version >= '3.2.22.5'
     assert_includes(span.get_tag('rails.template_name'), 'tracing/index.html')
     assert_equal(span.get_tag('rails.layout'), 'layouts/application') if Rails.version >= '3.2.22.5'
@@ -72,7 +72,8 @@ class TracingControllerTest < ActionController::TestCase
       span = spans[1]
       assert_equal(span.name, 'rails.render_template')
       assert_equal(span.span_type, 'template')
-      assert_equal(span.resource, 'rails.render_template')
+      assert_equal(span.resource, 'tracing/index.html.erb') if Rails.version >= '3.2.22.5'
+      assert_includes(span.resource, 'tracing/index.html')
       assert_equal(span.get_tag('rails.template_name'), 'tracing/index.html.erb') if Rails.version >= '3.2.22.5'
       assert_includes(span.get_tag('rails.template_name'), 'tracing/index.html')
     ensure
@@ -90,7 +91,7 @@ class TracingControllerTest < ActionController::TestCase
     _, span_partial, span_template = spans
     assert_equal(span_partial.name, 'rails.render_partial')
     assert_equal(span_partial.span_type, 'template')
-    assert_equal(span_partial.resource, 'rails.render_partial')
+    assert_equal(span_partial.resource, 'tracing/_body.html.erb')
     assert_equal(span_partial.get_tag('rails.template_name'), 'tracing/_body.html.erb') if Rails.version >= '3.2.22.5'
     assert_includes(span_partial.get_tag('rails.template_name'), 'tracing/_body.html')
     assert_equal(span_partial.parent, span_template)
@@ -108,12 +109,12 @@ class TracingControllerTest < ActionController::TestCase
     spans = @tracer.writer.spans
     assert_equal(spans.length, 4)
 
-    _, span_outer_partial, span_inner_partial, span_template = spans
+    _, span_inner_partial, span_outer_partial, span_template = spans
 
     # Outer partial
     assert_equal('rails.render_partial', span_outer_partial.name)
     assert_equal('template', span_outer_partial.span_type)
-    assert_equal('rails.render_partial', span_outer_partial.resource)
+    assert_equal('tracing/_outer_partial.html.erb', span_outer_partial.resource)
     if Rails.version >= '3.2.22.5'
       assert_equal('tracing/_outer_partial.html.erb', span_outer_partial.get_tag('rails.template_name'))
     end
@@ -123,7 +124,7 @@ class TracingControllerTest < ActionController::TestCase
     # Inner partial
     assert_equal('rails.render_partial', span_inner_partial.name)
     assert_equal('template', span_inner_partial.span_type)
-    assert_equal('rails.render_partial', span_inner_partial.resource)
+    assert_equal('tracing/_inner_partial.html.erb', span_inner_partial.resource)
     if Rails.version >= '3.2.22.5'
       assert_equal('tracing/_inner_partial.html.erb', span_inner_partial.get_tag('rails.template_name'))
     end

--- a/test/contrib/rails/errors_test.rb
+++ b/test/contrib/rails/errors_test.rb
@@ -125,7 +125,7 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_template.name, 'rails.render_template')
     assert_equal(span_template.status, 1)
     assert_equal(span_template.span_type, 'template')
-    assert_equal(span_template.resource, 'rails.render_template')
+    assert_equal(span_template.resource, 'tracing/missing_partial.html.erb')
     assert_equal(span_template.get_tag('rails.template_name'), 'tracing/missing_partial.html.erb')
     assert_equal(span_template.get_tag('rails.layout'), 'layouts/application')
     assert_includes(span_template.get_tag('error.msg'), error_msg)
@@ -153,8 +153,9 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_template.name, 'rails.render_template')
     assert_equal(span_template.status, 1)
     assert_equal(span_template.span_type, 'template')
-    assert_equal(span_template.resource, 'rails.render_template')
+    assert_includes(span_template.resource, 'tracing/error.html')
     if Rails.version >= '3.2.22.5'
+      assert_equal(span_template.resource, 'tracing/error.html.erb')
       assert_equal(span_template.get_tag('rails.template_name'),
                    'tracing/error.html.erb')
     end
@@ -189,8 +190,9 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_partial.name, 'rails.render_partial')
     assert_equal(span_partial.status, 1)
     assert_equal(span_partial.span_type, 'template')
-    assert_equal(span_partial.resource, 'rails.render_partial')
+    assert_includes(span_partial.resource, 'tracing/_inner_error.html')
     if Rails.version >= '3.2.22.5'
+      assert_equal(span_partial.resource, 'tracing/_inner_error.html.erb')
       assert_equal(span_partial.get_tag('rails.template_name'),
                    'tracing/_inner_error.html.erb')
     end
@@ -201,7 +203,7 @@ class TracingControllerTest < ActionController::TestCase
     assert_equal(span_template.name, 'rails.render_template')
     assert_equal(span_template.status, 1)
     assert_equal(span_template.span_type, 'template')
-    assert_equal(span_template.resource, 'rails.render_template')
+    assert_includes(span_template.resource, 'tracing/error_partial.html')
     if Rails.version >= '3.2.22.5'
       assert_equal(span_template.get_tag('rails.template_name'),
                    'tracing/error_partial.html.erb')

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -59,7 +59,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_equal(render_span.name, 'rails.render_template')
     assert_equal(render_span.span_type, 'template')
     assert_equal(render_span.service, Datadog.configuration[:rails][:service_name])
-    assert_equal(render_span.resource, 'rails.render_template')
+    assert_equal(render_span.resource, 'tracing/full.html.erb')
     assert_equal(render_span.get_tag('rails.template_name'), 'tracing/full.html.erb')
 
     adapter_name = get_adapter_name


### PR DESCRIPTION
Fixes #855

Sets `span.resource` to the template name for `rails.render_template` and `rails.render_partial` spans, if the template name is available.

We were already setting tags for template name and layout, but not span resource name.

In this example you see `posts/index.html.erb` as the resource name:
![Screen Shot 2019-12-10 at 5 17 23 PM](https://user-images.githubusercontent.com/583503/70573948-f3469e00-1b70-11ea-9a03-6874f3752c7a.png)
