### PR TITLE
Add profiling recorder

### DIFF
--- a/lib/ddtrace/buffer.rb
+++ b/lib/ddtrace/buffer.rb
@@ -3,7 +3,7 @@ require 'ddtrace/diagnostics/health'
 require 'ddtrace/runtime/object_space'
 
 module Datadog
-  # Trace buffer that stores objects. The buffer has a maximum size and when
+  # Buffer that stores objects. The buffer has a maximum size and when
   # the buffer is full, a random object is discarded. This class is thread-safe.
   class Buffer
     def initialize(max_size)

--- a/lib/ddtrace/profiling/buffer.rb
+++ b/lib/ddtrace/profiling/buffer.rb
@@ -1,0 +1,9 @@
+require 'ddtrace/buffer'
+
+module Datadog
+  module Profiling
+    # Profiling buffer that stores profiling events. The buffer has a maximum size and when
+    # the buffer is full, a random event is discarded. This class is thread-safe.
+    class Buffer < Datadog::Buffer; end
+  end
+end

--- a/lib/ddtrace/profiling/event.rb
+++ b/lib/ddtrace/profiling/event.rb
@@ -1,0 +1,13 @@
+module Datadog
+  module Profiling
+    # Describes a sample of some data obtained from the runtime.
+    class Event
+      attr_reader \
+        :timestamp
+
+      def initialize
+        @timestamp = Time.now.utc.to_i
+      end
+    end
+  end
+end

--- a/lib/ddtrace/profiling/recorder.rb
+++ b/lib/ddtrace/profiling/recorder.rb
@@ -1,0 +1,41 @@
+require 'ddtrace/profiling/buffer'
+
+module Datadog
+  module Profiling
+    # Profiling buffer that stores profiling events. The buffer has a maximum size and when
+    # the buffer is full, a random event is discarded. This class is thread-safe.
+    class Recorder
+      def initialize(event_classes, max_size)
+        @buffers = {}
+
+        # Add a buffer for each class
+        event_classes.each do |event_class|
+          @buffers[event_class] = Profiling::Buffer.new(max_size)
+        end
+      end
+
+      def push(event)
+        raise UnknownEventError, event.class unless @buffers.key?(event.class)
+        @buffers[event.class].push(event)
+      end
+
+      def pop(event_class)
+        raise UnknownEventError, event_class unless @buffers.key?(event_class)
+        @buffers[event_class].pop
+      end
+
+      # Error when event of an unknown type is used with the Recorder
+      class UnknownEventError < StandardError
+        attr_reader :event_class
+
+        def initialize(event_class)
+          @event_class = event_class
+        end
+
+        def message
+          @message ||= "Unknown event class '#{event_class}' for profiling recorder."
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/profiling/buffer_spec.rb
+++ b/spec/ddtrace/profiling/buffer_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+require 'ddtrace/profiling/buffer'
+
+RSpec.describe Datadog::Profiling::Buffer do
+  subject(:buffer) { described_class.new(max_size) }
+  let(:max_size) { 0 }
+
+  it { is_expected.to be_a_kind_of(Datadog::Buffer) }
+end

--- a/spec/ddtrace/profiling/event_spec.rb
+++ b/spec/ddtrace/profiling/event_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+require 'ddtrace/profiling/event'
+
+RSpec.describe Datadog::Profiling::Event do
+  subject(:event) { described_class.new }
+
+  describe '::new' do
+    it do
+      is_expected.to have_attributes(
+        timestamp: kind_of(Integer)
+      )
+    end
+  end
+end

--- a/spec/ddtrace/profiling/recorder_spec.rb
+++ b/spec/ddtrace/profiling/recorder_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+require 'ddtrace/profiling/recorder'
+require 'ddtrace/profiling/event'
+
+RSpec.describe Datadog::Profiling::Recorder do
+  subject(:recorder) { described_class.new(event_classes, max_size) }
+  let(:event_classes) { [] }
+  let(:max_size) { 0 }
+
+  shared_context 'test buffer' do
+    let(:buffer) { instance_double(Datadog::Profiling::Buffer) }
+
+    before do
+      allow(Datadog::Profiling::Buffer)
+        .to receive(:new)
+        .with(max_size)
+        .and_return(buffer)
+    end
+  end
+
+  describe '::new' do
+    context 'given events of different classes' do
+      let(:event_classes) { [event_one.class, event_two.class] }
+      let(:event_one) { Class.new(Datadog::Profiling::Event).new }
+      let(:event_two) { Class.new(Datadog::Profiling::Event).new }
+
+      it 'creates a buffer per class' do
+        expect(Datadog::Profiling::Buffer)
+          .to receive(:new)
+          .with(max_size)
+          .twice
+
+        recorder
+      end
+    end
+  end
+
+  describe '#push' do
+    include_context 'test buffer'
+    subject(:push) { recorder.push(event) }
+
+    before { allow(buffer).to receive(:push) }
+
+    context 'given an event' do
+      let(:event) { event_class.new }
+      let(:event_class) { Class.new(Datadog::Profiling::Event) }
+
+      context 'whose class has not been registered' do
+        it do
+          expect { push }.to raise_error(described_class::UnknownEventError)
+        end
+      end
+
+      context 'whose class has been registered' do
+        let(:event_classes) { [event_class] }
+
+        it do
+          push
+          expect(buffer).to have_received(:push).with(event)
+        end
+      end
+    end
+  end
+
+  describe '#pop' do
+    include_context 'test buffer'
+    subject(:pop) { recorder.pop(event_class) }
+
+    before { allow(buffer).to receive(:pop) }
+
+    context 'given an event class' do
+      let(:event_class) { Class.new(Datadog::Profiling::Event) }
+
+      context 'when event class has not been registered' do
+        it do
+          expect { pop }.to raise_error(described_class::UnknownEventError)
+        end
+      end
+
+      context 'when a matching event has been pushed' do
+        let(:event_classes) { [event_class] }
+
+        it do
+          pop
+          expect(buffer).to have_received(:pop)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds the profiling `Recorder` class, which acts like a buffer for profiling events. The "collector" will generate events and write data to this `Recorder`, then the "scheduler" will dequeue all events from this `Recorder` by invoking `pop`.