### PR TITLE
Add DD_VERSION environment variable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,12 +17,17 @@ namespace :spec do
 
   RSpec::Core::RakeTask.new(:main) do |t, args|
     t.pattern = 'spec/**/*_spec.rb'
-    t.exclude_pattern = 'spec/**/{contrib,benchmark,redis,opentracer}/**/*_spec.rb'
+    t.exclude_pattern = 'spec/**/{contrib,benchmark,redis,opentracer,opentelemetry}/**/*_spec.rb'
     t.rspec_opts = args.to_a.join(' ')
   end
 
   RSpec::Core::RakeTask.new(:opentracer) do |t, args|
     t.pattern = 'spec/ddtrace/opentracer/**/*_spec.rb'
+    t.rspec_opts = args.to_a.join(' ')
+  end
+
+  RSpec::Core::RakeTask.new(:opentelemetry) do |t, args|
+    t.pattern = 'spec/ddtrace/opentelemetry/**/*_spec.rb'
     t.rspec_opts = args.to_a.join(' ')
   end
 
@@ -430,6 +435,7 @@ task :ci do
     sh 'bundle exec rake spec:main'
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
+    sh 'bundle exec rake spec:opentelemetry'
 
     if RUBY_PLATFORM != 'java'
       # Benchmarks
@@ -491,6 +497,7 @@ task :ci do
     sh 'bundle exec rake spec:main'
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
+    sh 'bundle exec rake spec:opentelemetry'
 
     if RUBY_PLATFORM != 'java'
       # Benchmarks
@@ -562,6 +569,7 @@ task :ci do
     sh 'bundle exec rake spec:main'
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
+    sh 'bundle exec rake spec:opentelemetry'
 
     if RUBY_PLATFORM != 'java'
       # Benchmarks
@@ -632,6 +640,7 @@ task :ci do
     sh 'bundle exec rake spec:main'
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
+    sh 'bundle exec rake spec:opentelemetry'
 
     if RUBY_PLATFORM != 'java'
       # Benchmarks

--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -27,6 +27,10 @@ module Datadog
   require 'ddtrace/contrib/extensions'
   extend Contrib::Extensions
 
+  # Load and extend OpenTelemetry compatibility by default
+  require 'ddtrace/opentelemetry/extensions'
+  extend OpenTelemetry::Extensions
+
   # Add shutdown hook:
   # Ensures the tracer has an opportunity to flush traces
   # and cleanup before terminating the process.

--- a/lib/ddtrace/correlation.rb
+++ b/lib/ddtrace/correlation.rb
@@ -20,13 +20,11 @@ module Datadog
       end
     end.freeze
 
-    NULL_IDENTIFIER = Identifier.new.freeze
-
     module_function
 
     # Produces a CorrelationIdentifier from the Context provided
     def identifier_from_context(context)
-      return NULL_IDENTIFIER if context.nil?
+      return Identifier.new.freeze if context.nil?
       Identifier.new(context.trace_id, context.span_id).freeze
     end
   end

--- a/lib/ddtrace/correlation.rb
+++ b/lib/ddtrace/correlation.rb
@@ -18,8 +18,8 @@ module Datadog
       def to_s
         str =  "#{Ext::Correlation::ATTR_TRACE_ID}=#{trace_id}"
         str += " #{Ext::Correlation::ATTR_SPAN_ID}=#{span_id}"
-        str += " #{Ext::Correlation::ATTR_ENV}=#{env}" unless env.nil?
-        str += " #{Ext::Correlation::ATTR_VERSION}=#{version}" unless version.nil?
+        str += " #{Ext::Correlation::ATTR_ENV}=#{env}"
+        str += " #{Ext::Correlation::ATTR_VERSION}=#{version}"
         str
       end
     end.freeze

--- a/lib/ddtrace/correlation.rb
+++ b/lib/ddtrace/correlation.rb
@@ -5,17 +5,19 @@ module Datadog
   # e.g. Retrieve a correlation to the current trace for logging, etc.
   module Correlation
     # Struct representing correlation
