### PR TITLE
Support for Sinatra modular apps

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1532,7 +1532,6 @@ class NestedApp < Sinatra::Base
 end
 
 class App < Sinatra::Base
-  # use Datadog::Contrib::Rack::TraceMiddleware # If Rack instrumentation is enabled
   register Datadog::Contrib::Sinatra::Tracer
 
   use NestedApp
@@ -1544,8 +1543,6 @@ end
 ```
 
 Ensure you register `Datadog::Contrib::Sinatra::Tracer` as a middleware before you mount your nested applications.
-
-If Rack instrumentation is also enabled, mount `Datadog::Contrib::Rack::TraceMiddleware` before registering `Datadog::Contrib::Sinatra::Tracer`.
 
 #### Instrumentation options
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1498,6 +1498,8 @@ The Sinatra integration traces requests and template rendering.
 
 To start using the tracing client, make sure you import `ddtrace` and `use :sinatra` after either `sinatra` or `sinatra/base`, and before you define your application/routes:
 
+#### Classic application
+
 ```ruby
 require 'sinatra'
 require 'ddtrace'
@@ -1511,7 +1513,43 @@ get '/' do
 end
 ```
 
-Where `options` is an optional `Hash` that accepts the following parameters:
+#### Modular application
+
+```ruby
+require 'sinatra/base'
+require 'ddtrace'
+
+Datadog.configure do |c|
+  c.use :sinatra, options
+end
+
+class NestedApp < Sinatra::Base
+  register Datadog::Contrib::Sinatra::Tracer
+
+  get '/nested' do
+    'Hello from nested app!'
+  end
+end
+
+class App < Sinatra::Base
+  # use Datadog::Contrib::Rack::TraceMiddleware # If Rack instrumentation is enabled
+  register Datadog::Contrib::Sinatra::Tracer
+
+  use NestedApp
+
+  get '/' do
+    'Hello world!'
+  end
+end
+```
+
+Ensure you register `Datadog::Contrib::Sinatra::Tracer` as a middleware before you mount your nested applications.
+
+If Rack instrumentation is also enabled, mount `Datadog::Contrib::Rack::TraceMiddleware` before registering `Datadog::Contrib::Sinatra::Tracer`.
+
+#### Instrumentation options
+
+`options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |

--- a/lib/ddtrace/contrib/sinatra/env.rb
+++ b/lib/ddtrace/contrib/sinatra/env.rb
@@ -32,6 +32,26 @@ module Datadog
         def header_to_rack_header(name)
           "HTTP_#{name.to_s.upcase.gsub(/[-\s]/, '_')}"
         end
+
+        # Was a Sinatra already traced in this request?
+        # We don't want to create spans for intermediate Sinatra
+        # middlewares that don't match the request at hand.
+        def middleware_traced?(env)
+          env[Ext::RACK_ENV_MIDDLEWARE_TRACED]
+        end
+
+        def set_middleware_traced(env, bool)
+          env[Ext::RACK_ENV_MIDDLEWARE_TRACED] = bool
+        end
+
+        # The start time of the top-most Sinatra middleware.
+        def middleware_start_time(env)
+          env[Ext::RACK_ENV_MIDDLEWARE_START_TIME]
+        end
+
+        def set_middleware_start_time(env, time = Time.now.utc)
+          env[Ext::RACK_ENV_MIDDLEWARE_START_TIME] = time
+        end
       end
     end
   end

--- a/lib/ddtrace/contrib/sinatra/ext.rb
+++ b/lib/ddtrace/contrib/sinatra/ext.rb
@@ -7,10 +7,16 @@ module Datadog
         ENV_ANALYTICS_ENABLED = 'DD_SINATRA_ANALYTICS_ENABLED'.freeze
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_SINATRA_ANALYTICS_SAMPLE_RATE'.freeze
         RACK_ENV_REQUEST_SPAN = 'datadog.sinatra_request_span'.freeze
+        RACK_ENV_MIDDLEWARE_START_TIME = 'datadog.sinatra_middleware_start_time'.freeze
+        RACK_ENV_MIDDLEWARE_TRACED = 'datadog.sinatra_middleware_traced'.freeze
         SERVICE_NAME = 'sinatra'.freeze
         SPAN_RENDER_TEMPLATE = 'sinatra.render_template'.freeze
         SPAN_REQUEST = 'sinatra.request'.freeze
+        SPAN_ROUTE = 'sinatra.route'.freeze
+        TAG_APP_NAME = 'sinatra.app.name'.freeze
         TAG_ROUTE_PATH = 'sinatra.route.path'.freeze
+        TAG_SCRIPT_NAME = 'sinatra.script_name'.freeze
+        TAG_TEMPLATE_ENGINE = 'sinatra.template_engine'.freeze
         TAG_TEMPLATE_NAME = 'sinatra.template_name'.freeze
       end
     end

--- a/lib/ddtrace/contrib/sinatra/patcher.rb
+++ b/lib/ddtrace/contrib/sinatra/patcher.rb
@@ -20,6 +20,7 @@ module Datadog
 
         def register_tracer
           ::Sinatra.send(:register, Datadog::Contrib::Sinatra::Tracer)
+          ::Sinatra::Base.send(:prepend, Sinatra::Tracer::Base)
         end
       end
     end

--- a/lib/ddtrace/contrib/sinatra/tracer.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer.rb
@@ -21,6 +21,10 @@ module Datadog
           condition do
             # If the option to prepend script names is enabled, then
             # prepend the script name from the request onto the action.
+            #
+            # DEV: env['sinatra.route'] already exists with very similar information,
+            # DEV: but doesn't account for our `resource_script_names` logic.
+            #
             @datadog_route = if Datadog.configuration[:sinatra][:resource_script_names]
                                "#{request.script_name}#{action}"
                              else
