### PR TITLE
Reduce external warnings for Ruby 2.7

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -59,5 +59,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
   spec.add_development_dependency 'pry', '~> 0.10.4'
   spec.add_development_dependency 'pry-stack_explorer', '~> 0.4.9.2'
-  spec.add_development_dependency 'warning' if RUBY_VERSION >= '2.5.0'
+  spec.add_development_dependency 'warning', '~> 1' if RUBY_VERSION >= '2.5.0'
 end

--- a/spec/support/health_metric_helpers.rb
+++ b/spec/support/health_metric_helpers.rb
@@ -5,40 +5,40 @@ require 'ddtrace/ext/diagnostics'
 module HealthMetricHelpers
   include RSpec::Mocks::ArgumentMatchers
 
+  METRICS = {
+    api_errors: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_API_ERRORS },
+    api_requests: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_API_REQUESTS },
+    api_responses: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_API_RESPONSES },
+    error_context_overflow: {
+      type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_ERROR_CONTEXT_OVERFLOW
+    },
+    error_instrumentation_patch: {
+      type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_ERROR_INSTRUMENTATION_PATCH
+    },
+    error_span_finish: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_ERROR_SPAN_FINISH },
+    error_unfinished_spans: {
+      type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_ERROR_UNFINISHED_SPANS
+    },
+    instrumentation_patched: {
+      type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_INSTRUMENTATION_PATCHED
+    },
+    queue_accepted: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_ACCEPTED },
+    queue_accepted_lengths: {
+      type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_ACCEPTED_LENGTHS
+    },
+    queue_dropped: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_DROPPED },
+    traces_filtered: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_TRACES_FILTERED },
+    writer_cpu_time: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_WRITER_CPU_TIME },
+    queue_length: { type: :gauge, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_LENGTH },
+    queue_max_length: { type: :gauge, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_MAX_LENGTH },
+    queue_spans: { type: :gauge, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_SPANS },
+    sampling_service_cache_length: {
+      type: :gauge, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_SAMPLING_SERVICE_CACHE_LENGTH
+    }
+  }.freeze
+
   shared_context 'health metrics' do
     include_context 'metrics'
-
-    METRICS = {
-      api_errors: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_API_ERRORS },
-      api_requests: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_API_REQUESTS },
-      api_responses: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_API_RESPONSES },
-      error_context_overflow: {
-        type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_ERROR_CONTEXT_OVERFLOW
-      },
-      error_instrumentation_patch: {
-        type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_ERROR_INSTRUMENTATION_PATCH
-      },
-      error_span_finish: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_ERROR_SPAN_FINISH },
-      error_unfinished_spans: {
-        type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_ERROR_UNFINISHED_SPANS
-      },
-      instrumentation_patched: {
-        type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_INSTRUMENTATION_PATCHED
-      },
-      queue_accepted: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_ACCEPTED },
-      queue_accepted_lengths: {
-        type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_ACCEPTED_LENGTHS
-      },
-      queue_dropped: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_DROPPED },
-      traces_filtered: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_TRACES_FILTERED },
-      writer_cpu_time: { type: :count, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_WRITER_CPU_TIME },
-      queue_length: { type: :gauge, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_LENGTH },
-      queue_max_length: { type: :gauge, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_MAX_LENGTH },
-      queue_spans: { type: :gauge, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_SPANS },
-      sampling_service_cache_length: {
-        type: :gauge, name: Datadog::Ext::Diagnostics::Health::Metrics::METRIC_SAMPLING_SERVICE_CACHE_LENGTH
-      }
-    }.freeze
 
     let(:health_metrics) { Datadog::Diagnostics::Health.metrics }
     before { METRICS.each { |metric, _attrs| allow(health_metrics).to receive(metric) } }

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,7 +10,7 @@ require 'ddtrace/span'
 begin
   # Ignore interpreter warnings from external libraries
   require 'warning'
-  Warning.ignore([:method_redefined, :not_reached, :unused_var], %r{.*/gems/[^/]*/lib/})
+  Warning.ignore([:method_redefined, :not_reached, :unused_var, :safe, :taint], %r{.*/gems/[^/]*/lib/})
 rescue LoadError
   puts 'warning suppressing gem not available, external library warnings will be displayed'
 end


### PR DESCRIPTION
I was looking at the warning list for the new version of Ruby and noticed quite a few new deprecations.

This PR suppresses deprecations related to the use of native `rb_tainted_str_new_cstr` and `rb_tainted_str_new` methods, which will be removed in Ruby 3.2, and are not related to our library.

I've left one new warning unsuppressed, `Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`, as this warning might help us debug interface problems when Ruby 3.0 is released.

I've also fixed one small warning actually caused by our library:
```
health_metric_helpers.rb:11: warning: already initialized constant HealthMetricHelpers::METRICS
health_metric_helpers.rb:11: warning: previous definition of METRICS was here
```
This is the only warning that is attributed to us in CI currently.