### PR TITLE
Add runtime metrics worker

### DIFF
--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -1,6 +1,7 @@
 require 'time'
 
 require 'ddtrace/workers/trace_writer'
+require 'ddtrace/workers/runtime_metrics'
 
 require 'ddtrace/buffer'
 require 'ddtrace/runtime/metrics'

--- a/lib/ddtrace/workers/runtime_metrics.rb
+++ b/lib/ddtrace/workers/runtime_metrics.rb
@@ -1,0 +1,58 @@
+require 'forwardable'
+
+require 'ddtrace/environment'
+require 'ddtrace/runtime/metrics'
+
+require 'ddtrace/worker'
+require 'ddtrace/workers/polling'
+
+module Datadog
+  module Workers
+    # Emits runtime metrics asynchronously on a timed loop
+    class RuntimeMetrics < Worker
+      extend Forwardable
+      include Workers::Polling
+
+      attr_reader \
+        :metrics
+
+      def initialize(options = {})
+        @metrics = options.fetch(:metrics, Runtime::Metrics.new)
+
+        # Workers::Async::Thread settings
+        self.fork_policy = options.fetch(:fork_policy, Workers::Async::Thread::FORK_POLICY_STOP)
+
+        # Workers::IntervalLoop settings
+        self.interval = options[:interval] if options.key?(:interval)
+        self.back_off_ratio = options[:back_off_ratio] if options.key?(:back_off_ratio)
+        self.back_off_max = options[:back_off_max] if options.key?(:back_off_max)
+
+        self.enabled = options.fetch(
+          :enabled,
+          Datadog::Environment.env_to_bool(Ext::Runtime::Metrics::ENV_ENABLED, false)
+        )
+      end
+
+      def perform
+        metrics.flush
+        true
+      end
+
+      def enabled=(value)
+        old_state = enabled?
+        super
+        new_state = enabled?
+
+        # Auto-start/stop worker if state changed.
+        if old_state != new_state
+          new_state ? perform : stop
+        end
+      end
+
+      def_delegators \
+        :metrics,
+        :associate_with_span,
+        :register_service
+    end
+  end
+end

