### PR TITLE
Add gem startup benchmarking

### DIFF
--- a/spec/ddtrace/benchmark/gem_loading_spec.rb
+++ b/spec/ddtrace/benchmark/gem_loading_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+
+if !PlatformHelpers.jruby? && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1.0')
+  require 'benchmark/memory'
+  require 'memory_profiler'
+end
+
+RSpec.describe 'Gem loading' do
+  def subject
+    `ruby -e #{Shellwords.escape(load_path + program + flush_output)}`
+  end
+
+  let(:program) do
+    <<-RUBY
+      require 'ddtrace'
+    RUBY
+  end
+
+  let(:load_path) do
+    # Ensure we load the working directory version of 'ddtrace'
+    <<-RUBY
+      lib = File.expand_path('../lib', __FILE__)
+      $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+    RUBY
+  end
+
+  let(:flush_output) do
+    <<-RUBY
+      $stdout.flush
+    RUBY
+  end
+
+  let(:iterations) { 30 }
+  let(:benchmark) { iterations.times.reduce(0) { |acc, _| acc + subject.to_f } }
+  let(:report_average) { benchmark / iterations }
+
+  context 'timing' do
+    let(:program) do
+      <<-'RUBY'
+      require 'benchmark'
+      bm = Benchmark.measure do
+        require 'ddtrace'
+      end
+      puts bm.real
+      RUBY
+    end
+
+    it { puts "ddtrace gem load time: #{report_average}s" }
+  end
+
+  context 'memory' do
+    let(:program) do
+      <<-'RUBY'
+      puts `ps -o rss= -p #{Process.pid}`.to_i
+      require 'ddtrace'
+      puts `ps -o rss= -p #{Process.pid}`.to_i
+      RUBY
+    end
+
+    def subject
+      output = super()
+
+      before, after = output.split
+      after.to_i - before.to_i
+    end
+
+    it { puts "ddtrace gem memory footprint: #{report_average} KiB" }
+  end
+
+  context 'detailed report' do
+    before { skip('Detailed report are too verbose for CI') if ENV.key?('CI') }
+
+    let(:program) do
+      <<-'RUBY'
+      require 'memory_profiler'
+
+      # Exclude Ruby internals and gems from the report.
+      # The memory consumed by them will still be captured
+      # through 'require' statements and method calls present in ddtrace,
+      # but their internals won't pollute the report output.
+      ignore_files = %r{(.*/gems/[^/]*/lib/|/lib/ruby/\d)}
+
+      report = MemoryProfiler.report(ignore_files: ignore_files) do
+        require 'ddtrace'
+      end
+
+      report.pretty_print
+      RUBY
+    end
+
+    # Memory report with reference to each allocation site
+    it 'memory report' do
+      if PlatformHelpers.jruby? || Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1.0')
+        skip("'benchmark/memory' not supported")
+      end
+
+      puts subject
+    end
+  end
+end


### PR DESCRIPTION
Similar to #1043, this PR adds memory and timing benchmarking to the gem loading process: `require 'ddtrace'`.

Here's the sample output:

```
ddtrace gem memory footprint: 6199.06 KiB
ddtrace gem load time: 0.155863s
```

We run the gem loading process a few times in a new process (to be able to `require` again like it is the first time) and collect the average to create these results.

Plus, we also have the detailed memory report when running locally:
```
Total allocated: 6477394 bytes (47492 objects)
Total retained:  895123 bytes (7032 objects)

allocated memory by gem
-----------------------------------
   6455955  ./lib
     21439  other

allocated memory by file
-----------------------------------
    685735  ./lib/ddtrace.rb
    276785  ./lib/ddtrace/tracer.rb
    200023  ./lib/ddtrace/configuration/options.rb
    174986  ./lib/ddtrace/span.rb
    154700  ./lib/ddtrace/transport/http/adapters/unix_socket.rb
    139054  ./lib/ddtrace/configuration/option_definition.rb
    125707  ./lib/ddtrace/runtime/socket.rb
    125132  ./lib/ddtrace/transport/http.rb
     91641  ./lib/ddtrace/writer.rb