### PR TITLE
Update RuleSampler rate_limit doc string

### DIFF
--- a/lib/ddtrace/sampling/rule_sampler.rb
+++ b/lib/ddtrace/sampling/rule_sampler.rb
@@ -19,7 +19,7 @@ module Datadog
       attr_reader :rules, :rate_limiter, :default_sampler
 
       # @param rules [Array<Rule>] ordered list of rules to be applied to a span
-      # @param rate_limit [Float] number of traces per second, defaults to 100
+      # @param rate_limit [Float] number of traces per second, defaults to no rate limit
       # @param rate_limiter [RateLimiter] limiter applied after rule matching
       # @param default_sample_rate [Float] fallback sample rate when no rules apply to a span,
       #   between +[0,1]+, defaults to +1+


### PR DESCRIPTION
Quick update to the doc string for `RuleSampler` constructor, default `rate_limit` is not `nil` (no rate limit) rather than `100`