### PR TITLE
Populate env, service, and version from tags

### DIFF
--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -158,6 +158,19 @@ module Datadog
           # Coerce keys to strings
           string_tags = Hash[new_value.collect { |k, v| [k.to_s, v] }]
 
+          # Cross-populate tag values with other settings
+          if env.nil? && string_tags.key?(Ext::Environment::TAG_ENV)
+            self.env = string_tags[Ext::Environment::TAG_ENV]
+          end
+
+          if version.nil? && string_tags.key?(Ext::Environment::TAG_VERSION)
+            self.version = string_tags[Ext::Environment::TAG_VERSION]
+          end
+
+          if service.nil? && string_tags.key?(Ext::Environment::TAG_SERVICE)
+            self.service = string_tags[Ext::Environment::TAG_SERVICE]
+          end
+
           # Merge with previous tags
           (old_value || {}).merge(string_tags)
         end

--- a/lib/ddtrace/correlation.rb
+++ b/lib/ddtrace/correlation.rb
@@ -6,21 +6,24 @@ module Datadog
   # e.g. Retrieve a correlation to the current trace for logging, etc.
   module Correlation
     # Struct representing correlation
-    Identifier = Struct.new(:trace_id, :span_id, :env, :version) do
+    Identifier = Struct.new(:trace_id, :span_id, :env, :service, :version) do
       def initialize(*args)
         super
         self.trace_id = trace_id || 0
         self.span_id = span_id || 0
         self.env = env || Datadog.configuration.env
+        self.service = service || Datadog.configuration.service
         self.version = version || Datadog.configuration.version
       end
 
       def to_s
-        str =  "#{Ext::Correlation::ATTR_TRACE_ID}=#{trace_id}"
-        str += " #{Ext::Correlation::ATTR_SPAN_ID}=#{span_id}"
-        str += " #{Ext::Correlation::ATTR_ENV}=#{env}"
-        str += " #{Ext::Correlation::ATTR_VERSION}=#{version}"
-        str
+        attributes = []
+        attributes << "#{Ext::Correlation::ATTR_ENV}=#{env}" unless env.nil?
+        attributes << "#{Ext::Correlation::ATTR_SERVICE}=#{service}" unless service.nil?
+        attributes << "#{Ext::Correlation::ATTR_VERSION}=#{version}" unless version.nil?
+        attributes << "#{Ext::Correlation::ATTR_TRACE_ID}=#{trace_id}"
+        attributes << "#{Ext::Correlation::ATTR_SPAN_ID}=#{span_id}"
+        attributes.join(' ')
       end
     end.freeze
 

--- a/lib/ddtrace/ext/correlation.rb
+++ b/lib/ddtrace/ext/correlation.rb
@@ -2,6 +2,7 @@ module Datadog
   module Ext
     module Correlation
       ATTR_ENV = 'dd.env'.freeze
+      ATTR_SERVICE = 'dd.service'.freeze
       ATTR_SPAN_ID = 'dd.span_id'.freeze
       ATTR_TRACE_ID = 'dd.trace_id'.freeze
       ATTR_VERSION = 'dd.version'.freeze

--- a/lib/ddtrace/ext/environment.rb
+++ b/lib/ddtrace/ext/environment.rb
@@ -7,6 +7,7 @@ module Datadog
       ENV_VERSION = 'DD_VERSION'.freeze
 
       TAG_ENV = 'env'.freeze
+      TAG_SERVICE = 'service'.freeze
       TAG_VERSION = 'version'.freeze
     end
   end

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -544,6 +544,18 @@ RSpec.describe Datadog::Configuration::Settings do
         end
       end
 
+      context 'defines :env with missing #env' do
+        let(:env_tags) { "env:#{tag_env_value}" }
+        let(:tag_env_value) { 'tag-env-value' }
+
+        it 'populates #env from the tag' do
+          expect { tags }
+            .to change { settings.env }
+            .from(nil)
+            .to(tag_env_value)
+        end
+      end
+
       context 'conflicts with #env' do
         let(:env_tags) { "env:#{tag_env_value}" }
         let(:tag_env_value) { 'tag-env-value' }
