### PR TITLE
Updating dead link when clicking Net/HTTP.

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -45,7 +45,7 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
      - [gRPC](#grpc)
      - [MongoDB](#mongodb)
      - [MySQL2](#mysql2)
-     - [Net/HTTP](#nethttp)
+     - [Net/HTTP](#net-http)
      - [Presto](#presto)
      - [Racecar](#racecar)
      - [Rack](#rack)


### PR DESCRIPTION
What does this PR do?
---------------------
Updates the dead link for Net/HTTP(line 48) to match actual working link:
https://docs.datadoghq.com/tracing/setup/ruby/#net-http

Who will it impact?
-------------------
All of the documentation users.

Motivation
----------
I was using the documentation and realized this did  not redirect.


