### PR TITLE
Single pass SpanFilter

### DIFF
--- a/lib/ddtrace/pipeline/span_filter.rb
+++ b/lib/ddtrace/pipeline/span_filter.rb
@@ -10,6 +10,9 @@ module Datadog
         @criteria = filter || block
       end
 
+      # Note: this SpanFilter implementation only handles traces in which child spans appear
+      # after parent spans in the trace array. If in the future child spans can be before
+      # parent spans, then the code below will need to be updated.
       def call(trace)
         deleted = Set.new
 

--- a/lib/ddtrace/pipeline/span_filter.rb
+++ b/lib/ddtrace/pipeline/span_filter.rb
@@ -11,7 +11,7 @@ module Datadog
       end
 
       def call(trace)
-        deleted = Set.new.compare_by_identity
+        deleted = Set.new
 
         trace.delete_if do |span|
           if deleted.include?(span.parent)


### PR DESCRIPTION
This patch modifies `Datadog::Pipeline::SpanFilter` to make a single pass through the trace array.

The motivation for this change is that we ran into a situation where a trace was being generated with tens of thousands of spans. The trace was fairly shallow and we were filtering around half the spans (all without children). This became a performance issue as each span that was deleted results in another pass through the remaining array.

We have since modified our tracing to avoid the large traces, but I believe the SpanFilter remains a performance concern.

One case this does not handle is if a child span can appear before a parent in the trace array. The current tests do not cover that scenario. If that is a concern, then the approach below could be modified to make additional passes until the trace array stops changing. 