### PR TITLE
Make Patchable methods more specific

### DIFF
--- a/lib/ddtrace/contrib/action_cable/integration.rb
+++ b/lib/ddtrace/contrib/action_cable/integration.rb
@@ -15,8 +15,8 @@ module Datadog
           Gem.loaded_specs['actioncable'] && Gem.loaded_specs['actioncable'].version
         end
 
-        def self.present?
-          super && defined?(::ActionCable)
+        def self.loaded?
+          defined?(::ActionCable)
         end
 
         def self.compatible?

--- a/lib/ddtrace/contrib/action_pack/integration.rb
+++ b/lib/ddtrace/contrib/action_pack/integration.rb
@@ -15,8 +15,8 @@ module Datadog
           Gem.loaded_specs['actionpack'] && Gem.loaded_specs['actionpack'].version
         end
 
-        def self.present?
-          super && defined?(::ActionPack)
+        def self.loaded?
+          defined?(::ActionPack)
         end
 
         def self.compatible?

--- a/lib/ddtrace/contrib/action_view/integration.rb
+++ b/lib/ddtrace/contrib/action_view/integration.rb
@@ -22,8 +22,8 @@ module Datadog
           end
         end
 
-        def self.present?
-          super && defined?(::ActionView)
+        def self.loaded?
+          defined?(::ActionView)
         end
 
         def self.compatible?

--- a/lib/ddtrace/contrib/active_model_serializers/integration.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/integration.rb
@@ -16,14 +16,12 @@ module Datadog
             && Gem.loaded_specs['active_model_serializers'].version
         end
 
-        def self.present?
-          super && defined?(::ActiveModel::Serializer)
+        def self.loaded?
+          defined?(::ActiveModel::Serializer) && defined?(::ActiveSupport::Notifications)
         end
 
         def self.compatible?
-          super \
-            && defined?(::ActiveSupport::Notifications) \
-            && version >= Gem::Version.new('0.9.0')
+          super && version >= Gem::Version.new('0.9.0')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/active_record/integration.rb
+++ b/lib/ddtrace/contrib/active_record/integration.rb
@@ -19,8 +19,8 @@ module Datadog
           Gem.loaded_specs['activerecord'] && Gem.loaded_specs['activerecord'].version
         end
 
-        def self.present?
-          super && defined?(::ActiveRecord)
+        def self.loaded?
+          defined?(::ActiveRecord)
         end
 
         def self.compatible?

--- a/lib/ddtrace/contrib/active_support/integration.rb
+++ b/lib/ddtrace/contrib/active_support/integration.rb
@@ -17,8 +17,8 @@ module Datadog
           Gem.loaded_specs['activesupport'] && Gem.loaded_specs['activesupport'].version
         end
 
-        def self.present?
-          super && defined?(::ActiveSupport)
+        def self.loaded?
+          defined?(::ActiveSupport)
         end
 
         def self.compatible?

--- a/lib/ddtrace/contrib/aws/integration.rb
+++ b/lib/ddtrace/contrib/aws/integration.rb
@@ -19,8 +19,12 @@ module Datadog
           end
         end
 
-        def self.present?
-          super && defined?(::Seahorse::Client::Base)
+        def self.loaded?
+          defined?(::Seahorse::Client::Base)
+        end
+
+        def self.compatible?
+          super && version >= Gem::Version.new('2.0')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/concurrent_ruby/integration.rb
+++ b/lib/ddtrace/contrib/concurrent_ruby/integration.rb
@@ -15,8 +15,12 @@ module Datadog
           Gem.loaded_specs['concurrent-ruby'] && Gem.loaded_specs['concurrent-ruby'].version
         end
 