-    Identifier = Struct.new(:trace_id, :span_id, :env) do
+    Identifier = Struct.new(:trace_id, :span_id, :env, :version) do
       def initialize(*args)
         super
         self.trace_id = trace_id || 0
         self.span_id = span_id || 0
         self.env = env || Datadog::Environment.env
+        self.version = version || Datadog::Environment.version
       end
 
       def to_s
         str = "dd.trace_id=#{trace_id} dd.span_id=#{span_id}"
         str += " dd.env=#{env}" unless env.nil?
+        str += " dd.version=#{version}" unless version.nil?
         str
       end
     end.freeze

--- a/lib/ddtrace/correlation.rb
+++ b/lib/ddtrace/correlation.rb
@@ -1,3 +1,4 @@
+require 'ddtrace/ext/correlation'
 require 'ddtrace/environment'
 
 module Datadog
@@ -15,9 +16,10 @@ module Datadog
       end
 
       def to_s
-        str = "dd.trace_id=#{trace_id} dd.span_id=#{span_id}"
-        str += " dd.env=#{env}" unless env.nil?
-        str += " dd.version=#{version}" unless version.nil?
+        str =  "#{Ext::Correlation::ATTR_TRACE_ID}=#{trace_id}"
+        str += " #{Ext::Correlation::ATTR_SPAN_ID}=#{span_id}"
+        str += " #{Ext::Correlation::ATTR_ENV}=#{env}" unless env.nil?
+        str += " #{Ext::Correlation::ATTR_VERSION}=#{version}" unless version.nil?
         str
       end
     end.freeze

--- a/lib/ddtrace/environment.rb
+++ b/lib/ddtrace/environment.rb
@@ -17,8 +17,8 @@ module Datadog
         tags[pair.first] = pair.last if pair.length == 2
       end
 
-      tags['env'] = env unless env.nil?
-      tags['version'] = version unless version.nil?
+      tags[Ext::Environment::TAG_ENV] = env unless env.nil?
+      tags[Ext::Environment::TAG_VERSION] = version unless version.nil?
 
       tags
     end

--- a/lib/ddtrace/environment.rb
+++ b/lib/ddtrace/environment.rb
@@ -18,8 +18,13 @@ module Datadog
       end
 
       tags['env'] = env unless env.nil?
+      tags['version'] = version unless version.nil?
 
       tags
+    end
+
+    def self.version
+      ENV[Ext::Environment::ENV_VERSION]
     end
 
     # Defines helper methods for environment

--- a/lib/ddtrace/ext/correlation.rb
+++ b/lib/ddtrace/ext/correlation.rb
@@ -1,0 +1,10 @@
+module Datadog
+  module Ext
+    module Correlation
+      ATTR_ENV = 'dd.env'.freeze
+      ATTR_SPAN_ID = 'dd.span_id'.freeze
+      ATTR_TRACE_ID = 'dd.trace_id'.freeze
+      ATTR_VERSION = 'dd.version'.freeze
+    end
+  end
+end

--- a/lib/ddtrace/ext/environment.rb
+++ b/lib/ddtrace/ext/environment.rb
@@ -3,6 +3,7 @@ module Datadog
     module Environment
       ENV_ENVIRONMENT = 'DD_ENV'.freeze
       ENV_TAGS = 'DD_TAGS'.freeze
+      ENV_VERSION = 'DD_VERSION'.freeze
     end
   end
 end

--- a/lib/ddtrace/ext/environment.rb
+++ b/lib/ddtrace/ext/environment.rb
@@ -4,6 +4,9 @@ module Datadog
       ENV_ENVIRONMENT = 'DD_ENV'.freeze
       ENV_TAGS = 'DD_TAGS'.freeze
       ENV_VERSION = 'DD_VERSION'.freeze
