### PR TITLE
Prevent #use for missing integration from raising errors

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -328,37 +328,37 @@ For a list of available integrations, and their configuration options, please re
 | Name                     | Key                        | Versions Supported       | How to configure                    | Gem source                                                                     |
 | ------------------------ | -------------------------- | ------------------------ | ----------------------------------- | ------------------------------------------------------------------------------ |
 | Action Cable             | `action_cable`             | `>= 5.0`                 | *[Link](#action-cable)*             | *[Link](https://github.com/rails/rails/tree/master/actioncable)*               |
-| Action View              | `action_view`              | `>= 3.2`                 | *[Link](#action-view)*              | *[Link](https://github.com/rails/rails/tree/master/actionview)*                |
+| Action View              | `action_view`              | `>= 3.0`                 | *[Link](#action-view)*              | *[Link](https://github.com/rails/rails/tree/master/actionview)*                |
 | Active Model Serializers | `active_model_serializers` | `>= 0.9`                 | *[Link](#active-model-serializers)* | *[Link](https://github.com/rails-api/active_model_serializers)*                |
-| Action Pack              | `action_pack`              | `>= 3.2`                 | *[Link](#action-pack)*              | *[Link](https://github.com/rails/rails/tree/master/actionpack)*                |
-| Active Record            | `active_record`            | `>= 3.2`                 | *[Link](#active-record)*            | *[Link](https://github.com/rails/rails/tree/master/activerecord)*              |
-| Active Support           | `active_support`           | `>= 3.2`                 | *[Link](#active-support)*           | *[Link](https://github.com/rails/rails/tree/master/activesupport)*             |
+| Action Pack              | `action_pack`              | `>= 3.0`                 | *[Link](#action-pack)*              | *[Link](https://github.com/rails/rails/tree/master/actionpack)*                |
+| Active Record            | `active_record`            | `>= 3.0`                 | *[Link](#active-record)*            | *[Link](https://github.com/rails/rails/tree/master/activerecord)*              |
+| Active Support           | `active_support`           | `>= 3.0`                 | *[Link](#active-support)*           | *[Link](https://github.com/rails/rails/tree/master/activesupport)*             |
 | AWS                      | `aws`                      | `>= 2.0`                 | *[Link](#aws)*                      | *[Link](https://github.com/aws/aws-sdk-ruby)*                                  |
 | Concurrent Ruby          | `concurrent_ruby`          | `>= 0.9`                 | *[Link](#concurrent-ruby)*          | *[Link](https://github.com/ruby-concurrency/concurrent-ruby)*                  |
-| Dalli                    | `dalli`                    | `>= 2.7`                 | *[Link](#dalli)*                    | *[Link](https://github.com/petergoldstein/dalli)*                              |
+| Dalli                    | `dalli`                    | `>= 2.0`                 | *[Link](#dalli)*                    | *[Link](https://github.com/petergoldstein/dalli)*                              |
 | DelayedJob               | `delayed_job`              | `>= 4.1`                 | *[Link](#delayedjob)*               | *[Link](https://github.com/collectiveidea/delayed_job)*                        |
-| Elasticsearch           | `elasticsearch`            | `>= 6.0`                 | *[Link](#elasticsearch)*           | *[Link](https://github.com/elastic/elasticsearch-ruby)*                        |
-| Ethon                    | `ethon`                    | `>= 0.11.0`              | *[Link](#ethon)*                    | *[Link](https://github.com/typhoeus/ethon)*                                    |
-| Excon                    | `excon`                    | `>= 0.62`                | *[Link](#excon)*                    | *[Link](https://github.com/excon/excon)*                                       |
+| Elasticsearch            | `elasticsearch`            | `>= 1.0`                 | *[Link](#elasticsearch)*            | *[Link](https://github.com/elastic/elasticsearch-ruby)*                        |
+| Ethon                    | `ethon`                    | `>= 0.11`                | *[Link](#ethon)*                    | *[Link](https://github.com/typhoeus/ethon)*                                    |
+| Excon                    | `excon`                    | `>= 0.50`                | *[Link](#excon)*                    | *[Link](https://github.com/excon/excon)*                                       |
 | Faraday                  | `faraday`                  | `>= 0.14`                | *[Link](#faraday)*                  | *[Link](https://github.com/lostisland/faraday)*                                |
 | Grape                    | `grape`                    | `>= 1.0`                 | *[Link](#grape)*                    | *[Link](https://github.com/ruby-grape/grape)*                                  |
 | GraphQL                  | `graphql`                  | `>= 1.7.9`               | *[Link](#graphql)*                  | *[Link](https://github.com/rmosolgo/graphql-ruby)*                             |
-| gRPC                     | `grpc`                     | `>= 1.10`                | *[Link](#grpc)*                     | *[Link](https://github.com/grpc/grpc/tree/master/src/rubyc)*                   |
-| MongoDB                  | `mongo`                    | `>= 2.0`                 | *[Link](#mongodb)*                  | *[Link](https://github.com/mongodb/mongo-ruby-driver)*                         |
+| gRPC                     | `grpc`                     | `>= 1.7`                 | *[Link](#grpc)*                     | *[Link](https://github.com/grpc/grpc/tree/master/src/rubyc)*                   |
+| MongoDB                  | `mongo`                    | `>= 2.1`                 | *[Link](#mongodb)*                  | *[Link](https://github.com/mongodb/mongo-ruby-driver)*                         |
 | MySQL2                   | `mysql2`                   | `>= 0.3.21`              | *[Link](#mysql2)*                   | *[Link](https://github.com/brianmario/mysql2)*                                 |
 | Net/HTTP                 | `http`                     | *(Any supported Ruby)*   | *[Link](#nethttp)*                  | *[Link](https://ruby-doc.org/stdlib-2.4.0/libdoc/net/http/rdoc/Net/HTTP.html)* |
 | Presto                   | `presto`                   | `>= 0.5.14`              | *[Link](#presto)*                   | *[Link](https://github.com/treasure-data/presto-client-ruby)*                  |
 | Racecar                  | `racecar`                  | `>= 0.3.5`               | *[Link](#racecar)*                  | *[Link](https://github.com/zendesk/racecar)*                                   |
-| Rack                     | `rack`                     | `>= 1.1.0`               | *[Link](#rack)*                     | *[Link](https://github.com/rack/rack)*                                         |
-| Rails                    | `rails`                    | `>= 3.2`                 | *[Link](#rails)*                    | *[Link](https://github.com/rails/rails)*                                       |
+| Rack                     | `rack`                     | `>= 1.1`                 | *[Link](#rack)*                     | *[Link](https://github.com/rack/rack)*                                         |
+| Rails                    | `rails`                    | `>= 3.0`                 | *[Link](#rails)*                    | *[Link](https://github.com/rails/rails)*                                       |
 | Rake                     | `rake`                     | `>= 12.0`                | *[Link](#rake)*                     | *[Link](https://github.com/ruby/rake)*                                         |
 | Redis                    | `redis`                    | `>= 3.2`                 | *[Link](#redis)*                    | *[Link](https://github.com/redis/redis-rb)*                                    |
 | Resque                   | `resque`                   | `>= 1.0, < 2.0`          | *[Link](#resque)*                   | *[Link](https://github.com/resque/resque)*                                     |
 | Rest Client              | `rest-client`              | `>= 1.8`                 | *[Link](#rest-client)*              | *[Link](https://github.com/rest-client/rest-client)*                           |
 | Sequel                   | `sequel`                   | `>= 3.41`                | *[Link](#sequel)*                   | *[Link](https://github.com/jeremyevans/sequel)*                                |
-| Shoryuken                | `shoryuken`                | `>= 4.0.2`               | *[Link](#shoryuken)*                | *[Link](https://github.com/phstc/shoryuken)*                                   |
+| Shoryuken                | `shoryuken`                | `>= 3.2`                 | *[Link](#shoryuken)*                | *[Link](https://github.com/phstc/shoryuken)*                                   |
 | Sidekiq                  | `sidekiq`                  | `>= 3.5.4`               | *[Link](#sidekiq)*                  | *[Link](https://github.com/mperham/sidekiq)*                                   |
-| Sinatra                  | `sinatra`                  | `>= 1.4.5`               | *[Link](#sinatra)*                  | *[Link](https://github.com/sinatra/sinatra)*                                   |
+| Sinatra                  | `sinatra`                  | `>= 1.4`                 | *[Link](#sinatra)*                  | *[Link](https://github.com/sinatra/sinatra)*                                   |
 | Sucker Punch             | `sucker_punch`             | `>= 2.0`                 | *[Link](#sucker-punch)*             | *[Link](https://github.com/brandonhilkert/sucker_punch)*                       |
 
 ### Action Cable

--- a/lib/ddtrace/contrib/action_cable/integration.rb
+++ b/lib/ddtrace/contrib/action_cable/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('5.0.0')
+
         register_as :action_cable, auto_patch: false
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::ActionCable)
+          !defined?(::ActionCable).nil?
         end
 
         def self.compatible?
-          super && Rails::Integration.compatible?
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/action_pack/integration.rb
+++ b/lib/ddtrace/contrib/action_pack/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('3.0')
+
         register_as :action_pack, auto_patch: false
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::ActionPack)
+          !defined?(::ActionPack).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('3.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/action_view/integration.rb
+++ b/lib/ddtrace/contrib/action_view/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('3.0')
+
         register_as :action_view, auto_patch: false
 
         def self.version
@@ -23,11 +25,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::ActionView)
+          !defined?(::ActionView).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('3.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/active_model_serializers/integration.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('0.9.0')
+
         register_as :active_model_serializers
 
         def self.version
@@ -17,11 +19,12 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::ActiveModel::Serializer) && defined?(::ActiveSupport::Notifications)
+          !defined?(::ActiveModel::Serializer).nil? \
+            && !defined?(::ActiveSupport::Notifications).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('0.9.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/active_record/integration.rb
+++ b/lib/ddtrace/contrib/active_record/integration.rb
@@ -13,6 +13,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('3.0')
+
         register_as :active_record, auto_patch: false
 
         def self.version
@@ -20,11 +22,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::ActiveRecord)
+          !defined?(::ActiveRecord).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('3.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/active_support/integration.rb
+++ b/lib/ddtrace/contrib/active_support/integration.rb
@@ -11,6 +11,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('3.0')
+
         register_as :active_support, auto_patch: false
 
         def self.version
@@ -18,11 +20,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::ActiveSupport)
+          !defined?(::ActiveSupport).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('3.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/aws/integration.rb
+++ b/lib/ddtrace/contrib/aws/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('2.0')
+
         register_as :aws, auto_patch: true
 
         def self.version
@@ -20,11 +22,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Seahorse::Client::Base)
+          !defined?(::Seahorse::Client::Base).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('2.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/concurrent_ruby/integration.rb
+++ b/lib/ddtrace/contrib/concurrent_ruby/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('0.9')
+
         register_as :concurrent_ruby
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Concurrent::Future)
+          !defined?(::Concurrent::Future).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('0.9')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/dalli/integration.rb
+++ b/lib/ddtrace/contrib/dalli/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('2.0.0')
+
         register_as :dalli, auto_patch: true
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Dalli)
+          !defined?(::Dalli).nil?
         end
 
         def self.compatible?
-          super && version > Gem::Version.new('2.0.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/delayed_job/integration.rb
+++ b/lib/ddtrace/contrib/delayed_job/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('4.1')
+
         register_as :delayed_job
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Delayed)
+          !defined?(::Delayed).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('4.1')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/elasticsearch/integration.rb
+++ b/lib/ddtrace/contrib/elasticsearch/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('1.0.0')
+
         register_as :elasticsearch, auto_patch: true
 
         def self.version
@@ -17,11 +19,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Elasticsearch::Transport)
+          !defined?(::Elasticsearch::Transport).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('1.0.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/ethon/integration.rb
+++ b/lib/ddtrace/contrib/ethon/integration.rb
@@ -8,6 +8,9 @@ module Datadog
       # Description of Ethon integration
       class Integration
         include Contrib::Integration
+
+        MINIMUM_VERSION = Gem::Version.new('0.11.0')
+
         register_as :ethon
 
         def self.version
@@ -15,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Ethon::Easy)
+          !defined?(::Ethon::Easy).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('0.11.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/excon/integration.rb
+++ b/lib/ddtrace/contrib/excon/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('0.50.0')
+
         register_as :excon
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Excon)
+          !defined?(::Excon).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('0.62')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/faraday/integration.rb
+++ b/lib/ddtrace/contrib/faraday/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('0.14.0')
+
         register_as :faraday, auto_patch: true
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Faraday)
+          !defined?(::Faraday).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('0.14.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/grape/integration.rb
+++ b/lib/ddtrace/contrib/grape/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('1.0')
+
         register_as :grape, auto_patch: true
 
         def self.version
@@ -16,11 +18,12 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Grape) && defined?(::ActiveSupport::Notifications)
+          !defined?(::Grape).nil? \
+            && !defined?(::ActiveSupport::Notifications).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('1.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/graphql/integration.rb
+++ b/lib/ddtrace/contrib/graphql/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('1.7.9')
+
         register_as :graphql, auto_patch: true
 
         def self.version
@@ -16,11 +18,12 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::GraphQL) && defined?(::GraphQL::Tracing::DataDogTracing)
+          !defined?(::GraphQL).nil? \
+            && !defined?(::GraphQL::Tracing::DataDogTracing).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('1.7.9')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/grpc/integration.rb
+++ b/lib/ddtrace/contrib/grpc/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('1.7.0')
+
         register_as :grpc, auto_patch: true
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::GRPC)
+          !defined?(::GRPC).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('0.10.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/http/integration.rb
+++ b/lib/ddtrace/contrib/http/integration.rb
@@ -1,3 +1,5 @@
+require 'ddtrace/version'
+
 require 'ddtrace/contrib/integration'
 require 'ddtrace/contrib/http/configuration/settings'
 require 'ddtrace/contrib/http/patcher'
@@ -13,6 +15,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Datadog::VERSION::MINIMUM_RUBY_VERSION
+
         register_as :http, auto_patch: true
 
         def self.version
@@ -20,7 +24,7 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Net::HTTP)
+          !defined?(::Net::HTTP).nil?
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/mongodb/integration.rb
+++ b/lib/ddtrace/contrib/mongodb/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('2.1.0')
+
         register_as :mongo, auto_patch: true
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Mongo::Monitoring::Global)
+          !defined?(::Mongo::Monitoring::Global).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('2.1.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/mysql2/integration.rb
+++ b/lib/ddtrace/contrib/mysql2/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('0.3.21')
+
         register_as :mysql2
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Mysql2)
+          !defined?(::Mysql2).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('0.3.21')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/patchable.rb
+++ b/lib/ddtrace/contrib/patchable.rb
@@ -25,7 +25,7 @@ module Datadog
 
         # Is the loaded code compatible with this integration? (e.g. minimum version met?)
         def compatible?
-          Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(VERSION::MINIMUM_RUBY_VERSION)
+          available? && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(VERSION::MINIMUM_RUBY_VERSION)
         end
 
         # Can the patch for this integration be applied?

--- a/lib/ddtrace/contrib/presto/integration.rb
+++ b/lib/ddtrace/contrib/presto/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('0.5.14')
+
         register_as :presto
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Presto::Client::Client)
+          !defined?(::Presto::Client::Client).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('0.5.14')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/racecar/integration.rb
+++ b/lib/ddtrace/contrib/racecar/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('0.3.5')
+
         register_as :racecar, auto_patch: false
 
         def self.version
@@ -16,11 +18,12 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Racecar) && defined?(::ActiveSupport::Notifications)
+          !defined?(::Racecar).nil? \
+            && !defined?(::ActiveSupport::Notifications).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('0.3.5')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/rack/integration.rb
+++ b/lib/ddtrace/contrib/rack/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('1.1.0')
+
         register_as :rack, auto_patch: false
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Rack)
+          !defined?(::Rack).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('1.1.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/rails/ext.rb
+++ b/lib/ddtrace/contrib/rails/ext.rb
@@ -6,6 +6,7 @@ module Datadog
         APP = 'rails'.freeze
         ENV_ANALYTICS_ENABLED = 'DD_RAILS_ANALYTICS_ENABLED'.freeze
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_RAILS_ANALYTICS_SAMPLE_RATE'.freeze
+        ENV_DISABLE = 'DISABLE_DATADOG_RAILS'.freeze
       end
     end
   end

--- a/lib/ddtrace/contrib/rails/integration.rb
+++ b/lib/ddtrace/contrib/rails/integration.rb
@@ -1,4 +1,6 @@
 require 'ddtrace/contrib/integration'
+
+require 'ddtrace/contrib/rails/ext'
 require 'ddtrace/contrib/rails/configuration/settings'
 require 'ddtrace/contrib/rails/patcher'
 
@@ -9,6 +11,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('3.0')
+
         register_as :rails, auto_patch: false
 
         def self.version
@@ -16,15 +20,15 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Rails)
+          !defined?(::Rails).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('3.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def self.patchable?
-          super && !ENV.key?('DISABLE_DATADOG_RAILS')
+          super && !ENV.key?(Ext::ENV_DISABLE)
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/rake/integration.rb
+++ b/lib/ddtrace/contrib/rake/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('12.0')
+
         register_as :rake
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Rake)
+          !defined?(::Rake).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('12.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/redis/integration.rb
+++ b/lib/ddtrace/contrib/redis/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('3.2')
+
         register_as :redis, auto_patch: true
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Redis)
+          !defined?(::Redis).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('3.2')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/resque/integration.rb
+++ b/lib/ddtrace/contrib/resque/integration.rb
@@ -9,6 +9,10 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('1.0')
+        # Maximum is first version it's NOT compatible with (not inclusive)
+        MAXIMUM_VERSION = Gem::Version.new('2.0')
+
         register_as :resque, auto_patch: true
 
         def self.version
@@ -16,13 +20,13 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Resque)
+          !defined?(::Resque).nil?
         end
 
         def self.compatible?
           super \
             && version >= Gem::Version.new('1.0') \
-            && version < Gem::Version.new('2.0')
+            && version < MAXIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/rest_client/integration.rb
+++ b/lib/ddtrace/contrib/rest_client/integration.rb
@@ -8,6 +8,9 @@ module Datadog
       # Description of RestClient integration
       class Integration
         include Contrib::Integration
+
+        MINIMUM_VERSION = Gem::Version.new('1.8')
+
         register_as :rest_client
 
         def self.version
@@ -15,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::RestClient::Request)
+          !defined?(::RestClient::Request).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('1.8')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/sequel/integration.rb
+++ b/lib/ddtrace/contrib/sequel/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('3.41')
+
         register_as :sequel, auto_patch: false
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Sequel)
+          !defined?(::Sequel).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('3.41')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/shoryuken/integration.rb
+++ b/lib/ddtrace/contrib/shoryuken/integration.rb
@@ -10,6 +10,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('3.2')
+
         register_as :shoryuken
 
         def self.version
@@ -17,11 +19,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Shoryuken)
+          !defined?(::Shoryuken).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('4.0.2')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/sidekiq/integration.rb
+++ b/lib/ddtrace/contrib/sidekiq/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('3.5.4')
+
         register_as :sidekiq
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Sidekiq)
+          !defined?(::Sidekiq).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('3.5.4')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/sinatra/integration.rb
+++ b/lib/ddtrace/contrib/sinatra/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('1.4')
+
         register_as :sinatra
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::Sinatra)
+          !defined?(::Sinatra).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('1.4.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/sucker_punch/integration.rb
+++ b/lib/ddtrace/contrib/sucker_punch/integration.rb
@@ -9,6 +9,8 @@ module Datadog
       class Integration
         include Contrib::Integration
 
+        MINIMUM_VERSION = Gem::Version.new('2.0.0')
+
         register_as :sucker_punch, auto_patch: true
 
         def self.version
@@ -16,11 +18,11 @@ module Datadog
         end
 
         def self.loaded?
-          defined?(::SuckerPunch)
+          !defined?(::SuckerPunch).nil?
         end
 
         def self.compatible?
-          super && version >= Gem::Version.new('2.0.0')
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/spec/ddtrace/contrib/action_cable/integration_spec.rb
+++ b/spec/ddtrace/contrib/action_cable/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/action_cable/integration'
+
+RSpec.describe Datadog::Contrib::ActionCable::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:action_cable) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "actioncable" gem is loaded' do
+      include_context 'loaded gems', actioncable: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "actioncable" gem is not loaded' do
+      include_context 'loaded gems', actioncable: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when ActionCable is defined' do
+      before { stub_const('ActionCable', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when ActionCable is not defined' do
+      before { hide_const('ActionCable') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "actioncable" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', actioncable: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', actioncable: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', actioncable: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::ActionCable::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::ActionCable::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/action_pack/integration_spec.rb
+++ b/spec/ddtrace/contrib/action_pack/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/action_pack/integration'
+
+RSpec.describe Datadog::Contrib::ActionPack::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:action_pack) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "actionpack" gem is loaded' do
+      include_context 'loaded gems', actionpack: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "actionpack" gem is not loaded' do
+      include_context 'loaded gems', actionpack: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when ActionPack is defined' do
+      before { stub_const('ActionPack', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when ActionPack is not defined' do
+      before { hide_const('ActionPack') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "actionpack" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', actionpack: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', actionpack: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', actionpack: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::ActionPack::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::ActionPack::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/action_view/integration_spec.rb
+++ b/spec/ddtrace/contrib/action_view/integration_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/action_view/integration'
+
+RSpec.describe Datadog::Contrib::ActionView::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:action_view) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "actionview" gem is loaded' do
+      include_context 'loaded gems', actionview: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "actionview" gem is not loaded' do
+      context 'and "actionpack" gem is loaded' do
+        context 'of version < 4.1' do
+          include_context 'loaded gems', actionview: nil, actionpack: Gem::Version.new('4.0')
+          it { is_expected.to be_a_kind_of(Gem::Version) }
+        end
+
+        context 'of version >= 4.1' do
+          include_context 'loaded gems', actionview: nil, actionpack: Gem::Version.new('4.1')
+          # Because in Rails 4.1+, if ActionView isn't present, then there is no version.
+          it { is_expected.to be nil }
+        end
+      end
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when ActionView is defined' do
+      before { stub_const('ActionView', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when ActionView is not defined' do
+      before { hide_const('ActionView') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "actionview" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', actionview: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', actionview: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', actionpack: nil, actionview: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::ActionView::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::ActionView::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/active_model_serializers/integration_spec.rb
+++ b/spec/ddtrace/contrib/active_model_serializers/integration_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/active_model_serializers/integration'
+
+RSpec.describe Datadog::Contrib::ActiveModelSerializers::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:active_model_serializers) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "active_model_serializers" gem is loaded' do
+      include_context 'loaded gems', active_model_serializers: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "active_model_serializers" gem is not loaded' do
+      include_context 'loaded gems', active_model_serializers: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when neither ActiveModel::Serializer or ActiveSupport::Notifications are defined' do
+      before do
+        hide_const('ActiveModel::Serializer')
+        hide_const('ActiveSupport::Notifications')
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when only ActiveModel::Serializer is defined' do
+      before do
+        stub_const('ActiveModel::Serializer', Class.new)
+        hide_const('ActiveSupport::Notifications')
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when only ActiveSupport::Notifications is defined' do
+      before do
+        hide_const('ActiveModel::Serializer')
+        stub_const('ActiveSupport::Notifications', Class.new)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when both ActiveModel::Serializer and ActiveSupport::Notifications are defined' do
+      before do
+        stub_const('ActiveModel::Serializer', Class.new)
+        stub_const('ActiveSupport::Notifications', Class.new)
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "active_model_serializers" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', active_model_serializers: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', active_model_serializers: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', active_model_serializers: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::ActiveModelSerializers::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::ActiveModelSerializers::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/active_record/integration_spec.rb
+++ b/spec/ddtrace/contrib/active_record/integration_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/active_record/integration'
+
+RSpec.describe Datadog::Contrib::ActiveRecord::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:active_record) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "activerecord" gem is loaded' do
+      include_context 'loaded gems', activerecord: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "activerecord" gem is not loaded' do
+      include_context 'loaded gems', activerecord: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when ActiveRecord is defined' do
+      before { stub_const('ActiveRecord', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when ActiveRecord is not defined' do
+      before { hide_const('ActiveRecord') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "activerecord" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', activerecord: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', activerecord: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', activerecord: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::ActiveRecord::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::ActiveRecord::Patcher }
+  end
+
+  describe '#resolver' do
+    subject(:resolver) { integration.resolver }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::ActiveRecord::Configuration::Resolver) }
+  end
+end

--- a/spec/ddtrace/contrib/active_support/integration_spec.rb
+++ b/spec/ddtrace/contrib/active_support/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/active_support/integration'
+
+RSpec.describe Datadog::Contrib::ActiveSupport::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:active_support) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "activesupport" gem is loaded' do
+      include_context 'loaded gems', activesupport: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "activesupport" gem is not loaded' do
+      include_context 'loaded gems', activesupport: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when ActiveSupport is defined' do
+      before { stub_const('ActiveSupport', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when ActiveSupport is not defined' do
+      before { hide_const('ActiveSupport') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "activesupport" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', activesupport: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', activesupport: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', activesupport: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::ActiveSupport::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::ActiveSupport::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/aws/integration_spec.rb
+++ b/spec/ddtrace/contrib/aws/integration_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/aws/integration'
+
+RSpec.describe Datadog::Contrib::Aws::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:aws) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "aws-sdk" gem is loaded' do
+      include_context 'loaded gems', :'aws-sdk' => described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "aws-sdk" gem is not loaded but aws-sdk-core is' do
+      include_context 'loaded gems', :'aws-sdk' => nil, :'aws-sdk-core' => described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when neither "aws-sdk" or "aws-sdk-core" gems are loaded' do
+      include_context 'loaded gems', :'aws-sdk' => nil, :'aws-sdk-core' => nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Seahorse::Client::Base is defined' do
+      before { stub_const('Seahorse::Client::Base', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Seahorse::Client::Base is not defined' do
+      before { hide_const('Seahorse::Client::Base') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "aws-sdk" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', :'aws-sdk' => decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', :'aws-sdk' => described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', :'aws-sdk' => nil, :'aws-sdk-core' => nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Aws::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Aws::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/concurrent_ruby/integration_spec.rb
+++ b/spec/ddtrace/contrib/concurrent_ruby/integration_spec.rb
@@ -1,88 +1,68 @@
-require 'concurrent/future'
-
 require 'spec_helper'
-require 'ddtrace'
+
+require 'ddtrace/contrib/concurrent_ruby/integration'
 
 RSpec.describe Datadog::Contrib::ConcurrentRuby::Integration do
-  around do |example|
-    unmodified_future = ::Concurrent::Future.dup
-    example.run
-    ::Concurrent.send(:remove_const, :Future)
-    ::Concurrent.const_set('Future', unmodified_future)
-    remove_patch!(:concurrent_ruby)
-  end
+  extend ConfigurationHelpers
 
-  let(:tracer) { get_test_tracer }
-  let(:configuration_options) { { tracer: tracer } }
+  let(:integration) { described_class.new(:concurrent_ruby) }
 
-  subject(:deferred_execution) do
-    outer_span = tracer.trace('outer_span')
-    inner_span = nil
-    future = Concurrent::Future.new do
-      inner_span = tracer.trace('inner_span')
-      inner_span.finish
-    end
-    future.execute
+  describe '.version' do
+    subject(:version) { described_class.version }
 
-    future.wait
-    outer_span.finish
-
-    { outer_span: outer_span, inner_span: inner_span }
-  end
-
-  let(:outer_span) { deferred_execution[:outer_span] }
-  let(:inner_span) { deferred_execution[:inner_span] }
-
-  shared_examples_for 'deferred execution' do
-    before do
-      deferred_execution
+    context 'when the "actionpack" gem is loaded' do
+      include_context 'loaded gems', :'concurrent-ruby' => described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
     end
 
-    it 'creates outer span with nil parent' do
-      expect(outer_span.parent).to be_nil
-    end
-
-    it 'writes inner span to tracer' do
-      expect(tracer.writer.spans).to include(inner_span)
-    end
-
-    it 'writes outer span to tracer' do
-      expect(tracer.writer.spans).to include(outer_span)
+    context 'when "actionpack" gem is not loaded' do
+      include_context 'loaded gems', :'concurrent-ruby' => nil
+      it { is_expected.to be nil }
     end
   end
 
-  describe 'patching' do
-    subject(:patch) do
-      Datadog.configure do |c|
-        c.use :concurrent_ruby, tracer: tracer
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Concurrent::Future is defined' do
+      before { stub_const('Concurrent::Future', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Concurrent::Future is not defined' do
+      before { hide_const('Concurrent::Future') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "actionpack" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', :'concurrent-ruby' => decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', :'concurrent-ruby' => described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
       end
     end
 
-    it 'should add FuturePatch to Future ancestors' do
-      expect { patch }.to change { ::Concurrent::Future.ancestors.map(&:to_s) }
-        .to include('Datadog::Contrib::ConcurrentRuby::FuturePatch')
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', :'concurrent-ruby' => nil
+      it { is_expected.to be false }
     end
   end
 
-  context 'when context propagation is disabled' do
-    it_should_behave_like 'deferred execution'
-
-    it 'inner span should not have parent' do
-      expect(inner_span.parent).to be_nil
-    end
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::ConcurrentRuby::Configuration::Settings) }
   end
 
-  context 'when context propagation is enabled' do
-    it_should_behave_like 'deferred execution'
-
-    before do
-      Datadog.configure do |c|
-        c.use :concurrent_ruby, tracer: tracer
-      end
-    end
-
-    it 'inner span parent should be included in outer span' do
-      expect(inner_span.parent).to eq(outer_span)
-    end
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::ConcurrentRuby::Patcher }
   end
 end

--- a/spec/ddtrace/contrib/concurrent_ruby/integration_test_spec.rb
+++ b/spec/ddtrace/contrib/concurrent_ruby/integration_test_spec.rb
@@ -1,0 +1,88 @@
+require 'concurrent/future'
+
+require 'spec_helper'
+require 'ddtrace'
+
+RSpec.describe 'ConcurrentRuby integration tests' do
+  around do |example|
+    unmodified_future = ::Concurrent::Future.dup
+    example.run
+    ::Concurrent.send(:remove_const, :Future)
+    ::Concurrent.const_set('Future', unmodified_future)
+    remove_patch!(:concurrent_ruby)
+  end
+
+  let(:tracer) { get_test_tracer }
+  let(:configuration_options) { { tracer: tracer } }
+
+  subject(:deferred_execution) do
+    outer_span = tracer.trace('outer_span')
+    inner_span = nil
+    future = Concurrent::Future.new do
+      inner_span = tracer.trace('inner_span')
+      inner_span.finish
+    end
+    future.execute
+
+    future.wait
+    outer_span.finish
+
+    { outer_span: outer_span, inner_span: inner_span }
+  end
+
+  let(:outer_span) { deferred_execution[:outer_span] }
+  let(:inner_span) { deferred_execution[:inner_span] }
+
+  shared_examples_for 'deferred execution' do
+    before do
+      deferred_execution
+    end
+
+    it 'creates outer span with nil parent' do
+      expect(outer_span.parent).to be_nil
+    end
+
+    it 'writes inner span to tracer' do
+      expect(tracer.writer.spans).to include(inner_span)
+    end
+
+    it 'writes outer span to tracer' do
+      expect(tracer.writer.spans).to include(outer_span)
+    end
+  end
+
+  describe 'patching' do
+    subject(:patch) do
+      Datadog.configure do |c|
+        c.use :concurrent_ruby, tracer: tracer
+      end
+    end
+
+    it 'should add FuturePatch to Future ancestors' do
+      expect { patch }.to change { ::Concurrent::Future.ancestors.map(&:to_s) }
+        .to include('Datadog::Contrib::ConcurrentRuby::FuturePatch')
+    end
+  end
+
+  context 'when context propagation is disabled' do
+    it_should_behave_like 'deferred execution'
+
+    it 'inner span should not have parent' do
+      expect(inner_span.parent).to be_nil
+    end
+  end
+
+  context 'when context propagation is enabled' do
+    it_should_behave_like 'deferred execution'
+
+    before do
+      Datadog.configure do |c|
+        c.use :concurrent_ruby, tracer: tracer
+      end
+    end
+
+    it 'inner span parent should be included in outer span' do
+      expect(inner_span.parent).to eq(outer_span)
+    end
+  end
+end

--- a/spec/ddtrace/contrib/dalli/integration_spec.rb
+++ b/spec/ddtrace/contrib/dalli/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/dalli/integration'
+
+RSpec.describe Datadog::Contrib::Dalli::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:dalli) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "dalli" gem is loaded' do
+      include_context 'loaded gems', dalli: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "dalli" gem is not loaded' do
+      include_context 'loaded gems', dalli: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Dalli is defined' do
+      before { stub_const('Dalli', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Dalli is not defined' do
+      before { hide_const('Dalli') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "dalli" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', dalli: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', dalli: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', dalli: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Dalli::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Dalli::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/delayed_job/integration_spec.rb
+++ b/spec/ddtrace/contrib/delayed_job/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/delayed_job/integration'
+
+RSpec.describe Datadog::Contrib::DelayedJob::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:delayed_job) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "delayed_job" gem is loaded' do
+      include_context 'loaded gems', delayed_job: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "delayed_job" gem is not loaded' do
+      include_context 'loaded gems', delayed_job: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Delayed is defined' do
+      before { stub_const('Delayed', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Delayed is not defined' do
+      before { hide_const('Delayed') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "delayed_job" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', delayed_job: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', delayed_job: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', delayed_job: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::DelayedJob::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::DelayedJob::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/elasticsearch/integration_spec.rb
+++ b/spec/ddtrace/contrib/elasticsearch/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/elasticsearch/integration'
+
+RSpec.describe Datadog::Contrib::Elasticsearch::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:elasticsearch) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "elasticsearch-transport" gem is loaded' do
+      include_context 'loaded gems', :'elasticsearch-transport' => described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "elasticsearch-transport" gem is not loaded' do
+      include_context 'loaded gems', :'elasticsearch-transport' => nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Elasticsearch::Transport is defined' do
+      before { stub_const('Elasticsearch::Transport', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Elasticsearch::Transport is not defined' do
+      before { hide_const('Elasticsearch::Transport') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "elasticsearch-transport" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', :'elasticsearch-transport' => decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', :'elasticsearch-transport' => described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', :'elasticsearch-transport' => nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Elasticsearch::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Elasticsearch::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/ethon/integration_test_spec.rb
+++ b/spec/ddtrace/contrib/ethon/integration_test_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+require 'ddtrace'
+require 'ddtrace/contrib/ethon/easy_patch'
+require 'ddtrace/contrib/ethon/multi_patch'
+require 'typhoeus'
+require 'stringio'
+require 'webrick'
+require 'ddtrace/contrib/ethon/shared_examples'
+
+RSpec.describe 'Ethon integration tests' do
+  before { skip unless ENV['TEST_DATADOG_INTEGRATION'] }
+
+  context 'with Easy HTTP request' do
+    subject(:request) do
+      easy = Ethon::Easy.new
+      easy.http_request(url, 'GET', params: query, timeout_ms: timeout * 1000)
+      easy.perform
+      # Use Typhoeus response wrapper to simplify tests
+      Typhoeus::Response.new(easy.mirror.options)
+    end
+
+    it_behaves_like 'instrumented request' do
+      context 'distributed tracing disabled' do
+        let(:configuration_options) { super().merge(distributed_tracing: false) }
+
+        shared_examples_for 'does not propagate distributed headers' do
+          let(:return_headers) { true }
+
+          it 'does not propagate the headers' do
+            response = request
+            headers = JSON.parse(response.body)['headers']
+
+            expect(headers).not_to include('x-datadog-parent-id', 'x-datadog-trace-id')
+          end
+        end
+
+        it_behaves_like 'does not propagate distributed headers'
+
+        context 'with sampling priority' do
+          let(:return_headers) { true }
+          let(:sampling_priority) { 0.2 }
+
+          before do
+            tracer.provider.context.sampling_priority = sampling_priority
+          end
+
+          it_behaves_like 'does not propagate distributed headers'
+
+          it 'does not propagate sampling priority headers' do
+            response = request
+            headers = JSON.parse(response.body)['headers']
+
+            expect(headers).not_to include('x-datadog-sampling-priority')
+          end
+        end
+      end
+    end
+  end
+
+  context 'with simple Easy & headers override' do
+    subject(:request) do
+      easy = Ethon::Easy.new(url: url)
+      easy.customrequest = 'GET'
+      easy.set_attributes(timeout_ms: timeout * 1000)
+      easy.headers = { key: 'value' }
+      easy.perform
+      # Use Typhoeus response wrapper to simplify tests
+      Typhoeus::Response.new(easy.mirror.options)
+    end
+
+    it_behaves_like 'instrumented request' do
+      let(:method) { 'N/A' }
+    end
+  end
+
+  context 'with single Multi request' do
+    subject(:request) do
+      multi = Ethon::Multi.new
+      easy = Ethon::Easy.new
+      easy.http_request(url, 'GET', params: query, timeout_ms: timeout * 1000)
+      multi.add(easy)
+      multi.perform
+      Typhoeus::Response.new(easy.mirror.options)
+    end
+
+    it_behaves_like 'instrumented request'
+  end
+end

--- a/spec/ddtrace/contrib/excon/integration_spec.rb
+++ b/spec/ddtrace/contrib/excon/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/excon/integration'
+
+RSpec.describe Datadog::Contrib::Excon::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:excon) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "excon" gem is loaded' do
+      include_context 'loaded gems', excon: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "excon" gem is not loaded' do
+      include_context 'loaded gems', excon: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Excon is defined' do
+      before { stub_const('Excon', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Excon is not defined' do
+      before { hide_const('Excon') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "excon" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', excon: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', excon: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', excon: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Excon::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Excon::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/faraday/integration_spec.rb
+++ b/spec/ddtrace/contrib/faraday/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/faraday/integration'
+
+RSpec.describe Datadog::Contrib::Faraday::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:faraday) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "faraday" gem is loaded' do
+      include_context 'loaded gems', faraday: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "faraday" gem is not loaded' do
+      include_context 'loaded gems', faraday: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Faraday is defined' do
+      before { stub_const('Faraday', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Faraday is not defined' do
+      before { hide_const('Faraday') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "faraday" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', faraday: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', faraday: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', faraday: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Faraday::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Faraday::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/grape/integration_spec.rb
+++ b/spec/ddtrace/contrib/grape/integration_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/grape/integration'
+
+RSpec.describe Datadog::Contrib::Grape::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:grape) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "grape" gem is loaded' do
+      include_context 'loaded gems', grape: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "grape" gem is not loaded' do
+      include_context 'loaded gems', grape: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when neither Grape or ActiveSupport::Notifications are defined' do
+      before do
+        hide_const('Grape')
+        hide_const('ActiveSupport::Notifications')
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when only Grape is defined' do
+      before do
+        stub_const('Grape', Class.new)
+        hide_const('ActiveSupport::Notifications')
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when only ActiveSupport::Notifications is defined' do
+      before do
+        hide_const('Grape')
+        stub_const('ActiveSupport::Notifications', Class.new)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when both Grape and ActiveSupport::Notifications are defined' do
+      before do
+        stub_const('Grape', Class.new)
+        stub_const('ActiveSupport::Notifications', Class.new)
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "grape" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', grape: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', grape: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', grape: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Grape::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Grape::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/graphql/integration_spec.rb
+++ b/spec/ddtrace/contrib/graphql/integration_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/graphql/integration'
+
+RSpec.describe Datadog::Contrib::GraphQL::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:graphql) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "graphql" gem is loaded' do
+      include_context 'loaded gems', graphql: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "graphql" gem is not loaded' do
+      include_context 'loaded gems', graphql: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when neither GraphQL or GraphQL::Tracing::DataDogTracing are defined' do
+      before do
+        hide_const('GraphQL')
+        hide_const('GraphQL::Tracing::DataDogTracing')
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when only GraphQL is defined' do
+      before do
+        stub_const('GraphQL', Class.new)
+        hide_const('GraphQL::Tracing::DataDogTracing')
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when GraphQL::Tracing::DataDogTracing is defined' do
+      before { stub_const('GraphQL::Tracing::DataDogTracing', Class.new) }
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "graphql" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', graphql: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', graphql: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', graphql: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::GraphQL::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::GraphQL::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/grpc/integration_spec.rb
+++ b/spec/ddtrace/contrib/grpc/integration_spec.rb
@@ -1,75 +1,68 @@
 require 'spec_helper'
-require_relative 'support/grpc_helper'
-require 'ddtrace'
 
-RSpec.describe 'gRPC integration test' do
-  include GRPCHelper
+require 'ddtrace/contrib/grpc/integration'
 
-  let(:tracer) { get_test_tracer }
+RSpec.describe Datadog::Contrib::GRPC::Integration do
+  extend ConfigurationHelpers
 
-  let(:spans) do
-    tracer.writer.spans
-  end
+  let(:integration) { described_class.new(:grpc) }
 
-  before do
-    Datadog.configure do |c|
-      c.use :grpc, tracer: tracer, service_name: 'rspec'
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "grpc" gem is loaded' do
+      include_context 'loaded gems', grpc: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "grpc" gem is not loaded' do
+      include_context 'loaded gems', grpc: nil
+      it { is_expected.to be nil }
     end
   end
 
-  context 'multiple client configurations' do
-    let(:configured_interceptor) do
-      Datadog::Contrib::GRPC::DatadogInterceptor::Client.new do |c|
-        c.service_name = 'awesome sauce'
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when GRPC is defined' do
+      before { stub_const('GRPC', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when GRPC is not defined' do
+      before { hide_const('GRPC') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "grpc" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', grpc: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', grpc: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
       end
     end
-    let(:endpoint) { available_endpoint }
-    let(:alternate_client) do
-      GRPCHelper::TestService.rpc_stub_class.new(
-        endpoint,
-        :this_channel_is_insecure,
-        interceptors: [configured_interceptor]
-      )
-    end
 
-    it 'uses the correct configuration information' do
-      run_request_reply
-      span = spans.first
-      expect(span.service).to eq 'rspec'
-
-      run_request_reply(endpoint, alternate_client)
-      span = configured_interceptor.datadog_pin.tracer.writer.spans.first
-      expect(span.service).to eq 'awesome sauce'
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', grpc: nil
+      it { is_expected.to be false }
     end
   end
 
-  shared_examples 'associates child spans with the parent' do
-    let(:parent_span) { spans.first }
-    let(:child_span) { spans.last }
-
-    specify do
-      expect(child_span.trace_id).to eq parent_span.trace_id
-      expect(child_span.parent_id).to eq parent_span.span_id
-    end
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::GRPC::Configuration::Settings) }
   end
 
-  context 'request reply' do
-    before { run_request_reply }
-    it_behaves_like 'associates child spans with the parent'
-  end
-
-  context 'client stream' do
-    before { run_client_streamer }
-    it_behaves_like 'associates child spans with the parent'
-  end
-
-  context 'server stream' do
-    before { run_server_streamer }
-    it_behaves_like 'associates child spans with the parent'
-  end
-
-  context 'bidirectional stream' do
-    before { run_bidi_streamer }
-    it_behaves_like 'associates child spans with the parent'
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::GRPC::Patcher }
   end
 end

--- a/spec/ddtrace/contrib/grpc/integration_test_spec.rb
+++ b/spec/ddtrace/contrib/grpc/integration_test_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+require_relative 'support/grpc_helper'
+require 'ddtrace'
+
+RSpec.describe 'gRPC integration test' do
+  include GRPCHelper
+
+  let(:tracer) { get_test_tracer }
+
+  let(:spans) do
+    tracer.writer.spans
+  end
+
+  before do
+    Datadog.configure do |c|
+      c.use :grpc, tracer: tracer, service_name: 'rspec'
+    end
+  end
+
+  context 'multiple client configurations' do
+    let(:configured_interceptor) do
+      Datadog::Contrib::GRPC::DatadogInterceptor::Client.new do |c|
+        c.service_name = 'awesome sauce'
+      end
+    end
+    let(:endpoint) { available_endpoint }
+    let(:alternate_client) do
+      GRPCHelper::TestService.rpc_stub_class.new(
+        endpoint,
+        :this_channel_is_insecure,
+        interceptors: [configured_interceptor]
+      )
+    end
+
+    it 'uses the correct configuration information' do
+      run_request_reply
+      span = spans.first
+      expect(span.service).to eq 'rspec'
+
+      run_request_reply(endpoint, alternate_client)
+      span = configured_interceptor.datadog_pin.tracer.writer.spans.first
+      expect(span.service).to eq 'awesome sauce'
+    end
+  end
+
+  shared_examples 'associates child spans with the parent' do
+    let(:parent_span) { spans.first }
+    let(:child_span) { spans.last }
+
+    specify do
+      expect(child_span.trace_id).to eq parent_span.trace_id
+      expect(child_span.parent_id).to eq parent_span.span_id
+    end
+  end
+
+  context 'request reply' do
+    before { run_request_reply }
+    it_behaves_like 'associates child spans with the parent'
+  end
+
+  context 'client stream' do
+    before { run_client_streamer }
+    it_behaves_like 'associates child spans with the parent'
+  end
+
+  context 'server stream' do
+    before { run_server_streamer }
+    it_behaves_like 'associates child spans with the parent'
+  end
+
+  context 'bidirectional stream' do
+    before { run_bidi_streamer }
+    it_behaves_like 'associates child spans with the parent'
+  end
+end

--- a/spec/ddtrace/contrib/http/integration_spec.rb
+++ b/spec/ddtrace/contrib/http/integration_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/http/integration'
+
+RSpec.describe Datadog::Contrib::HTTP::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:http) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+    it { is_expected.to eq(Gem::Version.new(RUBY_VERSION)) }
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Net::HTTP is defined' do
+      before { stub_const('Net::HTTP', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Net::HTTP is not defined' do
+      before { hide_const('Net::HTTP') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::HTTP::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::HTTP::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/mongodb/integration_spec.rb
+++ b/spec/ddtrace/contrib/mongodb/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/action_pack/integration'
+
+RSpec.describe Datadog::Contrib::MongoDB::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:mongodb) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "mongo" gem is loaded' do
+      include_context 'loaded gems', mongo: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "mongo" gem is not loaded' do
+      include_context 'loaded gems', mongo: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Mongo::Monitoring::Global is defined' do
+      before { stub_const('Mongo::Monitoring::Global', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Mongo::Monitoring::Global is not defined' do
+      before { hide_const('Mongo::Monitoring::Global') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "mongo" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', mongo: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', mongo: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', mongo: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::MongoDB::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::MongoDB::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/mysql2/integration_spec.rb
+++ b/spec/ddtrace/contrib/mysql2/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/mysql2/integration'
+
+RSpec.describe Datadog::Contrib::Mysql2::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:mysql2) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "mysql2" gem is loaded' do
+      include_context 'loaded gems', mysql2: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "mysql2" gem is not loaded' do
+      include_context 'loaded gems', mysql2: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Mysql2 is defined' do
+      before { stub_const('Mysql2', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Mysql2 is not defined' do
+      before { hide_const('Mysql2') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "mysql2" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', mysql2: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', mysql2: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', mysql2: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Mysql2::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Mysql2::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/patchable_spec.rb
+++ b/spec/ddtrace/contrib/patchable_spec.rb
@@ -42,14 +42,25 @@ RSpec.describe Datadog::Contrib::Patchable do
       describe '#compatible?' do
         subject(:compatible?) { patchable_class.compatible? }
 
-        context 'when the Ruby version' do
-          context 'is below the minimum' do
-            before { stub_const('RUBY_VERSION', '1.9.3') }
+        context 'when #available?' do
+          context 'is false' do
+            before { allow(patchable_class).to receive(:available?).and_return(false) }
             it { is_expected.to be false }
           end
 
-          context 'is meets the minimum' do
-            it { is_expected.to be true }
+          context 'is true' do
+            before { allow(patchable_class).to receive(:available?).and_return(true) }
+
+            context 'and the Ruby version' do
+              context 'is below the minimum' do
+                before { stub_const('RUBY_VERSION', '1.9.3') }
+                it { is_expected.to be false }
+              end
+
+              context 'is meets the minimum' do
+                it { is_expected.to be true }
+              end
+            end
           end
         end
       end

--- a/spec/ddtrace/contrib/presto/integration_spec.rb
+++ b/spec/ddtrace/contrib/presto/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/presto/integration'
+
+RSpec.describe Datadog::Contrib::Presto::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:presto) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "presto-client" gem is loaded' do
+      include_context 'loaded gems', :'presto-client' => described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "presto-client" gem is not loaded' do
+      include_context 'loaded gems', :'presto-client' => nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Presto::Client::Client is defined' do
+      before { stub_const('Presto::Client::Client', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Presto::Client::Client is not defined' do
+      before { hide_const('Presto::Client::Client') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "presto-client" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', :'presto-client' => decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', :'presto-client' => described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', :'presto-client' => nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Presto::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Presto::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/racecar/integration_spec.rb
+++ b/spec/ddtrace/contrib/racecar/integration_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/racecar/integration'
+
+RSpec.describe Datadog::Contrib::Racecar::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:racecar) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "racecar" gem is loaded' do
+      include_context 'loaded gems', racecar: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "racecar" gem is not loaded' do
+      include_context 'loaded gems', racecar: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when neither Racecar or ActiveSupport::Notifications are defined' do
+      before do
+        hide_const('Racecar')
+        hide_const('ActiveSupport::Notifications')
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when only Racecar is defined' do
+      before do
+        stub_const('Racecar', Class.new)
+        hide_const('ActiveSupport::Notifications')
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when only ActiveSupport::Notifications is defined' do
+      before do
+        hide_const('Racecar')
+        stub_const('ActiveSupport::Notifications', Class.new)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when both Racecar and ActiveSupport::Notifications are defined' do
+      before do
+        stub_const('Racecar', Class.new)
+        stub_const('ActiveSupport::Notifications', Class.new)
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "racecar" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', racecar: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', racecar: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', racecar: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Racecar::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Racecar::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/rack/integration_spec.rb
+++ b/spec/ddtrace/contrib/rack/integration_spec.rb
@@ -1,629 +1,68 @@
 require 'spec_helper'
-require 'rack/test'
-require 'securerandom'
 
-require 'rack'
-require 'ddtrace'
-require 'ddtrace/contrib/rack/middlewares'
+require 'ddtrace/contrib/rack/integration'
 
-RSpec.describe 'Rack integration tests' do
-  include Rack::Test::Methods
+RSpec.describe Datadog::Contrib::Rack::Integration do
+  extend ConfigurationHelpers
 
-  let(:tracer) { get_test_tracer }
-  let(:rack_options) { { tracer: tracer } }
+  let(:integration) { described_class.new(:rack) }
 
-  let(:spans) { tracer.writer.spans }
-  let(:span) { spans.first }
+  describe '.version' do
+    subject(:version) { described_class.version }
 
-  before(:each) do
-    Datadog.configure do |c|
-      c.use :rack, rack_options
+    context 'when the "rack" gem is loaded' do
+      include_context 'loaded gems', rack: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "rack" gem is not loaded' do
+      include_context 'loaded gems', rack: nil
+      it { is_expected.to be nil }
     end
   end
 
-  context 'for an application' do
-    let(:app) do
-      app_routes = routes
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
 
-      Rack::Builder.new do
-        use Datadog::Contrib::Rack::TraceMiddleware
-        instance_eval(&app_routes)
-      end.to_app
+    context 'when Rack is defined' do
+      before { stub_const('Rack', Class.new) }
+      it { is_expected.to be true }
     end
 
-    context 'with no routes' do
-      # NOTE: Have to give a Rack app at least one route.
-      let(:routes) do
-        proc do
-          map '/no/routes' do
-            run(proc { |_env| })
-          end
-        end
+    context 'when Rack is not defined' do
+      before { hide_const('Rack') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "rack" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', rack: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
       end
 
-      before(:each) do
-        is_expected.to be_not_found
-        expect(spans).to have(1).items
-      end
-
-      describe 'GET request' do
-        subject(:response) { get '/not/exists/' }
-
-        it do
-          expect(span.name).to eq('rack.request')
-          expect(span.span_type).to eq('web')
-          expect(span.service).to eq('rack')
-          expect(span.resource).to eq('GET 404')
-          expect(span.get_tag('http.method')).to eq('GET')
-          expect(span.get_tag('http.status_code')).to eq('404')
-          expect(span.get_tag('http.url')).to eq('/not/exists/')
-          expect(span.get_tag('http.base_url')).to eq('http://example.org')
-          expect(span.status).to eq(0)
-          expect(span.parent).to be nil
-        end
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', rack: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
       end
     end
 
-    context 'with a basic route' do
-      let(:routes) do
-        proc do
-          map '/success/' do
-            run(proc { |_env| [200, { 'Content-Type' => 'text/html' }, ['OK']] })
-          end
-        end
-      end
-
-      before(:each) do
-        is_expected.to be_ok
-        expect(spans).to have(1).items
-      end
-
-      describe 'GET request' do
-        subject(:response) { get route }
-
-        context 'without parameters' do
-          let(:route) { '/success/' }
-
-          it do
-            expect(span.name).to eq('rack.request')
-            expect(span.span_type).to eq('web')
-            expect(span.service).to eq('rack')
-            expect(span.resource).to eq('GET 200')
-            expect(span.get_tag('http.method')).to eq('GET')
-            expect(span.get_tag('http.status_code')).to eq('200')
-            expect(span.get_tag('http.url')).to eq('/success/')
-            expect(span.get_tag('http.base_url')).to eq('http://example.org')
-            expect(span.status).to eq(0)
-            expect(span.parent).to be nil
-          end
-        end
-
-        context 'with query string parameters' do
-          let(:route) { '/success?foo=bar' }
-
-          it do
-            expect(span.name).to eq('rack.request')
-            expect(span.span_type).to eq('web')
-            expect(span.service).to eq('rack')
-            expect(span.resource).to eq('GET 200')
-            expect(span.get_tag('http.method')).to eq('GET')
-            expect(span.get_tag('http.status_code')).to eq('200')
-            # Since REQUEST_URI isn't available in Rack::Test by default (comes from WEBrick/Puma)
-            # it reverts to PATH_INFO, which doesn't have query string parameters.
-            expect(span.get_tag('http.url')).to eq('/success')
-            expect(span.get_tag('http.base_url')).to eq('http://example.org')
-            expect(span.status).to eq(0)
-            expect(span.parent).to be nil
-          end
-        end
-
-        context 'with REQUEST_URI' do
-          subject(:response) { get '/success?foo=bar', {}, 'REQUEST_URI' => '/success?foo=bar' }
-
-          context 'and default quantization' do
-            let(:rack_options) { super().merge(quantize: {}) }
-
-            it do
-              expect(span.name).to eq('rack.request')
-              expect(span.span_type).to eq('web')
-              expect(span.service).to eq('rack')
-              expect(span.resource).to eq('GET 200')
-              expect(span.get_tag('http.method')).to eq('GET')
-              expect(span.get_tag('http.status_code')).to eq('200')
-              # Since REQUEST_URI is set (usually provided by WEBrick/Puma)
-              # it uses REQUEST_URI, which has query string parameters.
-              # However, that query string will be quantized.
-              expect(span.get_tag('http.url')).to eq('/success?foo')
-              expect(span.get_tag('http.base_url')).to eq('http://example.org')
-              expect(span.status).to eq(0)
-              expect(span.parent).to be nil
-            end
-          end
-
-          context 'and quantization activated for the query' do
-            let(:rack_options) { super().merge(quantize: { query: { show: ['foo'] } }) }
-
-            it do
-              expect(span.name).to eq('rack.request')
-              expect(span.span_type).to eq('web')
-              expect(span.service).to eq('rack')
-              expect(span.resource).to eq('GET 200')
-              expect(span.get_tag('http.method')).to eq('GET')
-              expect(span.get_tag('http.status_code')).to eq('200')
-              # Since REQUEST_URI is set (usually provided by WEBrick/Puma)
-              # it uses REQUEST_URI, which has query string parameters.
-              # The query string will not be quantized, per the option.
-              expect(span.get_tag('http.url')).to eq('/success?foo=bar')
-              expect(span.get_tag('http.base_url')).to eq('http://example.org')
-              expect(span.status).to eq(0)
-              expect(span.parent).to be nil
-            end
-          end
-        end
-
-        context 'with sub-route' do
-          let(:route) { '/success/100' }
-
-          it do
-            expect(span.name).to eq('rack.request')
-            expect(span.span_type).to eq('web')
-            expect(span.service).to eq('rack')
-            expect(span.resource).to eq('GET 200')
-            expect(span.get_tag('http.method')).to eq('GET')
-            expect(span.get_tag('http.status_code')).to eq('200')
-            expect(span.get_tag('http.url')).to eq('/success/100')
-            expect(span.get_tag('http.base_url')).to eq('http://example.org')
-            expect(span.status).to eq(0)
-            expect(span.parent).to be nil
-          end
-        end
-
-        context 'when configured with a custom service name' do
-          let(:route) { '/success/' }
-          let(:rack_options) { super().merge(service_name: service_name) }
-          let(:service_name) { 'custom-rack' }
-
-          after(:each) do
-            Datadog.configure do |c|
-              c.use :rack, service_name: Datadog::Contrib::Rack::Ext::SERVICE_NAME
-            end
-          end
-
-          it do
-            expect(span.name).to eq('rack.request')
-            expect(span.span_type).to eq('web')
-            expect(span.service).to eq('custom-rack')
-            expect(span.resource).to eq('GET 200')
-            expect(span.get_tag('http.method')).to eq('GET')
-            expect(span.get_tag('http.status_code')).to eq('200')
-            expect(span.get_tag('http.url')).to eq('/success/')
-            expect(span.get_tag('http.base_url')).to eq('http://example.org')
-            expect(span.status).to eq(0)
-            expect(span.parent).to be nil
-          end
-        end
-      end
-
-      describe 'POST request' do
-        subject(:response) { post route }
-
-        context 'without parameters' do
-          let(:route) { '/success/' }
-
-          it do
-            expect(span.name).to eq('rack.request')
-            expect(span.span_type).to eq('web')
-            expect(span.service).to eq('rack')
-            expect(span.resource).to eq('POST 200')
-            expect(span.get_tag('http.method')).to eq('POST')
-            expect(span.get_tag('http.status_code')).to eq('200')
-            expect(span.get_tag('http.url')).to eq('/success/')
-            expect(span.get_tag('http.base_url')).to eq('http://example.org')
-            expect(span.status).to eq(0)
-            expect(span.parent).to be nil
-          end
-        end
-      end
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', rack: nil
+      it { is_expected.to be false }
     end
+  end
 
-    context 'with a route that has a client error' do
-      let(:routes) do
-        proc do
-          map '/failure/' do
-            run(proc { |_env| [400, { 'Content-Type' => 'text/html' }, ['KO']] })
-          end
-        end
-      end
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Rack::Configuration::Settings) }
+  end
 
-      before(:each) do
-        expect(response.status).to eq(400)
-        expect(spans).to have(1).items
-      end
-
-      describe 'GET request' do
-        subject(:response) { get '/failure/' }
-
-        it do
-          expect(span.name).to eq('rack.request')
-          expect(span.span_type).to eq('web')
-          expect(span.service).to eq('rack')
-          expect(span.resource).to eq('GET 400')
-          expect(span.get_tag('http.method')).to eq('GET')
-          expect(span.get_tag('http.status_code')).to eq('400')
-          expect(span.get_tag('http.url')).to eq('/failure/')
-          expect(span.get_tag('http.base_url')).to eq('http://example.org')
-          expect(span.status).to eq(0)
-          expect(span.parent).to be nil
-        end
-      end
-    end
-
-    context 'with a route that has a server error' do
-      let(:routes) do
-        proc do
-          map '/server_error/' do
-            run(proc { |_env| [500, { 'Content-Type' => 'text/html' }, ['KO']] })
-          end
-        end
-      end
-
-      before(:each) do
-        is_expected.to be_server_error
-        expect(spans).to have(1).items
-      end
-
-      describe 'GET request' do
-        subject(:response) { get '/server_error/' }
-
-        it do
-          expect(span.name).to eq('rack.request')
-          expect(span.span_type).to eq('web')
-          expect(span.service).to eq('rack')
-          expect(span.resource).to eq('GET 500')
-          expect(span.get_tag('http.method')).to eq('GET')
-          expect(span.get_tag('http.status_code')).to eq('500')
-          expect(span.get_tag('http.url')).to eq('/server_error/')
-          expect(span.get_tag('http.base_url')).to eq('http://example.org')
-          expect(span.get_tag('error.stack')).to be nil
-          expect(span.status).to eq(1)
-          expect(span.parent).to be nil
-        end
-      end
-    end
-
-    context 'with a route that raises an exception' do
-      context 'that is well known' do
-        let(:routes) do
-          proc do
-            map '/exception/' do
-              run(proc { |_env| raise StandardError, 'Unable to process the request' })
-            end
-          end
-        end
-
-        before(:each) do
-          expect { response }.to raise_error(StandardError)
-          expect(spans).to have(1).items
-        end
-
-        describe 'GET request' do
-          subject(:response) { get '/exception/' }
-
-          it do
-            expect(span.name).to eq('rack.request')
-            expect(span.span_type).to eq('web')
-            expect(span.service).to eq('rack')
-            expect(span.resource).to eq('GET')
-            expect(span.get_tag('http.method')).to eq('GET')
-            expect(span.get_tag('http.status_code')).to be nil
-            expect(span.get_tag('http.url')).to eq('/exception/')
-            expect(span.get_tag('http.base_url')).to eq('http://example.org')
-            expect(span.get_tag('error.type')).to eq('StandardError')
-            expect(span.get_tag('error.msg')).to eq('Unable to process the request')
-            expect(span.get_tag('error.stack')).to_not be nil
-            expect(span.status).to eq(1)
-            expect(span.parent).to be nil
-          end
-        end
-      end
-
-      context 'that is not a standard error' do
-        let(:routes) do
-          proc do
-            map '/exception/' do
-              run(proc { |_env| raise NoMemoryError, 'Non-standard error' })
-            end
-          end
-        end
-
-        before(:each) do
-          expect { response }.to raise_error(NoMemoryError)
-          expect(spans).to have(1).items
-        end
-
-        describe 'GET request' do
-          subject(:response) { get '/exception/' }
-
-          it do
-            expect(span.name).to eq('rack.request')
-            expect(span.span_type).to eq('web')
-            expect(span.service).to eq('rack')
-            expect(span.resource).to eq('GET')
-            expect(span.get_tag('http.method')).to eq('GET')
-            expect(span.get_tag('http.status_code')).to be nil
-            expect(span.get_tag('http.url')).to eq('/exception/')
-            expect(span.get_tag('http.base_url')).to eq('http://example.org')
-            expect(span.get_tag('error.type')).to eq('NoMemoryError')
-            expect(span.get_tag('error.msg')).to eq('Non-standard error')
-            expect(span.get_tag('error.stack')).to_not be nil
-            expect(span.status).to eq(1)
-            expect(span.parent).to be nil
-          end
-        end
-      end
-    end
-
-    context 'with a route with a nested application' do
-      context 'that is OK' do
-        let(:routes) do
-          proc do
-            map '/app/' do
-              run(proc do |env|
-                # This should be considered a web framework that can alter
-                # the request span after routing / controller processing
-                request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
-                request_span.resource = 'GET /app/'
-                request_span.set_tag('http.method', 'GET_V2')
-                request_span.set_tag('http.status_code', 201)
-                request_span.set_tag('http.url', '/app/static/')
-
-                [200, { 'Content-Type' => 'text/html' }, ['OK']]
-              end)
-            end
-          end
-        end
-
-        before(:each) do
-          is_expected.to be_ok
-          expect(spans).to have(1).items
-        end
-
-        describe 'GET request' do
-          subject(:response) { get route }
-
-          context 'without parameters' do
-            let(:route) { '/app/posts/100' }
-
-            it do
-              expect(span.name).to eq('rack.request')
-              expect(span.span_type).to eq('web')
-              expect(span.service).to eq('rack')
-              expect(span.resource).to eq('GET /app/')
-              expect(span.get_tag('http.method')).to eq('GET_V2')
-              expect(span.get_tag('http.status_code')).to eq('201')
-              expect(span.get_tag('http.url')).to eq('/app/static/')
-              expect(span.get_tag('http.base_url')).to eq('http://example.org')
-              expect(span.status).to eq(0)
-              expect(span.parent).to be nil
-            end
-          end
-        end
-      end
-
-      context 'that raises a server error' do
-        before(:each) do
-          is_expected.to be_server_error
-          expect(spans).to have(1).items
-        end
-
-        context 'while setting status' do
-          let(:routes) do
-            proc do
-              map '/app/500/' do
-                run(proc do |env|
-                  # this should be considered a web framework that can alter
-                  # the request span after routing / controller processing
-                  request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
-                  request_span.status = 1
-                  request_span.set_tag('error.stack', 'Handled exception')
-
-                  [500, { 'Content-Type' => 'text/html' }, ['OK']]
-                end)
-              end
-            end
-          end
-
-          describe 'GET request' do
-            subject(:response) { get '/app/500/' }
-
-            it do
-              expect(span.name).to eq('rack.request')
-              expect(span.span_type).to eq('web')
-              expect(span.service).to eq('rack')
-              expect(span.resource).to eq('GET 500')
-              expect(span.get_tag('http.method')).to eq('GET')
-              expect(span.get_tag('http.status_code')).to eq('500')
-              expect(span.get_tag('http.url')).to eq('/app/500/')
-              expect(span.get_tag('http.base_url')).to eq('http://example.org')
-              expect(span.get_tag('error.stack')).to eq('Handled exception')
-              expect(span.status).to eq(1)
-              expect(span.parent).to be nil
-            end
-          end
-        end
-
-        context 'without setting status' do
-          let(:routes) do
-            proc do
-              map '/app/500/' do
-                run(proc do |env|
-                  # this should be considered a web framework that can alter
-                  # the request span after routing / controller processing
-                  request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
-                  request_span.set_tag('error.stack', 'Handled exception')
-
-                  [500, { 'Content-Type' => 'text/html' }, ['OK']]
-                end)
-              end
-            end
-          end
-
-          describe 'GET request' do
-            subject(:response) { get '/app/500/' }
-
-            it do
-              expect(span.name).to eq('rack.request')
-              expect(span.span_type).to eq('web')
-              expect(span.service).to eq('rack')
-              expect(span.resource).to eq('GET 500')
-              expect(span.get_tag('http.method')).to eq('GET')
-              expect(span.get_tag('http.status_code')).to eq('500')
-              expect(span.get_tag('http.url')).to eq('/app/500/')
-              expect(span.get_tag('http.base_url')).to eq('http://example.org')
-              expect(span.get_tag('error.stack')).to eq('Handled exception')
-              expect(span.status).to eq(1)
-              expect(span.parent).to be nil
-            end
-          end
-        end
-      end
-    end
-
-    context 'with a route that leaks span context' do
-      let(:routes) do
-        app_tracer = tracer
-
-        proc do
-          map '/leak/' do
-            handler = proc do
-              app_tracer.trace('leaky-span-1')
-              app_tracer.trace('leaky-span-2')
-              app_tracer.trace('leaky-span-3')
-
-              [200, { 'Content-Type' => 'text/html' }, ['OK']]
-            end
-
-            run(handler)
-          end
-
-          map '/success/' do
-            run(proc { |_env| [200, { 'Content-Type' => 'text/html' }, ['OK']] })
-          end
-        end
-      end
-
-      describe 'subsequent GET requests' do
-        subject(:responses) { [(get '/leak'), (get '/success')] }
-
-        before(:each) do
-          responses.each { |response| expect(response).to be_ok }
-          expect(spans).to have(1).items
-        end
-
-        it do
-          # Ensure the context is properly cleaned between requests.
-          expect(tracer.provider.context.instance_variable_get(:@trace).length).to eq(0)
-          expect(spans).to have(1).items
-        end
-      end
-    end
-
-    context 'with a route that sets some headers' do
-      let(:routes) do
-        proc do
-          map '/headers/' do
-            run(proc do |_env|
-              response_headers = {
-                'Content-Type' => 'text/html',
-                'Cache-Control' => 'max-age=3600',
-                'ETag' => '"737060cd8c284d8af7ad3082f209582d"',
-                'Expires' => 'Thu, 01 Dec 1994 16:00:00 GMT',
-                'Last-Modified' => 'Tue, 15 Nov 1994 12:45:26 GMT',
-                'X-Request-ID' => 'f058ebd6-02f7-4d3f-942e-904344e8cde5',
-                'X-Fake-Response' => 'Don\'t tag me.'
-              }
-              [200, response_headers, ['OK']]
-            end)
-          end
-        end
-      end
-
-      context 'when configured to tag headers' do
-        before(:each) do
-          Datadog.configure do |c|
-            c.use :rack, headers: {
-              request: [
-                'Cache-Control'
-              ],
-              response: [
-                'Content-Type',
-                'Cache-Control',
-                'Content-Type',
-                'ETag',
-                'Expires',
-                'Last-Modified',
-                # This lowercase 'Id' header doesn't match.
-                # Ensure middleware allows for case-insensitive matching.
-                'X-Request-Id'
-              ]
-            }
-          end
-        end
-
-        after(:each) do
-          # Reset to default headers
-          Datadog.configure do |c|
-            c.use :rack, headers: {}
-          end
-        end
-
-        describe 'GET request' do
-          context 'that sends headers' do
-            subject(:response) { get '/headers/', {}, headers }
-
-            let(:headers) do
-              {
-                'HTTP_CACHE_CONTROL' => 'no-cache',
-                'HTTP_X_REQUEST_ID' => SecureRandom.uuid,
-                'HTTP_X_FAKE_REQUEST' => 'Don\'t tag me.'
-              }
-            end
-
-            before(:each) do
-              is_expected.to be_ok
-              expect(spans).to have(1).items
-            end
-
-            it do
-              expect(span.name).to eq('rack.request')
-              expect(span.span_type).to eq('web')
-              expect(span.service).to eq('rack')
-              expect(span.resource).to eq('GET 200')
-              expect(span.get_tag('http.method')).to eq('GET')
-              expect(span.get_tag('http.status_code')).to eq('200')
-              expect(span.get_tag('http.url')).to eq('/headers/')
-              expect(span.get_tag('http.base_url')).to eq('http://example.org')
-              expect(span.status).to eq(0)
-              expect(span.parent).to be nil
-
-              # Request headers
-              expect(span.get_tag('http.request.headers.cache_control')).to eq('no-cache')
-              # Make sure non-whitelisted headers don't become tags.
-              expect(span.get_tag('http.request.headers.x_request_id')).to be nil
-              expect(span.get_tag('http.request.headers.x_fake_request')).to be nil
-
-              # Response headers
-              expect(span.get_tag('http.response.headers.content_type')).to eq('text/html')
-              expect(span.get_tag('http.response.headers.cache_control')).to eq('max-age=3600')
-              expect(span.get_tag('http.response.headers.etag')).to eq('"737060cd8c284d8af7ad3082f209582d"')
-              expect(span.get_tag('http.response.headers.last_modified')).to eq('Tue, 15 Nov 1994 12:45:26 GMT')
-              expect(span.get_tag('http.response.headers.x_request_id')).to eq('f058ebd6-02f7-4d3f-942e-904344e8cde5')
-              # Make sure non-whitelisted headers don't become tags.
-              expect(span.get_tag('http.request.headers.x_fake_response')).to be nil
-            end
-          end
-        end
-      end
-    end
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Rack::Patcher }
   end
 end

--- a/spec/ddtrace/contrib/rack/integration_test_spec.rb
+++ b/spec/ddtrace/contrib/rack/integration_test_spec.rb
@@ -1,0 +1,629 @@
+require 'spec_helper'
+require 'rack/test'
+require 'securerandom'
+
+require 'rack'
+require 'ddtrace'
+require 'ddtrace/contrib/rack/middlewares'
+
+RSpec.describe 'Rack integration tests' do
+  include Rack::Test::Methods
+
+  let(:tracer) { get_test_tracer }
+  let(:rack_options) { { tracer: tracer } }
+
+  let(:spans) { tracer.writer.spans }
+  let(:span) { spans.first }
+
+  before(:each) do
+    Datadog.configure do |c|
+      c.use :rack, rack_options
+    end
+  end
+
+  context 'for an application' do
+    let(:app) do
+      app_routes = routes
+
+      Rack::Builder.new do
+        use Datadog::Contrib::Rack::TraceMiddleware
+        instance_eval(&app_routes)
+      end.to_app
+    end
+
+    context 'with no routes' do
+      # NOTE: Have to give a Rack app at least one route.
+      let(:routes) do
+        proc do
+          map '/no/routes' do
+            run(proc { |_env| })
+          end
+        end
+      end
+
+      before(:each) do
+        is_expected.to be_not_found
+        expect(spans).to have(1).items
+      end
+
+      describe 'GET request' do
+        subject(:response) { get '/not/exists/' }
+
+        it do
+          expect(span.name).to eq('rack.request')
+          expect(span.span_type).to eq('web')
+          expect(span.service).to eq('rack')
+          expect(span.resource).to eq('GET 404')
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.status_code')).to eq('404')
+          expect(span.get_tag('http.url')).to eq('/not/exists/')
+          expect(span.get_tag('http.base_url')).to eq('http://example.org')
+          expect(span.status).to eq(0)
+          expect(span.parent).to be nil
+        end
+      end
+    end
+
+    context 'with a basic route' do
+      let(:routes) do
+        proc do
+          map '/success/' do
+            run(proc { |_env| [200, { 'Content-Type' => 'text/html' }, ['OK']] })
+          end
+        end
+      end
+
+      before(:each) do
+        is_expected.to be_ok
+        expect(spans).to have(1).items
+      end
+
+      describe 'GET request' do
+        subject(:response) { get route }
+
+        context 'without parameters' do
+          let(:route) { '/success/' }
+
+          it do
+            expect(span.name).to eq('rack.request')
+            expect(span.span_type).to eq('web')
+            expect(span.service).to eq('rack')
+            expect(span.resource).to eq('GET 200')
+            expect(span.get_tag('http.method')).to eq('GET')
+            expect(span.get_tag('http.status_code')).to eq('200')
+            expect(span.get_tag('http.url')).to eq('/success/')
+            expect(span.get_tag('http.base_url')).to eq('http://example.org')
+            expect(span.status).to eq(0)
+            expect(span.parent).to be nil
+          end
+        end
+
+        context 'with query string parameters' do
+          let(:route) { '/success?foo=bar' }
+
+          it do
+            expect(span.name).to eq('rack.request')
+            expect(span.span_type).to eq('web')
+            expect(span.service).to eq('rack')
+            expect(span.resource).to eq('GET 200')
+            expect(span.get_tag('http.method')).to eq('GET')
+            expect(span.get_tag('http.status_code')).to eq('200')
+            # Since REQUEST_URI isn't available in Rack::Test by default (comes from WEBrick/Puma)
+            # it reverts to PATH_INFO, which doesn't have query string parameters.
+            expect(span.get_tag('http.url')).to eq('/success')
+            expect(span.get_tag('http.base_url')).to eq('http://example.org')
+            expect(span.status).to eq(0)
+            expect(span.parent).to be nil
+          end
+        end
+
+        context 'with REQUEST_URI' do
+          subject(:response) { get '/success?foo=bar', {}, 'REQUEST_URI' => '/success?foo=bar' }
+
+          context 'and default quantization' do
+            let(:rack_options) { super().merge(quantize: {}) }
+
+            it do
+              expect(span.name).to eq('rack.request')
+              expect(span.span_type).to eq('web')
+              expect(span.service).to eq('rack')
+              expect(span.resource).to eq('GET 200')
+              expect(span.get_tag('http.method')).to eq('GET')
+              expect(span.get_tag('http.status_code')).to eq('200')
+              # Since REQUEST_URI is set (usually provided by WEBrick/Puma)
+              # it uses REQUEST_URI, which has query string parameters.
+              # However, that query string will be quantized.
+              expect(span.get_tag('http.url')).to eq('/success?foo')
+              expect(span.get_tag('http.base_url')).to eq('http://example.org')
+              expect(span.status).to eq(0)
+              expect(span.parent).to be nil
+            end
+          end
+
+          context 'and quantization activated for the query' do
+            let(:rack_options) { super().merge(quantize: { query: { show: ['foo'] } }) }
+
+            it do
+              expect(span.name).to eq('rack.request')
+              expect(span.span_type).to eq('web')
+              expect(span.service).to eq('rack')
+              expect(span.resource).to eq('GET 200')
+              expect(span.get_tag('http.method')).to eq('GET')
+              expect(span.get_tag('http.status_code')).to eq('200')
+              # Since REQUEST_URI is set (usually provided by WEBrick/Puma)
+              # it uses REQUEST_URI, which has query string parameters.
+              # The query string will not be quantized, per the option.
+              expect(span.get_tag('http.url')).to eq('/success?foo=bar')
+              expect(span.get_tag('http.base_url')).to eq('http://example.org')
+              expect(span.status).to eq(0)
+              expect(span.parent).to be nil
+            end
+          end
+        end
+
+        context 'with sub-route' do
+          let(:route) { '/success/100' }
+
+          it do
+            expect(span.name).to eq('rack.request')
+            expect(span.span_type).to eq('web')
+            expect(span.service).to eq('rack')
+            expect(span.resource).to eq('GET 200')
+            expect(span.get_tag('http.method')).to eq('GET')
+            expect(span.get_tag('http.status_code')).to eq('200')
+            expect(span.get_tag('http.url')).to eq('/success/100')
+            expect(span.get_tag('http.base_url')).to eq('http://example.org')
+            expect(span.status).to eq(0)
+            expect(span.parent).to be nil
+          end
+        end
+
+        context 'when configured with a custom service name' do
+          let(:route) { '/success/' }
+          let(:rack_options) { super().merge(service_name: service_name) }
+          let(:service_name) { 'custom-rack' }
+
+          after(:each) do
+            Datadog.configure do |c|
+              c.use :rack, service_name: Datadog::Contrib::Rack::Ext::SERVICE_NAME
+            end
+          end
+
+          it do
+            expect(span.name).to eq('rack.request')
+            expect(span.span_type).to eq('web')
+            expect(span.service).to eq('custom-rack')
+            expect(span.resource).to eq('GET 200')
+            expect(span.get_tag('http.method')).to eq('GET')
+            expect(span.get_tag('http.status_code')).to eq('200')
+            expect(span.get_tag('http.url')).to eq('/success/')
+            expect(span.get_tag('http.base_url')).to eq('http://example.org')
+            expect(span.status).to eq(0)
+            expect(span.parent).to be nil
+          end
+        end
+      end
+
+      describe 'POST request' do
+        subject(:response) { post route }
+
+        context 'without parameters' do
+          let(:route) { '/success/' }
+
+          it do
+            expect(span.name).to eq('rack.request')
+            expect(span.span_type).to eq('web')
+            expect(span.service).to eq('rack')
+            expect(span.resource).to eq('POST 200')
+            expect(span.get_tag('http.method')).to eq('POST')
+            expect(span.get_tag('http.status_code')).to eq('200')
+            expect(span.get_tag('http.url')).to eq('/success/')
+            expect(span.get_tag('http.base_url')).to eq('http://example.org')
+            expect(span.status).to eq(0)
+            expect(span.parent).to be nil
+          end
+        end
+      end
+    end
+
+    context 'with a route that has a client error' do
+      let(:routes) do
+        proc do
+          map '/failure/' do
+            run(proc { |_env| [400, { 'Content-Type' => 'text/html' }, ['KO']] })
+          end
+        end
+      end
+
+      before(:each) do
+        expect(response.status).to eq(400)
+        expect(spans).to have(1).items
+      end
+
+      describe 'GET request' do
+        subject(:response) { get '/failure/' }
+
+        it do
+          expect(span.name).to eq('rack.request')
+          expect(span.span_type).to eq('web')
+          expect(span.service).to eq('rack')
+          expect(span.resource).to eq('GET 400')
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.status_code')).to eq('400')
+          expect(span.get_tag('http.url')).to eq('/failure/')
+          expect(span.get_tag('http.base_url')).to eq('http://example.org')
+          expect(span.status).to eq(0)
+          expect(span.parent).to be nil
+        end
+      end
+    end
+
+    context 'with a route that has a server error' do
+      let(:routes) do
+        proc do
+          map '/server_error/' do
+            run(proc { |_env| [500, { 'Content-Type' => 'text/html' }, ['KO']] })
+          end
+        end
+      end
+
+      before(:each) do
+        is_expected.to be_server_error
+        expect(spans).to have(1).items
+      end
+
+      describe 'GET request' do
+        subject(:response) { get '/server_error/' }
+
+        it do
+          expect(span.name).to eq('rack.request')
+          expect(span.span_type).to eq('web')
+          expect(span.service).to eq('rack')
+          expect(span.resource).to eq('GET 500')
+          expect(span.get_tag('http.method')).to eq('GET')
+          expect(span.get_tag('http.status_code')).to eq('500')
+          expect(span.get_tag('http.url')).to eq('/server_error/')
+          expect(span.get_tag('http.base_url')).to eq('http://example.org')
+          expect(span.get_tag('error.stack')).to be nil
+          expect(span.status).to eq(1)
+          expect(span.parent).to be nil
+        end
+      end
+    end
+
+    context 'with a route that raises an exception' do
+      context 'that is well known' do
+        let(:routes) do
+          proc do
+            map '/exception/' do
+              run(proc { |_env| raise StandardError, 'Unable to process the request' })
+            end
+          end
+        end
+
+        before(:each) do
+          expect { response }.to raise_error(StandardError)
+          expect(spans).to have(1).items
+        end
+
+        describe 'GET request' do
+          subject(:response) { get '/exception/' }
+
+          it do
+            expect(span.name).to eq('rack.request')
+            expect(span.span_type).to eq('web')
+            expect(span.service).to eq('rack')
+            expect(span.resource).to eq('GET')
+            expect(span.get_tag('http.method')).to eq('GET')
+            expect(span.get_tag('http.status_code')).to be nil
+            expect(span.get_tag('http.url')).to eq('/exception/')
+            expect(span.get_tag('http.base_url')).to eq('http://example.org')
+            expect(span.get_tag('error.type')).to eq('StandardError')
+            expect(span.get_tag('error.msg')).to eq('Unable to process the request')
+            expect(span.get_tag('error.stack')).to_not be nil
+            expect(span.status).to eq(1)
+            expect(span.parent).to be nil
+          end
+        end
+      end
+
+      context 'that is not a standard error' do
+        let(:routes) do
+          proc do
+            map '/exception/' do
+              run(proc { |_env| raise NoMemoryError, 'Non-standard error' })
+            end
+          end
+        end
+
+        before(:each) do
+          expect { response }.to raise_error(NoMemoryError)
+          expect(spans).to have(1).items
+        end
+
+        describe 'GET request' do
+          subject(:response) { get '/exception/' }
+
+          it do
+            expect(span.name).to eq('rack.request')
+            expect(span.span_type).to eq('web')
+            expect(span.service).to eq('rack')
+            expect(span.resource).to eq('GET')
+            expect(span.get_tag('http.method')).to eq('GET')
+            expect(span.get_tag('http.status_code')).to be nil
+            expect(span.get_tag('http.url')).to eq('/exception/')
+            expect(span.get_tag('http.base_url')).to eq('http://example.org')
+            expect(span.get_tag('error.type')).to eq('NoMemoryError')
+            expect(span.get_tag('error.msg')).to eq('Non-standard error')
+            expect(span.get_tag('error.stack')).to_not be nil
+            expect(span.status).to eq(1)
+            expect(span.parent).to be nil
+          end
+        end
+      end
+    end
+
+    context 'with a route with a nested application' do
+      context 'that is OK' do
+        let(:routes) do
+          proc do
+            map '/app/' do
+              run(proc do |env|
+                # This should be considered a web framework that can alter
+                # the request span after routing / controller processing
+                request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
+                request_span.resource = 'GET /app/'
+                request_span.set_tag('http.method', 'GET_V2')
+                request_span.set_tag('http.status_code', 201)
+                request_span.set_tag('http.url', '/app/static/')
+
+                [200, { 'Content-Type' => 'text/html' }, ['OK']]
+              end)
+            end
+          end
+        end
+
+        before(:each) do
+          is_expected.to be_ok
+          expect(spans).to have(1).items
+        end
+
+        describe 'GET request' do
+          subject(:response) { get route }
+
+          context 'without parameters' do
+            let(:route) { '/app/posts/100' }
+
+            it do
+              expect(span.name).to eq('rack.request')
+              expect(span.span_type).to eq('web')
+              expect(span.service).to eq('rack')
+              expect(span.resource).to eq('GET /app/')
+              expect(span.get_tag('http.method')).to eq('GET_V2')
+              expect(span.get_tag('http.status_code')).to eq('201')
+              expect(span.get_tag('http.url')).to eq('/app/static/')
+              expect(span.get_tag('http.base_url')).to eq('http://example.org')
+              expect(span.status).to eq(0)
+              expect(span.parent).to be nil
+            end
+          end
+        end
+      end
+
+      context 'that raises a server error' do
+        before(:each) do
+          is_expected.to be_server_error
+          expect(spans).to have(1).items
+        end
+
+        context 'while setting status' do
+          let(:routes) do
+            proc do
+              map '/app/500/' do
+                run(proc do |env|
+                  # this should be considered a web framework that can alter
+                  # the request span after routing / controller processing
+                  request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
+                  request_span.status = 1
+                  request_span.set_tag('error.stack', 'Handled exception')
+
+                  [500, { 'Content-Type' => 'text/html' }, ['OK']]
+                end)
+              end
+            end
+          end
+
+          describe 'GET request' do
+            subject(:response) { get '/app/500/' }
+
+            it do
+              expect(span.name).to eq('rack.request')
+              expect(span.span_type).to eq('web')
+              expect(span.service).to eq('rack')
+              expect(span.resource).to eq('GET 500')
+              expect(span.get_tag('http.method')).to eq('GET')
+              expect(span.get_tag('http.status_code')).to eq('500')
+              expect(span.get_tag('http.url')).to eq('/app/500/')
+              expect(span.get_tag('http.base_url')).to eq('http://example.org')
+              expect(span.get_tag('error.stack')).to eq('Handled exception')
+              expect(span.status).to eq(1)
+              expect(span.parent).to be nil
+            end
+          end
+        end
+
+        context 'without setting status' do
+          let(:routes) do
+            proc do
+              map '/app/500/' do
+                run(proc do |env|
+                  # this should be considered a web framework that can alter
+                  # the request span after routing / controller processing
+                  request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
+                  request_span.set_tag('error.stack', 'Handled exception')
+
+                  [500, { 'Content-Type' => 'text/html' }, ['OK']]
+                end)
+              end
+            end
+          end
+
+          describe 'GET request' do
+            subject(:response) { get '/app/500/' }
+
+            it do
+              expect(span.name).to eq('rack.request')
+              expect(span.span_type).to eq('web')
+              expect(span.service).to eq('rack')
+              expect(span.resource).to eq('GET 500')
+              expect(span.get_tag('http.method')).to eq('GET')
+              expect(span.get_tag('http.status_code')).to eq('500')
+              expect(span.get_tag('http.url')).to eq('/app/500/')
+              expect(span.get_tag('http.base_url')).to eq('http://example.org')
+              expect(span.get_tag('error.stack')).to eq('Handled exception')
+              expect(span.status).to eq(1)
+              expect(span.parent).to be nil
+            end
+          end
+        end
+      end
+    end
+
+    context 'with a route that leaks span context' do
+      let(:routes) do
+        app_tracer = tracer
+
+        proc do
+          map '/leak/' do
+            handler = proc do
+              app_tracer.trace('leaky-span-1')
+              app_tracer.trace('leaky-span-2')
+              app_tracer.trace('leaky-span-3')
+
+              [200, { 'Content-Type' => 'text/html' }, ['OK']]
+            end
+
+            run(handler)
+          end
+
+          map '/success/' do
+            run(proc { |_env| [200, { 'Content-Type' => 'text/html' }, ['OK']] })
+          end
+        end
+      end
+
+      describe 'subsequent GET requests' do
+        subject(:responses) { [(get '/leak'), (get '/success')] }
+
+        before(:each) do
+          responses.each { |response| expect(response).to be_ok }
+          expect(spans).to have(1).items
+        end
+
+        it do
+          # Ensure the context is properly cleaned between requests.
+          expect(tracer.provider.context.instance_variable_get(:@trace).length).to eq(0)
+          expect(spans).to have(1).items
+        end
+      end
+    end
+
+    context 'with a route that sets some headers' do
+      let(:routes) do
+        proc do
+          map '/headers/' do
+            run(proc do |_env|
+              response_headers = {
+                'Content-Type' => 'text/html',
+                'Cache-Control' => 'max-age=3600',
+                'ETag' => '"737060cd8c284d8af7ad3082f209582d"',
+                'Expires' => 'Thu, 01 Dec 1994 16:00:00 GMT',
+                'Last-Modified' => 'Tue, 15 Nov 1994 12:45:26 GMT',
+                'X-Request-ID' => 'f058ebd6-02f7-4d3f-942e-904344e8cde5',
+                'X-Fake-Response' => 'Don\'t tag me.'
+              }
+              [200, response_headers, ['OK']]
+            end)
+          end
+        end
+      end
+
+      context 'when configured to tag headers' do
+        before(:each) do
+          Datadog.configure do |c|
+            c.use :rack, headers: {
+              request: [
+                'Cache-Control'
+              ],
+              response: [
+                'Content-Type',
+                'Cache-Control',
+                'Content-Type',
+                'ETag',
+                'Expires',
+                'Last-Modified',
+                # This lowercase 'Id' header doesn't match.
+                # Ensure middleware allows for case-insensitive matching.
+                'X-Request-Id'
+              ]
+            }
+          end
+        end
+
+        after(:each) do
+          # Reset to default headers
+          Datadog.configure do |c|
+            c.use :rack, headers: {}
+          end
+        end
+
+        describe 'GET request' do
+          context 'that sends headers' do
+            subject(:response) { get '/headers/', {}, headers }
+
+            let(:headers) do
+              {
+                'HTTP_CACHE_CONTROL' => 'no-cache',
+                'HTTP_X_REQUEST_ID' => SecureRandom.uuid,
+                'HTTP_X_FAKE_REQUEST' => 'Don\'t tag me.'
+              }
+            end
+
+            before(:each) do
+              is_expected.to be_ok
+              expect(spans).to have(1).items
+            end
+
+            it do
+              expect(span.name).to eq('rack.request')
+              expect(span.span_type).to eq('web')
+              expect(span.service).to eq('rack')
+              expect(span.resource).to eq('GET 200')
+              expect(span.get_tag('http.method')).to eq('GET')
+              expect(span.get_tag('http.status_code')).to eq('200')
+              expect(span.get_tag('http.url')).to eq('/headers/')
+              expect(span.get_tag('http.base_url')).to eq('http://example.org')
+              expect(span.status).to eq(0)
+              expect(span.parent).to be nil
+
+              # Request headers
+              expect(span.get_tag('http.request.headers.cache_control')).to eq('no-cache')
+              # Make sure non-whitelisted headers don't become tags.
+              expect(span.get_tag('http.request.headers.x_request_id')).to be nil
+              expect(span.get_tag('http.request.headers.x_fake_request')).to be nil
+
+              # Response headers
+              expect(span.get_tag('http.response.headers.content_type')).to eq('text/html')
+              expect(span.get_tag('http.response.headers.cache_control')).to eq('max-age=3600')
+              expect(span.get_tag('http.response.headers.etag')).to eq('"737060cd8c284d8af7ad3082f209582d"')
+              expect(span.get_tag('http.response.headers.last_modified')).to eq('Tue, 15 Nov 1994 12:45:26 GMT')
+              expect(span.get_tag('http.response.headers.x_request_id')).to eq('f058ebd6-02f7-4d3f-942e-904344e8cde5')
+              # Make sure non-whitelisted headers don't become tags.
+              expect(span.get_tag('http.request.headers.x_fake_response')).to be nil
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/rails/integration_spec.rb
+++ b/spec/ddtrace/contrib/rails/integration_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/rails/integration'
+
+RSpec.describe Datadog::Contrib::Rails::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:rails) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "rails" gem is loaded' do
+      include_context 'loaded gems', rails: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "rails" gem is not loaded' do
+      include_context 'loaded gems', rails: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Rails is defined' do
+      before { stub_const('Rails', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Rails is not defined' do
+      before { hide_const('Rails') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "rails" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', rails: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', rails: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', rails: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.patchable?' do
+    subject(:patchable?) { described_class.patchable? }
+
+    context 'when available, loaded, and compatible' do
+      before do
+        allow(described_class).to receive(:available?).and_return(true)
+        allow(described_class).to receive(:loaded?).and_return(true)
+        allow(described_class).to receive(:compatible?).and_return(true)
+      end
+
+      context "and #{Datadog::Contrib::Rails::Ext::ENV_DISABLE}" do
+        context 'is not set' do
+          around do |example|
+            ClimateControl.modify Datadog::Contrib::Rails::Ext::ENV_DISABLE => nil do
+              example.run
+            end
+          end
+
+          it { is_expected.to be true }
+        end
+
+        context 'is set' do
+          around do |example|
+            ClimateControl.modify Datadog::Contrib::Rails::Ext::ENV_DISABLE => '1' do
+              example.run
+            end
+          end
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Rails::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Rails::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/rake/integration_spec.rb
+++ b/spec/ddtrace/contrib/rake/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/rake/integration'
+
+RSpec.describe Datadog::Contrib::Rake::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:rake) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "rake" gem is loaded' do
+      include_context 'loaded gems', rake: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "rake" gem is not loaded' do
+      include_context 'loaded gems', rake: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Rake is defined' do
+      before { stub_const('Rake', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Rake is not defined' do
+      before { hide_const('Rake') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "rake" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', rake: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', rake: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', rake: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Rake::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Rake::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/redis/integration_spec.rb
+++ b/spec/ddtrace/contrib/redis/integration_spec.rb
@@ -1,39 +1,73 @@
 require 'spec_helper'
 
-require 'time'
-require 'redis'
-require 'hiredis'
-require 'ddtrace'
+require 'ddtrace/contrib/redis/integration'
 
-RSpec.describe 'Redis integration test' do
-  # Use real tracer
-  let(:tracer) do
-    Datadog::Tracer.new
-  end
+RSpec.describe Datadog::Contrib::Redis::Integration do
+  extend ConfigurationHelpers
 
-  before(:each) do
-    skip unless ENV['TEST_DATADOG_INTEGRATION']
+  let(:integration) { described_class.new(:redis) }
 
-    # Make sure to reset default tracer
-    Datadog.configure do |c|
-      c.use :redis, tracer: tracer
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "redis" gem is loaded' do
+      include_context 'loaded gems', redis: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "redis" gem is not loaded' do
+      include_context 'loaded gems', redis: nil
+      it { is_expected.to be nil }
     end
   end
 
-  after(:each) do
-    Datadog.configure do |c|
-      c.use :redis
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Redis is defined' do
+      before { stub_const('Redis', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Redis is not defined' do
+      before { hide_const('Redis') }
+      it { is_expected.to be false }
     end
   end
 
-  let(:redis) { Redis.new(host: host, port: port) }
-  let(:host) { ENV.fetch('TEST_REDIS_HOST', '127.0.0.1') }
-  let(:port) { ENV.fetch('TEST_REDIS_PORT', 6379).to_i }
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
 
-  it do
-    expect(redis.set('FOO', 'bar')).to eq('OK')
-    expect(redis.get('FOO')).to eq('bar')
-    try_wait_until(attempts: 30) { tracer.writer.stats[:traces_flushed] >= 2 }
-    expect(tracer.writer.stats[:traces_flushed]).to be >= 2
+    context 'when "redis" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', redis: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', redis: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', redis: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Redis::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Redis::Patcher }
+  end
+
+  describe '#resolver' do
+    subject(:resolver) { integration.resolver }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Redis::Configuration::Resolver) }
   end
 end

--- a/spec/ddtrace/contrib/redis/integration_test_spec.rb
+++ b/spec/ddtrace/contrib/redis/integration_test_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+require 'time'
+require 'redis'
+require 'hiredis'
+require 'ddtrace'
+
+RSpec.describe 'Redis integration test' do
+  # Use real tracer
+  let(:tracer) do
+    Datadog::Tracer.new
+  end
+
+  before(:each) do
+    skip unless ENV['TEST_DATADOG_INTEGRATION']
+
+    # Make sure to reset default tracer
+    Datadog.configure do |c|
+      c.use :redis, tracer: tracer
+    end
+  end
+
+  after(:each) do
+    Datadog.configure do |c|
+      c.use :redis
+    end
+  end
+
+  let(:redis) { Redis.new(host: host, port: port) }
+  let(:host) { ENV.fetch('TEST_REDIS_HOST', '127.0.0.1') }
+  let(:port) { ENV.fetch('TEST_REDIS_PORT', 6379).to_i }
+
+  it do
+    expect(redis.set('FOO', 'bar')).to eq('OK')
+    expect(redis.get('FOO')).to eq('bar')
+    try_wait_until(attempts: 30) { tracer.writer.stats[:traces_flushed] >= 2 }
+    expect(tracer.writer.stats[:traces_flushed]).to be >= 2
+  end
+end

--- a/spec/ddtrace/contrib/resque/integration_spec.rb
+++ b/spec/ddtrace/contrib/resque/integration_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/resque/integration'
+
+RSpec.describe Datadog::Contrib::Resque::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:resque) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "resque" gem is loaded' do
+      include_context 'loaded gems', resque: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "resque" gem is not loaded' do
+      include_context 'loaded gems', resque: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Resque is defined' do
+      before { stub_const('Resque', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Resque is not defined' do
+      before { hide_const('Resque') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "resque" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', resque: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', resque: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+
+      context 'that exceeds the maximum version' do
+        include_context 'loaded gems', resque: described_class::MAXIMUM_VERSION
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', resque: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.sync_writer' do
+    it { expect(described_class).to respond_to(:sync_writer) }
+    it { expect(described_class).to respond_to(:sync_writer=) }
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Resque::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Resque::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/rest_client/integration_spec.rb
+++ b/spec/ddtrace/contrib/rest_client/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/rest_client/integration'
+
+RSpec.describe Datadog::Contrib::RestClient::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:rest_client) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "rest-client" gem is loaded' do
+      include_context 'loaded gems', :'rest-client' => described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "rest-client" gem is not loaded' do
+      include_context 'loaded gems', :'rest-client' => nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when RestClient::Request is defined' do
+      before { stub_const('RestClient::Request', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when RestClient::Request is not defined' do
+      before { hide_const('RestClient::Request') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "rest-client" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', :'rest-client' => decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', :'rest-client' => described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', :'rest-client' => nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::RestClient::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::RestClient::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/sequel/integration_spec.rb
+++ b/spec/ddtrace/contrib/sequel/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/sequel/integration'
+
+RSpec.describe Datadog::Contrib::Sequel::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:sequel) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "sequel" gem is loaded' do
+      include_context 'loaded gems', sequel: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "sequel" gem is not loaded' do
+      include_context 'loaded gems', sequel: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Sequel is defined' do
+      before { stub_const('Sequel', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Sequel is not defined' do
+      before { hide_const('Sequel') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "sequel" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', sequel: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', sequel: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', sequel: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Sequel::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Sequel::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/shoryuken/integration_spec.rb
+++ b/spec/ddtrace/contrib/shoryuken/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/shoryuken/integration'
+
+RSpec.describe Datadog::Contrib::Shoryuken::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:shoryuken) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "shoryuken" gem is loaded' do
+      include_context 'loaded gems', shoryuken: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "shoryuken" gem is not loaded' do
+      include_context 'loaded gems', shoryuken: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Shoryuken is defined' do
+      before { stub_const('Shoryuken', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Shoryuken is not defined' do
+      before { hide_const('Shoryuken') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "shoryuken" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', shoryuken: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', shoryuken: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', shoryuken: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Shoryuken::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Shoryuken::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/sidekiq/integration_spec.rb
+++ b/spec/ddtrace/contrib/sidekiq/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/sidekiq/integration'
+
+RSpec.describe Datadog::Contrib::Sidekiq::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:sidekiq) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "sidekiq" gem is loaded' do
+      include_context 'loaded gems', sidekiq: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "sidekiq" gem is not loaded' do
+      include_context 'loaded gems', sidekiq: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Sidekiq is defined' do
+      before { stub_const('Sidekiq', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Sidekiq is not defined' do
+      before { hide_const('Sidekiq') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "sidekiq" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', sidekiq: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', sidekiq: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', sidekiq: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Sidekiq::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Sidekiq::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/sinatra/integration_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/sinatra/integration'
+
+RSpec.describe Datadog::Contrib::Sinatra::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:sinatra) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "sinatra" gem is loaded' do
+      include_context 'loaded gems', sinatra: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "sinatra" gem is not loaded' do
+      include_context 'loaded gems', sinatra: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when Sinatra is defined' do
+      before { stub_const('Sinatra', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when Sinatra is not defined' do
+      before { hide_const('Sinatra') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "sinatra" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', sinatra: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', sinatra: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', sinatra: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::Sinatra::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::Sinatra::Patcher }
+  end
+end

--- a/spec/ddtrace/contrib/sucker_punch/integration_spec.rb
+++ b/spec/ddtrace/contrib/sucker_punch/integration_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/contrib/sucker_punch/integration'
+
+RSpec.describe Datadog::Contrib::SuckerPunch::Integration do
+  extend ConfigurationHelpers
+
+  let(:integration) { described_class.new(:sucker_punch) }
+
+  describe '.version' do
+    subject(:version) { described_class.version }
+
+    context 'when the "sucker_punch" gem is loaded' do
+      include_context 'loaded gems', sucker_punch: described_class::MINIMUM_VERSION
+      it { is_expected.to be_a_kind_of(Gem::Version) }
+    end
+
+    context 'when "sucker_punch" gem is not loaded' do
+      include_context 'loaded gems', sucker_punch: nil
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.loaded?' do
+    subject(:loaded?) { described_class.loaded? }
+
+    context 'when SuckerPunch is defined' do
+      before { stub_const('SuckerPunch', Class.new) }
+      it { is_expected.to be true }
+    end
+
+    context 'when SuckerPunch is not defined' do
+      before { hide_const('SuckerPunch') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.compatible?' do
+    subject(:compatible?) { described_class.compatible? }
+
+    context 'when "sucker_punch" gem is loaded with a version' do
+      context 'that is less than the minimum' do
+        include_context 'loaded gems', sucker_punch: decrement_gem_version(described_class::MINIMUM_VERSION)
+        it { is_expected.to be false }
+      end
+
+      context 'that meets the minimum version' do
+        include_context 'loaded gems', sucker_punch: described_class::MINIMUM_VERSION
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when gem is not loaded' do
+      include_context 'loaded gems', sucker_punch: nil
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#default_configuration' do
+    subject(:default_configuration) { integration.default_configuration }
+    it { is_expected.to be_a_kind_of(Datadog::Contrib::SuckerPunch::Configuration::Settings) }
+  end
+
+  describe '#patcher' do
+    subject(:patcher) { integration.patcher }
+    it { is_expected.to be Datadog::Contrib::SuckerPunch::Patcher }
+  end
+end


### PR DESCRIPTION
Fixes #964 

When activating instrumentation for a library that was not loaded via `c.use :integration_name`, integrations would return `nil` versions and raise an exception while checking their compatibility.

This pull request short circuits compatibility checks when `available?` is `false` to prevent this incorrect version comparison.

It also backfills a lot of missing unit tests for the integrations themselves, to verify that they return correct states when gems are loaded/unloaded or of different versions. This should prevent regressions of #964 from happening again.

While sweeping through each of the integrations and their version checks, I found a number of inconsistencies between the versions supported in documentation and the actual checks being applied. I corrected these, and as such, have adjusted minimum version support as follows:

 - ActionView: 3.2 --> 3.0
 - ActionPack: 3.2 --> 3.0
 - ActiveRecord: 3.2 --> 3.0
 - ActiveSupport: 3.2 --> 3.0
 - Dalli: 2.7 --> 2.0
 - Elasticsearch: 6.0 --> 1.0
 - Excon: 0.62 --> 0.50
 - GRPC: 1.10 --> 1.7
 - MongoDB: 2.0 --> 2.1
 - Rails: 3.2 --> 3.0
 - Shoryuken: 4.0.2 --> 3.2
 - Sinatra: 1.4.5 --> 1.4