### PR TITLE
Temporarily disable flaky TraceWriter#stop tests for JRuby

### DIFF
--- a/spec/ddtrace/workers/trace_writer_spec.rb
+++ b/spec/ddtrace/workers/trace_writer_spec.rb
@@ -385,6 +385,8 @@ RSpec.describe Datadog::Workers::AsyncTraceWriter do
   end
 
   describe '#stop' do
+    before { skip if PlatformHelpers.jruby? } # DEV: Temporarily disabled due to flakiness
+
     subject(:stop) { writer.stop }
 
     shared_context 'shuts down the worker' do


### PR DESCRIPTION
I'm temporarily disabling `TraceWriter#stop` for JRuby due to their flakiness.

I was not able to find the root cause within reasonable time, so I'm proposing these changes to allow for our CI to work smoothly until the correct fix is found.