### PR TITLE
Add profiling stack collector

### DIFF
--- a/lib/ddtrace/ext/profiling.rb
+++ b/lib/ddtrace/ext/profiling.rb
@@ -1,0 +1,9 @@
+module Datadog
+  module Ext
+    module Profiling
+      ENV_MAX_FRAMES = 'DD_PROFILING_MAX_FRAMES'.freeze
+      ENV_MAX_TIME_USAGE_PCT = 'DD_PROFILING_MAX_TIME_USAGE_PCT'.freeze
+      ENV_IGNORE_PROFILER = 'DD_PROFILING_IGNORE_PROFILER'.freeze
+    end
+  end
+end

--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -1,0 +1,115 @@
+require 'ddtrace/profiling/events/stack'
+require 'ddtrace/utils/time'
+require 'ddtrace/worker'
+require 'ddtrace/workers/polling'
+
+module Datadog
+  module Profiling
+    module Collectors
+      # Pulls and exports profiling data on an async interval basis
+      class Stack < Worker
+        include Workers::Polling
+
+        DEFAULT_MAX_FRAMES = 128
+        DEFAULT_MAX_TIME_USAGE_PCT = 2.0
+        MIN_INTERVAL = 0.01
+
+        attr_reader \
+          :ignore_thread,
+          :max_frames,
+          :max_time_usage_pct,
+          :recorder
+
+        def initialize(recorder, options = {})
+          @recorder = recorder
+          @max_frames = options.fetch(:max_frames, DEFAULT_MAX_FRAMES)
+          @ignore_thread = options.fetch(:ignore_thread, nil)
+          @max_time_usage_pct = options.fetch(:max_time_usage_pct, DEFAULT_MAX_TIME_USAGE_PCT)
+
+          # Workers::Async::Thread settings
+          # Restart in forks by default
+          self.fork_policy = options.fetch(:fork_policy, Workers::Async::Thread::FORK_POLICY_RESTART)
+
+          # Workers::IntervalLoop settings
+          self.loop_base_interval = options.fetch(:interval, MIN_INTERVAL)
+
+          # Workers::Polling settings
+          self.enabled = options.fetch(:enabled, false)
+        end
+
+        def start
+          @last_wall_time = Datadog::Utils::Time.get_time
+          perform
+        end
+
+        def perform
+          collect_and_wait
+        end
+
+        def loop_back_off?
+          false
+        end
+
+        def last_wall_time
+          @last_wall_time ||= Datadog::Utils::Time.get_time
+        end
+
+        def collect_and_wait
+          run_time = Datadog::Utils::Time.measure do
+            collect_events
+          end
+
+          # Update wait time to throttle profiling
+          self.loop_wait_time = compute_wait_time(run_time)
+        end
+
+        def collect_events
+          events = []
+
+          # Compute wall time interval
+          current_wall_time = Datadog::Utils::Time.get_time
+          wall_time_interval_ns = (current_wall_time - last_wall_time) * 1e9
+          @last_wall_time = current_wall_time
+
+          # Collect backtraces from each thread
+          Thread.list.each do |thread|
+            next unless thread.alive?
+            next if ignore_thread.is_a?(Proc) && ignore_thread.call(thread)
+
+            event = collect_thread_event(thread, wall_time_interval_ns)
+            events << event unless event.nil?
+          end
+
+          # Send events to recorder
+          recorder.push(events) unless events.empty?
+
+          events
+        end
+
+        def collect_thread_event(thread, wall_time_interval_ns)
+          locations = thread.backtrace_locations
+          return if locations.nil?
+
+          # Get actual stack size then trim the stack
+          stack_size = locations.length
+          locations = locations[0..(max_frames - 1)]
+
+          Events::StackSample.new(
+            nil,
+            locations,
+            stack_size,
+            thread.object_id,
+            wall_time_interval_ns
+          )
+        end
+
+        def compute_wait_time(used_time)
+          used_time_ns = used_time * 1e9
+
+          interval = (used_time_ns / (max_time_usage_pct / 100.0)) - used_time_ns
+          [interval / 1e9, MIN_INTERVAL].max
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/profiling/event.rb
+++ b/lib/ddtrace/profiling/event.rb
@@ -5,8 +5,8 @@ module Datadog
       attr_reader \
         :timestamp
 
-      def initialize
-        @timestamp = Time.now.utc.to_i
+      def initialize(timestamp = nil)
+        @timestamp = timestamp || Time.now.utc.to_f
       end
     end
   end

