### PR TITLE
Skip Rails version incompatible with Ruby 2.2

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -291,33 +291,33 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
     end
 
     appraise 'rails5-mysql2' do
-      gem 'rails', '~> 5.2.1'
+      gem 'rails', '~> 5.2.1', '!= 5.2.4.1'
       gem 'mysql2', '< 1', platform: :ruby
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres' do
-      gem 'rails', '~> 5.2.1'
+      gem 'rails', '~> 5.2.1', '!= 5.2.4.1'
       gem 'pg', '< 1.0', platform: :ruby
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres-redis' do
-      gem 'rails', '~> 5.2.1'
+      gem 'rails', '~> 5.2.1', '!= 5.2.4.1'
       gem 'pg', '< 1.0', platform: :ruby
       gem 'redis'
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres-redis-activesupport' do
-      gem 'rails', '~> 5.2.1'
+      gem 'rails', '~> 5.2.1', '!= 5.2.4.1'
       gem 'pg', '< 1.0', platform: :ruby
       gem 'redis'
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres-sidekiq' do
-      gem 'rails', '~> 5.2.1'
+      gem 'rails', '~> 5.2.1', '!= 5.2.4.1'
       gem 'pg', '< 1.0', platform: :ruby
       gem 'sidekiq'
       gem 'activejob'


### PR DESCRIPTION
The latest version of Rails 5.2, Rails 5.2.4.1, contains a bug when running uner Ruby 2.2: it is using syntax that is only available for Ruby 2.3 and above: https://github.com/rails/rails/commit/92f660b910c64176efd04d3b60af806fefe5827c#diff-0dd82841c763273551965fc0ea292a1bR96

This PR prevents us from installing this patch release of Rails for Ruby 2.2, in order to unblock our CI pipeline.