-        def self.present?
-          super && defined?(::Concurrent::Future)
+        def self.loaded?
+          defined?(::Concurrent::Future)
+        end
+
+        def self.compatible?
+          super && version >= Gem::Version.new('0.9')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/dalli/integration.rb
+++ b/lib/ddtrace/contrib/dalli/integration.rb
@@ -15,8 +15,8 @@ module Datadog
           Gem.loaded_specs['dalli'] && Gem.loaded_specs['dalli'].version
         end
 
-        def self.present?
-          super && defined?(::Dalli)
+        def self.loaded?
+          defined?(::Dalli)
         end
 
         def self.compatible?

--- a/lib/ddtrace/contrib/delayed_job/integration.rb
+++ b/lib/ddtrace/contrib/delayed_job/integration.rb
@@ -15,8 +15,12 @@ module Datadog
           Gem.loaded_specs['delayed_job'] && Gem.loaded_specs['delayed_job'].version
         end
 
-        def self.present?
-          super && defined?(::Delayed)
+        def self.loaded?
+          defined?(::Delayed)
+        end
+
+        def self.compatible?
+          super && version >= Gem::Version.new('4.1')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/elasticsearch/integration.rb
+++ b/lib/ddtrace/contrib/elasticsearch/integration.rb
@@ -16,8 +16,8 @@ module Datadog
             && Gem.loaded_specs['elasticsearch-transport'].version
         end
 
-        def self.present?
-          super && defined?(::Elasticsearch::Transport)
+        def self.loaded?
+          defined?(::Elasticsearch::Transport)
         end
 
         def self.compatible?

--- a/lib/ddtrace/contrib/ethon/integration.rb
+++ b/lib/ddtrace/contrib/ethon/integration.rb
@@ -14,8 +14,12 @@ module Datadog
           Gem.loaded_specs['ethon'] && Gem.loaded_specs['ethon'].version
         end
 
-        def self.present?
-          super && defined?(::Ethon::Easy)
+        def self.loaded?
+          defined?(::Ethon::Easy)
+        end
+
+        def self.compatible?
+          super && version >= Gem::Version.new('0.11.0')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/excon/integration.rb
+++ b/lib/ddtrace/contrib/excon/integration.rb
@@ -15,8 +15,12 @@ module Datadog
           Gem.loaded_specs['excon'] && Gem.loaded_specs['excon'].version
         end
 
-        def self.present?
-          super && defined?(::Excon)
+        def self.loaded?
+          defined?(::Excon)
+        end
+
+        def self.compatible?
+          super && version >= Gem::Version.new('0.62')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/faraday/integration.rb
+++ b/lib/ddtrace/contrib/faraday/integration.rb
@@ -15,8 +15,8 @@ module Datadog
           Gem.loaded_specs['faraday'] && Gem.loaded_specs['faraday'].version
         end
 
-        def self.present?
-          super && defined?(::Faraday)
+        def self.loaded?
+          defined?(::Faraday)
         end
 
         def self.compatible?

--- a/lib/ddtrace/contrib/grape/integration.rb
+++ b/lib/ddtrace/contrib/grape/integration.rb
@@ -15,12 +15,12 @@ module Datadog
           Gem.loaded_specs['grape'] && Gem.loaded_specs['grape'].version
         end
 
-        def self.present?
-          super && defined?(::Grape)
+        def self.loaded?
+          defined?(::Grape) && defined?(::ActiveSupport::Notifications)
         end
 
         def self.compatible?
-          super && defined?(::ActiveSupport::Notifications)
+          super && version >= Gem::Version.new('1.0')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/graphql/integration.rb
+++ b/lib/ddtrace/contrib/graphql/integration.rb
@@ -15,14 +15,12 @@ module Datadog
           Gem.loaded_specs['graphql'] && Gem.loaded_specs['graphql'].version
         end
 
-        def self.present?
-          super && defined?(::GraphQL)
+        def self.loaded?
+          defined?(::GraphQL) && defined?(::GraphQL::Tracing::DataDogTracing)
         end
 
         def self.compatible?