@@ -32,53 +36,115 @@ module Datadog
         end
 
         def self.registered(app)
-          ::Sinatra::Base.module_eval do
-            def render(engine, data, *)
-              output = ''
-              tracer = Datadog.configuration[:sinatra][:tracer]
-              if tracer.enabled
-                tracer.trace(Ext::SPAN_RENDER_TEMPLATE, span_type: Datadog::Ext::HTTP::TEMPLATE) do |span|
-                  # If data is a string, it is a literal template and we don't
-                  # want to record it.
-                  span.set_tag(Ext::TAG_TEMPLATE_NAME, data) if data.is_a? Symbol
-
-                  # Measure service stats
-                  Contrib::Analytics.set_measured(span)
-
-                  output = super
-                end
-              else
-                output = super
-              end
-
-              output
-            end
-          end
-
           app.use TracerMiddleware
 
-          app.before do
-            return unless Datadog.configuration[:sinatra][:tracer].enabled
+          app.after do
+            configuration = Datadog.configuration[:sinatra]
+            return unless configuration[:tracer].enabled
+            return if Sinatra::Env.middleware_traced?(env)
 
-            span = Sinatra::Env.datadog_span(env)
+            span = Sinatra::Tracer.fetch_middleware_span!(env, configuration)
+
+            route = if defined?(@datadog_route)
+                      @datadog_route
+                    else
+                      # Fallback in case no routes have matched
+                      request.path
+                    end
+
+            span.resource = "#{request.request_method} #{route}"
+
             span.set_tag(Datadog::Ext::HTTP::URL, request.path)
             span.set_tag(Datadog::Ext::HTTP::METHOD, request.request_method)
-          end
-
-          app.after do
-            return unless Datadog.configuration[:sinatra][:tracer].enabled
-
-            span = Sinatra::Env.datadog_span(env)
-
-            unless span
-              Datadog.logger.error('missing request span in :after hook')
-              return
+            span.set_tag(Ext::TAG_APP_NAME, app.settings.name)
+            span.set_tag(Ext::TAG_ROUTE_PATH, route)
+            if request.script_name && !request.script_name.empty?
+              span.set_tag(Ext::TAG_SCRIPT_NAME, request.script_name)
             end
 
-            span.resource = "#{request.request_method} #{@datadog_route}"
-            span.set_tag(Ext::TAG_ROUTE_PATH, @datadog_route)
             span.set_tag(Datadog::Ext::HTTP::STATUS_CODE, response.status)
             span.set_error(env['sinatra.error']) if response.server_error?
+
+            Sinatra::Env.set_middleware_traced(env, true)
+          end
+        end
+
+        # Retrieves of initializes the top-most middleware Sinatra span.
+        # This allows us to only create spans for Sinatra middlewares that
+        # have a matching route.
+        #
+        # If we traced all Sinatra middleware apps, we would have a chain
+        # of nested spans that were not responsible for handling this request,
+        # adding little value to users.
+        def self.fetch_middleware_span!(env, configuration)
+          span = Sinatra::Env.datadog_span(env)
+          return span if span
+
+          tracer = configuration[:tracer]
+          span = tracer.trace(
+            Ext::SPAN_REQUEST,
+            service: configuration[:service_name],
+            span_type: Datadog::Ext::HTTP::TYPE_INBOUND,
+            start_time: Sinatra::Env.middleware_start_time(env)
+          )
+
+          Sinatra::Env.set_datadog_span(env, span)
+          span
+        end
+
+        # Method overrides for Sinatra::Base
+        module Base
+          def render(engine, data, *)
+            tracer = Datadog.configuration[:sinatra][:tracer]
+            return super unless tracer.enabled
+
+            tracer.trace(Ext::SPAN_RENDER_TEMPLATE, span_type: Datadog::Ext::HTTP::TEMPLATE) do |span|
+              span.set_tag(Ext::TAG_TEMPLATE_ENGINE, engine)
+
+              # If data is a string, it is a literal template and we don't
+              # want to record it.
+              span.set_tag(Ext::TAG_TEMPLATE_NAME, data) if data.is_a? Symbol
+
+              # Measure service stats
+              Contrib::Analytics.set_measured(span)
+
+              super
+            end
+          end
+
+          # Invoked when a matching route is found.
+          # This method yields directly to user code.
+          def route_eval
+            configuration = Datadog.configuration[:sinatra]
+            tracer = configuration[:tracer]
+
+            return super unless tracer.enabled
+
+            # For initialization of Sinatra middleware span in order
+            # guarantee that the Ext::SPAN_ROUTE span being created below
+            # has the middleware span as its parent.
+            Sinatra::Tracer.fetch_middleware_span!(env, configuration)
+
+            tracer.trace(
+              Ext::SPAN_ROUTE,
+              service: configuration[:service_name],
+              span_type: Datadog::Ext::HTTP::TYPE_INBOUND
+            ) do |span|
+              span.resource = "#{request.request_method} #{@datadog_route}"
+
+              span.set_tag(Ext::TAG_APP_NAME, settings.name || settings.superclass.name)
+              span.set_tag(Ext::TAG_ROUTE_PATH, @datadog_route)
+              if request.script_name && !request.script_name.empty?
+                span.set_tag(Ext::TAG_SCRIPT_NAME, request.script_name)
+              end
+
+              rack_request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
+              rack_request_span.resource = span.resource if rack_request_span
+
+              Contrib::Analytics.set_measured(span)
+
+              super
+            end
           end
         end
       end

--- a/lib/ddtrace/contrib/sinatra/tracer_middleware.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer_middleware.rb
@@ -22,8 +22,7 @@ module Datadog
           Sinatra::Env.set_middleware_start_time(env)
 
           # Run application stack
