### PR TITLE
Add JRuby to local docker test environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '3.2'
 services:
+  # MRI
   tracer-2.0:
     image: palazzem/docker-library:ddtrace_rb_2_0_0
     command: /bin/bash
@@ -247,6 +248,38 @@ services:
       - .:/app
       - bundle-2.7:/usr/local/bundle
       - gemfiles-2.7:/app/gemfiles
+  # JRuby
+  tracer-jruby-9.2:
+    image: marcotc/docker-library:ddtrace_rb_jruby_9_2
+    command: /bin/bash
+    depends_on:
+      - ddagent
+      - elasticsearch
+      - memcached
+      - mongodb
+      - mysql
+      - postgres
+      - presto
+      - redis
+    env_file: ./.env
+    environment:
+      - BUNDLE_GEMFILE=/app/Gemfile
+      - DD_AGENT_HOST=ddagent
+      - TEST_DATADOG_INTEGRATION=1
+      - TEST_ELASTICSEARCH_HOST=elasticsearch
+      - TEST_MEMCACHED_HOST=memcached
+      - TEST_MONGODB_HOST=mongodb
+      - TEST_MYSQL_HOST=mysql
+      - TEST_POSTGRES_HOST=postgres
+      - TEST_PRESTO_HOST=presto
+      - TEST_PRESTO_PORT=8080
+      - TEST_REDIS_HOST=redis
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/app
+      - bundle-jruby-9.2:/usr/local/bundle
+      - gemfiles-jruby-9.2:/app/gemfiles
   ddagent:
     image: datadog/docker-dd-agent
     environment:
@@ -325,6 +358,7 @@ volumes:
   bundle-2.5:
   bundle-2.6:
   bundle-2.7:
+  bundle-jruby-9.2:
   gemfiles-2.0:
   gemfiles-2.1:
   gemfiles-2.2:
@@ -333,3 +367,4 @@ volumes:
   gemfiles-2.5:
   gemfiles-2.6:
   gemfiles-2.7:
+  gemfiles-jruby-9.2:


### PR DESCRIPTION
This PR adds a missing part of our support for JRuby: a local docker test environment.

We should not be able to:
```
$ docker-compose run --rm tracer-jruby-9.2
root@645db68092db:/app# ruby -v
jruby 9.2.11.1 (2.5.7) 2020-03-25 b1f55b1a40 OpenJDK 64-Bit Server VM 25.242-b08 on 1.8.0_242-b08 +jit [linux-x86_64]
```