### PR TITLE
Add Microbenchmarking

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,13 +11,18 @@ Dir.glob('tasks/*.rake').each { |r| import r }
 desc 'Run RSpec'
 # rubocop:disable Metrics/BlockLength
 namespace :spec do
-  task all: [:main,
+  task all: [:main, :benchmark,
              :rails, :railsredis, :railsactivejob,
              :elasticsearch, :http, :redis, :sidekiq, :sinatra]
 
   RSpec::Core::RakeTask.new(:main) do |t, args|
     t.pattern = 'spec/**/*_spec.rb'
     t.exclude_pattern = 'spec/**/{contrib,benchmark,redis,opentracer,opentelemetry}/**/*_spec.rb'
+    t.rspec_opts = args.to_a.join(' ')
+  end
+
+  RSpec::Core::RakeTask.new(:benchmark) do |t, args|
+    t.pattern = 'spec/ddtrace/benchmark/**/*_spec.rb'
     t.rspec_opts = args.to_a.join(' ')
   end
 
@@ -187,6 +192,8 @@ task :ci do
     sh 'bundle exec rake test:main'
     sh 'bundle exec rake spec:main'
     sh 'bundle exec rake spec:contrib'
+    # Benchmarks
+    sh 'bundle exec rake spec:benchmark'
 
     if RUBY_PLATFORM != 'java'
       # Contrib minitests
@@ -241,6 +248,8 @@ task :ci do
     sh 'bundle exec rake spec:main'
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
+    # Benchmarks
+    sh 'bundle exec rake spec:benchmark'
 
     if RUBY_PLATFORM != 'java'
       # Contrib minitests
@@ -302,6 +311,8 @@ task :ci do
     sh 'bundle exec rake spec:main'
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
+    # Benchmarks
+    sh 'bundle exec rake spec:benchmark'
 
     if RUBY_PLATFORM != 'java'
       # Contrib minitests
@@ -374,6 +385,8 @@ task :ci do
     sh 'bundle exec rake spec:main'
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
+    # Benchmarks
+    sh 'bundle exec rake spec:benchmark'
 
     if RUBY_PLATFORM != 'java'
       # Contrib minitests
@@ -449,6 +462,8 @@ task :ci do
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
     sh 'bundle exec rake spec:opentelemetry'
+    # Benchmarks
+    sh 'bundle exec rake spec:benchmark'
 
     if RUBY_PLATFORM != 'java'
       # Benchmarks
@@ -511,6 +526,8 @@ task :ci do
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
     sh 'bundle exec rake spec:opentelemetry'
+    # Benchmarks
+    sh 'bundle exec rake spec:benchmark'
 
     if RUBY_PLATFORM != 'java'
       # Benchmarks
@@ -583,6 +600,8 @@ task :ci do
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
     sh 'bundle exec rake spec:opentelemetry'
+    # Benchmarks
+    sh 'bundle exec rake spec:benchmark'
 
     if RUBY_PLATFORM != 'java'
       # Benchmarks
@@ -654,6 +673,8 @@ task :ci do
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
     sh 'bundle exec rake spec:opentelemetry'
+    # Benchmarks
+    sh 'bundle exec rake spec:benchmark'
 
     if RUBY_PLATFORM != 'java'
       # Benchmarks

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -59,6 +59,9 @@ Gem::Specification.new do |spec|
 
   # locking transitive dependency of webmock
   spec.add_development_dependency 'addressable', '~> 2.4.0'
+  spec.add_development_dependency 'benchmark-ips', '~> 2.8'
+  spec.add_development_dependency 'benchmark-memory', '~> 0.1'
+  spec.add_development_dependency 'memory_profiler', '~> 0.9'
   spec.add_development_dependency 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
   spec.add_development_dependency 'pry', '~> 0.10.4'
   spec.add_development_dependency 'pry-stack_explorer', '~> 0.4.9.2'

--- a/spec/ddtrace/benchmark/microbenchmark_spec.rb
+++ b/spec/ddtrace/benchmark/microbenchmark_spec.rb
@@ -1,0 +1,223 @@
+require 'spec_helper'
+
+require 'datadog/statsd'
+require 'ddtrace'
+
+require 'benchmark/ips'
+if !PlatformHelpers.jruby? && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1.0')
+  require 'benchmark/memory'
+  require 'memory_profiler'
+end
+
+require 'fileutils'
+require 'json'
+
+RSpec.describe 'Microbenchmark' do
+  shared_context 'benchmark' do
+    # When applicable, runs the test subject for different input sizes.
+    # Similar to how N in Big O notation works.
+    #
+    # This value is provided to the `subject(i)` method in order for the test
+    # to appropriately execute its run based on input size.
+    let(:steps) { defined?(super) ? super() : [1, 10, 100] }
+
+    # How many times we run our program when testing for memory allocation.
+    # In theory, we should only need to run it once, as memory tests are not
+    # dependent on competing system resources.
+    # But occasionally we do see a few blimps of inconsistency, making the benchmarks skewed.
+    # By running the benchmarked snippet many times, we drown out any one-off anomalies, allowing
+    # the real memory culprits to surface.
+    let(:memory_iterations) { defined?(super) ? super() : 100 }
+
+    # Outputs human readable information to STDERR.
+    # Most of the benchmarks have nicely formatted reports
+    # that are by default printed to terminal.
+    before do |e|
+      @test = e.metadata[:example_group][:full_description]
+      @type = e.description
+
+      STDERR.puts "Test:#{e.metadata[:example_group][:full_description]} #{e.description}"
+
+      # Warm up
+      steps.each do |s|
+        subject(s)
+      end
+    end
+
+    # Report JSON result objects to ./tmp/benchmark/ folder
+    # Theses results can be historically tracked (e.g. plotting) if needed.
+    def write_result(result)
+      STDERR.puts(@test, @type, result)
+
+      path = File.join('tmp', 'benchmark', @test, @type)
+      FileUtils.mkdir_p(File.dirname(path))
+
+      File.write(path, JSON.pretty_generate(result))
+
+      STDERR.puts("Result written to #{path}")
+    end
+
+    # Measure execution time
+    it 'timing' do
+      report = Benchmark.ips do |x|
+        x.config(time: 1, warmup: 0.1)
+
+        steps.each do |s|
+          x.report(s) do
+            subject(s)
+          end
+        end
+
+        x.compare!
+      end
+
+      result = report.entries.each_with_object({}) do |entry, hash|
+        hash[entry.label] = { ips: entry.stats.central_tendency, error: entry.stats.error_percentage / 100 }
+      end.to_h
+
+      write_result(result)
+    end
+
+    # Measure memory usage (object creation and memory size)
+    it 'memory' do
+      if PlatformHelpers.jruby? || Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1.0')
+        skip("'benchmark/memory' not supported")
+      end
+
+      report = Benchmark.memory do |x|
+        steps.each do |s|
+          x.report(s) do
+            memory_iterations.times { subject(s) }
+          end
+        end
+
+        x.compare!
+      end
+
+      result = report.entries.map do |entry|
+        row = entry.measurement.map do |metric|
+          { type: metric.type, allocated: metric.allocated, retained: metric.retained }
+        end
+
+        [entry.label, row]
+      end.to_h
+
+      write_result(result)
+    end
+
+    # Measure GC cycles triggered during run
+    it 'gc' do
+      skip if PlatformHelpers.jruby?
+
+      io = StringIO.new
+      GC::Profiler.enable
+
+      memory_iterations.times { subject(steps[0]) }
+
+      GC.disable # Prevent data collection from influencing results
+
+      data = GC::Profiler.raw_data
+      GC::Profiler.report(io)
+      GC::Profiler.disable
+
+      GC.enable
+
+      puts io.string
+
+      result = { count: data.size, time: data.map { |d| d[:GC_TIME] }.inject(0, &:+) }
+      write_result(result)
+    end
+
+    # Reports that generate non-aggregated data.
+    # Useful for debugging.
+    context 'detailed report' do
+      before { skip('Detailed report are too verbose for CI') if ENV.key?('CI') }
+
+      # Memory report with reference to each allocation site
+      it 'memory report' do
+        if PlatformHelpers.jruby? || Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1.0')
+          skip("'benchmark/memory' not supported")
+        end
+
+        report = MemoryProfiler.report do
+          memory_iterations.times { subject(steps[0]) }
+        end
+
+        report.pretty_print
+      end
+    end
+  end
+
+  # Empty benchmark to assess the overhead benchmarking tools
+  # and stability of underlying hardware.
+  describe 'baseline' do
+    include_examples 'benchmark'
+
+    def subject(_); end
+  end
+
+  describe Datadog::Tracer do
+    describe 'nested traces' do
+      include_examples 'benchmark'
+
+      let(:steps) { [1, 10, 100] }
+
+      let(:tracer) { new_tracer(writer: FauxWriter.new(call_original: false)) }
+      let(:name) { 'span'.freeze }
+
+      def trace(i, total)
+        tracer.trace(name) { trace(i + 1, total) unless i == total }
+      end
+
+      def subject(i)
+        trace(1, i)
+      end
+    end
+  end
+
+  describe Datadog::Writer do
+    describe '#write' do
+      let(:steps) { [1, 100] }
+      let(:memory_iterations) { 100 }
+
+      let(:writer) { described_class.new(transport: FauxTransport.new, buffer_size: buffer_size, flush_interval: 1e9) }
+      let(:span1) { get_test_traces(1).flatten }
+      let(:span100) { get_test_traces(100).flatten }
+      let(:span) { { 1 => span1, 100 => span100 } }
+
+      before do
+        writer.start
+      end
+
+      def subject(i)
+        reset_buffer # Ensure buffer is in a predictable state
+        writer.write(span[i])
+      end
+
+      def reset_buffer
+        # Keep in mind the overhead created by this method when analysing results
+        writer.worker.trace_buffer.instance_variable_set(:@traces, [])
+      end
+
+      context 'with space in buffer' do
+        include_examples 'benchmark'
+
+        let(:buffer_size) { -1 }
+      end
+
+      context 'with buffer full' do
+        include_examples 'benchmark'
+
+        let(:buffer_size) { Datadog::Workers::AsyncTransport::DEFAULT_BUFFER_MAX_SIZE }
+
+        before do
+          buffer_size.times { writer.write(span1) } # fill up buffer
+        end
+
+        def reset_buffer
+          # No need to reset, we actually want the buffer always full
+        end
+      end
+    end
+  end
+end

--- a/spec/support/faux_writer.rb
+++ b/spec/support/faux_writer.rb
@@ -6,7 +6,10 @@ require 'support/faux_transport'
 class FauxWriter < Datadog::Writer
   def initialize(options = {})
     options[:transport] ||= FauxTransport.new
-    super
+    options[:call_original] ||= true
+    @options = options
+
+    super if options[:call_original]
     @mutex = Mutex.new
 
     # easy access to registered components
@@ -15,7 +18,7 @@ class FauxWriter < Datadog::Writer
 
   def write(trace)
     @mutex.synchronize do
-      super(trace)
+      super(trace) if @options[:call_original]
       @spans << trace
     end
   end


### PR DESCRIPTION
This PR adds microbenchmarks to core components of `ddtrace`.
Currently we test:
* Trace creation (`tracer.trace`)
* Writer trace recording (`writer.write`)
* Baseline benchmark overhead: tests an empty method call, to validate if the benchmark environment is stable.

All test cases are measure for execution time, memory usage and GC impact.

The output looks like this (for testing `Datadog::Tracer nested traces` in this example):
```
Test:Microbenchmark Datadog::Tracer nested traces memory
Calculating -------------------------------------
                   1   253.544k memsize (    91.440k retained)
                         2.830k objects (   704.000  retained)
                         4.000  strings (     1.000  retained)
                  10     1.811M memsize (   862.280k retained)
                        14.488k objects (     5.661k retained)
                         3.000  strings (     0.000  retained)
                 100    17.340M memsize (     8.508M retained)
                       131.485k objects (    55.171k retained)
                         3.000  strings (     0.000  retained)

Comparison:
                   1:     253544 allocated
                  10:    1810560 allocated - 7.14x more
                 100:   17339976 allocated - 68.39x more

Test:Microbenchmark Datadog::Tracer nested traces timing
Warming up --------------------------------------
                   1     4.176k i/100ms
                  10     1.342k i/100ms
                 100   192.000  i/100ms
Calculating -------------------------------------
                   1     39.479k (±13.5%) i/s -     41.760k in   1.080583s
                  10      9.552k (±24.4%) i/s -     10.736k in   1.202755s
                 100      1.199k (±21.5%) i/s -      1.152k in   1.006056s

Comparison:
                   1:    39479.1 i/s
                  10:     9552.2 i/s - 4.13x  (± 0.00) slower
                 100:     1198.8 i/s - 32.93x  (± 0.00) slower
```

There's also a detailed, human-readable memory report under `detailed report` tests, which reports on every memory allocation site, like this:
```
allocated memory by location
-----------------------------------
     24000  lib/ddtrace/sampler.rb:188
     19200  lib/ddtrace/span.rb:69
     19200  lib/ddtrace/tracer.rb:193
     19200  lib/ddtrace/tracer.rb:259
     18400  lib/ddtrace/tracer.rb:201
```

This should give us a good starting point to measure small units of the tracer for performance impact and objectively measure future improvements.
