### PR TITLE
Add profiling exporter

### DIFF
--- a/lib/ddtrace/profiling/exporter.rb
+++ b/lib/ddtrace/profiling/exporter.rb
@@ -1,0 +1,26 @@
+require 'ddtrace/profiling/transport/io/client'
+
+module Datadog
+  module Profiling
+    # Writes profiling data to transport
+    class Exporter
+      attr_reader \
+        :transport
+
+      def initialize(transport)
+        @transport = transport
+
+        case @transport
+        when Datadog::Transport::IO::Client
+          @transport.extend(Profiling::Transport::IO::Client)
+        else
+          raise ArgumentError, 'Unsupported transport for profiling exporter.'
+        end
+      end
+
+      def export(events)
+        transport.send_events(events)
+      end
+    end
+  end
+end

--- a/lib/ddtrace/profiling/transport/io/client.rb
+++ b/lib/ddtrace/profiling/transport/io/client.rb
@@ -1,0 +1,33 @@
+require 'ddtrace/profiling/transport/request'
+require 'ddtrace/profiling/transport/io/response'
+
+module Datadog
+  module Profiling
+    module Transport
+      module IO
+        # Profiling extensions for IO client
+        module Client
+          def send_events(events)
+            # Build a request
+            req = Profiling::Transport::Request.new(events)
+
+            send_request(req) do |out, request|
+              # Encode trace data
+              data = encode_data(encoder, request)
+
+              # Write to IO
+              result = if block_given?
+                         yield(out, data)
+                       else
+                         write_data(out, data)
+                       end
+
+              # Generate response
+              Profiling::Transport::IO::Response.new(result)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/profiling/transport/io/response.rb
+++ b/lib/ddtrace/profiling/transport/io/response.rb
@@ -1,0 +1,16 @@
+require 'ddtrace/transport/io/response'
+require 'ddtrace/profiling/transport/response'
+
+module Datadog
+  module Profiling
+    module Transport
+      # IO transport behavior for profiling
+      module IO
+        # Response from IO transport for profiling
+        class Response < Datadog::Transport::IO::Response
+          include Profiling::Transport::Response
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/profiling/transport/parcel.rb
+++ b/lib/ddtrace/profiling/transport/parcel.rb
@@ -1,0 +1,17 @@
+require 'ddtrace/transport/parcel'
+
+module Datadog
+  module Profiling
+    module Transport
+      # Data transfer object for profiling data
+      class Parcel
+        include Datadog::Transport::Parcel
+
+        def encode_with(encoder)
+          # TODO: Determine encoding behavior
+          encoder.encode(data)
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/profiling/transport/request.rb
+++ b/lib/ddtrace/profiling/transport/request.rb
@@ -1,0 +1,15 @@
+require 'ddtrace/transport/request'
+require 'ddtrace/profiling/transport/parcel'
+
+module Datadog
+  module Profiling
+    module Transport
+      # Profiling request
+      class Request < Datadog::Transport::Request
+        def initialize(events)
+          super(Parcel.new(events))
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/profiling/transport/response.rb
+++ b/lib/ddtrace/profiling/transport/response.rb
@@ -1,0 +1,8 @@
+module Datadog
+  module Profiling
+    module Transport
+      # Profiling response
+      module Response; end
+    end
+  end
+end

--- a/spec/ddtrace/profiling/exporter_spec.rb
+++ b/spec/ddtrace/profiling/exporter_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+require 'ddtrace/profiling/exporter'
+
+RSpec.describe Datadog::Profiling::Exporter do
+  subject(:exporter) { described_class.new(transport) }
+  let(:transport) { double('transport') }
+
+  describe '::new' do
+    context 'given an IO transport' do
+      let(:transport) { Datadog::Transport::IO::Client.new(out, encoder) }
+      let(:out) { instance_double(IO) }
+      let(:encoder) { instance_double(Datadog::Encoding::Encoder) }
+
+      it 'extends the transport with profiling behavior' do
+        is_expected.to have_attributes(
+          transport: a_kind_of(Datadog::Profiling::Transport::IO::Client)
+        )
+      end
+    end
+
+    context 'given an HTTP transport' do
+      let(:transport) { instance_double(Datadog::Transport::HTTP::Client) }
+
+      # TODO: Should not raise an error when implemented.
+      it 'raises an error' do
+        expect { exporter }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end