-          status, headers, response_body = @app.call(env)
-          [status, headers, response_body]
+          response = @app.call(env)
         ensure
           # Augment current Sinatra middleware span if we are the top-most Sinatra app on the Rack stack.
           span = Sinatra::Env.datadog_span(env)
@@ -32,7 +31,7 @@ module Datadog
               span.set_tag(name, value) if span.get_tag(name).nil?
             end
 
-            if headers
+            if response && (headers = response[1])
               Sinatra::Headers.response_header_tags(headers, configuration[:headers][:response]).each do |name, value|
                 span.set_tag(name, value) if span.get_tag(name).nil?
               end

--- a/spec/ddtrace/contrib/sinatra/multi_app_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/multi_app_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
   let(:span) { spans.first }
   let(:spans) { tracer.writer.spans }
 
-  before(:each) do
+  before do
     Datadog.configure do |c|
       c.use :sinatra, options
     end
   end
 
-  after(:each) { Datadog.registry[:sinatra].reset_configuration! }
+  after { Datadog.registry[:sinatra].reset_configuration! }
 
   shared_context 'multi-app' do
     let(:app) do
@@ -72,8 +72,12 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
 
         it do
           is_expected.to be_ok
-          expect(spans).to have(1).items
-          expect(span.resource).to eq('GET /endpoint')
+          expect(spans).to have(2).items
+          spans.each do |span|
+            expect(span.resource).to eq('GET /endpoint')
+            expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_ROUTE_PATH)).to eq('/endpoint')
+            expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_SCRIPT_NAME)).to eq('/one')
+          end
         end
       end
 
@@ -82,8 +86,12 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
 
         it do
           is_expected.to be_ok
-          expect(spans).to have(1).items
-          expect(span.resource).to eq('GET /endpoint')
+          expect(spans).to have(2).items
+          spans.each do |span|
+            expect(span.resource).to eq('GET /endpoint')
+            expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_ROUTE_PATH)).to eq('/endpoint')
+            expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_SCRIPT_NAME)).to eq('/two')
+          end
         end
       end
     end
@@ -96,8 +104,12 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
 
         it do
           is_expected.to be_ok
-          expect(spans).to have(1).items
-          expect(span.resource).to eq('GET /one/endpoint')
+          expect(spans).to have(2).items
+          spans.each do |span|
+            expect(span.resource).to eq('GET /one/endpoint')
+            expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_ROUTE_PATH)).to eq('/one/endpoint')
+            expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_SCRIPT_NAME)).to eq('/one')
+          end
         end
       end
 
@@ -106,8 +118,12 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
 
         it do
           is_expected.to be_ok
-          expect(spans).to have(1).items
-          expect(span.resource).to eq('GET /two/endpoint')
+          expect(spans).to have(2).items
+          spans.each do |span|
+            expect(span.resource).to eq('GET /two/endpoint')
+            expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_ROUTE_PATH)).to eq('/two/endpoint')
+            expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_SCRIPT_NAME)).to eq('/two')
+          end
         end
       end
     end

--- a/spec/ddtrace/contrib/sinatra/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/tracer_spec.rb
@@ -13,11 +13,17 @@ RSpec.describe 'Sinatra instrumentation' do
   let(:tracer) { get_test_tracer }
   let(:configuration_options) { { tracer: tracer } }
 
-  let(:span) { spans.first }
+  let(:span) { spans.find { |x| x.name == Datadog::Contrib::Sinatra::Ext::SPAN_REQUEST } }
+  let(:route_span) { spans.find { |x| x.name == Datadog::Contrib::Sinatra::Ext::SPAN_ROUTE } }
   let(:spans) { tracer.writer.spans }
 
-  before(:each) do
+  let(:app) { sinatra_app }
+
+  let(:with_rack) { false }
+
+  before do
     Datadog.configure do |c|
+      c.use :rack, configuration_options if with_rack
       c.use :sinatra, configuration_options
     end
   end
@@ -29,426 +35,473 @@ RSpec.describe 'Sinatra instrumentation' do
     Datadog.registry[:sinatra].reset_configuration!
   end
 
-  shared_context 'app with simple route' do
+  shared_context 'with rack instrumentation' do
+    let(:with_rack) { true }
+    let(:rack_span) { spans.find { |x| !x.parent && x.name == Datadog::Contrib::Rack::Ext::SPAN_REQUEST } }
+
     let(:app) do
-      Class.new(Sinatra::Application) do
-        get '/' do
-          'Hello, world!'
-        end
-      end
+      sinatra_app = self.sinatra_app
+      Rack::Builder.new do
+        use Datadog::Contrib::Rack::TraceMiddleware
+        run sinatra_app
+      end.to_app
     end
   end
 
-  context 'when configured' do
-    context 'with default settings' do
-      context 'and a simple request is made' do
-        include_context 'app with simple route'
+  shared_examples 'sinatra examples' do
+    context 'when configured' do
+      context 'with default settings' do
+        context 'and a simple request is made' do
+          include_context 'with rack instrumentation'
 
