### PR TITLE
Backport master fixes to since 0.35.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -100,10 +100,11 @@ namespace :spec do
     :resque,
     :rest_client,
     :sequel,
+    :shoryuken,
     :sidekiq,
     :sinatra,
     :sucker_punch,
-    :shoryuken
+    :suite
   ].each do |contrib|
     RSpec::Core::RakeTask.new(contrib) do |t, args|
       t.pattern = "spec/ddtrace/contrib/#{contrib}/**/*_spec.rb"
@@ -217,6 +218,7 @@ task :ci do
       sh 'bundle exec appraisal contrib-old rake spec:sidekiq'
       sh 'bundle exec appraisal contrib-old rake spec:sinatra'
       sh 'bundle exec appraisal contrib-old rake spec:sucker_punch'
+      sh 'bundle exec appraisal contrib-old rake spec:suite'
       # Rails minitests
       sh 'bundle exec appraisal rails30-postgres rake test:rails'
       sh 'bundle exec appraisal rails30-postgres rake spec:railsdisableenv'
@@ -272,6 +274,7 @@ task :ci do
       sh 'bundle exec appraisal contrib-old rake spec:sidekiq'
       sh 'bundle exec appraisal contrib-old rake spec:sinatra'
       sh 'bundle exec appraisal contrib-old rake spec:sucker_punch'
+      sh 'bundle exec appraisal contrib-old rake spec:suite'
       # Rails minitests
       sh 'bundle exec appraisal rails30-postgres rake test:rails'
       sh 'bundle exec appraisal rails30-postgres rake spec:railsdisableenv'
@@ -340,6 +343,7 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:sidekiq'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:sucker_punch'
+      sh 'bundle exec appraisal contrib rake spec:suite'
       # Rails minitests
       sh 'bundle exec appraisal rails30-postgres rake test:rails'
       sh 'bundle exec appraisal rails30-postgres rake spec:railsdisableenv'
@@ -412,6 +416,7 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:sidekiq'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:sucker_punch'
+      sh 'bundle exec appraisal contrib rake spec:suite'
       # Contrib specs with old gem versions
       sh 'bundle exec appraisal contrib-old rake spec:faraday'
       # Rails minitests
@@ -489,6 +494,7 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:sidekiq'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:sucker_punch'
+      sh 'bundle exec appraisal contrib rake spec:suite'
       # Contrib specs with old gem versions
       sh 'bundle exec appraisal contrib-old rake spec:faraday'
       # Rails minitests
@@ -551,6 +557,7 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:sidekiq'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:sucker_punch'
+      sh 'bundle exec appraisal contrib rake spec:suite'
       # Contrib specs with old gem versions
       sh 'bundle exec appraisal contrib-old rake spec:faraday'
       # Rails minitests
@@ -623,6 +630,7 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:sidekiq'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:sucker_punch'
+      sh 'bundle exec appraisal contrib rake spec:suite'
       # Contrib specs with old gem versions
       sh 'bundle exec appraisal contrib-old rake spec:faraday'
       # Rails minitests
@@ -694,6 +702,7 @@ task :ci do
       sh 'bundle exec appraisal contrib rake spec:sidekiq'
       sh 'bundle exec appraisal contrib rake spec:sinatra'
       sh 'bundle exec appraisal contrib rake spec:sucker_punch'
+      sh 'bundle exec appraisal contrib rake spec:suite'
       # Contrib specs with old gem versions
       sh 'bundle exec appraisal contrib-old rake spec:faraday'
       # Rails minitests

--- a/lib/ddtrace/configuration/base.rb
+++ b/lib/ddtrace/configuration/base.rb
@@ -45,7 +45,7 @@ module Datadog
       # Instance methods for configuration
       module InstanceMethods
         def initialize(options = {})
-          configure(options)
+          configure(options) unless options.empty?
         end
 
         def configure(opts = {})

--- a/lib/ddtrace/configuration/options.rb
+++ b/lib/ddtrace/configuration/options.rb
@@ -80,7 +80,7 @@ module Datadog
         end
 
         def options_hash
-          options.each_with_object({}) do |(key, _), hash|
+          self.class.options.merge(options).each_with_object({}) do |(key, _), hash|
             hash[key] = get_option(key)
           end
         end

--- a/lib/ddtrace/contrib/configuration/settings.rb
+++ b/lib/ddtrace/contrib/configuration/settings.rb
@@ -16,7 +16,7 @@ module Datadog
 
         def configure(options = {})
           self.class.options.dependency_order.each do |name|
