### PR TITLE
Add Datadog::Worker and extensions

### DIFF
--- a/lib/ddtrace/worker.rb
+++ b/lib/ddtrace/worker.rb
@@ -1,0 +1,20 @@
+module Datadog
+  # Base class for work tasks
+  class Worker
+    attr_reader \
+      :task
+
+    def initialize(&block)
+      @task = block
+    end
+
+    def perform(*args)
+      task.call(*args) unless task.nil?
+    end
+
+    protected
+
+    attr_writer \
+      :task
+  end
+end

--- a/lib/ddtrace/workers/async.rb
+++ b/lib/ddtrace/workers/async.rb
@@ -1,0 +1,163 @@
+require 'ddtrace/logger'
+
+module Datadog
+  module Workers
+    module Async
+      # Adds threading behavior to workers
+      # to run tasks asynchronously.
+      # rubocop:disable Metrics/ModuleLength
+      module Thread
+        FORK_POLICY_STOP = :stop
+        FORK_POLICY_RESTART = :restart
+        SHUTDOWN_TIMEOUT = 1
+
+        def self.included(base)
+          base.send(:prepend, PrependedMethods)
+        end
+
+        # Methods that must be prepended
+        module PrependedMethods
+          def perform(*args)
+            start { self.result = super(*args) } if unstarted?
+          end
+        end
+
+        attr_reader \
+          :error,
+          :result
+
+        attr_writer \
+          :fork_policy
+
+        def join(timeout = nil)
+          return true unless running?
+          !worker.join(timeout).nil?
+        end
+
+        def terminate
+          return false unless running?
+          @run_async = false
+          worker.terminate
+          true
+        end
+
+        def run_async?
+          @run_async = false unless instance_variable_defined?(:@run_async)
+          @run_async == true
+        end
+
+        def unstarted?
+          worker.nil? || forked?
+        end
+
+        def running?
+          !worker.nil? && worker.alive?
+        end
+
+        def error?
+          @error = nil unless instance_variable_defined?(:@error)
+          !@error.nil?
+        end
+
+        def completed?
+          !worker.nil? && worker.status == false && !error?
+        end
+
+        def failed?
+          !worker.nil? && worker.status == false && error?
+        end
+
+        def forked?
+          !pid.nil? && pid != Process.pid
+        end
+
+        def fork_policy
+          @fork_policy ||= FORK_POLICY_STOP
+        end
+
+        protected
+
+        attr_writer \
+          :result
+
+        def mutex
+          @mutex ||= Mutex.new
+        end
+
+        def after_fork
+          # Do nothing by default
+        end
+
+        private
+
+        attr_reader \
+          :pid
+
+        def mutex_after_fork
+          @mutex_after_fork ||= Mutex.new
+        end
+
+        def worker
+          @worker ||= nil
+        end
+
+        def start(&block)
+          mutex.synchronize do
+            return if running?
+            if forked?
+              case fork_policy
+              when FORK_POLICY_STOP
+                stop_fork
+              when FORK_POLICY_RESTART
+                restart_after_fork(&block)
+              end
+            elsif !run_async?
+              start_worker(&block)
+            end
+          end
+        end
+
+        def start_worker
+          @run_async = true
+          @pid = Process.pid
+          @error = nil
+          Logger.log.debug("Starting thread in the process: #{Process.pid}")
+
+          @worker = ::Thread.new do
+            begin
+              yield
+            rescue StandardError => e
+              @error = e
+              Logger.log.debug("Worker thread error. Cause #{e.message} Location: #{e.backtrace.first}")
+            end
+          end
+        end
+
+        def stop_fork
+          mutex_after_fork.synchronize do
+            if forked?
+              # Trigger callback to allow workers to reset themselves accordingly
+              after_fork
+
+              # Reset and turn off
+              @pid = Process.pid
+              @run_async = false
+            end
+          end
+        end
+
+        def restart_after_fork(&block)
+          mutex_after_fork.synchronize do
+            if forked?
+              # Trigger callback to allow workers to reset themselves accordingly
+              after_fork
+
+              # Start worker
+              start_worker(&block)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/workers/loop.rb
+++ b/lib/ddtrace/workers/loop.rb
@@ -1,0 +1,105 @@
+module Datadog
+  module Workers
+    # Adds looping behavior to workers, with a sleep
+    # interval between each loop.
+    module IntervalLoop
+      BACK_OFF_RATIO = 1.2
+      BACK_OFF_MAX = 5
+      DEFAULT_INTERVAL = 1
+
+      def self.included(base)
+        base.send(:prepend, PrependedMethods)
+      end
+
+      # Methods that must be prepended
+      module PrependedMethods
+        def perform(*args)
+          perform_loop { super(*args) }
+        end
+      end
+
+      def stop_loop
+        mutex.synchronize do
+          return false unless run_loop?
+          @run_loop = false
+          shutdown.signal
+        end
+
+        true
+      end
+
+      def work_pending?
+        run_loop?
+      end
+
+      def run_loop?
+        @run_loop = false unless instance_variable_defined?(:@run_loop)
+        @run_loop == true
+      end
+
+      def loop_default_interval
+        @loop_default_interval ||= DEFAULT_INTERVAL
+      end
+
+      def loop_back_off_ratio
+        @loop_back_off_ratio ||= BACK_OFF_RATIO
+      end
+
+      def loop_back_off_max
+        @loop_back_off_max ||= BACK_OFF_MAX
+      end
+
+      def loop_wait_time
+        @loop_wait_time ||= loop_default_interval
+      end
+
+      def loop_back_off?
+        false
+      end
+
+      def loop_back_off!(amount = nil)
+        @loop_wait_time = amount || [loop_wait_time * BACK_OFF_RATIO, BACK_OFF_MAX].min
+      end
+
+      protected
+
+      attr_writer \
+        :loop_back_off_max,
+        :loop_back_off_ratio,
+        :loop_default_interval
+
+      def mutex
+        @mutex ||= Mutex.new
+      end
+
+      private
+
+      def perform_loop
+        @run_loop = true
+
+        loop do
+          if work_pending?
+            # Run the task
+            yield
+
+            # Reset the wait interval
+            loop_back_off!(loop_default_interval)
+          elsif loop_back_off?
+            # Back off the wait interval a bit
+            loop_back_off!
+          end
+
+          # Wait for an interval, unless shutdown has been signaled.
+          mutex.synchronize do
+            return unless run_loop? || work_pending?
+            shutdown.wait(mutex, loop_wait_time) if run_loop?
+          end
+        end
+      end
+
+      def shutdown
+        @shutdown ||= ConditionVariable.new
+      end
+    end
+  end
+end

