### PR TITLE
Unlock Rack where Graph 1.3 is available

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -345,7 +345,7 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
       gem 'racecar', '>= 0.3.5'
-      gem 'rack', '< 2.1.0' # Remove when grape bug is fixed: https://github.com/ruby-grape/grape/issues/1966
+      gem 'rack', '< 2.1.0' # Locked due to grape incompatibility: https://github.com/ruby-grape/grape/issues/1980
       gem 'rack-test'
       gem 'rake', '>= 12.3'
       gem 'redis', '< 4.0'
@@ -503,7 +503,7 @@ elsif Gem::Version.new('2.3.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
       gem 'racecar', '>= 0.3.5'
-      gem 'rack', '< 2.1.0' # Remove when grape bug is fixed: https://github.com/ruby-grape/grape/issues/1966
+      gem 'rack', '< 2.1.0' # Locked due to grape incompatibility: https://github.com/ruby-grape/grape/issues/1980
       gem 'rack-test'
       gem 'rake', '>= 12.3'
       gem 'redis', '< 4.0'
@@ -576,7 +576,7 @@ elsif Gem::Version.new('2.4.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
       gem 'racecar', '>= 0.3.5'
-      gem 'rack', '< 2.1.0' # Remove when grape bug is fixed: https://github.com/ruby-grape/grape/issues/1966
+      gem 'rack'
       gem 'rack-test'
       gem 'rake', '>= 12.3'
       gem 'redis', '< 4.0'
@@ -683,7 +683,7 @@ elsif Gem::Version.new('2.5.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
       gem 'racecar', '>= 0.3.5'
-      gem 'rack', '< 2.1.0' # Remove when grape bug is fixed: https://github.com/ruby-grape/grape/issues/1966
+      gem 'rack'
       gem 'rack-test'
       gem 'rake', '>= 12.3'
       gem 'redis', '< 4.0'
@@ -790,7 +790,7 @@ elsif Gem::Version.new('2.6.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
       gem 'racecar', '>= 0.3.5'
-      gem 'rack', '< 2.1.0' # Remove when grape bug is fixed: https://github.com/ruby-grape/grape/issues/1966
+      gem 'rack'
       gem 'rack-test'
       gem 'rake', '>= 12.3'
       gem 'redis', '< 4.0'
@@ -899,7 +899,7 @@ elsif Gem::Version.new('2.7.0') <= Gem::Version.new(RUBY_VERSION)
       gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
       gem 'racecar', '>= 0.3.5'
-      gem 'rack', '< 2.1.0' # Remove when grape bug is fixed: https://github.com/ruby-grape/grape/issues/1966
+      gem 'rack'
       gem 'rack-test'
       gem 'rake', '>= 12.3'
       gem 'redis', '< 4.0'


### PR DESCRIPTION
With the release of Grape 1.3, support for the latest version of Rack has been added, allowing us to test against the latest version of both gems once again.

Unfortunately, the new version of Grape that is compatible with Rack >= 2.1 is [only available for Ruby >= 2.4](https://rubygems.org/gems/grape/versions/1.3.0). This means that we are still locking Rack for Ruby <= 2.3.