### PR TITLE
Spans should error, if calls to AWS error out.

### DIFF
--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -25,8 +25,8 @@ To start a development environment, choose a target Ruby version then run the fo
 # In the root directory of the project...
 cd ~/dd-trace-rb
 
-# Create and start a Ruby 2.3 test environment with its dependencies
-docker-compose run --rm tracer-2.3 /bin/bash
+# Create and start a Ruby 2.4 test environment with its dependencies
+docker-compose run --rm tracer-2.4 /bin/bash
 
 # Then inside the container (e.g. `root@2a73c6d8673e:/app`)...
 # Install the library dependencies

--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -25,8 +25,8 @@ To start a development environment, choose a target Ruby version then run the fo
 # In the root directory of the project...
 cd ~/dd-trace-rb
 
-# Create and start a Ruby 2.4 test environment with its dependencies
-docker-compose run --rm tracer-2.4 /bin/bash
+# Create and start a Ruby 2.3 test environment with its dependencies
+docker-compose run --rm tracer-2.3 /bin/bash
 
 # Then inside the container (e.g. `root@2a73c6d8673e:/app`)...
 # Install the library dependencies

--- a/lib/ddtrace/contrib/aws/instrumentation.rb
+++ b/lib/ddtrace/contrib/aws/instrumentation.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/aws/ext'
+require 'ddtrace/ext/http'
 
 module Datadog
   module Contrib
@@ -28,6 +29,11 @@ module Datadog
           span.span_type = Datadog::Ext::AppTypes::WEB
           span.name = Ext::SPAN_COMMAND
           span.resource = context.safely(:resource)
+
+          # Set error on the span if the Response Status Code is in error range
+          if Datadog::Ext::HTTP::ERROR_RANGE.cover?(context.safely(:status_code))
+            span.set_error(context.safely(:http_response))
+          end
 
           # Set analytics sample rate
           if Contrib::Analytics.enabled?(configuration[:analytics_enabled])

--- a/lib/ddtrace/contrib/aws/parsed_context.rb
+++ b/lib/ddtrace/contrib/aws/parsed_context.rb
@@ -19,6 +19,10 @@ module Datadog
           context.operation_name
         end
 
+        def http_response
+          context.http_response
+        end
+
         def status_code
           context.http_response.status_code
         end

--- a/spec/ddtrace/contrib/aws/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/aws/instrumentation_spec.rb
@@ -62,4 +62,17 @@ RSpec.describe 'AWS instrumentation' do
       end
     end
   end
+
+  context 'when the client runs and the API returns an error' do
+    before(:each) do
+      client.stub_responses(:list_buckets, status_code: 500,
+                                           body: 'error',
+                                           headers: {})
+    end
+
+    it 'generates an errored span' do
+      expect { client.list_buckets }.to raise_error
+      expect(span.status).to eq 1
+    end
+  end
 end

--- a/spec/ddtrace/contrib/aws/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/aws/instrumentation_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe 'AWS instrumentation' do
 
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
+        expect(span.status).to eq 0
         expect(span.service).to eq('aws')
         expect(span.span_type).to eq('web')
         expect(span.resource).to eq('s3.list_buckets')

--- a/spec/ddtrace/contrib/aws/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/aws/instrumentation_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'AWS instrumentation' do
 
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
-        expect(span.status).to eq 0
+        expect(span).not_to have_error
         expect(span.service).to eq('aws')
         expect(span.span_type).to eq('web')
         expect(span.resource).to eq('s3.list_buckets')
@@ -73,7 +73,7 @@ RSpec.describe 'AWS instrumentation' do
 
     it 'generates an errored span' do
       expect { client.list_buckets }.to raise_error
-      expect(span.status).to eq 1
+      expect(span).to have_error
     end
   end
 end

--- a/spec/ddtrace/contrib/aws/parsed_context_spec.rb
+++ b/spec/ddtrace/contrib/aws/parsed_context_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Datadog::Contrib::Aws::ParsedContext do
           http_method: 'GET',
           region: 'us-west-2',
           retry_attempts: 0,
-          path: '/'
+          path: '/',
+          http_response: be_kind_of(Seahorse::Client::Http::Response)
         )
       end
 


### PR DESCRIPTION
Description
------------

I noticed that when calls to AWS error out (5xx), the spans show up as green and are not marked as being an error. The `http.status_code` tag was however being set correctly to the 5xx status code.

In this PR, the `aws/instrumentation.rb` code sets the error on the span, if the `status_code` is in the `Datadog::Ext::HTTP::ERROR_RANGE`. 

Additionally, I updated the `DevelopmentGuide.md`, since it looks like we require a `Ruby 2.4` environment now.

Testing
--------

- Added unit tests to ensure coverage.
- Is there any additional integration tests or checks that I need to run to ensure that this is a safe change ? I couldn't find information about that in the docs.
