### PR TITLE
Add #add to configuration resolver

### DIFF
--- a/lib/ddtrace/contrib/active_record/configuration/resolver.rb
+++ b/lib/ddtrace/contrib/active_record/configuration/resolver.rb
@@ -9,16 +9,10 @@ module Datadog
         class Resolver < Contrib::Configuration::Resolver
           def initialize(configurations = nil)
             @configurations = configurations
-            @well_known_keys = {}
           end
 
           def resolve(key)
-            return @well_known_keys[key] if @well_known_keys.key?(key)
             normalize(connection_resolver.resolve(key).symbolize_keys)
-          end
-
-          def add(key)
-            @well_known_keys[key] = resolve(key)
           end
 
           def configurations
@@ -30,9 +24,7 @@ module Datadog
               if defined?(::ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver)
                 ::ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(configurations)
               else
-                ::Datadog::Vendor::ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(
-                  configurations
-                )
+                ::Datadog::Vendor::ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(configurations)
               end
             end
           end

--- a/lib/ddtrace/contrib/active_record/integration.rb
+++ b/lib/ddtrace/contrib/active_record/integration.rb
@@ -36,7 +36,7 @@ module Datadog
         end
 
         def resolver
-          @resolver ||= Configuration::Resolver.new
+          @resolver ||= Configuration::Resolver.new { default_configuration }
         end
       end
     end

--- a/lib/ddtrace/contrib/active_record/integration.rb
+++ b/lib/ddtrace/contrib/active_record/integration.rb
@@ -36,7 +36,7 @@ module Datadog
         end
 
         def resolver
-          @resolver ||= Configuration::Resolver.new { default_configuration }
+          @resolver ||= Configuration::Resolver.new
         end
       end
     end

--- a/lib/ddtrace/contrib/configuration/resolver.rb
+++ b/lib/ddtrace/contrib/configuration/resolver.rb
@@ -1,10 +1,35 @@
 module Datadog
   module Contrib
     module Configuration
-      # Resolves a value to a configuration key
+      # Resolves a configuration key to a Datadog::Contrib::Configuration:Settings object
       class Resolver
-        def resolve(name)
-          name
+        attr_reader \
+          :configurations
+
+        def initialize(&block)
+          raise ArgumentError, 'Default configuration block must be provided!' unless block_given?
+
+          @default_configuration_block = block
+          @configurations = {}
+
+          add(:default)
+        end
+
+        def resolve(key)
+          key = :default unless match?(key)
+          @configurations[key]
+        end
+
+        def add(key, config = nil)
+          @configurations[key] = config || new_default_configuration
+        end
+
+        def match?(key)
+          @configurations.key?(key)
+        end
+
+        def new_default_configuration
+          @default_configuration_block.call
         end
       end
     end

--- a/lib/ddtrace/contrib/configuration/resolver.rb
+++ b/lib/ddtrace/contrib/configuration/resolver.rb
@@ -3,33 +3,12 @@ module Datadog
     module Configuration
       # Resolves a configuration key to a Datadog::Contrib::Configuration:Settings object
       class Resolver
-        attr_reader \
-          :configurations
-
-        def initialize(&block)
-          raise ArgumentError, 'Default configuration block must be provided!' unless block_given?
-
-          @default_configuration_block = block
-          @configurations = {}
-
-          add(:default)
-        end
-
         def resolve(key)
-          key = :default unless match?(key)
-          @configurations[key]
+          key
         end
 
-        def add(key, config = nil)
-          @configurations[key] = config || new_default_configuration
-        end
-
-        def match?(key)
-          @configurations.key?(key)
-        end
-
-        def new_default_configuration
-          @default_configuration_block.call
+        def add(key)
+          key
         end
       end
     end

--- a/spec/ddtrace/contrib/configurable_spec.rb
+++ b/spec/ddtrace/contrib/configurable_spec.rb
@@ -70,7 +70,9 @@ RSpec.describe Datadog::Contrib::Configurable do
 
           context 'that does not match any configuration' do
             it do
-              expect { configure }.to(change { configurable_object.configuration(name).object_id })
+              expect { configure }.to change { configurable_object.configuration(name) }
+                .from(configurable_object.configurations[:default])
+                .to(a_kind_of(Datadog::Contrib::Configuration::Settings))
             end
           end
         end

--- a/spec/ddtrace/contrib/configurable_spec.rb
+++ b/spec/ddtrace/contrib/configurable_spec.rb
@@ -20,59 +20,120 @@ RSpec.describe Datadog::Contrib::Configurable do
 
       describe '#reset_configuration!' do
         subject(:reset_configuration!) { configurable_object.reset_configuration! }
-        it do
-          expect { reset_configuration! }.to(change { configurable_object.configuration.object_id })
+
+        it 'generates a new default configuration' do
+          expect { reset_configuration! }.to(change { configurable_object.configuration })
+        end
+
+        context 'when a configuration has been added' do
+          before(:each) { configurable_object.configure(:foo, service_name: 'bar') }
+
+          it do
+            expect { reset_configuration! }.to change { configurable_object.configurations.keys }
+              .from([:default, :foo])
+              .to([:default])
+          end
         end
       end
 
       describe '#configuration' do