--- a/lib/ddtrace/workers/loop.rb
+++ b/lib/ddtrace/workers/loop.rb
@@ -5,7 +5,7 @@ module Datadog
     module IntervalLoop
       BACK_OFF_RATIO = 1.2
       BACK_OFF_MAX = 5
-      DEFAULT_INTERVAL = 1
+      BASE_INTERVAL = 1
 
       def self.included(base)
         base.send(:prepend, PrependedMethods)
@@ -37,8 +37,8 @@ module Datadog
         @run_loop == true
       end
 
-      def loop_default_interval
-        @loop_default_interval ||= DEFAULT_INTERVAL
+      def loop_base_interval
+        @loop_base_interval ||= BASE_INTERVAL
       end
 
       def loop_back_off_ratio
@@ -50,7 +50,7 @@ module Datadog
       end
 
       def loop_wait_time
-        @loop_wait_time ||= loop_default_interval
+        @loop_wait_time ||= loop_base_interval
       end
 
       def loop_back_off?
@@ -66,7 +66,7 @@ module Datadog
       attr_writer \
         :loop_back_off_max,
         :loop_back_off_ratio,
-        :loop_default_interval
+        :loop_base_interval
 
       def mutex
         @mutex ||= Mutex.new
@@ -83,7 +83,7 @@ module Datadog
             yield
 
             # Reset the wait interval
-            loop_back_off!(loop_default_interval)
+            loop_back_off!(loop_base_interval)
           elsif loop_back_off?
             # Back off the wait interval a bit
             loop_back_off!

--- a/lib/ddtrace/workers/polling.rb
+++ b/lib/ddtrace/workers/polling.rb
@@ -1,0 +1,48 @@
+require 'ddtrace/workers/async'
+require 'ddtrace/workers/loop'
+
+module Datadog
+  module Workers
+    # Adds polling (async looping) behavior to workers
+    module Polling
+      SHUTDOWN_TIMEOUT = 1
+
+      def self.included(base)
+        base.send(:include, Workers::IntervalLoop)
+        base.send(:include, Workers::Async::Thread)
+        base.send(:prepend, PrependedMethods)
+      end
+
+      # Methods that must be prepended
+      module PrependedMethods
+        def perform(*args)
+          super if enabled?
+        end
+      end
+
+      def stop(force_stop = false, timeout = SHUTDOWN_TIMEOUT)
+        if running?
+          # Attempt graceful stop and wait
+          stop_loop
+          graceful = join(timeout)
+
+          # If timeout and force stop...
+          !graceful && force_stop ? terminate : graceful
+        else
+          false
+        end
+      end
+
+      def enabled?
+        @enabled = true unless instance_variable_defined?(:@enabled)
+        @enabled
+      end
+
+      # Allow worker to be started
+      def enabled=(value)
+        # Coerce to boolean
+        @enabled = (value == true)
+      end
+    end
+  end
+end

--- a/lib/ddtrace/workers/queue.rb
+++ b/lib/ddtrace/workers/queue.rb
@@ -1,0 +1,39 @@
+module Datadog
+  module Workers
+    # Adds queue behavior to workers, with a buffer
+    # to which items can be queued then dequeued.
+    module Queue
+      def self.included(base)
+        base.send(:prepend, PrependedMethods)
+      end
+
+      # Methods that must be prepended
+      module PrependedMethods
+        def perform(*args)
+          super(*dequeue) if work_pending?
+        end
+      end
+
+      def buffer
+        @buffer ||= []
+      end
+
+      def enqueue(*args)
+        buffer.push(args)
+      end
+
+      def dequeue
+        buffer.shift
+      end
+
+      def work_pending?
+        !buffer.empty?
+      end
+
+      protected
+
+      attr_writer \
+        :buffer
+    end
+  end
+end