-            self[name] = options.fetch(name, self[name])
+            self[name] = options[name] if options.key?(name)
           end
 
           yield(self) if block_given?

--- a/lib/ddtrace/contrib/http/circuit_breaker.rb
+++ b/lib/ddtrace/contrib/http/circuit_breaker.rb
@@ -4,8 +4,8 @@ module Datadog
       # HTTP integration circuit breaker behavior
       # For avoiding recursive traces.
       module CircuitBreaker
-        def should_skip_tracing?(req, address, port, tracer)
-          return true if datadog_http_request?(req, address, port, tracer)
+        def should_skip_tracing?(request, tracer)
+          return true if datadog_http_request?(request)
 
           # we don't want a "shotgun" effect with two nested traces for one
           # logical get, and request is likely to call itself recursively
@@ -16,38 +16,14 @@ module Datadog
         end
 
         # We don't want to trace our own call to the API (they use net/http)
-        # TODO: We don't want this kind of coupling with the transport.
+        # TODO: We don't want this kind of soft-check on HTTP requests.
         #       Remove this when transport implements its own "skip tracing" mechanism.
-        def datadog_http_request?(req, address, port, tracer)
-          transport = tracer.writer.transport
-
-          transport_hostname = nil
-          transport_port = nil
-
-          # Get settings from transport, if available.
-          case transport
-          when Datadog::Transport::HTTP::Client
-            adapter = transport.current_api.adapter
-            if adapter.is_a?(Datadog::Transport::HTTP::Adapters::Net)
-              transport_hostname = adapter.hostname.to_s
-              transport_port = adapter.port.to_i
-            end
+        def datadog_http_request?(request)
+          if request[Datadog::Ext::Transport::HTTP::HEADER_META_TRACER_VERSION]
+            true
+          else
+            false
           end
-
-          # When we know the host & port (from the URI) we use it, else (most-likely
-          # called with a block) rely on the URL at the end.
-          if req.respond_to?(:uri) && req.uri
-            if req.uri.host.to_s == transport_hostname &&
-               req.uri.port.to_i == transport_port
-              return true
-            end
-          elsif address && port &&
-                address.to_s == transport_hostname &&
-                port.to_i == transport_port
-            return true
-          end
-
-          false
         end
 
         def should_skip_distributed_tracing?(pin)

--- a/lib/ddtrace/contrib/http/instrumentation.rb
+++ b/lib/ddtrace/contrib/http/instrumentation.rb
@@ -37,7 +37,7 @@ module Datadog
             pin = datadog_pin(request_options)
             return super(req, body, &block) unless pin && pin.tracer
 
-            if Datadog::Contrib::HTTP.should_skip_tracing?(req, @address, @port, pin.tracer)
+            if Datadog::Contrib::HTTP.should_skip_tracing?(req, pin.tracer)
               return super(req, body, &block)
             end
 

--- a/lib/ddtrace/contrib/rails/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rails/configuration/settings.rb
@@ -6,6 +6,19 @@ module Datadog
       module Configuration
         # Custom settings for the Rails integration
         class Settings < Contrib::Configuration::Settings
+          def initialize(options = {})
+            super(options)
+
+            # NOTE: Eager load these
+            #       Rails integration is responsible for orchestrating other integrations.
+            #       When using environment variables, settings will not be automatically
+            #       filled because nothing explicitly calls them. They must though, so
+            #       integrations like ActionPack can receive the value as it should.
+            #       Trigger these manually to force an eager load and propagate them.
+            analytics_enabled
+            analytics_sample_rate
+          end
+
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, nil) }
             o.lazy

--- a/spec/ddtrace/contrib/configuration/settings_spec.rb
+++ b/spec/ddtrace/contrib/configuration/settings_spec.rb
@@ -7,31 +7,47 @@ RSpec.describe Datadog::Contrib::Configuration::Settings do
 
   it { is_expected.to be_a_kind_of(Datadog::Configuration::Base) }
 
-  describe '#options' do
-    subject(:options) { settings.options }
+  describe '#service_name' do
+    subject(:service_name) { settings.service_name }
+    it { expect(settings.service_name).to be nil }
+    it { expect(settings[:service_name]).to be nil }
+  end
 
-    describe ':service_name' do
-      subject(:option) { options[:service_name] }
-      it { expect(options).to include(:service_name) }
-      it { expect(option.get).to be nil }
-    end
+  describe '#tracer' do
+    subject(:tracer) { settings.tracer }
+    it { expect(settings.tracer).to be Datadog.tracer }
+    it { expect(settings[:tracer]).to be Datadog.tracer }
+  end
 
