### PR TITLE
Add ability to specify service names by domain

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,7 +49,7 @@ namespace :spec do
 
   RSpec::Core::RakeTask.new(:contrib) do |t, args|
     # rubocop:disable Metrics/LineLength
-    t.pattern = 'spec/**/contrib/{analytics,configurable,extensions,integration,patchable,patcher,registerable,registry,configuration/*}_spec.rb'
+    t.pattern = 'spec/**/contrib/{analytics,configurable,configuration,extensions,integration,patchable,patcher,registerable,registry/*}_spec.rb'
     t.rspec_opts = args.to_a.join(' ')
   end
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -685,6 +685,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `error_handler` | A `Proc` that accepts a `response` parameter. If it evaluates to a *truthy* value, the trace span is marked as an error. By default only sets 5XX responses as errors. | `nil` |
 | `service_name` | Service name for Excon instrumentation. When provided to middleware for a specific connection, it applies only to that connection object. | `'excon'` |
 | `split_by_domain` | Uses the request domain as the service name when set to `true`. | `false` |
+| `split_by_domain_map` | When splitting by domain, provide a hash of regex => service name to override the service name for matched domains. | `{}` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 
 **Configuring connections to use different settings**
@@ -743,6 +744,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `error_handler` | A `Proc` that accepts a `response` parameter. If it evaluates to a *truthy* value, the trace span is marked as an error. By default only sets 5XX responses as errors. | `nil` |
 | `service_name` | Service name for Faraday instrumentation. When provided to middleware for a specific connection, it applies only to that connection object. | `'faraday'` |
 | `split_by_domain` | Uses the request domain as the service name when set to `true`. | `false` |
+| `split_by_domain_map` | When splitting by domain, provide a hash of regex => service name to override the service name for matched domains. | `{}` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually, you don't need to set this. | `Datadog.tracer` |
 
 ### Grape

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -647,6 +647,12 @@ require 'ddtrace'
 
 Datadog.configure do |c|
   c.use :ethon, options