--- a/spec/ddtrace/worker_spec.rb
+++ b/spec/ddtrace/worker_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+require 'ddtrace/worker'
+
+RSpec.describe Datadog::Worker do
+  subject(:worker) { described_class.new(&block) }
+  let(:block) { proc {} }
+
+  describe '#initialize' do
+    context 'given a block' do
+      it { is_expected.to have_attributes(task: block) }
+    end
+  end
+
+  describe '#perform' do
+    subject(:perform) { worker.perform(*args) }
+    let(:args) { [:a, :b] }
+
+    context 'when no task has been set' do
+      let(:block) { nil }
+      it { is_expected.to be nil }
+      it { expect { perform }.to_not raise_error }
+    end
+
+    context 'when a task has been set' do
+      let(:result) { double('result') }
+
+      before { allow(block).to receive(:call).and_return(result) }
+
+      it 'calls the task and returns its result' do
+        is_expected.to be result
+        expect(block).to have_received(:call).with(*args)
+      end
+    end
+  end
+end

--- a/spec/ddtrace/workers/async_spec.rb
+++ b/spec/ddtrace/workers/async_spec.rb
@@ -1,0 +1,427 @@
+require 'spec_helper'
+
+require 'ddtrace/worker'
+require 'ddtrace/workers/async'
+
+RSpec.describe Datadog::Workers::Async::Thread do
+  context 'when included into a worker' do
+    subject(:worker) { worker_class.new(&task) }
+
+    let(:worker_class) do
+      Class.new(Datadog::Worker) { include Datadog::Workers::Async::Thread }
+    end
+
+    let(:task) { proc { |*args| worker_spy.perform(*args) } }
+    let(:worker_spy) { double('worker spy') }
+
+    before { allow(worker_spy).to receive(:perform) }
+
+    shared_context 'perform and wait' do
+      let(:perform) { worker.perform(*args) }
+      let(:args) { [:foo, :bar] }
+      let(:perform_complete) { ConditionVariable.new }
+      let(:perform_result) { double('perform result') }
+      let(:perform_task) { proc { |*_args| } }
+
+      before do
+        allow(worker_spy).to receive(:perform) do |*actual_args|
+          perform_task.call(*actual_args)
+          perform_complete.signal
+          perform_result
+        end
+
+        perform
+
+        # Block until #perform gives signal or timeout is reached.
+        Mutex.new.tap do |mutex|
+          mutex.synchronize do
+            perform_complete.wait(mutex, 0.1)
+            sleep(0.1) # Give a little extra time to collect the thread.
+          end
+        end
+      end
+    end
+
+    shared_context 'perform and wait with error' do
+      include_context 'perform and wait' do
+        let(:error) { error_class.new }
+        let(:error_class) { stub_const('TestError', Class.new(StandardError)) }
+        let(:perform_task) do
+          proc do |*_actual_args|
+            raise error
+          end
+        end
+      end
+    end
+
+    describe '#perform' do
+      subject(:perform) { worker.perform(*args) }
+      let(:args) { [:foo, :bar] }
+
+      context 'given arguments' do
+        include_context 'perform and wait' do
+          let(:perform_task) do
+            proc do |*actual_args|
+              expect(actual_args).to eq args
+            end
+          end
+        end
+
+        it 'performs the task async' do
+          # expect(worker.result).to eq(perform_result)
+          expect(worker).to have_attributes(
+            result: perform_result,
+            error?: false,
+            error: nil,
+            completed?: true,
+            unstarted?: false,
+            run_async?: true
+          )
+        end
+      end
+    end
+
+    describe '#error?' do
+      subject(:error?) { worker.error? }
+
+      context 'by default' do
+        it { is_expected.to be false }
+      end
+
+      context 'when #perform raises an error' do
+        include_context 'perform and wait with error'
+        it { is_expected.to be true }
+      end
+    end
+
+    describe '#error' do
+      subject(:error) { worker.error }
+
+      context 'by default' do
+        it { is_expected.to be nil }
+      end
+
+      context 'when #perform raises an error' do
+        include_context 'perform and wait with error'
+        it { is_expected.to be error }
+      end
+    end
+
+    describe '#result' do
+      subject(:result) { worker.result }
+
+      context 'by default' do
+        it { is_expected.to be nil }
+      end
+
+      context 'after #perform completes' do
+        include_context 'perform and wait'
+        it { is_expected.to be perform_result }
+      end
+    end
+
+    describe '#fork_policy' do
+      subject(:fork_policy) { worker.fork_policy }
+
+      context 'by default' do
+        it { is_expected.to be described_class::FORK_POLICY_STOP }
+      end
+
+      context 'when set' do
+        let(:policy) { double('policy') }
+
+        it do
+          expect { worker.fork_policy = policy }
+            .to change { worker.fork_policy }
+            .from(described_class::FORK_POLICY_STOP)
+            .to(policy)
+        end
+      end
+    end
+
+    describe '#fork_policy=' do
+      subject(:set_fork_policy) { worker.fork_policy = policy }
+      let(:policy) { double('policy') }
+
+      it do
+        expect { set_fork_policy }
+          .to change { worker.fork_policy }
+          .from(described_class::FORK_POLICY_STOP)
+          .to(policy)
+      end
+    end
+
+    describe '#join' do
+      subject(:join) { worker.join }
+      let(:thread) { worker.send(:worker) }
+
+      context 'when not started' do
+        it { is_expected.to be true }
+      end
+
+      context 'when started' do
+        let(:task) { proc { sleep(1) } }
+        let(:join_result) { double('join result') }
+
+        before { worker.perform }
+
+        context 'given no arguments' do
+          before do
+            expect(thread).to receive(:join)
+              .with(nil)
+              .and_return(join_result)
+          end
+
+          it { is_expected.to be true }
+        end
+
+        context 'given a timeout' do
+          subject(:join) { worker.join(timeout) }
+          let(:timeout) { rand }
+
+          context 'which is not reached' do
+            before do
+              expect(thread).to receive(:join)
+                .with(timeout)
+                .and_return(join_result)
+            end
+
+            it { is_expected.to be true }
+          end
+
+          context 'which is reached' do
+            before do
+              expect(thread).to receive(:join)
+                .with(timeout)
+                .and_return(nil)
+            end
+
+            it { is_expected.to be false }
+          end
+        end
+      end
+    end
+
+    describe '#terminate' do
+      subject(:terminate) { worker.terminate }
+
+      context 'when not started' do
+        it { is_expected.to be false }
+      end
+
+      context 'when started' do
+        let(:task) { proc { sleep(1) } }
+        let(:join_result) { double('join result') }
+
+        before do
+          worker.perform
+          expect(worker.send(:worker)).to receive(:terminate)
+            .and_call_original
+        end
+
+        it do
+          is_expected.to be true
+          expect(worker.run_async?).to be false
+        end
+      end
+    end
+
+    describe '#run_async?' do
+      subject(:run_async?) { worker.run_async? }
+
+      context 'by default' do
+        it { is_expected.to be false }
+      end
+
+      context 'when started' do
+        before { worker.perform }
+        after { worker.terminate }
+        it { is_expected.to be true }
+      end
+    end
+
+    describe '#unstarted?' do
+      subject(:unstarted?) { worker.unstarted? }
+
+      context 'by default' do
+        it { is_expected.to be true }
+      end
+
+      context 'when started' do
+        before { worker.perform }
+        after { worker.terminate }
+        it { is_expected.to be false }
+      end
+    end
+
+    describe '#running?' do
+      subject(:running?) { worker.running? }
+
+      context 'by default' do
+        it { is_expected.to be false }
+      end
+
+      context 'when started' do
+        before { worker.perform }
+        after { worker.terminate }
+        it { is_expected.to be true }
+      end
+    end
+
+    describe '#completed?' do
+      subject(:completed?) { worker.completed? }
+
+      context 'by default' do
+        it { is_expected.to be false }
+      end
+
+      context 'when running' do
+        let(:task) { proc { sleep(1) } }
+
+        before { worker.perform }
+        after { worker.terminate }
+
+        it do
+          expect(worker.running?).to be true
+          is_expected.to be false
+        end
+      end
+
+      context 'when completed successfully' do
+        include_context 'perform and wait'
+        it { is_expected.to be true }
+      end
+
+      context 'when failed' do
+        include_context 'perform and wait with error'
+        it { is_expected.to be false }
+      end
+    end
+
+    describe '#failed?' do
+      subject(:failed?) { worker.failed? }
+
+      context 'by default' do
+        it { is_expected.to be false }
+      end
+
+      context 'when running' do
+        let(:task) { proc { sleep(1) } }
+
+        before { worker.perform }
+        after { worker.terminate }
+
+        it do
+          expect(worker.running?).to be true
+          is_expected.to be false
+        end
+      end
+
+      context 'when completed successfully' do
+        include_context 'perform and wait'
+        it { is_expected.to be false }
+      end
+
+      context 'when failed' do
+        include_context 'perform and wait with error'
+
+        it do
+          is_expected.to be true
+          expect(worker.error?).to be true
+        end
+      end
+    end
+
+    describe '#forked?' do
+      subject(:forked?) { worker.forked? }
+
+      context 'by default' do
+        it { is_expected.to be false }
+      end
+
+      context 'when started but not forked' do
+        let(:task) { proc { sleep(1) } }
+
+        before { worker.perform }
+        after { worker.terminate }
+
+        it do
+          expect(worker.running?).to be true
+          is_expected.to be false
+        end
+      end
+
+      context 'when started then forked' do
+        let(:task) { proc { sleep(1) } }
+
+        before { worker.perform }
+        after { worker.terminate }
+
+        it do
+          expect(worker.running?).to be true
+          expect(worker.forked?).to be false
+
+          expect_in_fork do
+            expect(worker.forked?).to be true
+          end
+        end
+      end
+    end
+
+    describe 'integration tests' do
+      describe 'forking' do
+        context 'when the process forks' do
+          context 'with FORK_POLICY_STOP fork policy' do
+            before { worker.fork_policy = described_class::FORK_POLICY_STOP }
+
+            it 'does not restart the worker' do
+              worker.perform
+
+              expect_in_fork do
+                expect(worker.running?).to be false
+
+                # Capture the flush
+                @performed = false
+                allow(worker_spy).to receive(:perform) do
+                  @performed = true
+                end
+
+                # Attempt restart of worker & verify it stops.
+                expect { worker.perform }.to change { worker.run_async? }
+                  .from(true)
+                  .to(false)
+              end
+            end
+          end
+
+          context 'with FORK_POLICY_RESTART fork policy' do
+            before { worker.fork_policy = described_class::FORK_POLICY_RESTART }
+
+            it 'restarts the worker' do
+              # Start worker
+              worker.perform
+
+              expect_in_fork do
+                expect(worker.running?).to be false
+
+                # Capture the flush
+                @performed = false
+                allow(worker_spy).to receive(:perform) do
+                  @performed = true
+                end
+
+                # Restart worker & wait
+                worker.perform
+                try_wait_until { @performed }
+
+                # Verify state of the worker
+                expect(worker.failed?).to be false
+                expect(worker_spy).to have_received(:perform).at_least(:once)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/workers/async_spec.rb
+++ b/spec/ddtrace/workers/async_spec.rb
@@ -68,13 +68,13 @@ RSpec.describe Datadog::Workers::Async::Thread do
         end
 
         it 'performs the task async' do
