### PR TITLE
Fix HTTP circuit breaker

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -100,10 +100,11 @@ namespace :spec do
     :resque,
     :rest_client,
     :sequel,
+    :shoryuken,
     :sidekiq,
     :sinatra,
     :sucker_punch,
-    :shoryuken
+    :suite
   ].each do |contrib|
     RSpec::Core::RakeTask.new(contrib) do |t, args|
       t.pattern = "spec/ddtrace/contrib/#{contrib}/**/*_spec.rb"
@@ -217,6 +218,7 @@ task :ci do
       sh 'bundle exec appraisal contrib-old rake spec:sidekiq'
       sh 'bundle exec appraisal contrib-old rake spec:sinatra'
       sh 'bundle exec appraisal contrib-old rake spec:sucker_punch'
+      sh 'bundle exec appraisal contrib-old rake spec:suite'
       # Rails minitests
       sh 'bundle exec appraisal rails30-postgres rake test:rails'
       sh 'bundle exec appraisal rails30-postgres rake spec:railsdisableenv'
@@ -272,6 +274,7 @@ task :ci do
       sh 'bundle exec appraisal contrib-old rake spec:sidekiq'
       sh 'bundle exec appraisal contrib-old rake spec:sinatra'
       sh 'bundle exec appraisal contrib-old rake spec:sucker_punch'
+      sh 'bundle exec appraisal contrib-old rake spec:suite'
       # Rails minitests
       sh 'bundle exec appraisal rails30-postgres rake test:rails'
       sh 'bundle exec appraisal rails30-postgres rake spec:railsdisableenv'
@@ -340,6 +343,7 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:sidekiq'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:sucker_punch'
+      sh 'bundle exec appraisal contrib rake spec:suite'
       # Rails minitests
       sh 'bundle exec appraisal rails30-postgres rake test:rails'
       sh 'bundle exec appraisal rails30-postgres rake spec:railsdisableenv'
@@ -412,6 +416,7 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:sidekiq'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:sucker_punch'
+      sh 'bundle exec appraisal contrib rake spec:suite'
       # Contrib specs with old gem versions
       sh 'bundle exec appraisal contrib-old rake spec:faraday'
       # Rails minitests
@@ -489,6 +494,7 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:sidekiq'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:sucker_punch'
+      sh 'bundle exec appraisal contrib rake spec:suite'
       # Contrib specs with old gem versions
       sh 'bundle exec appraisal contrib-old rake spec:faraday'
       # Rails minitests
@@ -551,6 +557,7 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:sidekiq'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:sucker_punch'
+      sh 'bundle exec appraisal contrib rake spec:suite'
       # Contrib specs with old gem versions
       sh 'bundle exec appraisal contrib-old rake spec:faraday'
       # Rails minitests
@@ -623,6 +630,7 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:sidekiq'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:sucker_punch'
+      sh 'bundle exec appraisal contrib rake spec:suite'
       # Contrib specs with old gem versions
       sh 'bundle exec appraisal contrib-old rake spec:faraday'
       # Rails minitests
@@ -694,6 +702,7 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:sidekiq'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:sucker_punch'
+      sh 'bundle exec appraisal contrib rake spec:suite'
       # Contrib specs with old gem versions
       sh 'bundle exec appraisal contrib-old rake spec:faraday'
       # Rails minitests

--- a/lib/ddtrace/contrib/http/circuit_breaker.rb
+++ b/lib/ddtrace/contrib/http/circuit_breaker.rb
@@ -4,8 +4,8 @@ module Datadog
       # HTTP integration circuit breaker behavior
       # For avoiding recursive traces.
       module CircuitBreaker
-        def should_skip_tracing?(req, address, port, tracer)
-          return true if datadog_http_request?(req, address, port, tracer)
+        def should_skip_tracing?(request, tracer)
+          return true if datadog_http_request?(request)
 
           # we don't want a "shotgun" effect with two nested traces for one
           # logical get, and request is likely to call itself recursively
@@ -16,38 +16,14 @@ module Datadog
         end
 
         # We don't want to trace our own call to the API (they use net/http)
-        # TODO: We don't want this kind of coupling with the transport.
+        # TODO: We don't want this kind of soft-check on HTTP requests.
         #       Remove this when transport implements its own "skip tracing" mechanism.
