### PR TITLE
patch to not drop runtime metrics config when creating new writer

### DIFF
--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -392,6 +392,14 @@ module Datadog
 
       writer_options[:transport_options] = transport_options
 
+      # ensure any configuration to runtime_metrics statsd client is
+      # passed on when writer gets rebuilt
+      unless writer_options.key?(:runtime_metrics)
+        if @writer && !@writer.runtime_metrics.nil?
+          writer_options[:runtime_metrics] = @writer.runtime_metrics
+        end
+      end
+
       if rebuild_writer || writer
         # Make sure old writer is shut down before throwing away.
         # Don't want additional threads running...

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -624,7 +624,7 @@ RSpec.describe 'Tracer integration tests' do
   end
 
   describe 'trace writer runtime metrics configuration' do
-    let(:hostname) { double('hostname') }
+    let(:hostname) { double('example_hostname') }
     let(:base_namespace) { 'original_example_namespace' }
     let(:updated_namespace) { 'updated_example_namespace' }
     let(:statsd_client) { Datadog::Statsd.new(hostname, 8125, tags: [], namespace: base_namespace) }

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 require 'ddtrace'
 require 'ddtrace/tracer'
+require 'datadog/statsd'
 require 'thread'
 
 RSpec.describe 'Tracer integration tests' do
@@ -619,6 +620,75 @@ RSpec.describe 'Tracer integration tests' do
           expect(spans2[1].name).to eq('thread_test2')
         end
       end
+    end
+  end
+
+  describe 'trace writer runtime metrics configuration' do
+    let(:hostname) { double('hostname') }
+    let(:base_namespace) { 'original_example_namespace' }
+    let(:updated_namespace) { 'updated_example_namespace' }
+    let(:statsd_client) { Datadog::Statsd.new(hostname, 8125, tags: [], namespace: base_namespace) }
+    let(:statsd_client_updated) { Datadog::Statsd.new(hostname, 8125, tags: [], namespace: updated_namespace) }
+    let(:transport) { Datadog::Transport::HTTP.default }
+
+    let(:writer_without_runtime) do
+      Datadog::Writer.new(
+        transport: transport,
+        priority_sampler: Datadog::PrioritySampler.new
+      )
+    end
+
+    let(:writer_with_runtime) do
+      Datadog::Writer.new(
+        transport: transport,
+        priority_sampler: Datadog::PrioritySampler.new,
+        runtime_metrics: Datadog::Runtime::Metrics.new(statsd: statsd_client_updated)
+      )
+    end
+
+    after(:each) do
+      statsd_client.close
+      statsd_client_updated.close
+    end
+
+    it 'should propogate runtime metrics configuration to the new writer when rebuilt' do
+      Datadog.configure do |c|
+        c.runtime_metrics_enabled
+        c.runtime_metrics statsd: statsd_client
+        c.tracer host: hostname
+      end
+
+      expect(Datadog.tracer.writer.runtime_metrics.statsd.namespace).to eq(base_namespace)
+    end
+
+    it 'should set runtime metrics configuration regardless of order' do
+      Datadog.configure do |c|
+        c.runtime_metrics_enabled
+        c.tracer host: hostname, writer: writer_without_runtime
+        c.runtime_metrics statsd: statsd_client
+      end
+
+      expect(Datadog.tracer.writer.runtime_metrics.statsd.namespace).to eq(base_namespace)
+    end
+
+    it 'should use new writer runtime metric configuration when available' do
+      Datadog.configure do |c|
+        c.runtime_metrics_enabled
+        c.runtime_metrics statsd: statsd_client
+        c.tracer host: hostname, writer: writer_with_runtime
+      end
+
+      expect(Datadog.tracer.writer.runtime_metrics.statsd.namespace).to eq(updated_namespace)
+    end
+
+    it 'should prioritize default writer runtime metric configuration when any writer is configured' do
+      Datadog.configure do |c|
+        c.runtime_metrics_enabled
+        c.runtime_metrics statsd: statsd_client
+        c.tracer host: hostname, writer: writer_without_runtime
+      end
+
+      expect(Datadog.tracer.writer.runtime_metrics.statsd.namespace).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
This PR is a POC to address https://github.com/DataDog/dd-trace-rb/issues/967 . It demonstrates one way to resolve the runtime metrics issue detailed in the referenced open issue, so I'm making it as a draft. If there's interest in getting merged I'd be happy to move it out of drafts and add some tests, but also feel free to close.