### PR TITLE
Don't show env/version when they are empty

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1977,12 +1977,12 @@ To properly correlate with Datadog logging, be sure the following is present in 
 
  - `dd.trace_id=<TRACE_ID>`: Where `<TRACE_ID>` is equal to `Datadog.tracer.active_correlation.trace_id` or `0` if no trace is active during logging.
  - `dd.span_id=<SPAN_ID>`: Where `<SPAN_ID>` is equal to `Datadog.tracer.active_correlation.span_id` or `0` if no trace is active during logging.
- - `dd.env=<ENV>`: Where `<ENV>` is equal to `Datadog.tracer.active_correlation.env` or empty string (no quotes) if no environment name is configured.
- - `dd.version=<SPAN_ID>`: Where `<SPAN_ID>` is equal to `Datadog.tracer.active_correlation.version` or empty string (no quotes) if no application version is configured.
+ - `dd.env=<ENV>`: Where `<ENV>` is equal to `Datadog.tracer.active_correlation.env`. If no environment name is configured, `dd.env=` will not appear in correlation ID.
+ - `dd.version=<SPAN_ID>`: Where `<SPAN_ID>` is equal to `Datadog.tracer.active_correlation.version`. If no application version is configured, `dd.version=` will not appear in correlation ID.
 
 By default, `Datadog::Correlation::Identifier#to_s` will return `dd.trace_id=<TRACE_ID> dd.span_id=<SPAN_ID> dd.env=<ENV> dd.version=<VERSION>`.
 
-If a trace is not active and the application environment & version is not configured, it will return `dd.trace_id=0 dd.span_id=0 dd.env= dd.version=`.
+If a trace is not active, and the application environment and version are not configured, it will return `dd.trace_id=0 dd.span_id=0`.
 
 An example of this in practice:
 

--- a/lib/ddtrace/correlation.rb
+++ b/lib/ddtrace/correlation.rb
@@ -18,8 +18,8 @@ module Datadog
       def to_s
         str =  "#{Ext::Correlation::ATTR_TRACE_ID}=#{trace_id}"
         str += " #{Ext::Correlation::ATTR_SPAN_ID}=#{span_id}"
-        str += " #{Ext::Correlation::ATTR_ENV}=#{env}"
-        str += " #{Ext::Correlation::ATTR_VERSION}=#{version}"
+        str += " #{Ext::Correlation::ATTR_ENV}=#{env}" if env
+        str += " #{Ext::Correlation::ATTR_VERSION}=#{version}" if version
         str
       end
     end.freeze

--- a/spec/ddtrace/correlation_spec.rb
+++ b/spec/ddtrace/correlation_spec.rb
@@ -31,8 +31,22 @@ RSpec.describe Datadog::Correlation do
         it { expect(correlation_ids.version).to eq version }
         it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_TRACE_ID}=0") }
         it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_SPAN_ID}=0") }
+      end
+
+      shared_examples_for 'a correlation identifier with DD_ENV' do
         it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_ENV}=#{environment}") }
+      end
+
+      shared_examples_for 'a correlation identifier without DD_ENV' do
+        it { expect(correlation_ids.to_s).to_not have_attribute("#{Datadog::Ext::Correlation::ATTR_ENV}=#{environment}") }
+      end
+
+      shared_examples_for 'a correlation identifier with DD_VERSION' do
         it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_VERSION}=#{version}") }
+      end
+
+      shared_examples_for 'a correlation identifier without DD_VERSION' do
+        it { expect(correlation_ids.to_s).to_not have_attribute("#{Datadog::Ext::Correlation::ATTR_VERSION}=#{version}") }
       end
 
       it_behaves_like 'an empty correlation identifier'
@@ -40,11 +54,15 @@ RSpec.describe Datadog::Correlation do
       context 'after Datadog::Environment::env has changed' do
         let(:environment) { 'my-env' }
         it_behaves_like 'an empty correlation identifier'
+        it_behaves_like 'a correlation identifier with DD_ENV'
+        it_behaves_like 'a correlation identifier without DD_VERSION'
       end
 
       context 'after Datadog::Environment::version has changed' do
         let(:version) { 'my-version' }
         it_behaves_like 'an empty correlation identifier'
+        it_behaves_like 'a correlation identifier without DD_ENV'
+        it_behaves_like 'a correlation identifier with DD_VERSION'
       end
     end
 
@@ -68,8 +86,22 @@ RSpec.describe Datadog::Correlation do
         it { expect(correlation_ids.version).to eq version }
         it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_TRACE_ID}=#{trace_id}") }
         it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_SPAN_ID}=#{span_id}") }
+      end
+
+      shared_examples_for 'a correlation identifier with DD_ENV' do
         it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_ENV}=#{environment}") }
+      end
+
+      shared_examples_for 'a correlation identifier without DD_ENV' do
+        it { expect(correlation_ids.to_s).to_not have_attribute("#{Datadog::Ext::Correlation::ATTR_ENV}=#{environment}") }
+      end
+
+      shared_examples_for 'a correlation identifier with DD_VERSION' do
         it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_VERSION}=#{version}") }
+      end
+
+      shared_examples_for 'a correlation identifier without DD_VERSION' do
+        it { expect(correlation_ids.to_s).to_not have_attribute("#{Datadog::Ext::Correlation::ATTR_VERSION}=#{version}") }
       end
 
       it_behaves_like 'a correlation identifier with basic properties'
@@ -78,11 +110,15 @@ RSpec.describe Datadog::Correlation do
         context 'is not defined' do
           let(:environment) { nil }
           it_behaves_like 'a correlation identifier with basic properties'
+          it_behaves_like 'a correlation identifier without DD_ENV'
+          it_behaves_like 'a correlation identifier without DD_VERSION'
         end
 
         context 'is defined' do
           let(:environment) { 'my-env' }
           it_behaves_like 'a correlation identifier with basic properties'
+          it_behaves_like 'a correlation identifier with DD_ENV'
+          it_behaves_like 'a correlation identifier without DD_VERSION'
         end
       end
 
@@ -90,11 +126,15 @@ RSpec.describe Datadog::Correlation do
         context 'is not defined' do
           let(:version) { nil }
           it_behaves_like 'a correlation identifier with basic properties'
+          it_behaves_like 'a correlation identifier without DD_ENV'
+          it_behaves_like 'a correlation identifier without DD_VERSION'
         end
 
         context 'is defined' do
           let(:version) { 'my-version' }
           it_behaves_like 'a correlation identifier with basic properties'
+          it_behaves_like 'a correlation identifier without DD_ENV'
+          it_behaves_like 'a correlation identifier with DD_VERSION'
         end
       end
     end


### PR DESCRIPTION
Address this issue: https://github.com/DataDog/dd-trace-rb/issues/1003