### PR TITLE
Feature: Redis multiplexing

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1293,6 +1293,33 @@ customer_cache.get(...)
 invoice_cache.get(...)
 ```
 
+**Configuring trace settings per connection**
+
+You can configure trace settings per connection by using the `describes` option:
+
+```ruby
+# Provide a `:describes` option with a connection key.
+# Any of the following keys are acceptable and equivalent to one another.
+# If a block is provided, it yields a Settings object that
+# accepts any of the configuration options listed above.
+
+Datadog.configure do |c|
+  # The default configuration for any redis client
+  c.use :redis, service_name: 'redis-default'
+
+  # The configuration matching a given unix socket
+  c.use :redis, describes: { url: 'unix://path/to/file' }, service_name: 'redis-unix'
+
+  # Connection string
+  c.use :redis, describes: { url: 'redis://127.0.0.1:6379/0' }, service_name: 'redis-connection-string'
+  # Client host, port, db, scheme
+  c.use :redis, describes: { host: 'my-host.com', port: 6379, db: 1, scheme: 'redis' }, service_name: 'redis-connection-hash'
+  # Only a subset of the connection hash
+  c.use :redis, describes: { host: ENV['APP_CACHE_HOST'], port: ENV['APP_CACHE_PORT'] }, service_name: 'redis-cache'
+  c.use :redis, describes: { host: ENV['SIDEKIQ_CACHE_HOST'] }, service_name: 'redis-sidekiq'
+end
+```
+
 ### Resque
 
 The Resque integration uses Resque hooks that wraps the `perform` method.

--- a/lib/ddtrace/contrib/redis/configuration/resolver.rb
+++ b/lib/ddtrace/contrib/redis/configuration/resolver.rb
@@ -30,14 +30,28 @@ module Datadog
               return resolved_config if uri.scheme == 'unix'
             end
 
-            resolved_config.concat(
+            resolved_hosts_config = resolved_hosts(options[:host]).map do |resolved_host|
               [
-                { host: options[:host], port: options[:port], db: options[:db] },
-                { host: options[:host], port: options[:port] },
-                { host: options[:host], db: options[:db] },
-                { host: options[:host] }
+                { host: resolved_host, port: options[:port], db: options[:db] },
+                { host: resolved_host, port: options[:port] },
+                { host: resolved_host, db: options[:db] },
+                { host: resolved_host }
               ]
-            )
+            end.flatten
+            resolved_config.concat(resolved_hosts_config)
+          end
+
+          # make sure that the configuration will be matched against hostnames as well
+          def resolved_hosts(host)
+            require 'resolv'
+
+            resolved = [host]
+            resolved += Resolv.getaddresses(host)
+            resolved += Resolv.getnames(host)
+          rescue Resolv::ResolvError
+            # Resolv.getnames('localhost') raises
+            # Resolv::ResolvError (cannot interpret as address: localhost)
+            resolved
           end
         end
       end

--- a/lib/ddtrace/contrib/redis/configuration/resolver.rb
+++ b/lib/ddtrace/contrib/redis/configuration/resolver.rb
@@ -4,7 +4,6 @@ module Datadog
       module Configuration
         # Converts Symbols, Strings, and Hashes to a normalized connection settings Hash.
         class Resolver
-
           attr_reader :options
           # Redis::Client@options
           def initialize(options)
@@ -12,7 +11,12 @@ module Datadog
           end
 
           def resolve
-              possible_configurations.find { |conf| Datadog.configuration[:redis, conf] } || Datadog.configuration[:redis]
+            possible_configurations.each do |conf|
+              if Datadog.configuration[:redis, conf] != Datadog.configuration[:redis]
+                return Datadog.configuration[:redis, conf]
+              end
+            end
+            Datadog.configuration[:redis]
           end
 
           def possible_configurations

--- a/lib/ddtrace/contrib/redis/configuration/resolver.rb
+++ b/lib/ddtrace/contrib/redis/configuration/resolver.rb
@@ -1,0 +1,42 @@
+module Datadog
+  module Contrib
+    module Redis
+      module Configuration
+        # Converts Symbols, Strings, and Hashes to a normalized connection settings Hash.
+        class Resolver
+
+          attr_reader :options
+          # Redis::Client@options
+          def initialize(options)
+            @options = options
+          end
+
+          def resolve
+              possible_configurations.find { |conf| Datadog.configuration[:redis, conf] } || Datadog.configuration[:redis]
+          end
+
+          def possible_configurations
+            resolved_config = []
+            if options[:url]
+              resolved_config << options[:url]
+
+              require 'uri'
+              uri = URI(options[:url])
+
+              return resolved_config if uri.scheme == 'unix'
+            end
+
+            resolved_config.concat(
+              [
+                { host: options[:host], port: options[:port], db: options[:db] },
+                { host: options[:host], port: options[:port] },
+                { host: options[:host], db: options[:db] },
+                { host: options[:host] }
+              ]
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/redis/configuration/resolver.rb
+++ b/lib/ddtrace/contrib/redis/configuration/resolver.rb
@@ -4,17 +4,20 @@ module Datadog
       module Configuration
         # Converts Symbols, Strings, and Hashes to a normalized connection settings Hash.
         class Resolver < Contrib::Configuration::Resolver
-
           def resolve(key_or_hash)
             return :default if key_or_hash == :default
 
-            normalize(key_or_hash).tap { |x| puts x.inspect }
+            normalize(key_or_hash)
           end
 
           def normalize(hash)
             resolved_configuration = resolve_configuration(hash)
+            return { url: resolved_configuration[:url] } if resolved_configuration[:scheme] == 'unix'
+
+            # Connexion strings are always converted to host, port, db and scheme
+            # but the host, port, db and scheme will generate the :url only after
+            # establishing a first connexion
             {
-              url: resolved_configuration[:url],
               host: resolved_configuration[:host],
               port: resolved_configuration[:port],
               db: resolved_configuration[:db],

--- a/lib/ddtrace/contrib/redis/configuration/resolver.rb
+++ b/lib/ddtrace/contrib/redis/configuration/resolver.rb
@@ -1,4 +1,4 @@
-require 'ddtrace/vendor/redis/connection_specification'
+require 'ddtrace/contrib/redis/vendor/resolver'
 
 module Datadog
   module Contrib
@@ -27,7 +27,7 @@ module Datadog
           end
 
           def connection_resolver
-            @connection_resolver ||= ::Datadog::Vendor::Redis::ConnectionSpecification::Resolver.new
+            @connection_resolver ||= ::Datadog::Contrib::Redis::Vendor::Resolver.new
           end
         end
       end

--- a/lib/ddtrace/contrib/redis/integration.rb
+++ b/lib/ddtrace/contrib/redis/integration.rb
@@ -30,6 +30,10 @@ module Datadog
         def patcher
           Patcher
         end
+
+        def resolver
+          @resolver ||= Configuration::Resolver.new
+        end
       end
     end
   end

--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -72,13 +72,19 @@ module Datadog
             def datadog_pin
               @datadog_pin ||= begin
                 pin = Datadog::Pin.new(
-                  Datadog.configuration[:redis][:service_name],
+                  datadog_configuration[:service_name],
                   app: Ext::APP,
                   app_type: Datadog::Ext::AppTypes::DB,
                   tracer: Datadog.configuration[:redis][:tracer]
                 )
                 pin.onto(self)
               end
+            end
+
+            private
+
+            def datadog_configuration
+              Datadog.configuration[:redis, "#{host}:#{port}"] || Datadog.configuration[:redis]
             end
           end
         end

--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/contrib/patcher'
 require 'ddtrace/contrib/redis/ext'
+require 'ddtrace/contrib/redis/configuration/resolver'
 
 module Datadog
   module Contrib
@@ -84,10 +85,16 @@ module Datadog
             private
 
             def datadog_configuration
-              Datadog.configuration[:redis, "#{host}:#{port}"] || Datadog.configuration[:redis]
+              @datadog_configuration ||= resolver.resolve
+            end
+
+            def resolver
+              @resolver ||= Datadog::Contrib::Redis::Configuration::Resolver.new(options)
             end
           end
         end
+        # rubocop:enable Metrics/MethodLength
+        # rubocop:enable Metrics/BlockLength
       end
     end
   end

--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -85,11 +85,11 @@ module Datadog
             private
 
             def datadog_configuration
-              @datadog_configuration ||= resolver.resolve
+              @datadog_configuration ||= Datadog.configuration[:redis, resolver.resolve(options)]
             end
 
             def resolver
-              @resolver ||= Datadog::Contrib::Redis::Configuration::Resolver.new(options)
+              @resolver ||= Datadog::Contrib::Redis::Configuration::Resolver.new
             end
           end
         end

--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -76,7 +76,7 @@ module Datadog
                   datadog_configuration[:service_name],
                   app: Ext::APP,
                   app_type: Datadog::Ext::AppTypes::DB,
-                  tracer: Datadog.configuration[:redis][:tracer]
+                  tracer: datadog_configuration[:tracer]
                 )
                 pin.onto(self)
               end
@@ -85,11 +85,7 @@ module Datadog
             private
 
             def datadog_configuration
-              @datadog_configuration ||= Datadog.configuration[:redis, resolver.resolve(options)]
-            end
-
-            def resolver
-              @resolver ||= Datadog::Contrib::Redis::Configuration::Resolver.new
+              Datadog.configuration[:redis, options]
             end
           end
         end

--- a/lib/ddtrace/contrib/redis/vendor/resolver.rb
+++ b/lib/ddtrace/contrib/redis/vendor/resolver.rb
@@ -6,13 +6,9 @@ require 'uri'
 #       library as a separated module and it allows to avoid
 #       instantiating a new Redis::Client for resolving the connection
 module Datadog
-  module Vendor
+  module Contrib
     module Redis
-      # The following module mirrors what has been done for ActiveRecord
-      # connection specification
-      module ConnectionSpecification
-        ##
-        # Builds a ConnectionSpecification from user input.
+      module Vendor
         class Resolver # :nodoc:
           # Connection DEFAULTS for a Redis::Client are unchanged for
           # the integration supported options.

--- a/lib/ddtrace/vendor/redis/connection_specification.rb
+++ b/lib/ddtrace/vendor/redis/connection_specification.rb
@@ -1,0 +1,163 @@
+require 'uri'
+
+# NOTE: This code is copied directly from Redis.
+#       Its purpose is to resolve connection information.
+#       It exists here only because it doesn't exist in the redis
+#       library as a separated module and it allows to avoid
+#       instantiating a new Redis::Client for resolving the connection
+module Datadog
+  module Vendor
+    module Redis
+      # The following module mirrors what has been done for ActiveRecord
+      # connection specification
+      module ConnectionSpecification
+        ##
+        # Builds a ConnectionSpecification from user input.
+        class Resolver # :nodoc:
+          # Connection DEFAULTS for a Redis::Client are unchanged for
+          # the integration supported options.
+          # https://github.com/redis/redis-rb/blob/v3.0.0/lib/redis/client.rb#L6-L14
+          # https://github.com/redis/redis-rb/blob/v4.1.3/lib/redis/client.rb#L10-L26
+          # Since the integration takes in consideration only few attributes, all
+          # versions are compatible for :url, :scheme, :host, :port, :db
+          DEFAULTS = {
+            url: -> { ENV['REDIS_URL'] },
+            scheme: 'redis',
+            host: '127.0.0.1',
+            port: 6379,
+            path: nil,
+            # :timeout => 5.0,
+            password: nil,
+            db: 0 # ,
+            # :driver => nil,
+            # :id => nil,
+            # :tcp_keepalive => 0,
+            # :reconnect_attempts => 1,
+            # :reconnect_delay => 0,
+            # :reconnect_delay_max => 0.5,
+            # :inherit_socket => false
+          }.freeze
+
+          def resolve(options)
+            _parse_options(options)
+          end
+
+          # rubocop:disable Metrics/AbcSize
+          # rubocop:disable Metrics/MethodLength
+          # rubocop:disable Metrics/PerceivedComplexity
+          #
+          # This method is a subset of the implementation provided in v3.0.0
+          # https://github.com/redis/redis-rb/blob/v3.0.0/lib/redis/client.rb
+          # https://github.com/redis/redis-rb/blob/v4.1.3/lib/redis/client.rb
+          #
+          # Since it has been backported from the original gem, some linting
+          # cops have been disabled
+          def _parse_options(options)
+            # https://github.com/redis/redis-rb/blob/v4.1.3/lib/redis/client.rb#L404
+            # Early return for modern client options
+            return options if options[:_parsed]
+
+            defaults = DEFAULTS.dup
+            options = options.dup
+
+            defaults.keys.each do |key|
+              # Fill in defaults if needed
+              if defaults[key].respond_to?(:call)
+                defaults[key] = defaults[key].call
+              end
+
+              # Symbolize only keys that are needed
+              options[key] = options[key.to_s] if options.key?(key.to_s)
+            end
+
+            url = options[:url]
+            url = defaults[:url] if url.nil?
+
+            # Override defaults from URL if given
+            if url
+              uri = URI(url)
+
+              if uri.scheme == 'unix'
+                defaults[:path] = uri.path
+              elsif uri.scheme == 'redis' || uri.scheme == 'rediss'
+                defaults[:scheme]   = uri.scheme
+                defaults[:host]     = uri.host if uri.host
+                defaults[:port]     = uri.port if uri.port
+                defaults[:password] = CGI.unescape(uri.password) if uri.password
+                defaults[:db]       = uri.path[1..-1].to_i if uri.path
+                defaults[:role] = :master
+              else
+                raise ArgumentError, "invalid uri scheme '#{uri.scheme}'"
+              end
+
+              # defaults[:ssl] = true if uri.scheme == "rediss"
+            end
+
+            # Use default when option is not specified or nil
+            defaults.keys.each do |key|
+              options[key] = defaults[key] if options[key].nil?
+            end
+
+            if options[:path]
+              # Unix socket
+              options[:scheme] = 'unix'
+              options.delete(:host)
+              options.delete(:port)
+            else
+              # TCP socket
+              options[:host] = options[:host].to_s
+              options[:port] = options[:port].to_i
+            end
+
+            # Options ignored by the integration
+            #
+            # if options.has_key?(:timeout)
+            #   options[:connect_timeout] ||= options[:timeout]
+            #   options[:read_timeout]    ||= options[:timeout]
+            #   options[:write_timeout]   ||= options[:timeout]
+            # end
+
+            # options[:connect_timeout] = Float(options[:connect_timeout])
+            # options[:read_timeout]    = Float(options[:read_timeout])
+            # options[:write_timeout]   = Float(options[:write_timeout])
+
+            # options[:reconnect_attempts] = options[:reconnect_attempts].to_i
+            # options[:reconnect_delay] = options[:reconnect_delay].to_f
+            # options[:reconnect_delay_max] = options[:reconnect_delay_max].to_f
+
+            options[:db] = options[:db].to_i
+            # options[:driver] = _parse_driver(options[:driver]) || Connection.drivers.last
+
+            # case options[:tcp_keepalive]
+            # when Hash
+            #   [:time, :intvl, :probes].each do |key|
+            #     unless options[:tcp_keepalive][key].is_a?(Integer)
+            #       raise "Expected the #{key.inspect} key in :tcp_keepalive to be an Integer"
+            #     end
+            #   end
+
+            # when Integer
+            #   if options[:tcp_keepalive] >= 60
+            #     options[:tcp_keepalive] = {:time => options[:tcp_keepalive] - 20, :intvl => 10, :probes => 2}
+
+            #   elsif options[:tcp_keepalive] >= 30
+            #     options[:tcp_keepalive] = {:time => options[:tcp_keepalive] - 10, :intvl => 5, :probes => 2}
+
+            #   elsif options[:tcp_keepalive] >= 5
+            #     options[:tcp_keepalive] = {:time => options[:tcp_keepalive] - 2, :intvl => 2, :probes => 1}
+            #   end
+            # end
+
+            options[:_parsed] = true
+
+            options
+          end
+
+          # rubocop:enable Metrics/AbcSize
+          # rubocop:enable Metrics/MethodLength
+          # rubocop:enable Metrics/PerceivedComplexity
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/redis/configuration/resolver_spec.rb
+++ b/spec/ddtrace/contrib/redis/configuration/resolver_spec.rb
@@ -4,62 +4,109 @@ require 'redis'
 require 'ddtrace'
 
 RSpec.describe 'Redis configuration resolver' do
-  let(:tracer) { get_test_tracer }
-  let(:client) { Redis::Client.new(connection_options) }
+  describe 'possible_configurations' do
+    it 'works with a unix socket' do
+      url = 'unix://file/to/path'
+      redis = Redis::Client.new(url: url)
 
-  subject(:service_name) { Datadog::Contrib::Redis::Configuration::Resolver.new(client.options).resolve[:service_name] }
+      resolver = Datadog::Contrib::Redis::Configuration::Resolver.new(redis.options)
 
-  around do |example|
-    # Reset before and after each example; don't allow global state to linger.
-    Datadog.registry[:redis].reset_configuration!
-    example.run
-    Datadog.registry[:redis].reset_configuration!
-  end
+      expect(resolver.possible_configurations).to match_array([url])
+    end
 
-  before do
-    Datadog.configure do |c|
-      c.use :redis, tracer: tracer, service_name: 'wrong-service-name'
-      c.use :redis, describes: connection_options[:url] || connection_options, tracer: tracer, service_name: 'good-service-name'
+    it 'works with a connection string' do
+      url = 'redis://127.0.0.1:6379/0'
+      redis = Redis::Client.new(url: url)
+
+      resolver = Datadog::Contrib::Redis::Configuration::Resolver.new(redis.options)
+
+      expect(resolver.possible_configurations).to match_array(
+        [
+          url,
+          { host: '127.0.0.1', port: 6379, db: 0 },
+          { host: '127.0.0.1', port: 6379 },
+          { host: '127.0.0.1', db: 0 },
+          { host: '127.0.0.1' }
+        ]
+      )
+    end
+
+    it 'works with host, port, db hash' do
+      args = { host: '127.0.0.1', port: 6379, db: 0 }
+      redis = Redis::Client.new(**args)
+
+      resolver = Datadog::Contrib::Redis::Configuration::Resolver.new(redis.options)
+
+      expect(resolver.possible_configurations).to match_array(
+        [
+          { host: '127.0.0.1', port: 6379, db: 0 },
+          { host: '127.0.0.1', port: 6379 },
+          { host: '127.0.0.1', db: 0 },
+          { host: '127.0.0.1' }
+        ]
+      )
     end
   end
 
-  context 'when host, port and db provided' do
-    let(:connection_options) { { host: '127.0.0.1', port: 6379, db: 0 } }
+  describe 'resolve' do
+    let(:tracer) { get_test_tracer }
+    let(:client) { Redis::Client.new(connection_options) }
 
-    it do
-      expect(service_name).to eq('good-service-name')
+    subject(:service_name) { Datadog::Contrib::Redis::Configuration::Resolver.new(client.options).resolve[:service_name] }
+
+    around do |example|
+      # Reset before and after each example; don't allow global state to linger.
+      Datadog.registry[:redis].reset_configuration!
+      example.run
+      Datadog.registry[:redis].reset_configuration!
     end
-  end
 
-  context 'when host and port provided' do
-    let(:connection_options) { { host: '127.0.0.1', port: 6379 } }
-
-    it do
-      expect(service_name).to eq('good-service-name')
+    before do
+      Datadog.configure do |c|
+        c.use :redis, tracer: tracer, service_name: 'wrong-service-name'
+        describes = connection_options[:url] || connection_options
+        c.use :redis, describes: describes, tracer: tracer, service_name: 'good-service-name'
+      end
     end
-  end
 
-  context 'when host and db provided' do
-    let(:connection_options) { { host: '127.0.0.1', db: 0 } }
+    context 'when host, port and db provided' do
+      let(:connection_options) { { host: '127.0.0.1', port: 6379, db: 0 } }
 
-    it do
-      expect(service_name).to eq('good-service-name')
+      it do
+        expect(service_name).to eq('good-service-name')
+      end
     end
-  end
 
-  context 'when unix connection string provided' do
-    let(:connection_options) { { url: "unix://file/to/path" } }
+    context 'when host and port provided' do
+      let(:connection_options) { { host: '127.0.0.1', port: 6379 } }
 
-    it do
-      expect(service_name).to eq('good-service-name')
+      it do
+        expect(service_name).to eq('good-service-name')
+      end
     end
-  end
 
-  context 'when redis connection string provided' do
-    let(:connection_options) { { url: "redis://localhost:6379/0" } }
+    context 'when host and db provided' do
+      let(:connection_options) { { host: '127.0.0.1', db: 0 } }
 
-    it do
-      expect(service_name).to eq('good-service-name')
+      it do
+        expect(service_name).to eq('good-service-name')
+      end
+    end
+
+    context 'when unix connection string provided' do
+      let(:connection_options) { { url: 'unix://file/to/path' } }
+
+      it do
+        expect(service_name).to eq('good-service-name')
+      end
+    end
+
+    context 'when redis connection string provided' do
+      let(:connection_options) { { url: 'redis://localhost:6379/0' } }
+
+      it do
+        expect(service_name).to eq('good-service-name')
+      end
     end
   end
 end

--- a/spec/ddtrace/contrib/redis/configuration/resolver_spec.rb
+++ b/spec/ddtrace/contrib/redis/configuration/resolver_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+require 'redis'
+require 'ddtrace'
+
+RSpec.describe 'Redis configuration resolver' do
+  let(:tracer) { get_test_tracer }
+  let(:client) { Redis::Client.new(connection_options) }
+
+  subject(:service_name) { Datadog::Contrib::Redis::Configuration::Resolver.new(client.options).resolve[:service_name] }
+
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:redis].reset_configuration!
+    example.run
+    Datadog.registry[:redis].reset_configuration!
+  end
+
+  before do
+    Datadog.configure do |c|
+      c.use :redis, tracer: tracer, service_name: 'wrong-service-name'
+      c.use :redis, describes: connection_options[:url] || connection_options, tracer: tracer, service_name: 'good-service-name'
+    end
+  end
+
+  context 'when host, port and db provided' do
+    let(:connection_options) { { host: '127.0.0.1', port: 6379, db: 0 } }
+
+    it do
+      expect(service_name).to eq('good-service-name')
+    end
+  end
+
+  context 'when host and port provided' do
+    let(:connection_options) { { host: '127.0.0.1', port: 6379 } }
+
+    it do
+      expect(service_name).to eq('good-service-name')
+    end
+  end
+
+  context 'when host and db provided' do
+    let(:connection_options) { { host: '127.0.0.1', db: 0 } }
+
+    it do
+      expect(service_name).to eq('good-service-name')
+    end
+  end
+
+  context 'when unix connection string provided' do
+    let(:connection_options) { { url: "unix://file/to/path" } }
+
+    it do
+      expect(service_name).to eq('good-service-name')
+    end
+  end
+
+  context 'when redis connection string provided' do
+    let(:connection_options) { { url: "redis://localhost:6379/0" } }
+
+    it do
+      expect(service_name).to eq('good-service-name')
+    end
+  end
+end

--- a/spec/ddtrace/contrib/redis/configuration/resolver_spec.rb
+++ b/spec/ddtrace/contrib/redis/configuration/resolver_spec.rb
@@ -20,13 +20,18 @@ RSpec.describe 'Redis configuration resolver' do
 
       resolver = Datadog::Contrib::Redis::Configuration::Resolver.new(redis.options)
 
+      allow(resolver).to receive(:resolved_hosts).with('127.0.0.1').and_return(['127.0.0.1', 'localhost'])
       expect(resolver.possible_configurations).to match_array(
         [
           url,
           { host: '127.0.0.1', port: 6379, db: 0 },
           { host: '127.0.0.1', port: 6379 },
           { host: '127.0.0.1', db: 0 },
-          { host: '127.0.0.1' }
+          { host: '127.0.0.1' },
+          { host: 'localhost', port: 6379, db: 0 },
+          { host: 'localhost', port: 6379 },
+          { host: 'localhost', db: 0 },
+          { host: 'localhost' }
         ]
       )
     end
@@ -37,12 +42,17 @@ RSpec.describe 'Redis configuration resolver' do
 
       resolver = Datadog::Contrib::Redis::Configuration::Resolver.new(redis.options)
 
+      allow(resolver).to receive(:resolved_hosts).with('127.0.0.1').and_return(['127.0.0.1', 'localhost'])
       expect(resolver.possible_configurations).to match_array(
         [
           { host: '127.0.0.1', port: 6379, db: 0 },
           { host: '127.0.0.1', port: 6379 },
           { host: '127.0.0.1', db: 0 },
-          { host: '127.0.0.1' }
+          { host: '127.0.0.1' },
+          { host: 'localhost', port: 6379, db: 0 },
+          { host: 'localhost', port: 6379 },
+          { host: 'localhost', db: 0 },
+          { host: 'localhost' }
         ]
       )
     end

--- a/spec/ddtrace/contrib/redis/configuration/resolver_spec.rb
+++ b/spec/ddtrace/contrib/redis/configuration/resolver_spec.rb
@@ -14,13 +14,7 @@ RSpec.describe 'Redis configuration resolver' do
     let(:options) { { url: 'unix://path/to/file' } }
 
     it do
-      expect(resolver.resolve(options)).to eq({
-        url: 'unix://path/to/file',
-        host: nil,
-        port: nil,
-        db: 0,
-        scheme: 'unix'
-      })
+      expect(resolver.resolve(options)).to eq(url: 'unix://path/to/file')
     end
   end
 
@@ -28,16 +22,12 @@ RSpec.describe 'Redis configuration resolver' do
     let(:options) { { url: 'redis://127.0.0.1:6379/0' } }
 
     it do
-      expect(resolver.resolve(options)).to eq({
-        url: 'redis://127.0.0.1:6379/0',
-        host: '127.0.0.1',
-        port: 6379,
-        db: 0,
-        scheme: 'redis'
-      })
+      expect(resolver.resolve(options)).to eq(host: '127.0.0.1',
+                                              port: 6379,
+                                              db: 0,
+                                              scheme: 'redis')
     end
   end
-
 
   context 'when host, port, db and scheme provided' do
     let(:options) do
@@ -47,17 +37,13 @@ RSpec.describe 'Redis configuration resolver' do
         db: 0,
         scheme: 'redis'
       }
-
     end
 
     it do
-      expect(resolver.resolve(options)).to eq({
-        url: nil,
-        host: '127.0.0.1',
-        port: 6379,
-        db: 0,
-        scheme: 'redis'
-      })
+      expect(resolver.resolve(options)).to eq(host: '127.0.0.1',
+                                              port: 6379,
+                                              db: 0,
+                                              scheme: 'redis')
     end
   end
 
@@ -68,17 +54,13 @@ RSpec.describe 'Redis configuration resolver' do
         port: 6379,
         db: 0
       }
-
     end
 
     it do
-      expect(resolver.resolve(options)).to eq({
-        url: nil,
-        host: '127.0.0.1',
-        port: 6379,
-        db: 0,
-        scheme: 'redis'
-      })
+      expect(resolver.resolve(options)).to eq(host: '127.0.0.1',
+                                              port: 6379,
+                                              db: 0,
+                                              scheme: 'redis')
     end
   end
 
@@ -88,17 +70,13 @@ RSpec.describe 'Redis configuration resolver' do
         host: '127.0.0.1',
         port: 6379
       }
-
     end
 
     it do
-      expect(resolver.resolve(options)).to eq({
-        url: nil,
-        host: '127.0.0.1',
-        port: 6379,
-        db: 0,
-        scheme: 'redis'
-      })
+      expect(resolver.resolve(options)).to eq(host: '127.0.0.1',
+                                              port: 6379,
+                                              db: 0,
+                                              scheme: 'redis')
     end
   end
 end

--- a/spec/ddtrace/contrib/redis/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/redis/instrumentation_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+require 'redis'
+require 'hiredis'
+require 'ddtrace'
+
+RSpec.describe 'Redis instrumentation test' do
+  let(:test_host) { ENV.fetch('TEST_REDIS_HOST', '127.0.0.1') }
+  let(:test_port) { ENV.fetch('TEST_REDIS_PORT', 6379).to_i }
+
+  let(:client) { Redis.new(host: test_host, port: test_port) }
+  let(:tracer) { get_test_tracer }
+  let(:configuration_options) { { tracer: tracer } }
+
+  def all_spans
+    tracer.writer.spans(:keep)
+  end
+  let(:span) { all_spans.first }
+
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:redis].reset_configuration!
+    example.run
+    Datadog.registry[:redis].reset_configuration!
+  end
+
+  before(:each) do
+    skip unless ENV['TEST_DATADOG_INTEGRATION']
+  end
+
+  describe 'when multiplexed configuration is provided' do
+    let(:default_service_name) { 'default-service' }
+    let(:service_name) { 'multiplex-service' }
+
+    before do
+      Datadog.configure do |c|
+        c.use :redis, tracer: tracer, service_name: default_service_name
+        c.use :redis, describes: "#{test_host}:#{test_port}", tracer: tracer, service_name: service_name
+      end
+    end
+
+    context 'and #set is called' do
+      before do
+        client.set('abc', 123)
+        try_wait_until { all_spans.any? }
+      end
+
+      it 'calls instrumentation' do
+        aggregate_failures do
+          expect(all_spans.size).to eq(1)
+          expect(span.service).to eq(service_name)
+          expect(span.name).to eq('redis.command')
+          expect(span.span_type).to eq('redis')
+          expect(span.resource).to eq('SET abc 123')
+          expect(span.get_tag('redis.raw_command')).to eq('SET abc 123')
+          expect(span.get_tag('out.host')).to eq(test_host)
+          expect(span.get_tag('out.port')).to eq(test_port.to_f)
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/redis/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/redis/instrumentation_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe 'Redis instrumentation test' do
   describe 'when multiplexed configuration is provided via url' do
     let(:default_service_name) { 'default-service' }
     let(:service_name) { 'multiplex-service' }
-    let(:redis_url) { "redis://#{test_host}:#{test_port}}" }
+    let(:redis_url) { "redis://#{test_host}:#{test_port}/0" }
+    let(:client) { Redis.new(url: redis_url) }
 
     before do
       Datadog.configure do |c|

--- a/spec/ddtrace/contrib/redis/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/redis/instrumentation_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Redis instrumentation test' do
     before do
       Datadog.configure do |c|
         c.use :redis, tracer: tracer, service_name: default_service_name
-        c.use :redis, describes: { host: test_host, port: test_port}, tracer: tracer, service_name: service_name
+        c.use :redis, describes: { host: test_host, port: test_port }, tracer: tracer, service_name: service_name
       end
     end
 

--- a/spec/ddtrace/contrib/redis/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/redis/instrumentation_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Redis instrumentation test' do
     before do
       Datadog.configure do |c|
         c.use :redis, tracer: tracer, service_name: default_service_name
-        c.use :redis, describes: redis_url, tracer: tracer, service_name: service_name
+        c.use :redis, describes: { url: redis_url }, tracer: tracer, service_name: service_name
       end
     end
 
@@ -63,6 +63,7 @@ RSpec.describe 'Redis instrumentation test' do
   describe 'when multiplexed configuration is provided via hash' do
     let(:default_service_name) { 'default-service' }
     let(:service_name) { 'multiplex-service' }
+    let(:client) { Redis.new(host: test_host, port: test_port) }
 
     before do
       Datadog.configure do |c|


### PR DESCRIPTION
As discussed with @delner in #861 
Adding multiplexing support for redis patcher

It may be interesting to add an instrumentation module as it was done for other contrib integrations. This would allow to clean up a bit the patcher module.

_Disclaimer_: the only doubt that I have about this implementation is that the redis client will resolve the hostname and the mapping on the host won't be done. I will try to test on my side once I will receive a review from your team. 🙏 