-        def datadog_http_request?(req, address, port, tracer)
-          transport = tracer.writer.transport
-
-          transport_hostname = nil
-          transport_port = nil
-
-          # Get settings from transport, if available.
-          case transport
-          when Datadog::Transport::HTTP::Client
-            adapter = transport.current_api.adapter
-            if adapter.is_a?(Datadog::Transport::HTTP::Adapters::Net)
-              transport_hostname = adapter.hostname.to_s
-              transport_port = adapter.port.to_i
-            end
+        def datadog_http_request?(request)
+          if request[Datadog::Ext::Transport::HTTP::HEADER_META_TRACER_VERSION]
+            true
+          else
+            false
           end
-
-          # When we know the host & port (from the URI) we use it, else (most-likely
-          # called with a block) rely on the URL at the end.
-          if req.respond_to?(:uri) && req.uri
-            if req.uri.host.to_s == transport_hostname &&
-               req.uri.port.to_i == transport_port
-              return true
-            end
-          elsif address && port &&
-                address.to_s == transport_hostname &&
-                port.to_i == transport_port
-            return true
-          end
-
-          false
         end
 
         def should_skip_distributed_tracing?(pin)

--- a/lib/ddtrace/contrib/http/instrumentation.rb
+++ b/lib/ddtrace/contrib/http/instrumentation.rb
@@ -37,7 +37,7 @@ module Datadog
             pin = datadog_pin(request_options)
             return super(req, body, &block) unless pin && pin.tracer
 
-            if Datadog::Contrib::HTTP.should_skip_tracing?(req, @address, @port, pin.tracer)
+            if Datadog::Contrib::HTTP.should_skip_tracing?(req, pin.tracer)
               return super(req, body, &block)
             end
 

