### PR TITLE
Make Datadog::Environment helpers to be accessible via module

### DIFF
--- a/lib/ddtrace/environment.rb
+++ b/lib/ddtrace/environment.rb
@@ -19,5 +19,7 @@ module Datadog
         end
       end
     end
+
+    extend Helpers
   end
 end


### PR DESCRIPTION
Makes `Datadog::Environment` functions accessible on the module instead of having to compose it into a class.