-        subject(:response) { get '/' }
-
-        it do
-          is_expected.to be_ok
-          expect(spans).to have(1).items
-
-          expect(span.service).to eq(Datadog::Contrib::Sinatra::Ext::SERVICE_NAME)
-          expect(span.resource).to eq('GET /')
-          expect(span.get_tag(Datadog::Ext::HTTP::METHOD)).to eq('GET')
-          expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/')
-          expect(span.get_tag('http.response.headers.content_type')).to eq('text/html;charset=utf-8')
-          expect(span.span_type).to eq(Datadog::Ext::HTTP::TYPE_INBOUND)
-          expect(span.status).to eq(0)
-          expect(span.parent).to be nil
-        end
-
-        it_behaves_like 'analytics for integration', ignore_global_flag: false do
-          before { is_expected.to be_ok }
-          let(:analytics_enabled_var) { Datadog::Contrib::Sinatra::Ext::ENV_ANALYTICS_ENABLED }
-          let(:analytics_sample_rate_var) { Datadog::Contrib::Sinatra::Ext::ENV_ANALYTICS_SAMPLE_RATE }
-        end
-
-        it_behaves_like 'measured span for integration', true do
-          before { is_expected.to be_ok }
-        end
-
-        context 'which sets X-Request-Id on the response' do
-          let(:app) do
-            req_id = request_id
-
-            Class.new(Sinatra::Application) do
-              get '/' do
-                headers['X-Request-Id'] = req_id
-                'Hello, world!'
-              end
-            end
-          end
-
-          let(:request_id) { SecureRandom.uuid }
+          subject(:response) { get '/' }
 
           it do
             is_expected.to be_ok
-            expect(spans).to have(1).items
-            expect(span.get_tag('http.response.headers.x_request_id')).to eq(request_id)
+            expect(spans).to have(3).items
+
+            expect(span.service).to eq(Datadog::Contrib::Sinatra::Ext::SERVICE_NAME)
+            expect(span.resource).to eq('GET /')
+            expect(span.get_tag(Datadog::Ext::HTTP::METHOD)).to eq('GET')
+            expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/')
+            expect(span.get_tag('http.response.headers.content_type')).to eq('text/html;charset=utf-8')
+            expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_APP_NAME)).to eq(app_name)
+            expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_ROUTE_PATH)).to eq('/')
+            expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_SCRIPT_NAME)).to be_nil
+            expect(span.span_type).to eq(Datadog::Ext::HTTP::TYPE_INBOUND)
+            expect(span).to_not have_error
+            expect(span.parent).to be(rack_span)
+
+            expect(route_span.service).to eq(Datadog::Contrib::Sinatra::Ext::SERVICE_NAME)
+            expect(route_span.resource).to eq('GET /')
+            expect(route_span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_APP_NAME)).to eq(app_name)
+            expect(route_span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_ROUTE_PATH)).to eq('/')
+            expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_SCRIPT_NAME)).to be_nil
+            expect(route_span.span_type).to eq(Datadog::Ext::HTTP::TYPE_INBOUND)
+            expect(route_span).to_not have_error
+            expect(route_span.parent).to eq(span)
+
+            expect(rack_span.resource).to eq('GET /')
           end
-        end
-      end
 
-      context 'and a request with a query string and fragment is made' do
-        include_context 'app with simple route'
+          it_behaves_like 'analytics for integration', ignore_global_flag: false do
+            before { is_expected.to be_ok }
+            let(:analytics_enabled_var) { Datadog::Contrib::Sinatra::Ext::ENV_ANALYTICS_ENABLED }
+            let(:analytics_sample_rate_var) { Datadog::Contrib::Sinatra::Ext::ENV_ANALYTICS_SAMPLE_RATE }
+          end
 
-        subject(:response) { get '/#foo?a=1' }
+          it_behaves_like 'measured span for integration', true do
+            before { is_expected.to be_ok }
+          end
 
-        it do
-          is_expected.to be_ok
-          expect(spans).to have(1).items
-          expect(span.resource).to eq('GET /')
-          expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/')
-        end
-      end
-
-      context 'and a request to a wildcard route is made' do
-        let(:app) do
-          Class.new(Sinatra::Application) do
-            get '/*' do
-              params['splat'][0]
+          context 'which sets X-Request-Id on the response' do
+            it do
+              subject
+              expect(span.get_tag('http.response.headers.x_request_id')).to eq('test request id')
             end
           end
         end
 
-        subject(:response) { get '/1/2/3' }
-
-        it do
-          is_expected.to be_ok
-          expect(spans).to have(1).items
-          expect(span.resource).to eq('GET /*')
-          expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/1/2/3')
-        end
-      end
-
-      context 'and a request to a template route is made' do
-        let(:app) do
-          Class.new(Sinatra::Application) do
-            get '/' do
-              erb :msg, locals: { msg: 'hello' }
-            end
-          end
-        end
-
-        subject(:response) { get '/' }
-
-        let(:parent_span) { spans[2] }
-        let(:child_span) { spans[0] }
-        let(:grandchild_span) { spans[1] }
-
-        before(:each) do
-          expect(response).to be_ok
-          expect(spans).to have(3).items
-        end
-
-        describe 'the sinatra.request span' do
-          subject(:span) { parent_span }
+        context 'and a request with a query string and fragment is made' do
+          subject(:response) { get '/#foo?a=1' }
 
           it do
-            expect(span.name).to eq(Datadog::Contrib::Sinatra::Ext::SPAN_REQUEST)
+            is_expected.to be_ok
+            expect(spans).to have(2).items
             expect(span.resource).to eq('GET /')
             expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/')
