### PR TITLE
Add Datadog::Transport::IO

### DIFF
--- a/lib/ddtrace/encoding.rb
+++ b/lib/ddtrace/encoding.rb
@@ -62,7 +62,9 @@ module Datadog
             trace.map(&:to_hash).tap do |spans|
               # Convert IDs to hexadecimal
               spans.each do |span|
-                ENCODED_IDS.each { |id| span[id] = span[id].to_s(16) }
+                ENCODED_IDS.each do |id|
+                  span[id] = span[id].to_s(16) if span.key?(id)
+                end
               end
             end
           end

--- a/lib/ddtrace/encoding.rb
+++ b/lib/ddtrace/encoding.rb
@@ -43,6 +43,34 @@ module Datadog
       def encode(obj)
         JSON.dump(obj)
       end
+
+      # New version of JSON Encoder that is API compliant.
+      module V2
+        extend JSONEncoder
+
+        ENCODED_IDS = [
+          :trace_id,
+          :span_id,
+          :parent_id
+        ].freeze
+
+        module_function
+
+        def encode_traces(traces)
+          trace_hashes = traces.collect do |trace|
+            # Convert each trace to hash
+            trace.map(&:to_hash).tap do |spans|
+              # Convert IDs to hexadecimal
+              spans.each do |span|
+                ENCODED_IDS.each { |id| span[id] = span[id].to_s(16) }
+              end
+            end
+          end
+
+          # Wrap traces & encode them
+          encode(traces: trace_hashes)
+        end
+      end
     end
 
     # Encoder for the Msgpack format

--- a/lib/ddtrace/transport/io.rb
+++ b/lib/ddtrace/transport/io.rb
@@ -1,0 +1,26 @@
+require 'ddtrace/encoding'
+require 'ddtrace/transport/io/client'
+require 'ddtrace/transport/io/traces'
+
+module Datadog
+  module Transport
+    # Namespace for IO transport components
+    module IO
+      module_function
+
+      # Builds a new Transport::IO::Client
+      def new(out, encoder)
+        Client.new(out, encoder)
+      end
+
+      # Builds a new Transport::IO::Client with default settings
+      # Pass options to override any settings.
+      def default(options = {})
+        new(
+          options.fetch(:out, STDOUT),
+          options.fetch(:encoder, Encoding::JSONEncoder)
+        )
+      end
+    end
+  end
+end

--- a/lib/ddtrace/transport/io.rb
+++ b/lib/ddtrace/transport/io.rb
@@ -18,7 +18,7 @@ module Datadog
       def default(options = {})
         new(
           options.fetch(:out, STDOUT),
-          options.fetch(:encoder, Encoding::JSONEncoder)
+          options.fetch(:encoder, Encoding::JSONEncoder::V2)
         )
       end
     end

--- a/lib/ddtrace/transport/io/client.rb
+++ b/lib/ddtrace/transport/io/client.rb
@@ -1,0 +1,62 @@
+require 'ddtrace/transport/statistics'
+require 'ddtrace/transport/io/response'
+
+module Datadog
+  module Transport
+    module IO
+      # Encodes and writes tracer data to IO
+      class Client
+        include Transport::Statistics
+
+        attr_reader \
+          :encoder,
+          :out
+
+        def initialize(out, encoder)
+          @out = out
+          @encoder = encoder
+        end
+
+        def send_request(request)
+          # Write data to IO
+          # If block is given, allow it to handle writing
+          # Otherwise use default encoding.
+          response = block_given? ? yield(out, request) : send_default_request(out, request)
+
+          # Update statistics
+          update_stats_from_response!(response)
+
+          # Return response
+          response
+        rescue StandardError => e
+          message = "Internal error during IO transport request. Cause: #{e.message} Location: #{e.backtrace.first}"
+
+          # Log error
+          if stats.consecutive_errors > 0
+            Datadog::Logger.log.debug(message)
+          else
+            Datadog::Logger.log.error(message)
+          end
+
+          # Update statistics
+          update_stats_from_exception!(e)
+
+          InternalErrorResponse.new(e)
+        end
+
+        private
+
+        def send_default_request(out, request)
+          # Encode data
+          encoded_data = encoder.encode(request.parcel.data)
+
+          # Write to IO
+          bytes_written = out.write(encoded_data)
+
+          # Generate a response
+          IO::Response.new(bytes_written)
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/transport/io/response.rb
+++ b/lib/ddtrace/transport/io/response.rb
@@ -1,0 +1,23 @@
+require 'ddtrace/transport/response'
+
+module Datadog
+  module Transport
+    module IO
+      # Response from HTTP transport for traces
+      class Response
+        include Transport::Response
+
+        attr_reader \
+          :bytes_written
+
+        def initialize(bytes_written)
+          @bytes_written = bytes_written
+        end
+
+        def ok?
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/transport/io/response.rb
+++ b/lib/ddtrace/transport/io/response.rb
@@ -8,10 +8,10 @@ module Datadog
         include Transport::Response
 
         attr_reader \
