### PR TITLE
Clear wording Faraday default integration

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -771,7 +771,7 @@ Datadog.configure do |c|
   end
 end
 
-# Configure Faraday tracing behavior for single connection
+# In case you want to override the global configuration for a certain client instance
 connection = Faraday.new('https://example.com') do |builder|
   builder.use(:ddtrace, options)
   builder.adapter Faraday.default_adapter


### PR DESCRIPTION
This PR makes it more clear that configuring each Faraday connection is not necessary anymore.

Because this was necessary in past versions, our documentation still had language that suggested this is still necessary.

The language used to explain how to override is the same we use when documenting our MongoDB integration overrides.