--- a/lib/ddtrace/profiling/events/stack.rb
+++ b/lib/ddtrace/profiling/events/stack.rb
@@ -1,0 +1,74 @@
+require 'ddtrace/profiling/event'
+
+module Datadog
+  module Profiling
+    module Events
+      # Describes a stack profiling event
+      class Stack < Event
+        attr_reader \
+          :frames,
+          :total_frame_count,
+          :thread_id
+
+        def initialize(
+          timestamp,
+          frames,
+          total_frame_count,
+          thread_id
+        )
+          super(timestamp)
+
+          @frames = frames
+          @total_frame_count = total_frame_count
+          @thread_id = thread_id
+        end
+      end
+
+      # Describes a stack sample
+      class StackSample < Stack
+        attr_reader \
+          :wall_time_interval_ns
+
+        def initialize(
+          timestamp,
+          frames,
+          total_frame_count,
+          thread_id,
+          wall_time_interval_ns
+        )
+          super(
+            timestamp,
+            frames,
+            total_frame_count,
+            thread_id
+          )
+
+          @wall_time_interval_ns = wall_time_interval_ns
+        end
+      end
+
+      # Describes a stack sample with exception
+      class StackExceptionSample < Stack
+        attr_reader \
+          :exception
+
+        def initialize(
+          timestamp,
+          frames,
+          total_frame_count,
+          thread_id,
+          exception
+        )
+          super(
+            timestamp,
+            frames,
+            total_frame_count,
+            thread_id,
+          )
+
+          @exception = exception
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/profiling/recorder.rb
+++ b/lib/ddtrace/profiling/recorder.rb
@@ -14,9 +14,10 @@ module Datadog
         end
       end
 
