### PR TITLE
Fix flaky Workers::Async test

### DIFF
--- a/spec/ddtrace/workers/async_spec.rb
+++ b/spec/ddtrace/workers/async_spec.rb
@@ -262,7 +262,11 @@ RSpec.describe Datadog::Workers::Async::Thread do
       end
 
       context 'when started' do
-        before { worker.perform }
+        before do
+          worker.perform
+          try_wait_until { worker.running? }
+        end
+
         after { worker.terminate }
         it { is_expected.to be true }
       end
@@ -278,7 +282,11 @@ RSpec.describe Datadog::Workers::Async::Thread do
       context 'when running' do
         let(:task) { proc { sleep(1) } }
 
-        before { worker.perform }
+        before do
+          worker.perform
+          try_wait_until { worker.running? }
+        end
+
         after { worker.terminate }
 
         it do


### PR DESCRIPTION
Sometimes the specs assert on `running?` before the worker thread has a chance to reach a running state, causing the test to fail. This pull request adds a delay to give the thread a time to start.