-    describe ':tracer' do
-      subject(:option) { options[:tracer] }
-      it { expect(options).to include(:tracer) }
-      it { expect(option.get).to be Datadog.tracer }
-    end
+  describe '#analytics_enabled' do
+    subject(:analytics_enabled) { settings.analytics_enabled }
+    it { expect(settings.analytics_enabled).to be false }
+    it { expect(settings[:analytics_enabled]).to be false }
+  end
 
-    describe ':analytics_enabled' do
-      subject(:option) { options[:analytics_enabled] }
-      it { expect(options).to include(:analytics_enabled) }
-      it { expect(option.get).to be false }
-    end
+  describe '#analytics_sample_rate' do
+    subject(:analytics_sample_rate) { settings.analytics_sample_rate }
+    it { expect(settings.analytics_sample_rate).to eq 1.0 }
+    it { expect(settings[:analytics_sample_rate]).to eq 1.0 }
+  end
 
-    describe ':analytics_sample_rate' do
-      subject(:option) { options[:analytics_sample_rate] }
-      it { expect(options).to include(:analytics_sample_rate) }
-      it { expect(option.get).to eq 1.0 }
+  describe '#configure' do
+    subject(:configure) { settings.configure(options) }
+
+    context 'given an option' do
+      let(:options) { { service_name: service_name } }
+      let(:service_name) { double('service_name') }
+
+      before { allow(settings).to receive(:set_option).and_call_original }
+
+      it 'doesn\'t initialize other options' do
+        expect { configure }
+          .to change { settings.service_name }
+          .from(nil)
+          .to(service_name)
+
+        expect(settings).to_not have_received(:set_option).with(:tracer, any_args)
+      end
     end
   end
 end

--- a/spec/ddtrace/contrib/http/circuit_breaker_spec.rb
+++ b/spec/ddtrace/contrib/http/circuit_breaker_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+require 'ddtrace'
+require 'ddtrace/contrib/http/circuit_breaker'
+
+RSpec.describe Datadog::Contrib::HTTP::CircuitBreaker do
+  subject(:circuit_breaker) { circuit_breaker_class.new }
+  let(:circuit_breaker_class) { Class.new { include Datadog::Contrib::HTTP::CircuitBreaker } }
+
+  describe '#should_skip_tracing?' do
+    subject(:should_skip_tracing?) { circuit_breaker.should_skip_tracing?(request, tracer) }
+    let(:request) { ::Net::HTTP::Post.new('/some/path') }
+    let(:tracer) { instance_double(Datadog::Tracer) }
+
+    context 'given a normal request' do
+      before do
+        allow(circuit_breaker).to receive(:datadog_http_request?)
+          .with(request)
+          .and_return(false)
+
+        allow(tracer).to receive(:active_span).and_return(nil)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'given a request that is a Datadog request' do
+      before do
+        allow(circuit_breaker).to receive(:datadog_http_request?)
+          .with(request)
+          .and_return(true)
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the request has an active HTTP request span' do
+      let(:active_span) { instance_double(Datadog::Span, name: Datadog::Contrib::HTTP::Ext::SPAN_REQUEST) }
+
+      before do
+        allow(circuit_breaker).to receive(:datadog_http_request?)
+          .with(request)
+          .and_return(false)
+
+        allow(tracer).to receive(:active_span).and_return(active_span)
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#datadog_http_request?' do
+    subject(:datadog_http_request?) { circuit_breaker.datadog_http_request?(request) }
+
+    context 'given an HTTP request' do
+      context "when the #{Datadog::Ext::Transport::HTTP::HEADER_META_TRACER_VERSION} header" do
+        context 'is present' do
+          let(:request) { ::Net::HTTP::Post.new('/some/path', headers) }
+          let(:headers) { { Datadog::Ext::Transport::HTTP::HEADER_META_TRACER_VERSION => Datadog::VERSION::STRING } }
+          it { is_expected.to be true }
+        end
+
+        context 'is missing' do
+          let(:request) { ::Net::HTTP::Post.new('/some/path') }
+          it { is_expected.to be false }
+        end
+      end
+    end
+
+    context 'integration' do
+      context 'given a request from' do
+        let(:request) { @request }
+
+        before do
+          # Capture the HTTP request directly from the transport,
+          # to make sure we have legitimate example.
+          expect(::Net::HTTP::Post).to receive(:new).and_wrap_original do |m, *args|
+            @request = m.call(*args)
+          end
+
+          # The request may produce an error (because the transport cannot connect)
+          # but ignore this... we just need the request, not a successful response.
+          allow(Datadog.logger).to receive(:error)
+
+          # Send a request, and make sure we captured it.
+          transport.send_traces(get_test_traces(1))
+          expect(@request).to be_a_kind_of(::Net::HTTP::Post)
+        end
+
+        context 'a Datadog Net::HTTP transport' do
+          let(:transport) { Datadog::Transport::HTTP.default }
+          it { is_expected.to be true }
+        end
+
+        context 'a Datadog UDS transport' do
+          let(:transport) do
+            Datadog::Transport::HTTP.default do |t|
+              t.adapter :unix, '/tmp/ddagent/trace.sock'
+            end
+          end
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/rails/analytics_spec.rb
+++ b/spec/ddtrace/contrib/rails/analytics_spec.rb
@@ -19,8 +19,10 @@ RSpec.describe 'Rails trace analytics' do
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
     Datadog.registry[:rails].reset_configuration!
