### PR TITLE
Fix remaining usages of Datadog::Tracer.log

### DIFF
--- a/lib/ddtrace/context_flush.rb
+++ b/lib/ddtrace/context_flush.rb
@@ -58,7 +58,7 @@ module Datadog
         if trace[0]
           context.annotate_for_flush!(trace[0])
         else
-          Datadog::Tracer.log.debug('Tried to retrieve trace from context, but got nothing. ' \
+          Datadog::Logger.log.debug('Tried to retrieve trace from context, but got nothing. ' \
             "Is there another consumer for this context? #{context.trace_id}")
         end
 

--- a/lib/ddtrace/contrib/action_cable/instrumentation.rb
+++ b/lib/ddtrace/contrib/action_cable/instrumentation.rb
@@ -18,7 +18,7 @@ module Datadog
                 rack_request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
                 rack_request_span.resource = span.resource if rack_request_span
               rescue StandardError => e
-                Datadog::Tracer.log.error("Error preparing span for ActionCable::Connection: #{e}")
+                Datadog::Logger.log.error("Error preparing span for ActionCable::Connection: #{e}")
               end
 
               super


### PR DESCRIPTION
When the extraction of `Datadog::Tracer.log` to `Datadog::Logger.log` happened in #880, #824 was still in progress.

Given that this changed affected #824 in non-critical error paths that are not common, they were not exercised by CI during brach rebasing.

This PR migrates all remaining reference to log methods in `Datadog::Tracer` to use `Datadog::Logger` instead.