### PR TITLE
Fix Rails caching stale instance of tracer

### DIFF
--- a/lib/ddtrace/contrib/rails/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rails/configuration/settings.rb
@@ -76,18 +76,6 @@ module Datadog
               Datadog.configuration[:action_view][:template_base_path] = value
             end
           end
-
-          option :tracer do |o|
-            o.delegate_to { Datadog.tracer }
-            o.on_set do |value|
-              Datadog.configuration[:action_cable][:tracer] = value
-              Datadog.configuration[:active_record][:tracer] = value
-              Datadog.configuration[:active_support][:tracer] = value
-              Datadog.configuration[:action_pack][:tracer] = value
-              Datadog.configuration[:action_view][:tracer] = value
-              Datadog.configuration[:rack][:tracer] = value
-            end
-          end
         end
       end
     end

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -64,7 +64,6 @@ module Datadog
         def self.activate_rack!(datadog_config, rails_config)
           datadog_config.use(
             :rack,
-            tracer: rails_config[:tracer],
             application: ::Rails.application,
             service_name: rails_config[:service_name],
             middleware_names: rails_config[:middleware_names],
@@ -77,8 +76,7 @@ module Datadog
 
           datadog_config.use(
             :active_support,
-            cache_service: rails_config[:cache_service],
-            tracer: rails_config[:tracer]
+            cache_service: rails_config[:cache_service]
           )
         end
 
@@ -87,8 +85,7 @@ module Datadog
 
           datadog_config.use(
             :action_cable,
-            service_name: "#{rails_config[:service_name]}-#{Contrib::ActionCable::Ext::SERVICE_NAME}",
-            tracer: rails_config[:tracer]
+            service_name: "#{rails_config[:service_name]}-#{Contrib::ActionCable::Ext::SERVICE_NAME}"
           )
         end
 
@@ -101,8 +98,7 @@ module Datadog
 
           datadog_config.use(
             :action_pack,
-            service_name: rails_config[:service_name],
-            tracer: rails_config[:tracer]
+            service_name: rails_config[:service_name]
           )
         end
 
@@ -111,8 +107,7 @@ module Datadog
 
           datadog_config.use(
             :action_view,
-            service_name: rails_config[:service_name],
-            tracer: rails_config[:tracer]
+            service_name: rails_config[:service_name]
           )
         end
 
@@ -121,8 +116,7 @@ module Datadog
 
           datadog_config.use(
             :active_record,
-            service_name: rails_config[:database_service],
-            tracer: rails_config[:tracer]
+            service_name: rails_config[:database_service]
           )
         end
       end

--- a/spec/ddtrace/contrib/rails/action_controller_spec.rb
+++ b/spec/ddtrace/contrib/rails/action_controller_spec.rb
@@ -1,8 +1,9 @@
 require 'ddtrace/contrib/rails/rails_helper'
 
 RSpec.describe 'Rails ActionController' do
-  let(:tracer) { get_test_tracer }
-  let(:rails_options) { { tracer: tracer } }
+  include_context 'global test tracer'
+
+  let(:rails_options) { {} }
 
   before do
     Datadog.configure do |c|

--- a/spec/ddtrace/contrib/rails/cache_spec.rb
+++ b/spec/ddtrace/contrib/rails/cache_spec.rb
@@ -2,6 +2,7 @@ require 'securerandom'
 require 'ddtrace/contrib/rails/ext'
 
 require 'ddtrace/contrib/rails/rails_helper'
+require 'ddtrace/contrib/analytics_examples'
 
 RSpec.describe 'Rails cache' do
   include_context 'Rails test application'

--- a/spec/ddtrace/contrib/rails/redis_cache_spec.rb
+++ b/spec/ddtrace/contrib/rails/redis_cache_spec.rb
@@ -30,7 +30,7 @@ MESSAGE
 
   before do
     Datadog.configure { |c| c.use :redis }
-    Datadog.configure(client_from_driver(driver), tracer_options)
+    Datadog.configure(client_from_driver(driver), tracer: tracer)
   end
 
   let(:driver) do

--- a/spec/ddtrace/contrib/rails/support/application.rb
+++ b/spec/ddtrace/contrib/rails/support/application.rb
@@ -2,11 +2,10 @@ require 'ddtrace/contrib/rails/support/base'
 
 RSpec.shared_context 'Rails test application' do
   include_context 'Rails base application'
+  include_context 'global test tracer'
 
   before do
     Datadog.configuration[:rails].reset_options!
-    Datadog.configuration[:rails][:tracer] = tracer
-
     reset_rails_configuration!
   end
 
@@ -67,7 +66,7 @@ RSpec.shared_context 'Rails test application' do
     logger.error 'A Rails app for this version is not found!'
   end
 
-  let(:tracer_options) { { tracer: tracer } }
+  let(:tracer_options) { {} }
 
   let(:app_name) { Datadog::Contrib::Rails::Utils.app_name }
 

--- a/spec/support/tracer_helpers.rb
+++ b/spec/support/tracer_helpers.rb
@@ -4,6 +4,11 @@ require 'support/faux_writer'
 
 # rubocop:disable Metrics/ModuleLength
 module TracerHelpers
+  shared_context 'global test tracer' do
+    before { Datadog.configure { |c| c.tracer.instance = tracer } }
+    after { Datadog.configure { |c| c.tracer.instance = nil } }
+  end
+
   # Return a test tracer instance with a faux writer.
   def tracer
     @tracer ||= new_tracer

--- a/test/contrib/rails/controller_test.rb
+++ b/test/contrib/rails/controller_test.rb
@@ -5,16 +5,16 @@ require 'contrib/rails/test_helper'
 # rubocop:disable Metrics/ClassLength
 class TracingControllerTest < ActionController::TestCase
   setup do
-    @original_tracer = Datadog.configuration[:rails][:tracer]
     @tracer = get_test_tracer
 
     Datadog.configure do |c|
-      c.use :rails, tracer: @tracer
+      c.tracer.instance = @tracer
+      c.use :rails
     end
   end
 
   teardown do
-    Datadog.configuration[:rails][:tracer] = @original_tracer
+    Datadog.configure { |c| c.tracer.instance = nil }
   end
 
   test 'request is properly traced' do

--- a/test/contrib/rails/errors_test.rb
+++ b/test/contrib/rails/errors_test.rb
@@ -5,16 +5,16 @@ require 'contrib/rails/test_helper'
 # rubocop:disable Metrics/ClassLength
 class TracingControllerTest < ActionController::TestCase
   setup do
-    @original_tracer = Datadog.configuration[:rails][:tracer]
     @tracer = get_test_tracer
 
     Datadog.configure do |c|
-      c.use :rails, tracer: @tracer
+      c.tracer.instance = @tracer
+      c.use :rails
     end
   end
 
   teardown do
-    Datadog.configuration[:rails][:tracer] = @original_tracer
+    Datadog.configure { |c| c.tracer.instance = nil }
   end
 
   test 'error in the controller must be traced' do

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -5,16 +5,16 @@ require 'contrib/rails/test_helper'
 # rubocop:disable Metrics/ClassLength
 class FullStackTest < ActionDispatch::IntegrationTest
   setup do
-    @original_tracer = Datadog.configuration[:rails][:tracer]
     @tracer = get_test_tracer
 
     Datadog.configure do |c|
-      c.use :rails, tracer: @tracer
+      c.tracer.instance = @tracer
+      c.use :rails
     end
   end
 
   teardown do
-    Datadog.configuration[:rails][:tracer] = @original_tracer
+    Datadog.configure { |c| c.tracer.instance = nil }
   end
 
   test 'a full request is properly traced' do


### PR DESCRIPTION
Per #1061, Rails is ending up with a stale instance of the tracer, which can cause traces or certain settings to look as if they've disappeared. This is because when Rails instrumentation applied itself in `after_initialize`, it would set the tracer on Rails components explicitly, causing it to be cached.

This issue was exposed in 0.36.0 when we introduced lazy patching, which necessitated the rebuilding of trace components when activating Rails instrumentation.

In this pull request, we remove the caching of the tracer instance during the instrumentation activation phase, such that Rails components will always delegate to the current global tracer instead.