### PR TITLE
Add profiling scheduler

### DIFF
--- a/lib/ddtrace/profiling/scheduler.rb
+++ b/lib/ddtrace/profiling/scheduler.rb
@@ -1,0 +1,83 @@
+require 'ddtrace/utils/time'
+
+require 'ddtrace/worker'
+require 'ddtrace/workers/polling'
+
+module Datadog
+  module Profiling
+    # Pulls and exports profiling data on an async interval basis
+    class Scheduler < Worker
+      include Workers::Polling
+
+      DEFAULT_INTERVAL = 60
+      MIN_INTERVAL = 0
+
+      attr_reader \
+        :exporters,
+        :recorder
+
+      def initialize(recorder, exporters, options = {})
+        @recorder = recorder
+        @exporters = [exporters].flatten
+
+        # Workers::Async::Thread settings
+        # Restart in forks by default
+        self.fork_policy = options.fetch(:fork_policy, Workers::Async::Thread::FORK_POLICY_RESTART)
+
+        # Workers::IntervalLoop settings
+        self.loop_base_interval = options.fetch(:interval, DEFAULT_INTERVAL)
+
+        # Workers::Polling settings
+        self.enabled = options.fetch(:enabled, false)
+      end
+
+      def start
+        perform
+      end
+
+      def perform
+        flush_and_wait
+      end
+
+      def loop_back_off?
+        false
+      end
+
+      def after_fork
+        # Clear recorder's buffers by flushing events.
+        # Objects from parent process will copy-on-write,
+        # and we don't want to send events for the wrong process.
+        recorder.pop
+      end
+
+      def flush_and_wait
+        run_time = Datadog::Utils::Time.measure do
+          flush_events
+        end
+
+        # Update wait time to try to wake consistently on time.
+        # Don't drop below the minimum interval.
+        self.loop_wait_time = [loop_base_interval - run_time, MIN_INTERVAL].max
+      end
+
+      def flush_events
+        # Get events from recorder
+        events = recorder.pop
+        num_events = events.inject(0) { |sum, flush| sum + flush.events.length }
+        return unless num_events > 0
+
+        # Send events to each exporter
+        exporters.each do |exporter|
+          begin
+            exporter.export(events)
+          rescue StandardError => e
+            error_details = "Cause: #{e} Location: #{e.backtrace.first}"
+            Datadog.logger.error("Unable to export #{num_events} profiling events. #{error_details}")
+          end
+        end
+
+        num_events
+      end
+    end
+  end
+end

--- a/lib/ddtrace/utils/time.rb
+++ b/lib/ddtrace/utils/time.rb
@@ -9,6 +9,13 @@ module Datadog
       def get_time
         PROCESS_TIME_SUPPORTED ? Process.clock_gettime(Process::CLOCK_MONOTONIC) : ::Time.now.to_f
       end
+
+      def measure
+        before = get_time
+        yield
+        after = get_time
+        after - before
+      end
     end
   end
 end

--- a/lib/ddtrace/workers/async.rb
+++ b/lib/ddtrace/workers/async.rb
@@ -18,7 +18,7 @@ module Datadog
         # Methods that must be prepended
         module PrependedMethods
           def perform(*args)
-            start { self.result = super(*args) } unless started?
+            start_async { self.result = super(*args) } unless started?
           end
         end
 
@@ -101,7 +101,7 @@ module Datadog
           @worker ||= nil
         end
 
-        def start(&block)
+        def start_async(&block)
           mutex.synchronize do
             return if running?
             if forked?

--- a/lib/ddtrace/workers/loop.rb
+++ b/lib/ddtrace/workers/loop.rb
@@ -53,12 +53,21 @@ module Datadog
         @loop_wait_time ||= loop_base_interval
       end
 
+      def loop_wait_time=(value)
+        @loop_wait_time = value
+      end
+
+      def reset_loop_wait_time
+        self.loop_wait_time = loop_base_interval
+      end
+
+      # Should the loop "back off" when there's no work?
       def loop_back_off?
         false
       end
 
-      def loop_back_off!(amount = nil)
-        @loop_wait_time = amount || [loop_wait_time * BACK_OFF_RATIO, BACK_OFF_MAX].min
+      def loop_back_off!
+        self.loop_wait_time = [loop_wait_time * BACK_OFF_RATIO, BACK_OFF_MAX].min
       end
 
       protected
@@ -79,12 +88,14 @@ module Datadog
 
         loop do
           if work_pending?
+            # There's work to do...
             # Run the task
             yield
 
             # Reset the wait interval
-            loop_back_off!(loop_base_interval)
+            reset_loop_wait_time if loop_back_off?
           elsif loop_back_off?
+            # There's no work to do...
             # Back off the wait interval a bit
             loop_back_off!
           end