+
+      TAG_ENV = 'env'.freeze
+      TAG_VERSION = 'version'.freeze
     end
   end
 end

--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -153,6 +153,7 @@ module Datadog
         DEFAULT.dup.tap do |options|
           options[:tags] = options[:tags].dup
           options[:tags] << "env:#{Datadog::Environment.env}" unless Datadog::Environment.env.nil?
+          options[:tags] << "version:#{Datadog::Environment.version}" unless Datadog::Environment.version.nil?
         end
       end
     end

--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -152,8 +152,9 @@ module Datadog
         # and defaults are unfrozen for mutation in Statsd.
         DEFAULT.dup.tap do |options|
           options[:tags] = options[:tags].dup
-          options[:tags] << "env:#{Datadog::Environment.env}" unless Datadog::Environment.env.nil?
-          options[:tags] << "version:#{Datadog::Environment.version}" unless Datadog::Environment.version.nil?
+          # rubocop:disable Metrics/LineLength
+          options[:tags] << "#{Datadog::Ext::Environment::TAG_ENV}:#{Datadog::Environment.env}" unless Datadog::Environment.env.nil?
+          options[:tags] << "#{Datadog::Ext::Environment::TAG_VERSION}:#{Datadog::Environment.version}" unless Datadog::Environment.version.nil?
         end
       end
     end

--- a/lib/ddtrace/opentelemetry/extensions.rb
+++ b/lib/ddtrace/opentelemetry/extensions.rb
@@ -1,0 +1,13 @@
+require 'ddtrace/span'
+require 'ddtrace/opentelemetry/span'
+
+module Datadog
+  module OpenTelemetry
+    # Defines extensions to ddtrace for OpenTelemetry support
+    module Extensions
+      def self.extended(base)
+        Datadog::Span.send(:prepend, OpenTelemetry::Span)
+      end
+    end
+  end
+end

--- a/lib/ddtrace/opentelemetry/span.rb
+++ b/lib/ddtrace/opentelemetry/span.rb
@@ -1,0 +1,26 @@
+require 'ddtrace/ext/environment'
+
+module Datadog
+  module OpenTelemetry
+    # Extensions for Datadog::Span
+    module Span
+      TAG_SERVICE_VERSION = 'service.version'.freeze
+
+      def set_tag(key, value)
+        # Configure sampling priority if they give us a forced tracing tag
+        # DEV: Do not set if the value they give us is explicitly "false"
+        case key
+        when TAG_SERVICE_VERSION
+          if defined?(super)
+            # Set original tag and Datadog version tag
+            super
+            super(Datadog::Ext::Environment::TAG_VERSION, value)
+          end
+        else
+          # Otherwise, set the tag normally.
+          super if defined?(super)
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/correlation_spec.rb
+++ b/spec/ddtrace/correlation_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe Datadog::Correlation do
 
   describe '::identifier_from_context' do
     subject(:correlation_ids) { described_class.identifier_from_context(context) }
+    let(:environment) { nil }
+    let(:version) { nil }
+
+    before do
+      allow(Datadog::Environment).to receive(:env).and_return(environment)
+      allow(Datadog::Environment).to receive(:version).and_return(version)
+    end
 
     context 'given nil' do
       let(:context) { nil }
@@ -20,27 +27,23 @@ RSpec.describe Datadog::Correlation do
         it { is_expected.to be_a_kind_of(Datadog::Correlation::Identifier) }
         it { expect(correlation_ids.trace_id).to be 0 }
         it { expect(correlation_ids.span_id).to be 0 }
+        it { expect(correlation_ids.env).to eq environment }
+        it { expect(correlation_ids.version).to eq version }
         it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_TRACE_ID}=0") }
         it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_SPAN_ID}=0") }
+        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_ENV}=#{environment}") }
+        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_VERSION}=#{version}") }
       end
 
       it_behaves_like 'an empty correlation identifier'
 
       context 'after Datadog::Environment::env has changed' do
         let(:environment) { 'my-env' }
