### PR TITLE
Add DD_ENV environment variable

### DIFF
--- a/lib/ddtrace/correlation.rb
+++ b/lib/ddtrace/correlation.rb
@@ -1,17 +1,22 @@
+require 'ddtrace/ext/environment'
+
 module Datadog
   # Contains behavior for managing correlations with tracing
   # e.g. Retrieve a correlation to the current trace for logging, etc.
   module Correlation
     # Struct representing correlation
-    Identifier = Struct.new(:trace_id, :span_id) do
+    Identifier = Struct.new(:trace_id, :span_id, :env) do
       def initialize(*args)
         super
         self.trace_id = trace_id || 0
         self.span_id = span_id || 0
+        self.env = env || ENV[Datadog::Ext::Environment::ENV_ENVIRONMENT]
       end
 
       def to_s
-        "dd.trace_id=#{trace_id} dd.span_id=#{span_id}"
+        str = "dd.trace_id=#{trace_id} dd.span_id=#{span_id}"
+        str += " dd.env=#{env}" unless env.nil?
+        str
       end
     end.freeze
 

--- a/lib/ddtrace/ext/environment.rb
+++ b/lib/ddtrace/ext/environment.rb
@@ -1,0 +1,7 @@
+module Datadog
+  module Ext
+    module Environment
+      ENV_ENVIRONMENT = 'DD_ENV'.freeze
+    end
+  end
+end

--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -1,4 +1,5 @@
 require 'ddtrace/ext/metrics'
+require 'ddtrace/ext/environment'
 
 require 'set'
 require 'logger'
@@ -151,6 +152,7 @@ module Datadog
         # and defaults are unfrozen for mutation in Statsd.
         DEFAULT.dup.tap do |options|
           options[:tags] = options[:tags].dup
+          options[:tags] << "env:#{ENV[Ext::Environment::ENV_ENVIRONMENT]}" if ENV.key?(Ext::Environment::ENV_ENVIRONMENT)
         end
       end
     end

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -3,6 +3,8 @@ require 'thread'
 require 'logger'
 require 'pathname'
 
+require 'ddtrace/ext/environment'
+
 require 'ddtrace/span'
 require 'ddtrace/context'
 require 'ddtrace/logger'
@@ -83,7 +85,9 @@ module Datadog
                        end
 
       @mutex = Mutex.new
-      @tags = {}
+      @tags = {}.tap do |tags|
+        tags[:env] = ENV[Ext::Environment::ENV_ENVIRONMENT] if ENV.key?(Ext::Environment::ENV_ENVIRONMENT)
+      end
 
       # Enable priority sampling by default
       activate_priority_sampling!(@sampler)

--- a/spec/ddtrace/correlation_spec.rb
+++ b/spec/ddtrace/correlation_spec.rb
@@ -36,6 +36,32 @@ RSpec.describe Datadog::Correlation do
         expect(correlation_ids.span_id).to eq(span_id)
         expect(correlation_ids.to_s).to eq("dd.trace_id=#{trace_id} dd.span_id=#{span_id}")
       end
+
+      context "when #{Datadog::Ext::Environment::ENV_ENVIRONMENT}" do
+        context 'is not defined' do
+          around do |example|
+            ClimateControl.modify(Datadog::Ext::Environment::ENV_ENVIRONMENT => nil) do
+              example.run
+            end
+          end
+
+          it { expect(correlation_ids.env).to be nil }
+          it { expect(correlation_ids.to_s).to eq("dd.trace_id=#{trace_id} dd.span_id=#{span_id}") }
+        end
+
+        context 'is defined' do
+          let(:environment) { 'my-env' }
+
+          around do |example|
+            ClimateControl.modify(Datadog::Ext::Environment::ENV_ENVIRONMENT => environment) do
+              example.run
+            end
+          end
+
+          it { expect(correlation_ids.env).to eq environment }
+          it { expect(correlation_ids.to_s).to eq("dd.trace_id=#{trace_id} dd.span_id=#{span_id} dd.env=#{environment}") }
+        end
+      end
     end
   end
 end

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -19,6 +19,36 @@ RSpec.describe Datadog::Tracer do
     end
   end
 
+  describe '#tags' do
+    subject(:tags) { tracer.tags }
+
+    it { is_expected.to be_a_kind_of(Hash) }
+
+    context "when #{Datadog::Ext::Environment::ENV_ENVIRONMENT}" do
+      context 'is not defined' do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::Environment::ENV_ENVIRONMENT => nil) do
+            example.run
+          end
+        end
+
+        it { is_expected.to_not include(:env) }
+      end
+
+      context 'is defined' do
+        let(:environment) { 'my-env' }
+
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::Environment::ENV_ENVIRONMENT => environment) do
+            example.run
+          end
+        end
+
+        it { is_expected.to include(env: environment) }
+      end
+    end
+  end
+
   describe '#trace' do
     let(:name) { 'span.name' }
     let(:options) { {} }


### PR DESCRIPTION
To make it easier to tag traces with the application environment, this pull request defines `DD_ENV` which users can set, which will automatically:

 - Be set as a tag on all traces
 - Be set as a tag on all metrics
 - Be added as an attribute to `Datadog::Correlation` for logs correlation