@@ -554,6 +566,18 @@ RSpec.describe Datadog::Configuration::Settings do
         it { is_expected.to include('env' => env_value) }
       end
 
+      context 'defines :service with missing #service' do
+        let(:env_tags) { "service:#{tag_service_value}" }
+        let(:tag_service_value) { 'tag-service-value' }
+
+        it 'populates #service from the tag' do
+          expect { tags }
+            .to change { settings.service }
+            .from(nil)
+            .to(tag_service_value)
+        end
+      end
+
       context 'conflicts with #version' do
         let(:env_tags) { "env:#{tag_version_value}" }
         let(:tag_version_value) { 'tag-version-value' }
@@ -562,6 +586,18 @@ RSpec.describe Datadog::Configuration::Settings do
         before { allow(settings).to receive(:version).and_return(version_value) }
 
         it { is_expected.to include('version' => version_value) }
+      end
+
+      context 'defines :version with missing #version' do
+        let(:env_tags) { "version:#{tag_version_value}" }
+        let(:tag_version_value) { 'tag-version-value' }
+
+        it 'populates #version from the tag' do
+          expect { tags }
+            .to change { settings.version }
+            .from(nil)
+            .to(tag_version_value)
+        end
       end
     end
   end

--- a/spec/ddtrace/correlation_spec.rb
+++ b/spec/ddtrace/correlation_spec.rb
@@ -4,48 +4,29 @@ require 'ddtrace/correlation'
 require 'ddtrace/context'
 
 RSpec.describe Datadog::Correlation do
-  # Expect string to contain the attribute, at the beginning/end of the string,
-  # or buffered by a whitespace character to delimit it.
-  def have_attribute(attribute)
-    match(/(?<=\A|\s)#{Regexp.escape(attribute)}(?=\z|\s)/)
+  let(:default_env) { 'default-env' }
+  let(:default_service) { 'default-service' }
+  let(:default_version) { 'default-version' }
+
+  before do
+    allow(Datadog.configuration).to receive(:env).and_return(default_env)
+    allow(Datadog.configuration).to receive(:service).and_return(default_service)
+    allow(Datadog.configuration).to receive(:version).and_return(default_version)
   end
 
   describe '::identifier_from_context' do
-    subject(:correlation_ids) { described_class.identifier_from_context(context) }
-    let(:environment) { nil }
-    let(:version) { nil }
-
-    before do
-      allow(Datadog.configuration).to receive(:env).and_return(environment)
-      allow(Datadog.configuration).to receive(:version).and_return(version)
-    end
+    subject(:identifier_from_context) { described_class.identifier_from_context(context) }
 
     context 'given nil' do
       let(:context) { nil }
 
-      shared_examples_for 'an empty correlation identifier' do
-        it { is_expected.to be_a_kind_of(Datadog::Correlation::Identifier) }
-        it { expect(correlation_ids.trace_id).to be 0 }
-        it { expect(correlation_ids.span_id).to be 0 }
-        it { expect(correlation_ids.env).to eq environment }
-        it { expect(correlation_ids.version).to eq version }
-        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_TRACE_ID}=0") }
-        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_SPAN_ID}=0") }
-        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_ENV}=#{environment}") }
-        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_VERSION}=#{version}") }
-      end
-
-      it_behaves_like 'an empty correlation identifier'
-
-      context 'after Datadog::Environment::env has changed' do
-        let(:environment) { 'my-env' }
-        it_behaves_like 'an empty correlation identifier'
-      end
-
-      context 'after Datadog::Environment::version has changed' do
-        let(:version) { 'my-version' }
-        it_behaves_like 'an empty correlation identifier'
-      end
+      it { is_expected.to be_a_kind_of(described_class::Identifier) }
+      it { expect(identifier_from_context.frozen?).to be true }
+      it { expect(identifier_from_context.trace_id).to be 0 }
+      it { expect(identifier_from_context.span_id).to be 0 }
+      it { expect(identifier_from_context.env).to be default_env }
+      it { expect(identifier_from_context.service).to be default_service }
+      it { expect(identifier_from_context.version).to be default_version }
     end
 
     context 'given a Context object' do