-          :bytes_written
+          :result
 
-        def initialize(bytes_written)
-          @bytes_written = bytes_written
+        def initialize(result)
+          @result = result
         end
 
         def ok?

--- a/lib/ddtrace/transport/io/traces.rb
+++ b/lib/ddtrace/transport/io/traces.rb
@@ -21,22 +21,18 @@ module Datadog
 
             send_request(req) do |out, request|
               # Encode trace data
-              encoded_data = request.parcel.encode_with(encoder)
+              data = encode_data(encoder, request)
 
               # Write to IO
-              bytes_written = if block_given?
-                                yield(out, encoded_data)
-                              else
-                                write_trace_data(out, encoded_data)
-                              end
+              result = if block_given?
+                         yield(out, data)
+                       else
+                         write_data(out, data)
+                       end
 
               # Generate response
-              Traces::Response.new(bytes_written)
+              Traces::Response.new(result)
             end
-          end
-
-          def write_trace_data(out, data)
-            out.puts(data)
           end
         end
 

--- a/lib/ddtrace/transport/io/traces.rb
+++ b/lib/ddtrace/transport/io/traces.rb
@@ -1,0 +1,40 @@
+require 'ddtrace/transport/traces'
+
+require 'ddtrace/transport/io/response'
+require 'ddtrace/transport/io/client'
+
+module Datadog
+  module Transport
+    module IO
+      # IO transport behavior for traces
+      module Traces
+        # Response from HTTP transport for traces
+        class Response < IO::Response
+          include Transport::Traces::Response
+        end
+
+        # Extensions for HTTP client
+        module Client
+          def send_traces(traces)
+            # Build a request
+            req = Transport::Traces::Request.new(traces)
+
+            send_request(req) do |out, request|
+              # Encode trace data
+              encoded_data = request.parcel.encode_with(encoder)
+
+              # Write to IO
+              bytes_written = out.write(encoded_data)
+
+              # Generate response
+              Traces::Response.new(bytes_written)
+            end
+          end
+        end
+
+        # Add traces behavior to transport components
+        IO::Client.send(:include, Traces::Client)
+      end
+    end
+  end
+end

--- a/lib/ddtrace/transport/io/traces.rb
+++ b/lib/ddtrace/transport/io/traces.rb
@@ -24,11 +24,19 @@ module Datadog
               encoded_data = request.parcel.encode_with(encoder)
 
               # Write to IO
-              bytes_written = out.write(encoded_data)
+              bytes_written = if block_given?
+                                yield(out, encoded_data)
+                              else
+                                write_trace_data(out, encoded_data)
+                              end
 
               # Generate response
               Traces::Response.new(bytes_written)
             end
+          end
+
+          def write_trace_data(out, data)
+            out.puts(data)
           end
         end
 

--- a/lib/ddtrace/transport/parcel.rb
+++ b/lib/ddtrace/transport/parcel.rb
@@ -8,6 +8,10 @@ module Datadog
       def initialize(data)
         @data = data
       end
+
+      def encode_with(encoder)
+        encoder.encode(data)
+      end
     end
   end
 end

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -4,6 +4,7 @@ require 'ddtrace/ext/net'
 require 'ddtrace/runtime/socket'
 
 require 'ddtrace/transport/http'
+require 'ddtrace/transport/io'
 require 'ddtrace/encoding'
 require 'ddtrace/workers'
 

