### PR TITLE
Ensure Datadog::Statsd is loaded during test

### DIFF
--- a/spec/ddtrace/metrics_spec.rb
+++ b/spec/ddtrace/metrics_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 require 'ddtrace'
 require 'ddtrace/metrics'
+
 require 'benchmark'
+require 'datadog/statsd'
 
 RSpec.describe Datadog::Metrics do
   include_context 'metrics'
@@ -155,6 +157,21 @@ RSpec.describe Datadog::Metrics do
     end
 
     it { is_expected.to be(statsd_client) }
+
+    context 'with Datadog::Statsd not loaded' do
+      before do
+        const = Datadog::Statsd
+        hide_const('Datadog::Statsd')
+
+        expect(metrics).to receive(:require).with('datadog/statsd') do
+          stub_const('Datadog::Statsd', const)
+        end
+      end
+
+      it 'loads Datadog::Statsd library' do
+        is_expected.to be(statsd_client)
+      end
+    end
   end
 
   describe '#configure' do


### PR DESCRIPTION
This PR fixes this flaky `metrics_spec.rb` test: https://app.circleci.com/jobs/github/DataDog/dd-trace-rb/52268

The failure happens because a few tests reference `Datadog::Statsd` in their `before` steps without ensuring that it has been loaded:  https://github.com/DataDog/dd-trace-rb/blob/97e8e0d005ce675b1577c473146a3285304668d1/spec/ddtrace/metrics_spec.rb#L166

More often then not, `Datadog::Statsd` gets dynamically loaded by `metrics.rb` https://github.com/DataDog/dd-trace-rb/blob/97e8e0d005ce675b1577c473146a3285304668d1/lib/ddtrace/metrics.rb#L43
and tests run fine, but we shouldn't depend on the side-effects of other tests for a correct test run.

Because I explicitly `require 'datadog/statsd'` in the test file, I've added a new test to ensure that our code that dynamically loads `Datadog::Statsd` still works.