-        before { allow(Datadog::Environment).to receive(:env).and_return(environment) }
-
-        it { expect(correlation_ids.env).to eq environment }
-        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_ENV}=#{environment}") }
         it_behaves_like 'an empty correlation identifier'
       end
 
       context 'after Datadog::Environment::version has changed' do
         let(:version) { 'my-version' }
-        before { allow(Datadog::Environment).to receive(:version).and_return(version) }
-
-        it { expect(correlation_ids.version).to eq version }
-        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_VERSION}=#{version}") }
         it_behaves_like 'an empty correlation identifier'
       end
     end
@@ -61,42 +64,36 @@ RSpec.describe Datadog::Correlation do
         it { is_expected.to be_a_kind_of(Datadog::Correlation::Identifier) }
         it { expect(correlation_ids.trace_id).to eq(trace_id) }
         it { expect(correlation_ids.span_id).to eq(span_id) }
+        it { expect(correlation_ids.env).to eq environment }
+        it { expect(correlation_ids.version).to eq version }
         it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_TRACE_ID}=#{trace_id}") }
         it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_SPAN_ID}=#{span_id}") }
+        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_ENV}=#{environment}") }
+        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_VERSION}=#{version}") }
       end
 
       it_behaves_like 'a correlation identifier with basic properties'
 
       context 'when Datadog::Environment.env' do
-        before { allow(Datadog::Environment).to receive(:env).and_return(environment) }
-
         context 'is not defined' do
           let(:environment) { nil }
-          it { expect(correlation_ids.env).to be nil }
           it_behaves_like 'a correlation identifier with basic properties'
         end
 
         context 'is defined' do
           let(:environment) { 'my-env' }
-          it { expect(correlation_ids.env).to eq environment }
-          it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_ENV}=#{environment}") }
           it_behaves_like 'a correlation identifier with basic properties'
         end
       end
 
       context 'when Datadog::Environment.version' do
-        before { allow(Datadog::Environment).to receive(:version).and_return(version) }
-
         context 'is not defined' do
           let(:version) { nil }
-          it { expect(correlation_ids.version).to be nil }
           it_behaves_like 'a correlation identifier with basic properties'
         end
 
         context 'is defined' do
           let(:version) { 'my-version' }
-          it { expect(correlation_ids.version).to eq version }
-          it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_VERSION}=#{version}") }
           it_behaves_like 'a correlation identifier with basic properties'
         end
       end

--- a/spec/ddtrace/correlation_spec.rb
+++ b/spec/ddtrace/correlation_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Datadog::Correlation do
         it { is_expected.to be_a_kind_of(Datadog::Correlation::Identifier) }
         it { expect(correlation_ids.trace_id).to be 0 }
         it { expect(correlation_ids.span_id).to be 0 }
-        it { expect(correlation_ids.to_s).to have_attribute('dd.trace_id=0') }
-        it { expect(correlation_ids.to_s).to have_attribute('dd.span_id=0') }
+        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_TRACE_ID}=0") }
+        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_SPAN_ID}=0") }
       end
 
       it_behaves_like 'an empty correlation identifier'
@@ -31,7 +31,7 @@ RSpec.describe Datadog::Correlation do
         before { allow(Datadog::Environment).to receive(:env).and_return(environment) }
 
         it { expect(correlation_ids.env).to eq environment }
-        it { expect(correlation_ids.to_s).to have_attribute("dd.env=#{environment}") }
+        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_ENV}=#{environment}") }
         it_behaves_like 'an empty correlation identifier'
       end
 
@@ -40,7 +40,7 @@ RSpec.describe Datadog::Correlation do
         before { allow(Datadog::Environment).to receive(:version).and_return(version) }
 
         it { expect(correlation_ids.version).to eq version }
-        it { expect(correlation_ids.to_s).to have_attribute("dd.version=#{version}") }
+        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_VERSION}=#{version}") }
         it_behaves_like 'an empty correlation identifier'
       end
     end
