### PR TITLE
Lock Rack version due to Grape incompatibility

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -345,7 +345,7 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
       gem 'racecar', '>= 0.3.5'
-      gem 'rack'
+      gem 'rack', '< 2.1.0' # Remove when grape bug is fixed: https://github.com/ruby-grape/grape/issues/1966
       gem 'rack-test'
       gem 'rake', '>= 12.3'
       gem 'redis', '< 4.0'
@@ -503,7 +503,7 @@ elsif Gem::Version.new('2.3.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
       gem 'racecar', '>= 0.3.5'
-      gem 'rack'
+      gem 'rack', '< 2.1.0' # Remove when grape bug is fixed: https://github.com/ruby-grape/grape/issues/1966
       gem 'rack-test'
       gem 'rake', '>= 12.3'
       gem 'redis', '< 4.0'
@@ -576,7 +576,7 @@ elsif Gem::Version.new('2.4.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
       gem 'racecar', '>= 0.3.5'
-      gem 'rack'
+      gem 'rack', '< 2.1.0' # Remove when grape bug is fixed: https://github.com/ruby-grape/grape/issues/1966
       gem 'rack-test'
       gem 'rake', '>= 12.3'
       gem 'redis', '< 4.0'
@@ -683,7 +683,7 @@ elsif Gem::Version.new('2.5.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
       gem 'racecar', '>= 0.3.5'
-      gem 'rack'
+      gem 'rack', '< 2.1.0' # Remove when grape bug is fixed: https://github.com/ruby-grape/grape/issues/1966
       gem 'rack-test'
       gem 'rake', '>= 12.3'
       gem 'redis', '< 4.0'
@@ -790,7 +790,7 @@ elsif Gem::Version.new('2.6.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
       gem 'racecar', '>= 0.3.5'
-      gem 'rack'
+      gem 'rack', '< 2.1.0' # Remove when grape bug is fixed: https://github.com/ruby-grape/grape/issues/1966
       gem 'rack-test'
       gem 'rake', '>= 12.3'
       gem 'redis', '< 4.0'
@@ -899,7 +899,7 @@ elsif Gem::Version.new('2.7.0') <= Gem::Version.new(RUBY_VERSION)
       gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
       gem 'racecar', '>= 0.3.5'
-      gem 'rack'
+      gem 'rack', '< 2.1.0' # Remove when grape bug is fixed: https://github.com/ruby-grape/grape/issues/1966
       gem 'rack-test'
       gem 'rake', '>= 12.3'
       gem 'redis', '< 4.0'


### PR DESCRIPTION
The newly released version of Rack, `2.1.0`, is incompatible with the latest version of Grape: https://github.com/ruby-grape/grape/issues/1966

This PR locks Rack to `< 2.1.0` until Grape updates the issue with further instructions.

This unblocks our CI builds.