-          # expect(worker.result).to eq(perform_result)
+          expect(worker.result).to eq(perform_result)
           expect(worker).to have_attributes(
             result: perform_result,
             error?: false,
             error: nil,
             completed?: true,
-            unstarted?: false,
+            started?: true,
             run_async?: true
           )
         end
@@ -240,17 +240,17 @@ RSpec.describe Datadog::Workers::Async::Thread do
       end
     end
 
-    describe '#unstarted?' do
-      subject(:unstarted?) { worker.unstarted? }
+    describe '#started?' do
+      subject(:started?) { worker.started? }
 
       context 'by default' do
-        it { is_expected.to be true }
+        it { is_expected.to be false }
       end
 
       context 'when started' do
         before { worker.perform }
         after { worker.terminate }
-        it { is_expected.to be false }
+        it { is_expected.to be true }
       end
     end
 

--- a/spec/ddtrace/workers/loop_spec.rb
+++ b/spec/ddtrace/workers/loop_spec.rb
@@ -1,0 +1,226 @@
+require 'spec_helper'
+
+require 'ddtrace/worker'
+require 'ddtrace/workers/loop'
+
+RSpec.describe Datadog::Workers::IntervalLoop do
+  context 'when included into a worker' do
+    subject(:worker) { worker_class.new(&task) }
+
+    let(:worker_class) do
+      Class.new(Datadog::Worker) { include Datadog::Workers::IntervalLoop }
+    end
+
+    let(:task) { proc { |*args| worker_spy.perform(*args) } }
+    let(:worker_spy) { double('worker spy') }
+
+    before { allow(worker_spy).to receive(:perform) }
+
+    # Stub conditional wait so tests run faster
+    before { allow(worker.send(:shutdown)).to receive(:wait) }
+
+    shared_context 'loop limit' do
+      let(:perform_limit) { 2 }
+
+      before do
+        @perform_invocations ||= 0
+
+        allow(worker_spy).to receive(:perform) do |*actual_args|
+          expect(actual_args).to eq args
+
+          # Abort loop if limit reached
+          @perform_invocations += 1
+          worker.stop_loop if @perform_invocations >= perform_limit
+        end
+      end
+    end
+
+    shared_context 'perform loop in thread' do
+      before do
+        # Start the loop in a thread, give it time to warm up.
+        @thread = Thread.new { worker.perform }
+        sleep(0.1)
+      end
+
+      after { @thread.kill }
+    end
+
+    describe '#perform' do
+      subject(:perform) { worker.perform(*args) }
+      let(:args) { [:foo, :bar] }
+
+      context 'given arguments' do
+        include_context 'loop limit'
+
+        it 'performs the loop' do
+          perform
+          expect(@perform_invocations).to eq(perform_limit)
+        end
+      end
+    end
+
+    describe '#stop_loop' do
+      subject(:stop_loop) { worker.stop_loop }
+
+      context 'when the worker is not running' do
+        before { worker.stop_loop }
+        it { is_expected.to be false }
+      end
+
+      context 'when the worker is running' do
+        include_context 'perform loop in thread'
+
+        it { is_expected.to be true }
+
+        it do
+          expect { stop_loop }.to change { worker.run_loop? }
+            .from(true)
+            .to(false)
+        end
+
+        it do
+          expect { stop_loop }.to change { worker.work_pending? }
+            .from(true)
+            .to(false)
+        end
+      end
+    end
+
+    describe '#work_pending?' do
+      subject(:work_pending?) { worker.work_pending? }
+
+      context 'when the worker is not running' do
+        it { is_expected.to be false }
+      end
+
+      context 'when the worker is running' do
+        include_context 'perform loop in thread'
+        it { is_expected.to be true }
+      end
+    end
+
+    describe '#run_loop?' do
+      subject(:run_loop?) { worker.run_loop? }
+
+      context 'when worker is not running' do
+        it { is_expected.to be false }
+      end
+
+      context 'when worker is running' do
+        include_context 'perform loop in thread'
+        it { is_expected.to be true }
+      end
+    end
+
+    describe '#loop_default_interval' do
+      subject(:loop_default_interval) { worker.loop_default_interval }
+
+      context 'default' do
+        it { is_expected.to eq(described_class::DEFAULT_INTERVAL) }
+      end
+
+      context 'when set' do
+        let(:value) { rand }
+
+        it do
+          expect { worker.send(:loop_default_interval=, value) }
+            .to change { worker.loop_default_interval }
+            .from(described_class::DEFAULT_INTERVAL)
+            .to(value)
+        end
+      end
+    end
+
+    describe '#loop_back_off_ratio' do
+      subject(:loop_back_off_ratio) { worker.loop_back_off_ratio }
+
+      context 'default' do
+        it { is_expected.to eq(described_class::BACK_OFF_RATIO) }
+      end
+
+      context 'when set' do
+        let(:value) { rand }
+
+        it do
+          expect { worker.send(:loop_back_off_ratio=, value) }
+            .to change { worker.loop_back_off_ratio }
+            .from(described_class::BACK_OFF_RATIO)
+            .to(value)
+        end
+      end
+    end
+
+    describe '#loop_back_off_max' do
+      subject(:loop_back_off_max) { worker.loop_back_off_max }
+
+      context 'default' do
+        it { is_expected.to eq(described_class::BACK_OFF_MAX) }
+      end
+
+      context 'when set' do
+        let(:value) { rand }
+
+        it do
+          expect { worker.send(:loop_back_off_max=, value) }
+            .to change { worker.loop_back_off_max }
+            .from(described_class::BACK_OFF_MAX)
+            .to(value)
+        end
+      end
+    end
+
+    describe '#loop_wait_time' do
+      subject(:loop_wait_time) { worker.loop_wait_time }
+
+      context 'default' do
+        it { is_expected.to eq(described_class::DEFAULT_INTERVAL) }
+      end
+
+      context 'when set' do
+        let(:value) { rand }
+
+        it do
+          expect { worker.send(:loop_default_interval=, value) }
+            .to change { worker.loop_default_interval }
+            .from(described_class::DEFAULT_INTERVAL)
+            .to(value)
+        end
+      end
+    end
+
+    describe '#loop_back_off?' do
+      subject(:loop_back_off?) { worker.loop_back_off? }
+      it { is_expected.to be false }
+    end
+
+    describe '#loop_back_off!' do
+      subject(:loop_back_off!) { worker.loop_back_off! }
+
+      context 'given no arguments' do
+        it do
+          expect { loop_back_off! }
+            .to change { worker.loop_wait_time }
+            .from(described_class::DEFAULT_INTERVAL)
+            .to(described_class::BACK_OFF_RATIO)
+
+          expect { worker.loop_back_off! }
+            .to change { worker.loop_wait_time }
+            .from(described_class::BACK_OFF_RATIO)
+            .to(described_class::BACK_OFF_RATIO * described_class::BACK_OFF_RATIO)
+        end
+      end
+
+      context 'given an amount to back off' do
+        subject(:loop_back_off!) { worker.loop_back_off!(value) }
+        let(:value) { rand }
+
+        it do
+          expect { loop_back_off! }
+            .to change { worker.loop_wait_time }
+            .from(described_class::DEFAULT_INTERVAL)
+            .to(value)
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/workers/loop_spec.rb
+++ b/spec/ddtrace/workers/loop_spec.rb
@@ -112,20 +112,20 @@ RSpec.describe Datadog::Workers::IntervalLoop do
       end
     end
 