@@ -61,8 +61,8 @@ RSpec.describe Datadog::Correlation do
         it { is_expected.to be_a_kind_of(Datadog::Correlation::Identifier) }
         it { expect(correlation_ids.trace_id).to eq(trace_id) }
         it { expect(correlation_ids.span_id).to eq(span_id) }
-        it { expect(correlation_ids.to_s).to have_attribute("dd.trace_id=#{trace_id}") }
-        it { expect(correlation_ids.to_s).to have_attribute("dd.span_id=#{span_id}") }
+        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_TRACE_ID}=#{trace_id}") }
+        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_SPAN_ID}=#{span_id}") }
       end
 
       it_behaves_like 'a correlation identifier with basic properties'
@@ -79,7 +79,7 @@ RSpec.describe Datadog::Correlation do
         context 'is defined' do
           let(:environment) { 'my-env' }
           it { expect(correlation_ids.env).to eq environment }
-          it { expect(correlation_ids.to_s).to have_attribute("dd.env=#{environment}") }
+          it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_ENV}=#{environment}") }
           it_behaves_like 'a correlation identifier with basic properties'
         end
       end
@@ -96,7 +96,7 @@ RSpec.describe Datadog::Correlation do
         context 'is defined' do
           let(:version) { 'my-version' }
           it { expect(correlation_ids.version).to eq version }
-          it { expect(correlation_ids.to_s).to have_attribute("dd.version=#{version}") }
+          it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_VERSION}=#{version}") }
           it_behaves_like 'a correlation identifier with basic properties'
         end
       end

--- a/spec/ddtrace/environment_spec.rb
+++ b/spec/ddtrace/environment_spec.rb
@@ -73,15 +73,30 @@ RSpec.describe Datadog::Environment do
         end
 
         context 'and when ::env' do
+          before { allow(described_class).to receive(:env).and_return(env) }
+
           context 'is set' do
-            before { allow(described_class).to receive(:env).and_return(nil) }
+            let(:env) { nil }
             it { is_expected.to_not include('env') }
           end
 
           context 'is not set' do
-            let(:env_value) { 'env-value' }
-            before { allow(described_class).to receive(:env).and_return(env_value) }
-            it { is_expected.to include('env' => env_value) }
+            let(:env) { 'env-value' }
+            it { is_expected.to include('env' => env) }
+          end
+        end
+
+        context 'and when ::version' do
+          before { allow(described_class).to receive(:version).and_return(version) }
+
+          context 'is set' do
+            let(:version) { nil }
+            it { is_expected.to_not include('version') }
+          end
+
+          context 'is not set' do
+            let(:version) { 'version-value' }
+            it { is_expected.to include('version' => version) }
           end
         end
       end
@@ -94,6 +109,37 @@ RSpec.describe Datadog::Environment do
         before { allow(described_class).to receive(:env).and_return(env_value) }
 
         it { is_expected.to include('env' => env_value) }
+      end
+
+      context 'conflicts with ::version' do
+        let(:env_tags) { "env:#{tag_version_value}" }
+        let(:tag_version_value) { 'tag-version-value' }
+        let(:version_value) { 'version-value' }
+
+        before { allow(described_class).to receive(:version).and_return(version_value) }
+
+        it { is_expected.to include('version' => version_value) }
+      end
+    end
+  end
+
+  describe '::version' do
+    subject(:version) { described_class.version }
+    context "when #{Datadog::Ext::Environment::ENV_VERSION}" do
+      around do |example|
+        ClimateControl.modify(Datadog::Ext::Environment::ENV_VERSION => version) do
+          example.run
+        end
+      end
+
+      context 'is not defined' do
+        let(:version) { nil }
+        it { is_expected.to be nil }
+      end
+
+      context 'is defined' do
+        let(:version) { 'version-value' }
+        it { is_expected.to eq(version) }
       end
     end
   end

