### PR TITLE
Fix RuleSampler forwarding #update to sampler without #update

### DIFF
--- a/lib/ddtrace/sampling/rule_sampler.rb
+++ b/lib/ddtrace/sampling/rule_sampler.rb
@@ -86,7 +86,10 @@ module Datadog
         end
       end
 
-      def_delegators :@default_sampler, :update
+      def update(*args)
+        return false unless @default_sampler.respond_to?(:update)
+        @default_sampler.update(*args)
+      end
 
       private
 


### PR DESCRIPTION
Fixes #949 

Normally, the `RuleSampler` has a default sampler of `RateByServiceSampler` which responds to `#update`. When the `RuleSampler` is configured with a default sample rate, it sets a `RateSampler` as its default sampler, which does not respond to `#update`.

Thus when the transport receives priority sampling rates and attempts to update the sampler, it calls `RuleSampler` with `update` and attempts to forward to `RateSampler` which raises a `NoMethodError`.

In this pull request, we check if the default sampler responds to `#update` before forwarding. If it does not, return `false` instead.