-          super \
-            && defined?(::GraphQL::Tracing::DataDogTracing) \
-            && version >= Gem::Version.new('1.7.9')
+          super && version >= Gem::Version.new('1.7.9')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/grpc/integration.rb
+++ b/lib/ddtrace/contrib/grpc/integration.rb
@@ -15,8 +15,8 @@ module Datadog
           Gem.loaded_specs['grpc'] && Gem.loaded_specs['grpc'].version
         end
 
-        def self.present?
-          super && defined?(::GRPC)
+        def self.loaded?
+          defined?(::GRPC)
         end
 
         def self.compatible?

--- a/lib/ddtrace/contrib/http/integration.rb
+++ b/lib/ddtrace/contrib/http/integration.rb
@@ -19,6 +19,10 @@ module Datadog
           Gem::Version.new(RUBY_VERSION)
         end
 
+        def self.loaded?
+          defined?(::Net::HTTP)
+        end
+
         def default_configuration
           Configuration::Settings.new
         end

--- a/lib/ddtrace/contrib/mongodb/integration.rb
+++ b/lib/ddtrace/contrib/mongodb/integration.rb
@@ -15,8 +15,8 @@ module Datadog
           Gem.loaded_specs['mongo'] && Gem.loaded_specs['mongo'].version
         end
 
-        def self.present?
-          super && defined?(::Mongo::Monitoring::Global)
+        def self.loaded?
+          defined?(::Mongo::Monitoring::Global)
         end
 
         def self.compatible?

--- a/lib/ddtrace/contrib/mysql2/integration.rb
+++ b/lib/ddtrace/contrib/mysql2/integration.rb
@@ -15,8 +15,12 @@ module Datadog
           Gem.loaded_specs['mysql2'] && Gem.loaded_specs['mysql2'].version
         end
 
-        def self.present?
-          super && defined?(::Mysql2)
+        def self.loaded?
+          defined?(::Mysql2)
+        end
+
+        def self.compatible?
+          super && version >= Gem::Version.new('0.3.21')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/patchable.rb
+++ b/lib/ddtrace/contrib/patchable.rb
@@ -13,12 +13,24 @@ module Datadog
           nil
         end
 
-        def present?
+        # Is the target available? (e.g. gem installed?)
+        def available?
           !version.nil?
         end
 
+        # Is the target loaded into the application? (e.g. constants defined?)
+        def loaded?
+          true
+        end
+
+        # Is the loaded code compatible with this integration? (e.g. minimum version met?)
         def compatible?
-          Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(VERSION::MINIMUM_RUBY_VERSION) && present?
+          Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(VERSION::MINIMUM_RUBY_VERSION)
+        end
+
+        # Can the patch for this integration be applied?
+        def patchable?
+          available? && loaded? && compatible?
         end
       end
 
@@ -29,8 +41,13 @@ module Datadog
         end
 
         def patch
-          if !self.class.compatible? || patcher.nil?
-            Datadog::Logger.log.warn("Unable to patch #{self.class.name}")
+          if !self.class.patchable? || patcher.nil?
+            desc = "Available?: #{self.class.available?}"
+            desc += ", Loaded? #{self.class.loaded?}"
+            desc += ", Compatible? #{self.class.compatible?}"
+            desc += ", Patchable? #{self.class.patchable?}"
+
+            Datadog::Logger.log.warn("Unable to patch #{self.class.name} (#{desc})")
             return
           end
 

--- a/lib/ddtrace/contrib/presto/integration.rb
+++ b/lib/ddtrace/contrib/presto/integration.rb
@@ -15,8 +15,12 @@ module Datadog
           Gem.loaded_specs['presto-client'] && Gem.loaded_specs['presto-client'].version
         end
 
-        def self.present?
-          super && defined?(::Presto::Client::Client)
+        def self.loaded?
+          defined?(::Presto::Client::Client)
+        end
+
+        def self.compatible?
+          super && version >= Gem::Version.new('0.5.14')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/racecar/integration.rb
+++ b/lib/ddtrace/contrib/racecar/integration.rb
@@ -15,12 +15,12 @@ module Datadog
           Gem.loaded_specs['racecar'] && Gem.loaded_specs['racecar'].version
         end
 