-    describe '#loop_default_interval' do
-      subject(:loop_default_interval) { worker.loop_default_interval }
+    describe '#loop_base_interval' do
+      subject(:loop_base_interval) { worker.loop_base_interval }
 
       context 'default' do
-        it { is_expected.to eq(described_class::DEFAULT_INTERVAL) }
+        it { is_expected.to eq(described_class::BASE_INTERVAL) }
       end
 
       context 'when set' do
         let(:value) { rand }
 
         it do
-          expect { worker.send(:loop_default_interval=, value) }
-            .to change { worker.loop_default_interval }
-            .from(described_class::DEFAULT_INTERVAL)
+          expect { worker.send(:loop_base_interval=, value) }
+            .to change { worker.loop_base_interval }
+            .from(described_class::BASE_INTERVAL)
             .to(value)
         end
       end
@@ -173,16 +173,16 @@ RSpec.describe Datadog::Workers::IntervalLoop do
       subject(:loop_wait_time) { worker.loop_wait_time }
 
       context 'default' do
-        it { is_expected.to eq(described_class::DEFAULT_INTERVAL) }
+        it { is_expected.to eq(described_class::BASE_INTERVAL) }
       end
 
       context 'when set' do
         let(:value) { rand }
 
         it do
-          expect { worker.send(:loop_default_interval=, value) }
-            .to change { worker.loop_default_interval }
-            .from(described_class::DEFAULT_INTERVAL)
+          expect { worker.send(:loop_base_interval=, value) }
+            .to change { worker.loop_base_interval }
+            .from(described_class::BASE_INTERVAL)
             .to(value)
         end
       end
