### PR TITLE
Fix Sidekiq setting non-serializable Class as resource

### DIFF
--- a/lib/ddtrace/contrib/sidekiq/tracing.rb
+++ b/lib/ddtrace/contrib/sidekiq/tracing.rb
@@ -19,16 +19,16 @@ module Datadog
         # primarily to support `ActiveJob`.
         def job_resource(job)
           if job['wrapped']
-            job['wrapped']
+            job['wrapped'].to_s
           elsif job['class'] == 'Sidekiq::Extensions::DelayedClass'
-            delay_extension_class(job)
+            delay_extension_class(job).to_s
           else
-            job['class']
+            job['class'].to_s
           end
         rescue => e
           Datadog::Logger.log.debug { "Error retrieving Sidekiq job class name (jid:#{job['jid']}): #{e}" }
 
-          job['class']
+          job['class'].to_s
         end
 
         #


### PR DESCRIPTION
Fixes #943 

In Rails ActiveJob via https://github.com/rails/rails/commit/0e64348ccaf513de731f403259ec5b49e7b3f028 they pass `wrapped` as a Class constant instead of a String. When this constant is set as the resource, it's suspected that it cannot be converted via Msgpack and raises an error on serialization.

This pull request makes sure the job resource is always a string.