### PR TITLE
test: Error on integration patch failure

### DIFF
--- a/lib/ddtrace/contrib/patcher.rb
+++ b/lib/ddtrace/contrib/patcher.rb
@@ -31,16 +31,20 @@ module Datadog
                 Datadog.health_metrics.instrumentation_patched(1, tags: default_tags)
               end
             rescue StandardError => e
-              # Log the error
-              Datadog.logger.error("Failed to apply #{patch_name} patch. Cause: #{e} Location: #{e.backtrace.first}")
-
-              # Emit a metric
-              tags = default_tags
-              tags << "error:#{e.class.name}"
-
-              Datadog.health_metrics.error_instrumentation_patch(1, tags: tags)
+              on_patch_error(e)
             end
           end
+        end
+
+        def on_patch_error(e)
+          # Log the error
+          Datadog.logger.error("Failed to apply #{patch_name} patch. Cause: #{e} Location: #{e.backtrace.first}")
+
+          # Emit a metric
+          tags = default_tags
+          tags << "error:#{e.class.name}"
+
+          Datadog.health_metrics.error_instrumentation_patch(1, tags: tags)
         end
 
         private

--- a/spec/ddtrace/contrib/action_cable/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/action_cable/instrumentation_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace'
 
 require 'ddtrace/contrib/rails/rails_helper'

--- a/spec/ddtrace/contrib/action_cable/integration_spec.rb
+++ b/spec/ddtrace/contrib/action_cable/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/action_cable/integration'
 

--- a/spec/ddtrace/contrib/action_cable/patcher_spec.rb
+++ b/spec/ddtrace/contrib/action_cable/patcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace'
 require 'ddtrace/contrib/analytics_examples'

--- a/spec/ddtrace/contrib/action_pack/integration_spec.rb
+++ b/spec/ddtrace/contrib/action_pack/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/action_pack/integration'
 

--- a/spec/ddtrace/contrib/action_view/integration_spec.rb
+++ b/spec/ddtrace/contrib/action_view/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/action_view/integration'
 

--- a/spec/ddtrace/contrib/active_model_serializers/integration_spec.rb
+++ b/spec/ddtrace/contrib/active_model_serializers/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/active_model_serializers/integration'
 

--- a/spec/ddtrace/contrib/active_model_serializers/patcher_spec.rb
+++ b/spec/ddtrace/contrib/active_model_serializers/patcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 require 'spec/ddtrace/contrib/active_model_serializers/helpers'
 

--- a/spec/ddtrace/contrib/active_record/integration_spec.rb
+++ b/spec/ddtrace/contrib/active_record/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/active_record/integration'
 

--- a/spec/ddtrace/contrib/active_record/multi_db_spec.rb
+++ b/spec/ddtrace/contrib/active_record/multi_db_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace'
 
 require 'active_record'

--- a/spec/ddtrace/contrib/active_record/performance_spec.rb
+++ b/spec/ddtrace/contrib/active_record/performance_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace'
 
 require 'active_record'

--- a/spec/ddtrace/contrib/active_record/tracer_spec.rb
+++ b/spec/ddtrace/contrib/active_record/tracer_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 require 'ddtrace'
 

--- a/spec/ddtrace/contrib/active_record/utils_spec.rb
+++ b/spec/ddtrace/contrib/active_record/utils_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/active_record/utils'
 

--- a/spec/ddtrace/contrib/active_support/integration_spec.rb
+++ b/spec/ddtrace/contrib/active_support/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/active_support/integration'
 

--- a/spec/ddtrace/contrib/active_support/notifications/event_spec.rb
+++ b/spec/ddtrace/contrib/active_support/notifications/event_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace'
 
 require 'active_support/notifications'

--- a/spec/ddtrace/contrib/active_support/notifications/subscriber_spec.rb
+++ b/spec/ddtrace/contrib/active_support/notifications/subscriber_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace'
 
 require 'ddtrace/contrib/active_support/notifications/subscriber'

--- a/spec/ddtrace/contrib/active_support/notifications/subscription_spec.rb
+++ b/spec/ddtrace/contrib/active_support/notifications/subscription_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace'
 
 require 'active_support/notifications'

--- a/spec/ddtrace/contrib/analytics_spec.rb
+++ b/spec/ddtrace/contrib/analytics_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/analytics'
 

--- a/spec/ddtrace/contrib/aws/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/aws/instrumentation_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'aws-sdk'