-        def self.present?
-          super && defined?(::Racecar)
+        def self.loaded?
+          defined?(::Racecar) && defined?(::ActiveSupport::Notifications)
         end
 
         def self.compatible?
-          super && defined?(::ActiveSupport::Notifications)
+          super && version >= Gem::Version.new('0.3.5')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/rack/integration.rb
+++ b/lib/ddtrace/contrib/rack/integration.rb
@@ -15,8 +15,12 @@ module Datadog
           Gem.loaded_specs['rack'] && Gem.loaded_specs['rack'].version
         end
 
-        def self.present?
-          super && defined?(::Rack)
+        def self.loaded?
+          defined?(::Rack)
+        end
+
+        def self.compatible?
+          super && version >= Gem::Version.new('1.4.7')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/rails/integration.rb
+++ b/lib/ddtrace/contrib/rails/integration.rb
@@ -15,13 +15,16 @@ module Datadog
           Gem.loaded_specs['rails'] && Gem.loaded_specs['rails'].version
         end
 
-        def self.present?
+        def self.loaded?
           defined?(::Rails)
         end
 
         def self.compatible?
-          return false if ENV['DISABLE_DATADOG_RAILS']
-          super && defined?(::Rails::VERSION) && ::Rails::VERSION::MAJOR.to_i >= 3
+          super && version >= Gem::Version.new('3.0')
+        end
+
+        def self.patchable?
+          super && !ENV.key?('DISABLE_DATADOG_RAILS')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/rake/integration.rb
+++ b/lib/ddtrace/contrib/rake/integration.rb
@@ -15,8 +15,12 @@ module Datadog
           Gem.loaded_specs['rake'] && Gem.loaded_specs['rake'].version
         end
 
-        def self.present?
-          super && defined?(::Rake)
+        def self.loaded?
+          defined?(::Rake)
+        end
+
+        def self.compatible?
+          super && version >= Gem::Version.new('12.0')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/redis/integration.rb
+++ b/lib/ddtrace/contrib/redis/integration.rb
@@ -15,12 +15,12 @@ module Datadog
           Gem.loaded_specs['redis'] && Gem.loaded_specs['redis'].version
         end
 
-        def self.present?
-          super && defined?(::Redis)
+        def self.loaded?
+          defined?(::Redis)
         end
 
         def self.compatible?
-          !version.nil? && version >= Gem::Version.new('3.0.0')
+          super && version >= Gem::Version.new('3.2')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/resque/integration.rb
+++ b/lib/ddtrace/contrib/resque/integration.rb
@@ -15,8 +15,14 @@ module Datadog
           Gem.loaded_specs['resque'] && Gem.loaded_specs['resque'].version
         end
 
-        def self.present?
-          super && defined?(::Resque)
+        def self.loaded?
+          defined?(::Resque)
+        end
+
+        def self.compatible?
+          super \
+            && version >= Gem::Version.new('1.0') \
+            && version < Gem::Version.new('2.0')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/rest_client/integration.rb
+++ b/lib/ddtrace/contrib/rest_client/integration.rb
@@ -14,8 +14,12 @@ module Datadog
           Gem.loaded_specs['rest-client'] && Gem.loaded_specs['rest-client'].version
         end
 
-        def self.present?
-          super && defined?(::RestClient::Request)
+        def self.loaded?
+          defined?(::RestClient::Request)
+        end
+
+        def self.compatible?
+          super && version >= Gem::Version.new('1.8')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/sequel/integration.rb
+++ b/lib/ddtrace/contrib/sequel/integration.rb
@@ -15,8 +15,12 @@ module Datadog
           Gem.loaded_specs['sequel'] && Gem.loaded_specs['sequel'].version
         end
 