--- a/spec/ddtrace/workers/runtime_metrics_spec.rb
+++ b/spec/ddtrace/workers/runtime_metrics_spec.rb
@@ -1,0 +1,267 @@
+require 'spec_helper'
+
+require 'ddtrace'
+require 'ddtrace/workers/runtime_metrics'
+
+RSpec.describe Datadog::Workers::RuntimeMetrics do
+  subject(:worker) { described_class.new(options) }
+  let(:metrics) { instance_double(Datadog::Runtime::Metrics) }
+  let(:options) { { metrics: metrics, enabled: true } }
+
+  before { allow(metrics).to receive(:flush) }
+  after { worker.stop(true, 0) }
+
+  describe '#initialize' do
+    it { expect(worker).to be_a_kind_of(Datadog::Workers::Polling) }
+
+    context 'by default' do
+      subject(:worker) { described_class.new }
+      it { expect(worker.enabled?).to be false }
+    end
+
+    context 'when :enabled is given' do
+      let(:options) { super().merge(enabled: true) }
+      it { expect(worker.enabled?).to be true }
+    end
+
+    context 'when :enabled is not given' do
+      before { options.delete(:enabled) }
+
+      context "and #{Datadog::Ext::Runtime::Metrics::ENV_ENABLED} is not set" do
+        before do
+          expect(Datadog::Environment).to receive(:env_to_bool)
+            .with(Datadog::Ext::Runtime::Metrics::ENV_ENABLED, false)
+            .and_return(false)
+        end
+
+        it { expect(worker.enabled?).to be false }
+      end
+
+      context "and #{Datadog::Ext::Runtime::Metrics::ENV_ENABLED} is set" do
+        before do
+          expect(Datadog::Environment).to receive(:env_to_bool)
+            .with(Datadog::Ext::Runtime::Metrics::ENV_ENABLED, false)
+            .and_return(true)
+        end
+
+        it { expect(worker.enabled?).to be true }
+      end
+    end
+  end
+
+  describe '#perform' do
+    subject(:perform) { worker.perform }
+    after { worker.stop(true, 0) }
+
+    context 'when #enabled? is true' do
+      before { allow(worker).to receive(:enabled?).and_return(true) }
+
+      it 'starts a worker thread' do
+        perform
+        expect(worker).to have_attributes(
+          metrics: metrics,
+          run_async?: true,
+          running?: true,
+          started?: true,
+          forked?: false,
+          fork_policy: Datadog::Workers::Async::Thread::FORK_POLICY_STOP,
+          result: nil
+        )
+      end
+    end
+  end
+
+  describe '#enabled=' do
+    subject(:set_enabled_value) { worker.enabled = value }
+    after { worker.stop(true, 0) }
+
+    context 'when not running' do
+      before do
+        worker.enabled = false
+        allow(worker).to receive(:perform)
+        allow(worker).to receive(:stop)
+      end
+
+      context 'and given true' do
+        let(:value) { true }
+
+        it 'starts the worker' do
+          expect { set_enabled_value }
+            .to change { worker.enabled? }
+            .from(false)
+            .to(true)
+
+          expect(worker).to have_received(:perform)
+          expect(worker).to_not have_received(:stop)
+        end
+      end
+
+      context 'and given false' do
+        let(:value) { false }
+
+        it 'does nothing' do
+          expect { set_enabled_value }
+            .to_not change { worker.enabled? }
+            .from(false)
+
+          expect(worker).to_not have_received(:perform)
+          expect(worker).to_not have_received(:stop)
+        end
+      end
+
+      context 'and given nil' do
+        let(:value) { nil }
+
+        it 'does nothing' do
+          expect { set_enabled_value }
+            .to_not change { worker.enabled? }
+            .from(false)
+
+          expect(worker).to_not have_received(:perform)
+          expect(worker).to_not have_received(:stop)
+        end
+      end
+    end
+
+    context 'when already running' do
+      before do
+        worker.enabled = true
+        allow(worker).to receive(:perform)
+        allow(worker).to receive(:stop)
+      end
+
+      context 'and given true' do
+        let(:value) { true }
+
+        it 'does nothing' do
+          expect { set_enabled_value }
+            .to_not change { worker.enabled? }
+            .from(true)
+
+          expect(worker).to_not have_received(:perform)
+          expect(worker).to_not have_received(:stop)
+        end
+      end
+
+      context 'and given false' do
+        let(:value) { false }
+
+        it 'stops the worker' do
+          expect { set_enabled_value }
+            .to change { worker.enabled? }
+            .from(true)
+            .to(false)
+
+          expect(worker).to_not have_received(:perform)
+          expect(worker).to have_received(:stop)
+        end
+      end
+
+      context 'and given nil' do
+        let(:value) { nil }
+
+        it 'stops the worker' do
+          expect { set_enabled_value }
+            .to change { worker.enabled? }
+            .from(true)
+            .to(false)
+
+          expect(worker).to_not have_received(:perform)
+          expect(worker).to have_received(:stop)
+        end
+      end
+    end
+  end
+
+  describe 'forwarded methods' do
+    describe '#associate_with_span' do
+      subject(:associate_with_span) { worker.associate_with_span(span) }
+      let(:span) { instance_double(Datadog::Span) }
+
+      before { allow(worker.metrics).to receive(:associate_with_span) }
+
+      it 'forwards to #metrics' do
+        associate_with_span
+        expect(worker.metrics).to have_received(:associate_with_span)
+          .with(span)
+      end
+    end
+
+    describe '#register_service' do
+      subject(:register_service) { worker.register_service(service) }
+      let(:service) { double('service') }
+
+      before { allow(worker.metrics).to receive(:register_service) }
+
+      it 'forwards to #metrics' do
+        register_service
+        expect(worker.metrics).to have_received(:register_service)
+          .with(service)
+      end
+    end
+  end
+
+  describe 'integration tests' do
+    let(:options) do
+      {
+        metrics: metrics,
+        fork_policy: fork_policy,
+        enabled: true
+      }
+    end
+
+    describe 'forking' do
+      context 'when the process forks' do
+        before { allow(metrics).to receive(:flush) }
+        after { worker.stop }
+
+        context 'with FORK_POLICY_STOP fork policy' do
+          let(:fork_policy) { Datadog::Workers::Async::Thread::FORK_POLICY_STOP }
+
+          it 'does not produce metrics' do
+            # Start worker in main process
+            worker.perform
+
+            expect_in_fork do
+              # Capture the flush
+              @flushed = false
+              allow(metrics).to receive(:flush) do
+                @flushed = true
+              end
+
+              # Attempt restart of worker & verify it stops.
+              expect { worker.perform }.to change { worker.run_async? }
+                .from(true)
+                .to(false)
+            end
+          end
+        end
+
+        context 'with FORK_POLICY_RESTART fork policy' do
+          let(:fork_policy) { Datadog::Workers::Async::Thread::FORK_POLICY_RESTART }
+
+          it 'continues producing metrics' do
+            # Start worker
+            worker.perform
+
+            expect_in_fork do
+              # Capture the flush
+              @flushed = false
+              allow(metrics).to receive(:flush) do
+                @flushed = true
+              end
+
+              # Restart worker & wait
+              worker.perform
+              try_wait_until(attempts: 30) { @flushed }
+
+              # Verify state of the worker
+              expect(worker.error?).to be false
+              expect(metrics).to have_received(:flush).at_least(:once)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extracted from #879

This pull request introduces the `Datadog::Workers::RuntimeMetrics` worker, which is responsible for collecting and submitting runtime metrics via Statsd. The pull request effectively extracts this runtime metrics behavior from the `AsyncTransport` which runtime metrics had previously hitchhiked on; it now separates it into its own thread and component, by using the same base as the `AsyncTraceWriter`.

It is the complement to `AsyncTraceWriter` in the respect that the combination of the two replace the responsibilities of `Datadog::Writer`; we will use this component when we also transition to the new `TraceWriter` by default.