--- a/spec/ddtrace/contrib/aws/integration_spec.rb
+++ b/spec/ddtrace/contrib/aws/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/aws/integration'
 

--- a/spec/ddtrace/contrib/aws/parsed_context_spec.rb
+++ b/spec/ddtrace/contrib/aws/parsed_context_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'aws-sdk'
 require 'ddtrace/contrib/aws/parsed_context'

--- a/spec/ddtrace/contrib/concurrent_ruby/integration_spec.rb
+++ b/spec/ddtrace/contrib/concurrent_ruby/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/concurrent_ruby/integration'
 

--- a/spec/ddtrace/contrib/concurrent_ruby/integration_test_spec.rb
+++ b/spec/ddtrace/contrib/concurrent_ruby/integration_test_spec.rb
@@ -1,6 +1,6 @@
 require 'concurrent/future'
 
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace'
 
 RSpec.describe 'ConcurrentRuby integration tests' do

--- a/spec/ddtrace/contrib/configurable_spec.rb
+++ b/spec/ddtrace/contrib/configurable_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace'
 

--- a/spec/ddtrace/contrib/configuration/resolver_spec.rb
+++ b/spec/ddtrace/contrib/configuration/resolver_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/configuration/resolver'
 

--- a/spec/ddtrace/contrib/configuration/resolvers/pattern_resolver_spec.rb
+++ b/spec/ddtrace/contrib/configuration/resolvers/pattern_resolver_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace'
 
 RSpec.describe Datadog::Contrib::Configuration::Resolvers::PatternResolver do

--- a/spec/ddtrace/contrib/configuration/settings_spec.rb
+++ b/spec/ddtrace/contrib/configuration/settings_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace'
 

--- a/spec/ddtrace/contrib/dalli/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/dalli/instrumentation_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'dalli'

--- a/spec/ddtrace/contrib/dalli/integration_spec.rb
+++ b/spec/ddtrace/contrib/dalli/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/dalli/integration'
 

--- a/spec/ddtrace/contrib/dalli/patcher_spec.rb
+++ b/spec/ddtrace/contrib/dalli/patcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'dalli'
 require 'ddtrace'

--- a/spec/ddtrace/contrib/dalli/quantize_spec.rb
+++ b/spec/ddtrace/contrib/dalli/quantize_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'dalli'
 require 'ddtrace'

--- a/spec/ddtrace/contrib/delayed_job/integration_spec.rb
+++ b/spec/ddtrace/contrib/delayed_job/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/delayed_job/integration'
 

--- a/spec/ddtrace/contrib/delayed_job/patcher_spec.rb
+++ b/spec/ddtrace/contrib/delayed_job/patcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace'
 require_relative 'delayed_job_active_record'
 

--- a/spec/ddtrace/contrib/delayed_job/plugin_spec.rb
+++ b/spec/ddtrace/contrib/delayed_job/plugin_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'active_record'

--- a/spec/ddtrace/contrib/elasticsearch/integration_spec.rb
+++ b/spec/ddtrace/contrib/elasticsearch/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/elasticsearch/integration'
 

--- a/spec/ddtrace/contrib/elasticsearch/patcher_spec.rb
+++ b/spec/ddtrace/contrib/elasticsearch/patcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'ddtrace'

--- a/spec/ddtrace/contrib/elasticsearch/quantize_spec.rb
+++ b/spec/ddtrace/contrib/elasticsearch/quantize_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'elasticsearch-transport'
 
 require 'ddtrace'

--- a/spec/ddtrace/contrib/elasticsearch/transport_spec.rb
+++ b/spec/ddtrace/contrib/elasticsearch/transport_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'time'
 require 'elasticsearch-transport'
 require 'faraday'

--- a/spec/ddtrace/contrib/ethon/integration_spec.rb
+++ b/spec/ddtrace/contrib/ethon/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/ethon/integration'
 

--- a/spec/ddtrace/contrib/ethon/integration_test_spec.rb
+++ b/spec/ddtrace/contrib/ethon/integration_test_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace'
 require 'ddtrace/contrib/ethon/easy_patch'
 require 'ddtrace/contrib/ethon/multi_patch'

--- a/spec/ddtrace/contrib/ethon/patcher_spec.rb
+++ b/spec/ddtrace/contrib/ethon/patcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace'
 require 'ethon'
 

--- a/spec/ddtrace/contrib/excon/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/excon/instrumentation_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'excon'

