### PR TITLE
Revert Rails default env

### DIFF
--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -35,16 +35,9 @@ module Datadog
           # Don't set this if service has been explicitly provided by the user.
           Datadog.configuration.service ||= config[:service_name]
 
-          # Set the environment to the Rails environment.
-          # Don't set this if env has been explicitly provided by the user.
-          Datadog.configuration.env ||= ::Rails.env if ::Rails.respond_to?(:env)
-
           # Update the tracer if its not the default tracer.
           if config[:tracer] != Datadog.configuration.tracer
             config[:tracer].default_service = config[:service_name]
-
-            env = Datadog.configuration.env || (::Rails.respond_to?(:env) && ::Rails.env)
-            config[:tracer].set_tags('env' => env) if env
           end
         end
 

--- a/spec/ddtrace/contrib/rails/defaults_spec.rb
+++ b/spec/ddtrace/contrib/rails/defaults_spec.rb
@@ -49,42 +49,4 @@ RSpec.describe 'Rails defaults' do
       end
     end
   end
-
-  context 'when Datadog.configuration.env' do
-    before do
-      skip('Rails#env is not defined.') unless Rails.respond_to?(:env)
-      Datadog.configuration.env = default_env
-      app
-    end
-
-    after { Datadog.configuration.env = nil }
-
-    context 'is not configured' do
-      let(:default_env) { nil }
-
-      describe 'Datadog.configuration.env' do
-        subject(:global_default_env) { Datadog.configuration.env }
-        it { expect(global_default_env).to eq Rails.env }
-      end
-
-      describe 'Tracer#tags' do
-        subject(:tracer_tags) { Datadog.configuration[:rails].tracer.tags }
-        it { expect(tracer_tags).to include('env' => Rails.env) }
-      end
-    end
-
-    context 'is configured' do
-      let(:default_env) { 'default-env' }
-
-      describe 'Datadog.configuration.env' do
-        subject(:global_default_env) { Datadog.configuration.env }
-        it { expect(global_default_env).to eq default_env }
-      end
-
-      describe 'Tracer#tags' do
-        subject(:tracer_tags) { Datadog.configuration[:rails].tracer.tags }
-        it { expect(tracer_tags).to include('env' => default_env) }
-      end
-    end
-  end
 end


### PR DESCRIPTION
Introduced via #990, the Rails integration was auto-setting `env` to the Rails env as a default when no setting was provided. This had the unintended consequence of overriding `env` tags set explicitly through other means, and configuration at the agent level. This pull request reverts this behavior, leaving the `env` untouched.