@@ -57,44 +38,181 @@ RSpec.describe Datadog::Correlation do
         )
       end
 
-      let(:trace_id) { double('trace id') }
-      let(:span_id) { double('span id') }
+      let(:trace_id) { double('trace ID') }
+      let(:span_id) { double('span ID') }
 
-      shared_examples_for 'a correlation identifier with basic properties' do
-        it { is_expected.to be_a_kind_of(Datadog::Correlation::Identifier) }
-        it { expect(correlation_ids.trace_id).to eq(trace_id) }
-        it { expect(correlation_ids.span_id).to eq(span_id) }
-        it { expect(correlation_ids.env).to eq environment }
-        it { expect(correlation_ids.version).to eq version }
-        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_TRACE_ID}=#{trace_id}") }
-        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_SPAN_ID}=#{span_id}") }
-        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_ENV}=#{environment}") }
-        it { expect(correlation_ids.to_s).to have_attribute("#{Datadog::Ext::Correlation::ATTR_VERSION}=#{version}") }
+      it { is_expected.to be_a_kind_of(described_class::Identifier) }
+      it { expect(identifier_from_context.frozen?).to be true }
+      it { expect(identifier_from_context.trace_id).to be trace_id }
+      it { expect(identifier_from_context.span_id).to be span_id }
+      it { expect(identifier_from_context.env).to be default_env }
+      it { expect(identifier_from_context.service).to be default_service }
+      it { expect(identifier_from_context.version).to be default_version }
+    end
+  end
+
+  describe described_class::Identifier do
+    describe '#new' do
+      context 'given no arguments' do
+        subject(:identifier) { described_class.new }
+
+        it do
+          is_expected.to have_attributes(
+            trace_id: 0,
+            span_id: 0,
+            env: default_env,
+            service: default_service,
+            version: default_version
+          )
+        end
       end
 
-      it_behaves_like 'a correlation identifier with basic properties'
-
-      context 'when #env configuration setting' do
-        context 'is not defined' do
-          let(:environment) { nil }
-          it_behaves_like 'a correlation identifier with basic properties'
+      context 'given full arguments' do
+        subject(:identifier) do
+          described_class.new(
+            trace_id,
+            span_id,
+            env,
+            service,
+            version
+          )
         end
 
-        context 'is defined' do
-          let(:environment) { 'my-env' }
-          it_behaves_like 'a correlation identifier with basic properties'
+        let(:trace_id) { double('trace_id') }
+        let(:span_id) { double('span_id') }
+        let(:env) { double('env') }
+        let(:service) { double('service') }
+        let(:version) { double('version') }
+
+        it do
+          is_expected.to have_attributes(
+            trace_id: trace_id,
+            span_id: span_id,
+            env: env,
+            service: service,
+            version: version
+          )
+        end
+      end
+    end
+
+    describe '#to_s' do
+      shared_examples_for 'an identifier string' do
+        subject(:string) { identifier.to_s }
+
+        let(:identifier) do
+          described_class.new(
+            trace_id,
+            span_id,
+            env,
+            service,
+            version
+          )
+        end
+
+        let(:trace_id) { double('trace_id') }
+        let(:span_id) { double('span_id') }
+        let(:env) { double('env') }
+        let(:service) { double('service') }
+        let(:version) { double('version') }
+
+        it 'doesn\'t have attributes without values' do
+          is_expected.to_not match(/.*=(?=\z|\s)/)
         end
       end
 