--- a/spec/ddtrace/contrib/excon/integration_spec.rb
+++ b/spec/ddtrace/contrib/excon/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/excon/integration'
 

--- a/spec/ddtrace/contrib/extensions_spec.rb
+++ b/spec/ddtrace/contrib/extensions_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace'
 require 'ddtrace/contrib/extensions'

--- a/spec/ddtrace/contrib/faraday/integration_spec.rb
+++ b/spec/ddtrace/contrib/faraday/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/faraday/integration'
 

--- a/spec/ddtrace/contrib/faraday/middleware_spec.rb
+++ b/spec/ddtrace/contrib/faraday/middleware_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'ddtrace'

--- a/spec/ddtrace/contrib/faraday/patcher_spec.rb
+++ b/spec/ddtrace/contrib/faraday/patcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'faraday'
 require 'ddtrace'

--- a/spec/ddtrace/contrib/grape/integration_spec.rb
+++ b/spec/ddtrace/contrib/grape/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/grape/integration'
 

--- a/spec/ddtrace/contrib/graphql/integration_spec.rb
+++ b/spec/ddtrace/contrib/graphql/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/graphql/integration'
 

--- a/spec/ddtrace/contrib/graphql/tracer_spec.rb
+++ b/spec/ddtrace/contrib/graphql/tracer_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/graphql/test_types'
 
 require 'ddtrace'

--- a/spec/ddtrace/contrib/grpc/datadog_interceptor/client_spec.rb
+++ b/spec/ddtrace/contrib/grpc/datadog_interceptor/client_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'grpc'

--- a/spec/ddtrace/contrib/grpc/datadog_interceptor/server_spec.rb
+++ b/spec/ddtrace/contrib/grpc/datadog_interceptor/server_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'grpc'

--- a/spec/ddtrace/contrib/grpc/integration_spec.rb
+++ b/spec/ddtrace/contrib/grpc/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/grpc/integration'
 

--- a/spec/ddtrace/contrib/grpc/integration_test_spec.rb
+++ b/spec/ddtrace/contrib/grpc/integration_test_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require_relative 'support/grpc_helper'
 require 'ddtrace'
 

--- a/spec/ddtrace/contrib/grpc/interception_context_spec.rb
+++ b/spec/ddtrace/contrib/grpc/interception_context_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'grpc'

--- a/spec/ddtrace/contrib/grpc/patcher_spec.rb
+++ b/spec/ddtrace/contrib/grpc/patcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'grpc'
 require 'ddtrace'

--- a/spec/ddtrace/contrib/http/circuit_breaker_spec.rb
+++ b/spec/ddtrace/contrib/http/circuit_breaker_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace'
 require 'ddtrace/contrib/http/circuit_breaker'

--- a/spec/ddtrace/contrib/http/integration_spec.rb
+++ b/spec/ddtrace/contrib/http/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/http/integration'
 

--- a/spec/ddtrace/contrib/http/miniapp_spec.rb
+++ b/spec/ddtrace/contrib/http/miniapp_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace'
 require 'net/http'
 require 'time'

--- a/spec/ddtrace/contrib/http/patcher_spec.rb
+++ b/spec/ddtrace/contrib/http/patcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace'
 require 'net/http'
 

--- a/spec/ddtrace/contrib/http/request_spec.rb
+++ b/spec/ddtrace/contrib/http/request_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'ddtrace'

--- a/spec/ddtrace/contrib/integration_spec.rb
+++ b/spec/ddtrace/contrib/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace'
 

--- a/spec/ddtrace/contrib/mongodb/client_spec.rb
+++ b/spec/ddtrace/contrib/mongodb/client_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'ddtrace'

--- a/spec/ddtrace/contrib/mongodb/integration_spec.rb
+++ b/spec/ddtrace/contrib/mongodb/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/action_pack/integration'
 

--- a/spec/ddtrace/contrib/mysql2/integration_spec.rb
+++ b/spec/ddtrace/contrib/mysql2/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/mysql2/integration'
 

--- a/spec/ddtrace/contrib/mysql2/patcher_spec.rb
+++ b/spec/ddtrace/contrib/mysql2/patcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'ddtrace'

--- a/spec/ddtrace/contrib/patchable_spec.rb
+++ b/spec/ddtrace/contrib/patchable_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace'
 

--- a/spec/ddtrace/contrib/patcher_spec.rb
+++ b/spec/ddtrace/contrib/patcher_spec.rb
@@ -1,8 +1,14 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/patcher'
 
 RSpec.describe Datadog::Contrib::Patcher do
