### PR TITLE
Wait for WEBrick server start during tests

### DIFF
--- a/spec/ddtrace/contrib/ethon/integration_context.rb
+++ b/spec/ddtrace/contrib/ethon/integration_context.rb
@@ -4,7 +4,14 @@ RSpec.shared_context 'integration context' do
     log = WEBrick::Log.new(@log_buffer, WEBrick::Log::DEBUG)
     access_log = [[@log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]]
 
-    server = WEBrick::HTTPServer.new(Port: 0, Logger: log, AccessLog: access_log)
+    init_signal = Queue.new
+    server = WEBrick::HTTPServer.new(
+      Port: 0,
+      Logger: log,
+      AccessLog: access_log,
+      StartCallback: -> { init_signal.push(1) }
+    )
+
     server.mount_proc '/' do |req, res|
       sleep(1) if req.query['simulate_timeout']
       res.status = (req.query['status'] || req.body['status']).to_i
@@ -19,6 +26,8 @@ RSpec.shared_context 'integration context' do
       end
     end
     Thread.new { server.start }
+    init_signal.pop
+
     @server = server
     @port = server[:Port]
   end


### PR DESCRIPTION
Fixes this flaky test:
```
  1) Adapters::UnixSocket integration tests when sending traces through Unix socket client sends traces successfully
     Failure/Error: expect(messages).to have(1).items
       expected 1 items, got 0
     # ./spec/ddtrace/transport/http/adapters/unix_socket_integration_spec.rb:79:in `block (3 levels) in <top (required)>'
```

This happens because we don't wait until `WEBrick::HTTPServer#start` finishes its internal socket initialization before trying to use it.

Unfortunately, `WEBrick::HTTPServer#start` is a method that never returns. We need to use a special callback parameter, `StartCallback`, to inform us that the server is ready.