--- a/spec/ddtrace/encoding_spec.rb
+++ b/spec/ddtrace/encoding_spec.rb
@@ -41,5 +41,30 @@ RSpec.describe Datadog::Encoding::JSONEncoder::V2 do
         end
       end
     end
+
+    context 'when ID is missing' do
+      subject(:encoded_traces) { JSON.parse(encode_traces)['traces'] }
+      let(:missing_id) { :span_id }
+
+      before do
+        # Delete ID from each Span
+        traces.each do |trace|
+          trace.each do |span|
+            allow(span).to receive(:to_hash)
+              .and_wrap_original do |m, *_args|
+                m.call.tap { |h| h.delete(missing_id) }
+              end
+          end
+        end
+      end
+
+      it 'does not include the missing ID' do
+        compare_arrays(traces, encoded_traces) do |trace, encoded_trace|
+          compare_arrays(trace, encoded_trace) do |_span, encoded_span|
+            expect(encoded_span).to_not include(missing_id.to_s)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/ddtrace/encoding_spec.rb
+++ b/spec/ddtrace/encoding_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+require 'ddtrace/encoding'
+
+RSpec.describe Datadog::Encoding::JSONEncoder::V2 do
+  def compare_arrays(left = [], right = [])
+    left.zip(right).each { |tuple| yield(*tuple) }
+  end
+
+  describe '::encode_traces' do
+    subject(:encode_traces) { described_class.encode_traces(traces) }
+    let(:traces) { get_test_traces(2) }
+
+    it { is_expected.to be_a_kind_of(String) }
+
+    describe 'produces a JSON schema' do
+      subject(:schema) { JSON.parse(encode_traces) }
+
+      it 'which is wrapped' do
+        is_expected.to be_a_kind_of(Hash)
+        is_expected.to include('traces' => kind_of(Array))
+      end
+
+      describe 'whose encoded traces' do
+        subject(:encoded_traces) { schema['traces'] }
+
+        it 'contains the traces' do
+          is_expected.to have(traces.length).items
+        end
+
+        it 'has IDs that are hex encoded' do
+          compare_arrays(traces, encoded_traces) do |trace, encoded_trace|
+            compare_arrays(trace, encoded_trace) do |span, encoded_span|
+              described_class::ENCODED_IDS.each do |id|
+                encoded_id = encoded_span[id.to_s].to_i(16)
+                original_id = span.send(id)
+                expect(encoded_id).to eq(original_id)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -380,7 +380,7 @@ RSpec.describe 'Tracer integration tests' do
       expect(tracer.sampler).to be(tracer.writer.priority_sampler)
 
       # Verify IO is written to
-      allow(out).to receive(:write)
+      allow(out).to receive(:puts)
 
       # Priority sampler does not receive updates because IO is one-way.
       expect(tracer.sampler).to_not receive(:update)
@@ -408,7 +408,7 @@ RSpec.describe 'Tracer integration tests' do
         expect(stats[:transport].server_error).to eq(0)
         expect(stats[:transport].internal_error).to eq(0)
 
-        expect(out).to have_received(:write)
+        expect(out).to have_received(:puts)
       end
     end
   end

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -370,8 +370,9 @@ RSpec.describe 'Tracer integration tests' do
         writer: writer
       )
 
-      # Verify Transport::HTTP is configured
+      # Verify Transport::IO is configured
       expect(tracer.writer.transport).to be_a_kind_of(Datadog::Transport::IO::Client)
+      expect(tracer.writer.transport.encoder).to be(Datadog::Encoding::JSONEncoder::V2)
 
       # Verify sampling is configured properly
       expect(tracer.writer.priority_sampler).to_not be nil
@@ -406,7 +407,8 @@ RSpec.describe 'Tracer integration tests' do
         expect(stats[:transport].client_error).to eq(0)
         expect(stats[:transport].server_error).to eq(0)
         expect(stats[:transport].internal_error).to eq(0)
-        expect(out).to have_received(:write).with(/"parent_id":0/)
+
+        expect(out).to have_received(:write)
       end
     end
   end

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -356,6 +356,61 @@ RSpec.describe 'Tracer integration tests' do
     end
   end
 
