### PR TITLE
Lock Rails 5.2 version for Ruby 2.2

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -292,33 +292,33 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
     end
 
     appraise 'rails5-mysql2' do
-      gem 'rails', '~> 5.2.1', '!= 5.2.4.1', '!= 5.2.4.2'
+      gem 'rails', '5.2.3'
       gem 'mysql2', '< 1', platform: :ruby
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres' do
-      gem 'rails', '~> 5.2.1', '!= 5.2.4.1', '!= 5.2.4.2'
+      gem 'rails', '5.2.3'
       gem 'pg', '< 1.0', platform: :ruby
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres-redis' do
-      gem 'rails', '~> 5.2.1', '!= 5.2.4.1', '!= 5.2.4.2'
+      gem 'rails', '5.2.3'
       gem 'pg', '< 1.0', platform: :ruby
       gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres-redis-activesupport' do
-      gem 'rails', '~> 5.2.1', '!= 5.2.4.1', '!= 5.2.4.2'
+      gem 'rails', '5.2.3'
       gem 'pg', '< 1.0', platform: :ruby
       gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
     end
 
     appraise 'rails5-postgres-sidekiq' do
-      gem 'rails', '~> 5.2.1', '!= 5.2.4.1', '!= 5.2.4.2'
+      gem 'rails', '5.2.3'
       gem 'pg', '< 1.0', platform: :ruby
       gem 'sidekiq'
       gem 'activejob'


### PR DESCRIPTION
The same issue we had with Rails 5.2 running on Ruby 2.2 is back: https://github.com/rails/rails/issues/39371

Because Rails 5.2 is only receiving security updates (but those have been flaky recently) we should be safe with not updating the version of Rails for Ruby 2.2.