### PR TITLE
Lazily activate integrations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,6 +67,10 @@ Metrics/PerceivedComplexity:
 Lint/UnusedMethodArgument:
   Enabled: false
 
+# alias and alias_method are not equivalent
+Style/Alias:
+  Enabled: false
+
 # Disabling advices that would lead to incompatible Ruby 1.9 code
 Style/SymbolArray:
   Enabled: false

--- a/lib/ddtrace/contrib/extensions.rb
+++ b/lib/ddtrace/contrib/extensions.rb
@@ -1,3 +1,4 @@
+require 'set'
 require 'ddtrace/contrib/registry'
 
 module Datadog
@@ -7,6 +8,7 @@ module Datadog
     module Extensions
       def self.extended(base)
         Datadog.send(:extend, Helpers)
+        Datadog.send(:extend, Configuration)
         Datadog::Configuration::Settings.send(:include, Configuration::Settings)
       end
 
@@ -17,7 +19,24 @@ module Datadog
         end
       end
 
+      # Configuration methods for Datadog module.
       module Configuration
+        def configure(target = configuration, opts = {})
+          # Reconfigure core settings
+          super
+
+          # Activate integrations
+          if target.respond_to?(:integrations_pending_activation)
+            target.integrations_pending_activation.each do |integration|
+              integration.patch if integration.respond_to?(:patch)
+            end
+
+            target.integrations_pending_activation.clear
+          end
+
+          target
+        end
+
         # Extensions for Datadog::Configuration::Settings
         module Settings
           InvalidIntegrationError = Class.new(StandardError)
@@ -34,22 +53,27 @@ module Datadog
             integration.configuration(configuration_name) unless integration.nil?
           end
 
-          def use(integration_name, options = {}, &block)
+          def instrument(integration_name, options = {}, &block)
             integration = fetch_integration(integration_name)
 
             unless integration.nil?
               configuration_name = options[:describes] || :default
               filtered_options = options.reject { |k, _v| k == :describes }
               integration.configure(configuration_name, filtered_options, &block)
-            end
 
-            integration.patch if integration.respond_to?(:patch)
+              # Add to activation list
+              integrations_pending_activation << integration
+            end
           end
 
-          private
+          alias_method :use, :instrument
+
+          def integrations_pending_activation
+            @integrations_pending_activation ||= Set.new
+          end
 
           def fetch_integration(name)
-            get_option(:registry)[name] ||
+            registry[name] ||
               raise(InvalidIntegrationError, "'#{name}' is not a valid integration.")
           end
         end

--- a/lib/ddtrace/contrib/rails/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rails/configuration/settings.rb
@@ -85,6 +85,7 @@ module Datadog
               Datadog.configuration[:active_support][:tracer] = value
               Datadog.configuration[:action_pack][:tracer] = value
               Datadog.configuration[:action_view][:tracer] = value
+              Datadog.configuration[:rack][:tracer] = value
             end
           end
         end

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -21,23 +21,32 @@ module Datadog
       module Framework
         # configure Datadog settings
         def self.setup
-          config = config_with_defaults
+          rails_config = config_with_defaults
 
-          activate_rack!(config)
-          activate_action_cable!(config)
-          activate_active_support!(config)
-          activate_action_pack!(config)
-          activate_action_view!(config)
-          activate_active_record!(config)
+          # NOTE: #configure has the side effect of rebuilding trace components.
+          #       During a typical Rails application lifecycle, we will see trace
+          #       components initialized twice because of this. This is necessary
+          #       because key configuration is not available until after the Rails
+          #       application has fully loaded, and some of this configuration is
+          #       used to reconfigure tracer components with Rails-sourced defaults.
+          #       This is a trade-off we take to get nice defaults.
+          Datadog.configure do |datadog_config|
+            # By default, default service would be guessed from the script
+            # being executed, but here we know better, get it from Rails config.
+            # Don't set this if service has been explicitly provided by the user.
+            datadog_config.service ||= rails_config[:service_name]
 
-          # By default, default service would be guessed from the script
-          # being executed, but here we know better, get it from Rails config.
-          # Don't set this if service has been explicitly provided by the user.
-          Datadog.configuration.service ||= config[:service_name]
+            activate_rack!(datadog_config, rails_config)
+            activate_action_cable!(datadog_config, rails_config)
+            activate_active_support!(datadog_config, rails_config)
+            activate_action_pack!(datadog_config, rails_config)
+            activate_action_view!(datadog_config, rails_config)
+            activate_active_record!(datadog_config, rails_config)
+          end
 
           # Update the tracer if its not the default tracer.
-          if config[:tracer] != Datadog.configuration.tracer
-            config[:tracer].default_service = config[:service_name]
+          if rails_config[:tracer] != Datadog.configuration.tracer
+            rails_config[:tracer].default_service = rails_config[:service_name]
           end
         end
 
@@ -52,64 +61,68 @@ module Datadog
           end
         end
 
