### PR TITLE
Instrument Sidekiq traces with Delayed Extensions

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -492,6 +492,7 @@ elsif Gem::Version.new('2.3.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'dalli'
       gem 'delayed_job'
       gem 'delayed_job_active_record'
+      gem 'ruby-prof', '< 1.0'
       gem 'elasticsearch-transport'
       gem 'ethon'
       gem 'excon'

--- a/Appraisals
+++ b/Appraisals
@@ -492,7 +492,6 @@ elsif Gem::Version.new('2.3.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'dalli'
       gem 'delayed_job'
       gem 'delayed_job_active_record'
-      gem 'ruby-prof', '< 1.0'
       gem 'elasticsearch-transport'
       gem 'ethon'
       gem 'excon'

--- a/lib/ddtrace/contrib/sidekiq/tracing.rb
+++ b/lib/ddtrace/contrib/sidekiq/tracing.rb
@@ -18,6 +18,8 @@ module Datadog
         def job_resource(job)
           if job['wrapped']
             job['wrapped']
+          elsif job['class'] == 'Sidekiq::Extensions::DelayedClass'
+            YAML.load(job['args'].first)[0..1].join('.') rescue job['class'] # rubocop:disable Security/YAMLLoad
           else
             job['class']
           end

--- a/lib/ddtrace/contrib/sidekiq/tracing.rb
+++ b/lib/ddtrace/contrib/sidekiq/tracing.rb
@@ -26,7 +26,7 @@ module Datadog
             job['class']
           end
         rescue => e
-          Datadog::Logger.log.debug("Error retrieving Sidekiq job class name (jid:#{job['jid']}): #{e}")
+          Datadog::Logger.log.debug { "Error retrieving Sidekiq job class name (jid:#{job['jid']}): #{e}" }
 
           job['class']
         end

--- a/test/contrib/sidekiq/client_tracer_test.rb
+++ b/test/contrib/sidekiq/client_tracer_test.rb
@@ -24,7 +24,7 @@ class ClientTracerTest < TracerTestBase
     end
 
     Sidekiq::Testing.server_middleware.clear
-    Sidekiq::Extensions.enable_delay!
+    Sidekiq::Extensions.enable_delay! if Sidekiq::VERSION > '5.0.0'
   end
 
   def test_empty

--- a/test/contrib/sidekiq/client_tracer_test.rb
+++ b/test/contrib/sidekiq/client_tracer_test.rb
@@ -7,6 +7,10 @@ class ClientTracerTest < TracerTestBase
     def perform(); end
   end
 
+  class DelayableClass
+    def self.do_work; end
+  end
+
   def setup
     super
 
@@ -20,6 +24,7 @@ class ClientTracerTest < TracerTestBase
     end
 
     Sidekiq::Testing.server_middleware.clear
+    Sidekiq::Extensions.enable_delay!
   end
 
   def test_empty
@@ -55,5 +60,10 @@ class ClientTracerTest < TracerTestBase
     assert_equal('default', span.get_tag('sidekiq.job.queue'))
     assert_equal(0, span.status)
     assert_nil(span.parent)
+  end
+
+  def test_delayed_extensions
+    DelayableClass.delay.do_work
+    assert_equal('ClientTracerTest::DelayableClass.do_work', @writer.spans.first.resource)
   end
 end

--- a/test/contrib/sidekiq/server_tracer_test.rb
+++ b/test/contrib/sidekiq/server_tracer_test.rb
@@ -38,7 +38,7 @@ class ServerTracerTest < TracerTestBase
       chain.add(Datadog::Contrib::Sidekiq::ServerTracer,
                 tracer: @tracer, enabled: true)
     end
-    Sidekiq::Extensions.enable_delay!
+    Sidekiq::Extensions.enable_delay! if Sidekiq::VERSION > '5.0.0'
   end
 
   def test_empty

--- a/test/contrib/sidekiq/server_tracer_test.rb
+++ b/test/contrib/sidekiq/server_tracer_test.rb
@@ -27,6 +27,10 @@ class ServerTracerTest < TracerTestBase
     def perform(); end
   end
 
+  class DelayableClass
+    def self.do_work; end
+  end
+
   def setup
     super
 
@@ -34,6 +38,7 @@ class ServerTracerTest < TracerTestBase
       chain.add(Datadog::Contrib::Sidekiq::ServerTracer,
                 tracer: @tracer, enabled: true)
     end
+    Sidekiq::Extensions.enable_delay!
   end
 
   def test_empty
@@ -93,5 +98,10 @@ class ServerTracerTest < TracerTestBase
     assert_equal('default', custom.get_tag('sidekiq.job.queue'))
     assert_equal(0, custom.status)
     assert_nil(custom.parent)
+  end
+
+  def test_delayed_extensions
+    DelayableClass.delay.do_work
+    assert_equal('ServerTracerTest::DelayableClass.do_work', @writer.spans.first.resource)
   end
 end


### PR DESCRIPTION
_Follow up from #798_

Sidekiq provides [Delayed-extensions](https://github.com/mperham/sidekiq/wiki/Delayed-extensions/c03d6d910ebb5dd7984525beac353d26b41c4ad7) to allow for any method call to be made asynchronous.

When tracing jobs scheduled with Delayed-extensions, we receive information about what class and method were invoked as a YAML argument to the job, instead of the default `job['class']` attribute: `job['class']` is always set to `Sidekiq::Extensions::DelayedClass` for delayed jobs.

This PR decodes that YAML and retrieves information about the job invoked, setting it as the trace resource.

We use `YAML.parse` (instead of `YAML.load`) as it only parses the source text into a syntax tree, without loading any native Ruby objects. `YAML.load` can lead to vulnerabilities during object loading, but `YAML.parse` cannot.