### PR TITLE
Add DD_SERVICE environment variable

### DIFF
--- a/lib/ddtrace/environment.rb
+++ b/lib/ddtrace/environment.rb
@@ -9,6 +9,11 @@ module Datadog
     end
 
     # TODO: Extract to Datadog::Configuration::Settings
+    def self.service
+      ENV[Ext::Environment::ENV_SERVICE]
+    end
+
+    # TODO: Extract to Datadog::Configuration::Settings
     def self.tags
       tags = {}
 

--- a/lib/ddtrace/ext/environment.rb
+++ b/lib/ddtrace/ext/environment.rb
@@ -2,6 +2,7 @@ module Datadog
   module Ext
     module Environment
       ENV_ENVIRONMENT = 'DD_ENV'.freeze
+      ENV_SERVICE = 'DD_SERVICE'.freeze
       ENV_TAGS = 'DD_TAGS'.freeze
       ENV_VERSION = 'DD_VERSION'.freeze
 

--- a/lib/ddtrace/opentelemetry/span.rb
+++ b/lib/ddtrace/opentelemetry/span.rb
@@ -4,12 +4,19 @@ module Datadog
   module OpenTelemetry
     # Extensions for Datadog::Span
     module Span
+      TAG_SERVICE_NAME = 'service.name'.freeze
       TAG_SERVICE_VERSION = 'service.version'.freeze
 
       def set_tag(key, value)
         # Configure sampling priority if they give us a forced tracing tag
         # DEV: Do not set if the value they give us is explicitly "false"
         case key
+        when TAG_SERVICE_NAME
+          if defined?(super)
+            # Set original tag and Datadog version tag
+            self.service = value
+            super
+          end
         when TAG_SERVICE_VERSION
           if defined?(super)
             # Set original tag and Datadog version tag

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -4,6 +4,7 @@ require 'thread'
 require 'ddtrace/utils'
 require 'ddtrace/ext/errors'
 require 'ddtrace/ext/priority'
+require 'ddtrace/environment'
 require 'ddtrace/analytics'
 require 'ddtrace/forced_tracing'
 require 'ddtrace/diagnostics/health'
@@ -172,7 +173,7 @@ module Datadog
       # spans without a service would be dropped, so here we provide a default.
       # This should really never happen with integrations in contrib, as a default
       # service is always set. It's only for custom instrumentation.
-      @service ||= @tracer.default_service unless @tracer.nil?
+      @service ||= (Datadog::Environment.service || (@tracer && @tracer.default_service))
 
       begin
         @context.close_span(self)

--- a/spec/ddtrace/environment_spec.rb
+++ b/spec/ddtrace/environment_spec.rb
@@ -25,6 +25,27 @@ RSpec.describe Datadog::Environment do
     end
   end
 
+  describe '::service' do
+    subject(:service) { described_class.service }
+    context "when #{Datadog::Ext::Environment::ENV_SERVICE}" do
+      around do |example|
+        ClimateControl.modify(Datadog::Ext::Environment::ENV_SERVICE => service) do
+          example.run
+        end
+      end
+
+      context 'is not defined' do
+        let(:service) { nil }
+        it { is_expected.to be nil }
+      end
+
+      context 'is defined' do
+        let(:service) { 'service-value' }
+        it { is_expected.to eq(service) }
+      end
+    end
+  end
+
   describe '::tags' do
     subject(:tags) { described_class.tags }
 

--- a/spec/ddtrace/opentelemetry/span_spec.rb
+++ b/spec/ddtrace/opentelemetry/span_spec.rb
@@ -14,6 +14,16 @@ RSpec.describe Datadog::OpenTelemetry::Span do
     describe '#set_tag' do
       subject(:set_tag) { span.set_tag(tag_name, tag_value) }
 
+      context "when given '#{Datadog::OpenTelemetry::Span::TAG_SERVICE_NAME}'" do
+        let(:tag_name) { Datadog::OpenTelemetry::Span::TAG_SERVICE_NAME }
+        let(:tag_value) { 'opentelemetry-service' }
+
+        before { set_tag }
+
+        it { expect(span.get_tag(tag_name)).to eq tag_value }
+        it { expect(span.service).to eq tag_value }
+      end
+
       context "when given '#{Datadog::OpenTelemetry::Span::TAG_SERVICE_VERSION}'" do
         let(:tag_name) { Datadog::OpenTelemetry::Span::TAG_SERVICE_VERSION }
         let(:tag_value) { '1.2.3' }
@@ -22,6 +32,15 @@ RSpec.describe Datadog::OpenTelemetry::Span do
 
         it { expect(span.get_tag(tag_name)).to eq tag_value }
         it { expect(span.get_tag(Datadog::Ext::Environment::TAG_VERSION)).to eq tag_value }
+      end
+
+      context 'when given an arbitrary tag' do
+        let(:tag_name) { 'custom-tag' }
+        let(:tag_value) { 'custom-value' }
+
+        before { set_tag }
+
+        it { expect(span.get_tag(tag_name)).to eq tag_value }
       end
     end
   end

--- a/spec/ddtrace/span_spec.rb
+++ b/spec/ddtrace/span_spec.rb
@@ -39,6 +39,36 @@ RSpec.describe Datadog::Span do
           .with(1, tags: ["error:#{error_class.name}"])
       end
     end
+
+    context 'when service' do
+      subject(:service) do
+        finish
+        span.service
+      end
+
+      context 'is set' do
+        let(:service_value) { 'span-service' }
+        before { span.service = service_value }
+        it { is_expected.to eq service_value }
+      end
+
+      context 'is only defined in the environment' do
+        let(:env_service) { 'env-service' }
+        before { allow(Datadog::Environment).to receive(:service).and_return(env_service) }
+        it { is_expected.to eq env_service }
+      end
+
+      context 'is not set anywhere' do
+        let(:default_service) { 'default-service' }
+
+        before do
+          allow(Datadog::Environment).to receive(:service).and_return(nil)
+          allow(tracer).to receive(:default_service).and_return(default_service)
+        end
+
+        it { is_expected.to eq default_service }
+      end
+    end
   end
 
   describe '#clear_tag' do


### PR DESCRIPTION
To make it easier to tag traces with the application version, this pull request defines `DD_SERVICE` which users can set, which will act as the default service for spans if a service isn't explicitly provided for that span.

Additionally it also adds conversion of OpenTelemetry's `service.name` tag to the `service` attribute on `Datadog::Span`.

In its current implementation, `DD_SERVICE` will only affect manual instrumentation that does not provide a `service`, as most integrations automatically have their own default service name defined. Integration behavior will be adjusted to use this default where appropriate in another pull request.