+  before do
+    # DEV Resetting with +.and_call_original+ is currently raising a stack overflow error.
+    # DEV This seems like a bug in RSpec that we should investigate further.
+    RSpec::Mocks.space.any_instance_proxy_for(Datadog::Contrib::Patcher::CommonMethods).unstub(:on_patch_error)
+  end
+
   RSpec::Matchers.define :a_patch_error do |name|
     match { |actual| actual.include?("Failed to apply #{name} patch.") }
   end

--- a/spec/ddtrace/contrib/presto/client_spec.rb
+++ b/spec/ddtrace/contrib/presto/client_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'ddtrace'

--- a/spec/ddtrace/contrib/presto/integration_spec.rb
+++ b/spec/ddtrace/contrib/presto/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/presto/integration'
 

--- a/spec/ddtrace/contrib/racecar/integration_spec.rb
+++ b/spec/ddtrace/contrib/racecar/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/racecar/integration'
 

--- a/spec/ddtrace/contrib/racecar/patcher_spec.rb
+++ b/spec/ddtrace/contrib/racecar/patcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'racecar'

--- a/spec/ddtrace/contrib/rack/configuration_spec.rb
+++ b/spec/ddtrace/contrib/rack/configuration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 require 'rack/test'
 

--- a/spec/ddtrace/contrib/rack/distributed_spec.rb
+++ b/spec/ddtrace/contrib/rack/distributed_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'rack/test'
 
 require 'rack'

--- a/spec/ddtrace/contrib/rack/integration_spec.rb
+++ b/spec/ddtrace/contrib/rack/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/rack/integration'
 

--- a/spec/ddtrace/contrib/rack/integration_test_spec.rb
+++ b/spec/ddtrace/contrib/rack/integration_test_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'rack/test'
 require 'securerandom'
 

--- a/spec/ddtrace/contrib/rack/middleware_spec.rb
+++ b/spec/ddtrace/contrib/rack/middleware_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'rack'
 require 'ddtrace'

--- a/spec/ddtrace/contrib/rack/queue_time_spec.rb
+++ b/spec/ddtrace/contrib/rack/queue_time_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'rack'
 require 'ddtrace'

--- a/spec/ddtrace/contrib/rack/resource_name_spec.rb
+++ b/spec/ddtrace/contrib/rack/resource_name_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'rack/test'
 
 require 'rack'

--- a/spec/ddtrace/contrib/rails/integration_spec.rb
+++ b/spec/ddtrace/contrib/rails/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/rails/integration'
 

--- a/spec/ddtrace/contrib/rails/rails_helper.rb
+++ b/spec/ddtrace/contrib/rails/rails_helper.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'logger'
 require 'rails'

--- a/spec/ddtrace/contrib/rake/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/rake/instrumentation_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'securerandom'

--- a/spec/ddtrace/contrib/rake/integration_spec.rb
+++ b/spec/ddtrace/contrib/rake/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/rake/integration'
 

--- a/spec/ddtrace/contrib/redis/configuration/resolver_spec.rb
+++ b/spec/ddtrace/contrib/redis/configuration/resolver_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'redis'
 require 'ddtrace'

--- a/spec/ddtrace/contrib/redis/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/redis/instrumentation_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'redis'
 require 'hiredis'

--- a/spec/ddtrace/contrib/redis/integration_spec.rb
+++ b/spec/ddtrace/contrib/redis/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/redis/integration'
 

--- a/spec/ddtrace/contrib/redis/integration_test_spec.rb
+++ b/spec/ddtrace/contrib/redis/integration_test_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'time'
 require 'redis'

--- a/spec/ddtrace/contrib/redis/method_replaced_spec.rb
+++ b/spec/ddtrace/contrib/redis/method_replaced_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'redis'
 require 'hiredis'

--- a/spec/ddtrace/contrib/redis/miniapp_spec.rb
+++ b/spec/ddtrace/contrib/redis/miniapp_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'time'
 require 'redis'

--- a/spec/ddtrace/contrib/redis/quantize_spec.rb
+++ b/spec/ddtrace/contrib/redis/quantize_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'redis'
 require 'hiredis'

--- a/spec/ddtrace/contrib/redis/redis_spec.rb
+++ b/spec/ddtrace/contrib/redis/redis_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'time'