-            expect(span.parent).to be nil
-          end
-
-          it_behaves_like 'measured span for integration', true
-        end
-
-        describe 'the sinatra.render_template child span' do
-          subject(:span) { child_span }
-
-          it do
-            expect(span.name).to eq(Datadog::Contrib::Sinatra::Ext::SPAN_RENDER_TEMPLATE)
-            expect(span.resource).to eq('sinatra.render_template')
-            expect(span.get_tag('sinatra.template_name')).to eq('msg')
-            expect(span.parent).to eq(parent_span)
-          end
-
-          it_behaves_like 'measured span for integration', true
-        end
-
-        describe 'the sinatra.render_template grandchild span' do
-          subject(:span) { grandchild_span }
-
-          it do
-            expect(span.name).to eq(Datadog::Contrib::Sinatra::Ext::SPAN_RENDER_TEMPLATE)
-            expect(span.resource).to eq('sinatra.render_template')
-            expect(span.get_tag('sinatra.template_name')).to eq('layout')
-            expect(span.parent).to eq(child_span)
-          end
-
-          it_behaves_like 'measured span for integration', true
-        end
-      end
-
-      context 'and a request to a literal template route is made' do
-        let(:app) do
-          Class.new(Sinatra::Application) do
-            get '/' do
-              erb '<%= msg %>', locals: { msg: 'hello' }
-            end
           end
         end
 
-        subject(:response) { get '/' }
-
-        let(:parent_span) { spans[2] }
-        let(:child_span) { spans[0] }
-        let(:grandchild_span) { spans[1] }
-
-        before(:each) do
-          expect(response).to be_ok
-          expect(spans).to have(3).items
-        end
-
-        describe 'the sinatra.request span' do
-          subject(:span) { parent_span }
-
-          it do
-            expect(span.name).to eq(Datadog::Contrib::Sinatra::Ext::SPAN_REQUEST)
-            expect(span.resource).to eq('GET /')
-            expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/')
-            expect(span.parent).to be nil
-          end
-
-          it_behaves_like 'measured span for integration', true
-        end
-
-        describe 'the sinatra.render_template child span' do
-          subject(:span) { child_span }
-
-          it do
-            expect(span.name).to eq(Datadog::Contrib::Sinatra::Ext::SPAN_RENDER_TEMPLATE)
-            expect(span.resource).to eq('sinatra.render_template')
-            expect(span.get_tag('sinatra.template_name')).to be nil
-            expect(span.parent).to eq(parent_span)
-          end
-
-          it_behaves_like 'measured span for integration', true
-        end
-
-        describe 'the sinatra.render_template grandchild span' do
-          subject(:span) { grandchild_span }
-
-          it do
-            expect(span.name).to eq(Datadog::Contrib::Sinatra::Ext::SPAN_RENDER_TEMPLATE)
-            expect(span.resource).to eq('sinatra.render_template')
-            expect(span.get_tag('sinatra.template_name')).to eq('layout')
-            expect(span.parent).to eq(child_span)
-          end
-
-          it_behaves_like 'measured span for integration', true
-        end
-      end
-
-      context 'and a bad request is made' do
-        let(:app) do
-          Class.new(Sinatra::Application) do
-            get '/' do
-              halt 400, 'bad request'
-            end
-          end
-        end
-
-        subject(:response) { get '/' }
-
-        it do
-          is_expected.to be_bad_request
-          expect(spans).to have(1).items
-          expect(span).to_not have_error_type
-          expect(span).to_not have_error_message
-          expect(span.status).to eq(0)
-        end
-      end
-
-      context 'and a request resulting in an internal error is made' do
-        let(:app) do
-          Class.new(Sinatra::Application) do
-            get '/' do
-              halt 500, 'server error'
-            end
-          end
-        end
-
-        subject(:response) { get '/' }
-
-        it do
-          is_expected.to be_server_error
-          expect(spans).to have(1).items
-          expect(span).to_not have_error_type
-          expect(span).to_not have_error_message
-          expect(span.status).to eq(1)
-        end
-      end
-
-      context 'and a request that raises an exception is made' do
-        let(:app) do
-          Class.new(Sinatra::Application) do
-            get '/' do
-              raise StandardError, 'something bad'
-            end
-          end
-        end
-
-        subject(:response) { get '/' }
-
-        it do
-          is_expected.to be_server_error
-          expect(spans).to have(1).items
-          expect(span).to have_error_type('StandardError')
-          expect(span).to have_error_message('something bad')
-          expect(span.status).to eq(1)
-        end
-      end
-    end
-
-    context 'with a custom service name' do
-      let(:configuration_options) { super().merge(service_name: service_name) }
-      let(:service_name) { 'my-sinatra-app' }
-
-      context 'and a simple request is made' do
-        include_context 'app with simple route'
-
-        subject(:response) { get '/' }
-
-        it do
-          is_expected.to be_ok
-          expect(spans).to have(1).items
-          expect(span.service).to eq(service_name)
-        end
-      end
-    end
-
-    context 'with distributed tracing default' do
-      context 'and a simple request is made' do
-        include_context 'app with simple route'
-
-        subject(:response) { get '/', query_string, headers }
-        let(:query_string) { {} }
-        let(:headers) { {} }
-
-        context 'with distributed tracing headers' do
-          let(:headers) do
-            {
-              'HTTP_X_DATADOG_TRACE_ID' => '1',
-              'HTTP_X_DATADOG_PARENT_ID' => '2',
-              'HTTP_X_DATADOG_SAMPLING_PRIORITY' => Datadog::Ext::Priority::USER_KEEP.to_s,
-              'HTTP_X_DATADOG_ORIGIN' => 'synthetics'
-            }
-          end
+        context 'and a request to a wildcard route is made' do
+          subject(:response) { get '/wildcard/1/2/3' }
 
           it do
             is_expected.to be_ok