-        def self.present?
-          super && defined?(::Sequel)
+        def self.loaded?
+          defined?(::Sequel)
+        end
+
+        def self.compatible?
+          super && version >= Gem::Version.new('3.41')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/shoryuken/integration.rb
+++ b/lib/ddtrace/contrib/shoryuken/integration.rb
@@ -12,14 +12,16 @@ module Datadog
 
         register_as :shoryuken
 
-        class << self
-          def version
-            Gem.loaded_specs['shoryuken'] && Gem.loaded_specs['shoryuken'].version
-          end
+        def self.version
+          Gem.loaded_specs['shoryuken'] && Gem.loaded_specs['shoryuken'].version
+        end
 
-          def present?
-            super && defined?(::Shoryuken)
-          end
+        def self.loaded?
+          defined?(::Shoryuken)
+        end
+
+        def self.compatible?
+          super && version >= Gem::Version.new('4.0.2')
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/sidekiq/integration.rb
+++ b/lib/ddtrace/contrib/sidekiq/integration.rb
@@ -15,8 +15,8 @@ module Datadog
           Gem.loaded_specs['sidekiq'] && Gem.loaded_specs['sidekiq'].version
         end
 
-        def self.present?
-          super && defined?(::Sidekiq)
+        def self.loaded?
+          defined?(::Sidekiq)
         end
 
         def self.compatible?

--- a/lib/ddtrace/contrib/sinatra/integration.rb
+++ b/lib/ddtrace/contrib/sinatra/integration.rb
@@ -15,8 +15,8 @@ module Datadog
           Gem.loaded_specs['sinatra'] && Gem.loaded_specs['sinatra'].version
         end
 
-        def self.present?
-          super && defined?(::Sinatra)
+        def self.loaded?
+          defined?(::Sinatra)
         end
 
         def self.compatible?

--- a/lib/ddtrace/contrib/sucker_punch/integration.rb
+++ b/lib/ddtrace/contrib/sucker_punch/integration.rb
@@ -15,12 +15,12 @@ module Datadog
           Gem.loaded_specs['sucker_punch'] && Gem.loaded_specs['sucker_punch'].version
         end
 
-        def self.present?
-          super && defined?(::SuckerPunch)
+        def self.loaded?
+          defined?(::SuckerPunch)
         end
 
         def self.compatible?
-          super && Gem::Version.new(::SuckerPunch::VERSION) >= Gem::Version.new('2.0.0')
+          super && version >= Gem::Version.new('2.0.0')
         end
 
         def default_configuration

--- a/spec/ddtrace/contrib/rails/disable_env_spec.rb
+++ b/spec/ddtrace/contrib/rails/disable_env_spec.rb
@@ -17,9 +17,10 @@ MESSAGE
   include Rack::Test::Methods
   include_context 'Rails test application'
 
-  before do
-    allow(ENV).to receive(:[]).and_call_original
-    allow(ENV).to receive(:[]).with('DISABLE_DATADOG_RAILS').and_return('1')
+  around do |example|
+    ClimateControl.modify('DISABLE_DATADOG_RAILS' => '1') do
+      example.run
+    end
   end
 
   let(:routes) { { '/' => 'test#index' } }


### PR DESCRIPTION
To support some better loading and detection of integrations, we need more specific methods that can break down the state of an integration.

In this pull request, I removed `present?` and added `available?`, `loaded?` and `patchable?`. The patchable methods are then as follows:

- `available?`: Is the target available? (e.g. gem installed?) Default true if `version` is defined.
- `loaded?`: Is the target loaded? (e.g. constants defined?) Default true.
- `compatible?`: # Is the loaded code compatible with this integration? (e.g. minimum version met?) Default true if minimum version of Ruby met, otherwise false.
- `patchable?`: Can the patch for this integration be applied? Default true if `available?` & `loaded?` & `compatible?`