-        context 'when no name is provided' do
+        context 'when no key is provided' do
           subject(:configuration) { configurable_object.configuration }
           it { is_expected.to be_a_kind_of(Datadog::Contrib::Configuration::Settings) }
-          it { expect(configuration.service_name).to be nil }
+          it { is_expected.to be(configurable_object.configurations[:default]) }
         end
 
-        context 'when a name is provided' do
-          subject(:configuration) { configurable_object.configuration(name) }
-          let(:name) { :foo }
+        context 'when a key is provided' do
+          subject(:configuration) { configurable_object.configuration(key) }
+          let(:key) { :foo }
 
           context 'and the configuration exists' do
             before { configurable_object.configure(:foo, service_name: 'bar') }
             it { is_expected.to be_a_kind_of(Datadog::Contrib::Configuration::Settings) }
-            it { expect(configuration.service_name).to eq('bar') }
+            it { is_expected.to be(configurable_object.configurations[:foo]) }
           end
 
           context 'but the configuration doesn\'t exist' do
             it { is_expected.to be_a_kind_of(Datadog::Contrib::Configuration::Settings) }
-            it { expect(configuration.service_name).to be nil }
+            it { is_expected.to be(configurable_object.configurations[:default]) }
+          end
+        end
+      end
+
+      describe '#configuration_for?' do
+        context 'when a key is provided' do
+          subject(:configuration_for?) { configurable_object.configuration_for?(key) }
+          let(:key) { :foo }
+
+          context 'as :default' do
+            let(:key) { :default }
+            it { is_expected.to be true }
+          end
+
+          context 'and the configuration exists' do
+            before { configurable_object.configure(:foo, service_name: 'bar') }
+            it { is_expected.to be true }
+          end
+
+          context 'but the configuration doesn\'t exist' do
+            it { is_expected.to be false }
+          end
+        end
+      end
+
+      describe '#configurations' do
+        subject(:configurations) { configurable_object.configurations }
+
+        context 'when nothing has been explicitly configured' do
+          it { is_expected.to include(default: a_kind_of(Datadog::Contrib::Configuration::Settings)) }
+        end
+
+        context 'when a configuration has been added' do
+          before { configurable_object.configure(:foo, service_name: 'bar') }
+
+          it do
+            is_expected.to include(
+              default: a_kind_of(Datadog::Contrib::Configuration::Settings),
+              foo: a_kind_of(Datadog::Contrib::Configuration::Settings)
+            )
           end
         end
       end
 
       describe '#configure' do
-        context 'when provided a name' do
-          subject(:configure) { configurable_object.configure(name, service_name: 'bar') }
-          let(:name) { :foo }
+        context 'when provided a key' do
+          subject(:configure) { configurable_object.configure(key, service_name: 'bar') }
+          let(:key) { :foo }
+
+          context 'as nil or :default' do
+            [nil, :default].each do |k|
+              let(:key) { k }
+
+              it 'reuses the default configuration object' do
+                expect { configure }.to_not(change { configurable_object.configuration(key) })
+                expect(configurable_object.configuration(key)).to be(configurable_object.configuration(:default))
+                expect(configurable_object.configuration(:default).service_name).to eq('bar')
+              end
+            end
+          end
 
           context 'that matches an existing configuration' do
-            before { configurable_object.configure(name, service_name: 'baz') }
+            before { configurable_object.configure(key, service_name: 'baz') }
 
             it 'updates the configuration' do
-              expect { configure }.to change { configurable_object.configuration(name).service_name }
+              expect { configure }.to change { configurable_object.configuration(key).service_name }
                 .from('baz')
                 .to('bar')
             end
 
             it 'reuses the same configuration object' do
-              expect { configure }.to_not(change { configurable_object.configuration(name).object_id })
+              expect { configure }.to_not(change { configurable_object.configuration(key) })
             end
           end
 
           context 'that does not match any configuration' do
             it do
-              expect { configure }.to change { configurable_object.configuration(name) }
-                .from(configurable_object.configurations[:default])
-                .to(a_kind_of(Datadog::Contrib::Configuration::Settings))
+              expect { configure }.to(change { configurable_object.configuration(key) })
             end
           end
         end

--- a/spec/ddtrace/contrib/configuration/resolver_spec.rb
+++ b/spec/ddtrace/contrib/configuration/resolver_spec.rb
@@ -7,74 +7,15 @@ RSpec.describe Datadog::Contrib::Configuration::Resolver do
   let(:default_config_block) { proc { config_class.new } }
   let(:config_class) { Class.new }
 
-  describe '.new' do
-    context 'when given no arguments' do
-      it { expect { described_class.new }.to raise_error(ArgumentError) }
-    end
-
-    context 'when given a block' do
-      it { is_expected.to be_a_kind_of(described_class) }
-      it { expect(resolver.configurations).to include(default: kind_of(config_class)) }
-    end
-  end
-
   describe '#resolve' do
     subject(:resolve) { resolver.resolve(key) }
     let(:key) { double('key') }
