### PR TITLE
Add env vars for RuleSampler

### DIFF
--- a/lib/ddtrace/configuration/base.rb
+++ b/lib/ddtrace/configuration/base.rb
@@ -23,7 +23,8 @@ module Datadog
           settings_class = new_settings_class(&block)
 
           option(name) do |o|
-            o.default settings_class.new
+            o.default -> { settings_class.new }
+            o.lazy
             o.resetter do |value|
               value.reset! if value.respond_to?(:reset!)
               value

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -3,6 +3,7 @@ require 'ddtrace/configuration/base'
 require 'ddtrace/ext/analytics'
 require 'ddtrace/ext/distributed'
 require 'ddtrace/ext/runtime'
+require 'ddtrace/ext/sampling'
 
 require 'ddtrace/tracer'
 require 'ddtrace/metrics'
@@ -52,6 +53,18 @@ module Datadog
                         [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG])
           end
 
+          o.lazy
+        end
+      end
+
+      settings :sampling do
+        option :default_rate do |o|
+          o.default { env_to_float(Ext::Sampling::ENV_SAMPLE_RATE, nil) }
+          o.lazy
+        end
+
+        option :rate_limit do |o|
+          o.default { env_to_float(Ext::Sampling::ENV_RATE_LIMIT, 100) }
           o.lazy
         end
       end

--- a/lib/ddtrace/ext/sampling.rb
+++ b/lib/ddtrace/ext/sampling.rb
@@ -1,6 +1,9 @@
 module Datadog
   module Ext
     module Sampling
+      ENV_SAMPLE_RATE = 'DD_TRACE_SAMPLE_RATE'.freeze
+      ENV_RATE_LIMIT = 'DD_TRACE_RATE_LIMIT'.freeze
+
       # If rule sampling is applied to a span, set this metric the sample rate configured for that rule.
       # This should be done regardless of sampling outcome.
       RULE_SAMPLE_RATE = '_dd.rule_psr'.freeze

--- a/lib/ddtrace/sampling/rule_sampler.rb
+++ b/lib/ddtrace/sampling/rule_sampler.rb
@@ -18,8 +18,6 @@ module Datadog
 
       attr_reader :rules, :rate_limiter, :default_sampler
 
-      DEFAULT_RATE_LIMIT = 100
-
       # @param rules [Array<Rule>] ordered list of rules to be applied to a span
       # @param rate_limit [Float] number of traces per second, defaults to +100+
       # @param rate_limiter [RateLimiter] limiter applied after rule matching
@@ -27,9 +25,9 @@ module Datadog
       #   between +[0,1]+, defaults to +1+
       # @param default_sampler [Sample] fallback strategy when no rules apply to a span
       def initialize(rules = [],
-                     rate_limit: DEFAULT_RATE_LIMIT,
+                     rate_limit: Datadog.configuration.sampling.rate_limit,
                      rate_limiter: nil,
-                     default_sample_rate: nil,
+                     default_sample_rate: Datadog.configuration.sampling.default_rate,
                      default_sampler: nil)
 
         @rules = rules

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -6,6 +6,44 @@ require 'ddtrace/configuration/settings'
 RSpec.describe Datadog::Configuration::Settings do
   subject(:settings) { described_class.new }
 
+  describe '#sampling' do
+    describe '#rate_limit' do
+      subject(:rate_limit) { settings.sampling.rate_limit }
+
+      context 'default' do
+        it { is_expected.to be 100 }
+      end
+
+      context 'when ENV is provided' do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::Sampling::ENV_RATE_LIMIT => '20.0') do
+            example.run
+          end
+        end
+
+        it { is_expected.to eq(20.0) }
+      end
+    end
+
+    describe '#default_rate' do
+      subject(:default_rate) { settings.sampling.default_rate }
+
+      context 'default' do
+        it { is_expected.to be nil }
+      end
+
+      context 'when ENV is provided' do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::Sampling::ENV_SAMPLE_RATE => '0.5') do
+            example.run
+          end
+        end
+
+        it { is_expected.to eq(0.5) }
+      end
+    end
+  end
+
   describe '#tracer' do
     let(:tracer) { Datadog::Tracer.new }
     let(:debug_state) { Datadog::Logger.debug_logging }

--- a/spec/ddtrace/sampling/rule_sampler_spec.rb
+++ b/spec/ddtrace/sampling/rule_sampler_spec.rb
@@ -23,25 +23,43 @@ RSpec.describe Datadog::Sampling::RuleSampler do
   context '#initialize' do
     subject(:rule_sampler) { described_class.new(rules) }
 
-    it { expect(subject.rate_limiter).to be_a(Datadog::Sampling::TokenBucket) }
-    it { expect(subject.default_sampler).to be_a(Datadog::AllSampler) }
+    it { expect(rule_sampler.rate_limiter).to be_a(Datadog::Sampling::TokenBucket) }
+    it { expect(rule_sampler.default_sampler).to be_a(Datadog::AllSampler) }
+
+    context 'with rate_limit ENV' do
+      before do
+        allow(Datadog.configuration.sampling).to receive(:rate_limit)
+          .and_return(20.0)
+      end
+
+      it { expect(rule_sampler.rate_limiter).to be_a(Datadog::Sampling::TokenBucket) }
+    end
+
+    context 'with default_sample_rate ENV' do
+      before do
+        allow(Datadog.configuration.sampling).to receive(:default_rate)
+          .and_return(0.5)
+      end
+
+      it { expect(rule_sampler.default_sampler).to be_a(Datadog::RateSampler) }
+    end
 
     context 'with rate_limit' do
       subject(:rule_sampler) { described_class.new(rules, rate_limit: 1.0) }
 
-      it { expect(subject.rate_limiter).to be_a(Datadog::Sampling::TokenBucket) }
+      it { expect(rule_sampler.rate_limiter).to be_a(Datadog::Sampling::TokenBucket) }
     end
 
     context 'with nil rate_limit' do
       subject(:rule_sampler) { described_class.new(rules, rate_limit: nil) }
 
-      it { expect(subject.rate_limiter).to be_a(Datadog::Sampling::UnlimitedLimiter) }
+      it { expect(rule_sampler.rate_limiter).to be_a(Datadog::Sampling::UnlimitedLimiter) }
     end
 
     context 'with default_sample_rate' do
       subject(:rule_sampler) { described_class.new(rules, default_sample_rate: 1.0) }
 
-      it { expect(subject.default_sampler).to be_a(Datadog::RateSampler) }
+      it { expect(rule_sampler.default_sampler).to be_a(Datadog::RateSampler) }
     end
   end
 


### PR DESCRIPTION
Adds env vars to configure RuleSampler defaults with:

 - `DD_TRACE_SAMPLE_RATE` --> `Datadog.configuration.sampling.default_rate`
 - `DD_TRACE_RATE_LIMIT` --> `Datadog.configuration.sampling.rate_limit`