@@ -200,7 +200,7 @@ RSpec.describe Datadog::Workers::IntervalLoop do
         it do
           expect { loop_back_off! }
             .to change { worker.loop_wait_time }
-            .from(described_class::DEFAULT_INTERVAL)
+            .from(described_class::BASE_INTERVAL)
             .to(described_class::BACK_OFF_RATIO)
 
           expect { worker.loop_back_off! }
@@ -217,7 +217,7 @@ RSpec.describe Datadog::Workers::IntervalLoop do
         it do
           expect { loop_back_off! }
             .to change { worker.loop_wait_time }
-            .from(described_class::DEFAULT_INTERVAL)
+            .from(described_class::BASE_INTERVAL)
             .to(value)
         end
       end

--- a/spec/ddtrace/workers/polling_spec.rb
+++ b/spec/ddtrace/workers/polling_spec.rb
@@ -1,0 +1,181 @@
+require 'spec_helper'
+
+require 'ddtrace/worker'
+require 'ddtrace/workers/polling'
+
+RSpec.describe Datadog::Workers::Polling do
+  context 'when included into a worker' do
+    subject(:worker) { worker_class.new }
+
+    let(:worker_class) do
+      Class.new(Datadog::Worker) { include Datadog::Workers::Polling }
+    end
+
+    describe '#perform' do
+      subject(:perform) { worker.perform }
+      after { worker.stop(true, 0) }
+
+      let(:worker) { worker_class.new(&task) }
+      let(:task) { proc { |*args| worker_spy.perform(*args) } }
+      let(:worker_spy) { double('worker spy') }
+
+      before { allow(worker_spy).to receive(:perform) }
+
+      context 'by default' do
+        it do
+          perform
+          try_wait_until { worker.running? && worker.run_loop? }
+          expect(worker_spy).to have_received(:perform).at_least(:once)
+        end
+      end
+
+      context 'when #enabled? is true' do
+        before { allow(worker).to receive(:enabled?).and_return(true) }
+
+        it do
+          perform
+          try_wait_until { worker.running? && worker.run_loop? }
+          expect(worker_spy).to have_received(:perform).at_least(:once)
+        end
+      end
+
+      context 'when #enabled? is false' do
+        before { allow(worker).to receive(:enabled?).and_return(false) }
+
+        it do
+          perform
+          expect(worker_spy).to_not have_received(:perform)
+        end
+      end
+    end
+
+    describe '#stop' do
+      subject(:stop) { worker.stop }
+
+      shared_context 'graceful stop' do
+        before do
+          allow(worker).to receive(:join)
+            .with(described_class::SHUTDOWN_TIMEOUT)
+            .and_return(true)
+        end
+      end
+
+      context 'when the worker has not been started' do
+        before do
+          allow(worker).to receive(:join)
+            .with(described_class::SHUTDOWN_TIMEOUT)
+            .and_return(true)
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the worker has been started' do
+        include_context 'graceful stop'
+
+        before do
+          worker.perform
+          try_wait_until { worker.running? && worker.run_loop? }
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context 'called multiple times with graceful stop' do
+        include_context 'graceful stop'
+
+        before do
+          worker.perform
+          try_wait_until { worker.running? && worker.run_loop? }
+        end
+
+        it do
+          expect(worker.stop).to be true
+          try_wait_until { !worker.running? }
+          expect(worker.stop).to be false
+        end
+      end
+
+      context 'given force_stop: true' do
+        subject(:stop) { worker.stop(true) }
+
+        context 'and the worker does not gracefully stop' do
+          before do
+            # Make it ignore graceful stops
+            allow(worker).to receive(:stop_loop).and_return(false)
+            allow(worker).to receive(:join).and_return(nil)
+          end
+
+          context 'after the worker has been started' do
+            before { worker.perform }
+
+            it do
+              is_expected.to be true
+
+              # Give thread time to be terminated
+              try_wait_until { !worker.running? }
+
+              expect(worker.run_async?).to be false
+              expect(worker.running?).to be false
+            end
+          end
+        end
+      end
+    end
+
+    describe '#enabled?' do
+      subject(:enabled?) { worker.enabled? }
+
+      before { allow(worker).to receive(:perform) }
+
+      context 'by default' do
+        it { is_expected.to be true }
+      end
+
+      context 'when enabled= is set to false' do
+        it do
+          expect { worker.enabled = false }
+            .to change { worker.enabled? }
+            .from(true)
+            .to(false)
+        end
+      end
+    end
+
+    describe '#enabled=' do
+      subject(:set_enabled_value) { worker.enabled = value }
+
+      context 'and given true' do
+        let(:value) { true }
+
+        it do
+          expect { set_enabled_value }
+            .to_not change { worker.enabled? }
+            .from(true)
+        end
+      end
+
+      context 'and given false' do
+        let(:value) { false }
+
+        it do
+          expect { set_enabled_value }
+            .to change { worker.enabled? }
+            .from(true)
+            .to(false)
+        end
+      end
+
+      context 'and given nil' do
+        let(:value) { nil }
+
+        it 'does nothing' do
+          expect { set_enabled_value }
+            .to change { worker.enabled? }
+            .from(true)
+            .to(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/workers/queue_spec.rb
+++ b/spec/ddtrace/workers/queue_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+require 'ddtrace/worker'
+require 'ddtrace/workers/queue'
+
+RSpec.describe Datadog::Workers::Queue do
+  context 'when included into a worker' do
+    subject(:worker) { worker_class.new(&task) }
+
+    let(:worker_class) do
+      Class.new(Datadog::Worker) { include Datadog::Workers::Queue }
+    end
+
+    let(:task) { proc { |*args| worker_spy.perform(*args) } }
+    let(:worker_spy) { double('worker spy') }
+
+    describe '#perform' do
+      subject(:perform) { worker.perform }
+
+      context 'when no work is queued' do
+        it 'does not perform the task' do
+          expect(worker_spy).to_not receive(:perform)
+          perform
+        end
+      end
+
+      context 'when work is queued' do
+        let(:args) { [:foo, :bar] }
+        before { worker.enqueue(*args) }
+
+        it 'performs the task with arguments provided' do
+        end
+      end
+    end
+
+    describe '#buffer' do
+      subject(:buffer) { worker.buffer }
+      it { is_expected.to be_a_kind_of(Array) }
+      it { is_expected.to be_empty }
+    end
+
+    describe '#enqueue' do
+      subject(:enqueue) { worker.enqueue(*args) }
+      let(:args) { [:foo, :bar] }
+
+      it do
+        expect { enqueue }.to change { worker.buffer }
+          .from([])
+          .to([args])
+      end
+    end
+
+    describe '#dequeue' do
+      subject(:dequeue) { worker.dequeue }
+
+      context 'when nothing is queued' do
+        it { is_expected.to be nil }
+      end
+
+      context 'when args are queued' do
+        let(:args) { [:foo, :bar] }
+        before { worker.enqueue(*args) }
+
+        it do
+          expect { dequeue }.to change { worker.buffer }
+            .from([args])
+            .to([])
+
+          is_expected.to eq args
+        end
+      end
+    end
+
+    describe '#work_pending?' do
+      subject(:work_pending?) { worker.work_pending? }
+
+      context 'when the buffer is empty' do
+        it { is_expected.to be false }
+      end
+
+      context 'when the buffer is not empty' do
+        before { worker.enqueue(*args) }
+        let(:args) { [:foo, :bar] }
+        it { is_expected.to be true }
+      end
+    end
+  end
+end

--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -1,4 +1,20 @@
+require 'English'
+
 module SynchronizationHelpers
+  def expect_in_fork
+    # Start in fork
+    pid = fork do
+      yield
+    end
+
+    # Wait for fork to finish, retrieve its status.
+    Process.wait(pid)
+    status = $CHILD_STATUS if $CHILD_STATUS && $CHILD_STATUS.pid == pid
+
+    # Expect fork and assertions to have completed successfully.
+    expect(status && status.success?).to be true
+  end
+
   def try_wait_until(options = {})
     attempts = options.fetch(:attempts, 10)
     backoff = options.fetch(:backoff, 0.1)


### PR DESCRIPTION
Extracted from #879 

This pull request adds the `Datadog::Worker` base class and its extension modules. It is intended to act as the foundation for background processes that run within the tracing library. Examples of these would be "writing traces to the agent" and "flushing runtime metrics to Statsd".

At its core, there is the `Datadog::Worker` class which itself defines a simple task, and a `perform` function.

Each background process would extend this base class, and define its work behavior within. e.g.

```ruby
class TraceWriter < Datadog::Worker
  def perform(traces)
    # Write traces to agent
  end
end
```

Because each worker might need to behave differently (e.g. polling, queuing, threading etc) these behaviors are provided through modules `Polling`, `Async::Thread`, `IntervalLoop`, `Queue` which can then be composed into the worker. Each of these layers wrap the `perform` function with additional behavior, and provide new functions to the worker. e.g.

```ruby
class AsyncTraceWriter < TraceWriter
  include Workers::Queue
  include Workers::Polling
end

class RuntimeMetrics < Datadog::Worker
  include Workers::Polling

  def perform
    # Flush runtime metrics
  end
end
```

As described in #879, some of the benefits of implementing this include:

 - Allows us to eliminate the `SyncWriter` by having one common definition for trace flushing behavior, then having `AsyncTraceWriter` decorated upon that.
 - `AsyncTraceWriter` can optionally automatically switch to synchronous writing when forked (addresses the need for SyncWriter in integrations like Resque.)
 - Breaks the worker behaviors into smaller, composable behaviors (e.g. Async, Queue, IntervalLoop, etc) which should be easier to test and re-use, which will...
 - ...allow us to extract and introduce a runtime metrics worker. These changes make building & maintaining the runtime metrics worker easier because it shares many of the same basic worker components

The `Datadog::Worker` and its other components will be used in another set of PRs which will introduce the `TraceWriter` and `RuntimeMetrics` workers.