-            expect(spans).to have(1).items
-            expect(span.trace_id).to eq(1)
-            expect(span.parent_id).to eq(2)
-            expect(span.get_metric(Datadog::Ext::DistributedTracing::SAMPLING_PRIORITY_KEY)).to eq(2.0)
-            expect(span.get_tag(Datadog::Ext::DistributedTracing::ORIGIN_KEY)).to eq('synthetics')
+            expect(spans).to have(2).items
+            expect(span.resource).to eq('GET /wildcard/*')
+            expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/wildcard/1/2/3')
+            expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_ROUTE_PATH)).to eq('/wildcard/*')
+          end
+        end
+
+        context 'and a request to a template route is made' do
+          subject(:response) { get '/erb' }
+
+          let(:request_span) { spans[2] }
+          let(:route_span) { spans[3] }
+          let(:template_parent_span) { spans[0] }
+          let(:template_child_span) { spans[1] }
+
+          before do
+            expect(response).to be_ok
+            expect(spans).to have(4).items
+          end
+
+          describe 'the sinatra.request span' do
+            subject(:span) { request_span }
+
+            it do
+              expect(span.resource).to eq('GET /erb')
+              expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/erb')
+              expect(span.parent).to be nil
+            end
+
+            it_behaves_like 'measured span for integration', true
+          end
+
+          describe 'the sinatra.render_template child span' do
+            subject(:span) { template_parent_span }
+
+            it do
+              expect(span.name).to eq(Datadog::Contrib::Sinatra::Ext::SPAN_RENDER_TEMPLATE)
+              expect(span.resource).to eq('sinatra.render_template')
+              expect(span.get_tag('sinatra.template_name')).to eq('msg')
+              expect(span.parent).to eq(route_span)
+            end
+
+            it_behaves_like 'measured span for integration', true
+          end
+
+          describe 'the sinatra.render_template grandchild span' do
+            subject(:span) { template_child_span }
+
+            it do
+              expect(span.name).to eq(Datadog::Contrib::Sinatra::Ext::SPAN_RENDER_TEMPLATE)
+              expect(span.resource).to eq('sinatra.render_template')
+              expect(span.get_tag('sinatra.template_name')).to eq('layout')
+              expect(span.parent).to eq(template_parent_span)
+            end
+
+            it_behaves_like 'measured span for integration', true
+          end
+        end
+
+        context 'and a request to a literal template route is made' do
+          subject(:response) { get '/erb_literal' }
+
+          let(:template_parent_span) { spans[0] }
+          let(:template_child_span) { spans[1] }
+
+          before do
+            expect(response).to be_ok
+            expect(spans).to have(4).items
+          end
+
+          describe 'the sinatra.request span' do
+            it do
+              expect(span.resource).to eq('GET /erb_literal')
+              expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/erb_literal')
+              expect(span.parent).to be nil
+            end
+
+            it_behaves_like 'measured span for integration', true
+          end
+
+          describe 'the sinatra.render_template child span' do
+            subject(:span) { template_parent_span }
+
+            it do
+              expect(span.name).to eq(Datadog::Contrib::Sinatra::Ext::SPAN_RENDER_TEMPLATE)
+              expect(span.resource).to eq('sinatra.render_template')
+              expect(span.get_tag('sinatra.template_name')).to be nil
+              expect(span.parent).to eq(route_span)
+            end
+
+            it_behaves_like 'measured span for integration', true
+          end
+
+          describe 'the sinatra.render_template grandchild span' do
+            subject(:span) { template_child_span }
+
+            it do
+              expect(span.name).to eq(Datadog::Contrib::Sinatra::Ext::SPAN_RENDER_TEMPLATE)
+              expect(span.resource).to eq('sinatra.render_template')
+              expect(span.get_tag('sinatra.template_name')).to eq('layout')
+              expect(span.parent).to eq(template_parent_span)
+            end
+
+            it_behaves_like 'measured span for integration', true
+          end
+        end
+
+        context 'and a bad request is made' do
+          subject(:response) { get '/client_error' }
+
+          it do
+            is_expected.to be_bad_request
+            expect(spans).to have(2).items
+            expect(span).to_not have_error
+          end
+        end
+
+        context 'and a request resulting in an internal error is made' do
+          subject(:response) { get '/server_error' }
+
+          it do
+            is_expected.to be_server_error
+            expect(spans).to have(2).items
+            expect(span).to_not have_error_type
+            expect(span).to_not have_error_message
+            expect(span.status).to eq(1)
+          end
+        end
+
+        context 'and a request that raises an exception is made' do
+          subject(:response) { get '/error' }
+
+          it do
+            is_expected.to be_server_error
+            expect(spans).to have(2).items
+            expect(span).to have_error_type('RuntimeError')
+            expect(span).to have_error_message('test error')
+            expect(span.status).to eq(1)
+          end
+        end
+
+        context 'and a request to a nonexistent route' do
+          include_context 'with rack instrumentation'
+
+          subject(:response) { get '/not_a_route' }
+
+          it do
+            is_expected.to be_not_found
+            expect(spans).to have(2).items
+
+            expect(span.service).to eq(Datadog::Contrib::Sinatra::Ext::SERVICE_NAME)
+            expect(span.resource).to eq('GET /not_a_route')
+            expect(span.get_tag(Datadog::Ext::HTTP::METHOD)).to eq('GET')
+            expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/not_a_route')
+            expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_APP_NAME)).to eq(app_name)
+            expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_ROUTE_PATH)).to eq('/not_a_route')
+            expect(span.span_type).to eq(Datadog::Ext::HTTP::TYPE_INBOUND)
+            expect(span).to_not have_error
+            expect(span.parent).to be(rack_span)
+
+            expect(rack_span.resource).to eq('GET 404')
+          end
+        end
+      end
+
+      context 'with a custom service name' do
+        let(:configuration_options) { super().merge(service_name: service_name) }
+        let(:service_name) { 'my-sinatra-app' }
+
+        context 'and a simple request is made' do
+          subject(:response) { get '/' }
+
+          it do
+            is_expected.to be_ok
+            expect(spans).to have(2).items
+            expect(span.service).to eq(service_name)
+          end
+        end
+      end
+
+      context 'with distributed tracing default' do
+        context 'and a simple request is made' do
+          subject(:response) { get '/', query_string, headers }
+          let(:query_string) { {} }
+          let(:headers) { {} }
+
+          context 'with distributed tracing headers' do
+            let(:headers) do
+              {
+                'HTTP_X_DATADOG_TRACE_ID' => '1',
+                'HTTP_X_DATADOG_PARENT_ID' => '2',
+                'HTTP_X_DATADOG_SAMPLING_PRIORITY' => Datadog::Ext::Priority::USER_KEEP.to_s,
+                'HTTP_X_DATADOG_ORIGIN' => 'synthetics'
+              }
+            end
+
+            it do
+              is_expected.to be_ok
+              expect(spans).to have(2).items
+              expect(span.trace_id).to eq(1)
+              expect(span.parent_id).to eq(2)
+              expect(span.get_metric(Datadog::Ext::DistributedTracing::SAMPLING_PRIORITY_KEY)).to eq(2.0)
+              expect(span.get_tag(Datadog::Ext::DistributedTracing::ORIGIN_KEY)).to eq('synthetics')
+            end
+          end
+        end
+      end
+
+      context 'with distributed tracing disabled' do
+        let(:configuration_options) { super().merge(distributed_tracing: false) }
+
+        context 'and a simple request is made' do
+          subject(:response) { get '/', query_string, headers }
+          let(:query_string) { {} }
+          let(:headers) { {} }
+
+          context 'without distributed tracing headers' do
+            let(:headers) do
+              {
+                'HTTP_X_DATADOG_TRACE_ID' => '1',
+                'HTTP_X_DATADOG_PARENT_ID' => '2',
+                'HTTP_X_DATADOG_SAMPLING_PRIORITY' => Datadog::Ext::Priority::USER_KEEP.to_s
+              }
+            end
+
+            it do
+              is_expected.to be_ok
+              expect(spans).to have(2).items
+              expect(span.trace_id).to_not eq(1)
+              expect(span.parent_id).to_not eq(2)
+              expect(span.get_metric(Datadog::Ext::DistributedTracing::SAMPLING_PRIORITY_KEY)).to_not eq(2.0)
+            end
+          end
+        end
+      end
+
+      context 'with header tags' do
+        let(:configuration_options) { super().merge(headers: { request: request_headers, response: response_headers }) }
+        let(:request_headers) { [] }
+        let(:response_headers) { [] }
+
+        context 'and a simple request is made' do
+          subject(:response) { get '/', query_string, headers }
+          let(:query_string) { {} }
+          let(:headers) { {} }
+
+          context 'with a header that should be tagged' do
+            let(:request_headers) { ['X-Request-Header'] }
+            let(:headers) { { 'HTTP_X_REQUEST_HEADER' => header_value } }
+            let(:header_value) { SecureRandom.uuid }
+
+            it do
+              is_expected.to be_ok
+              expect(spans).to have(2).items
+              expect(span.get_tag('http.request.headers.x_request_header')).to eq(header_value)
+            end
+          end
+
+          context 'with a header that should not be tagged' do
+            let(:headers) { { 'HTTP_X_REQUEST_HEADER' => header_value } }
+            let(:header_value) { SecureRandom.uuid }
+
+            it do
+              is_expected.to be_ok
+              expect(spans).to have(2).items
+              expect(span.get_tag('http.request.headers.x_request_header')).to be nil
+            end
           end
         end
       end
     end
 
