### PR TITLE
Update net/http instrumentation span annotation

### DIFF
--- a/lib/ddtrace/contrib/http/instrumentation.rb
+++ b/lib/ddtrace/contrib/http/instrumentation.rb
@@ -83,13 +83,15 @@ module Datadog
           end
 
           def annotate_span_with_res!(span, response)
+            return unless response && response.code
+
             span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, response.code)
 
             case response.code.to_i
             when 400...599
               span.set_error(response)
             end
-          end          
+          end
 
           def datadog_pin
             @datadog_pin ||= begin

--- a/spec/ddtrace/contrib/http/request_spec.rb
+++ b/spec/ddtrace/contrib/http/request_spec.rb
@@ -393,5 +393,23 @@ RSpec.describe 'net/http requests' do
         expect(span.get_tag('error.msg')).to eq(custom_error_message)
       end
     end
+
+    context 'when configured with #after_request hook' do
+      before(:each) { Datadog::Contrib::HTTP::Instrumentation.after_request(&callback) }
+      after(:each) { Datadog::Contrib::HTTP::Instrumentation.instance_variable_set(:@after_request, nil) }
+
+      context 'which defines each parameter' do
+        let(:callback) do
+          proc do |span, http, request, response|
+            expect(span).to be_a_kind_of(Datadog::Span)
+            expect(http).to be_a_kind_of(Net::HTTP)
+            expect(request).to be_a_kind_of(Net::HTTP::Get)
+            expect(response).to be nil
+          end
+        end
+
+        it { expect(response).to be nil }
+      end
+    end
   end
 end

--- a/spec/ddtrace/contrib/http/request_spec.rb
+++ b/spec/ddtrace/contrib/http/request_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe 'net/http requests' do
               expect(span).to be_a_kind_of(Datadog::Span)
               expect(http).to be_a_kind_of(Net::HTTP)
               expect(request).to be_a_kind_of(Net::HTTP::Get)
-              expect(request).to be_a_kind_of(Net::HTTP::Get)
               expect(response).to be_a_kind_of(Net::HTTPNotFound)
             end
           end

--- a/spec/ddtrace/contrib/http/request_spec.rb
+++ b/spec/ddtrace/contrib/http/request_spec.rb
@@ -341,6 +341,7 @@ RSpec.describe 'net/http requests' do
         client.get(path)
       # rubocop:disable Lint/UselessAssignment
       rescue => e
+        nil
       end
     end
 


### PR DESCRIPTION
### Summary

This PR addresses [Issue-888](https://github.com/DataDog/dd-trace-rb/issues/888) . Currently, when a request raises an exception from a timeout(or otherwise), we don't annotate the span with any of the request or response details, since the `span_annotation!` method is called after the request is made and an exception would get raised. 

This PR splits the `annotate_span!` method into request and response specific annotation methods so that the span can be annotated with at least minimal tags in the case of an exception being raised by the request.

Per the Contribution Guidelines I've also added a test for this use case.

### Notes / Comments

Let me know what you think, happy to make any changes y'all feel would be appropriate here.