### PR TITLE
Reduce memory overhead of Tracer#trace

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,13 +11,18 @@ Dir.glob('tasks/*.rake').each { |r| import r }
 desc 'Run RSpec'
 # rubocop:disable Metrics/BlockLength
 namespace :spec do
-  task all: [:main,
+  task all: [:main, :benchmark,
              :rails, :railsredis, :railsactivejob,
              :elasticsearch, :http, :redis, :sidekiq, :sinatra]
 
   RSpec::Core::RakeTask.new(:main) do |t, args|
     t.pattern = 'spec/**/*_spec.rb'
     t.exclude_pattern = 'spec/**/{contrib,benchmark,redis,opentracer,opentelemetry}/**/*_spec.rb'
+    t.rspec_opts = args.to_a.join(' ')
+  end
+
+  RSpec::Core::RakeTask.new(:benchmark) do |t, args|
+    t.pattern = 'spec/ddtrace/benchmark/**/*_spec.rb'
     t.rspec_opts = args.to_a.join(' ')
   end
 
@@ -187,6 +192,8 @@ task :ci do
     sh 'bundle exec rake test:main'
     sh 'bundle exec rake spec:main'
     sh 'bundle exec rake spec:contrib'
+    # Benchmarks
+    sh 'bundle exec rake spec:benchmark'
 
     if RUBY_PLATFORM != 'java'
       # Contrib minitests
@@ -241,6 +248,8 @@ task :ci do
     sh 'bundle exec rake spec:main'
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
+    # Benchmarks
+    sh 'bundle exec rake spec:benchmark'
 
     if RUBY_PLATFORM != 'java'
       # Contrib minitests
@@ -302,6 +311,8 @@ task :ci do
     sh 'bundle exec rake spec:main'
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
+    # Benchmarks
+    sh 'bundle exec rake spec:benchmark'
 
     if RUBY_PLATFORM != 'java'
       # Contrib minitests
@@ -374,6 +385,8 @@ task :ci do
     sh 'bundle exec rake spec:main'
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
+    # Benchmarks
+    sh 'bundle exec rake spec:benchmark'
 
     if RUBY_PLATFORM != 'java'
       # Contrib minitests
@@ -449,6 +462,8 @@ task :ci do
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
     sh 'bundle exec rake spec:opentelemetry'
+    # Benchmarks
+    sh 'bundle exec rake spec:benchmark'
 
     if RUBY_PLATFORM != 'java'
       # Benchmarks
@@ -511,6 +526,8 @@ task :ci do
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
     sh 'bundle exec rake spec:opentelemetry'
+    # Benchmarks
+    sh 'bundle exec rake spec:benchmark'
 
     if RUBY_PLATFORM != 'java'
       # Benchmarks
@@ -583,6 +600,8 @@ task :ci do
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
     sh 'bundle exec rake spec:opentelemetry'
+    # Benchmarks
+    sh 'bundle exec rake spec:benchmark'
 
     if RUBY_PLATFORM != 'java'
       # Benchmarks
@@ -654,6 +673,8 @@ task :ci do
     sh 'bundle exec rake spec:contrib'
     sh 'bundle exec rake spec:opentracer'
     sh 'bundle exec rake spec:opentelemetry'
+    # Benchmarks
+    sh 'bundle exec rake spec:benchmark'
 
     if RUBY_PLATFORM != 'java'
       # Benchmarks

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -59,6 +59,9 @@ Gem::Specification.new do |spec|
 
   # locking transitive dependency of webmock
   spec.add_development_dependency 'addressable', '~> 2.4.0'
+  spec.add_development_dependency 'benchmark-ips', '~> 2.8'
+  spec.add_development_dependency 'benchmark-memory', '~> 0.1'
+  spec.add_development_dependency 'memory_profiler', '~> 0.9'
   spec.add_development_dependency 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
   spec.add_development_dependency 'pry', '~> 0.10.4'
   spec.add_development_dependency 'pry-stack_explorer', '~> 0.4.9.2'

--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -193,3 +193,15 @@ Datadog.configure do |c|
   }
 end
 ```
+
+### Performance
+
+Writing idiomatic Ruby code should always be your first stylistic priority, but having performance considerations
+guiding your decisions is also important when writing a tracer library that is often part of an application's critical path.
+
+Here are a few performance learnings we've collected while writing `ddtrace`:
+* Freeze string literals. If not frozen, a new string is created every time the statement is evaluated.
+* Prefer `Hash[:key] || default` over `Hash#fetch`. The former is faster for both miss or hit key lookups and prevents the allocation of `default` when not needed.
+* Use mutable array operations when possible (e.g. `map!`, `select!`), as this prevents the creation of a new array.
+* If you need an empty array as a placeholder (e.g. `def foo(opt = {})`) and you won't mutate it, use `Datadog::Utils::EMPTY_HASH`. This avoids the allocation of a new hash.
+ 