--- a/spec/ddtrace/profiling/transport/io/client_spec.rb
+++ b/spec/ddtrace/profiling/transport/io/client_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'ddtrace/transport/io/client'
+require 'ddtrace/profiling/transport/io/client'
+
+RSpec.describe Datadog::Profiling::Transport::IO::Client do
+  subject(:client) do
+    Datadog::Transport::IO::Client.new(out, encoder).tap do |client|
+      client.extend(described_class)
+    end
+  end
+
+  let(:out) { instance_double(IO) }
+  let(:encoder) { instance_double(Datadog::Encoding::Encoder) }
+
+  describe '#send_events' do
+    context 'given events' do
+      subject(:send_events) { client.send_events(events) }
+      let(:events) { instance_double(Array) }
+      let(:encoded_events) { double('encoded events') }
+      let(:result) { double('IO result') }
+
+      before do
+        expect(client.encoder).to receive(:encode)
+          .with(events)
+          .and_return(encoded_events)
+
+        expect(client.out).to receive(:puts)
+          .with(encoded_events)
+          .and_return(result)
+
+        expect(client).to receive(:update_stats_from_response!)
+          .with(kind_of(Datadog::Profiling::Transport::IO::Response))
+      end
+
+      it do
+        is_expected.to be_a_kind_of(Datadog::Profiling::Transport::IO::Response)
+        expect(send_events.result).to eq(result)
+      end
+    end
+
+    context 'given events and a block' do
+      subject(:send_events) { client.send_events(events) { |out, data| target.write(out, data) } }
+      let(:events) { instance_double(Array) }
+      let(:encoded_events) { double('encoded events') }
+      let(:result) { double('IO result') }
+      let(:target) { double('target') }
+
+      before do
+        expect(client.encoder).to receive(:encode)
+          .with(events)
+          .and_return(encoded_events)
+
+        expect(target).to receive(:write)
+          .with(client.out, encoded_events)
+          .and_return(result)
+
+        expect(client).to receive(:update_stats_from_response!)
+          .with(kind_of(Datadog::Profiling::Transport::IO::Response))
+      end
+
+      it do
+        is_expected.to be_a_kind_of(Datadog::Profiling::Transport::IO::Response)
+        expect(send_events.result).to eq(result)
+      end
+    end
+  end
+end

--- a/spec/ddtrace/profiling/transport/io/response_spec.rb
+++ b/spec/ddtrace/profiling/transport/io/response_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+require 'ddtrace/profiling/transport/io/response'
+
+RSpec.describe Datadog::Profiling::Transport::IO::Response do
+  subject(:response) { described_class.new(result) }
+  let(:result) { double('result') }
+
+  it { is_expected.to be_a_kind_of(Datadog::Transport::IO::Response) }
+  it { is_expected.to be_a_kind_of(Datadog::Profiling::Transport::Response) }
+end

--- a/spec/ddtrace/profiling/transport/parcel_spec.rb
+++ b/spec/ddtrace/profiling/transport/parcel_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+require 'ddtrace/profiling/transport/parcel'
+
+RSpec.describe Datadog::Profiling::Transport::Parcel do
+  subject(:parcel) { described_class.new(data) }
+  let(:data) { instance_double(Array) }
+
+  it { is_expected.to be_a_kind_of(Datadog::Transport::Parcel) }
+
+  describe '#initialize' do
+    it { is_expected.to have_attributes(data: data) }
+  end
+
+  describe '#encode_with' do
+    subject(:encode_with) { parcel.encode_with(encoder) }
+    let(:encoder) { instance_double(Datadog::Encoding::Encoder) }
+    let(:encoded_data) { double('encoded data') }
+
+    before do
+      expect(encoder).to receive(:encode)
+        .with(data)
+        .and_return(encoded_data)
+    end
+
+    it { is_expected.to be encoded_data }
+  end
+end

--- a/spec/ddtrace/profiling/transport/request_spec.rb
+++ b/spec/ddtrace/profiling/transport/request_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+require 'ddtrace/profiling/transport/request'
+
+RSpec.describe Datadog::Profiling::Transport::Request do
+  subject(:request) { described_class.new(events) }
+  let(:events) { instance_double(Array) }
+
+  it { is_expected.to be_a_kind_of(Datadog::Transport::Request) }
+
+  describe '#initialize' do
+    it { is_expected.to have_attributes(parcel: kind_of(Datadog::Profiling::Transport::Parcel)) }
+  end
+end

--- a/spec/ddtrace/profiling/transport/response_spec.rb
+++ b/spec/ddtrace/profiling/transport/response_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+require 'ddtrace/profiling/transport/response'
+
+RSpec.describe Datadog::Profiling::Transport::Response do
+  context 'when implemented by a class' do
+    subject(:response) { response_class.new }
+
+    let(:response_class) do
+      stub_const('TestResponse', Class.new { include Datadog::Profiling::Transport::Response })
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds the `Profiling::Exporter`, which writes profiling events to a given output. Then exporter receives `#export` with profiling events then uses a `Datadog::Transport::IO::Client` to transmit the data.

By design it implements an extension for its IO protocol, allowing profiling events to be written to IO. It's possible to support other protocols in the future as well (HTTP), but is not currently implemented in this PR.