### PR TITLE
Fix CI Actionpack 5.2.4.2 syntax error breaking Ruby 2.2

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -292,33 +292,33 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
     end
 
     appraise 'rails5-mysql2' do
-      gem 'rails', '~> 5.2.1', '!= 5.2.4.1'
+      gem 'rails', '~> 5.2.1', '!= 5.2.4.1', '!= 5.2.4.2'
       gem 'mysql2', '< 1', platform: :ruby
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres' do
-      gem 'rails', '~> 5.2.1', '!= 5.2.4.1'
+      gem 'rails', '~> 5.2.1', '!= 5.2.4.1', '!= 5.2.4.2'
       gem 'pg', '< 1.0', platform: :ruby
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres-redis' do
-      gem 'rails', '~> 5.2.1', '!= 5.2.4.1'
+      gem 'rails', '~> 5.2.1', '!= 5.2.4.1', '!= 5.2.4.2'
       gem 'pg', '< 1.0', platform: :ruby
       gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres-redis-activesupport' do
-      gem 'rails', '~> 5.2.1', '!= 5.2.4.1'
+      gem 'rails', '~> 5.2.1', '!= 5.2.4.1', '!= 5.2.4.2'
       gem 'pg', '< 1.0', platform: :ruby
       gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres-sidekiq' do
-      gem 'rails', '~> 5.2.1', '!= 5.2.4.1'
+      gem 'rails', '~> 5.2.1', '!= 5.2.4.1', '!= 5.2.4.2'
       gem 'pg', '< 1.0', platform: :ruby
       gem 'sidekiq'
       gem 'activejob'


### PR DESCRIPTION
A continuation of #894, the 5.2.4.2 Rails release does not include the bugfix for the Ruby 2.2 syntax error. This prevents CI from breaking.