### PR TITLE
Fix Components#teardown! NoMethodError

### DIFF
--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -135,13 +135,13 @@ module Datadog
         old_statsd = [
           runtime_metrics.metrics.statsd,
           health_metrics.statsd
-        ].uniq
+        ].compact.uniq
 
         new_statsd =  if replacement
                         [
                           replacement.runtime_metrics.metrics.statsd,
                           replacement.health_metrics.statsd
-                        ].uniq
+                        ].compact.uniq
                       else
                         []
                       end

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -673,6 +673,25 @@ RSpec.describe Datadog::Configuration::Components do
 
           teardown!
         end
+
+        context 'and Statsd is not initialized' do
+          before do
+            allow(components.runtime_metrics.metrics)
+              .to receive(:statsd)
+              .and_return(nil)
+          end
+
+          it 'shuts down all components' do
+            expect(components.tracer).to receive(:shutdown!)
+            expect(components.runtime_metrics).to receive(:enabled=)
+              .with(false)
+            expect(components.runtime_metrics).to receive(:stop)
+              .with(true)
+            expect(components.health_metrics.statsd).to receive(:close)
+
+            teardown!
+          end
+        end
       end
 
       context 'when the tracer is re-used' do


### PR DESCRIPTION
Fixes #1021 

This line was collecting old Statsd instances and shutting them down if not in use on `teardown!`. Looks like somehow we were getting `nil` Statsd instances in for metrics, and this array did not `compact` them out, resulting in the function attempting to `nil.close`.

https://github.com/DataDog/dd-trace-rb/blob/10592cebfed7d4f9c509910e4d11faaf00cca668/lib/ddtrace/configuration/components.rb#L135

Added a `compact` and test to address the issue.