### PR TITLE
Unlock Bundler version for testing

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -47,7 +47,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.1'
   spec.add_development_dependency 'minitest', '= 5.10.1'
   spec.add_development_dependency 'appraisal', '~> 2.2'
-  spec.add_development_dependency 'bundler', '<= 2.1.2' # Remove when https://github.com/thoughtbot/appraisal/issues/162 is fixed
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'webmock', '~> 2.0'
   spec.add_development_dependency 'builder'


### PR DESCRIPTION
The version of bundler we use for testing in CircleCI was locked for Ruby 2.7 due to a bug which seemed to be related to the Appraisal gem.

That issue was [addressed in the upstream ruby docker image](https://github.com/thoughtbot/appraisal/issues/162#issuecomment-614141295), so new docker images we build for CI will work correctly with new versions of bundler.

This PR unlocks the version of bundler so we can continue testing with the latest available version. One thing to note is that the version of bundler we use in CI is locked at the time we publish the image, so we are not actually constantly upgrading bundler. This PR then publishes a new version of the Ruby 2.7 CI image, to allow it to upgrade to the latest version.