### PR TITLE
Log sidekiq job arguments

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1463,6 +1463,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `client_service_name` | Service name used for client-side `sidekiq` instrumentation | `'sidekiq-client'` |
 | `service_name` | Service name used for server-side `sidekiq` instrumentation | `'sidekiq'` |
+| `tag_args` | Enable tagging of job arguments. `true` for on, `false` for off. | `false` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 
 ### Sinatra

--- a/lib/ddtrace/contrib/sidekiq/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sidekiq/configuration/settings.rb
@@ -17,6 +17,11 @@ module Datadog
             o.lazy
           end
 
+          option :tag_args do |o|
+            o.default { env_to_bool(Ext::ENV_TAG_JOB_ARGS, false) }
+            o.lazy
+          end
+
           option :service_name, default: Ext::SERVICE_NAME
           option :client_service_name, default: Ext::CLIENT_SERVICE_NAME
         end

--- a/lib/ddtrace/contrib/sidekiq/ext.rb
+++ b/lib/ddtrace/contrib/sidekiq/ext.rb
@@ -7,6 +7,7 @@ module Datadog
         CLIENT_SERVICE_NAME = 'sidekiq-client'.freeze
         ENV_ANALYTICS_ENABLED = 'DD_SIDEKIQ_ANALYTICS_ENABLED'.freeze
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_SIDEKIQ_ANALYTICS_SAMPLE_RATE'.freeze
+        ENV_TAG_JOB_ARGS = 'DD_SIDEKIQ_TAG_JOB_ARGS'.freeze
         SERVICE_NAME = 'sidekiq'.freeze
         SPAN_PUSH = 'sidekiq.push'.freeze
         SPAN_JOB = 'sidekiq.job'.freeze
@@ -15,6 +16,7 @@ module Datadog
         TAG_JOB_QUEUE = 'sidekiq.job.queue'.freeze
         TAG_JOB_RETRY = 'sidekiq.job.retry'.freeze
         TAG_JOB_WRAPPER = 'sidekiq.job.wrapper'.freeze
+        TAG_JOB_ARGS = 'sidekiq.job.args'.freeze
       end
     end
   end

--- a/lib/ddtrace/contrib/sidekiq/server_tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/server_tracer.rb
@@ -16,7 +16,8 @@ module Datadog
         def call(worker, job, queue)
           resource = job_resource(job)
 
-          service = service_from_worker_config(resource) || @sidekiq_service
+          service = worker_config(resource, :service_name) || @sidekiq_service
+          tag_args = worker_config(resource, :tag_args) || configuration[:tag_args]
 
           @tracer.trace(Ext::SPAN_JOB, service: service, span_type: Datadog::Ext::AppTypes::WORKER) do |span|
             span.resource = resource
@@ -29,6 +30,9 @@ module Datadog
             span.set_tag(Ext::TAG_JOB_QUEUE, job['queue'])
             span.set_tag(Ext::TAG_JOB_WRAPPER, job['class']) if job['wrapped']
             span.set_tag(Ext::TAG_JOB_DELAY, 1000.0 * (Time.now.utc.to_f - job['enqueued_at'].to_f))
+            if tag_args && !job['args'].nil? && !job['args'].empty?
+              span.set_tag(Ext::TAG_JOB_ARGS, job['args'])
+            end
 
             yield
           end
@@ -40,7 +44,7 @@ module Datadog
           Datadog.configuration[:sidekiq]
         end
 
-        def service_from_worker_config(resource)
+        def worker_config(resource, key)
           # Try to get the Ruby class from the resource name.
           worker_klass = begin
             Object.const_get(resource)
@@ -49,7 +53,7 @@ module Datadog
           end
 
           if worker_klass.respond_to?(:datadog_tracer_config)
-            worker_klass.datadog_tracer_config[:service_name]
+            worker_klass.datadog_tracer_config[key]
           end
         end
       end

--- a/test/contrib/sidekiq/server_tracer_test.rb
+++ b/test/contrib/sidekiq/server_tracer_test.rb
@@ -21,10 +21,10 @@ class ServerTracerTest < TracerTestBase
     include Sidekiq::Worker
 
     def self.datadog_tracer_config
-      { service_name: 'sidekiq-slow' }
+      { service_name: 'sidekiq-slow', tag_args: true }
     end
 
-    def perform(); end
+    def perform(args); end
   end
 
   class DelayableClass
@@ -54,6 +54,7 @@ class ServerTracerTest < TracerTestBase
     refute_nil(span.get_tag('sidekiq.job.delay'))
     assert_equal(0, span.status)
     assert_nil(span.parent)
+    assert_nil(span.get_tag('sidekiq.job.args'))
   end
 
   # rubocop:disable Lint/HandleExceptions
@@ -75,11 +76,12 @@ class ServerTracerTest < TracerTestBase
     assert_equal('job error', span.get_tag(Datadog::Ext::Errors::MSG))
     assert_equal('ServerTracerTest::TestError', span.get_tag(Datadog::Ext::Errors::TYPE))
     assert_nil(span.parent)
+    assert_nil(span.get_tag('sidekiq.job.args'))
   end
 
   def test_custom
     EmptyWorker.perform_async()
-    CustomWorker.perform_async()
+    CustomWorker.perform_async('random_id')
 
     spans = @writer.spans()
     assert_equal(2, spans.length)
@@ -98,6 +100,7 @@ class ServerTracerTest < TracerTestBase
     assert_equal('default', custom.get_tag('sidekiq.job.queue'))
     assert_equal(0, custom.status)
     assert_nil(custom.parent)
+    assert_equal(['random_id'].to_s, custom.get_tag('sidekiq.job.args'))
   end
 
   def test_delayed_extensions


### PR DESCRIPTION
Sidekiq job arguments are currently not being logged. I heavily rely on the arguments to see how a job has performed. I guess not many use it, so I wrapped it as an option so the user can turn it on/off.

Here is an example: 
![image](https://user-images.githubusercontent.com/1121579/72960499-29c82900-3d6b-11ea-8377-0483411afb3d.png)


