### PR TITLE
Address Faraday warnings on v0.x

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -518,6 +518,10 @@ elsif Gem::Version.new('2.3.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'sucker_punch'
       gem 'typhoeus'
     end
+
+    appraise 'contrib-old' do
+      gem 'faraday', '0.17'
+    end
   end
 elsif Gem::Version.new('2.4.0') <= Gem::Version.new(RUBY_VERSION) \
       && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5.0')
@@ -590,6 +594,10 @@ elsif Gem::Version.new('2.4.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'sqlite3', '~> 1.3.6'
       gem 'sucker_punch'
       gem 'typhoeus'
+    end
+
+    appraise 'contrib-old' do
+      gem 'faraday', '0.17'
     end
   end
 elsif Gem::Version.new('2.5.0') <= Gem::Version.new(RUBY_VERSION) \
@@ -698,6 +706,10 @@ elsif Gem::Version.new('2.5.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'sucker_punch'
       gem 'typhoeus'
     end
+
+    appraise 'contrib-old' do
+      gem 'faraday', '0.17'
+    end
   end
 elsif Gem::Version.new('2.6.0') <= Gem::Version.new(RUBY_VERSION) \
       && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
@@ -805,6 +817,10 @@ elsif Gem::Version.new('2.6.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'sqlite3', '~> 1.4.1'
       gem 'sucker_punch'
       gem 'typhoeus'
+    end
+
+    appraise 'contrib-old' do
+      gem 'faraday', '0.17'
     end
   end
 elsif Gem::Version.new('2.7.0') <= Gem::Version.new(RUBY_VERSION)
@@ -915,6 +931,10 @@ elsif Gem::Version.new('2.7.0') <= Gem::Version.new(RUBY_VERSION)
       gem 'sqlite3', '~> 1.4.1'
       gem 'sucker_punch'
       gem 'typhoeus'
+    end
+
+    appraise 'contrib-old' do
+      gem 'faraday', '0.17'
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -381,6 +381,8 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:shoryuken'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:ethon'
+      # Contrib specs with old gem versions
+      sh 'bundle exec appraisal contrib-old rake spec:faraday'
       # Rails minitests
       sh 'bundle exec appraisal rails30-postgres rake test:rails'
       sh 'bundle exec appraisal rails30-postgres rake spec:railsdisableenv'
@@ -451,6 +453,8 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:shoryuken'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:ethon'
+      # Contrib specs with old gem versions
+      sh 'bundle exec appraisal contrib-old rake spec:faraday'
       # Rails minitests
       # We only test Rails 5+ because older versions require Bundler < 2.0
       sh 'bundle exec appraisal rails5-mysql2 rake test:rails'
@@ -506,6 +510,8 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:shoryuken'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:ethon'
+      # Contrib specs with old gem versions
+      sh 'bundle exec appraisal contrib-old rake spec:faraday'
       # Rails minitests
       # We only test Rails 5+ because older versions require Bundler < 2.0
       sh 'bundle exec appraisal rails5-mysql2 rake test:rails'
@@ -571,6 +577,8 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:shoryuken'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:ethon'
+      # Contrib specs with old gem versions
+      sh 'bundle exec appraisal contrib-old rake spec:faraday'
       # Rails minitests
       # We only test Rails 5+ because older versions require Bundler < 2.0
       sh 'bundle exec appraisal rails5-mysql2 rake test:rails'
@@ -635,6 +643,8 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:shoryuken'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:ethon'
+      # Contrib specs with old gem versions
+      sh 'bundle exec appraisal contrib-old rake spec:faraday'
       # Rails minitests
       # We only test Rails 5+ because older versions require Bundler < 2.0
       sh 'bundle exec appraisal rails5-mysql2 rake test:rails'

--- a/lib/ddtrace/contrib/faraday/patcher.rb
+++ b/lib/ddtrace/contrib/faraday/patcher.rb
@@ -2,6 +2,7 @@ require 'ddtrace/contrib/patcher'
 require 'ddtrace/ext/app_types'
 require 'ddtrace/contrib/faraday/ext'
 require 'ddtrace/contrib/faraday/connection'
+require 'ddtrace/contrib/faraday/rack_builder'
 
 module Datadog
   module Contrib
@@ -39,7 +40,11 @@ module Datadog
         end
 
         def add_default_middleware!
-          ::Faraday::Connection.send(:prepend, Connection)
+          if target_version >= Gem::Version.new('1.0.0')
+            ::Faraday::Connection.send(:prepend, Connection)
+          else
+            ::Faraday::RackBuilder.send(:prepend, RackBuilder)
+          end
         end
 
         def get_option(option)

--- a/lib/ddtrace/contrib/faraday/rack_builder.rb
+++ b/lib/ddtrace/contrib/faraday/rack_builder.rb
@@ -1,0 +1,18 @@
+module Datadog
+  module Contrib
+    module Faraday
+      # Handles installation of our middleware if the user has *not*
+      # already explicitly configured it for this correction.
+      #
+      # RackBuilder class was introduced in faraday 0.9.0:
+      # https://github.com/lostisland/faraday/commit/77d7546d6d626b91086f427c56bc2cdd951353b3
+      module RackBuilder
+        def adapter(*args)
+          use(:ddtrace) unless @handlers.any? { |h| h.klass == Middleware }
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/faraday/middleware_spec.rb
+++ b/spec/ddtrace/contrib/faraday/middleware_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Faraday middleware' do
   end
 
   context 'without explicit middleware configured' do
-    subject!(:response) { client.get('/success') }
+    subject(:response) { client.get('/success') }
     let(:use_middleware) { false }
 
     it 'uses default configuration' do
@@ -59,6 +59,10 @@ RSpec.describe 'Faraday middleware' do
       expect(request_span.get_tag(Datadog::Ext::NET::TARGET_PORT)).to eq(80)
       expect(request_span.span_type).to eq(Datadog::Ext::HTTP::TYPE_OUTBOUND)
       expect(request_span).to_not have_error
+    end
+
+    it 'executes without warnings' do
+      expect { response }.to_not output(/WARNING/).to_stderr
     end
   end
 


### PR DESCRIPTION
Fixes #965 

When we added support for Faraday v1 in https://github.com/DataDog/dd-trace-rb/pull/906, a warning started to be emitted by Faraday versions < 1.0: `WARNING: Unexpected middleware set after the adapter. This won't be supported from Faraday 1.0.`
This did not affect the correct behaviour of instrumentation on Faraday < 1.0.

This PR addresses that warning by patching Faraday < 1.0 using our old approach, the one removed in https://github.com/DataDog/dd-trace-rb/pull/906, instead of the new patching used by v1.0.

The removal of the old approach was originally intended, as the new patching used for 1.0 also works for < 1.0, as stated, but this warning we are seeing is not desirable either.

I've added a new Appraisal category for `contrib` to allow us to test older version: `contrib-old`. I'm using it to test Faraday 0.17, while keeping our regular tests of the latest version of Faraday under `contrib`.