### PR TITLE
Specify minimum rubygems version

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |spec|
   spec.name                  = 'ddtrace'
   spec.version               = Datadog::VERSION::STRING
   spec.required_ruby_version = ">= #{Datadog::VERSION::MINIMUM_RUBY_VERSION}"
+  spec.required_rubygems_version = '>= 2.0.0'
   spec.authors               = ['Datadog, Inc.']
   spec.email                 = ['dev@datadoghq.com']
 


### PR DESCRIPTION
Encountered while trying to setup instrumentation on host with RubyGems 1.8.23 and Ruby 2.2.0

https://github.com/DataDog/dd-trace-rb/blob/master/lib/ddtrace/utils/time.rb#L5
Gem::Version.new with frozen string is going to crash. It was resolved in commit
https://github.com/rubygems/rubygems/commit/da4362a6644ca5a75c210677ac500bccfe75f529#diff-94d386526b8b558035d4e4c7602d647c, so version of RubyGems 2.0.0 and greater is required.