--- a/spec/ddtrace/contrib/registerable_spec.rb
+++ b/spec/ddtrace/contrib/registerable_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace'
 

--- a/spec/ddtrace/contrib/registry_spec.rb
+++ b/spec/ddtrace/contrib/registry_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace'
 

--- a/spec/ddtrace/contrib/resque/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/resque/instrumentation_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 require_relative 'job'
 

--- a/spec/ddtrace/contrib/resque/integration_spec.rb
+++ b/spec/ddtrace/contrib/resque/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/resque/integration'
 

--- a/spec/ddtrace/contrib/rest_client/integration_spec.rb
+++ b/spec/ddtrace/contrib/rest_client/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/rest_client/integration'
 

--- a/spec/ddtrace/contrib/rest_client/patcher_spec.rb
+++ b/spec/ddtrace/contrib/rest_client/patcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace'
 require 'restclient/request'
 

--- a/spec/ddtrace/contrib/rest_client/request_patch_spec.rb
+++ b/spec/ddtrace/contrib/rest_client/request_patch_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'ddtrace'

--- a/spec/ddtrace/contrib/sequel/configuration_spec.rb
+++ b/spec/ddtrace/contrib/sequel/configuration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'time'
 require 'sequel'

--- a/spec/ddtrace/contrib/sequel/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/sequel/instrumentation_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'time'

--- a/spec/ddtrace/contrib/sequel/integration_spec.rb
+++ b/spec/ddtrace/contrib/sequel/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/sequel/integration'
 

--- a/spec/ddtrace/contrib/shoryuken/integration_spec.rb
+++ b/spec/ddtrace/contrib/shoryuken/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/shoryuken/integration'
 

--- a/spec/ddtrace/contrib/shoryuken/patcher_spec.rb
+++ b/spec/ddtrace/contrib/shoryuken/patcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace'
 require 'shoryuken'
 

--- a/spec/ddtrace/contrib/shoryuken/tracer_spec.rb
+++ b/spec/ddtrace/contrib/shoryuken/tracer_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'ddtrace'

--- a/spec/ddtrace/contrib/sidekiq/integration_spec.rb
+++ b/spec/ddtrace/contrib/sidekiq/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/sidekiq/integration'
 

--- a/spec/ddtrace/contrib/sinatra/activerecord_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/activerecord_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'rack/test'
 
 require 'sinatra/base'

--- a/spec/ddtrace/contrib/sinatra/integration_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/sinatra/integration'
 

--- a/spec/ddtrace/contrib/sinatra/multi_app_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/multi_app_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'rack/test'
 
 require 'sinatra/base'

--- a/spec/ddtrace/contrib/sinatra/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/tracer_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 require 'rack/test'
 

--- a/spec/ddtrace/contrib/sucker_punch/integration_spec.rb
+++ b/spec/ddtrace/contrib/sucker_punch/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 require 'ddtrace/contrib/sucker_punch/integration'
 

--- a/spec/ddtrace/contrib/suite/transport_spec.rb
+++ b/spec/ddtrace/contrib/suite/transport_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'ddtrace/contrib/support/spec_helper'
 
 # Load integrations so they're available
 %w[

--- a/spec/ddtrace/contrib/support/spec_helper.rb
+++ b/spec/ddtrace/contrib/support/spec_helper.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.configure do |config|
+  # Raise error when patching an integration fails.
+  # This can be disabled by unstubbing +CommonMethods#on_patch_error+
+  require 'ddtrace/contrib/patcher'
+  config.before(:each) do
+    allow_any_instance_of(Datadog::Contrib::Patcher::CommonMethods).to(receive(:on_patch_error)) { |_, e| raise e }
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -236,3 +236,11 @@ def remove_patch!(integration)
     .registry[integration]
     .instance_variable_set('@patched', false)
 end
+
+require 'ddtrace/contrib/patcher'
+Datadog::Contrib::Patcher::CommonMethods.send(:prepend, Module.new do
+  # Raise error during tests that fail to patch integration, instead of simply printing a warning message.
+  def on_patch_error(e)
+    raise e
+  end
+end)


### PR DESCRIPTION
This PR adds a safeguard to our test suite that explicitly raises an error when integration patching fails. The default behaviour is to log a warning message. This could hide issues on integration tests, specially negative tests (`expect(spans).to be_empty`).

To add this check across all affected tests, I created a spec_helper version for the `contrib` test folder. This contrib-specific helper will only contain logic related to integrations, like the patching safeguard added in this PR.