### PR TITLE
Fix RuntimeMetrics accumulating service names when disabled

### DIFF
--- a/lib/ddtrace/runtime/metrics.rb
+++ b/lib/ddtrace/runtime/metrics.rb
@@ -19,7 +19,7 @@ module Datadog
       end
 
       def associate_with_span(span)
-        return if span.nil?
+        return if !enabled? || span.nil?
 
         # Register service as associated with metrics
         register_service(span.service) unless span.service.nil?
@@ -30,7 +30,7 @@ module Datadog
 
       # Associate service with runtime metrics
       def register_service(service)
-        return if service.nil?
+        return if !enabled? || service.nil?
 
         service = service.to_s
 

--- a/spec/ddtrace/runtime/metrics_spec.rb
+++ b/spec/ddtrace/runtime/metrics_spec.rb
@@ -12,15 +12,58 @@ RSpec.describe Datadog::Runtime::Metrics do
     let(:span) { instance_double(Datadog::Span, service: service) }
     let(:service) { 'parser' }
 
-    before do
-      expect(span).to receive(:set_tag)
-        .with(Datadog::Ext::Runtime::TAG_LANG, Datadog::Runtime::Identity.lang)
+    context 'when enabled' do
+      before do
+        runtime_metrics.enabled = true
 
-      associate_with_span
+        expect(span).to receive(:set_tag)
+          .with(Datadog::Ext::Runtime::TAG_LANG, Datadog::Runtime::Identity.lang)
+
+        associate_with_span
+      end
+
+      it 'registers the span\'s service' do
+        expect(runtime_metrics.default_metric_options[:tags]).to include("service:#{service}")
+      end
     end
 
-    it 'registers the span\'s service' do
-      expect(runtime_metrics.default_metric_options[:tags]).to include("service:#{service}")
+    context 'when disabled' do
+      before do
+        runtime_metrics.enabled = false
+        expect(span).to_not receive(:set_tag)
+        associate_with_span
+      end
+
+      it 'registers the span\'s service' do
+        expect(runtime_metrics.default_metric_options[:tags]).to_not include("service:#{service}")
+      end
+    end
+  end
+
+  describe '#register_service' do
+    subject(:register_service) { runtime_metrics.register_service(service) }
+    let(:service) { 'parser' }
+
+    context 'when enabled' do
+      before do
+        runtime_metrics.enabled = true
+        register_service
+      end
+
+      it 'registers the span\'s service' do
+        expect(runtime_metrics.default_metric_options[:tags]).to include("service:#{service}")
+      end
+    end
+
+    context 'when disabled' do
+      before do
+        runtime_metrics.enabled = false
+        register_service
+      end
+
+      it 'registers the span\'s service' do
+        expect(runtime_metrics.default_metric_options[:tags]).to_not include("service:#{service}")
+      end
     end
   end
 
@@ -134,7 +177,7 @@ RSpec.describe Datadog::Runtime::Metrics do
 
       context 'when services have been registered' do
         let(:services) { %w[parser serializer] }
-        before(:each) { services.each { |service| runtime_metrics.register_service(service) } }
+        before { services.each { |service| runtime_metrics.register_service(service) } }
 
         it do
           is_expected.to include(*Datadog::Metrics.default_metric_options[:tags])


### PR DESCRIPTION
When runtime metrics are disabled, they won't emit metrics, but it still accumulates service names to tag metrics with. This pull request prevents that accumulation from happening, out of consideration for performance.