### PR TITLE
Extract components from configuration

### DIFF
--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -183,7 +183,7 @@ Then pass an adapter instance to the tracer configuration:
 
 ```ruby
 Datadog.configure do |c|
-  c.tracer transport_options: proc { |t|
+  c.tracer.transport_options = proc { |t|
     # By name
     t.adapter :custom
 

--- a/lib/ddtrace/buffer.rb
+++ b/lib/ddtrace/buffer.rb
@@ -96,16 +96,16 @@ module Datadog
 
     def measure_pop(traces)
       # Accepted
-      Diagnostics::Health.metrics.queue_accepted(@buffer_accepted)
-      Diagnostics::Health.metrics.queue_accepted_lengths(@buffer_accepted_lengths)
+      Datadog.health_metrics.queue_accepted(@buffer_accepted)
+      Datadog.health_metrics.queue_accepted_lengths(@buffer_accepted_lengths)
 
       # Dropped
-      Diagnostics::Health.metrics.queue_dropped(@buffer_dropped)
+      Datadog.health_metrics.queue_dropped(@buffer_dropped)
 
       # Queue gauges
-      Diagnostics::Health.metrics.queue_max_length(@max_size)
-      Diagnostics::Health.metrics.queue_spans(@buffer_spans)
-      Diagnostics::Health.metrics.queue_length(traces.length)
+      Datadog.health_metrics.queue_max_length(@max_size)
+      Datadog.health_metrics.queue_spans(@buffer_spans)
+      Datadog.health_metrics.queue_length(traces.length)
 
       # Reset aggregated metrics
       @buffer_accepted = 0

--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -30,6 +30,7 @@ module Datadog
 
     def_delegators \
       :components,
+      :health_metrics,
       :runtime_metrics,
       :tracer
 
@@ -57,7 +58,10 @@ module Datadog
 
       # Shutdown the old metrics, unless they are still being used.
       # (e.g. custom Statsd instances.)
-      old.runtime_metrics.statsd.close unless old.runtime_metrics.statsd == current.runtime_metrics.statsd
+      old_statsd = [old.runtime_metrics.statsd, old.health_metrics.statsd].uniq
+      new_statsd = [current.runtime_metrics.statsd, current.health_metrics.statsd].uniq
+      unused_statsd = (old_statsd - (old_statsd & new_statsd))
+      unused_statsd.each(&:close)
     end
   end
 end

--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -1,0 +1,12 @@
+require 'ddtrace/tracer'
+
+module Datadog
+  module Configuration
+    # Global components for the trace library.
+    class Components
+      def initialize(settings); end
+
+      def teardown!; end
+    end
+  end
+end

--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -11,9 +11,13 @@ module Datadog
 
         # Runtime metrics
         build_runtime_metrics(settings)
+
+        # Health metrics
+        @health_metrics = build_health_metrics(settings)
       end
 
       attr_reader \
+        :health_metrics,
         :tracer
 
       def runtime_metrics
@@ -76,6 +80,14 @@ module Datadog
         #       within the tracer/writer. Build a new runtime metrics instance when
         #       runtime metrics are extracted from tracer/writer.
         runtime_metrics.configure(options)
+      end
+
+      def build_health_metrics(settings)
+        settings = settings.diagnostics.health_metrics
+        options = { enabled: settings.enabled }
+        options[:statsd] = settings.statsd unless settings.statsd.nil?
+
+        Datadog::Diagnostics::Health::Metrics.new(options)
       end
     end
   end

--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -3,10 +3,80 @@ require 'ddtrace/tracer'
 module Datadog
   module Configuration
     # Global components for the trace library.
+    # rubocop:disable Metrics/LineLength
     class Components
-      def initialize(settings); end
+      def initialize(settings)
+        # Tracer
+        @tracer = build_tracer(settings)
 
-      def teardown!; end
+        # Runtime metrics
+        build_runtime_metrics(settings)
+      end
+
+      attr_reader \
+        :tracer
+
+      def runtime_metrics
+        tracer.writer.runtime_metrics
+      end
+
+      private
+
+      def build_tracer(settings)
+        # If a custom tracer has been provided, use it instead.
+        # Ignore all other options (they should already be configured.)
+        return settings.tracer.instance unless settings.tracer.instance.nil?
+
+        tracer = Tracer.new(
+          default_service: settings.service,
+          enabled: settings.tracer.enabled,
+          partial_flush: settings.tracer.partial_flush,
+          tags: build_tracer_tags(settings)
+        )
+
+        # TODO: We reconfigure the tracer here because it has way too many
+        #       options it allows to mutate, and it's overwhelming to rewrite
+        #       tracer initialization for now. Just reconfigure using the
+        #       existing mutable #configure function. Remove when these components
+        #       are extracted.
+        tracer.configure(build_tracer_options(settings))
+
+        tracer
+      end
+
+      def build_tracer_tags(settings)
+        settings.tags.dup.tap do |tags|
+          tags['env'] = settings.env unless settings.env.nil?
+          tags['version'] = settings.version unless settings.version.nil?
+        end
+      end
+
+      def build_tracer_options(settings)
+        settings = settings.tracer
+
+        {}.tap do |opts|
+          opts[:hostname] = settings.hostname unless settings.hostname.nil?
+          opts[:min_spans_before_partial_flush] = settings.partial_flush.min_spans_threshold unless settings.partial_flush.min_spans_threshold.nil?
+          opts[:partial_flush] = settings.partial_flush.enabled unless settings.partial_flush.enabled.nil?
+          opts[:port] = settings.port unless settings.port.nil?
+          opts[:priority_sampling] = settings.priority_sampling unless settings.priority_sampling.nil?
+          opts[:sampler] = settings.sampler unless settings.sampler.nil?
+          opts[:transport_options] = settings.transport_options
+          opts[:writer] = settings.writer unless settings.writer.nil?
+          opts[:writer_options] = settings.writer_options if settings.writer.nil?
+        end
+      end
+
+      def build_runtime_metrics(settings)
+        settings = settings.runtime_metrics
+        options = { enabled: settings.enabled }
+        options[:statsd] = settings.statsd unless settings.statsd.nil?
+
+        # TODO: We reconfigure runtime metrics here because it is too deeply nested
+        #       within the tracer/writer. Build a new runtime metrics instance when
+        #       runtime metrics are extracted from tracer/writer.
+        runtime_metrics.configure(options)
+      end
     end
   end
 end

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -34,14 +34,13 @@ module Datadog
       end
 
       settings :diagnostics do
-        option :health_metrics do |o|
-          o.default do
-            Datadog::Diagnostics::Health::Metrics.new(
-              enabled: env_to_bool(Datadog::Ext::Diagnostics::Health::Metrics::ENV_ENABLED, false)
-            )
+        settings :health_metrics do
+          option :enabled do |o|
+            o.default { env_to_bool(Datadog::Ext::Diagnostics::Health::Metrics::ENV_ENABLED, false) }
+            o.lazy
           end
 
-          o.lazy
+          option :statsd
         end
       end
 

--- a/lib/ddtrace/context.rb
+++ b/lib/ddtrace/context.rb
@@ -100,7 +100,7 @@ module Datadog
           # If overflow has already occurred, don't send this metric.
           # Prevents metrics spam if buffer repeatedly overflows for the same trace.
           unless @overflow
-            Diagnostics::Health.metrics.error_context_overflow(1, tags: ["max_length:#{@max_length}"])
+            Datadog.health_metrics.error_context_overflow(1, tags: ["max_length:#{@max_length}"])
             @overflow = true
           end
 
@@ -131,7 +131,7 @@ module Datadog
 
           @trace.reject(&:finished?).group_by(&:name).each do |unfinished_span_name, unfinished_spans|
             Datadog::Logger.log.debug("unfinished span: #{unfinished_spans.first}") if Datadog::Logger.debug_logging
-            Diagnostics::Health.metrics.error_unfinished_spans(
+            Datadog.health_metrics.error_unfinished_spans(
               unfinished_spans.length,
               tags: ["name:#{unfinished_span_name}"]
             )

--- a/lib/ddtrace/contrib/analytics.rb
+++ b/lib/ddtrace/contrib/analytics.rb
@@ -9,7 +9,7 @@ module Datadog
       # Checks whether analytics should be enabled.
       # `flag` is a truthy/falsey value that represents a setting on the integration.
       def enabled?(flag = nil)
-        (Datadog.configuration.analytics_enabled && flag != false) || flag == true
+        (Datadog.configuration.analytics.enabled && flag != false) || flag == true
       end
 
       def set_sample_rate(span, sample_rate)

--- a/lib/ddtrace/contrib/patcher.rb
+++ b/lib/ddtrace/contrib/patcher.rb
@@ -28,7 +28,7 @@ module Datadog
             begin
               super.tap do
                 # Emit a metric
-                Diagnostics::Health.metrics.instrumentation_patched(1, tags: default_tags)
+                Datadog.health_metrics.instrumentation_patched(1, tags: default_tags)
               end
             rescue StandardError => e
               # Log the error
@@ -38,7 +38,7 @@ module Datadog
               tags = default_tags
               tags << "error:#{e.class.name}"
 
-              Diagnostics::Health.metrics.error_instrumentation_patch(1, tags: tags)
+              Datadog.health_metrics.error_instrumentation_patch(1, tags: tags)
             end
           end
         end

--- a/lib/ddtrace/diagnostics/health.rb
+++ b/lib/ddtrace/diagnostics/health.rb
@@ -26,12 +26,6 @@ module Datadog
         gauge :queue_spans, Ext::Diagnostics::Health::Metrics::METRIC_QUEUE_SPANS
         gauge :sampling_service_cache_length, Ext::Diagnostics::Health::Metrics::METRIC_SAMPLING_SERVICE_CACHE_LENGTH
       end
-
-      module_function
-
-      def metrics
-        Datadog.configuration.diagnostics.health_metrics
-      end
     end
   end
 end

--- a/lib/ddtrace/opentracer/global_tracer.rb
+++ b/lib/ddtrace/opentracer/global_tracer.rb
@@ -6,7 +6,7 @@ module Datadog
         super.tap do
           if tracer.class <= Datadog::OpenTracer::Tracer
             # Update the Datadog global tracer, too.
-            Datadog.configuration.tracer = tracer.datadog_tracer
+            Datadog.configure { |c| c.tracer = tracer.datadog_tracer }
           end
         end
       end

--- a/lib/ddtrace/sampler.rb
+++ b/lib/ddtrace/sampler.rb
@@ -176,7 +176,7 @@ module Datadog
       update_all(rate_by_service)
 
       # Emit metric for service cache size
-      Diagnostics::Health.metrics.sampling_service_cache_length(length)
+      Datadog.health_metrics.sampling_service_cache_length(length)
     end
 
     private

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -180,7 +180,7 @@ module Datadog
         @tracer.record(self)
       rescue StandardError => e
         Datadog::Logger.log.debug("error recording finished trace: #{e}")
-        Diagnostics::Health.metrics.error_span_finish(1, tags: ["error:#{e.class.name}"])
+        Datadog.health_metrics.error_span_finish(1, tags: ["error:#{e.class.name}"])
       end
       self
     end

--- a/lib/ddtrace/transport/statistics.rb
+++ b/lib/ddtrace/transport/statistics.rb
@@ -20,7 +20,7 @@ module Datadog
         end
 
         # Send health metrics
-        Diagnostics::Health.metrics.send_metrics(
+        Datadog.health_metrics.send_metrics(
           metrics_for_response(response).values
         )
       end
@@ -37,7 +37,7 @@ module Datadog
         stats.consecutive_errors += 1
 
         # Send health metrics
-        Diagnostics::Health.metrics.send_metrics(
+        Datadog.health_metrics.send_metrics(
           metrics_for_exception(exception).values
         )
       end

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+require 'ddtrace/configuration/components'
+
+RSpec.describe Datadog::Configuration::Components do
+  describe '::new' do
+    subject(:components) { described_class.new(settings) }
+    let(:settings) { Datadog::Configuration::Settings.new }
+
+    context 'given a tracer instance' do
+      let(:tracer) { instance_double(Datadog::Tracer, writer: writer) }
+      let(:writer) { instance_double(Datadog::Writer, runtime_metrics: runtime_metrics) }
+      let(:runtime_metrics) { instance_double(Datadog::Runtime::Metrics) }
+
+      before do
+        settings.tracer = tracer
+        settings.service = 'my-service'
+        settings.tags = { 'custom-tag' => 'custom-value' }
+
+        # NOTE: When given a tracer instance, it is expected to be fully configured.
+        #       Do not expect the other settings to mutate the tracer instance.
+        expect(tracer).to_not receive(:configure)
+        expect(tracer).to_not receive(:set_tags)
+        allow(runtime_metrics).to receive(:configure)
+      end
+
+      it 'uses the tracer instance' do
+        expect(components.tracer).to be(tracer)
+      end
+    end
+
+    context 'given some tracer settings' do
+      before do
+        settings.service = 'my-service'
+        settings.env = 'test-env'
+        settings.tags = { 'custom-tag' => 'custom-value' }
+        settings.version = '0.1.0.alpha'
+        settings.tracer.enabled = false
+        settings.tracer.hostname = 'my-agent'
+        settings.tracer.port = 1234
+        settings.tracer.partial_flush.enabled = true
+        settings.tracer.partial_flush.min_spans_threshold = 123
+      end
+
+      describe '#tracer' do
+        subject(:tracer) { components.tracer }
+
+        it { expect(tracer.enabled).to be false }
+        it { expect(tracer.default_service).to eq('my-service') }
+        it { expect(tracer.context_flush).to be_a_kind_of(Datadog::ContextFlush::Partial) }
+        it { expect(tracer.context_flush.instance_variable_get(:@min_spans_for_partial)).to eq 123 }
+        it { expect(tracer.writer.transport.current_api.adapter.hostname).to eq 'my-agent' }
+        it { expect(tracer.writer.transport.current_api.adapter.port).to eq 1234 }
+
+        it 'has tags applied' do
+          expect(tracer.tags).to include(
+            'env' => 'test-env',
+            'custom-tag' => 'custom-value',
+            'version' => '0.1.0.alpha'
+          )
+        end
+      end
+
+      context 'including :writer' do
+        subject(:tracer) { components.tracer }
+        let(:writer) { Datadog::Writer.new }
+
+        before do
+          settings.tracer.hostname = 'my-agent'
+          settings.tracer.port = 1234
+          settings.tracer.writer = writer
+        end
+
+        it { expect(tracer.writer).to be writer }
+
+        # NOTE: Expect settings to NOT be retained because custom writer instances
+        #       supersede these settings: declare settings in Writer::new instead.
+        it { expect(tracer.writer.transport.current_api.adapter.hostname).to_not eq 'my-agent' }
+        it { expect(tracer.writer.transport.current_api.adapter.port).to_not eq 1234 }
+      end
+
+      context 'including :writer_options' do
+        subject(:tracer) { components.tracer }
+
+        before do
+          settings.tracer.writer_options = { buffer_size: 1234 }
+        end
+
+        it { expect(tracer.writer.instance_variable_get(:@buff_size)).to eq 1234 }
+      end
+    end
+
+    context 'given some runtime metrics settings' do
+      context 'in the old style' do
+        context 'with #runtime_metrics_enabled=' do
+          before { settings.runtime_metrics_enabled = true }
+          it { expect(components.runtime_metrics.enabled?).to be true }
+        end
+
+        context 'with #runtime_metrics' do
+          let(:statsd) { instance_double('statsd') }
+          before { settings.runtime_metrics enabled: true, statsd: statsd }
+          it { expect(components.runtime_metrics.enabled?).to be true }
+          it { expect(components.runtime_metrics.statsd).to be statsd }
+        end
+      end
+
+      context 'in the new style' do
+        let(:statsd) { instance_double('statsd') }
+
+        before do
+          settings.runtime_metrics.enabled = true
+          settings.runtime_metrics.statsd = statsd
+        end
+
+        it { expect(components.runtime_metrics.enabled?).to be true }
+        it { expect(components.runtime_metrics.statsd).to be statsd }
+      end
+    end
+
+    context 'given some health metrics settings' do
+    end
+  end
+end

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -119,6 +119,15 @@ RSpec.describe Datadog::Configuration::Components do
     end
 
     context 'given some health metrics settings' do
+      let(:statsd) { instance_double('statsd') }
+
+      before do
+        settings.diagnostics.health_metrics.enabled = true
+        settings.diagnostics.health_metrics.statsd = statsd
+      end
+
+      it { expect(components.health_metrics.enabled?).to be true }
+      it { expect(components.health_metrics.statsd).to be statsd }
     end
   end
 end

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -6,6 +6,137 @@ require 'ddtrace/configuration/settings'
 RSpec.describe Datadog::Configuration::Settings do
   subject(:settings) { described_class.new }
 
+  describe '#analytics' do
+    describe '#enabled' do
+      subject(:enabled) { settings.analytics.enabled }
+
+      context "when #{Datadog::Ext::Analytics::ENV_TRACE_ANALYTICS_ENABLED}" do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::Analytics::ENV_TRACE_ANALYTICS_ENABLED => environment) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:environment) { nil }
+          it { is_expected.to be nil }
+        end
+
+        context 'is defined' do
+          let(:environment) { 'true' }
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    describe '#enabled=' do
+      it 'changes the #enabled setting' do
+        expect { settings.analytics.enabled = true }
+          .to change { settings.analytics.enabled }
+          .from(nil)
+          .to(true)
+      end
+    end
+  end
+
+  describe '#analytics_enabled' do
+    subject(:analytics_enabled) { settings.analytics_enabled }
+    let(:value) { double }
+
+    before { expect(settings.analytics).to receive(:enabled).and_return(value) }
+
+    it 'retrieves the value from the new setting' do
+      is_expected.to be value
+    end
+  end
+
+  describe '#analytics_enabled=' do
+    it 'changes the new #enabled setting' do
+      expect { settings.analytics_enabled = true }
+        .to change { settings.analytics.enabled }
+        .from(nil)
+        .to(true)
+    end
+  end
+
+  describe '#diagnostics' do
+    describe '#health_metrics' do
+      # TODO
+    end
+
+    describe '#health_metrics=' do
+      # TODO
+    end
+  end
+
+  describe '#distributed_tracing' do
+    describe '#propagation_extract_style' do
+      subject(:propagation_extract_style) { settings.distributed_tracing.propagation_extract_style }
+
+      context "when #{Datadog::Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV}" do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV => environment) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:environment) { nil }
+          it do
+            is_expected.to eq(
+              [
+                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG,
+                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_B3,
+                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_B3_SINGLE_HEADER
+              ]
+            )
+          end
+        end
+
+        context 'is defined' do
+          let(:environment) { 'B3,B3 single header' }
+          it do
+            is_expected.to eq(
+              [
+                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_B3,
+                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_B3_SINGLE_HEADER
+              ]
+            )
+          end
+        end
+      end
+    end
+
+    describe '#propagation_inject_style' do
+      subject(:propagation_inject_style) { settings.distributed_tracing.propagation_inject_style }
+
+      context "when #{Datadog::Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV}" do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV => environment) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:environment) { nil }
+          it { is_expected.to eq([Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG]) }
+        end
+
+        context 'is defined' do
+          let(:environment) { 'Datadog,B3' }
+          it do
+            is_expected.to eq(
+              [
+                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG,
+                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_B3
+              ]
+            )
+          end
+        end
+      end
+    end
+  end
+
   describe '#env' do
     subject(:env) { settings.env }
     context "when #{Datadog::Ext::Environment::ENV_ENVIRONMENT}" do
@@ -33,9 +164,177 @@ RSpec.describe Datadog::Configuration::Settings do
     context 'when given a value' do
       let(:env) { 'custom-env' }
       before { set_env }
-
       it { expect(settings.env).to eq(env) }
-      it { expect(settings.tracer.tags).to include('env' => env) }
+    end
+  end
+
+  describe '#report_hostname' do
+    subject(:report_hostname) { settings.report_hostname }
+
+    context "when #{Datadog::Ext::NET::ENV_REPORT_HOSTNAME}" do
+      around do |example|
+        ClimateControl.modify(Datadog::Ext::NET::ENV_REPORT_HOSTNAME => environment) do
+          example.run
+        end
+      end
+
+      context 'is not defined' do
+        let(:environment) { nil }
+        it { is_expected.to be false }
+      end
+
+      context 'is defined' do
+        let(:environment) { 'true' }
+        it { is_expected.to be true }
+      end
+    end
+  end
+
+  describe '#report_hostname=' do
+    it 'changes the #report_hostname setting' do
+      expect { settings.report_hostname = true }
+        .to change { settings.report_hostname }
+        .from(false)
+        .to(true)
+    end
+  end
+
+  describe '#runtime_metrics' do
+    describe 'old style' do
+      context 'given nothing' do
+        subject(:runtime_metrics) { settings.runtime_metrics }
+        it 'returns the new settings object' do
+          is_expected.to be_a_kind_of(Datadog::Configuration::Base)
+        end
+      end
+
+      context 'given :enabled' do
+        subject(:runtime_metrics) { settings.runtime_metrics enabled: true }
+
+        it 'updates the new #enabled setting' do
+          expect { settings.runtime_metrics enabled: true }
+            .to change { settings.runtime_metrics.enabled }
+            .from(false)
+            .to(true)
+        end
+      end
+
+      context 'given :statsd' do
+        subject(:runtime_metrics) { settings.runtime_metrics statsd: statsd }
+        let(:statsd) { double('statsd') }
+
+        it 'updates the new #statsd setting' do
+          expect { settings.runtime_metrics statsd: statsd }
+            .to change { settings.runtime_metrics.statsd }
+            .from(nil)
+            .to(statsd)
+        end
+      end
+    end
+
+    describe '#enabled' do
+      subject(:enabled) { settings.runtime_metrics.enabled }
+
+      context "when #{Datadog::Ext::Runtime::Metrics::ENV_ENABLED}" do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::Runtime::Metrics::ENV_ENABLED => environment) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:environment) { nil }
+          it { is_expected.to be false }
+        end
+
+        context 'is defined' do
+          let(:environment) { 'true' }
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    describe '#enabled=' do
+      it 'changes the #enabled setting' do
+        expect { settings.runtime_metrics.enabled = true }
+          .to change { settings.runtime_metrics.enabled }
+          .from(false)
+          .to(true)
+      end
+    end
+
+    describe '#statsd' do
+      subject(:statsd) { settings.runtime_metrics.statsd }
+      it { is_expected.to be nil }
+    end
+
+    describe '#statsd=' do
+      let(:statsd) { double('statsd') }
+
+      it 'changes the #statsd setting' do
+        expect { settings.runtime_metrics.statsd = statsd }
+          .to change { settings.runtime_metrics.statsd }
+          .from(nil)
+          .to(statsd)
+      end
+    end
+  end
+
+  describe '#runtime_metrics_enabled' do
+    subject(:runtime_metrics_enabled) { settings.runtime_metrics_enabled }
+    let(:value) { double }
+
+    before { expect(settings.runtime_metrics).to receive(:enabled).and_return(value) }
+
+    it 'retrieves the value from the new setting' do
+      is_expected.to be value
+    end
+  end
+
+  describe '#runtime_metrics_enabled=' do
+    it 'changes the new #enabled setting' do
+      expect { settings.runtime_metrics_enabled = true }
+        .to change { settings.runtime_metrics.enabled }
+        .from(false)
+        .to(true)
+    end
+  end
+
+  describe '#sampling' do
+    describe '#rate_limit' do
+      subject(:rate_limit) { settings.sampling.rate_limit }
+
+      context 'default' do
+        it { is_expected.to be 100 }
+      end
+
+      context 'when ENV is provided' do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::Sampling::ENV_RATE_LIMIT => '20.0') do
+            example.run
+          end
+        end
+
+        it { is_expected.to eq(20.0) }
+      end
+    end
+
+    describe '#default_rate' do
+      subject(:default_rate) { settings.sampling.default_rate }
+
+      context 'default' do
+        it { is_expected.to be nil }
+      end
+
+      context 'when ENV is provided' do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::Sampling::ENV_SAMPLE_RATE => '0.5') do
+            example.run
+          end
+        end
+
+        it { is_expected.to eq(0.5) }
+      end
     end
   end
 
@@ -66,9 +365,7 @@ RSpec.describe Datadog::Configuration::Settings do
     context 'when given a value' do
       let(:service) { 'custom-service' }
       before { set_service }
-
       it { expect(settings.service).to eq(service) }
-      it { expect(settings.tracer.default_service).to eq(service) }
     end
   end
 
@@ -177,17 +474,13 @@ RSpec.describe Datadog::Configuration::Settings do
       context 'with Symbol keys' do
         let(:tags) { { :'custom-tag' => 'custom-value' } }
         before { set_tags }
-
         it { expect(settings.tags).to eq('custom-tag' => 'custom-value') }
-        it { expect(settings.tracer.tags).to include('custom-tag' => 'custom-value') }
       end
 
       context 'with String keys' do
         let(:tags) { { 'custom-tag' => 'custom-value' } }
         before { set_tags }
-
         it { expect(settings.tags).to eq(tags) }
-        it { expect(settings.tracer.tags).to include(tags) }
       end
     end
 
@@ -200,6 +493,339 @@ RSpec.describe Datadog::Configuration::Settings do
       before { set_tags }
 
       it { expect(settings.tags).to eq('foo' => 'oof', 'bar' => 'bar', 'baz' => 'baz') }
+    end
+  end
+
+  describe '#tracer' do
+    context 'old style' do
+      context 'given :debug' do
+        subject(:configure) { settings.tracer(debug: debug) }
+
+        shared_examples_for 'debug toggle' do
+          before { Datadog::Logger.debug_logging = !debug }
+          after { Datadog::Logger.debug_logging = false }
+
+          it do
+            expect { configure }.to change { Datadog::Logger.debug_logging }
+              .from(!debug)
+              .to(debug)
+          end
+        end
+
+        context 'as true' do
+          it_behaves_like 'debug toggle' do
+            let(:debug) { true }
+          end
+        end
+
+        context 'as false' do
+          it_behaves_like 'debug toggle' do
+            let(:debug) { false }
+          end
+        end
+      end
+
+      context 'given :env' do
+        let(:env) { 'my-env' }
+
+        it 'updates the new #env setting' do
+          expect { settings.tracer env: env }
+            .to change { settings.env }
+            .from(nil)
+            .to(env)
+        end
+      end
+
+      context 'given :log' do
+        let(:custom_log) { Logger.new(STDOUT, level: Logger::INFO) }
+
+        before do
+          @original_log = Datadog::Logger.log
+          settings.tracer(log: custom_log)
+        end
+
+        after do
+          Datadog::Logger.log = @original_log
+        end
+
+        it 'uses the logger for logging' do
+          expect(Datadog::Logger.log).to eq(custom_log)
+        end
+      end
+
+      describe 'given :min_spans_before_partial_flush' do
+        let(:value) { 1234 }
+
+        it 'updates the new #min_spans_threshold setting' do
+          expect { settings.tracer min_spans_before_partial_flush: value }
+            .to change { settings.tracer.partial_flush.min_spans_threshold }
+            .from(nil)
+            .to(value)
+        end
+      end
+
+      describe 'given :partial_flush' do
+        it 'updates the new #enabled setting' do
+          expect { settings.tracer partial_flush: true }
+            .to change { settings.tracer.partial_flush.enabled }
+            .from(false)
+            .to(true)
+        end
+      end
+
+      context 'given :tags' do
+        let(:tags) { { 'custom-tag' => 'custom-value' } }
+
+        it 'updates the new #tags setting' do
+          expect { settings.tracer tags: tags }
+            .to change { settings.tags }
+            .from({})
+            .to(tags)
+        end
+      end
+
+      context 'given :writer_options' do
+        before { settings.tracer(writer_options: { buffer_size: 1234 }) }
+
+        it 'updates the new #writer_options setting' do
+          expect(settings.tracer.writer_options).to eq(buffer_size: 1234)
+        end
+      end
+
+      context 'given some settings' do
+        let(:tracer) { Datadog::Tracer.new }
+
+        before do
+          settings.tracer(
+            enabled: false,
+            hostname: 'tracer.host.com',
+            port: 1234,
+            env: :config_test,
+            tags: { foo: :bar },
+            writer_options: { buffer_size: 1234 },
+            instance: tracer
+          )
+        end
+
+        after do
+          Datadog::Logger.debug_logging = false
+        end
+
+        it 'applies settings correctly' do
+          expect(settings.tracer.enabled).to be false
+          expect(settings.tracer.hostname).to eq('tracer.host.com')
+          expect(settings.tracer.port).to eq(1234)
+          expect(settings.env).to eq(:config_test)
+          expect(settings.tags['foo']).to eq(:bar)
+        end
+      end
+
+      it 'acts on the tracer option' do
+        previous_state = settings.tracer.enabled
+        settings.tracer(enabled: !previous_state)
+        expect(settings.tracer.enabled).to eq(!previous_state)
+        settings.tracer(enabled: previous_state)
+        expect(settings.tracer.enabled).to eq(previous_state)
+      end
+    end
+
+    describe '#enabled' do
+      subject(:enabled) { settings.tracer.enabled }
+      it { is_expected.to be true }
+    end
+
+    describe '#enabled=' do
+      it 'updates the #enabled setting' do
+        expect { settings.tracer.enabled = false }
+          .to change { settings.tracer.enabled }
+          .from(true)
+          .to(false)
+      end
+    end
+
+    describe '#hostname' do
+      subject(:hostname) { settings.tracer.hostname }
+      it { is_expected.to be nil }
+    end
+
+    describe '#hostname=' do
+      let(:hostname) { 'my-agent' }
+
+      it 'updates the #hostname setting' do
+        expect { settings.tracer.hostname = hostname }
+          .to change { settings.tracer.hostname }
+          .from(nil)
+          .to(hostname)
+      end
+    end
+
+    describe '#instance' do
+      subject(:instance) { settings.tracer.instance }
+      it { is_expected.to be nil }
+    end
+
+    describe '#instance=' do
+      let(:tracer) { instance_double(Datadog::Tracer) }
+
+      it 'updates the #instance setting' do
+        expect { settings.tracer.instance = tracer }
+          .to change { settings.tracer.instance }
+          .from(nil)
+          .to(tracer)
+      end
+    end
+
+    describe '#partial_flush' do
+      describe '#enabled' do
+        subject(:enabled) { settings.tracer.partial_flush.enabled }
+        it { is_expected.to be false }
+      end
+
+      describe '#enabled=' do
+        it 'updates the #enabled setting' do
+          expect { settings.tracer.partial_flush.enabled = true }
+            .to change { settings.tracer.partial_flush.enabled }
+            .from(false)
+            .to(true)
+        end
+      end
+
+      describe '#min_spans_threshold' do
+        subject(:min_spans_threshold) { settings.tracer.partial_flush.min_spans_threshold }
+        it { is_expected.to be nil }
+      end
+
+      describe '#min_spans_threshold=' do
+        let(:value) { 1234 }
+
+        it 'updates the #min_spans_before_partial_flush setting' do
+          expect { settings.tracer.partial_flush.min_spans_threshold = value }
+            .to change { settings.tracer.partial_flush.min_spans_threshold }
+            .from(nil)
+            .to(value)
+        end
+      end
+    end
+
+    describe '#port' do
+      subject(:port) { settings.tracer.port }
+      it { is_expected.to be nil }
+    end
+
+    describe '#port=' do
+      let(:port) { 1234 }
+
+      it 'updates the #port setting' do
+        expect { settings.tracer.port = port }
+          .to change { settings.tracer.port }
+          .from(nil)
+          .to(port)
+      end
+    end
+
+    describe '#priority_sampling' do
+      subject(:priority_sampling) { settings.tracer.priority_sampling }
+      it { is_expected.to be nil }
+    end
+
+    describe '#priority_sampling=' do
+      it 'updates the #priority_sampling setting' do
+        expect { settings.tracer.priority_sampling = true }
+          .to change { settings.tracer.priority_sampling }
+          .from(nil)
+          .to(true)
+      end
+    end
+
+    describe '#sampler' do
+      subject(:sampler) { settings.tracer.sampler }
+      it { is_expected.to be nil }
+    end
+
+    describe '#sampler=' do
+      let(:sampler) { instance_double(Datadog::PrioritySampler) }
+
+      it 'updates the #sampler setting' do
+        expect { settings.tracer.sampler = sampler }
+          .to change { settings.tracer.sampler }
+          .from(nil)
+          .to(sampler)
+      end
+    end
+
+    describe '#transport_options' do
+      subject(:transport_options) { settings.tracer.transport_options }
+      it { is_expected.to eq({}) }
+
+      context 'when modified' do
+        it 'does not modify the default by reference' do
+          settings.tracer.transport_options[:foo] = :bar
+          expect(settings.tracer.transport_options).to_not be_empty
+          expect(settings.tracer.options[:transport_options].default_value).to be_empty
+        end
+      end
+    end
+
+    describe '#transport_options=' do
+      let(:options) { { hostname: 'my-agent' } }
+
+      it 'updates the #transport_options setting' do
+        expect { settings.tracer.transport_options = options }
+          .to change { settings.tracer.transport_options }
+          .from({})
+          .to(options)
+      end
+    end
+
+    describe '#writer' do
+      subject(:writer) { settings.tracer.writer }
+      it { is_expected.to be nil }
+    end
+
+    describe '#writer=' do
+      let(:writer) { instance_double(Datadog::Writer) }
+
+      it 'updates the #writer setting' do
+        expect { settings.tracer.writer = writer }
+          .to change { settings.tracer.writer }
+          .from(nil)
+          .to(writer)
+      end
+    end
+
+    describe '#writer_options' do
+      subject(:writer_options) { settings.tracer.writer_options }
+      it { is_expected.to eq({}) }
+
+      context 'when modified' do
+        it 'does not modify the default by reference' do
+          settings.tracer.writer_options[:foo] = :bar
+          expect(settings.tracer.writer_options).to_not be_empty
+          expect(settings.tracer.options[:writer_options].default_value).to be_empty
+        end
+      end
+    end
+
+    describe '#writer_options=' do
+      let(:options) { { priority_sampling: true } }
+
+      it 'updates the #writer_options setting' do
+        expect { settings.tracer.writer_options = options }
+          .to change { settings.tracer.writer_options }
+          .from({})
+          .to(options)
+      end
+    end
+  end
+
+  describe '#tracer=' do
+    subject(:set_tracer) { settings.tracer = tracer }
+    let(:tracer) { instance_double(Datadog::Tracer) }
+
+    it 'sets the tracer instance' do
+      expect { set_tracer }.to change { settings.tracer.instance }
+        .from(nil)
+        .to(tracer)
     end
   end
 
@@ -230,137 +856,7 @@ RSpec.describe Datadog::Configuration::Settings do
     context 'when given a value' do
       let(:version) { '0.1.0.alpha' }
       before { set_version }
-
       it { expect(settings.version).to eq(version) }
-      it { expect(settings.tracer.tags).to include('version' => version) }
-    end
-  end
-
-  describe '#sampling' do
-    describe '#rate_limit' do
-      subject(:rate_limit) { settings.sampling.rate_limit }
-
-      context 'default' do
-        it { is_expected.to be 100 }
-      end
-
-      context 'when ENV is provided' do
-        around do |example|
-          ClimateControl.modify(Datadog::Ext::Sampling::ENV_RATE_LIMIT => '20.0') do
-            example.run
-          end
-        end
-
-        it { is_expected.to eq(20.0) }
-      end
-    end
-
-    describe '#default_rate' do
-      subject(:default_rate) { settings.sampling.default_rate }
-
-      context 'default' do
-        it { is_expected.to be nil }
-      end
-
-      context 'when ENV is provided' do
-        around do |example|
-          ClimateControl.modify(Datadog::Ext::Sampling::ENV_SAMPLE_RATE => '0.5') do
-            example.run
-          end
-        end
-
-        it { is_expected.to eq(0.5) }
-      end
-    end
-  end
-
-  describe '#tracer' do
-    context 'given :log' do
-      let(:custom_log) { Logger.new(STDOUT, level: Logger::INFO) }
-
-      before do
-        @original_log = Datadog::Logger.log
-        settings.tracer(log: custom_log)
-      end
-
-      after do
-        Datadog::Logger.log = @original_log
-      end
-
-      it 'uses the logger for logging' do
-        expect(Datadog::Logger.log).to eq(custom_log)
-      end
-    end
-
-    context 'given :debug' do
-      subject(:configure) { settings.tracer(debug: debug) }
-
-      shared_examples_for 'debug toggle' do
-        before { Datadog::Logger.debug_logging = !debug }
-        after { Datadog::Logger.debug_logging = false }
-
-        it do
-          expect { configure }.to change { Datadog::Logger.debug_logging }
-            .from(!debug)
-            .to(debug)
-        end
-      end
-
-      context 'as true' do
-        it_behaves_like 'debug toggle' do
-          let(:debug) { true }
-        end
-      end
-
-      context 'as false' do
-        it_behaves_like 'debug toggle' do
-          let(:debug) { false }
-        end
-      end
-    end
-
-    context 'given some settings' do
-      let(:tracer) { Datadog::Tracer.new }
-
-      before do
-        settings.tracer(
-          enabled: false,
-          hostname: 'tracer.host.com',
-          port: 1234,
-          env: :config_test,
-          tags: { foo: :bar },
-          writer_options: { buffer_size: 1234 },
-          instance: tracer
-        )
-      end
-
-      after do
-        Datadog::Logger.debug_logging = false
-      end
-
-      it 'applies settings correctly' do
-        expect(tracer.enabled).to be false
-        expect(tracer.writer.transport.current_api.adapter.hostname).to eq('tracer.host.com')
-        expect(tracer.writer.transport.current_api.adapter.port).to eq(1234)
-        expect(tracer.tags['env']).to eq(:config_test)
-        expect(tracer.tags['foo']).to eq(:bar)
-      end
-    end
-
-    context 'given :writer_options' do
-      before { settings.tracer(writer_options: { buffer_size: 1234 }) }
-
-      it 'applies settings correctly' do
-        expect(settings.tracer.writer.instance_variable_get(:@buff_size)).to eq(1234)
-      end
-    end
-
-    it 'acts on the tracer option' do
-      previous_state = settings.tracer.enabled
-      settings.tracer(enabled: !previous_state)
-      expect(settings.tracer.enabled).to eq(!previous_state)
-      settings.tracer(enabled: previous_state)
-      expect(settings.tracer.enabled).to eq(previous_state)
     end
   end
 end

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -61,11 +61,52 @@ RSpec.describe Datadog::Configuration::Settings do
 
   describe '#diagnostics' do
     describe '#health_metrics' do
-      # TODO
-    end
+      describe '#enabled' do
+        subject(:enabled) { settings.diagnostics.health_metrics.enabled }
 
-    describe '#health_metrics=' do
-      # TODO
+        context "when #{Datadog::Ext::Diagnostics::Health::Metrics::ENV_ENABLED}" do
+          around do |example|
+            ClimateControl.modify(Datadog::Ext::Diagnostics::Health::Metrics::ENV_ENABLED => environment) do
+              example.run
+            end
+          end
+
+          context 'is not defined' do
+            let(:environment) { nil }
+            it { is_expected.to be false }
+          end
+
+          context 'is defined' do
+            let(:environment) { 'true' }
+            it { is_expected.to be true }
+          end
+        end
+      end
+
+      describe '#enabled=' do
+        it 'changes the #enabled setting' do
+          expect { settings.diagnostics.health_metrics.enabled = true }
+            .to change { settings.diagnostics.health_metrics.enabled }
+            .from(false)
+            .to(true)
+        end
+      end
+
+      describe '#statsd' do
+        subject(:statsd) { settings.diagnostics.health_metrics.statsd }
+        it { is_expected.to be nil }
+      end
+
+      describe '#statsd=' do
+        let(:statsd) { double('statsd') }
+
+        it 'changes the #statsd setting' do
+          expect { settings.diagnostics.health_metrics.statsd = statsd }
+            .to change { settings.diagnostics.health_metrics.statsd }
+            .from(nil)
+            .to(statsd)
+        end
+      end
     end
   end
 

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -62,14 +62,45 @@ RSpec.describe Datadog::Configuration do
         let(:new_statsd) { instance_double(Datadog::Statsd) }
 
         before do
-          expect(old_statsd).to receive(:close)
+          expect(old_statsd).to receive(:close).once
 
-          test_class.configure { |c| c.runtime_metrics.statsd = old_statsd }
-          test_class.configure { |c| c.runtime_metrics.statsd = new_statsd }
+          test_class.configure do |c|
+            c.runtime_metrics.statsd = old_statsd
+            c.diagnostics.health_metrics.statsd = old_statsd
+          end
+
+          test_class.configure do |c|
+            c.runtime_metrics.statsd = new_statsd
+            c.diagnostics.health_metrics.statsd = new_statsd
+          end
         end
 
         it 'replaces the old Statsd and closes it' do
           expect(test_class.runtime_metrics.statsd).to be new_statsd
+          expect(test_class.health_metrics.statsd).to be new_statsd
+        end
+      end
+
+      context 'when replacing one of the metrics' do
+        let(:old_statsd) { instance_double(Datadog::Statsd) }
+        let(:new_statsd) { instance_double(Datadog::Statsd) }
+
+        before do
+          expect(old_statsd).to_not receive(:close)
+
+          test_class.configure do |c|
+            c.runtime_metrics.statsd = old_statsd
+            c.diagnostics.health_metrics.statsd = old_statsd
+          end
+
+          test_class.configure do |c|
+            c.runtime_metrics.statsd = new_statsd
+          end
+        end
+
+        it 'replaces the old Statsd and closes it' do
+          expect(test_class.runtime_metrics.statsd).to be new_statsd
+          expect(test_class.health_metrics.statsd).to be old_statsd
         end
       end
 
@@ -79,8 +110,15 @@ RSpec.describe Datadog::Configuration do
         before do
           expect(statsd).to_not receive(:close)
 
-          test_class.configure { |c| c.runtime_metrics.statsd = statsd }
-          test_class.configure { |c| c.runtime_metrics.statsd = statsd }
+          test_class.configure do |c|
+            c.runtime_metrics.statsd = statsd
+            c.diagnostics.health_metrics.statsd = statsd
+          end
+
+          test_class.configure do |c|
+            c.runtime_metrics.statsd = statsd
+            c.diagnostics.health_metrics.statsd = statsd
+          end
         end
 
         it 'replaces the old Statsd and closes it' do
@@ -94,7 +132,11 @@ RSpec.describe Datadog::Configuration do
         before do
           expect(statsd).to_not receive(:close)
 
-          test_class.configure { |c| c.runtime_metrics.statsd = statsd }
+          test_class.configure do |c|
+            c.runtime_metrics.statsd = statsd
+            c.diagnostics.health_metrics.statsd = statsd
+          end
+
           test_class.configure { |_c| }
         end
 

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+require 'datadog/statsd'
 require 'ddtrace/patcher'
 require 'ddtrace/configuration'
 
@@ -9,6 +10,98 @@ RSpec.describe Datadog::Configuration do
 
     describe '#configure' do
       subject(:configure) { test_class.configure }
+
+      context 'when replacing a tracer' do
+        let(:old_tracer) { Datadog::Tracer.new }
+        let(:new_tracer) { Datadog::Tracer.new }
+
+        before do
+          expect(old_tracer).to receive(:shutdown!)
+
+          test_class.configure { |c| c.tracer = old_tracer }
+          test_class.configure { |c| c.tracer = new_tracer }
+        end
+
+        it 'replaces the old tracer and shuts it down' do
+          expect(test_class.tracer).to be new_tracer
+        end
+      end
+
+      context 'when reusing the same tracer' do
+        let(:tracer) { Datadog::Tracer.new }
+
+        before do
+          expect(tracer).to_not receive(:shutdown!)
+
+          test_class.configure { |c| c.tracer = tracer }
+          test_class.configure { |c| c.tracer = tracer }
+        end
+
+        it 'replaces the old tracer and shuts it down' do
+          expect(test_class.tracer).to be tracer
+        end
+      end
+
+      context 'when not changing the tracer' do
+        let(:tracer) { Datadog::Tracer.new }
+
+        before do
+          expect(tracer).to_not receive(:shutdown!)
+
+          test_class.configure { |c| c.tracer = tracer }
+          test_class.configure { |_c| }
+        end
+
+        it 'replaces the old tracer and shuts it down' do
+          expect(test_class.tracer).to be tracer
+        end
+      end
+
+      context 'when replacing metrics' do
+        let(:old_statsd) { instance_double(Datadog::Statsd) }
+        let(:new_statsd) { instance_double(Datadog::Statsd) }
+
+        before do
+          expect(old_statsd).to receive(:close)
+
+          test_class.configure { |c| c.runtime_metrics.statsd = old_statsd }
+          test_class.configure { |c| c.runtime_metrics.statsd = new_statsd }
+        end
+
+        it 'replaces the old Statsd and closes it' do
+          expect(test_class.runtime_metrics.statsd).to be new_statsd
+        end
+      end
+
+      context 'when reusing metrics' do
+        let(:statsd) { instance_double(Datadog::Statsd) }
+
+        before do
+          expect(statsd).to_not receive(:close)
+
+          test_class.configure { |c| c.runtime_metrics.statsd = statsd }
+          test_class.configure { |c| c.runtime_metrics.statsd = statsd }
+        end
+
+        it 'replaces the old Statsd and closes it' do
+          expect(test_class.runtime_metrics.statsd).to be statsd
+        end
+      end
+
+      context 'when not changing the metrics' do
+        let(:statsd) { instance_double(Datadog::Statsd) }
+
+        before do
+          expect(statsd).to_not receive(:close)
+
+          test_class.configure { |c| c.runtime_metrics.statsd = statsd }
+          test_class.configure { |_c| }
+        end
+
+        it 'replaces the old Statsd and closes it' do
+          expect(test_class.runtime_metrics.statsd).to be statsd
+        end
+      end
     end
   end
 end

--- a/spec/ddtrace/contrib/analytics_examples.rb
+++ b/spec/ddtrace/contrib/analytics_examples.rb
@@ -176,8 +176,8 @@ RSpec.shared_examples_for 'analytics for integration' do |options = { ignore_glo
 
         context 'is explicitly enabled' do
           around do |example|
-            Datadog.configuration.analytics_enabled = Datadog.configuration.analytics_enabled.tap do
-              Datadog.configuration.analytics_enabled = true
+            Datadog.configuration.analytics.enabled = Datadog.configuration.analytics.enabled.tap do
+              Datadog.configuration.analytics.enabled = true
               example.run
             end
           end
@@ -187,8 +187,8 @@ RSpec.shared_examples_for 'analytics for integration' do |options = { ignore_glo
 
         context 'is explicitly disabled' do
           around do |example|
-            Datadog.configuration.analytics_enabled = Datadog.configuration.analytics_enabled.tap do
-              Datadog.configuration.analytics_enabled = false
+            Datadog.configuration.analytics.enabled = Datadog.configuration.analytics.enabled.tap do
+              Datadog.configuration.analytics.enabled = false
               example.run
             end
           end
@@ -220,8 +220,8 @@ RSpec.shared_examples_for 'analytics for integration' do |options = { ignore_glo
 
         context 'is explicitly enabled' do
           around do |example|
-            Datadog.configuration.analytics_enabled = Datadog.configuration.analytics_enabled.tap do
-              Datadog.configuration.analytics_enabled = true
+            Datadog.configuration.analytics.enabled = Datadog.configuration.analytics.enabled.tap do
+              Datadog.configuration.analytics.enabled = true
               example.run
             end
           end
@@ -231,8 +231,8 @@ RSpec.shared_examples_for 'analytics for integration' do |options = { ignore_glo
 
         context 'is explicitly disabled' do
           around do |example|
-            Datadog.configuration.analytics_enabled = Datadog.configuration.analytics_enabled.tap do
-              Datadog.configuration.analytics_enabled = false
+            Datadog.configuration.analytics.enabled = Datadog.configuration.analytics.enabled.tap do
+              Datadog.configuration.analytics.enabled = false
               example.run
             end
           end

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -623,72 +623,58 @@ RSpec.describe 'Tracer integration tests' do
     end
   end
 
-  describe 'trace writer runtime metrics configuration' do
+  describe 'writer runtime metrics configuration' do
     let(:hostname) { double('example_hostname') }
-    let(:base_namespace) { 'original_example_namespace' }
-    let(:updated_namespace) { 'updated_example_namespace' }
-    let(:statsd_client) { Datadog::Statsd.new(hostname, 8125, tags: [], namespace: base_namespace) }
-    let(:statsd_client_updated) { Datadog::Statsd.new(hostname, 8125, tags: [], namespace: updated_namespace) }
-    let(:transport) { Datadog::Transport::HTTP.default }
+    let(:statsd) { Datadog::Statsd.new(hostname, 8125) }
 
-    let(:writer_without_runtime) do
-      Datadog::Writer.new(
-        transport: transport,
-        priority_sampler: Datadog::PrioritySampler.new
-      )
-    end
+    after { statsd.close }
 
-    let(:writer_with_runtime) do
-      Datadog::Writer.new(
-        transport: transport,
-        priority_sampler: Datadog::PrioritySampler.new,
-        runtime_metrics: Datadog::Runtime::Metrics.new(statsd: statsd_client_updated)
-      )
-    end
+    context 'when tracer and runtime metrics are configured' do
+      context 'without a writer' do
+        before do
+          Datadog.configure do |c|
+            c.runtime_metrics statsd: statsd
+            c.tracer host: hostname
+          end
+        end
 
-    after(:each) do
-      statsd_client.close
-      statsd_client_updated.close
-    end
-
-    it 'should propogate runtime metrics configuration to the new writer when rebuilt' do
-      Datadog.configure do |c|
-        c.runtime_metrics_enabled
-        c.runtime_metrics statsd: statsd_client
-        c.tracer host: hostname
+        it { expect(Datadog.runtime_metrics.statsd).to be(statsd) }
       end
 
-      expect(Datadog.tracer.writer.runtime_metrics.statsd.namespace).to eq(base_namespace)
-    end
+      context 'with a writer' do
+        let(:writer_runtime_metrics) { Datadog::Runtime::Metrics.new }
+        let(:writer) do
+          Datadog::Writer.new(
+            transport: Datadog::Transport::HTTP.default,
+            priority_sampler: Datadog::PrioritySampler.new,
+            runtime_metrics: Datadog::Runtime::Metrics.new
+          )
+        end
 
-    it 'should set runtime metrics configuration regardless of order' do
-      Datadog.configure do |c|
-        c.runtime_metrics_enabled
-        c.tracer host: hostname, writer: writer_without_runtime
-        c.runtime_metrics statsd: statsd_client
+        after { writer_runtime_metrics.statsd.close }
+
+        context '(writer first then runtime metrics)' do
+          before do
+            Datadog.configure do |c|
+              c.tracer host: hostname, writer: writer
+              c.runtime_metrics statsd: statsd
+            end
+          end
+
+          it { expect(Datadog.runtime_metrics.statsd).to be(statsd) }
+        end
+
+        context '(runtime metrics first then writer)' do
+          before do
+            Datadog.configure do |c|
+              c.runtime_metrics statsd: statsd
+              c.tracer host: hostname, writer: writer
+            end
+          end
+
+          it { expect(Datadog.runtime_metrics.statsd).to be(statsd) }
+        end
       end
-
-      expect(Datadog.tracer.writer.runtime_metrics.statsd.namespace).to eq(base_namespace)
-    end
-
-    it 'should use new writer runtime metric configuration when available' do
-      Datadog.configure do |c|
-        c.runtime_metrics_enabled
-        c.runtime_metrics statsd: statsd_client
-        c.tracer host: hostname, writer: writer_with_runtime
-      end
-
-      expect(Datadog.tracer.writer.runtime_metrics.statsd.namespace).to eq(updated_namespace)
-    end
-
-    it 'should prioritize default writer runtime metric configuration when any writer is configured' do
-      Datadog.configure do |c|
-        c.runtime_metrics_enabled
-        c.runtime_metrics statsd: statsd_client
-        c.tracer host: hostname, writer: writer_without_runtime
-      end
-
-      expect(Datadog.tracer.writer.runtime_metrics.statsd.namespace).to eq(nil)
     end
   end
 end

--- a/spec/ddtrace/span_spec.rb
+++ b/spec/ddtrace/span_spec.rb
@@ -52,20 +52,9 @@ RSpec.describe Datadog::Span do
         it { is_expected.to eq service_value }
       end
 
-      context 'is only defined in the configuration' do
-        let(:env_service) { 'env-service' }
-        before { allow(Datadog.configuration).to receive(:service).and_return(env_service) }
-        it { is_expected.to eq env_service }
-      end
-
-      context 'is not set anywhere' do
+      context 'is not set' do
         let(:default_service) { 'default-service' }
-
-        before do
-          allow(Datadog.configuration).to receive(:service).and_return(nil)
-          allow(tracer).to receive(:default_service).and_return(default_service)
-        end
-
+        before { allow(tracer).to receive(:default_service).and_return(default_service) }
         it { is_expected.to eq default_service }
       end
     end

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Datadog::Tracer do
     before { allow(Datadog.configuration).to receive(:tags).and_return(env_tags) }
 
     context 'by default' do
-      it { is_expected.to be env_tags }
+      it { is_expected.to eq env_tags }
     end
 
     context 'when equivalent String and Symbols are added' do

--- a/spec/ddtrace/transport/http/client_spec.rb
+++ b/spec/ddtrace/transport/http/client_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Datadog::Transport::HTTP::Client do
     let(:response_class) { stub_const('TestResponse', Class.new { include Datadog::Transport::HTTP::Response }) }
     let(:response) { instance_double(response_class, code: double('status code')) }
 
-    before { allow(Datadog::Diagnostics::Health.metrics).to receive(:send_metrics) }
+    before { allow(Datadog.health_metrics).to receive(:send_metrics) }
 
     context 'given a block' do
       let(:handler) { double }

--- a/spec/ddtrace/transport/statistics_spec.rb
+++ b/spec/ddtrace/transport/statistics_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Datadog::Transport::Statistics do
       subject(:update) { object.update_stats_from_response!(response) }
       let(:response) { instance_double(Datadog::Transport::Response) }
 
-      before { allow(Datadog::Diagnostics::Health.metrics).to receive(:send_metrics) }
+      before { allow(Datadog.health_metrics).to receive(:send_metrics) }
 
       context 'when the response' do
         context 'is OK' do
@@ -35,7 +35,7 @@ RSpec.describe Datadog::Transport::Statistics do
             expect(object.stats.internal_error).to eq(0)
             expect(object.stats.consecutive_errors).to eq(0)
 
-            expect(Datadog::Diagnostics::Health.metrics).to have_received(:send_metrics) do |metrics|
+            expect(Datadog.health_metrics).to have_received(:send_metrics) do |metrics|
               expect(metrics).to be_a_kind_of(Array)
               expect(metrics).to have(1).item
               expect(metrics).to include(kind_of(Datadog::Metrics::Metric))
@@ -64,7 +64,7 @@ RSpec.describe Datadog::Transport::Statistics do
             expect(object.stats.internal_error).to eq(0)
             expect(object.stats.consecutive_errors).to eq(1)
 
-            expect(Datadog::Diagnostics::Health.metrics).to have_received(:send_metrics) do |metrics|
+            expect(Datadog.health_metrics).to have_received(:send_metrics) do |metrics|
               expect(metrics).to be_a_kind_of(Array)
               expect(metrics).to have(1).item
               expect(metrics).to include(kind_of(Datadog::Metrics::Metric))
@@ -93,7 +93,7 @@ RSpec.describe Datadog::Transport::Statistics do
             expect(object.stats.internal_error).to eq(0)
             expect(object.stats.consecutive_errors).to eq(1)
 
-            expect(Datadog::Diagnostics::Health.metrics).to have_received(:send_metrics) do |metrics|
+            expect(Datadog.health_metrics).to have_received(:send_metrics) do |metrics|
               expect(metrics).to be_a_kind_of(Array)
               expect(metrics).to have(1).item
               expect(metrics).to include(kind_of(Datadog::Metrics::Metric))
@@ -122,7 +122,7 @@ RSpec.describe Datadog::Transport::Statistics do
             expect(object.stats.internal_error).to eq(1)
             expect(object.stats.consecutive_errors).to eq(1)
 
-            expect(Datadog::Diagnostics::Health.metrics).to have_received(:send_metrics) do |metrics|
+            expect(Datadog.health_metrics).to have_received(:send_metrics) do |metrics|
               expect(metrics).to be_a_kind_of(Array)
               expect(metrics).to have(1).item
               expect(metrics).to include(kind_of(Datadog::Metrics::Metric))
@@ -226,7 +226,7 @@ RSpec.describe Datadog::Transport::Statistics do
       subject(:update) { object.update_stats_from_exception!(exception) }
       let(:exception) { instance_double(StandardError) }
 
-      before { allow(Datadog::Diagnostics::Health.metrics).to receive(:send_metrics) }
+      before { allow(Datadog.health_metrics).to receive(:send_metrics) }
 
       it do
         update
@@ -236,7 +236,7 @@ RSpec.describe Datadog::Transport::Statistics do
         expect(object.stats.internal_error).to eq(1)
         expect(object.stats.consecutive_errors).to eq(1)
 
-        expect(Datadog::Diagnostics::Health.metrics).to have_received(:send_metrics) do |metrics|
+        expect(Datadog.health_metrics).to have_received(:send_metrics) do |metrics|
           expect(metrics).to be_a_kind_of(Array)
           expect(metrics).to have(1).item
           expect(metrics).to include(kind_of(Datadog::Metrics::Metric))

--- a/spec/support/health_metric_helpers.rb
+++ b/spec/support/health_metric_helpers.rb
@@ -40,7 +40,7 @@ module HealthMetricHelpers
   shared_context 'health metrics' do
     include_context 'metrics'
 
-    let(:health_metrics) { Datadog::Diagnostics::Health.metrics }
+    let(:health_metrics) { Datadog.health_metrics }
     before { METRICS.each { |metric, _attrs| allow(health_metrics).to receive(metric) } }
 
     def have_received_lazy_health_metric(metric, *expected_args)


### PR DESCRIPTION
Currently our configuration settings and tracer components (`Tracer`, `RuntimeMetrics`, etc) are mutable which makes state management cumbersome and can result in some undesirable side effects when reconfigured.

In this pull request, we'd like to address some of these issues by moving towards an immutable configuration model, where tracer components are not mutated, but recreated. This should make state management of tracer components simpler and consistent.

In practice:

1. Users configure the application with `Datadog.configure { |c| #... }` and apply the settings they desire, which mutates the `Datadog.configuration` settings object.
2. When `Datadog.configure` block completes, it creates a `Components` object from the settings, which contains all the major components used by the tracer (e.g. `Tracer`, `HealthMetrics`, etc.)
3. The old `Components` are torn down (e.g. clean up threads, etc), then replaced by the new `Components` instance.
4. Trace components become available through helper methods e.g. `Datadog.tracer` for use.

To accomplish this, it requires moving a lot of parts around, including that used to be inside `Datadog::Configuration::Settings` to `Datadog::Configuration::Components`, including:

 - `Tracer`, `RuntimeMetrics`, `HealthMetrics` from `Datadog::Configuration::Settings` to `Datadog::Configuration::Components`
 - Changing a number of old configuration settings to new ones (these will be deprecated in the future):
   - `c.tracer { enabled: true, ... }` --> `c.tracer.enabled = true` and more.
   - `c.runtime_metrics { enabled: true, ... }` --> `c.runtime_metrics.enabled = true` and more.
   - `c.analytics_enabled = true` --> `c.analytics.enabled = true`
 - Backfilling a lot of configuration tests