-      def push(event)
-        raise UnknownEventError, event.class unless @buffers.key?(event.class)
-        @buffers[event.class].push(event)
+      def push(events)
+        event_class = events.is_a?(Array) ? events.first.class : events.class
+        raise UnknownEventError, event_class unless @buffers.key?(event_class)
+        @buffers[event_class].push(events)
       end
 
       def pop

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -1,0 +1,265 @@
+require 'spec_helper'
+
+require 'ddtrace/profiling/collectors/stack'
+require 'ddtrace/profiling/recorder'
+
+RSpec.describe Datadog::Profiling::Collectors::Stack do
+  subject(:collector) { described_class.new(recorder, options) }
+  let(:recorder) { instance_double(Datadog::Profiling::Recorder) }
+  let(:options) { {} }
+
+  describe '::new' do
+    it 'with default settings' do
+      is_expected.to have_attributes(
+        enabled?: false,
+        fork_policy: Datadog::Workers::Async::Thread::FORK_POLICY_RESTART,
+        ignore_thread: nil,
+        last_wall_time: kind_of(Float),
+        loop_base_interval: described_class::MIN_INTERVAL,
+        max_frames: described_class::DEFAULT_MAX_FRAMES,
+        max_time_usage_pct: described_class::DEFAULT_MAX_TIME_USAGE_PCT,
+        recorder: recorder
+      )
+    end
+  end
+
+  describe '#start' do
+    subject(:start) { collector.start }
+
+    it 'starts the worker' do
+      expect(collector).to receive(:perform)
+      start
+    end
+  end
+
+  describe '#perform' do
+    subject(:perform) { collector.perform }
+    after { collector.stop(true, 0) }
+
+    context 'when disabled' do
+      before { collector.enabled = false }
+
+      it 'does not start a worker thread' do
+        is_expected.to be nil
+
+        expect(collector).to have_attributes(
+          run_async?: false,
+          running?: false,
+          started?: false,
+          forked?: false,
+          fork_policy: :restart,
+          result: nil
+        )
+      end
+    end
+
+    context 'when enabled' do
+      before { collector.enabled = true }
+
+      it 'starts a worker thread' do
+        allow(collector).to receive(:collect_events)
+
+        is_expected.to be_a_kind_of(Thread)
+        try_wait_until { collector.running? }
+
+        expect(collector).to have_attributes(
+          run_async?: true,
+          running?: true,
+          started?: true,
+          forked?: false,
+          fork_policy: :restart,
+          result: nil
+        )
+      end
+    end
+  end
+
+  describe '#loop_back_off?' do
+    subject(:loop_back_off?) { collector.loop_back_off? }
+    it { is_expected.to be false }
+  end
+
+  describe '#collect_and_wait' do
+    subject(:collect_and_wait) { collector.collect_and_wait }
+    let(:collect_time) { 0.05 }
+    let(:updated_wait_time) { rand }
+
+    before do
+      expect(collector).to receive(:collect_events)
+      allow(collector).to receive(:compute_wait_time)
+        .with(collect_time)
+        .and_return(updated_wait_time)
+
+      allow(Datadog::Utils::Time).to receive(:measure) do |&block|
+        block.call
+        collect_time
+      end
+    end
+
+    it 'changes its wait interval after collecting' do
+      expect(collector).to receive(:loop_wait_time=)
+        .with(updated_wait_time)
+
+      collect_and_wait
+    end
+  end
+
+  describe '#collect_events' do
+    subject(:collect_events) { collector.collect_events }
+
+    before do
+      allow(recorder).to receive(:push)
+    end
+
+    context 'by default' do
+      it 'produces stack events' do
+        is_expected.to be_a_kind_of(Array)
+        is_expected.to include(kind_of(Datadog::Profiling::Events::StackSample))
+      end
+    end
+
+    context 'when the thread' do
+      let(:thread) { instance_double(Thread, alive?: alive?) }
+      let(:threads) { [thread] }
+      let(:alive?) { true }
+
+      before do
+        allow(Thread).to receive(:list).and_return(threads)
+      end
+
+      context 'is dead' do
+        let(:alive?) { false }
+
+        it 'skips the thread' do
+          expect(collector).to_not receive(:collect_thread_event)
+          is_expected.to be_empty
+          expect(recorder).to_not have_received(:push)
+        end
+      end
+
+      context 'is ignored' do
+        let(:options) { { ignore_thread: ->(t) { t == thread } } }
+
+        it 'skips the thread' do
+          expect(collector).to_not receive(:collect_thread_event)
+          is_expected.to be_empty
+          expect(recorder).to_not have_received(:push)
+        end
+      end
+
+      context 'doesn\'t have an associated event' do
+        before do
+          expect(collector)
+            .to receive(:collect_thread_event)
+            .with(thread, kind_of(Float))
+            .and_return(nil)
+        end
+
+        it 'no event is produced' do
+          is_expected.to be_empty
+          expect(recorder).to_not have_received(:push)
+        end
+      end
+
+      context 'produces an event' do
+        let(:event) { instance_double(Datadog::Profiling::Events::StackSample) }
+
+        before do
+          expect(collector)
+            .to receive(:collect_thread_event)
+            .with(thread, kind_of(Float))
+            .and_return(event)
+        end
+
+        it 'records the event' do
+          is_expected.to eq([event])
+          expect(recorder).to have_received(:push).with([event])
+        end
+      end
+    end
+  end
+
+  describe '#collect_thread_event' do
+    subject(:collect_events) { collector.collect_thread_event(thread, wall_time_interval_ns) }
+    let(:thread) { instance_double(Thread) }
+    let(:wall_time_interval_ns) { double('wall time interval in nanoseconds') }
+
+    before { allow(thread).to receive(:backtrace_locations).and_return(backtrace) }
+
+    context 'when the backtrace is empty' do
+      let(:backtrace) { nil }
+      it { is_expected.to be nil }
+    end
+
+    context 'when the backtrace is not empty' do
+      let(:backtrace) { Array.new(backtrace_size) { instance_double(Thread::Backtrace::Location) } }
+      let(:backtrace_size) { collector.max_frames }
+
+      it 'builds an event' do
+        is_expected.to be_a_kind_of(Datadog::Profiling::Events::StackSample)
+
+        is_expected.to have_attributes(
+          timestamp: kind_of(Float),
+          frames: backtrace,
+          total_frame_count: backtrace.length,
+          thread_id: thread.object_id,
+          wall_time_interval_ns: wall_time_interval_ns
+        )
+      end
+
+      context 'but is over the maximum length' do
+        let(:backtrace_size) { collector.max_frames * 2 }
+
+        it 'constrains the size of the backtrace' do
+          is_expected.to have_attributes(total_frame_count: backtrace.length)
+
+          collect_events.frames.tap do |frames|
+            expect(frames).to be_a_kind_of(Array)
+            expect(frames.length).to eq(collector.max_frames)
+          end
+        end
+      end
+
+      context 'and max_frames is 0' do
+        let(:options) { { max_frames: 0 } }
+        let(:backtrace_size) { described_class::DEFAULT_MAX_FRAMES * 2 }
+
+        it 'does not constrain the size of the backtrace' do
+          is_expected.to have_attributes(total_frame_count: backtrace.length)
+
+          collect_events.frames.tap do |frames|
+            expect(frames).to be_a_kind_of(Array)
+            expect(frames.length).to eq(backtrace.length)
+          end
+        end
+      end
+    end
+  end
+
+  describe '#compute_wait_time' do
+    subject(:compute_wait_time) { collector.compute_wait_time(used_time) }
+    let(:used_time) { 1 }
+
+    context 'when max time usage' do
+      let(:options) { { max_time_usage_pct: max_time_usage_pct } }
+
+      context 'is 100%' do
+        let(:max_time_usage_pct) { 100.0 }
+
+        it 'doesn\'t drop below the min interval' do
+          is_expected.to eq described_class::MIN_INTERVAL
+        end
+      end
+
+      context 'is 50%' do
+        let(:max_time_usage_pct) { 50.0 }
+        it { is_expected.to eq 1.0 }
+      end
+
+      context 'is 2%' do
+        let(:max_time_usage_pct) { 2.0 }
+        it { is_expected.to eq 49.0 }
+      end
+    end
+  end
+end