+  describe 'Transport::IO' do
+    include_context 'agent-based test'
+
+    let(:writer) { Datadog::Writer.new(transport: transport, priority_sampler: Datadog::PrioritySampler.new) }
+    let(:transport) { Datadog::Transport::IO.default(out: out) }
+    let(:out) { instance_double(IO) } # Dummy output so we don't pollute STDOUT
+
+    before(:each) do
+      tracer.configure(
+        enabled: true,
+        priority_sampling: true,
+        writer: writer
+      )
+
+      # Verify Transport::HTTP is configured
+      expect(tracer.writer.transport).to be_a_kind_of(Datadog::Transport::IO::Client)
+
+      # Verify sampling is configured properly
+      expect(tracer.writer.priority_sampler).to_not be nil
+      expect(tracer.sampler).to be_a_kind_of(Datadog::PrioritySampler)
+      expect(tracer.sampler).to be(tracer.writer.priority_sampler)
+
+      # Verify IO is written to
+      allow(out).to receive(:write)
+
+      # Priority sampler does not receive updates because IO is one-way.
+      expect(tracer.sampler).to_not receive(:update)
+    end
+
+    # Reset the writer
+    after { tracer.configure(writer: Datadog::Writer.new) }
+
+    it do
+      3.times do |i|
+        parent_span = tracer.start_span('parent_span')
+        child_span = tracer.start_span('child_span', child_of: parent_span.context)
+
+        # I want to keep the trace to which `child_span` belongs
+        child_span.context.sampling_priority = i
+
+        child_span.finish
+        parent_span.finish
+
+        try_wait_until(attempts: 20) { tracer.writer.stats[:traces_flushed] >= 1 }
+        stats = tracer.writer.stats
+
+        expect(stats[:traces_flushed]).to eq(1)
+        expect(stats[:transport].client_error).to eq(0)
+        expect(stats[:transport].server_error).to eq(0)
+        expect(stats[:transport].internal_error).to eq(0)
+        expect(out).to have_received(:write).with(/"parent_id":0/)
+      end
+    end
+  end
+
   describe 'Transport::HTTP' do
     include_context 'agent-based test'
 

--- a/spec/ddtrace/transport/io/client_spec.rb
+++ b/spec/ddtrace/transport/io/client_spec.rb
@@ -26,16 +26,16 @@ RSpec.describe Datadog::Transport::IO::Client do
       let(:parcel) { instance_double(Datadog::Transport::Parcel, data: data) }
       let(:data) { 'Hello, world!' }
       let(:encoded_data) { double('encoded data') }
-      let(:bytes_written) { data.bytesize }
+      let(:result) { double('IO result') }
 
       before do
-        expect(client.encoder).to receive(:encode)
-          .with(data)
+        expect(parcel).to receive(:encode_with)
+          .with(encoder)
           .and_return(encoded_data)
 
-        expect(client.out).to receive(:write)
+        expect(client.out).to receive(:puts)
           .with(encoded_data)
-          .and_return(bytes_written)
+          .and_return(result)
 
         expect(client).to receive(:update_stats_from_response!)
           .with(kind_of(Datadog::Transport::IO::Response))
@@ -45,7 +45,7 @@ RSpec.describe Datadog::Transport::IO::Client do
 
       it do
         is_expected.to be_a_kind_of(Datadog::Transport::IO::Response)
-        expect(send_request.bytes_written).to eq(bytes_written)
+        expect(send_request.result).to eq(result)
       end
     end
 