--- a/lib/ddtrace/context.rb
+++ b/lib/ddtrace/context.rb
@@ -234,7 +234,7 @@ module Datadog
 
     private
 
-    def reset(options = {})
+    def reset(options = Utils::EMPTY_HASH)
       @trace = []
       @parent_trace_id = options.fetch(:trace_id, nil)
       @parent_span_id = options.fetch(:span_id, nil)

--- a/lib/ddtrace/ext/system.rb
+++ b/lib/ddtrace/ext/system.rb
@@ -1,0 +1,7 @@
+module Datadog
+  module Ext
+    module System
+      PID = 'system.pid'.freeze
+    end
+  end
+end

--- a/lib/ddtrace/utils.rb
+++ b/lib/ddtrace/utils.rb
@@ -3,6 +3,11 @@ require 'ddtrace/utils/database'
 module Datadog
   # Utils contains low-level utilities, typically to provide pseudo-random trace IDs.
   module Utils
+    # Empty immutable hash to be used.
+    # Useful to avoid allocations when the hash won't be modified:
+    # e.g. methods with empty +options={}+ as default.
+    EMPTY_HASH = {}.freeze
+
     STRING_PLACEHOLDER = ''.encode(::Encoding::UTF_8).freeze
     # We use a custom random number generator because we want no interference
     # with the default one. Using the default prng, we could break code that

