### PR TITLE
Allow Rails patching to occur if Railties are loaded

### DIFF
--- a/lib/ddtrace/contrib/rails/integration.rb
+++ b/lib/ddtrace/contrib/rails/integration.rb
@@ -16,7 +16,7 @@ module Datadog
         register_as :rails, auto_patch: false
 
         def self.version
-          Gem.loaded_specs['rails'] && Gem.loaded_specs['rails'].version
+          Gem.loaded_specs['railties'] && Gem.loaded_specs['railties'].version
         end
 
         def self.loaded?

--- a/spec/ddtrace/contrib/rails/integration_spec.rb
+++ b/spec/ddtrace/contrib/rails/integration_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe Datadog::Contrib::Rails::Integration do
   describe '.version' do
     subject(:version) { described_class.version }
 
-    context 'when the "rails" gem is loaded' do
-      include_context 'loaded gems', rails: described_class::MINIMUM_VERSION
+    context 'when the "railties" gem is loaded' do
+      include_context 'loaded gems', railties: described_class::MINIMUM_VERSION
       it { is_expected.to be_a_kind_of(Gem::Version) }
     end
 
-    context 'when "rails" gem is not loaded' do
-      include_context 'loaded gems', rails: nil
+    context 'when the "railties" gem is not loaded' do
+      include_context 'loaded gems', railties: nil
       it { is_expected.to be nil }
     end
   end
@@ -38,20 +38,20 @@ RSpec.describe Datadog::Contrib::Rails::Integration do
   describe '.compatible?' do
     subject(:compatible?) { described_class.compatible? }
 
-    context 'when "rails" gem is loaded with a version' do
+    context 'when "railties" gem is loaded with a version' do
       context 'that is less than the minimum' do
-        include_context 'loaded gems', rails: decrement_gem_version(described_class::MINIMUM_VERSION)
+        include_context 'loaded gems', railties: decrement_gem_version(described_class::MINIMUM_VERSION)
         it { is_expected.to be false }
       end
 
       context 'that meets the minimum version' do
-        include_context 'loaded gems', rails: described_class::MINIMUM_VERSION
+        include_context 'loaded gems', railties: described_class::MINIMUM_VERSION
         it { is_expected.to be true }
       end
     end
 
-    context 'when gem is not loaded' do
-      include_context 'loaded gems', rails: nil
+    context 'when "railties" gem and "railties" gem are not loaded' do
+      include_context 'loaded gems', railties: nil
       it { is_expected.to be false }
     end
   end


### PR DESCRIPTION
Per #993, when users run Rails applications without `gem 'rails'` and opt to load gems manually, the Rails patcher aborts patching because it can't find the Rails version in the Rails gem.

This had to do with some changes we made to add stricter version checks for integrations in 0.33.0. It was checking if `Gem.loaded_specs['rails']` was loaded, and when it didn't find it, it would assume Rails wasn't present.

This pull request changes this check to also see if `gem 'railties'` are loaded, which are used in Rails applications, regardless of whether `gem 'rails'` is included or not. If `railties` are present, it will attempt Rails patching.