--- a/spec/ddtrace/profiling/event_spec.rb
+++ b/spec/ddtrace/profiling/event_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Datadog::Profiling::Event do
   describe '::new' do
     it do
       is_expected.to have_attributes(
-        timestamp: kind_of(Integer)
+        timestamp: kind_of(Float)
       )
     end
   end

--- a/spec/ddtrace/profiling/events/stack_spec.rb
+++ b/spec/ddtrace/profiling/events/stack_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+require 'ddtrace/profiling/events/stack'
+
+RSpec.describe Datadog::Profiling::Events::Stack do
+  describe '::new' do
+    subject(:event) do
+      described_class.new(
+        timestamp,
+        frames,
+        total_frame_count,
+        thread_id
+      )
+    end
+
+    let(:timestamp) { double('timestamp') }
+    let(:frames) { double('frames') }
+    let(:total_frame_count) { double('total_frame_count') }
+    let(:thread_id) { double('thread_id') }
+
+    it do
+      is_expected.to have_attributes(
+        timestamp: timestamp,
+        frames: frames,
+        total_frame_count: total_frame_count,
+        thread_id: thread_id
+      )
+    end
+  end
+end
+
+RSpec.describe Datadog::Profiling::Events::StackSample do
+  describe '::new' do
+    subject(:event) do
+      described_class.new(
+        timestamp,
+        frames,
+        total_frame_count,
+        thread_id,
+        wall_time_interval_ns
+      )
+    end
+
+    let(:timestamp) { double('timestamp') }
+    let(:frames) { double('frames') }
+    let(:total_frame_count) { double('total_frame_count') }
+    let(:thread_id) { double('thread_id') }
+    let(:wall_time_interval_ns) { double('wall_time_interval_ns') }
+
+    it do
+      is_expected.to have_attributes(
+        timestamp: timestamp,
+        frames: frames,
+        total_frame_count: total_frame_count,
+        thread_id: thread_id,
+        wall_time_interval_ns: wall_time_interval_ns
+      )
+    end
+  end
+end
+
+RSpec.describe Datadog::Profiling::Events::StackExceptionSample do
+  describe '::new' do
+    subject(:event) do
+      described_class.new(
+        timestamp,
+        frames,
+        total_frame_count,
+        thread_id,
+        exception
+      )
+    end
+
+    let(:timestamp) { double('timestamp') }
+    let(:frames) { double('frames') }
+    let(:total_frame_count) { double('total_frame_count') }
+    let(:thread_id) { double('thread_id') }
+    let(:exception) { double('exception') }
+
+    it do
+      is_expected.to have_attributes(
+        timestamp: timestamp,
+        frames: frames,
+        total_frame_count: total_frame_count,
+        thread_id: thread_id,
+        exception: exception
+      )
+    end
+  end
+end

--- a/spec/ddtrace/profiling/recorder_spec.rb
+++ b/spec/ddtrace/profiling/recorder_spec.rb
@@ -38,13 +38,14 @@ RSpec.describe Datadog::Profiling::Recorder do
 
   describe '#push' do
     include_context 'test buffer'
-    subject(:push) { recorder.push(event) }
+
+    let(:event_class) { Class.new(Datadog::Profiling::Event) }
 
     before { allow(buffer).to receive(:push) }
 
     context 'given an event' do
+      subject(:push) { recorder.push(event) }
       let(:event) { event_class.new }
-      let(:event_class) { Class.new(Datadog::Profiling::Event) }
 
       context 'whose class has not been registered' do
         it do
@@ -58,6 +59,26 @@ RSpec.describe Datadog::Profiling::Recorder do
         it do
           push
           expect(buffer).to have_received(:push).with(event)
+        end
+      end
+    end
+
+    context 'given an Array of events' do
+      subject(:push) { recorder.push(events) }
+      let(:events) { Array.new(2) { event_class.new } }
+
+      context 'whose class has not been registered' do
+        it do
+          expect { push }.to raise_error(described_class::UnknownEventError)
+        end
+      end
+
+      context 'whose class has been registered' do
+        let(:event_classes) { [event_class] }
+
+        it do
+          push
+          expect(buffer).to have_received(:push).with(events)
         end
       end
     end


### PR DESCRIPTION
This pull request adds the `Profiling::Collectors::Stack` which polls the available threads (every 10ms by default) for their backtraces, which are packaged inside `StackSample` events, then written to the `Recorder`.

To do this, `Scheduler` is a `Datadog::Worker` that re-uses `Workers::Polling` to wrap its `perform` method with a polling thread. It also defines some behaviors to manage behavior when forks occur: it should automatically restart the worker thread and clear its buffers on fork, to allow stack collection to continue on a child process.