-      context 'when #version configuration setting' do
-        context 'is not defined' do
-          let(:version) { nil }
-          it_behaves_like 'a correlation identifier with basic properties'
+      # Expect string to contain the attribute, at the beginning/end of the string,
+      # or buffered by a whitespace character to delimit it.
+      def have_attribute(attribute)
+        match(/(?<=\A|\s)#{Regexp.escape(attribute)}(?=\z|\s)/)
+      end
+
+      context 'when #trace_id' do
+        context 'is defined' do
+          it_behaves_like 'an identifier string' do
+            let(:trace_id) { double('trace_id') }
+            it { is_expected.to have_attribute("#{Datadog::Ext::Correlation::ATTR_TRACE_ID}=#{trace_id}") }
+          end
         end
 
+        context 'is not defined' do
+          it_behaves_like 'an identifier string' do
+            let(:trace_id) { nil }
+            it { is_expected.to have_attribute("#{Datadog::Ext::Correlation::ATTR_TRACE_ID}=0") }
+          end
+        end
+      end
+
+      context 'when #span_id' do
         context 'is defined' do
-          let(:version) { 'my-version' }
-          it_behaves_like 'a correlation identifier with basic properties'
+          it_behaves_like 'an identifier string' do
+            let(:span_id) { double('span_id') }
+            it { is_expected.to have_attribute("#{Datadog::Ext::Correlation::ATTR_SPAN_ID}=#{span_id}") }
+          end
+        end
+
+        context 'is not defined' do
+          it_behaves_like 'an identifier string' do
+            let(:span_id) { nil }
+            it { is_expected.to have_attribute("#{Datadog::Ext::Correlation::ATTR_SPAN_ID}=0") }
+          end
+        end
+      end
+
+      context 'when #env' do
+        context 'is defined' do
+          it_behaves_like 'an identifier string' do
+            let(:env) { double('env') }
+            it { is_expected.to have_attribute("#{Datadog::Ext::Correlation::ATTR_ENV}=#{env}") }
+            it 'puts the env attribute before trace ID and span ID' do
+              is_expected.to match(/(dd\.env=).*(dd\.trace_id=).*(dd\.span_id=).*/)
+            end
+          end
+        end
+
+        context 'is not defined' do
+          it_behaves_like 'an identifier string' do
+            let(:env) { nil }
+            it { is_expected.to_not have_attribute("#{Datadog::Ext::Correlation::ATTR_ENV}=#{env}") }
+          end
+        end
+      end
+
+      context 'when #service' do
+        context 'is defined' do
+          it_behaves_like 'an identifier string' do
+            let(:service) { double('service') }
+            it { is_expected.to have_attribute("#{Datadog::Ext::Correlation::ATTR_SERVICE}=#{service}") }
+            it 'puts the service attribute before trace ID and span ID' do
+              is_expected.to match(/(dd\.service=).*(dd\.trace_id=).*(dd\.span_id=).*/)
+            end
+          end
+        end
+
+        context 'is not defined' do
+          it_behaves_like 'an identifier string' do
+            let(:service) { nil }
+            it { is_expected.to_not have_attribute("#{Datadog::Ext::Correlation::ATTR_SERVICE}=#{service}") }
+          end
+        end
+      end
+
+      context 'when #version' do
+        context 'is defined' do
+          it_behaves_like 'an identifier string' do
+            let(:version) { double('version') }
+            it { is_expected.to have_attribute("#{Datadog::Ext::Correlation::ATTR_VERSION}=#{version}") }
+            it 'puts the version attribute before trace ID and span ID' do
+              is_expected.to match(/(dd\.version=).*(dd\.trace_id=).*(dd\.span_id=).*/)
+            end
+          end
+        end
+
+        context 'is not defined' do
+          it_behaves_like 'an identifier string' do
+            let(:version) { nil }
+            it { is_expected.to_not have_attribute("#{Datadog::Ext::Correlation::ATTR_VERSION}=#{version}") }
+          end
         end
       end
     end


### PR DESCRIPTION
This pull request:

 - Populates configuration `env`, `service`, and `version` to be populated from `tags`, if no value is set but a corresponding tag is configured.
 - Omits correlation attributes that have blank values from correlation strings.
 - Adds `dd.service` as a correlation attribute.