### PR TITLE
Support for Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,6 +295,10 @@ job_configuration:
     <<: *filters_all_branches_and_tags
     ruby_version: '2.6'
     image: marcotc/docker-library:ddtrace_rb_2_6_4
+  - &config-2_7
+    <<: *filters_all_branches_and_tags
+    ruby_version: '2.7'
+    image: marcotc/docker-library:ddtrace_rb_2_7_0
 
 workflows:
   version: 2
@@ -397,6 +401,19 @@ workflows:
           name: test-2.6
           requires:
             - build-2.6
+      - orb/checkout:
+          <<: *config-2_7
+          name: checkout-2.7
+      - orb/build:
+          <<: *config-2_7
+          name: build-2.7
+          requires:
+            - checkout-2.7
+      - orb/test:
+          <<: *config-2_7
+          name: test-2.7
+          requires:
+            - build-2.7
       - "deploy prerelease Gem":
           <<: *filters_all_branches_and_tags
           requires:
@@ -407,6 +424,7 @@ workflows:
             - test-2.4
             - test-2.5
             - test-2.6
+            - test-2.7
       - "deploy release":
           <<: *filters_only_release_tags
           requires:
@@ -417,3 +435,4 @@ workflows:
             - test-2.4
             - test-2.5
             - test-2.6
+            - test-2.7

