### PR TITLE
Lock gRPC version for older Rubies

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -342,7 +342,7 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'faraday'
       gem 'grape'
       gem 'graphql', '< 1.9.4'
-      gem 'grpc'
+      gem 'grpc', '~> 1.21.0' # Last version to support Ruby < 2.3
       gem 'hiredis'
       gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
@@ -501,6 +501,7 @@ elsif Gem::Version.new('2.3.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'grape'
       gem 'graphql'
       gem 'grpc'
+      gem 'google-protobuf', '~> 3.11.0' # Last version to support Ruby < 2.5
       gem 'hiredis'
       gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby
@@ -579,6 +580,7 @@ elsif Gem::Version.new('2.4.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'grape'
       gem 'graphql'
       gem 'grpc'
+      gem 'google-protobuf', '~> 3.11.0' # Last version to support Ruby < 2.5
       gem 'hiredis'
       gem 'mongo', '>= 2.8.0'
       gem 'mysql2', '< 0.5', platform: :ruby


### PR DESCRIPTION
Since `google-protobuf` `3.12.0` has been released, our older versions of Ruby have been trying to install it, but this new version only support Ruby => 2.5.

Bundler/rubygems should know this and not try to install an compatible version, but that doesn't seem to be the case. I found a few older GH issues about this issue, but nothing conclusive.

I believe the older version of bundler+rubygems are likely part of the problem, but it's ok to use those old versions when testing older Rubies.

This PR locks gRPC and it's dependency, `google-protobuf`, to the latest supported version for Ruby 2.2, 2.3 and 2.4. Ruby >= 2.5 continue to be supported by the latest release as usual.