### PR TITLE
Only associate spans with runtime metrics if enabled

### DIFF
--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -128,7 +128,9 @@ module Datadog
       end
 
       # Associate root span with runtime metrics
-      runtime_metrics.associate_with_span(trace.first) unless trace.empty?
+      if Datadog.configuration.runtime_metrics_enabled && !trace.empty?
+        runtime_metrics.associate_with_span(trace.first)
+      end
 
       @worker.enqueue_trace(trace)
     end

--- a/spec/ddtrace/contrib/rack/configuration_spec.rb
+++ b/spec/ddtrace/contrib/rack/configuration_spec.rb
@@ -78,7 +78,6 @@ RSpec.describe 'Rack integration configuration' do
         expect(queue_span.start_time.to_i).to eq(queue_time)
         # Queue span gets tagged for runtime metrics because its a local root span.
         # TODO: It probably shouldn't get tagged like this in the future; it's not part of the runtime.
-        expect(queue_span.get_tag(Datadog::Ext::Runtime::TAG_LANG)).to eq('ruby')
 
         expect(rack_span.name).to eq('rack.request')
         expect(rack_span.span_type).to eq('web')
@@ -87,7 +86,6 @@ RSpec.describe 'Rack integration configuration' do
         expect(rack_span.get_tag('http.method')).to eq('GET')
         expect(rack_span.get_tag('http.status_code')).to eq('200')
         expect(rack_span.get_tag('http.url')).to eq('/')
-        expect(rack_span.get_tag(Datadog::Ext::Runtime::TAG_LANG)).to eq('ruby')
         expect(rack_span.status).to eq(0)
 
         expect(queue_span.span_id).to eq(rack_span.parent_id)
@@ -107,7 +105,6 @@ RSpec.describe 'Rack integration configuration' do
         expect(span.get_tag('http.method')).to eq('GET')
         expect(span.get_tag('http.status_code')).to eq('200')
         expect(span.get_tag('http.url')).to eq('/')
-        expect(span.get_tag(Datadog::Ext::Runtime::TAG_LANG)).to eq('ruby')
         expect(span.status).to eq(0)
 
         expect(span.parent_id).to eq(0)

--- a/spec/ddtrace/tracer_integration_spec.rb
+++ b/spec/ddtrace/tracer_integration_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Datadog::Tracer do
       let(:parent_span_name) { 'operation.parent' }
       let(:child_span_name) { 'operation.child' }
 
-      before(:each) do
+      let(:trace) do
         # Create parent span
         tracer.trace(parent_span_name) do |parent_span|
           @parent_span = parent_span
@@ -56,24 +56,55 @@ RSpec.describe Datadog::Tracer do
       let(:parent_span) { spans.last }
       let(:child_span) { spans.first }
 
-      it { expect(spans).to have(2).items }
-      it { expect(parent_span.name).to eq(parent_span_name) }
-      it { expect(parent_span.finished?).to be(true) }
-      it { expect(parent_span.parent_id).to eq(0) }
-      it { expect(sampling_priority_metric(parent_span)).to eq(1) }
-      it { expect(origin_tag(parent_span)).to eq('synthetics') }
-      it { expect(lang_tag(parent_span)).to eq('ruby') }
-      it { expect(child_span.name).to eq(child_span_name) }
-      it { expect(child_span.finished?).to be(true) }
-      it { expect(child_span.trace_id).to eq(parent_span.trace_id) }
-      it { expect(child_span.parent_id).to eq(parent_span.span_id) }
-      it { expect(sampling_priority_metric(child_span)).to eq(1) }
-      it { expect(origin_tag(child_span)).to eq('synthetics') }
-      it { expect(lang_tag(child_span)).to eq('ruby') }
-      # This is expected to be child_span because when propagated, we don't
-      # propagate the root span, only its ID. Therefore the span reference
-      # should be the first span on the other end of the distributed trace.
-      it { expect(@child_root_span).to be child_span }
+      context 'by default' do
+        before { trace }
+
+        it { expect(spans).to have(2).items }
+        it { expect(parent_span.name).to eq(parent_span_name) }
+        it { expect(parent_span.finished?).to be(true) }
+        it { expect(parent_span.parent_id).to eq(0) }
+        it { expect(sampling_priority_metric(parent_span)).to eq(1) }
+        it { expect(origin_tag(parent_span)).to eq('synthetics') }
+        it { expect(child_span.name).to eq(child_span_name) }
+        it { expect(child_span.finished?).to be(true) }
+        it { expect(child_span.trace_id).to eq(parent_span.trace_id) }
+        it { expect(child_span.parent_id).to eq(parent_span.span_id) }
+        it { expect(sampling_priority_metric(child_span)).to eq(1) }
+        it { expect(origin_tag(child_span)).to eq('synthetics') }
+        # This is expected to be child_span because when propagated, we don't
+        # propagate the root span, only its ID. Therefore the span reference
+        # should be the first span on the other end of the distributed trace.
+        it { expect(@child_root_span).to be child_span }
+        it 'does not set runtime metrics language tag' do
+          expect(lang_tag(parent_span)).to be nil
+          expect(lang_tag(child_span)).to be nil
+        end
+      end
+
+      context 'when runtime metrics' do
+        before do
+          allow(Datadog.configuration).to receive(:runtime_metrics_enabled)
+            .and_return(runtime_metrics_enabled)
+
+          trace
+        end
+
+        context 'are enabled' do
+          let(:runtime_metrics_enabled) { true }
+          it 'sets the language tag' do
+            expect(lang_tag(parent_span)).to eq('ruby')
+            expect(lang_tag(child_span)).to eq('ruby')
+          end
+        end
+
+        context 'disabled' do
+          let(:runtime_metrics_enabled) { false }
+          it 'sets the language tag' do
+            expect(lang_tag(parent_span)).to be nil
+            expect(lang_tag(child_span)).to be nil
+          end
+        end
+      end
     end
   end
 

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -177,7 +177,8 @@ class TracerTest < Minitest::Test
     assert_equal('special-service', span.service)
     assert_equal('extra-resource', span.resource)
     assert_equal('my-type', span.span_type)
-    assert_equal(6, span.meta.length)
+    expected_length = Datadog.configuration.runtime_metrics_enabled ? 6 : 5
+    assert_equal(expected_length, span.meta.length)
     assert_equal('test', span.get_tag('env'))
     assert_equal('cool', span.get_tag('temp'))
     assert_equal('value1', span.get_tag('tag1'))


### PR DESCRIPTION
The trace writer associates spans with runtime metrics so the metrics are assigned to the correct services. However, it was not checking if runtime metrics was enabled, meaning it would accumulate service names regardless of whether runtime metrics was on or off.

This pull request changes the writer behavior to respect the runtime metrics enabled flag when associating with traces.