+
+  # optionally, specify a different service name for hostnames matching a regex
+  c.use :ethon, describes: /user-[^.]+\.example\.com/ do |ethon|
+    ethon.service_name = 'user.example.com'
+    ethon.split_by_domain = false # Only necessary if split_by_domain is true by default
+  end
 end
 ```
 
@@ -657,6 +663,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) | `true` |
 | `service_name` | Service name for `ethon` instrumentation. | `'ethon'` |
+| `split_by_domain` | Uses the request domain as the service name when set to `true`. | `false` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 
 ### Excon
@@ -670,6 +677,12 @@ require 'ddtrace'
 # Configure default Excon tracing behavior
 Datadog.configure do |c|
   c.use :excon, options
+
+  # optionally, specify a different service name for hostnames matching a regex
+  c.use :excon, describes: /user-[^.]+\.example\.com/ do |excon|
+    excon.service_name = 'user.example.com'
+    excon.split_by_domain = false # Only necessary if split_by_domain is true by default
+  end
 end
 
 connection = Excon.new('https://example.com')
@@ -685,7 +698,6 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `error_handler` | A `Proc` that accepts a `response` parameter. If it evaluates to a *truthy* value, the trace span is marked as an error. By default only sets 5XX responses as errors. | `nil` |
 | `service_name` | Service name for Excon instrumentation. When provided to middleware for a specific connection, it applies only to that connection object. | `'excon'` |
 | `split_by_domain` | Uses the request domain as the service name when set to `true`. | `false` |
-| `split_by_domain_map` | When splitting by domain, provide a hash of regex => service name to override the service name for matched domains. | `{}` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 
 **Configuring connections to use different settings**
@@ -724,6 +736,12 @@ require 'ddtrace'
 # Configure default Faraday tracing behavior
 Datadog.configure do |c|
   c.use :faraday, options
+
+  # optionally, specify a different service name for hostnames matching a regex
+  c.use :faraday, describes: /user-[^.]+\.example\.com/ do |faraday|
+    faraday.service_name = 'user.example.com'
+    faraday.split_by_domain = false # Only necessary if split_by_domain is true by default
+  end
 end
 
 # Configure Faraday tracing behavior for single connection
@@ -744,7 +762,6 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `error_handler` | A `Proc` that accepts a `response` parameter. If it evaluates to a *truthy* value, the trace span is marked as an error. By default only sets 5XX responses as errors. | `nil` |
 | `service_name` | Service name for Faraday instrumentation. When provided to middleware for a specific connection, it applies only to that connection object. | `'faraday'` |
 | `split_by_domain` | Uses the request domain as the service name when set to `true`. | `false` |
-| `split_by_domain_map` | When splitting by domain, provide a hash of regex => service name to override the service name for matched domains. | `{}` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually, you don't need to set this. | `Datadog.tracer` |
 
 ### Grape
@@ -946,6 +963,12 @@ require 'ddtrace'
 
 Datadog.configure do |c|
   c.use :http, options
+
+  # optionally, specify a different service name for hostnames matching a regex
+  c.use :http, describes: /user-[^.]+\.example\.com/ do |http|
+    http.service_name = 'user.example.com'
+    http.split_by_domain = false # Only necessary if split_by_domain is true by default
+  end
 end
 
 Net::HTTP.start('127.0.0.1', 8080) do |http|
@@ -963,6 +986,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) | `true` |
 | `service_name` | Service name used for `http` instrumentation | `'net/http'` |
+| `split_by_domain` | Uses the request domain as the service name when set to `true`. | `false` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 
 If you wish to configure each connection object individually, you may use the `Datadog.configure` as it follows:

--- a/lib/ddtrace/contrib/configurable.rb
+++ b/lib/ddtrace/contrib/configurable.rb
@@ -30,12 +30,13 @@ module Datadog
           end
         end
 
-        def configure(key, options = {}, &block)
-          key = resolver.resolve(key || :default)
+        def configure(key = :default, options = {}, &block)
+          resolver.add_key(key) unless key == :default
+          resolved_key = resolver.resolve(key)
 
-          configurations[key].tap do |settings|
+          configurations[resolved_key].tap do |settings|
             settings.configure(options, &block)
-            configurations[key] = settings
+            configurations[resolved_key] = settings
           end
         end
 

--- a/lib/ddtrace/contrib/configuration/resolver.rb
+++ b/lib/ddtrace/contrib/configuration/resolver.rb
@@ -3,6 +3,10 @@ module Datadog
     module Configuration
       # Resolves a value to a configuration key
       class Resolver
+        def add_key(key)
+          # noop here, override in your subclass to customize
+        end
+
         def resolve(name)
           name
         end

--- a/lib/ddtrace/contrib/configuration/resolvers/regexp_resolver.rb
+++ b/lib/ddtrace/contrib/configuration/resolvers/regexp_resolver.rb
@@ -1,0 +1,31 @@
+require 'ddtrace/contrib/configuration/resolver'
+
+module Datadog
+  module Contrib
+    module Configuration
+      # Resolves a value to a configuration key
+      module Resolvers
+        # Matches strings against Regexps.
+        class RegexpResolver < Datadog::Contrib::Configuration::Resolver
+          def add_key(pattern)
+            patterns << pattern.is_a?(Regexp) ? pattern : /#{pattern}/
+          end
+
+          def resolve(name)
+            return :default if name == :default
+
+            name = name.to_s
+            matching_pattern = patterns.find { |p| p =~ name }
+            matching_pattern || :default
+          end
+
+          private
+
+          def patterns
+            @patterns ||= Set.new
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/configuration/resolvers/regexp_resolver.rb
+++ b/lib/ddtrace/contrib/configuration/resolvers/regexp_resolver.rb
@@ -8,7 +8,7 @@ module Datadog
         # Matches strings against Regexps.
         class RegexpResolver < Datadog::Contrib::Configuration::Resolver
           def add_key(pattern)
-            patterns << pattern.is_a?(Regexp) ? pattern : /#{pattern}/
+            patterns << pattern.is_a?(Regexp) ? pattern : /#{Regexp.quote(pattern)}/
           end
 
           def resolve(name)

--- a/lib/ddtrace/contrib/ethon/configuration/settings.rb
+++ b/lib/ddtrace/contrib/ethon/configuration/settings.rb
@@ -19,6 +19,7 @@ module Datadog
 
           option :distributed_tracing, default: true
           option :service_name, default: Ext::SERVICE_NAME
+          option :split_by_domain, default: false
         end
       end
     end

--- a/lib/ddtrace/contrib/ethon/easy_patch.rb
+++ b/lib/ddtrace/contrib/ethon/easy_patch.rb
@@ -2,6 +2,7 @@ require 'ddtrace/ext/net'
 require 'ddtrace/ext/distributed'
 require 'ddtrace/propagation/http_propagator'
 require 'ddtrace/contrib/ethon/ext'
+require 'ddtrace/contrib/http_annotation_helper'
 
 module Datadog
   module Contrib
@@ -14,7 +15,10 @@ module Datadog
 
         # InstanceMethods - implementing instrumentation
         module InstanceMethods
+          include Datadog::Contrib::HttpAnnotationHelper
+
           def http_request(url, action_name, options = {})
+            load_datadog_configuration_for(url)
             return super unless tracer_enabled?
 
             # It's tricky to get HTTP method from libcurl
@@ -23,14 +27,13 @@ module Datadog
           end
 
           def headers=(headers)
-            return super unless tracer_enabled?
-
             # Store headers to call this method again when span is ready
             @datadog_original_headers = headers
             super
           end
 
           def perform
+            load_datadog_configuration_for(url)
             return super unless tracer_enabled?
             datadog_before_request
             super
@@ -61,14 +64,14 @@ module Datadog
           def reset
             super
           ensure
-            if tracer_enabled?
-              @datadog_span = nil
-              @datadog_method = nil
-              @datadog_original_headers = nil
-            end
+            @datadog_span = nil
+            @datadog_method = nil
+            @datadog_original_headers = nil
+            @datadog_configuration = nil
           end
 
           def datadog_before_request(parent_span: nil)
+            load_datadog_configuration_for(url)
             @datadog_span = datadog_configuration[:tracer].trace(
               Ext::SPAN_REQUEST,
               service: datadog_configuration[:service_name],
@@ -90,6 +93,8 @@ module Datadog
           end
 
           private
+
+          attr_reader :datadog_configuration
 
           def datadog_tag_request
             span = @datadog_span
@@ -117,8 +122,8 @@ module Datadog
             @datadog_span.set_tag(Datadog::Ext::Errors::MSG, message)
           end
 
-          def datadog_configuration
-            Datadog.configuration[:ethon]
+          def load_datadog_configuration_for(host = :default)
+            @datadog_configuration ||= Datadog.configuration[:ethon, host]
           end
 
           def tracer_enabled?

--- a/lib/ddtrace/contrib/ethon/integration.rb
+++ b/lib/ddtrace/contrib/ethon/integration.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/contrib/integration'
 require 'ddtrace/contrib/ethon/configuration/settings'
+require 'ddtrace/contrib/configuration/resolvers/regexp_resolver'
 require 'ddtrace/contrib/ethon/patcher'
 
 module Datadog
@@ -24,6 +25,10 @@ module Datadog
 
         def patcher
           Patcher
+        end
+
+        def resolver
+          @resolver ||= Contrib::Configuration::Resolvers::RegexpResolver.new
         end
       end
     end

--- a/lib/ddtrace/contrib/excon/configuration/settings.rb
+++ b/lib/ddtrace/contrib/excon/configuration/settings.rb
@@ -21,6 +21,7 @@ module Datadog
           option :error_handler
           option :service_name, default: Ext::SERVICE_NAME
           option :split_by_domain, default: false
+          option :split_by_domain_map, default: {}
         end
       end
     end

--- a/lib/ddtrace/contrib/excon/configuration/settings.rb
+++ b/lib/ddtrace/contrib/excon/configuration/settings.rb
@@ -21,7 +21,6 @@ module Datadog
           option :error_handler
           option :service_name, default: Ext::SERVICE_NAME
           option :split_by_domain, default: false
-          option :split_by_domain_map, default: {}
         end
       end
     end

--- a/lib/ddtrace/contrib/excon/integration.rb
+++ b/lib/ddtrace/contrib/excon/integration.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/contrib/integration'
 require 'ddtrace/contrib/excon/configuration/settings'
+require 'ddtrace/contrib/configuration/resolvers/regexp_resolver'
 require 'ddtrace/contrib/excon/patcher'
 
 module Datadog
@@ -25,6 +26,10 @@ module Datadog
 
         def patcher
           Patcher
+        end
+
+        def resolver
+          @resolver ||= Contrib::Configuration::Resolvers::RegexpResolver.new
         end
       end
     end

--- a/lib/ddtrace/contrib/excon/middleware.rb
+++ b/lib/ddtrace/contrib/excon/middleware.rb
@@ -146,7 +146,15 @@ module Datadog
 
         def service_name(datum)
           # TODO: Change this to implement more sensible multiplexing
-          split_by_domain? ? datum[:host] : @options[:service_name]
+          if split_by_domain?
+            host = datum[:host]
+            @options[:split_by_domain_map].each do |matcher, service_name|
+              return service_name if matcher =~ host
+            end
+            return host
+          end
+
+          @options[:service_name]
         end
       end
     end

--- a/lib/ddtrace/contrib/excon/middleware.rb
+++ b/lib/ddtrace/contrib/excon/middleware.rb
@@ -5,24 +5,28 @@ require 'ddtrace/ext/distributed'
 require 'ddtrace/propagation/http_propagator'
 require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/excon/ext'
+require 'ddtrace/contrib/http_annotation_helper'
 
 module Datadog
   module Contrib
     module Excon
       # Middleware implements an excon-middleware for ddtrace instrumentation
       class Middleware < ::Excon::Middleware::Base
+        include Datadog::Contrib::HttpAnnotationHelper
+
         DEFAULT_ERROR_HANDLER = lambda do |response|
           Datadog::Ext::HTTP::ERROR_RANGE.cover?(response[:status])
         end
 
         def initialize(stack, options = {})
           super(stack)
-          @options = Datadog.configuration[:excon].options_hash.merge(options)
+          @default_options = datadog_configuration.options_hash.merge(options)
         end
 
         def request_call(datum)
           begin
             unless datum.key?(:datadog_span)
+              @options = build_request_options!(datum)
               tracer.trace(Ext::SPAN_REQUEST).tap do |span|
                 datum[:datadog_span] = span
                 annotate!(span, datum)
@@ -99,13 +103,9 @@ module Datadog
           @options[:error_handler] || DEFAULT_ERROR_HANDLER
         end
 
-        def split_by_domain?
-          @options[:split_by_domain] == true
-        end
-
         def annotate!(span, datum)
           span.resource = datum[:method].to_s.upcase
-          span.service = service_name(datum)
+          span.service = service_name(datum[:host], @options)
           span.span_type = Datadog::Ext::HTTP::TYPE_OUTBOUND
 
           # Set analytics sample rate
@@ -144,17 +144,12 @@ module Datadog
           Datadog::HTTPPropagator.inject!(span.context, datum[:headers])
         end
 
-        def service_name(datum)
-          # TODO: Change this to implement more sensible multiplexing
-          if split_by_domain?
-            host = datum[:host]
-            @options[:split_by_domain_map].each do |matcher, service_name|
-              return service_name if matcher =~ host
-            end
-            return host
-          end
+        def build_request_options!(datum)
+          datadog_configuration(datum[:host]).options_hash.merge(@default_options)
+        end
 
-          @options[:service_name]
+        def datadog_configuration(host = :default)
+          Datadog.configuration[:excon, host]
         end
       end
     end

--- a/lib/ddtrace/contrib/faraday/configuration/settings.rb
+++ b/lib/ddtrace/contrib/faraday/configuration/settings.rb
@@ -26,6 +26,7 @@ module Datadog
           option :error_handler, default: DEFAULT_ERROR_HANDLER
           option :service_name, default: Ext::SERVICE_NAME
           option :split_by_domain, default: false
+          option :split_by_domain_map, default: {}
         end
       end
     end

--- a/lib/ddtrace/contrib/faraday/configuration/settings.rb
+++ b/lib/ddtrace/contrib/faraday/configuration/settings.rb
@@ -26,7 +26,6 @@ module Datadog
           option :error_handler, default: DEFAULT_ERROR_HANDLER
           option :service_name, default: Ext::SERVICE_NAME
           option :split_by_domain, default: false
-          option :split_by_domain_map, default: {}
         end
       end
     end

--- a/lib/ddtrace/contrib/faraday/integration.rb
+++ b/lib/ddtrace/contrib/faraday/integration.rb
@@ -1,4 +1,5 @@
 require 'ddtrace/contrib/integration'
+require 'ddtrace/contrib/configuration/resolvers/regexp_resolver'
 require 'ddtrace/contrib/faraday/configuration/settings'
 require 'ddtrace/contrib/faraday/patcher'
 
@@ -29,6 +30,10 @@ module Datadog
 
         def patcher
           Patcher
+        end
+
+        def resolver
+          @resolver ||= Contrib::Configuration::Resolvers::RegexpResolver.new
         end
       end
     end

--- a/lib/ddtrace/contrib/faraday/middleware.rb
+++ b/lib/ddtrace/contrib/faraday/middleware.rb
@@ -4,6 +4,7 @@ require 'ddtrace/ext/net'
 require 'ddtrace/propagation/http_propagator'
 require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/faraday/ext'
+require 'ddtrace/contrib/http_annotation_helper'
 
 module Datadog
   module Contrib
@@ -11,18 +12,22 @@ module Datadog
       # Middleware implements a faraday-middleware for ddtrace instrumentation
       class Middleware < ::Faraday::Middleware
         include Datadog::Ext::DistributedTracing
+        include Datadog::Contrib::HttpAnnotationHelper
 
         def initialize(app, options = {})
           super(app)
           @options = datadog_configuration.options_hash.merge(options)
-          setup_service!
         end
 
         def call(env)
-          tracer.trace(Ext::SPAN_REQUEST) do |span|
-            annotate!(span, env)
-            propagate!(span, env) if options[:distributed_tracing] && tracer.enabled
-            app.call(env).on_complete { |resp| handle_response(span, resp) }
+          # Resolve configuration settings to use for this request.
+          # Do this once to reduce expensive regex calls.
+          request_options = build_request_options!(env)
+
+          request_options[:tracer].trace(Ext::SPAN_REQUEST) do |span|
+            annotate!(span, env, request_options)
+            propagate!(span, env) if request_options[:distributed_tracing] && request_options[:tracer].enabled
+            app.call(env).on_complete { |resp| handle_response(span, resp, request_options) }
           end
         end
 
@@ -30,14 +35,15 @@ module Datadog
 
         attr_reader :app, :options
 
-        def annotate!(span, env)
+        def annotate!(span, env, options)
           span.resource = resource_name(env)
-          span.service = service_name(env)
+          service_name(env[:url].host, options)
+          span.service = options[:split_by_domain] ? env[:url].host : options[:service_name]
           span.span_type = Datadog::Ext::HTTP::TYPE_OUTBOUND
 
           # Set analytics sample rate
-          if analytics_enabled?
-            Contrib::Analytics.set_sample_rate(span, analytics_sample_rate)
+          if Contrib::Analytics.enabled?(options[:analytics_enabled])
+            Contrib::Analytics.set_sample_rate(span, options[:analytics_sample_rate])
           end
 
           span.set_tag(Datadog::Ext::HTTP::URL, env[:url].path)
@@ -46,7 +52,7 @@ module Datadog
           span.set_tag(Datadog::Ext::NET::TARGET_PORT, env[:url].port)
         end
 
-        def handle_response(span, env)
+        def handle_response(span, env, options)
           if options.fetch(:error_handler).call(env)
             span.set_error(["Error #{env[:status]}", env[:body]])
           end
@@ -58,40 +64,16 @@ module Datadog
           Datadog::HTTPPropagator.inject!(span.context, env[:request_headers])
         end
 
-        def datadog_configuration
-          Datadog.configuration[:faraday]
-        end
-
-        def tracer
-          options[:tracer]
-        end
-
-        def service_name(env)
-          if options[:split_by_domain]
-            host = env[:url].host
-            options[:split_by_domain_map].each do |matcher, service_name|
-              return service_name if matcher =~ host
-            end
-            return host
-          end
-
-          options[:service_name]
-        end
-
         def resource_name(env)
           env[:method].to_s.upcase
         end
 
-        def analytics_enabled?
-          Contrib::Analytics.enabled?(options[:analytics_enabled])
+        def build_request_options!(env)
+          datadog_configuration(env[:url].host).options_hash.merge(options)
         end
 
-        def analytics_sample_rate
-          options[:analytics_sample_rate]
-        end
-
-        def setup_service!
-          return if options[:service_name] == datadog_configuration[:service_name]
+        def datadog_configuration(host = :default)
+          Datadog.configuration[:faraday, host]
         end
       end
     end

--- a/lib/ddtrace/contrib/faraday/middleware.rb
+++ b/lib/ddtrace/contrib/faraday/middleware.rb
@@ -67,7 +67,13 @@ module Datadog
         end
 
         def service_name(env)
-          return env[:url].host if options[:split_by_domain]
+          if options[:split_by_domain]
+            host = env[:url].host
+            options[:split_by_domain_map].each do |matcher, service_name|
+              return service_name if matcher =~ host
+            end
+            return host
+          end
 
           options[:service_name]
         end

--- a/lib/ddtrace/contrib/http/configuration/settings.rb
+++ b/lib/ddtrace/contrib/http/configuration/settings.rb
@@ -19,6 +19,7 @@ module Datadog
 
           option :distributed_tracing, default: true
           option :service_name, default: Ext::SERVICE_NAME
+          option :split_by_domain, default: false
         end
       end
     end

--- a/lib/ddtrace/contrib/http/instrumentation.rb
+++ b/lib/ddtrace/contrib/http/instrumentation.rb
@@ -5,6 +5,7 @@ require 'ddtrace/ext/http'
 require 'ddtrace/ext/net'
 require 'ddtrace/ext/distributed'
 require 'ddtrace/contrib/analytics'
+require 'ddtrace/contrib/http_annotation_helper'
 
 module Datadog
   module Contrib
@@ -28,8 +29,12 @@ module Datadog
 
         # InstanceMethods - implementing instrumentation
         module InstanceMethods
+          include Datadog::Contrib::HttpAnnotationHelper
+
           def request(req, body = nil, &block) # :yield: +response+
-            pin = datadog_pin
+            host, = host_and_port(req)
+            request_options = datadog_configuration(host)
+            pin = datadog_pin(request_options)
             return super(req, body, &block) unless pin && pin.tracer
 
             if Datadog::Contrib::HTTP.should_skip_tracing?(req, @address, @port, pin.tracer)
@@ -38,7 +43,11 @@ module Datadog
 
             pin.tracer.trace(Ext::SPAN_REQUEST) do |span|
               begin
-                span.service = pin.service
+                # even though service_name might already be in request_options,
+                # we need to capture the name from the pin since it could be
+                # overridden. But it might also be the same :)
+                request_options[:service_name] = datadog_pin.service_name
+                span.service = service_name(host, request_options)
                 span.span_type = Datadog::Ext::HTTP::TYPE_OUTBOUND
                 span.resource = req.method
 
@@ -52,7 +61,7 @@ module Datadog
               end
 
               # Add additional tags to the span.
-              annotate_span!(span, req, response)
+              annotate_span!(span, req, response, request_options)
 
               # Invoke hook, if set.
               unless Contrib::HTTP::Instrumentation.after_request.nil?
@@ -63,21 +72,16 @@ module Datadog
             end
           end
 
-          def annotate_span!(span, request, response)
+          def annotate_span!(span, request, response, request_options)
             span.set_tag(Datadog::Ext::HTTP::URL, request.path)
             span.set_tag(Datadog::Ext::HTTP::METHOD, request.method)
             span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, response.code)
 
-            if request.respond_to?(:uri) && request.uri
-              span.set_tag(Datadog::Ext::NET::TARGET_HOST, request.uri.host)
-              span.set_tag(Datadog::Ext::NET::TARGET_PORT, request.uri.port.to_s)
-            else
-              span.set_tag(Datadog::Ext::NET::TARGET_HOST, @address)
-              span.set_tag(Datadog::Ext::NET::TARGET_PORT, @port.to_s)
-            end
+            host, port = host_and_port(request)
+            span.set_tag(Datadog::Ext::NET::TARGET_HOST, host)
+            span.set_tag(Datadog::Ext::NET::TARGET_PORT, port.to_s)
 
-            # Set analytics sample rate
-            Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
+            set_analytics_sample_rate(span, request_options)
 
             case response.code.to_i
             when 400...599
@@ -85,10 +89,15 @@ module Datadog
             end
           end
 
-          def datadog_pin
+          def set_analytics_sample_rate(span, request_options)
+            return unless analytics_enabled?(request_options)
+            Contrib::Analytics.set_sample_rate(span, analytics_sample_rate(request_options))
+          end
+
+          def datadog_pin(config = Datadog.configuration[:http])
             @datadog_pin ||= begin
-              service = Datadog.configuration[:http][:service_name]
-              tracer = Datadog.configuration[:http][:tracer]
+              service = config[:service_name]
+              tracer = config[:tracer]
 
               Datadog::Pin.new(service, app: Ext::APP, app_type: Datadog::Ext::AppTypes::WEB, tracer: tracer)
             end
@@ -96,16 +105,24 @@ module Datadog
 
           private
 
-          def datadog_configuration
-            Datadog.configuration[:http]
+          def host_and_port(request)
+            if request.respond_to?(:uri) && request.uri
+              [request.uri.host, request.uri.port]
+            else
+              [@address, @port]
+            end
           end
 
-          def analytics_enabled?
-            Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])
+          def datadog_configuration(host = :default)
+            Datadog.configuration[:http, host]
           end
 
-          def analytics_sample_rate
-            datadog_configuration[:analytics_sample_rate]
+          def analytics_enabled?(request_options)
+            Contrib::Analytics.enabled?(request_options[:analytics_enabled])
+          end
+
+          def analytics_sample_rate(request_options)
+            request_options[:analytics_sample_rate]
           end
         end
       end

--- a/lib/ddtrace/contrib/http/integration.rb
+++ b/lib/ddtrace/contrib/http/integration.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/contrib/integration'
 require 'ddtrace/contrib/http/configuration/settings'
+require 'ddtrace/contrib/configuration/resolvers/regexp_resolver'
 require 'ddtrace/contrib/http/patcher'
 require 'ddtrace/contrib/http/circuit_breaker'
 
@@ -25,6 +26,10 @@ module Datadog
 
         def patcher
           Patcher
+        end
+
+        def resolver
+          @resolver ||= Contrib::Configuration::Resolvers::RegexpResolver.new
         end
       end
     end

--- a/lib/ddtrace/contrib/http_annotation_helper.rb
+++ b/lib/ddtrace/contrib/http_annotation_helper.rb
@@ -1,0 +1,10 @@
+module Datadog
+  module Contrib
+    # Contains methods helpful for tracing/annotating HTTP request libraries
+    module HttpAnnotationHelper
+      def service_name(hostname, configuration_options)
+        configuration_options[:split_by_domain] ? hostname : configuration_options[:service_name]
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/configuration/regexp_resolver_spec.rb
+++ b/spec/ddtrace/contrib/configuration/regexp_resolver_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'ddtrace'
+
+RSpec.describe Datadog::Contrib::Configuration::Resolvers::RegexpResolver do
+  subject(:resolver) { described_class.new }
+
+  describe '#resolve' do
+    subject(:resolve) { resolver.resolve(name) }
+
+    context 'when the key is already added' do
+      let(:name) { double('name') }
+      before do
+        resolver.add_key(/name/)
+      end
+
+      it do
+        is_expected.to eq(/name/)
+      end
+    end
+
+    context 'when the pattern is not found' do
+      let(:name) { 'not_found' }
+
+      it do
+        is_expected.to be :default
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/ethon/easy_patch_spec.rb
+++ b/spec/ddtrace/contrib/ethon/easy_patch_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Datadog::Contrib::Ethon::EasyPatch do
 
     before do
       expect(::Ethon::Curl).to receive(:easy_perform).and_return(0)
-      expect(easy).to receive(:url).and_return('http://example.com/test').once
+      expect(easy).to receive(:url).and_return('http://example.com/test').at_least(:once)
       # Note: suppress call to #complete to isolate #perform functionality
       expect(easy).to receive(:complete)
     end
@@ -76,7 +76,7 @@ RSpec.describe Datadog::Contrib::Ethon::EasyPatch do
     let(:span) { tracer.writer.spans.first }
 
     before do
-      expect(easy).to receive(:url).and_return('http://example.com/test').once
+      expect(easy).to receive(:url).and_return('http://example.com/test').at_least(:once)
       allow(easy).to receive(:mirror).and_return(double('Fake mirror', options: { response_code: 200 }))
       easy.datadog_before_request
     end
@@ -180,7 +180,7 @@ RSpec.describe Datadog::Contrib::Ethon::EasyPatch do
 
     context 'with span initialized' do
       before do
-        expect(easy).to receive(:url).and_return('http://example.com/test').once
+        expect(easy).to receive(:url).and_return('http://example.com/test').at_least(:once)
         easy.datadog_before_request
       end
 

--- a/spec/ddtrace/contrib/ethon/multi_patch_spec.rb
+++ b/spec/ddtrace/contrib/ethon/multi_patch_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Datadog::Contrib::Ethon::MultiPatch do
 
     context 'multi already performing' do
       before do
-        expect(easy).to receive(:url).and_return('http://example.com/test').once
+        expect(easy).to receive(:url).and_return('http://example.com/test').at_least(:once)
 
         # Trigger parent span creation, which will force easy span creation in #add
         multi.instance_eval { datadog_multi_span }

--- a/spec/ddtrace/contrib/ethon/shared_examples.rb
+++ b/spec/ddtrace/contrib/ethon/shared_examples.rb
@@ -150,30 +150,5 @@ RSpec.shared_examples_for 'instrumented request' do
         end
       end
     end
-
-    context 'when split by domain' do
-      let(:configuration_options) { super().merge(split_by_domain: true) }
-
-      it do
-        expect(span.name).to eq(Datadog::Contrib::Ethon::Ext::SPAN_REQUEST)
-        expect(span.service).to eq('example.com')
-        expect(span.resource).to eq('GET')
-      end
-
-      context 'and the host matches a specific configuration' do
-        before do
-          Datadog.configure do |c|
-            c.use :ethon, describe: /example\.com/ do |ethon|
-              ethon.service_name = 'bar'
-              ethon.split_by_domain = false
-            end
-          end
-        end
-
-        it 'uses the configured service name over the domain name' do
-          expect(request_span.service).to eq('bar')
-        end
-      end
-    end
   end
 end

--- a/spec/ddtrace/contrib/excon/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/excon/instrumentation_spec.rb
@@ -163,6 +163,19 @@ RSpec.describe Datadog::Contrib::Excon::Middleware do
     end
   end
 
+  context 'when split by domain with a domain map' do
+    subject!(:response) { connection.get(path: '/success') }
+    let(:configuration_options) { super().merge(split_by_domain: true, split_by_domain_map: { /example\.com/ => 'bar' }) }
+    after(:each) do
+      Datadog.configuration[:excon][:split_by_domain] = false
+      Datadog.configuration[:excon][:split_by_domain_map] = {}
+    end
+
+    it 'overrides the domain from the map' do
+      expect(request_span.service).to eq('bar')
+    end
+  end
+
   context 'default request headers' do
     subject!(:response) do
       expect_any_instance_of(Datadog::Contrib::Excon::Middleware).to receive(:request_call)

--- a/spec/ddtrace/contrib/excon/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/excon/instrumentation_spec.rb
@@ -152,27 +152,31 @@ RSpec.describe Datadog::Contrib::Excon::Middleware do
   end
 
   context 'when split by domain' do
-    subject!(:response) { connection.get(path: '/success') }
+    subject(:response) { connection.get(path: '/success') }
     let(:configuration_options) { super().merge(split_by_domain: true) }
     after(:each) { Datadog.configuration[:excon][:split_by_domain] = false }
 
     it do
+      response
       expect(request_span.name).to eq(Datadog::Contrib::Excon::Ext::SPAN_REQUEST)
       expect(request_span.service).to eq('example.com')
       expect(request_span.resource).to eq('GET')
     end
-  end
 
-  context 'when split by domain with a domain map' do
-    subject!(:response) { connection.get(path: '/success') }
-    let(:configuration_options) { super().merge(split_by_domain: true, split_by_domain_map: { /example\.com/ => 'bar' }) }
-    after(:each) do
-      Datadog.configuration[:excon][:split_by_domain] = false
-      Datadog.configuration[:excon][:split_by_domain_map] = {}
-    end
+    context 'and the host matches a specific configuration' do
+      before do
+        Datadog.configure do |c|
+          c.use :excon, describe: /example\.com/ do |faraday|
+            faraday.service_name = 'bar'
+            faraday.split_by_domain = false
+          end
+        end
+      end
 
-    it 'overrides the domain from the map' do
-      expect(request_span.service).to eq('bar')
+      it 'uses the configured service name over the domain name' do
+        response
+        expect(request_span.service).to eq('bar')
+      end
     end
   end
 

--- a/spec/ddtrace/contrib/faraday/middleware_spec.rb
+++ b/spec/ddtrace/contrib/faraday/middleware_spec.rb
@@ -129,23 +129,31 @@ RSpec.describe 'Faraday middleware' do
   end
 
   context 'when split by domain' do
-    subject!(:response) { client.get('/success') }
+    subject(:response) { client.get('/success') }
 
-    let(:middleware_options) { { split_by_domain: true } }
+    let(:configuration_options) { super().merge(split_by_domain: true) }
 
     it do
+      response
       expect(request_span.name).to eq(Datadog::Contrib::Faraday::Ext::SPAN_REQUEST)
       expect(request_span.service).to eq('example.com')
       expect(request_span.resource).to eq('GET')
     end
-  end
 
-  context 'when split by domain with a domain map' do
-    subject!(:response) { client.get('/success') }
-    let(:middleware_options) { { split_by_domain: true, split_by_domain_map: { /example\.com/ => 'bar' } } }
+    context 'and the host matches a specific configuration' do
+      before do
+        Datadog.configure do |c|
+          c.use :faraday, describe: /example\.com/ do |faraday|
+            faraday.service_name = 'bar'
+            faraday.split_by_domain = false
+          end
+        end
+      end
 
-    it 'overrides the domain from the map' do
-      expect(request_span.service).to eq('bar')
+      it 'uses the configured service name over the domain name' do
+        response
+        expect(request_span.service).to eq('bar')
+      end
     end
   end
 

--- a/spec/ddtrace/contrib/faraday/middleware_spec.rb
+++ b/spec/ddtrace/contrib/faraday/middleware_spec.rb
@@ -140,6 +140,15 @@ RSpec.describe 'Faraday middleware' do
     end
   end
 
+  context 'when split by domain with a domain map' do
+    subject!(:response) { client.get('/success') }
+    let(:middleware_options) { { split_by_domain: true, split_by_domain_map: { /example\.com/ => 'bar' } } }
+
+    it 'overrides the domain from the map' do
+      expect(request_span.service).to eq('bar')
+    end
+  end
+
   context 'default request headers' do
     subject(:response) { client.get('/success') }
 


### PR DESCRIPTION
## What?
When using the `faraday` and `excon` contribs with the `split_by_domain` feature turned on, allow users to specify an additional hash that can override the service name by domain.

## Why?
We use an external service that makes a per-customer domain name. When we create HTTP requests to this service for our customers, it looks like `user-123.foo.com` and `user-abc.foo.com` (and so on). When we split by domain (which we want to do for all the _other_ HTTP services we use), it ends up creating hundreds of separate "services" on the service map - all of which are really the same external service. We'd like to have these all show up as one service.

## How?
By providing a hash in the form of `{/regex/ => 'desired_service_name'}`, we can match the desired domain names (`/user-[^.]+\.foo\.com/`) and provide the service name we want to see instead (`user.foo.com`)