-    context 'with distributed tracing disabled' do
-      let(:configuration_options) { super().merge(distributed_tracing: false) }
-
-      context 'and a simple request is made' do
-        include_context 'app with simple route'
-
-        subject(:response) { get '/', query_string, headers }
-        let(:query_string) { {} }
-        let(:headers) { {} }
-
-        context 'without distributed tracing headers' do
-          let(:headers) do
-            {
-              'HTTP_X_DATADOG_TRACE_ID' => '1',
-              'HTTP_X_DATADOG_PARENT_ID' => '2',
-              'HTTP_X_DATADOG_SAMPLING_PRIORITY' => Datadog::Ext::Priority::USER_KEEP.to_s
-            }
-          end
-
-          it do
-            is_expected.to be_ok
-            expect(spans).to have(1).items
-            expect(span.trace_id).to_not eq(1)
-            expect(span.parent_id).to_not eq(2)
-            expect(span.get_metric(Datadog::Ext::DistributedTracing::SAMPLING_PRIORITY_KEY)).to_not eq(2.0)
-          end
-        end
-      end
-    end
-
-    context 'with header tags' do
-      let(:configuration_options) { super().merge(headers: { request: request_headers, response: response_headers }) }
-      let(:request_headers) { [] }
-      let(:response_headers) { [] }
-
-      context 'and a simple request is made' do
-        include_context 'app with simple route'
-
-        subject(:response) { get '/', query_string, headers }
-        let(:query_string) { {} }
-        let(:headers) { {} }
-
-        context 'with a header that should be tagged' do
-          let(:request_headers) { ['X-Request-Header'] }
-          let(:headers) { { 'HTTP_X_REQUEST_HEADER' => header_value } }
-          let(:header_value) { SecureRandom.uuid }
-
-          it do
-            is_expected.to be_ok
-            expect(spans).to have(1).items
-            expect(span.get_tag('http.request.headers.x_request_header')).to eq(header_value)
-          end
-        end
-
-        context 'with a header that should not be tagged' do
-          let(:headers) { { 'HTTP_X_REQUEST_HEADER' => header_value } }
-          let(:header_value) { SecureRandom.uuid }
-
-          it do
-            is_expected.to be_ok
-            expect(spans).to have(1).items
-            expect(span.get_tag('http.request.headers.x_request_header')).to be nil
-          end
-        end
-      end
-    end
-
-    context 'with script names' do
-      let(:configuration_options) { super().merge(resource_script_names: true) }
-
-      let(:app) do
-        Class.new(Sinatra::Application) do
-          get '/endpoint' do
-            '1'
-          end
-        end
-      end
-
-      subject(:response) { get '/endpoint' }
+    context 'when the tracer is disabled' do
+      subject(:response) { get '/' }
+      let(:tracer) { get_test_tracer(enabled: false) }
 
       it do
         is_expected.to be_ok
