### PR TITLE
Initialize tracer before concurrency test

### DIFF
--- a/test/concurrent_test.rb
+++ b/test/concurrent_test.rb
@@ -2,6 +2,11 @@ require 'helper'
 require 'ddtrace/tracer'
 
 class ConcurrentTest < Minitest::Test
+  def setup
+    # Ensure library is initialized in the main thread first
+    Datadog.configure
+  end
+
   def traced_task
     @tracer.trace('a-root-task') do |_root_span|
       delay = rand()


### PR DESCRIPTION
Our new JRuby test suite fails frequently while running `test/concurrent_test.rb`. This happens because the tracer is lazily initialized concurrently across many threads, which we currently do not support.

This PR ensures the tracer is properly initialized before the concurrency test runs.