### PR TITLE
Set default RuleSampler rate_limit of 100

### DIFF
--- a/lib/ddtrace/sampling/rule_sampler.rb
+++ b/lib/ddtrace/sampling/rule_sampler.rb
@@ -18,6 +18,8 @@ module Datadog
 
       attr_reader :rules, :rate_limiter, :default_sampler
 
+      DEFAULT_RATE_LIMIT = 100
+
       # @param rules [Array<Rule>] ordered list of rules to be applied to a span
       # @param rate_limit [Float] number of traces per second, defaults to +100+
       # @param rate_limiter [RateLimiter] limiter applied after rule matching
@@ -25,7 +27,7 @@ module Datadog
       #   between +[0,1]+, defaults to +1+
       # @param default_sampler [Sample] fallback strategy when no rules apply to a span
       def initialize(rules = [],
-                     rate_limit: 100,
+                     rate_limit: DEFAULT_RATE_LIMIT,
                      rate_limiter: nil,
                      default_sample_rate: nil,
                      default_sampler: nil)

--- a/lib/ddtrace/sampling/rule_sampler.rb
+++ b/lib/ddtrace/sampling/rule_sampler.rb
@@ -19,13 +19,13 @@ module Datadog
       attr_reader :rules, :rate_limiter, :default_sampler
 
       # @param rules [Array<Rule>] ordered list of rules to be applied to a span
-      # @param rate_limit [Float] number of traces per second, defaults to no rate limit
+      # @param rate_limit [Float] number of traces per second, defaults to +100+
       # @param rate_limiter [RateLimiter] limiter applied after rule matching
       # @param default_sample_rate [Float] fallback sample rate when no rules apply to a span,
       #   between +[0,1]+, defaults to +1+
       # @param default_sampler [Sample] fallback strategy when no rules apply to a span
       def initialize(rules = [],
-                     rate_limit: nil,
+                     rate_limit: 100,
                      rate_limiter: nil,
                      default_sample_rate: nil,
                      default_sampler: nil)

--- a/spec/ddtrace/sampling/rule_sampler_spec.rb
+++ b/spec/ddtrace/sampling/rule_sampler_spec.rb
@@ -23,13 +23,19 @@ RSpec.describe Datadog::Sampling::RuleSampler do
   context '#initialize' do
     subject(:rule_sampler) { described_class.new(rules) }
 
-    it { expect(subject.rate_limiter).to be_a(Datadog::Sampling::UnlimitedLimiter) }
+    it { expect(subject.rate_limiter).to be_a(Datadog::Sampling::TokenBucket) }
     it { expect(subject.default_sampler).to be_a(Datadog::AllSampler) }
 
     context 'with rate_limit' do
       subject(:rule_sampler) { described_class.new(rules, rate_limit: 1.0) }
 
       it { expect(subject.rate_limiter).to be_a(Datadog::Sampling::TokenBucket) }
+    end
+
+    context 'with nil rate_limit' do
+      subject(:rule_sampler) { described_class.new(rules, rate_limit: nil) }
+
+      it { expect(subject.rate_limiter).to be_a(Datadog::Sampling::UnlimitedLimiter) }
     end
 
     context 'with default_sample_rate' do


### PR DESCRIPTION
We want to default to 100 traces per second by default as a safety mechanism for high volume customers.