-
-    context 'when it doesn\'t match a configuration' do
-      it { is_expected.to be resolver.configurations[:default] }
-    end
-
-    context 'when it matches a configuration' do
-      let(:matching_config) { config_class.new }
-      before { resolver.add(key, matching_config) }
-      it { is_expected.to be matching_config }
-    end
+    it { is_expected.to be key }
   end
 
   describe '#add' do
+    subject(:add) { resolver.add(key) }
     let(:key) { double('key') }
-
-    context 'given a key' do
-      subject(:add) { resolver.add(key) }
-      it { expect { add }.to(change { resolver.resolve(key).object_id }) }
-    end
-
-    context 'given a key and configuration' do
-      subject(:add) { resolver.add(key, added_config) }
-      let(:added_config) { instance_double(config_class) }
-
-      it do
-        expect { add }.to change { resolver.resolve(key) }
-          .from(resolver.configurations[:default])
-          .to(added_config)
-      end
-    end
-  end
-
-  describe '#match?' do
-    subject(:resolve) { resolver.match?(key) }
-    let(:key) { double('key') }
-
-    context 'when it doesn\'t match a configuration' do
-      it { is_expected.to be false }
-    end
-
-    context 'when it matches a configuration' do
-      before { resolver.add(key) }
-      it { is_expected.to be true }
-    end
-  end
-
-  describe '#new_default_configuration' do
-    subject(:new_default_configuration) { resolver.new_default_configuration }
-
-    it { is_expected.to be_a_kind_of(config_class) }
-    it 'doesn\'t return the same object twice' do
-      first = resolver.new_default_configuration
-      second = resolver.new_default_configuration
-      expect(first).to_not be(second)
-    end
+    it { is_expected.to be key }
   end
 end

--- a/spec/ddtrace/contrib/configuration/resolver_spec.rb
+++ b/spec/ddtrace/contrib/configuration/resolver_spec.rb
@@ -1,13 +1,80 @@
 require 'spec_helper'
 
-require 'ddtrace'
+require 'ddtrace/contrib/configuration/resolver'
 
 RSpec.describe Datadog::Contrib::Configuration::Resolver do
-  subject(:resolver) { described_class.new }
+  subject(:resolver) { described_class.new(&default_config_block) }
+  let(:default_config_block) { proc { config_class.new } }
+  let(:config_class) { Class.new }
+
+  describe '.new' do
+    context 'when given no arguments' do
+      it { expect { described_class.new }.to raise_error(ArgumentError) }
+    end
+
+    context 'when given a block' do
+      it { is_expected.to be_a_kind_of(described_class) }
+      it { expect(resolver.configurations).to include(default: kind_of(config_class)) }
+    end
+  end
 
   describe '#resolve' do
-    subject(:resolve) { resolver.resolve(name) }
-    let(:name) { double('name') }
-    it { is_expected.to be name }
+    subject(:resolve) { resolver.resolve(key) }
+    let(:key) { double('key') }
+
+    context 'when it doesn\'t match a configuration' do
+      it { is_expected.to be resolver.configurations[:default] }
+    end
+
+    context 'when it matches a configuration' do
+      let(:matching_config) { config_class.new }
+      before { resolver.add(key, matching_config) }
+      it { is_expected.to be matching_config }
+    end
+  end
+
+  describe '#add' do
+    let(:key) { double('key') }
+
+    context 'given a key' do
+      subject(:add) { resolver.add(key) }
+      it { expect { add }.to(change { resolver.resolve(key).object_id }) }
+    end
+
+    context 'given a key and configuration' do
+      subject(:add) { resolver.add(key, added_config) }
+      let(:added_config) { instance_double(config_class) }
+
+      it do
+        expect { add }.to change { resolver.resolve(key) }
+          .from(resolver.configurations[:default])
+          .to(added_config)
+      end
+    end
+  end
+
+  describe '#match?' do
+    subject(:resolve) { resolver.match?(key) }
+    let(:key) { double('key') }
+
+    context 'when it doesn\'t match a configuration' do
+      it { is_expected.to be false }
+    end
+
+    context 'when it matches a configuration' do
+      before { resolver.add(key) }
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#new_default_configuration' do
+    subject(:new_default_configuration) { resolver.new_default_configuration }
+
+    it { is_expected.to be_a_kind_of(config_class) }
+    it 'doesn\'t return the same object twice' do
+      first = resolver.new_default_configuration
+      second = resolver.new_default_configuration
+      expect(first).to_not be(second)
+    end
   end
 end


### PR DESCRIPTION
To support the expansion of "multiplexing" (having multiple configurations per integration) and its applications in #882 and #861/#937, this pull request refactors the `Datadog::Contrib::Configuration::Resolver` and adds an `#add` function to it, to allow for certain use cases to operate more efficiently. See linked issues/PRs for example cases.

This was originally a change introduced in #882 by @stormsilver, but extracted it out as a base for other PRs as well.