### PR TITLE
Add _dd.agent_psr tag to PrioritySampler

### DIFF
--- a/lib/ddtrace/sampler.rb
+++ b/lib/ddtrace/sampler.rb
@@ -194,7 +194,6 @@ module Datadog
     extend Forwardable
 
     SAMPLE_RATE_METRIC_KEY = '_sample_rate'.freeze
-    AGENT_RATE_METRIC_KEY = '_dd.agent_psr'.freeze
 
     def initialize(opts = {})
       @pre_sampler = opts[:base_sampler] || AllSampler.new
@@ -248,15 +247,7 @@ module Datadog
 
     def priority_sample!(span)
       preserving_sampling(span) do
-        @priority_sampler.sample!(span).tap do
-          # We want to make sure the span is tagged with the agent-derived
-          # service rate. Retrieve this from the rate by service sampler.
-          # Only do this if it was set by a RateByServiceSampler.
-          if @priority_sampler.is_a?(RateByServiceSampler)
-            agent_rate = @priority_sampler.sample_rate(span)
-            span.set_metric(AGENT_RATE_METRIC_KEY, agent_rate)
-          end
-        end
+        @priority_sampler.sample!(span)
       end
     end
 

--- a/lib/ddtrace/sampling/rule_sampler.rb
+++ b/lib/ddtrace/sampling/rule_sampler.rb
@@ -16,6 +16,8 @@ module Datadog
     class RuleSampler
       extend Forwardable
 
+      AGENT_RATE_METRIC_KEY = '_dd.agent_psr'.freeze
+
       attr_reader :rules, :rate_limiter, :default_sampler
 
       # @param rules [Array<Rule>] ordered list of rules to be applied to a span
@@ -68,7 +70,16 @@ module Datadog
       end
 
       def sample!(span)
-        sampled = sample_span(span) { |s| @default_sampler.sample!(s) }
+        sampled = sample_span(span) do |s|
+          @default_sampler.sample!(s).tap do
+            # We want to make sure the span is tagged with the agent-derived
+            # service rate. Retrieve this from the rate by service sampler.
+            # Only do this if it was set by a RateByServiceSampler.
+            if @default_sampler.is_a?(RateByServiceSampler)
+              s.set_metric(AGENT_RATE_METRIC_KEY, @default_sampler.sample_rate(span))
+            end
+          end
+        end
 
         sampled.tap do
           span.sampled = sampled

--- a/spec/ddtrace/sampler_spec.rb
+++ b/spec/ddtrace/sampler_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe Datadog::PrioritySampler do
         end
 
         context 'and USER_KEEP sampling priority' do
-          before(:each) { context.sampling_priority = Datadog::Ext::Priority::USER_KEEP }
+          before { context.sampling_priority = Datadog::Ext::Priority::USER_KEEP }
 
           it do
             expect(sample).to be true
@@ -272,7 +272,7 @@ RSpec.describe Datadog::PrioritySampler do
         end
 
         context 'and AUTO_KEEP sampling priority' do
-          before(:each) { context.sampling_priority = Datadog::Ext::Priority::AUTO_KEEP }
+          before { context.sampling_priority = Datadog::Ext::Priority::AUTO_KEEP }
 
           it do
             expect(sample).to be true
@@ -283,7 +283,7 @@ RSpec.describe Datadog::PrioritySampler do
         end
 
         context 'and AUTO_REJECT sampling priority' do
-          before(:each) { context.sampling_priority = Datadog::Ext::Priority::AUTO_REJECT }
+          before { context.sampling_priority = Datadog::Ext::Priority::AUTO_REJECT }
 
           it do
             expect(sample).to be true
@@ -294,7 +294,7 @@ RSpec.describe Datadog::PrioritySampler do
         end
 
         context 'and USER_REJECT sampling priority' do
-          before(:each) { context.sampling_priority = Datadog::Ext::Priority::USER_REJECT }
+          before { context.sampling_priority = Datadog::Ext::Priority::USER_REJECT }
 
           it do
             expect(sample).to be true
@@ -313,9 +313,54 @@ RSpec.describe Datadog::PrioritySampler do
       end
     end
 