--- a/spec/ddtrace/transport/io/client_spec.rb
+++ b/spec/ddtrace/transport/io/client_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+require 'ddtrace/transport/io/client'
+
+RSpec.describe Datadog::Transport::IO::Client do
+  subject(:client) { described_class.new(out, encoder) }
+  let(:out) { instance_double(IO) }
+  let(:encoder) { instance_double(Datadog::Encoding::Encoder) }
+
+  describe '#initialize' do
+    it { is_expected.to be_a_kind_of Datadog::Transport::Statistics }
+
+    it 'has the correct default properties' do
+      is_expected.to have_attributes(
+        out: out,
+        encoder: encoder
+      )
+    end
+  end
+
+  describe '#send_request' do
+    context 'given a request' do
+      subject(:send_request) { client.send_request(request) }
+
+      let(:request) { instance_double(Datadog::Transport::Request, parcel: parcel) }
+      let(:parcel) { instance_double(Datadog::Transport::Parcel, data: data) }
+      let(:data) { 'Hello, world!' }
+      let(:encoded_data) { double('encoded data') }
+      let(:bytes_written) { data.bytesize }
+
+      before do
+        expect(client.encoder).to receive(:encode)
+          .with(data)
+          .and_return(encoded_data)
+
+        expect(client.out).to receive(:write)
+          .with(encoded_data)
+          .and_return(bytes_written)
+
+        expect(client).to receive(:update_stats_from_response!)
+          .with(kind_of(Datadog::Transport::IO::Response))
+
+        send_request
+      end
+
+      it do
+        is_expected.to be_a_kind_of(Datadog::Transport::IO::Response)
+        expect(send_request.bytes_written).to eq(bytes_written)
+      end
+    end
+
+    context 'given a request and block' do
+      subject(:send_request) do
+        client.send_request(request) do |out, request|
+          expect(out).to be(client.out)
+          expect(request).to be(request)
+          response
+        end
+      end
+
+      let(:request) { instance_double(Datadog::Transport::Request) }
+      let(:response) { instance_double(Datadog::Transport::IO::Response) }
+
+      before do
+        expect(client).to receive(:update_stats_from_response!)
+          .with(response)
+
+        send_request
+      end
+
+      it do
+        is_expected.to be response
+      end
+    end
+  end
+end

--- a/spec/ddtrace/transport/io/response_spec.rb
+++ b/spec/ddtrace/transport/io/response_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+require 'ddtrace/transport/io/response'
+
+RSpec.describe Datadog::Transport::IO::Response do
+  context 'when implemented by a class' do
+    subject(:response) { described_class.new(bytes) }
+    let(:bytes) { 16 }
+
+    describe '#bytes_written' do
+      subject(:bytes_written) { response.bytes_written }
+      it { is_expected.to eq bytes }
+    end
+
+    describe '#ok?' do
+      subject(:ok?) { response.ok? }
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/ddtrace/transport/io/response_spec.rb
+++ b/spec/ddtrace/transport/io/response_spec.rb
@@ -4,12 +4,12 @@ require 'ddtrace/transport/io/response'
 
 RSpec.describe Datadog::Transport::IO::Response do
   context 'when implemented by a class' do
-    subject(:response) { described_class.new(bytes) }
-    let(:bytes) { 16 }
+    subject(:response) { described_class.new(result) }
+    let(:result) { double('result') }
 
-    describe '#bytes_written' do
-      subject(:bytes_written) { response.bytes_written }
-      it { is_expected.to eq bytes }
+    describe '#result' do
+      subject(:get_result) { response.result }
+      it { is_expected.to eq result }
     end
 
     describe '#ok?' do

--- a/spec/ddtrace/transport/io/traces_spec.rb
+++ b/spec/ddtrace/transport/io/traces_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Datadog::Transport::IO::Client do
       subject(:send_traces) { client.send_traces(traces) }
       let(:traces) { instance_double(Array) }
       let(:encoded_traces) { double('encoded traces') }
-      let(:bytes_written) { 16 }
+      let(:result) { double('IO result') }
 
       before do
         expect(client.encoder).to receive(:encode_traces)
@@ -21,7 +21,7 @@ RSpec.describe Datadog::Transport::IO::Client do
 
         expect(client.out).to receive(:puts)
           .with(encoded_traces)
-          .and_return(bytes_written)
+          .and_return(result)
 
         expect(client).to receive(:update_stats_from_response!)
           .with(kind_of(Datadog::Transport::IO::Traces::Response))
@@ -29,7 +29,7 @@ RSpec.describe Datadog::Transport::IO::Client do
 
       it do
         is_expected.to be_a_kind_of(Datadog::Transport::IO::Traces::Response)
-        expect(send_traces.bytes_written).to eq(bytes_written)
+        expect(send_traces.result).to eq(result)
       end
     end
 
