### PR TITLE
Set Redis version for Rails >= 5.2 cache

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -305,14 +305,14 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
     appraise 'rails5-postgres-redis' do
       gem 'rails', '~> 5.2.1'
       gem 'pg', '< 1.0', platform: :ruby
-      gem 'redis'
+      gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres-redis-activesupport' do
       gem 'rails', '~> 5.2.1'
       gem 'pg', '< 1.0', platform: :ruby
-      gem 'redis'
+      gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
@@ -463,14 +463,14 @@ elsif Gem::Version.new('2.3.0') <= Gem::Version.new(RUBY_VERSION) \
     appraise 'rails5-postgres-redis' do
       gem 'rails', '~> 5.2.1'
       gem 'pg', '< 1.0', platform: :ruby
-      gem 'redis'
+      gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres-redis-activesupport' do
       gem 'rails', '~> 5.2.1'
       gem 'pg', '< 1.0', platform: :ruby
-      gem 'redis'
+      gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
@@ -536,14 +536,14 @@ elsif Gem::Version.new('2.4.0') <= Gem::Version.new(RUBY_VERSION) \
     appraise 'rails5-postgres-redis' do
       gem 'rails', '~> 5.2.1'
       gem 'pg', '< 1.0', platform: :ruby
-      gem 'redis'
+      gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres-redis-activesupport' do
       gem 'rails', '~> 5.2.1'
       gem 'pg', '< 1.0', platform: :ruby
-      gem 'redis'
+      gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
@@ -609,14 +609,14 @@ elsif Gem::Version.new('2.5.0') <= Gem::Version.new(RUBY_VERSION) \
     appraise 'rails5-postgres-redis' do
       gem 'rails', '~> 5.2.1'
       gem 'pg', '< 1.0', platform: :ruby
-      gem 'redis'
+      gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres-redis-activesupport' do
       gem 'rails', '~> 5.2.1'
       gem 'pg', '< 1.0', platform: :ruby
-      gem 'redis'
+      gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
@@ -643,14 +643,14 @@ elsif Gem::Version.new('2.5.0') <= Gem::Version.new(RUBY_VERSION) \
     appraise 'rails6-postgres-redis' do
       gem 'rails', '~> 6.0.0'
       gem 'pg', '< 1.0', platform: :ruby
-      gem 'redis'
+      gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails6-postgres-redis-activesupport' do
       gem 'rails', '~> 6.0.0'
       gem 'pg', '< 1.0', platform: :ruby
-      gem 'redis'
+      gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
@@ -715,14 +715,14 @@ elsif Gem::Version.new('2.6.0') <= Gem::Version.new(RUBY_VERSION)
     appraise 'rails5-postgres-redis' do
       gem 'rails', '~> 5.2.1'
       gem 'pg', '< 1.0', platform: :ruby
-      gem 'redis'
+      gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres-redis-activesupport' do
       gem 'rails', '~> 5.2.1'
       gem 'pg', '< 1.0', platform: :ruby
-      gem 'redis'
+      gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
@@ -749,14 +749,14 @@ elsif Gem::Version.new('2.6.0') <= Gem::Version.new(RUBY_VERSION)
     appraise 'rails6-postgres-redis' do
       gem 'rails', '~> 6.0.0'
       gem 'pg', '< 1.0', platform: :ruby
-      gem 'redis'
+      gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails6-postgres-redis-activesupport' do
       gem 'rails', '~> 6.0.0'
       gem 'pg', '< 1.0', platform: :ruby
-      gem 'redis'
+      gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 


### PR DESCRIPTION
We are currently not requiring the minimum version of `redis` required by [Rails >= 5.2](https://github.com/rails/rails/blob/v5.2.0/activesupport/lib/active_support/cache/redis_cache_store.rb#L8) to use the default `redis_cache_store` implementation.

This allows `bundler` to install `redis ~> 3` in CI sometimes, causing random test breakage.

This dependency is not a transitive requirement for Rails because using `redis` for caching is not mandatory.