### PR TITLE
Fix priority_sampler NoMethodError for SyncWriter

### DIFF
--- a/lib/ddtrace/sync_writer.rb
+++ b/lib/ddtrace/sync_writer.rb
@@ -6,6 +6,7 @@ module Datadog
   # SyncWriter flushes both services and traces synchronously
   class SyncWriter
     attr_reader \
+      :priority_sampler,
       :runtime_metrics,
       :transport
 
@@ -19,6 +20,8 @@ module Datadog
       @runtime_metrics = options.fetch(:runtime_metrics) do
         Runtime::Metrics.new
       end
+
+      @priority_sampler = options.fetch(:priority_sampler, nil)
     end
 
     def write(trace, services = nil)

--- a/spec/ddtrace/sync_writer_spec.rb
+++ b/spec/ddtrace/sync_writer_spec.rb
@@ -66,4 +66,17 @@ RSpec.describe Datadog::SyncWriter do
       end
     end
   end
+
+  describe 'integration' do
+    context 'when initializing a tracer' do
+      subject(:tracer) { Datadog::Tracer.new(writer: sync_writer) }
+      it { expect(tracer.writer).to be sync_writer }
+    end
+
+    context 'when configuring a tracer' do
+      subject(:tracer) { Datadog::Tracer.new }
+      before { tracer.configure(writer: sync_writer) }
+      it { expect(tracer.writer).to be sync_writer }
+    end
+  end
 end


### PR DESCRIPTION
Our logic in the tracer configuration code assumed a `Writer` always has a `priority_sampler` method, which is not true of the `SyncWriter`. This manifested as an error when `tracer.configure(writer: SyncWriter.new)` was called.

This pull request adds a priority sampler option to the `SyncWriter` which defaults to `nil`, as most applications of the `SyncWriter` would not benefit from priority sampling rates.