### PR TITLE
Update class-based GraphQL schema

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -833,6 +833,17 @@ The `use :graphql` method accepts the following parameters. Additional options c
 If you prefer to individually configure the tracer settings for a schema (e.g. you have multiple schemas with different service names), in the schema definition, you can add the following [using the GraphQL API](http://graphql-ruby.org/queries/tracing.html):
 
 ```ruby
+# Class-based schema
+class YourSchema < GraphQL::Schema
+  use(
+    GraphQL::Tracing::DataDogTracing,
+    service: 'graphql'
+  )
+end
+```
+
+```ruby
+# .define-style schema
 YourSchema = GraphQL::Schema.define do
   use(
     GraphQL::Tracing::DataDogTracing,
@@ -844,6 +855,15 @@ end
 Or you can modify an already defined schema:
 
 ```ruby
+# Class-based schema
+YourSchema.use(
+    GraphQL::Tracing::DataDogTracing,
+    service: 'graphql'
+)
+```
+
+```ruby
+# .define-style schema
 YourSchema.define do
   use(
     GraphQL::Tracing::DataDogTracing,


### PR DESCRIPTION
_Fixes [CI failure](https://app.circleci.com/jobs/github/DataDog/dd-trace-rb/52168)_

The GraphQL gem has deprecated [`.define`-style schema definition](https://github.com/rmosolgo/graphql-ruby/blob/80da07a9545af9407c6c5fe112d4489b0e89cbf2/CHANGELOG.md#deprecations-1).

Documentation has been updated to provide configuration examples using a class-based schema definition, while also keeping the original examples as define-style is still supported.

In our test suite, were mixing class-based and .define-style schema definition, which triggered issues with the release of `graphql 1.10`.

This PR expands our CI test fixture by creating the whole schema definition with both versions (class and .define styles).