+    shared_examples_for 'sampling with agent priority sampling rate tag' do
+      let(:span) { Datadog::Span.new(nil, '', trace_id: 1, context: context) }
+      let(:context) { Datadog::Context.new }
+      let(:service_sample_rate) { rand }
+
+      before do
+        if post_sampler.is_a?(Datadog::RateByServiceSampler)
+          allow(post_sampler).to receive(:sample_rate)
+            .with(span)
+            .and_return(service_sample_rate)
+        else
+          expect(post_sampler).to_not receive(:sample_rate)
+            .with(span)
+        end
+
+        expect(sample).to be true
+      end
+
+      it 'sets the tag if post sampler is a RateByServiceSampler' do
+        if post_sampler.is_a?(Datadog::RateByServiceSampler)
+          expect(span.get_metric(described_class::AGENT_RATE_METRIC_KEY)).to eq(service_sample_rate)
+        else
+          expect(span.get_metric(described_class::AGENT_RATE_METRIC_KEY)).to be nil
+        end
+      end
+    end
+
     context 'when configured with defaults' do
       let(:sampler) { described_class.new }
       it_behaves_like 'priority sampling without scaling'
+
+      describe 'agent priority sampling rate tag' do
+        let(:span) { Datadog::Span.new(nil, '', trace_id: 1, context: context) }
+        let(:context) { Datadog::Context.new }
+        let(:service_sample_rate) { rand }
+
+        before do
+          allow_any_instance_of(Datadog::RateByServiceSampler).to receive(:sample_rate)
+            .with(span)
+            .and_return(service_sample_rate)
+
+          expect(sample).to be true
+        end
+
+        it 'is set from the RateByService sampler' do
+          expect(span.get_metric(described_class::AGENT_RATE_METRIC_KEY)).to eq(service_sample_rate)
+        end
+      end
     end
 
     context 'when configured with a pre-sampler RateSampler < 1.0' do
@@ -334,6 +379,8 @@ RSpec.describe Datadog::PrioritySampler do
           # It must set this tag; otherwise it won't scale up metrics properly.
           let(:sample_rate_tag_value) { sample_rate }
         end
+
+        it_behaves_like 'sampling with agent priority sampling rate tag'
       end
     end
 
@@ -347,6 +394,7 @@ RSpec.describe Datadog::PrioritySampler do
         let(:post_sampler) { Datadog::RateSampler.new(1.0) }
 
         it_behaves_like 'priority sampling without scaling'
+        it_behaves_like 'sampling with agent priority sampling rate tag'
       end
     end
 
@@ -355,6 +403,7 @@ RSpec.describe Datadog::PrioritySampler do
       let(:sample_rate) { 0.5 }
 
       it_behaves_like 'priority sampling without scaling'
+      it_behaves_like 'sampling with agent priority sampling rate tag'
     end
   end
 end

--- a/spec/ddtrace/sampler_spec.rb
+++ b/spec/ddtrace/sampler_spec.rb
@@ -13,8 +13,8 @@ end
 RSpec.describe Datadog::AllSampler do
   subject(:sampler) { described_class.new }
 
-  before(:each) { Datadog::Logger.log.level = Logger::FATAL }
-  after(:each) { Datadog::Logger.log.level = Logger::WARN }
+  before { Datadog::Logger.log.level = Logger::FATAL }
+  after { Datadog::Logger.log.level = Logger::WARN }
 
   describe '#sample!' do
     let(:spans) do
@@ -39,8 +39,8 @@ end
 RSpec.describe Datadog::RateSampler do
   subject(:sampler) { described_class.new(sample_rate) }
 
-  before(:each) { Datadog::Logger.log.level = Logger::FATAL }
-  after(:each) { Datadog::Logger.log.level = Logger::WARN }
+  before { Datadog::Logger.log.level = Logger::FATAL }
+  after { Datadog::Logger.log.level = Logger::WARN }
 
   describe '#initialize' do
     context 'given a sample rate' do
@@ -231,8 +231,8 @@ RSpec.describe Datadog::PrioritySampler do
 
   let(:sample_rate_tag_value) { nil }
 
-  before(:each) { Datadog::Logger.log.level = Logger::FATAL }
-  after(:each) { Datadog::Logger.log.level = Logger::WARN }
+  before { Datadog::Logger.log.level = Logger::FATAL }
+  after { Datadog::Logger.log.level = Logger::WARN }
 
   describe '#sample!' do
     subject(:sample) { sampler.sample!(span) }
@@ -313,54 +313,9 @@ RSpec.describe Datadog::PrioritySampler do
       end
     end
 