-        def self.activate_rack!(config)
-          Datadog.configuration.use(
+        def self.activate_rack!(datadog_config, rails_config)
+          datadog_config.use(
             :rack,
-            tracer: config[:tracer],
+            tracer: rails_config[:tracer],
             application: ::Rails.application,
-            service_name: config[:service_name],
-            middleware_names: config[:middleware_names],
-            distributed_tracing: config[:distributed_tracing]
+            service_name: rails_config[:service_name],
+            middleware_names: rails_config[:middleware_names],
+            distributed_tracing: rails_config[:distributed_tracing]
           )
         end
 
-        def self.activate_active_support!(config)
+        def self.activate_active_support!(datadog_config, rails_config)
           return unless defined?(::ActiveSupport)
 
-          Datadog.configuration.use(
+          datadog_config.use(
             :active_support,
-            cache_service: config[:cache_service],
-            tracer: config[:tracer]
+            cache_service: rails_config[:cache_service],
+            tracer: rails_config[:tracer]
           )
         end
 
-        def self.activate_action_cable!(config)
+        def self.activate_action_cable!(datadog_config, rails_config)
           return unless defined?(::ActionCable)
 
-          Datadog.configuration.use(
+          datadog_config.use(
             :action_cable,
-            service_name: "#{config[:service_name]}-#{Contrib::ActionCable::Ext::SERVICE_NAME}",
-            tracer: config[:tracer]
+            service_name: "#{rails_config[:service_name]}-#{Contrib::ActionCable::Ext::SERVICE_NAME}",
+            tracer: rails_config[:tracer]
           )
         end
 
-        def self.activate_action_pack!(config)
+        def self.activate_action_pack!(datadog_config, rails_config)
           return unless defined?(::ActionPack)
 
-          Datadog.configuration.use(
+          # TODO: This is configuring ActionPack but not patching. It will queue ActionPack
+          #       for patching, but patching won't take place until Datadog.configure completes.
+          #       Should we manually patch here?
+
+          datadog_config.use(
             :action_pack,
-            service_name: config[:service_name],
-            tracer: config[:tracer]
+            service_name: rails_config[:service_name],
+            tracer: rails_config[:tracer]
           )
         end
 
-        def self.activate_action_view!(config)
+        def self.activate_action_view!(datadog_config, rails_config)
           return unless defined?(::ActionView)
 
-          Datadog.configuration.use(
+          datadog_config.use(
             :action_view,
-            service_name: config[:service_name],
-            tracer: config[:tracer]
+            service_name: rails_config[:service_name],
+            tracer: rails_config[:tracer]
           )
         end
 
-        def self.activate_active_record!(config)
+        def self.activate_active_record!(datadog_config, rails_config)
           return unless defined?(::ActiveRecord)
 
-          Datadog.configuration.use(
+          datadog_config.use(
             :active_record,
-            service_name: config[:database_service],
-            tracer: config[:tracer]
+            service_name: rails_config[:database_service],
+            tracer: rails_config[:tracer]
           )
         end
       end

--- a/spec/ddtrace/contrib/extensions_spec.rb
+++ b/spec/ddtrace/contrib/extensions_spec.rb
@@ -4,10 +4,62 @@ require 'ddtrace'
 require 'ddtrace/contrib/extensions'
 
 RSpec.describe Datadog::Contrib::Extensions do
+  shared_context 'registry with integration' do
+    let(:registry) { Datadog::Contrib::Registry.new }
+    let(:integration_name) { :example }
+    let(:integration) { instance_double(integration_class) }
+    let(:integration_class) { Class.new { include Datadog::Contrib::Integration } }
+
+    before { registry.add(integration_name, integration) }
+  end
+
   context 'for' do
+    describe Datadog do
+      describe '#configure' do
+        include_context 'registry with integration' do
+          before do
+            allow(Datadog.configuration).to receive(:registry).and_return(registry)
+          end
+        end
+
+        context 'given a block' do
+          subject(:configure) { described_class.configure(&block) }
+
+          context 'that calls #use for an integration' do
+            let(:block) { proc { |c| c.use integration_name } }
+
+            it 'configures & patches the integration' do
+              expect(integration).to receive(:configure).with(:default, any_args)
+              expect(integration).to receive(:patch)
+              configure
+            end
+          end
+
+          context 'that calls #instrument for an integration' do
+            let(:block) { proc { |c| c.instrument integration_name } }
+
+            it 'configures & patches the integration' do
+              expect(integration).to receive(:configure).with(:default, any_args)
+              expect(integration).to receive(:patch)
+              configure
+            end
+          end
+        end
+
+        context 'given a target and options' do
+          subject(:configure) { described_class.configure(target, opts) }
+          let(:target) { double('target') }
+          let(:opts) { {} }
+
+          it { expect { configure }.to_not raise_error }
+        end
+      end
+    end
+
     describe Datadog::Configuration::Settings do
+      include_context 'registry with integration'
+
       subject(:settings) { described_class.new(registry: registry) }
-      let(:registry) { Datadog::Contrib::Registry.new }
 
       describe '#[]' do
         context 'when the integration doesn\'t exist' do
@@ -20,66 +72,69 @@ RSpec.describe Datadog::Contrib::Extensions do
       end
 
       describe '#use' do
-        subject(:result) { settings.use(name, options) }
-        let(:name) { :example }
-        let(:integration) { double('integration') }
+        subject(:result) { settings.use(integration_name, options) }
         let(:options) { {} }
 
-        before(:each) do
-          registry.add(name, integration)
-        end
-
         context 'for a generic integration' do
-          before(:each) do
-            expect(integration).to receive(:configure).with(:default, options).and_return([])
-            expect(integration).to receive(:patch).and_return(true)
+          include_context 'registry with integration' do
+            let(:integration) { double('integration') }
           end
 
-          it { expect { result }.to_not raise_error }
+          before do
+            expect(integration).to receive(:configure).with(:default, options).and_return([])
+            expect(integration).to_not receive(:patch)
+          end
+
+          it do
+            expect { result }.to_not raise_error
+            expect(settings.integrations_pending_activation).to include(integration)
+          end
         end
 
         context 'for an integration that includes Datadog::Contrib::Integration' do
-          let(:patcher_module) do
-            stub_const('Patcher', Module.new do
-              include Datadog::Contrib::Patcher
+          include_context 'registry with integration' do
+            let(:integration) do
+              integration_class.new(integration_name)
+            end
 
-              def self.patch
-                true
-              end
-            end)
-          end
+            let(:integration_class) do
+              patcher_module
 
-          let(:integration_class) do
-            patcher_module
+              Class.new do
+                include Datadog::Contrib::Integration
 
-            Class.new do
-              include Datadog::Contrib::Integration
+                def self.version
+                  Gem::Version.new('0.1')
+                end
 
-              def self.version
-                Gem::Version.new('0.1')
-              end
-
-              def patcher
-                Patcher
+                def patcher
+                  Patcher
+                end
               end
             end
-          end
 
-          let(:integration) do
-            integration_class.new(name)
+            let(:patcher_module) do
+              stub_const('Patcher', Module.new do
+                include Datadog::Contrib::Patcher
+
+                def self.patch
+                  true
+                end
+              end)
+            end
           end
 
           context 'which is provided only a name' do
             it do
               expect(integration).to receive(:configure).with(:default, {})
-              settings.use(name)
+              settings.use(integration_name)
             end
           end
 
           context 'which is provided a block' do
             it do
               expect(integration).to receive(:configure).with(:default, {}).and_call_original
-              expect { |b| settings.use(name, options, &b) }.to yield_with_args(
+              expect { |b| settings.use(integration_name, options, &b) }.to yield_with_args(
                 a_kind_of(Datadog::Contrib::Configuration::Settings)
               )
             end

--- a/spec/ddtrace/contrib/rails/middleware_spec.rb
+++ b/spec/ddtrace/contrib/rails/middleware_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Rails middleware' do
   end
 
   let(:use_rack) { true }
-  let(:rails_options) { {} }
+  let(:rails_options) { { tracer: tracer } }
 
   context 'with middleware' do
     context 'that does nothing' do

--- a/spec/ddtrace/contrib/rails/redis_cache_spec.rb
+++ b/spec/ddtrace/contrib/rails/redis_cache_spec.rb
@@ -29,7 +29,7 @@ MESSAGE
   before { app }
 
   before do
-    Datadog.configuration.use(:redis)
+    Datadog.configure { |c| c.use :redis }
     Datadog.configure(client_from_driver(driver), tracer_options)
   end
 

--- a/test/contrib/rails/controller_test.rb
+++ b/test/contrib/rails/controller_test.rb
@@ -7,7 +7,10 @@ class TracingControllerTest < ActionController::TestCase
   setup do
     @original_tracer = Datadog.configuration[:rails][:tracer]
     @tracer = get_test_tracer
-    Datadog.configuration[:rails][:tracer] = @tracer
+
+    Datadog.configure do |c|
+      c.use :rails, tracer: @tracer
+    end
   end
 
   teardown do

--- a/test/contrib/rails/errors_test.rb
+++ b/test/contrib/rails/errors_test.rb
@@ -7,7 +7,10 @@ class TracingControllerTest < ActionController::TestCase
   setup do
     @original_tracer = Datadog.configuration[:rails][:tracer]
     @tracer = get_test_tracer
-    Datadog.configuration[:rails][:tracer] = @tracer
+
+    Datadog.configure do |c|
+      c.use :rails, tracer: @tracer
+    end
   end
 
   teardown do


### PR DESCRIPTION
Today, in a configuration block...

```ruby
Datadog.configure do |c|
  c.use :faraday
end
```

`c.use` configures and patches the integration immediately. This has the unwanted side effect of causing trace components being initialized with default settings before the configuration block is completed, because patching integrations often calls `Datadog.logger` which is a trace component.

In this pull request, `c.use` adds the integration to a list of pending integrations, which are each patched after the configuration block completes and the trace components are initialized. This prevents trace components from being re-initialized multiple times during setup.