### PR TITLE
Fix runtime metrics not starting after #write

### DIFF
--- a/lib/ddtrace/workers/runtime_metrics.rb
+++ b/lib/ddtrace/workers/runtime_metrics.rb
@@ -34,9 +34,13 @@ module Datadog
         true
       end
 
+      def associate_with_span(*args)
+        # Start the worker
+        metrics.associate_with_span(*args).tap { perform }
+      end
+
       def_delegators \
         :metrics,
-        :associate_with_span,
         :register_service
     end
   end

--- a/spec/ddtrace/workers/runtime_metrics_spec.rb
+++ b/spec/ddtrace/workers/runtime_metrics_spec.rb
@@ -154,20 +154,25 @@ RSpec.describe Datadog::Workers::RuntimeMetrics do
     end
   end
 
-  describe 'forwarded methods' do
-    describe '#associate_with_span' do
-      subject(:associate_with_span) { worker.associate_with_span(span) }
-      let(:span) { instance_double(Datadog::Span) }
+  describe '#associate_with_span' do
+    subject(:associate_with_span) { worker.associate_with_span(span) }
+    let(:span) { instance_double(Datadog::Span) }
 
-      before { allow(worker.metrics).to receive(:associate_with_span) }
-
-      it 'forwards to #metrics' do
-        associate_with_span
-        expect(worker.metrics).to have_received(:associate_with_span)
-          .with(span)
-      end
+    before do
+      allow(worker.metrics).to receive(:associate_with_span)
+      allow(worker).to receive(:perform)
     end
 
+    it 'forwards to #metrics' do
+      associate_with_span
+
+      expect(worker.metrics).to have_received(:associate_with_span)
+        .with(span)
+      expect(worker).to have_received(:perform)
+    end
+  end
+
+  describe 'forwarded methods' do
     describe '#register_service' do
       subject(:register_service) { worker.register_service(service) }
       let(:service) { double('service') }

--- a/spec/ddtrace/writer_spec.rb
+++ b/spec/ddtrace/writer_spec.rb
@@ -208,6 +208,47 @@ RSpec.describe Datadog::Writer do
           end
         end
       end
+
+      describe '#write' do
+        subject(:write) { writer.write(trace, services) }
+        let(:trace) { instance_double(Array) }
+        let(:services) { nil }
+
+        before do
+          allow_any_instance_of(Datadog::Workers::AsyncTransport)
+            .to receive(:start)
+
+          expect_any_instance_of(Datadog::Workers::AsyncTransport)
+            .to receive(:enqueue_trace)
+            .with(trace)
+        end
+
+        context 'when runtime metrics are enabled' do
+          before do
+            allow(Datadog.configuration.runtime_metrics)
+              .to receive(:enabled)
+              .and_return(true)
+          end
+
+          context 'and the trace is not empty' do
+            let(:root_span) { instance_double(Datadog::Span) }
+
+            before do
+              allow(trace).to receive(:empty?).and_return(false)
+              allow(trace).to receive(:first).and_return(root_span)
+              allow(Datadog.runtime_metrics).to receive(:associate_with_span)
+            end
+
+            it 'associates the root span with runtime_metrics' do
+              write
+
+              expect(Datadog.runtime_metrics)
+                .to have_received(:associate_with_span)
+                .with(root_span)
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
After refactoring the runtime metrics worker out of `Writer` in #1004, the worker was not lazily starting after a trace was written, preventing runtime metrics from being emitted.

This pull request changes `Workers::RuntimeMetrics#associate_with_span` to now start the worker when called.