### PR TITLE
Improved support for multiple tracer instances

### DIFF
--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -82,7 +82,8 @@ module Datadog
       end
 
       option :tracer do |o|
-        o.default Tracer.new
+        o.default { Tracer.new }
+        o.lazy
 
         # On reset, shut down the old tracer,
         # then instantiate a new one.

--- a/lib/ddtrace/context_provider.rb
+++ b/lib/ddtrace/context_provider.rb
@@ -28,18 +28,23 @@ module Datadog
     # a different \Context for each thread. In synchronous tracer, this
     # is required to prevent multiple threads sharing the same \Context
     # in different executions.
+    #
+    # To support multiple tracers simultaneously, each \ThreadLocalContext
+    # instance has its own thread-local variable.
     def initialize
+      @key = "datadog_context_#{object_id}".to_sym
+
       self.local = Datadog::Context.new
     end
 
     # Override the thread-local context with a new context.
     def local=(ctx)
-      Thread.current[:datadog_context] = ctx
+      Thread.current[@key] = ctx
     end
 
     # Return the thread-local context.
     def local
-      Thread.current[:datadog_context] ||= Datadog::Context.new
+      Thread.current[@key] ||= Datadog::Context.new
     end
   end
 end

--- a/spec/ddtrace/context_provider_spec.rb
+++ b/spec/ddtrace/context_provider_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+require 'ddtrace/context_provider'
+
+RSpec.describe Datadog::ThreadLocalContext do
+  subject(:thread_local_context) { described_class.new }
+
+  describe '#local' do
+    context 'with a second ThreadLocalContext' do
+      let(:thread_local_context2) { described_class.new }
+
+      it 'should not interfere with other ThreadLocalContext' do
+        local_context = thread_local_context.local
+        local_context2 = thread_local_context2.local
+
+        expect(local_context).to_not eq(local_context2)
+        expect(thread_local_context.local).to eq(local_context)
+        expect(thread_local_context2.local).to eq(local_context2)
+      end
+    end
+  end
+end

--- a/spec/ddtrace/context_provider_spec.rb
+++ b/spec/ddtrace/context_provider_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe Datadog::ThreadLocalContext do
         context = thread_local_context.local
 
         Thread.new do
-          expect { @thread_context = thread_local_context.local }.
-            to change { thread_contexts.size }.from(0).to(1)
+          expect { @thread_context = thread_local_context.local }
+            .to change { thread_contexts.size }.from(0).to(1)
 
           expect(@thread_context).to be_a Datadog::Context
         end.join

--- a/spec/ddtrace/contrib/action_cable/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/action_cable/instrumentation_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'ActionCable Rack override' do
   before do
     Datadog.configure do |c|
       c.use :rails, options
-      c.use :action_cable
+      c.use :action_cable, options
     end
 
     rails_test_application.instance.routes.draw do
@@ -45,11 +45,9 @@ RSpec.describe 'ActionCable Rack override' do
   context 'on ActionCable connection request' do
     subject! { get '/cable' }
 
-    let(:rack_span) { spans.find { |s| s.name == 'rack.request' } }
-
     it 'overrides parent Rack resource' do
-      expect(spans).to have(2).items
-      expect(rack_span.resource).to eq('ActionCable::Connection::Base#on_open')
+      expect(span.name).to eq('rack.request')
+      expect(span.resource).to eq('ActionCable::Connection::Base#on_open')
     end
   end
 end

--- a/spec/ddtrace/contrib/rails/analytics_spec.rb
+++ b/spec/ddtrace/contrib/rails/analytics_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Rails trace analytics' do
       # This is because Rails instrumentation normally defers patching until #after_initialize
       # when it activates and configures each of the Rails components with application details.
       # We aren't initializing a full Rails application here, so the patch doesn't auto-apply.
-      c.use :action_pack
+      c.use :action_pack, configuration_options
     end
   end
 

--- a/spec/ddtrace/contrib/sinatra/activerecord_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/activerecord_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Sinatra instrumentation with ActiveRecord' do
   before(:each) do
     Datadog.configure do |c|
       c.use :sinatra, options
-      c.use :active_record
+      c.use :active_record, options
     end
   end
 
@@ -71,12 +71,12 @@ RSpec.describe 'Sinatra instrumentation with ActiveRecord' do
         adapter: 'sqlite3',
         database: ':memory:'
       ).tap do |conn|
-        conn.connection.execute('SELECT 42')
+        conn.connection.execute("SELECT 'bootstrap query'")
       end
     end
 
-    let(:sinatra_span) { spans.first }
-    let(:sqlite_span) { spans.last }
+    let(:sinatra_span) { spans.find { |s| s.name == 'sinatra.request' } }
+    let(:sqlite_span) { spans.find { |s| s.parent_id != 0 } }
 
     let(:adapter_name) { Datadog::Contrib::ActiveRecord::Utils.adapter_name }
     let(:database_name) { Datadog::Contrib::ActiveRecord::Utils.database_name }


### PR DESCRIPTION
When instantiating multiple `Datadog::Tracer`s, we currently override the thread-local `Context` with the one belonging to the latest instantiated Tracer. This happens because of this line: https://github.com/DataDog/dd-trace-rb/blob/adc046a6e38b22ab59d57868943b5063bbd0a610/lib/ddtrace/tracer.rb#L76

By creating a new `DefaultContextProvider` for each tracer, we override the previous `Context` that was present in `Thread.current[:datadog_context]`.

This PR adds support for multiple concurrent thread-local contexts.
This is done by uniquely "namespacing" the thread-local variable for each `DefaultContextProvider` instance: https://github.com/DataDog/dd-trace-rb/blob/adc046a6e38b22ab59d57868943b5063bbd0a610/lib/ddtrace/context_provider.rb#L35

This allows for the follow code to work as expected:
```ruby
tracer1 = Datadog::Tracer.new
tracer2 = Datadog::Tracer.new

tracer1.trace('1.1') do
  tracer2.trace('2') do
    tracer1.trace('1.2') {}
  end
end

tracer1.shutdown! # tracer1 flushes: [Span('1.1'), Span('1.2', parent_id: '1.1')
tracer2.shutdown! # tracer2 flushes: [Span('2')]
```

In practice, this only affects us today while testing with custom tracer instances, like the ones created by `get_test_tracer`: these custom instances compete with the default `Tracer.trace` for the context thread-local spot and only one of them can win.
A few tests came out as misconfigured after implementing these changes: they were not properly providing the `{tracer: get_test_tracer}` option to their integration but were lucky that `get_test_tracer` hijacked the thread-local context from `Tracer.trace`, thus the expected spans ended up in the "wrong" tracer (`get_test_tracer`) which incidentally is the one under test.

An alternative to implementing this is enforcing a singleton `Tracer`: making it impossible to have two tracers at one time, even for testing, and always retrieving the same instance from a central point.