@@ -37,7 +37,7 @@ RSpec.describe Datadog::Transport::IO::Client do
       subject(:send_traces) { client.send_traces(traces) { |out, data| target.write(out, data) } }
       let(:traces) { instance_double(Array) }
       let(:encoded_traces) { double('encoded traces') }
-      let(:bytes_written) { 16 }
+      let(:result) { double('IO result') }
       let(:target) { double('target') }
 
       before do
@@ -47,7 +47,7 @@ RSpec.describe Datadog::Transport::IO::Client do
 
         expect(target).to receive(:write)
           .with(client.out, encoded_traces)
-          .and_return(bytes_written)
+          .and_return(result)
 
         expect(client).to receive(:update_stats_from_response!)
           .with(kind_of(Datadog::Transport::IO::Traces::Response))
@@ -55,7 +55,7 @@ RSpec.describe Datadog::Transport::IO::Client do
 
       it do
         is_expected.to be_a_kind_of(Datadog::Transport::IO::Traces::Response)
-        expect(send_traces.bytes_written).to eq(bytes_written)
+        expect(send_traces.result).to eq(result)
       end
     end
   end

--- a/spec/ddtrace/transport/io/traces_spec.rb
+++ b/spec/ddtrace/transport/io/traces_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+require 'ddtrace/transport/io/traces'
+
+RSpec.describe Datadog::Transport::IO::Client do
+  subject(:client) { described_class.new(out, encoder) }
+  let(:out) { instance_double(IO) }
+  let(:encoder) { instance_double(Datadog::Encoding::Encoder) }
+
+  describe '#send_traces' do
+    subject(:send_traces) { client.send_traces(traces) }
+    let(:traces) { instance_double(Array) }
+    let(:encoded_traces) { double('encoded traces') }
+    let(:bytes_written) { 16 }
+
+    before do
+      expect(client.encoder).to receive(:encode_traces)
+        .with(traces)
+        .and_return(encoded_traces)
+
+      expect(client.out).to receive(:write)
+        .with(encoded_traces)
+        .and_return(bytes_written)
+
+      expect(client).to receive(:update_stats_from_response!)
+        .with(kind_of(Datadog::Transport::IO::Traces::Response))
+    end
+
+    it do
+      is_expected.to be_a_kind_of(Datadog::Transport::IO::Traces::Response)
+      expect(send_traces.bytes_written).to eq(bytes_written)
+    end
+  end
+end

--- a/spec/ddtrace/transport/io/traces_spec.rb
+++ b/spec/ddtrace/transport/io/traces_spec.rb
@@ -8,27 +8,55 @@ RSpec.describe Datadog::Transport::IO::Client do
   let(:encoder) { instance_double(Datadog::Encoding::Encoder) }
 
   describe '#send_traces' do
-    subject(:send_traces) { client.send_traces(traces) }
-    let(:traces) { instance_double(Array) }
-    let(:encoded_traces) { double('encoded traces') }
-    let(:bytes_written) { 16 }
+    context 'given traces' do
+      subject(:send_traces) { client.send_traces(traces) }
+      let(:traces) { instance_double(Array) }
+      let(:encoded_traces) { double('encoded traces') }
+      let(:bytes_written) { 16 }
 
-    before do
-      expect(client.encoder).to receive(:encode_traces)
-        .with(traces)
-        .and_return(encoded_traces)
+      before do
+        expect(client.encoder).to receive(:encode_traces)
+          .with(traces)
+          .and_return(encoded_traces)
 
-      expect(client.out).to receive(:write)
-        .with(encoded_traces)
-        .and_return(bytes_written)
+        expect(client.out).to receive(:puts)
+          .with(encoded_traces)
+          .and_return(bytes_written)
 
-      expect(client).to receive(:update_stats_from_response!)
-        .with(kind_of(Datadog::Transport::IO::Traces::Response))
+        expect(client).to receive(:update_stats_from_response!)
+          .with(kind_of(Datadog::Transport::IO::Traces::Response))
+      end
+
+      it do
+        is_expected.to be_a_kind_of(Datadog::Transport::IO::Traces::Response)
+        expect(send_traces.bytes_written).to eq(bytes_written)
+      end
     end
 