--- a/spec/ddtrace/benchmark/microbenchmark_spec.rb
+++ b/spec/ddtrace/benchmark/microbenchmark_spec.rb
@@ -1,0 +1,223 @@
+require 'spec_helper'
+
+require 'datadog/statsd'
+require 'ddtrace'
+
+require 'benchmark/ips'
+if !PlatformHelpers.jruby? && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1.0')
+  require 'benchmark/memory'
+  require 'memory_profiler'
+end
+
+require 'fileutils'
+require 'json'
+
+RSpec.describe 'Microbenchmark' do
+  shared_context 'benchmark' do
+    # When applicable, runs the test subject for different input sizes.
+    # Similar to how N in Big O notation works.
+    #
+    # This value is provided to the `subject(i)` method in order for the test
+    # to appropriately execute its run based on input size.
+    let(:steps) { defined?(super) ? super() : [1, 10, 100] }
+
+    # How many times we run our program when testing for memory allocation.
+    # In theory, we should only need to run it once, as memory tests are not
+    # dependent on competing system resources.
+    # But occasionally we do see a few blimps of inconsistency, making the benchmarks skewed.
+    # By running the benchmarked snippet many times, we drown out any one-off anomalies, allowing
+    # the real memory culprits to surface.
+    let(:memory_iterations) { defined?(super) ? super() : 100 }
+
+    # Outputs human readable information to STDERR.
+    # Most of the benchmarks have nicely formatted reports
+    # that are by default printed to terminal.
+    before do |e|
+      @test = e.metadata[:example_group][:full_description]
+      @type = e.description
+
+      STDERR.puts "Test:#{e.metadata[:example_group][:full_description]} #{e.description}"
+
+      # Warm up
+      steps.each do |s|
+        subject(s)
+      end
+    end
+
+    # Report JSON result objects to ./tmp/benchmark/ folder
+    # Theses results can be historically tracked (e.g. plotting) if needed.
+    def write_result(result)
+      STDERR.puts(@test, @type, result)
+
+      path = File.join('tmp', 'benchmark', @test, @type)
+      FileUtils.mkdir_p(File.dirname(path))
+
+      File.write(path, JSON.pretty_generate(result))
+
+      STDERR.puts("Result written to #{path}")
+    end
+
+    # Measure execution time
+    it 'timing' do
+      report = Benchmark.ips do |x|
+        x.config(time: 1, warmup: 0.1)
+
+        steps.each do |s|
+          x.report(s) do
+            subject(s)
+          end
+        end
+
+        x.compare!
+      end
+
+      result = report.entries.each_with_object({}) do |entry, hash|
+        hash[entry.label] = { ips: entry.stats.central_tendency, error: entry.stats.error_percentage / 100 }
+      end.to_h
+
+      write_result(result)
+    end
+
+    # Measure memory usage (object creation and memory size)
+    it 'memory' do
+      if PlatformHelpers.jruby? || Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1.0')
+        skip("'benchmark/memory' not supported")
+      end
+
+      report = Benchmark.memory do |x|
+        steps.each do |s|
+          x.report(s) do
+            memory_iterations.times { subject(s) }
+          end
+        end
+
+        x.compare!
+      end
+
+      result = report.entries.map do |entry|
+        row = entry.measurement.map do |metric|
+          { type: metric.type, allocated: metric.allocated, retained: metric.retained }
+        end
+
+        [entry.label, row]
+      end.to_h
+
+      write_result(result)
+    end
+
+    # Measure GC cycles triggered during run
+    it 'gc' do
+      skip if PlatformHelpers.jruby?
+
+      io = StringIO.new
+      GC::Profiler.enable
+
+      memory_iterations.times { subject(steps[0]) }
+
+      GC.disable # Prevent data collection from influencing results
+
+      data = GC::Profiler.raw_data
+      GC::Profiler.report(io)
+      GC::Profiler.disable
+
+      GC.enable
+
+      puts io.string
+
+      result = { count: data.size, time: data.map { |d| d[:GC_TIME] }.inject(0, &:+) }
+      write_result(result)
+    end
+
+    # Reports that generate non-aggregated data.
+    # Useful for debugging.
+    context 'detailed report' do
+      before { skip('Detailed report are too verbose for CI') if ENV.key?('CI') }
+
+      # Memory report with reference to each allocation site
+      it 'memory report' do
+        if PlatformHelpers.jruby? || Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1.0')
+          skip("'benchmark/memory' not supported")
+        end
+
+        report = MemoryProfiler.report do
+          memory_iterations.times { subject(steps[0]) }
+        end
+
+        report.pretty_print
+      end
+    end
+  end
+
+  # Empty benchmark to assess the overhead benchmarking tools
+  # and stability of underlying hardware.
+  describe 'baseline' do
+    include_examples 'benchmark'
+
+    def subject(_); end
+  end
+
+  describe Datadog::Tracer do
+    describe 'nested traces' do
+      include_examples 'benchmark'
+
+      let(:steps) { [1, 10, 100] }
+
+      let(:tracer) { new_tracer(writer: FauxWriter.new(call_original: false)) }
+      let(:name) { 'span'.freeze }
+
+      def trace(i, total)
+        tracer.trace(name) { trace(i + 1, total) unless i == total }
+      end
+
+      def subject(i)
+        trace(1, i)
+      end
+    end
+  end
+
+  describe Datadog::Writer do
+    describe '#write' do
+      let(:steps) { [1, 100] }
+      let(:memory_iterations) { 100 }
+
+      let(:writer) { described_class.new(transport: FauxTransport.new, buffer_size: buffer_size, flush_interval: 1e9) }
+      let(:span1) { get_test_traces(1).flatten }
+      let(:span100) { get_test_traces(100).flatten }
+      let(:span) { { 1 => span1, 100 => span100 } }
+
+      before do
+        writer.start
+      end
+
+      def subject(i)
+        reset_buffer # Ensure buffer is in a predictable state
+        writer.write(span[i])
+      end
+
+      def reset_buffer
+        # Keep in mind the overhead created by this method when analysing results
+        writer.worker.trace_buffer.instance_variable_set(:@traces, [])
+      end
+
+      context 'with space in buffer' do
+        include_examples 'benchmark'
+
+        let(:buffer_size) { -1 }
+      end
+
+      context 'with buffer full' do
+        include_examples 'benchmark'
+
+        let(:buffer_size) { Datadog::Workers::AsyncTransport::DEFAULT_BUFFER_MAX_SIZE }
+
+        before do
+          buffer_size.times { writer.write(span1) } # fill up buffer
+        end
+
+        def reset_buffer
+          # No need to reset, we actually want the buffer always full
+        end
+      end
+    end
+  end
+end

