### PR TITLE
Temporarily disable Rails 6 ActionCable tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -524,7 +524,7 @@ task :ci do
       sh 'bundle exec appraisal rails5-mysql2 rake spec:action_cable'
       sh 'bundle exec appraisal rails5-mysql2 rake spec:rails'
       sh 'bundle exec appraisal rails5-postgres rake spec:rails'
-      sh 'bundle exec appraisal rails6-mysql2 rake spec:action_cable'
+      # sh 'bundle exec appraisal rails6-mysql2 rake spec:action_cable' # TODO: Hangs CI jobs... fix and re-enable.
       sh 'bundle exec appraisal rails6-mysql2 rake spec:rails'
       sh 'bundle exec appraisal rails6-postgres rake spec:rails'
     end
@@ -589,7 +589,7 @@ task :ci do
       sh 'bundle exec appraisal rails5-mysql2 rake spec:action_cable'
       sh 'bundle exec appraisal rails5-mysql2 rake spec:rails'
       sh 'bundle exec appraisal rails5-postgres rake spec:rails'
-      sh 'bundle exec appraisal rails6-mysql2 rake spec:action_cable'
+      # sh 'bundle exec appraisal rails6-mysql2 rake spec:action_cable' # TODO: Hangs CI jobs... fix and re-enable.
       sh 'bundle exec appraisal rails6-mysql2 rake spec:rails'
       sh 'bundle exec appraisal rails6-postgres rake spec:rails'
     end


### PR DESCRIPTION
CI pipeline routinely hangs and times out when running `bundle exec appraisal rails6-mysql2 rake spec:action_cable` tests for Ruby 2.5 and 2.6. e.g. [from a failing CircleCI build](https://circleci.com/gh/DataDog/dd-trace-rb/55560?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)

```
bundle exec appraisal rails6-mysql2 rake spec:action_cable
>> BUNDLE_GEMFILE=/app/gemfiles/rails6_mysql2.gemfile bundle exec rake spec:action_cable
/usr/local/bin/ruby -I/usr/local/bundle/gems/rspec-core-3.9.1/lib:/usr/local/bundle/gems/rspec-support-3.9.2/lib /usr/local/bundle/gems/rspec-core-3.9.1/exe/rspec --pattern spec/ddtrace/contrib/action_cable/\*\*/\*_spec.rb
pg gem not found, trying another connector
I, [2020-02-18T18:53:06.652495 #7330]  INFO -- : Testing against Rails 6.0.2.1 with adapter 'mysql2://root:root@127.0.0.1:3306/mysql'

Randomized with seed 29299
......................................................................................

Finished in 0.83312 seconds (files took 1.64 seconds to load)
86 examples, 0 failures

Randomized with seed 29299

rake aborted!
Interrupt: 
/app/Rakefile:592:in `block in <top (required)>'
/usr/local/bundle/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/cli/exec.rb:74:in `load'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/cli/exec.rb:74:in `kernel_load'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/cli/exec.rb:28:in `run'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/cli.rb:465:in `exec'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/cli.rb:27:in `dispatch'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/cli.rb:18:in `start'
/usr/local/bin/bundle:30:in `block in <main>'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
/usr/local/bin/bundle:22:in `<main>'
Tasks: TOP => ci
(See full trace by running task with --trace)
rake aborted!
SignalException: SIGHUP
/usr/local/bundle/gems/rspec-core-3.9.1/lib/rspec/core/rake_task.rb:97:in `system'
/usr/local/bundle/gems/rspec-core-3.9.1/lib/rspec/core/rake_task.rb:97:in `run_task'
/usr/local/bundle/gems/rspec-core-3.9.1/lib/rspec/core/rake_task.rb:116:in `block (2 levels) in define'
/usr/local/bundle/gems/rspec-core-3.9.1/lib/rspec/core/rake_task.rb:114:in `block in define'
/usr/local/bundle/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/cli/exec.rb:74:in `load'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/cli/exec.rb:74:in `kernel_load'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/cli/exec.rb:28:in `run'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/cli.rb:465:in `exec'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/cli.rb:27:in `dispatch'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/cli.rb:18:in `start'
/usr/local/bundle/gems/bundler-2.0.2/exe/bundle:30:in `block in <top (required)>'
/usr/local/bundle/gems/bundler-2.0.2/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
/usr/local/bundle/gems/bundler-2.0.2/exe/bundle:22:in `<top (required)>'
/usr/local/bundle/bin/bundle:23:in `load'
/usr/local/bundle/bin/bundle:23:in `<main>'
Tasks: TOP => spec:action_cable
(See full trace by running task with --trace)

Too long with no output (exceeded 10m0s): context deadline exceeded
```

The tests pass relatively quickly, but then the build freezes there (often for 10+ mins) until a `SIGHUP` is received the the build terminates. (Maybe a process keeps running that prevents the build from continuing?)

In any case, this pull request disables these jobs until they're more stable, so as to unblock other builds.