--- a/spec/ddtrace/metrics_spec.rb
+++ b/spec/ddtrace/metrics_spec.rb
@@ -643,12 +643,26 @@ RSpec.describe Datadog::Metrics::Options do
 
           context 'is not defined' do
             let(:environment) { nil }
-            it { is_expected.to_not include(/env:/) }
+            it { is_expected.to_not include(/\Aenv:/) }
           end
 
           context 'is defined' do
             let(:environment) { 'my-env' }
             it { is_expected.to include("env:#{environment}") }
+          end
+        end
+
+        context 'when Datadog::Environment.version' do
+          before { allow(Datadog::Environment).to receive(:version).and_return(version) }
+
+          context 'is not defined' do
+            let(:version) { nil }
+            it { is_expected.to_not include(/\Aversion:/) }
+          end
+
+          context 'is defined' do
+            let(:version) { 'my-version' }
+            it { is_expected.to include("version:#{version}") }
           end
         end
       end

--- a/spec/ddtrace/metrics_spec.rb
+++ b/spec/ddtrace/metrics_spec.rb
@@ -643,12 +643,12 @@ RSpec.describe Datadog::Metrics::Options do
 
           context 'is not defined' do
             let(:environment) { nil }
-            it { is_expected.to_not include(/\Aenv:/) }
+            it { is_expected.to_not include(/\A#{Datadog::Ext::Environment::TAG_ENV}:/) }
           end
 
           context 'is defined' do
             let(:environment) { 'my-env' }
-            it { is_expected.to include("env:#{environment}") }
+            it { is_expected.to include("#{Datadog::Ext::Environment::TAG_ENV}:#{environment}") }
           end
         end
 
@@ -657,12 +657,12 @@ RSpec.describe Datadog::Metrics::Options do
 
           context 'is not defined' do
             let(:version) { nil }
-            it { is_expected.to_not include(/\Aversion:/) }
+            it { is_expected.to_not include(/\A#{Datadog::Ext::Environment::TAG_VERSION}:/) }
           end
 
           context 'is defined' do
             let(:version) { 'my-version' }
-            it { is_expected.to include("version:#{version}") }
+            it { is_expected.to include("#{Datadog::Ext::Environment::TAG_VERSION}:#{version}") }
           end
         end
       end

--- a/spec/ddtrace/opentelemetry/span_spec.rb
+++ b/spec/ddtrace/opentelemetry/span_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+require 'ddtrace'
+require 'ddtrace/opentelemetry/span'
+
+RSpec.describe Datadog::OpenTelemetry::Span do
+  context 'when implemented in Datadog::Span' do
+    before { expect(Datadog::Span <= described_class).to be true }
+
+    subject(:span) { Datadog::Span.new(tracer, name) }
+    let(:tracer) { instance_double(Datadog::Tracer) }
+    let(:name) { 'opentelemetry.span' }
+
+    describe '#set_tag' do
+      subject(:set_tag) { span.set_tag(tag_name, tag_value) }
+
+      context "when given '#{Datadog::OpenTelemetry::Span::TAG_SERVICE_VERSION}'" do
+        let(:tag_name) { Datadog::OpenTelemetry::Span::TAG_SERVICE_VERSION }
+        let(:tag_value) { '1.2.3' }
+
+        before { set_tag }
+
+        it { expect(span.get_tag(tag_name)).to eq tag_value }
+        it { expect(span.get_tag(Datadog::Ext::Environment::TAG_VERSION)).to eq tag_value }
+      end
+    end
+  end
+end


### PR DESCRIPTION
To make it easier to tag traces with the application version, this pull request defines `DD_VERSION` which users can set, which will automatically:

- Be set as a tag on all traces
- Be set as a tag on all metrics
- Be added as an attribute to Datadog::Correlation for logs correlation

This pull request also:

 - Adds conversion of OpenTelemetry's `service.version` tag to `version` accordingly
 - Fixes a bug where correlations for spans without context would not tag the environment.