### PR TITLE
fix reference to old Datadog::Tracer.log

### DIFF
--- a/lib/ddtrace/contrib/presto/patcher.rb
+++ b/lib/ddtrace/contrib/presto/patcher.rb
@@ -20,7 +20,7 @@ module Datadog
             begin
               ::Presto::Client::Client.send(:include, Instrumentation::Client)
             rescue StandardError => e
-              Datadog::Tracer.log.error("Unable to apply Presto integration: #{e}")
+              Datadog::Logger.log.error("Unable to apply Presto integration: #{e}")
             end
           end
         end


### PR DESCRIPTION
In between this branch getting approved and merged I missed the cleanup that happened here in  https://github.com/DataDog/dd-trace-rb/pull/912 , 

This PR removes the remaining reference to Datadog::Tracer.log in favor of Datadog::Logger.log