### PR TITLE
Measure worker thread CPU time

### DIFF
--- a/lib/ddtrace/utils/time.rb
+++ b/lib/ddtrace/utils/time.rb
@@ -1,13 +1,21 @@
 module Datadog
   module Utils
-    # Common database-related utility functions.
+    # Common time-related utility functions
     module Time
-      PROCESS_TIME_SUPPORTED = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1.0')
+      # Check for architecture-dependent support
+      PROCESS_TIME_SUPPORTED = defined? Process::CLOCK_MONOTONIC
+      THREAD_CPU_TIME_SUPPORTED = defined? Process::CLOCK_THREAD_CPUTIME_ID
 
       module_function
 
+      # @return [Float] if supported, monotonic time in seconds; system wall time otherwise
       def get_time
         PROCESS_TIME_SUPPORTED ? Process.clock_gettime(Process::CLOCK_MONOTONIC) : ::Time.now.to_f
+      end
+
+      # @return [Float] if supported, total thread cpu time used in seconds; +nil+ otherwise
+      def get_thread_cpu_time
+        THREAD_CPU_TIME_SUPPORTED ? Process.clock_gettime(Process::CLOCK_THREAD_CPUTIME_ID) : nil
       end
     end
   end

--- a/spec/ddtrace/workers_spec.rb
+++ b/spec/ddtrace/workers_spec.rb
@@ -23,4 +23,19 @@ RSpec.describe Datadog::Workers::AsyncTransport do
       end
     end
   end
+
+  describe '#thread_cpu_time_diff' do
+    def subject
+      transport.send(:thread_cpu_time_diff)
+    end
+
+    let(:transport) { described_class.new }
+
+    it 'calculates difference since last measurement' do
+      expect(Datadog::Utils::Time).to receive(:get_thread_cpu_time).and_return(1, 10)
+
+      is_expected.to eq(1)
+      is_expected.to eq(9)
+    end
+  end
 end


### PR DESCRIPTION
This PR captures the CPU time used by our trace writer when executed in a separate thread.
This value is captured as the health metric `datadog.tracer.writer.cpu_time`.