### PR TITLE
Remove Datadog::Pin#tracer=

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1307,6 +1307,13 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 You can also set *per-instance* configuration as it follows:
 
 ```ruby
+require 'redis'
+require 'ddtrace'
+
+Datadog.configure do |c|
+  c.use :redis # Enabling integration instrumentation is still required
+end
+
 customer_cache = Redis.new
 invoice_cache = Redis.new
 

--- a/lib/ddtrace/configuration/pin_setup.rb
+++ b/lib/ddtrace/configuration/pin_setup.rb
@@ -13,7 +13,7 @@ module Datadog
 
         ATTRS.each { |key| pin.public_send("#{key}=", opts[key]) if opts[key] }
 
-        pin.config = opts.reject { |key, _| ATTRS.include?(key) }
+        pin.config = opts.reject { |key, _| ATTRS.include?(key) || DEPRECATED_ATTRS.include?(key) }
 
         true
       end
@@ -22,7 +22,8 @@ module Datadog
 
       attr_reader :pin, :opts
 
-      ATTRS = [:app, :tags, :app_type, :name, :tracer, :service_name].freeze
+      ATTRS = [:app, :tags, :app_type, :name, :service_name].freeze
+      DEPRECATED_ATTRS = [:tracer].freeze
 
       private_constant :ATTRS
     end

--- a/lib/ddtrace/contrib/dalli/patcher.rb
+++ b/lib/ddtrace/contrib/dalli/patcher.rb
@@ -29,7 +29,7 @@ module Datadog
               get_option(:service_name),
               app: Ext::APP,
               app_type: Datadog::Ext::AppTypes::CACHE,
-              tracer: get_option(:tracer)
+              tracer: -> { get_option(:tracer) }
             ).onto(::Dalli)
         end
 
@@ -46,10 +46,6 @@ module Datadog
             Use of Datadog::Pin with Dalli is DEPRECATED.
             Upgrade to the configuration API using the migration guide here:
             https://github.com/DataDog/dd-trace-rb/releases/tag/v0.11.0).freeze
-
-          def tracer=(tracer)
-            Datadog.configuration[:dalli][:tracer] = tracer
-          end
 
           def service_name=(service_name)
             Datadog.configuration[:dalli][:service_name] = service_name

--- a/lib/ddtrace/contrib/elasticsearch/patcher.rb
+++ b/lib/ddtrace/contrib/elasticsearch/patcher.rb
@@ -37,14 +37,13 @@ module Datadog
             end
 
             def initialize(*args, &block)
-              tracer = Datadog.configuration[:elasticsearch][:tracer]
               service = Datadog.configuration[:elasticsearch][:service_name]
 
               pin = Datadog::Pin.new(
                 service,
                 app: Datadog::Contrib::Elasticsearch::Ext::APP,
                 app_type: Datadog::Ext::AppTypes::DB,
-                tracer: tracer
+                tracer: -> { Datadog.configuration[:elasticsearch][:tracer] }
               )
               pin.onto(self)
               initialize_without_datadog(*args, &block)

--- a/lib/ddtrace/contrib/faraday/patcher.rb
+++ b/lib/ddtrace/contrib/faraday/patcher.rb
@@ -31,7 +31,7 @@ module Datadog
               get_option(:service_name),
               app: Ext::APP,
               app_type: Datadog::Ext::AppTypes::WEB,
-              tracer: get_option(:tracer)
+              tracer: -> { get_option(:tracer) }
             ).onto(::Faraday)
         end
 
@@ -60,10 +60,6 @@ module Datadog
             Use of Datadog::Pin with Faraday is DEPRECATED.
             Upgrade to the configuration API using the migration guide here:
             https://github.com/DataDog/dd-trace-rb/releases/tag/v0.11.0).freeze
-
-          def tracer=(tracer)
-            Datadog.configuration[:faraday][:tracer] = tracer
-          end
 
           def service_name=(service_name)
             Datadog.configuration[:faraday][:service_name] = service_name

--- a/lib/ddtrace/contrib/grape/patcher.rb
+++ b/lib/ddtrace/contrib/grape/patcher.rb
@@ -34,7 +34,7 @@ module Datadog
             get_option(:service_name),
             app: Ext::APP,
             app_type: Datadog::Ext::AppTypes::WEB,
-            tracer: get_option(:tracer)
+            tracer: -> { get_option(:tracer) }
           )
           pin.onto(::Grape)
         end

--- a/lib/ddtrace/contrib/grpc/datadog_interceptor.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor.rb
@@ -38,7 +38,7 @@ module Datadog
               service_name,
               app: Ext::APP,
               app_type: Datadog::Ext::AppTypes::WEB,
-              tracer: tracer
+              tracer: -> { datadog_configuration[:tracer] }
             ).tap do |pin|
               yield(pin) if block_given?
               pin.onto(self)

--- a/lib/ddtrace/contrib/grpc/patcher.rb
+++ b/lib/ddtrace/contrib/grpc/patcher.rb
@@ -29,7 +29,7 @@ module Datadog
             get_option(:service_name),
             app: Ext::APP,
             app_type: Datadog::Ext::AppTypes::WEB,
-            tracer: get_option(:tracer)
+            tracer: -> { get_option(:tracer) }
           ).onto(::GRPC)
         end
 
@@ -51,10 +51,6 @@ module Datadog
             Use of Datadog::Pin with GRPC is DEPRECATED.
             Upgrade to the configuration API using the migration guide here:
             https://github.com/DataDog/dd-trace-rb/releases/tag/v0.11.0).freeze
-
-          def tracer=(tracer)
-            Datadog.configuration[:grpc][:tracer] = tracer
-          end
 
           def service_name=(service_name)
             Datadog.configuration[:grpc][:service_name] = service_name

--- a/lib/ddtrace/contrib/http/instrumentation.rb
+++ b/lib/ddtrace/contrib/http/instrumentation.rb
@@ -111,9 +111,12 @@ module Datadog
             service = config[:service_name]
             tracer = config[:tracer]
 
-            @datadog_pin ||= begin
-              Datadog::Pin.new(service, app: Ext::APP, app_type: Datadog::Ext::AppTypes::WEB, tracer: tracer)
-            end
+            @datadog_pin ||= Datadog::Pin.new(
+              service,
+              app: Ext::APP,
+              app_type: Datadog::Ext::AppTypes::WEB,
+              tracer: -> { config[:tracer] }
+            )
 
             # this shockingly poor code exists to solve the case where someone
             # calls datadog_pin on this object before running a request, which
@@ -136,10 +139,12 @@ module Datadog
           def default_datadog_pin
             config = Datadog.configuration[:http]
             service = config[:service_name]
-            tracer = config[:tracer]
-            @default_datadog_pin ||= begin
-              Datadog::Pin.new(service, app: Ext::APP, app_type: Datadog::Ext::AppTypes::WEB, tracer: tracer)
-            end
+            @default_datadog_pin ||= Datadog::Pin.new(
+              service,
+              app: Ext::APP,
+              app_type: Datadog::Ext::AppTypes::WEB,
+              tracer: -> { config[:tracer] }
+            )
           end
 
           private

--- a/lib/ddtrace/contrib/mongodb/instrumentation.rb
+++ b/lib/ddtrace/contrib/mongodb/instrumentation.rb
@@ -49,14 +49,13 @@ module Datadog
           module InstanceMethods
             def datadog_pin
               @datadog_pin ||= begin
-                tracer = Datadog.configuration[:mongo][:tracer]
                 service = Datadog.configuration[:mongo][:service_name]
 
                 Datadog::Pin.new(
                   service,
                   app: Datadog::Contrib::MongoDB::Ext::APP,
                   app_type: Datadog::Ext::AppTypes::DB,
-                  tracer: tracer
+                  tracer: -> { Datadog.configuration[:mongo][:tracer] }
                 )
               end
             end

--- a/lib/ddtrace/contrib/mysql2/instrumentation.rb
+++ b/lib/ddtrace/contrib/mysql2/instrumentation.rb
@@ -36,7 +36,7 @@ module Datadog
               Datadog.configuration[:mysql2][:service_name],
               app: Ext::APP,
               app_type: Datadog::Ext::AppTypes::DB,
-              tracer: Datadog.configuration[:mysql2][:tracer]
+              tracer: -> { Datadog.configuration[:mysql2][:tracer] }
             )
           end
 

--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -76,7 +76,7 @@ module Datadog
                   datadog_configuration[:service_name],
                   app: Ext::APP,
                   app_type: Datadog::Ext::AppTypes::DB,
-                  tracer: datadog_configuration[:tracer]
+                  tracer: -> { datadog_configuration[:tracer] }
                 )
                 pin.onto(self)
               end

--- a/lib/ddtrace/contrib/sequel/database.rb
+++ b/lib/ddtrace/contrib/sequel/database.rb
@@ -36,7 +36,7 @@ module Datadog
               Datadog.configuration[:sequel][:service_name] || adapter_name,
               app: Ext::APP,
               app_type: Datadog::Ext::AppTypes::DB,
-              tracer: Datadog.configuration[:sequel][:tracer] || Datadog.tracer
+              tracer: -> { Datadog.configuration[:sequel][:tracer] }
             )
           end
 

--- a/lib/ddtrace/contrib/sucker_punch/patcher.rb
+++ b/lib/ddtrace/contrib/sucker_punch/patcher.rb
@@ -29,7 +29,7 @@ module Datadog
             get_option(:service_name),
             app: Ext::APP,
             app_type: Datadog::Ext::AppTypes::WORKER,
-            tracer: get_option(:tracer)
+            tracer: -> { get_option(:tracer) }
           ).onto(::SuckerPunch)
         end
 

--- a/spec/ddtrace/configuration/pin_setup_spec.rb
+++ b/spec/ddtrace/configuration/pin_setup_spec.rb
@@ -18,20 +18,18 @@ RSpec.describe Datadog::Configuration::PinSetup do
           service_name: 'my-service',
           app: 'my-app',
           app_type: :cache,
-          tracer: tracer,
           tags: { env: :prod },
+          tracer: 'deprecated option',
           distributed_tracing: true
         }
       end
-
-      let(:tracer) { get_test_tracer }
 
       it do
         expect(target.datadog_pin.service).to eq('my-service')
         expect(target.datadog_pin.app).to eq('my-app')
         expect(target.datadog_pin.tags).to eq(env: :prod)
         expect(target.datadog_pin.config).to eq(distributed_tracing: true)
-        expect(target.datadog_pin.tracer).to eq(tracer)
+        expect(target.datadog_pin.tracer).to eq(Datadog.tracer)
       end
     end
 

--- a/spec/ddtrace/contrib/dalli/patcher_spec.rb
+++ b/spec/ddtrace/contrib/dalli/patcher_spec.rb
@@ -60,13 +60,6 @@ RSpec.describe 'Dalli instrumentation' do
           after(:each) { pin.service_name = original_service_name }
           it { expect(Datadog.configuration[:dalli][:service_name]).to eq(service_name) }
         end
-
-        # Make sure 'tracer' passes through to underlying configuration
-        describe 'tracer=' do
-          before(:each) { pin.tracer = new_tracer }
-          let(:new_tracer) { double('tracer') }
-          it { expect(Datadog.configuration[:dalli][:tracer]).to eq(new_tracer) }
-        end
       end
     end
 

--- a/spec/ddtrace/contrib/faraday/patcher_spec.rb
+++ b/spec/ddtrace/contrib/faraday/patcher_spec.rb
@@ -61,18 +61,6 @@ RSpec.describe 'Faraday instrumentation' do
               .from(original_service_name).to(new_service_name)
           end
         end
-
-        # Make sure 'tracer' passes through to underlying configuration
-        describe 'tracer=' do
-          let(:new_tracer) { double('tracer') }
-          after(:each) { pin.tracer = tracer }
-
-          it 'updates the configuration service name' do
-            expect { pin.tracer = new_tracer }
-              .to change { Datadog.configuration[:faraday][:tracer] }
-              .from(tracer).to(new_tracer)
-          end
-        end
       end
     end
 

--- a/spec/ddtrace/contrib/grpc/patcher_spec.rb
+++ b/spec/ddtrace/contrib/grpc/patcher_spec.rb
@@ -61,18 +61,6 @@ RSpec.describe 'GRPC instrumentation' do
               .from(original_service_name).to(new_service_name)
           end
         end
-
-        # Make sure 'tracer' passes through to underlying configuration
-        describe 'tracer=' do
-          let(:new_tracer) { double('tracer') }
-          after(:each) { pin.tracer = tracer }
-
-          it 'updates the configuration service name' do
-            expect { pin.tracer = new_tracer }
-              .to change { Datadog.configuration[:grpc][:tracer] }
-              .from(tracer).to(new_tracer)
-          end
-        end
       end
     end
 

--- a/spec/ddtrace/contrib/http/request_spec.rb
+++ b/spec/ddtrace/contrib/http/request_spec.rb
@@ -161,7 +161,6 @@ RSpec.describe 'net/http requests' do
         stub_request(:get, "#{uri}#{path}").to_return(status: 200, body: '{}')
 
         Net::HTTP.start(host, port) do |http|
-          Datadog::Pin.get_from(http).tracer = tracer
           http.request(request)
         end
       end

--- a/spec/ddtrace/contrib/rails/redis_cache_spec.rb
+++ b/spec/ddtrace/contrib/rails/redis_cache_spec.rb
@@ -29,8 +29,8 @@ MESSAGE
   before { app }
 
   before do
-    Datadog.configure { |c| c.use :redis }
-    Datadog.configure(client_from_driver(driver), tracer_options)
+    Datadog.configure { |c| c.use :redis, tracer: tracer }
+    Datadog.configure(client_from_driver(driver))
   end
 
   let(:driver) do

--- a/spec/ddtrace/contrib/redis/miniapp_spec.rb
+++ b/spec/ddtrace/contrib/redis/miniapp_spec.rb
@@ -15,11 +15,10 @@ RSpec.describe 'Redis mini app test' do
   end
 
   before(:each) do
-    # Patch redis (don't bother configuring tracer)
-    Datadog.configure { |c| c.use :redis }
+    Datadog.configure { |c| c.use :redis, tracer: tracer }
 
-    # Configure client instance with tracer
-    Datadog.configure(client, tracer: tracer)
+    # Configure client instance with custom options
+    Datadog.configure(client, service_name: 'test-service')
   end
 
   let(:client) do
@@ -89,12 +88,12 @@ RSpec.describe 'Redis mini app test' do
     describe '"command spans"' do
       it do
         expect(redis_cmd1_span.name).to eq('redis.command')
-        expect(redis_cmd1_span.service).to eq('redis')
+        expect(redis_cmd1_span.service).to eq('test-service')
         expect(redis_cmd1_span.parent_id).to eq(process_span.span_id)
         expect(redis_cmd1_span.trace_id).to eq(publish_span.trace_id)
 
         expect(redis_cmd2_span.name).to eq('redis.command')
-        expect(redis_cmd2_span.service).to eq('redis')
+        expect(redis_cmd2_span.service).to eq('test-service')
         expect(redis_cmd2_span.parent_id).to eq(process_span.span_id)
         expect(redis_cmd2_span.trace_id).to eq(publish_span.trace_id)
       end

--- a/spec/ddtrace/pin_spec.rb
+++ b/spec/ddtrace/pin_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe Datadog::Pin do
           config: double('config'),
           name: double('name'),
           tags: double('tags'),
-          tracer: double('tracer'),
           writer: double('writer')
         }
       end
@@ -33,7 +32,6 @@ RSpec.describe Datadog::Pin do
           name: nil,
           service_name: service_name,
           tags: options[:tags],
-          tracer: options[:tracer],
           writer: nil
         )
       end
@@ -46,7 +44,15 @@ RSpec.describe Datadog::Pin do
     context 'when a tracer has been provided' do
       let(:options) { super().merge(tracer: tracer_option) }
       let(:tracer_option) { get_test_tracer }
-      it { is_expected.to be tracer_option }
+
+      before do
+        allow_any_instance_of(Datadog::Pin).to receive(:deprecation_warning).and_call_original
+      end
+
+      it 'expect a deprecation warning' do
+        expect(Datadog.logger).to receive(:warn).with(include('DEPRECATED'))
+        subject
+      end
     end
 
     context 'when no tracer has been provided' do
@@ -139,7 +145,6 @@ RSpec.describe Datadog::Pin do
     it { is_expected.to be true }
 
     context 'when the tracer is disabled' do
-      let(:options) { { tracer: Datadog::Tracer.new(writer: FauxWriter.new) } }
       before(:each) { pin.tracer.enabled = false }
       it { is_expected.to be false }
     end

--- a/spec/support/configuration_helpers.rb
+++ b/spec/support/configuration_helpers.rb
@@ -49,4 +49,13 @@ module ConfigurationHelpers
         .instance_variable_set('@patched', false)
     end
   end
+
+  def self.included(config)
+    config.before(:each) do
+      allow_any_instance_of(Datadog::Pin)
+        .to receive(:deprecation_warning)
+        .and_raise('DEPRECATED: Tracer cannot be eagerly cached.' \
+      'A warning will be emitted in production for such cases.')
+    end
+  end
 end

--- a/test/contrib/sucker_punch/patcher_test.rb
+++ b/test/contrib/sucker_punch/patcher_test.rb
@@ -8,14 +8,14 @@ module Datadog
     module SuckerPunch
       class PatcherTest < Minitest::Test
         def setup
+          @tracer = get_test_tracer
+
           Datadog.configure do |c|
-            c.use :sucker_punch
+            c.use :sucker_punch, tracer: @tracer
           end
 
           ::SuckerPunch::Queue.clear
           ::SuckerPunch::RUNNING.make_true
-
-          @tracer = enable_test_tracer!
         end
 
         def test_two_spans_per_job
@@ -85,10 +85,6 @@ module Datadog
 
         def all_spans
           tracer.writer.spans(:keep)
-        end
-
-        def enable_test_tracer!
-          get_test_tracer.tap { |tracer| pin.tracer = tracer }
         end
 
         def pin


### PR DESCRIPTION
_Work towards fixing https://github.com/DataDog/dd-trace-rb/issues/1072_

This PR removes the ability to explicitly set the tracer instance on a `Datadog::Pin` object. This is problematic because most call sites were resolving the tracer instance at "patch" time, which normally happens very early in the application life-cycle. This causes any updates to the tracer instance to not be captured by integrations using the pin.

All references to the tracer by pins have been replace with an indirect reference to the tracer though the integration configuration (e.g. `tracer: ->{ Datadog.configuration[:redis][tracer] }`). This allows for configuration to still take place at integration level. One thing to note is that `:tracer` in our integration configurations, when not set, defaults to delegating to `->{ Datadog.tracer }`, which is now the most common code path.

The API being removed in this PR is not public nor externally documented.

For some background information, we use this `Pin` internally to store configuration information for integrations that instantiate new client objects (e.g. a `Connection` from an HTTP client library) and that require different settings for different client objects (e.g. HTTP connections to domain `internal.com` have a different `service_name` than domain `external.com`).