--- a/spec/ddtrace/contrib/http/circuit_breaker_spec.rb
+++ b/spec/ddtrace/contrib/http/circuit_breaker_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+require 'ddtrace'
+require 'ddtrace/contrib/http/circuit_breaker'
+
+RSpec.describe Datadog::Contrib::HTTP::CircuitBreaker do
+  subject(:circuit_breaker) { circuit_breaker_class.new }
+  let(:circuit_breaker_class) { Class.new { include Datadog::Contrib::HTTP::CircuitBreaker } }
+
+  describe '#should_skip_tracing?' do
+    subject(:should_skip_tracing?) { circuit_breaker.should_skip_tracing?(request, tracer) }
+    let(:request) { ::Net::HTTP::Post.new('/some/path') }
+    let(:tracer) { instance_double(Datadog::Tracer) }
+
+    context 'given a normal request' do
+      before do
+        allow(circuit_breaker).to receive(:datadog_http_request?)
+          .with(request)
+          .and_return(false)
+
+        allow(tracer).to receive(:active_span).and_return(nil)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'given a request that is a Datadog request' do
+      before do
+        allow(circuit_breaker).to receive(:datadog_http_request?)
+          .with(request)
+          .and_return(true)
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the request has an active HTTP request span' do
+      let(:active_span) { instance_double(Datadog::Span, name: Datadog::Contrib::HTTP::Ext::SPAN_REQUEST) }
+
+      before do
+        allow(circuit_breaker).to receive(:datadog_http_request?)
+          .with(request)
+          .and_return(false)
+
+        allow(tracer).to receive(:active_span).and_return(active_span)
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#datadog_http_request?' do
+    subject(:datadog_http_request?) { circuit_breaker.datadog_http_request?(request) }
+
+    context 'given an HTTP request' do
+      context "when the #{Datadog::Ext::Transport::HTTP::HEADER_META_TRACER_VERSION} header" do
+        context 'is present' do
+          let(:request) { ::Net::HTTP::Post.new('/some/path', headers) }
+          let(:headers) { { Datadog::Ext::Transport::HTTP::HEADER_META_TRACER_VERSION => Datadog::VERSION::STRING } }
+          it { is_expected.to be true }
+        end
+
+        context 'is missing' do
+          let(:request) { ::Net::HTTP::Post.new('/some/path') }
+          it { is_expected.to be false }
+        end
+      end
+    end
+
+    context 'integration' do
+      context 'given a request from' do
+        let(:request) { @request }
+
+        before do
+          # Capture the HTTP request directly from the transport,
+          # to make sure we have legitimate example.
+          expect(::Net::HTTP::Post).to receive(:new).and_wrap_original do |m, *args|
+            @request = m.call(*args)
+          end
+
+          # The request may produce an error (because the transport cannot connect)
+          # but ignore this... we just need the request, not a successful response.
+          allow(Datadog.logger).to receive(:error)
+
+          # Send a request, and make sure we captured it.
+          transport.send_traces(get_test_traces(1))
+          expect(@request).to be_a_kind_of(::Net::HTTP::Post)
+        end
+
+        context 'a Datadog Net::HTTP transport' do
+          let(:transport) { Datadog::Transport::HTTP.default }
+          it { is_expected.to be true }
+        end
+
+        context 'a Datadog UDS transport' do
+          let(:transport) do
+            Datadog::Transport::HTTP.default do |t|
+              t.adapter :unix, '/tmp/ddagent/trace.sock'
+            end
+          end
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/suite/transport_spec.rb
+++ b/spec/ddtrace/contrib/suite/transport_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+# Load integrations so they're available
+%w[
+  ethon
+  excon
+  faraday
+  grpc
+  rest_client
+].each do |integration|
+  begin
+    require integration
+  # rubocop:disable Lint/HandleExceptions
+  rescue LoadError
+    # If library isn't available, it can't be instrumented.
+  end
+end
+
+require 'ddtrace'
+
+# Tests that combine the core library with integrations,
+# whose examples don't belong exclusively to either.
+RSpec.describe 'transport with integrations' do
+  describe 'when sending traces' do
+    before do
+      Datadog.configure do |c|
+        # Activate all outbound integrations...
+        # Although the transport by default only uses Net/HTTP
+        # its possible for other adapters to be used instead.
+        c.use :ethon
+        c.use :excon
+        c.use :faraday
+        c.use :grpc
+        c.use :http
+        c.use :rest_client
+      end
+
+      # Requests may produce an error (because the transport cannot connect)
+      # but ignore this... we just need requests, not a successful response.
+      allow(Datadog.logger).to receive(:error)
+    end
+
+    shared_examples_for 'an uninstrumented transport' do
+      before do
+        expect_any_instance_of(Datadog::Tracer).to_not receive(:trace)
+        expect_any_instance_of(Datadog::Tracer).to_not receive(:start_span)
+      end
+
+      describe '#send_traces' do
+        subject(:send_traces) { transport.send_traces(traces) }
+        let(:traces) { get_test_traces(1) }
+
+        it 'does not produce traces for itself' do
+          send_traces
+        end
+      end
+    end
+
+    context 'given the default transport' do
+      let(:transport) { Datadog::Transport::HTTP.default }
+      it_behaves_like 'an uninstrumented transport'
+    end
+
+    context 'given an Unix socket transport' do
+      let(:transport) do
+        Datadog::Transport::HTTP.default do |t|
+          t.adapter :unix, '/tmp/ddagent/trace.sock'
+        end
+      end
+
+      it_behaves_like 'an uninstrumented transport'
+    end
+
+    context 'given an IO transport' do
+      let(:transport) { Datadog::Transport::IO.default(out: out) }
+      let(:out) { instance_double(::IO) }
+
+      before { allow(out).to receive(:puts) }
+
+      it_behaves_like 'an uninstrumented transport'
+    end
+  end
+end

--- a/spec/support/faux_transport.rb
+++ b/spec/support/faux_transport.rb
@@ -7,10 +7,10 @@ class FauxTransport < Datadog::Transport::HTTP::Client
 
   def send_traces(*)
     # Emulate an OK response
-    Datadog::Transport::HTTP::Traces::Response.new(
+    [Datadog::Transport::HTTP::Traces::Response.new(
       Datadog::Transport::HTTP::Adapters::Net::Response.new(
         Net::HTTPResponse.new(1.0, 200, 'OK')
       )
-    )
+    )]
   end
 end


### PR DESCRIPTION
Fixes #1030 

After refactoring the transport for payload chunking in #840 (released in 0.35.0), it appears that the HTTP circuit breaker misread the transport and didn't flag Net::HTTP requests from the transport as it should have, causing traces to be produced erroneously.

This pull request changes the circuit breaker strategy; rather than to be dependent on reading transport internals and match host/port, it inspects the HTTP request itself for the tracer version header which should only be present on Datadog-made HTTP requests. It will prevent transport changes from causing this error to re-occur.

Note that this is still not optimal; if the trace library makes HTTP calls that do not have this header (which they always should), it will re-occur. We'll need to introduce a better trace-disabling mechanism in the transport itself.