-    shared_examples_for 'sampling with agent priority sampling rate tag' do
-      let(:span) { Datadog::Span.new(nil, '', trace_id: 1, context: context) }
-      let(:context) { Datadog::Context.new }
-      let(:service_sample_rate) { rand }
-
-      before do
-        if post_sampler.is_a?(Datadog::RateByServiceSampler)
-          allow(post_sampler).to receive(:sample_rate)
-            .with(span)
-            .and_return(service_sample_rate)
-        else
-          expect(post_sampler).to_not receive(:sample_rate)
-            .with(span)
-        end
-
-        expect(sample).to be true
-      end
-
-      it 'sets the tag if post sampler is a RateByServiceSampler' do
-        if post_sampler.is_a?(Datadog::RateByServiceSampler)
-          expect(span.get_metric(described_class::AGENT_RATE_METRIC_KEY)).to eq(service_sample_rate)
-        else
-          expect(span.get_metric(described_class::AGENT_RATE_METRIC_KEY)).to be nil
-        end
-      end
-    end
-
     context 'when configured with defaults' do
       let(:sampler) { described_class.new }
       it_behaves_like 'priority sampling without scaling'
-
-      describe 'agent priority sampling rate tag' do
-        let(:span) { Datadog::Span.new(nil, '', trace_id: 1, context: context) }
-        let(:context) { Datadog::Context.new }
-        let(:service_sample_rate) { rand }
-
-        before do
-          allow_any_instance_of(Datadog::RateByServiceSampler).to receive(:sample_rate)
-            .with(span)
-            .and_return(service_sample_rate)
-
-          expect(sample).to be true
-        end
-
-        it 'is set from the RateByService sampler' do
-          expect(span.get_metric(described_class::AGENT_RATE_METRIC_KEY)).to eq(service_sample_rate)
-        end
-      end
     end
 
     context 'when configured with a pre-sampler RateSampler < 1.0' do
@@ -379,8 +334,6 @@ RSpec.describe Datadog::PrioritySampler do
           # It must set this tag; otherwise it won't scale up metrics properly.
           let(:sample_rate_tag_value) { sample_rate }
         end
-
-        it_behaves_like 'sampling with agent priority sampling rate tag'
       end
     end
 
@@ -394,7 +347,6 @@ RSpec.describe Datadog::PrioritySampler do
         let(:post_sampler) { Datadog::RateSampler.new(1.0) }
 
         it_behaves_like 'priority sampling without scaling'
-        it_behaves_like 'sampling with agent priority sampling rate tag'
       end
     end
 
@@ -403,7 +355,6 @@ RSpec.describe Datadog::PrioritySampler do
       let(:sample_rate) { 0.5 }
 
       it_behaves_like 'priority sampling without scaling'
-      it_behaves_like 'sampling with agent priority sampling rate tag'
     end
   end
 end

--- a/spec/ddtrace/sampling/rule_sampler_spec.rb
+++ b/spec/ddtrace/sampling/rule_sampler_spec.rb
@@ -142,6 +142,19 @@ RSpec.describe Datadog::Sampling::RuleSampler do
         expect(span.get_metric(Datadog::Ext::Sampling::RULE_SAMPLE_RATE)).to be_nil
         expect(span.get_metric(Datadog::Ext::Sampling::RATE_LIMITER_RATE)).to be_nil
       end
+
+      context 'when the default sampler is a RateByServiceSampler' do
+        let(:default_sampler) { Datadog::RateByServiceSampler.new }
+        let(:sample_rate) { rand }
+
+        it 'sets the agent rate metric' do
+          expect(default_sampler).to receive(:sample_rate)
+            .with(span)
+            .and_return(sample_rate)
+          sample
+          expect(span.get_metric(described_class::AGENT_RATE_METRIC_KEY)).to eq(sample_rate)
+        end
+      end
     end
   end
 

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -179,7 +179,9 @@ class TracerTest < Minitest::Test
     assert_equal('my-type', span.span_type)
     # 2 tags from tracer, 2 for span, metrics for PID, and sampling priority,
     # then optionally 1 from runtime metrics if enabled.
-    expected_length = Datadog.configuration.runtime_metrics_enabled ? 7 : 6
+    expected_length = 7 # 4 tags, 3 metrics
+    expected_length += 1 if Datadog.configuration.runtime_metrics_enabled
+
     assert_equal(expected_length, span.meta.length + span.metrics.length)
     assert_equal('test', span.get_tag('env'))
     assert_equal('cool', span.get_tag('temp'))


### PR DESCRIPTION
We want to tag the priority sampled spans with the agent's rate limit. This pull request adds that tag.