--- a/spec/ddtrace/profiling/scheduler_spec.rb
+++ b/spec/ddtrace/profiling/scheduler_spec.rb
@@ -1,0 +1,191 @@
+require 'spec_helper'
+
+require 'ddtrace/profiling/exporter'
+require 'ddtrace/profiling/recorder'
+require 'ddtrace/profiling/scheduler'
+
+RSpec.describe Datadog::Profiling::Scheduler do
+  subject(:scheduler) { described_class.new(recorder, exporters, options) }
+  let(:recorder) { instance_double(Datadog::Profiling::Recorder) }
+  let(:exporters) { [instance_double(Datadog::Profiling::Exporter)] }
+  let(:options) { {} }
+
+  describe '::new' do
+    it 'with default settings' do
+      is_expected.to have_attributes(
+        enabled?: false,
+        exporters: exporters,
+        fork_policy: Datadog::Workers::Async::Thread::FORK_POLICY_RESTART,
+        loop_base_interval: described_class::DEFAULT_INTERVAL,
+        recorder: recorder
+      )
+    end
+
+    context 'given a single exporter' do
+      let(:exporters) { instance_double(Datadog::Profiling::Exporter) }
+      it { is_expected.to have_attributes(exporters: [exporters]) }
+    end
+  end
+
+  describe '#start' do
+    subject(:start) { scheduler.start }
+
+    it 'starts the worker' do
+      expect(scheduler).to receive(:perform)
+      start
+    end
+  end
+
+  describe '#perform' do
+    subject(:perform) { scheduler.perform }
+    after { scheduler.stop(true, 0) }
+
+    context 'when disabled' do
+      before { scheduler.enabled = false }
+
+      it 'does not start a worker thread' do
+        is_expected.to be nil
+
+        expect(scheduler).to have_attributes(
+          run_async?: false,
+          running?: false,
+          started?: false,
+          forked?: false,
+          fork_policy: :restart,
+          result: nil
+        )
+      end
+    end
+
+    context 'when enabled' do
+      before { scheduler.enabled = true }
+
+      it 'starts a worker thread' do
+        allow(scheduler).to receive(:flush_events)
+
+        is_expected.to be_a_kind_of(Thread)
+        try_wait_until { scheduler.running? }
+
+        expect(scheduler).to have_attributes(
+          run_async?: true,
+          running?: true,
+          started?: true,
+          forked?: false,
+          fork_policy: :restart,
+          result: nil
+        )
+      end
+    end
+  end
+
+  describe '#loop_back_off?' do
+    subject(:loop_back_off?) { scheduler.loop_back_off? }
+    it { is_expected.to be false }
+  end
+
+  describe '#after_fork' do
+    subject(:after_fork) { scheduler.after_fork }
+
+    it 'clears the buffer' do
+      expect(recorder).to receive(:pop)
+      after_fork
+    end
+  end
+
+  describe '#flush_and_wait' do
+    subject(:flush_and_wait) { scheduler.flush_and_wait }
+    let(:flush_time) { 0.05 }
+
+    before do
+      expect(scheduler).to receive(:flush_events) do
+        sleep(flush_time)
+      end
+    end
+
+    it 'changes its wait interval after flushing' do
+      expect(scheduler).to receive(:loop_wait_time=) do |value|
+        expected_interval = described_class::DEFAULT_INTERVAL - flush_time
+        expect(value).to be <= expected_interval
+      end
+
+      flush_and_wait
+    end
+
+    context 'when the flush takes longer than an interval' do
+      let(:options) { { interval: 0.01 } }
+
+      # Assert that the interval isn't set below the min interval
+      it "floors the wait interval to #{described_class::MIN_INTERVAL}" do
+        expect(scheduler).to receive(:loop_wait_time=)
+          .with(described_class::MIN_INTERVAL)
+
+        flush_and_wait
+      end
+    end
+  end
+
+  describe '#flush_events' do
+    subject(:flush_events) { scheduler.flush_events }
+
+    before do
+      expect(recorder).to receive(:pop).and_return(events)
+      exporters.each { |exporter| allow(exporter).to receive(:export).with(events) }
+    end
+
+    context 'when no events are available' do
+      let(:events) { [] }
+
+      it 'does not export' do
+        is_expected.to be nil
+
+        exporters.each do |exporter|
+          expect(exporter).to_not have_received(:export)
+        end
+      end
+    end
+
+    context 'when events are available' do
+      let(:events) do
+        Array.new(2) do
+          instance_double(
+            Datadog::Profiling::Recorder::Flush,
+            event_class: double('event class'),
+            events: Array.new(2) { double('event') }
+          )
+        end
+      end
+
+      context 'and all the exporters succeed' do
+        it 'returns the number of events flushed' do
+          is_expected.to eq 4
+
+          exporters.each do |exporter|
+            expect(exporter)
+              .to have_received(:export)
+              .with(events)
+          end
+        end
+      end
+
+      context 'and one of the exporters fail' do
+        before do
+          allow(exporters.first).to receive(:export)
+            .and_raise(StandardError)
+
+          expect(Datadog.logger).to receive(:error)
+            .with(/Unable to export \d+ profiling events/)
+        end
+
+        it 'returns the number of events flushed' do
+          is_expected.to eq 4
+
+          exporters.each do |exporter|
+            expect(exporter)
+              .to have_received(:export)
+              .with(events)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/utils/time_spec.rb
+++ b/spec/ddtrace/utils/time_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+require 'ddtrace/utils/time'
+
+RSpec.describe Datadog::Utils::Time do
+  describe '#get_time' do
+    subject(:get_time) { described_class.get_time }
+    it { is_expected.to be_a_kind_of(Float) }
+  end
+
+  describe '#measure' do
+    it { expect { |b| described_class.measure(&b) }.to yield_control }
+
+    context 'given a block' do
+      subject(:measure) { described_class.measure(&block) }
+      let(:block) { proc { sleep(run_time) } }
+      let(:run_time) { 0.01 }
+
+      it do
+        is_expected.to be_a_kind_of(Float)
+        is_expected.to be >= run_time
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds the `Profiling::Scheduler`, which is responsible for keeping a worker thread which wakes up on an interval to flush all profiling events from the `Recorder` to all the provided `Exporters`.

To do this, `Scheduler` is a `Datadog::Worker` that re-uses `Workers::Polling` to wrap its `perform` method with a polling thread. It also defines some behaviors to manage behavior when forks occur: it should automatically restart the worker thread and clear its buffers on fork, to allow profiling to continue on a child process.