--- a/.circleci/images/primary/Dockerfile-2.7.0
+++ b/.circleci/images/primary/Dockerfile-2.7.0
@@ -1,0 +1,73 @@
+# Current version: https://github.com/docker-library/ruby/blob/defb10adcd6dd2178be3cd9c884fd035b52d42fb/2.7/buster/Dockerfile
+FROM ruby:2.7.0
+
+# Make apt non-interactive
+RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
+  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install required packages
+RUN set -ex; \
+        apt-get update; \
+        mkdir -p /usr/share/man/man1; \
+        apt-get install -y --no-install-recommends \
+            git mercurial xvfb \
+            locales sudo openssh-client ca-certificates tar gzip parallel \
+            net-tools netcat unzip zip bzip2 gnupg curl wget \
+            tzdata rsync vim; \
+        rm -rf /var/lib/apt/lists/*;
+
+# Set timezone to UTC by default
+RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
+
+# Set language
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+
+# Install jq
+RUN JQ_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/jq-latest" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/jq $JQ_URL \
+  && chmod +x /usr/bin/jq \
+  && jq --version
+
+# Install Docker
+RUN set -ex \
+  && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/x86_64/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
+  && DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/${DOCKER_VERSION}" \
+  && echo Docker URL: $DOCKER_URL \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
+  && ls -lha /tmp/docker.tgz \
+  && tar -xz -C /tmp -f /tmp/docker.tgz \
+  && mv /tmp/docker/* /usr/bin \
+  && rm -rf /tmp/docker /tmp/docker.tgz \
+  && which docker \
+  && (docker version || true)
+
+# Install Docker Compose
+RUN COMPOSE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/docker-compose-latest" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
+  && chmod +x /usr/bin/docker-compose \
+  && docker-compose version
+
+# Install Dockerize
+RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/dockerize-latest.tar.gz" \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/dockerize-linux-amd64.tar.gz $DOCKERIZE_URL \
+  && tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64.tar.gz \
+  && rm -rf /tmp/dockerize-linux-amd64.tar.gz \
+  && dockerize --version
+
+# Install RubyGems
+# RUN gem update --system # Upgrading disabled until https://github.com/thoughtbot/appraisal/issues/162 is fixed
+RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
+
+# Upgrade RubyGems and Bundler # Upgrading disabled until https://github.com/thoughtbot/appraisal/issues/162 is fixed
+# RUN gem update --system
+# RUN gem install bundler
+ENV BUNDLE_SILENCE_ROOT_WARNING 1
+
+RUN mkdir /app
+WORKDIR /app
+
+CMD ["/bin/sh"]

--- a/Appraisals
+++ b/Appraisals
@@ -698,7 +698,8 @@ elsif Gem::Version.new('2.5.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'typhoeus'
     end
   end
-elsif Gem::Version.new('2.6.0') <= Gem::Version.new(RUBY_VERSION)
+elsif Gem::Version.new('2.6.0') <= Gem::Version.new(RUBY_VERSION) \
+      && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
   if RUBY_PLATFORM != 'java'
     appraise 'rails5-mysql2' do
       gem 'rails', '~> 5.2.1'
@@ -804,5 +805,113 @@ elsif Gem::Version.new('2.6.0') <= Gem::Version.new(RUBY_VERSION)
       gem 'typhoeus'
     end
   end
-end
+elsif Gem::Version.new('2.7.0') <= Gem::Version.new(RUBY_VERSION)
+  if RUBY_PLATFORM != 'java'
+    appraise 'rails5-mysql2' do
+      gem 'rails', '~> 5.2.1'
+      gem 'mysql2', '< 0.5', platform: :ruby
+      gem 'sprockets', '< 4'
+    end
 
+    appraise 'rails5-postgres' do
+      gem 'rails', '~> 5.2.1'
+      gem 'pg', '< 1.0', platform: :ruby
+      gem 'sprockets', '< 4'
+    end
+
+    appraise 'rails5-postgres-redis' do
+      gem 'rails', '~> 5.2.1'
+      gem 'pg', '< 1.0', platform: :ruby
+      gem 'redis-rails'
+      gem 'redis'
+      gem 'sprockets', '< 4'
+    end
+
+    appraise 'rails5-postgres-redis-activesupport' do
+      gem 'rails', '~> 5.2.1'
+      gem 'pg', '< 1.0', platform: :ruby
+      gem 'redis-rails'
+      gem 'redis'
+      gem 'sprockets', '< 4'
+    end
+
+    appraise 'rails5-postgres-sidekiq' do
+      gem 'rails', '~> 5.2.1'
+      gem 'pg', '< 1.0', platform: :ruby
+      gem 'sidekiq'
+      gem 'activejob'
+      gem 'sprockets', '< 4'
+    end
+
+    appraise 'rails6-mysql2' do
+      gem 'rails', '~> 6.0.0'
+      gem 'mysql2', '< 0.6', platform: :ruby
+      gem 'sprockets', '< 4'
+    end
+
+    appraise 'rails6-postgres' do
+      gem 'rails', '~> 6.0.0'
+      gem 'pg', '< 1.0', platform: :ruby
+      gem 'sprockets', '< 4'
+    end
+
+    appraise 'rails6-postgres-redis' do
+      gem 'rails', '~> 6.0.0'
+      gem 'pg', '< 1.0', platform: :ruby
+      gem 'redis-rails'
+      gem 'redis'
+      gem 'sprockets', '< 4'
+    end
+
+    appraise 'rails6-postgres-redis-activesupport' do
+      gem 'rails', '~> 6.0.0'
+      gem 'pg', '< 1.0', platform: :ruby
+      gem 'redis-rails'
+      gem 'redis'
+      gem 'sprockets', '< 4'
+    end
+
+    appraise 'rails6-postgres-sidekiq' do
+      gem 'rails', '~> 6.0.0'
+      gem 'pg', '< 1.0', platform: :ruby
+      gem 'sidekiq'
+      gem 'activejob'
+      gem 'sprockets', '< 4'
+    end
+
+    appraise 'contrib' do
+      gem 'actionpack'
+      gem 'actionview'
+      gem 'active_model_serializers', '>= 0.10.0'
+      gem 'activerecord'
+      gem 'aws-sdk'
+      gem 'concurrent-ruby'
+      gem 'dalli'
+      gem 'delayed_job'
+      gem 'delayed_job_active_record'
+      gem 'elasticsearch-transport'
+      gem 'ethon'
+      gem 'excon'
+      gem 'grape'
+      gem 'graphql'
+      # gem 'grpc' # Pending 2.7 support: https://github.com/grpc/grpc/issues/21514
+      gem 'hiredis'
+      gem 'mongo', '>= 2.8.0'
+      gem 'mysql2', '< 0.5', platform: :ruby
+      gem 'racecar', '>= 0.3.5'
+      gem 'rack'
+      gem 'rack-test'
+      gem 'rake', '>= 12.3'
+      gem 'redis', '< 4.0'
+      gem 'rest-client'
+      gem 'resque', '< 2.0'
+      gem 'sequel'
+      gem 'shoryuken'
+      gem 'sidekiq'
+      gem 'sinatra'
+      gem 'sqlite3', '~> 1.4.1'
+      gem 'sucker_punch'
+      gem 'typhoeus'
+    end
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -527,7 +527,8 @@ task :ci do
       sh 'bundle exec appraisal rails6-mysql2 rake spec:rails'
       sh 'bundle exec appraisal rails6-postgres rake spec:rails'
     end
-  elsif Gem::Version.new('2.6.0') <= Gem::Version.new(RUBY_VERSION)
+  elsif Gem::Version.new('2.6.0') <= Gem::Version.new(RUBY_VERSION) \
+      && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
     # Main library
     sh 'bundle exec rake test:main'
     sh 'bundle exec rake spec:main'
@@ -588,6 +589,68 @@ task :ci do
       sh 'bundle exec appraisal rails5-mysql2 rake spec:rails'
       sh 'bundle exec appraisal rails5-postgres rake spec:rails'
       sh 'bundle exec appraisal rails6-mysql2 rake spec:action_cable'
+      sh 'bundle exec appraisal rails6-mysql2 rake spec:rails'
+      sh 'bundle exec appraisal rails6-postgres rake spec:rails'
+    end
+  elsif Gem::Version.new('2.7.0') <= Gem::Version.new(RUBY_VERSION)
+    # Main library
+    sh 'bundle exec rake test:main'
+    sh 'bundle exec rake spec:main'
+    sh 'bundle exec rake spec:contrib'
+    sh 'bundle exec rake spec:opentracer'
+
+    if RUBY_PLATFORM != 'java'
+      # Benchmarks
+      sh 'bundle exec rake benchmark'
+      # Contrib minitests
+      sh 'bundle exec appraisal contrib rake test:grape'
+      sh 'bundle exec appraisal contrib rake test:sidekiq'
+      sh 'bundle exec appraisal contrib rake test:sucker_punch'
+      # Contrib specs
+      sh 'bundle exec appraisal contrib rake spec:action_pack'
+      sh 'bundle exec appraisal contrib rake spec:action_view'
+      sh 'bundle exec appraisal contrib rake spec:active_model_serializers'
+      sh 'bundle exec appraisal contrib rake spec:active_record'
+      sh 'bundle exec appraisal contrib rake spec:active_support'
+      sh 'bundle exec appraisal contrib rake spec:aws'
+      sh 'bundle exec appraisal contrib rake spec:concurrent_ruby'
+      sh 'bundle exec appraisal contrib rake spec:dalli'
+      sh 'bundle exec appraisal contrib rake spec:delayed_job'
+      sh 'bundle exec appraisal contrib rake spec:elasticsearch'
+      sh 'bundle exec appraisal contrib rake spec:excon'
+      sh 'bundle exec appraisal contrib rake spec:faraday'
+      sh 'bundle exec appraisal contrib rake spec:graphql'
+      # sh 'bundle exec appraisal contrib rake spec:grpc' # Pending 2.7 support: https://github.com/grpc/grpc/issues/21514
+      sh 'bundle exec appraisal contrib rake spec:http'
+      sh 'bundle exec appraisal contrib rake spec:mongodb'
+      sh 'bundle exec appraisal contrib rake spec:mysql2'
+      sh 'bundle exec appraisal contrib rake spec:racecar'
+      sh 'bundle exec appraisal contrib rake spec:rack'
+      sh 'bundle exec appraisal contrib rake spec:rake'
+      sh 'bundle exec appraisal contrib rake spec:redis'
+      sh 'bundle exec appraisal contrib rake spec:resque'
+      sh 'bundle exec appraisal contrib rake spec:rest_client'
+      sh 'bundle exec appraisal contrib rake spec:sequel'
+      sh 'bundle exec appraisal contrib rake spec:shoryuken'
+      sh 'bundle exec appraisal contrib rake spec:sinatra'
+      sh 'bundle exec appraisal contrib rake spec:ethon'
+      # Rails minitests
+      # We only test Rails 5+ because older versions require Bundler < 2.0
+      sh 'bundle exec appraisal rails5-mysql2 rake test:rails'
+      sh 'bundle exec appraisal rails5-postgres rake test:rails'
+      sh 'bundle exec appraisal rails5-postgres-redis rake spec:railsredis'
+      sh 'bundle exec appraisal rails5-postgres-redis-activesupport rake spec:railsredis'
+      sh 'bundle exec appraisal rails5-postgres-sidekiq rake spec:railsactivejob'
+      sh 'bundle exec appraisal rails5-postgres rake spec:railsdisableenv'
+      sh 'bundle exec appraisal rails6-mysql2 rake test:rails'
+      sh 'bundle exec appraisal rails6-postgres rake test:rails'
+      sh 'bundle exec appraisal rails6-postgres-redis rake spec:railsredis'
+      sh 'bundle exec appraisal rails6-postgres-redis-activesupport rake spec:railsredis'
+      sh 'bundle exec appraisal rails6-postgres-sidekiq rake spec:railsactivejob'
+      sh 'bundle exec appraisal rails6-postgres rake spec:railsdisableenv'
+      # Rails specs
+      sh 'bundle exec appraisal rails5-mysql2 rake spec:rails'
+      sh 'bundle exec appraisal rails5-postgres rake spec:rails'
       sh 'bundle exec appraisal rails6-mysql2 rake spec:rails'
       sh 'bundle exec appraisal rails6-postgres rake spec:rails'
     end

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.1'
   spec.add_development_dependency 'minitest', '= 5.10.1'
   spec.add_development_dependency 'appraisal', '~> 2.2'
+  spec.add_development_dependency 'bundler', '<= 2.1.2' # Remove when https://github.com/thoughtbot/appraisal/issues/162 is fixed
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'webmock', '~> 2.0'
   spec.add_development_dependency 'builder'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -196,6 +196,34 @@ services:
       - .:/app
       - bundle-2.6:/usr/local/bundle
       - gemfiles-2.6:/app/gemfiles
+  tracer-2.7:
+    image: marcotc/docker-library:ddtrace_rb_2_7_0
+    command: /bin/bash
+    depends_on:
+      - ddagent
+      - elasticsearch
+      - memcached
+      - mongodb
+      - mysql
+      - postgres
+      - redis
+    env_file: ./.env
+    environment:
+      - BUNDLE_GEMFILE=/app/Gemfile
+      - DD_AGENT_HOST=ddagent
+      - TEST_DATADOG_INTEGRATION=1
+      - TEST_ELASTICSEARCH_HOST=elasticsearch
+      - TEST_MEMCACHED_HOST=memcached
+      - TEST_MONGODB_HOST=mongodb
+      - TEST_MYSQL_HOST=mysql
+      - TEST_POSTGRES_HOST=postgres
+      - TEST_REDIS_HOST=redis
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/app
+      - bundle-2.7:/usr/local/bundle
+      - gemfiles-2.7:/app/gemfiles
   ddagent:
     image: datadog/docker-dd-agent
     environment:
@@ -267,6 +295,7 @@ volumes:
   bundle-2.4:
   bundle-2.5:
   bundle-2.6:
+  bundle-2.7:
   gemfiles-2.0:
   gemfiles-2.1:
   gemfiles-2.2:
@@ -274,3 +303,4 @@ volumes:
   gemfiles-2.4:
   gemfiles-2.5:
   gemfiles-2.6:
+  gemfiles-2.7:

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -81,7 +81,8 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
 
 | Type  | Documentation              | Version | Support type                         | Gem version support |
 | ----- | -------------------------- | -----   | ------------------------------------ | ------------------- |
-| MRI   | https://www.ruby-lang.org/ | 2.6     | Full                                 | Latest              |
+| MRI   | https://www.ruby-lang.org/ | 2.7     | Full                                 | Latest              |
+|       |                            | 2.6     | Full                                 | Latest              |
 |       |                            | 2.5     | Full                                 | Latest              |
 |       |                            | 2.4     | Full                                 | Latest              |
 |       |                            | 2.3     | Full                                 | Latest              |
@@ -1129,7 +1130,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 |  2.2 - 2.3    |  3.0 - 5.2               |
 |  2.4          |  4.2.8 - 5.2             |
 |  2.5          |  4.2.8 - 6.0             |
-|  2.6          |  5.0 - 6.0               |
+|  2.6 - 2.7    |  5.0 - 6.0               |
 
 ### Rake
 


### PR DESCRIPTION
Fixes #805 

This PR adds a new branch to our CI pipeline and Rakefile to support testing `ddtrace` with Ruby 2.7.

No incompatibilities have been found with `ddtrace` code.

gRPC is the only gem that does not successfully install with Ruby 2.7, explicitly failing with `grpc requires Ruby version >= 2.3, < 2.7.dev`, so we skip testing it with Ruby 2.7 until an update is released.