### PR TITLE
Auto instrument Faraday default connection

### DIFF
--- a/lib/ddtrace/contrib/faraday/middleware.rb
+++ b/lib/ddtrace/contrib/faraday/middleware.rb
@@ -16,7 +16,7 @@ module Datadog
 
         def initialize(app, options = {})
           super(app)
-          @options = datadog_configuration.options_hash.merge(options)
+          @options = options
         end
 
         def call(env)
@@ -33,7 +33,7 @@ module Datadog
 
         private
 
-        attr_reader :app, :options
+        attr_reader :app
 
         def annotate!(span, env, options)
           span.resource = resource_name(env)
@@ -69,7 +69,9 @@ module Datadog
         end
 
         def build_request_options!(env)
-          datadog_configuration(env[:url].host).options_hash.merge(options)
+          datadog_configuration.options_hash # integration level settings
+                               .merge(datadog_configuration(env[:url].host).options_hash) # per-host override
+                               .merge(@options) # middleware instance override
         end
 
         def datadog_configuration(host = :default)

--- a/lib/ddtrace/contrib/faraday/patcher.rb
+++ b/lib/ddtrace/contrib/faraday/patcher.rb
@@ -45,6 +45,9 @@ module Datadog
           else
             ::Faraday::RackBuilder.send(:prepend, RackBuilder)
           end
+
+          # Instrument the Faraday default connection (e.g. +Faraday.get+)
+          ::Faraday.default_connection.use(:ddtrace)
         end
 
         def get_option(option)

--- a/spec/ddtrace/contrib/faraday/middleware_spec.rb
+++ b/spec/ddtrace/contrib/faraday/middleware_spec.rb
@@ -64,6 +64,39 @@ RSpec.describe 'Faraday middleware' do
     it 'executes without warnings' do
       expect { response }.to_not output(/WARNING/).to_stderr
     end
+
+    context 'with default Faraday connection' do
+      subject(:response) { client.get('http://example.com/success') }
+      let(:client) { ::Faraday } # Use the singleton client
+
+      before do
+        # We mock HTTP requests we we can't configure
+        # the test adapter for the default connection
+        WebMock.enable!
+        stub_request(:get, 'http://example.com/success').to_return(status: 200)
+      end
+
+      after { WebMock.disable! }
+
+      it 'uses default configuration' do
+        expect(response.status).to eq(200)
+
+        expect(request_span.service).to eq(Datadog::Contrib::Faraday::Ext::SERVICE_NAME)
+        expect(request_span.name).to eq(Datadog::Contrib::Faraday::Ext::SPAN_REQUEST)
+        expect(request_span.resource).to eq('GET')
+        expect(request_span.get_tag(Datadog::Ext::HTTP::METHOD)).to eq('GET')
+        expect(request_span.get_tag(Datadog::Ext::HTTP::STATUS_CODE)).to eq('200')
+        expect(request_span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/success')
+        expect(request_span.get_tag(Datadog::Ext::NET::TARGET_HOST)).to eq('example.com')
+        expect(request_span.get_tag(Datadog::Ext::NET::TARGET_PORT)).to eq(80)
+        expect(request_span.span_type).to eq(Datadog::Ext::HTTP::TYPE_OUTBOUND)
+        expect(request_span).to_not have_error
+      end
+
+      it 'executes without warnings' do
+        expect { response }.to_not output(/WARNING/).to_stderr
+      end
+    end
   end
 
   context 'when there is no interference' do
@@ -240,6 +273,41 @@ RSpec.describe 'Faraday middleware' do
 
     it do
       expect(request_span.service).to eq(service_name)
+    end
+  end
+
+  context 'configuration override' do
+    subject(:response) { client.get('/success') }
+
+    context 'with global configuration' do
+      let(:configuration_options) { super().merge(service_name: 'global') }
+
+      it 'uses the global value' do
+        subject
+        expect(request_span.service).to eq('global')
+      end
+
+      context 'and per-host configuration' do
+        before do
+          Datadog.configure do |c|
+            c.use :faraday, describes: /example\.com/, service_name: 'host'
+          end
+        end
+
+        it 'uses per-host override' do
+          subject
+          expect(request_span.service).to eq('host')
+        end
+
+        context 'with middleware instance configuration' do
+          let(:middleware_options) { super().merge(service_name: 'instance') }
+
+          it 'uses middleware instance override' do
+            subject
+            expect(request_span.service).to eq('instance')
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Our auto instrumentation did not configure itself to work with Faraday's default connection.
The default connection is used when using the short Faraday syntax: `Faraday.get("http://domain.com/path")`.

Other use cases that create a `Faraday::Connection` (`Faraday.new`, for example) are already auto instrumented.