+    Datadog.registry[:action_pack].reset_configuration!
     example.run
     Datadog.registry[:rails].reset_configuration!
+    Datadog.registry[:action_pack].reset_configuration!
   end
 
   let(:span) { spans.first }

--- a/spec/ddtrace/contrib/suite/transport_spec.rb
+++ b/spec/ddtrace/contrib/suite/transport_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+# Load integrations so they're available
+%w[
+  ethon
+  excon
+  faraday
+  grpc
+  rest_client
+].each do |integration|
+  begin
+    require integration
+  # rubocop:disable Lint/HandleExceptions
+  rescue LoadError
+    # If library isn't available, it can't be instrumented.
+  end
+end
+
+require 'ddtrace'
+
+# Tests that combine the core library with integrations,
+# whose examples don't belong exclusively to either.
+RSpec.describe 'transport with integrations' do
+  describe 'when sending traces' do
+    before do
+      Datadog.configure do |c|
+        # Activate all outbound integrations...
+        # Although the transport by default only uses Net/HTTP
+        # its possible for other adapters to be used instead.
+        c.use :ethon
+        c.use :excon
+        c.use :faraday
+        c.use :grpc
+        c.use :http
+        c.use :rest_client
+      end
+
+      # Requests may produce an error (because the transport cannot connect)
+      # but ignore this... we just need requests, not a successful response.
+      allow(Datadog.logger).to receive(:error)
+    end
+
+    shared_examples_for 'an uninstrumented transport' do
+      before do
+        expect_any_instance_of(Datadog::Tracer).to_not receive(:trace)
+        expect_any_instance_of(Datadog::Tracer).to_not receive(:start_span)
+      end
+
+      describe '#send_traces' do
+        subject(:send_traces) { transport.send_traces(traces) }
+        let(:traces) { get_test_traces(1) }
+
+        it 'does not produce traces for itself' do
+          send_traces
+        end
+      end
+    end
+
+    context 'given the default transport' do
+      let(:transport) { Datadog::Transport::HTTP.default }
+      it_behaves_like 'an uninstrumented transport'
+    end
+
+    context 'given an Unix socket transport' do
+      let(:transport) do
+        Datadog::Transport::HTTP.default do |t|
+          t.adapter :unix, '/tmp/ddagent/trace.sock'
+        end
+      end
+
+      it_behaves_like 'an uninstrumented transport'
+    end
+
+    context 'given an IO transport' do
+      let(:transport) { Datadog::Transport::IO.default(out: out) }
+      let(:out) { instance_double(::IO) }
+
+      before { allow(out).to receive(:puts) }
+
+      it_behaves_like 'an uninstrumented transport'
+    end
+  end
+end

--- a/spec/support/faux_transport.rb
+++ b/spec/support/faux_transport.rb
@@ -7,10 +7,10 @@ class FauxTransport < Datadog::Transport::HTTP::Client
 
   def send_traces(*)
     # Emulate an OK response
-    Datadog::Transport::HTTP::Traces::Response.new(
+    [Datadog::Transport::HTTP::Traces::Response.new(
       Datadog::Transport::HTTP::Adapters::Net::Response.new(
         Net::HTTPResponse.new(1.0, 200, 'OK')
       )
-    )
+    )]
   end
 end


### PR DESCRIPTION
Backport #1033 and #1034 from `master` to `0.35-stable` to allow for a 0.35.2 bugfix release.

These pull requests address issues introduced in 0.35.