-        expect(spans).to have(1).items
-        expect(span.resource).to eq('GET /endpoint')
+        expect(spans).to be_empty
       end
     end
   end
 
-  context 'when the tracer is disabled' do
-    include_context 'app with simple route'
+  let(:sinatra_routes) do
+    lambda do
+      get '/' do
+        headers['X-Request-Id'] = 'test request id'
+        'ok'
+      end
 
-    subject(:response) { get '/' }
-    let(:tracer) { get_test_tracer(enabled: false) }
+      get '/wildcard/*' do
+        params['splat'][0]
+      end
 
-    it do
-      is_expected.to be_ok
-      expect(spans).to be_empty
+      get '/error' do
+        raise 'test error'
+      end
+
+      get '/client_error' do
+        halt 400, 'bad request'
+      end
+
+      get '/server_error' do
+        halt 500, 'server error'
+      end
+
+      get '/erb' do
+        erb :msg, locals: { msg: 'hello' }
+      end
+
+      get '/erb_literal' do
+        erb '<%= msg %>', locals: { msg: 'hello' }
+      end
+    end
+  end
+
+  context 'with classic app' do
+    let(:sinatra_app) do
+      sinatra_routes = self.sinatra_routes
+      Class.new(Sinatra::Application) do
+        instance_exec(&sinatra_routes)
+      end
+    end
+
+    let(:app_name) { 'Sinatra::Application' }
+
+    include_examples 'sinatra examples'
+  end
+
+  context 'with modular app' do
+    let(:sinatra_app) do
+      stub_const('NestedApp', Class.new(Sinatra::Base) do
+        register Datadog::Contrib::Sinatra::Tracer
+
+        get '/nested' do
+          'nested ok'
+        end
+      end)
+
+      sinatra_routes = self.sinatra_routes
+      stub_const('App', Class.new(Sinatra::Base) do
+        register Datadog::Contrib::Sinatra::Tracer
+        use NestedApp
+
+        instance_exec(&sinatra_routes)
+      end)
+    end
+
+    let(:app_name) { 'App' }
+
+    include_examples 'sinatra examples'
+
+    context 'with nested app' do
+      include_context 'with rack instrumentation'
+
+      let(:app_name) { 'NestedApp' }
+
+      subject(:response) { get '/nested' }
+
+      it 'does not create spans for intermediate middlewares' do
+        is_expected.to be_ok
+        expect(spans).to have(3).items
+
+        expect(span.service).to eq(Datadog::Contrib::Sinatra::Ext::SERVICE_NAME)
+        expect(span.resource).to eq('GET /nested')
+        expect(span.get_tag(Datadog::Ext::HTTP::METHOD)).to eq('GET')
+        expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/nested')
+        expect(span.get_tag('http.response.headers.content_type')).to eq('text/html;charset=utf-8')
+        expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_APP_NAME)).to eq(app_name)
+        expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_ROUTE_PATH)).to eq('/nested')
+        expect(span.span_type).to eq(Datadog::Ext::HTTP::TYPE_INBOUND)
+        expect(span).to_not have_error
+        expect(span.parent).to eq(rack_span)
+
+        expect(route_span.service).to eq(Datadog::Contrib::Sinatra::Ext::SERVICE_NAME)
+        expect(route_span.resource).to eq('GET /nested')
+        expect(route_span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_APP_NAME)).to eq(app_name)
+        expect(route_span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_ROUTE_PATH)).to eq('/nested')
+        expect(route_span.span_type).to eq(Datadog::Ext::HTTP::TYPE_INBOUND)
+        expect(route_span).to_not have_error
+        expect(route_span.parent).to eq(span)
+
+        expect(rack_span.resource).to eq('GET /nested')
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #486 and #913
Closes #491 (thank you @jpaulgs!)

This PR adds improved support for [Sinatra modular applications](
https://github.com/sinatra/sinatra/blob/d112f8f67119e0248b90e98a4a384e2f4287e1fb/README.md#serving-a-modular-application).

We already had support for [classic applications](https://github.com/sinatra/sinatra/blob/d112f8f67119e0248b90e98a4a384e2f4287e1fb/README.md#using-a-classic-style-application-with-a-configru), but it did not translate correctly to modular apps.

We now support nested modular Sinatra apps, and added a new span measuring the specific application route that was matched for a request (`sinatra.route`).

To help support modular apps, a new tag (`sinatra.app.name`) was added to the existing `sinatra.request` span, to identify which modular app handled to the request.

## Action shots

The existing `sinatra.request` span, which measures the total Sinatra middleware time. Now including the application name:
![Screen Shot 2020-04-23 at 4 00 14 PM](https://user-images.githubusercontent.com/583503/80153748-1efc7a80-858c-11ea-94ec-635c62e35ae5.png)

The new `sinatra.route` span, which measures only the user application time of a matched route:
![Screen Shot 2020-04-23 at 4 00 00 PM](https://user-images.githubusercontent.com/583503/80153632-ec528200-858b-11ea-8c7c-81d74beb606b.png)