--- a/spec/support/faux_writer.rb
+++ b/spec/support/faux_writer.rb
@@ -6,7 +6,10 @@ require 'support/faux_transport'
 class FauxWriter < Datadog::Writer
   def initialize(options = {})
     options[:transport] ||= FauxTransport.new
-    super
+    options[:call_original] ||= true
+    @options = options
+
+    super if options[:call_original]
     @mutex = Mutex.new
 
     # easy access to registered components
@@ -15,7 +18,7 @@ class FauxWriter < Datadog::Writer
 
   def write(trace)
     @mutex.synchronize do
-      super(trace)
+      super(trace) if @options[:call_original]
       @spans << trace
     end
   end


### PR DESCRIPTION
_**TL;DR: 26%-35% memory reduction, 3%-17% speedup**_

This PR aims to reduce the memory footprint of a trace object creation. Execution time improvement is not the goal, but a regression should be avoided.

This work was mostly guided by the results of our benchmark memory report `Microbenchmark benchmark detailed report memory report`. This test provides a very detailed result of all allocation sites exercised during a run.

We use the benchmark `Microbenchmark Datadog::Tracer nested traces` to measure the impact of our changes. This benchmark runs the statement `tracer.trace('my.op'){ ... }` with varying amount of nested spans: `1`, `10` and `100` in the results below represent the number of nested spans created during a test run.

Bellow are the results after the changes have been applied:

### Memory
#### Before
```
Calculating -------------------------------------
                   1   254.312k memsize (    92.048k retained)
                         2.848k objects (   718.000  retained)
                         4.000  strings (     1.000  retained)
                  10     1.811M memsize (   861.400k retained)
                        14.510k objects (     5.639k retained)
                         3.000  strings (     0.000  retained)
                 100    17.342M memsize (     8.505M retained)
                       131.531k objects (    55.102k retained)
                         3.000  strings (     0.000  retained)

Comparison:
                   1:     254312 allocated
                  10:    1811440 allocated - 7.12x more
                 100:   17341816 allocated - 68.19x more
```
#### After
```
Calculating -------------------------------------
                   1   164.504k memsize (    91.760k retained)
                         2.044k objects (   712.000  retained) 1 - 2.044/2.848
                         1.000  strings (     1.000  retained)
                  10     1.306M memsize (   862.720k retained)
                        11.876k objects (     5.640k retained) 1 - 11.876/14.510
                         1.000  strings (     1.000  retained)
                 100    12.663M memsize (     8.512M retained)
                       110.968k objects (    55.184k retained) 1 - 110.968/131.531
                         1.000  strings (     1.000  retained)

Comparison:
                   1:     164504 allocated
                  10:    1306024 allocated - 7.94x more
                 100:   12663240 allocated - 76.98x more
```
#### Comparison
```
  1: 100% -   164504.0/254312.0   = 0.35314102362452415
 10: 100% -  1306024.0/1811440.0  = 0.27901338161904343
100: 100% - 12663240.0/17341816.0 = 0.269785817125496
```

We have a **reduction of bytes allocated of 26%-35%**, depending on the trace nesting depth.

### Time
Even though time performance was not the goal, it is important to ensure there are not regressions. Here are the timing results:
#### Before
```
Calculating -------------------------------------
                   1     37.323k (±24.6%) i/s -    168.652k in   5.076209s
                  10      9.328k (±37.7%) i/s -     37.098k in   5.844379s
                 100      1.150k (±47.2%) i/s -      3.910k in   5.899024s
Comparison:
                   1:    37322.6 i/s
                  10:     9328.3 i/s - 4.00x  (± 0.00) slower
                 100:     1150.0 i/s - 32.46x  (± 0.00) slower
```
#### After
```
Calculating -------------------------------------
                   1     38.473k (±23.0%) i/s -    175.725k in   5.003995s
                  10      9.606k (±39.2%) i/s -     34.768k in   5.013167s
                 100      1.354k (±39.4%) i/s -      4.484k in   5.054625s
Comparison:
                   1:    38472.9 i/s
                  10:     9606.2 i/s - 4.00x  (± 0.00) slower
                 100:     1354.3 i/s - 28.41x  (± 0.00) slower
```

#### Comparison
```
  1: 38472.9/37322.6 = 1.030820468027415115
 10:  9606.2/9328.3  = 1.029791065896251245
100:  1354.3/1150.0  = 1.17765217391304344
```

We have a minor **speedup of 3%-17%**, depending on the trace nesting depth.
