### PR TITLE
Support for Rack 1.1.0+

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -349,7 +349,7 @@ For a list of available integrations, and their configuration options, please re
 | Net/HTTP                 | `http`                     | *(Any supported Ruby)*   | *[Link](#nethttp)*                  | *[Link](https://ruby-doc.org/stdlib-2.4.0/libdoc/net/http/rdoc/Net/HTTP.html)* |
 | Presto                   | `presto`                   | `>= 0.5.14`              | *[Link](#presto)*                   | *[Link](https://github.com/treasure-data/presto-client-ruby)*                  |
 | Racecar                  | `racecar`                  | `>= 0.3.5`               | *[Link](#racecar)*                  | *[Link](https://github.com/zendesk/racecar)*                                   |
-| Rack                     | `rack`                     | `>= 1.4.7`               | *[Link](#rack)*                     | *[Link](https://github.com/rack/rack)*                                         |
+| Rack                     | `rack`                     | `>= 1.1.0`               | *[Link](#rack)*                     | *[Link](https://github.com/rack/rack)*                                         |
 | Rails                    | `rails`                    | `>= 3.2`                 | *[Link](#rails)*                    | *[Link](https://github.com/rails/rails)*                                       |
 | Rake                     | `rake`                     | `>= 12.0`                | *[Link](#rake)*                     | *[Link](https://github.com/ruby/rake)*                                         |
 | Redis                    | `redis`                    | `>= 3.2`                 | *[Link](#redis)*                    | *[Link](https://github.com/redis/redis-rb)*                                    |

--- a/lib/ddtrace/contrib/rack/integration.rb
+++ b/lib/ddtrace/contrib/rack/integration.rb
@@ -20,7 +20,7 @@ module Datadog
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('1.4.7')
+          super && version >= Gem::Version.new('1.1.0')
         end
 
         def default_configuration

--- a/spec/ddtrace/contrib/rack/configuration_spec.rb
+++ b/spec/ddtrace/contrib/rack/configuration_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Rack integration configuration' do
         use Datadog::Contrib::Rack::TraceMiddleware
 
         map '/' do
-          run(proc { |_env| [200, { 'Content-Type' => 'text/html' }, 'OK'] })
+          run(proc { |_env| [200, { 'Content-Type' => 'text/html' }, ['OK']] })
         end
       end.to_app
     end

--- a/spec/ddtrace/contrib/rack/distributed_spec.rb
+++ b/spec/ddtrace/contrib/rack/distributed_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Rack integration distributed tracing' do
         use Datadog::Contrib::Rack::TraceMiddleware
 
         map '/' do
-          run(proc { |_env| [200, { 'Content-Type' => 'text/html' }, 'OK'] })
+          run(proc { |_env| [200, { 'Content-Type' => 'text/html' }, ['OK']] })
         end
       end.to_app
     end

--- a/spec/ddtrace/contrib/rack/integration_spec.rb
+++ b/spec/ddtrace/contrib/rack/integration_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Rack integration tests' do
       let(:routes) do
         proc do
           map '/success/' do
-            run(proc { |_env| [200, { 'Content-Type' => 'text/html' }, 'OK'] })
+            run(proc { |_env| [200, { 'Content-Type' => 'text/html' }, ['OK']] })
           end
         end
       end
@@ -230,7 +230,7 @@ RSpec.describe 'Rack integration tests' do
       let(:routes) do
         proc do
           map '/failure/' do
-            run(proc { |_env| [400, { 'Content-Type' => 'text/html' }, 'KO'] })
+            run(proc { |_env| [400, { 'Content-Type' => 'text/html' }, ['KO']] })
           end
         end
       end
@@ -262,7 +262,7 @@ RSpec.describe 'Rack integration tests' do
       let(:routes) do
         proc do
           map '/server_error/' do
-            run(proc { |_env| [500, { 'Content-Type' => 'text/html' }, 'KO'] })
+            run(proc { |_env| [500, { 'Content-Type' => 'text/html' }, ['KO']] })
           end
         end
       end
@@ -377,7 +377,7 @@ RSpec.describe 'Rack integration tests' do
                 request_span.set_tag('http.status_code', 201)
                 request_span.set_tag('http.url', '/app/static/')
 
-                [200, { 'Content-Type' => 'text/html' }, 'OK']
+                [200, { 'Content-Type' => 'text/html' }, ['OK']]
               end)
             end
           end
@@ -427,7 +427,7 @@ RSpec.describe 'Rack integration tests' do
                   request_span.status = 1
                   request_span.set_tag('error.stack', 'Handled exception')
 
-                  [500, { 'Content-Type' => 'text/html' }, 'OK']
+                  [500, { 'Content-Type' => 'text/html' }, ['OK']]
                 end)
               end
             end
@@ -462,7 +462,7 @@ RSpec.describe 'Rack integration tests' do
                   request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
                   request_span.set_tag('error.stack', 'Handled exception')
 
-                  [500, { 'Content-Type' => 'text/html' }, 'OK']
+                  [500, { 'Content-Type' => 'text/html' }, ['OK']]
                 end)
               end
             end
@@ -500,14 +500,14 @@ RSpec.describe 'Rack integration tests' do
               app_tracer.trace('leaky-span-2')
               app_tracer.trace('leaky-span-3')
 
-              [200, { 'Content-Type' => 'text/html' }, 'OK']
+              [200, { 'Content-Type' => 'text/html' }, ['OK']]
             end
 
             run(handler)
           end
 
           map '/success/' do
-            run(proc { |_env| [200, { 'Content-Type' => 'text/html' }, 'OK'] })
+            run(proc { |_env| [200, { 'Content-Type' => 'text/html' }, ['OK']] })
           end
         end
       end
@@ -542,7 +542,7 @@ RSpec.describe 'Rack integration tests' do
                 'X-Request-ID' => 'f058ebd6-02f7-4d3f-942e-904344e8cde5',
                 'X-Fake-Response' => 'Don\'t tag me.'
               }
-              [200, response_headers, 'OK']
+              [200, response_headers, ['OK']]
             end)
           end
         end


### PR DESCRIPTION
When codifying version requirements for integrations via #944, we made Rack requirements fairly strict (1.4.7+)

This pull request relaxes that requirement to 1.1.0+, such that older integrations like Rails 3.0 (which depends on Rack 1.2.8) can still patch Rack properly. I've verified Rack 1.1.0 works with `dd-trace-rb` by running it through our unit tests, just needed to make some small alterations to make test cases compatible.