-    it do
-      is_expected.to be_a_kind_of(Datadog::Transport::IO::Traces::Response)
-      expect(send_traces.bytes_written).to eq(bytes_written)
+    context 'given traces and a block' do
+      subject(:send_traces) { client.send_traces(traces) { |out, data| target.write(out, data) } }
+      let(:traces) { instance_double(Array) }
+      let(:encoded_traces) { double('encoded traces') }
+      let(:bytes_written) { 16 }
+      let(:target) { double('target') }
+
+      before do
+        expect(client.encoder).to receive(:encode_traces)
+          .with(traces)
+          .and_return(encoded_traces)
+
+        expect(target).to receive(:write)
+          .with(client.out, encoded_traces)
+          .and_return(bytes_written)
+
+        expect(client).to receive(:update_stats_from_response!)
+          .with(kind_of(Datadog::Transport::IO::Traces::Response))
+      end
+
+      it do
+        is_expected.to be_a_kind_of(Datadog::Transport::IO::Traces::Response)
+        expect(send_traces.bytes_written).to eq(bytes_written)
+      end
     end
   end
 end

--- a/spec/ddtrace/transport/io_spec.rb
+++ b/spec/ddtrace/transport/io_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Datadog::Transport::IO do
 
       before do
         expect(Datadog::Transport::IO::Client).to receive(:new)
-          .with(STDOUT, Datadog::Encoding::JSONEncoder)
+          .with(STDOUT, Datadog::Encoding::JSONEncoder::V2)
           .and_return(client)
       end
 

--- a/spec/ddtrace/transport/io_spec.rb
+++ b/spec/ddtrace/transport/io_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+require 'ddtrace/transport/io'
+
+RSpec.describe Datadog::Transport::IO do
+  describe '.new' do
+    subject(:new_io) { described_class.new(out, encoder) }
+    let(:out) { instance_double(IO) }
+    let(:encoder) { instance_double(Datadog::Encoding::Encoder) }
+    let(:client) { instance_double(Datadog::Transport::IO::Client) }
+
+    before do
+      expect(Datadog::Transport::IO::Client).to receive(:new)
+        .with(out, encoder)
+        .and_return(client)
+    end
+
+    it { is_expected.to be client }
+  end
+
+  describe '.default' do
+    let(:client) { instance_double(Datadog::Transport::IO::Client) }
+
+    context 'given no options' do
+      subject(:default) { described_class.default }
+
+      before do
+        expect(Datadog::Transport::IO::Client).to receive(:new)
+          .with(STDOUT, Datadog::Encoding::JSONEncoder)
+          .and_return(client)
+      end
+
+      it { is_expected.to be client }
+    end
+
+    context 'given overrides' do
+      subject(:default) { described_class.default(options) }
+      let(:options) { { out: out, encoder: encoder } }
+      let(:out) { instance_double(IO) }
+      let(:encoder) { instance_double(Datadog::Encoding::Encoder) }
+
+      before do
+        expect(Datadog::Transport::IO::Client).to receive(:new)
+          .with(out, encoder)
+          .and_return(client)
+      end
+
+      it { is_expected.to be client }
+    end
+  end
+end

--- a/spec/ddtrace/transport/parcel_spec.rb
+++ b/spec/ddtrace/transport/parcel_spec.rb
@@ -13,5 +13,19 @@ RSpec.describe Datadog::Transport::Parcel do
     describe '#initialize' do
       it { is_expected.to have_attributes(data: data) }
     end
+
+    describe '#encode_with' do
+      subject(:encode_with) { parcel.encode_with(encoder) }
+      let(:encoder) { instance_double(Datadog::Encoding::Encoder) }
+      let(:encoded_data) { double('encoded data') }
+
+      before do
+        expect(encoder).to receive(:encode)
+          .with(data)
+          .and_return(encoded_data)
+      end
+
+      it { is_expected.to be encoded_data }
+    end
   end
 end


### PR DESCRIPTION
To support writing traces to generic outputs such as STDOUT or log files, this pull request introduces the `Datadog::Transport::IO`. This transport which encodes data (default JSON) and writes to a generic output (default STDOUT) is designed to be interchangeable with the existing `Datadog::Transport::HTTP`.

Some caveats; as it does not support two-way communication, it does not provide priority sampler updates and has a limited set of health metrics it can emit.

