### PR TITLE
Add at_exit hook for Tracer shutdown

### DIFF
--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -26,6 +26,11 @@ module Datadog
   # Load and extend Contrib by default
   require 'ddtrace/contrib/extensions'
   extend Contrib::Extensions
+
+  # Add shutdown hook:
+  # Ensures the tracer has an opportunity to flush traces
+  # and cleanup before terminating the process.
+  at_exit { Datadog.tracer.shutdown! }
 end
 
 require 'ddtrace/contrib/action_pack/integration'

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -50,8 +50,9 @@ module Datadog
     #   tracer.shutdown!
     #
     def shutdown!
-      return if !@enabled || @writer.worker.nil?
-      @writer.worker.stop
+      return unless @enabled
+
+      @writer.stop unless @writer.nil?
     end
 
     # Return the current active \Context for this traced execution. This method is

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -61,7 +61,7 @@ module Datadog
         interval: @flush_interval
       )
 
-      @worker.start()
+      @worker.start
     end
 
     # stops worker for spans.
@@ -69,6 +69,7 @@ module Datadog
       return if worker.nil?
       @worker.stop
       @worker = nil
+      true
     end
 
     # flush spans to the trace-agent, handles spans only

--- a/spec/ddtrace/contrib/resque/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/resque/instrumentation_spec.rb
@@ -113,6 +113,9 @@ RSpec.describe 'Resque instrumentation' do
           expect(tracer.active_span.parent_id).to eq(0)
         end
 
+        # On completion of the fork, `Datadog.tracer.shutdown!` will be invoked.
+        expect(tracer.writer).to receive(:stop)
+
         tracer.trace('main.process') do
           perform_job(job_class)
         end

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe 'Tracer integration tests' do
     include_context 'agent-based test'
 
     context 'executes only once' do
-      subject(:multiple_shutdown) do
+      subject!(:multiple_shutdown) do
         tracer.trace('my.short.op') do |span|
           span.service = 'my.service'
         end
@@ -222,10 +222,7 @@ RSpec.describe 'Tracer integration tests' do
 
       let(:stats) { tracer.writer.stats }
 
-      it do
-        multiple_shutdown
-        expect(stats[:services_flushed]).to be_nil
-      end
+      it { expect(stats[:services_flushed]).to be_nil }
 
       it_behaves_like 'flushed trace'
     end

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -204,32 +204,70 @@ RSpec.describe 'Tracer integration tests' do
     end
   end
 
-  describe 'shutdown executes only once' do
+  describe 'shutdown' do
     include_context 'agent-based test'
 
-    before(:each) do
-      tracer.trace('my.short.op') do |span|
-        span.service = 'my.service'
+    context 'executes only once' do
+      subject(:multiple_shutdown) do
+        tracer.trace('my.short.op') do |span|
+          span.service = 'my.service'
+        end
+
+        threads = Array.new(10) do
+          Thread.new { tracer.shutdown! }
+        end
+
+        threads.each(&:join)
       end
 
-      mutex = Mutex.new
-      @shutdown_results = []
+      let(:stats) { tracer.writer.stats }
 
-      threads = Array.new(10) do
-        Thread.new { mutex.synchronize { @shutdown_results << tracer.shutdown! } }
+      it do
+        multiple_shutdown
+        expect(stats[:services_flushed]).to be_nil
       end
 
-      threads.each(&:join)
+      it_behaves_like 'flushed trace'
     end
 
-    let(:stats) { tracer.writer.stats }
+    context 'when sent TERM' do
+      subject(:terminated_process) do
+        # Initiate IO pipe
+        pipe
 
-    it do
-      expect(@shutdown_results.count(true)).to eq(1)
-      expect(stats[:services_flushed]).to be_nil
+        # Fork the process
+        fork_id = fork do
+          allow(Datadog.tracer).to receive(:shutdown!).and_wrap_original do |m, *args|
+            m.call(*args).tap { write.write(graceful_signal) }
+          end
+
+          tracer.trace('my.short.op') do |span|
+            span.service = 'my.service'
+          end
+
+          sleep(1)
+        end
+
+        # Give the fork a chance to setup and sleep
+        sleep(0.2)
+
+        # Kill the process
+        write.close
+        Process.kill('TERM', fork_id) rescue nil
+
+        # Read and return any output
+        read.read.tap do
+          Process.waitpid(fork_id)
+        end
+      end
+
+      let(:pipe) { IO.pipe }
+      let(:read) { pipe.first }
+      let(:write) { pipe.last }
+      let(:graceful_signal) { 'graceful' }
+
+      it { expect(terminated_process).to eq(graceful_signal) }
     end
-
-    it_behaves_like 'flushed trace'
   end
 
   describe 'sampling priority metrics' do


### PR DESCRIPTION
#820 was merged into the old release branch.
This PR applies that same changeset to master instead.

Original description:
> When traced Ruby processes are terminated, they may not permit the worker an opportunity to flush existing traces. This pull request adds an `at_exit` hook that calls `shutdown!` on the Tracer, so it can be cleaned up in a more graceful fashion.