### PR TITLE
Restore gRPC testing for Ruby 2.7

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -916,7 +916,7 @@ elsif Gem::Version.new('2.7.0') <= Gem::Version.new(RUBY_VERSION)
       gem 'excon'
       gem 'grape'
       gem 'graphql'
-      # gem 'grpc' # Pending 2.7 support: https://github.com/grpc/grpc/issues/21514
+      gem 'grpc'
       gem 'hiredis'
       gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby

--- a/Rakefile
+++ b/Rakefile
@@ -678,7 +678,7 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:faraday'
       sh 'bundle exec appraisal contrib rake spec:grape'
       sh 'bundle exec appraisal contrib rake spec:graphql'
-      # sh 'bundle exec appraisal contrib rake spec:grpc' # Pending 2.7 support: https://github.com/grpc/grpc/issues/21514
+      sh 'bundle exec appraisal contrib rake spec:grpc'
       sh 'bundle exec appraisal contrib rake spec:http'
       sh 'bundle exec appraisal contrib rake spec:mongodb'
       sh 'bundle exec appraisal contrib rake spec:mysql2'


### PR DESCRIPTION
Support for Ruby 2.7 has been added to [gRPC 1.28.0](https://github.com/grpc/grpc/releases/tag/v1.28.0).

This allows us to re-enable our gRPC CI tests for Ruby 2.7.