### PR TITLE
Add SyncWriter#stop method

### DIFF
--- a/lib/ddtrace/sync_writer.rb
+++ b/lib/ddtrace/sync_writer.rb
@@ -41,6 +41,12 @@ module Datadog
       Logger.log.debug(e)
     end
 
+    # Added for interface completeness
+    def stop
+      # No cleanup to do for the SyncWriter
+      true
+    end
+
     private
 
     def perform_concurrently(*tasks)

--- a/spec/ddtrace/sync_writer_spec.rb
+++ b/spec/ddtrace/sync_writer_spec.rb
@@ -100,6 +100,11 @@ RSpec.describe Datadog::SyncWriter do
     end
   end
 
+  describe '#stop' do
+    subject(:stop) { sync_writer.stop }
+    it { is_expected.to eq(true) }
+  end
+
   describe 'integration' do
     context 'when initializing a tracer' do
       subject(:tracer) { Datadog::Tracer.new(writer: sync_writer) }


### PR DESCRIPTION
Fixes #914 

`SyncWriter` was missing the contract method `#stop`, which is implemented by the async writer class `Writer`.

This causes an error to be raised during shutdown:
https://github.com/DataDog/dd-trace-rb/blob/8a9fb5529bc1491de4963542ac95b413b3bacac5/lib/ddtrace/tracer.rb#L53

I verified and no other method is missing from the writer contract for `SyncWriter`