### PR TITLE
Add active_job support for resque

### DIFF
--- a/lib/ddtrace/contrib/resque/resque_job.rb
+++ b/lib/ddtrace/contrib/resque/resque_job.rb
@@ -9,11 +9,11 @@ module Datadog
     module Resque
       # Uses Resque job hooks to create traces
       module ResqueJob
-        def around_perform(*_)
+        def around_perform(args = {})
           return yield unless datadog_configuration && tracer
 
           tracer.trace(Ext::SPAN_JOB, span_options) do |span|
-            span.resource = name
+            span.resource = args.is_a?(Hash) && args['job_class'] || name
             span.span_type = Datadog::Ext::AppTypes::WORKER
             # Set analytics sample rate
             if Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])

--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -1,7 +1,7 @@
 module Datadog
   module VERSION
     MAJOR = 0
-    MINOR = 30
+    MINOR = 31
     PATCH = 0
     PRE = nil
 


### PR DESCRIPTION
To prevent that every job has the class name JobWrapper.

I didn't change specs and the commit is a little bit older so you have to adjust a few things ;) but it should be clear where the problem is