### PR TITLE
Increse sample size on rate sampler test

### DIFF
--- a/test/rate_by_service_sampler_test.rb
+++ b/test/rate_by_service_sampler_test.rb
@@ -3,8 +3,8 @@ require 'ddtrace/sampler'
 
 module Datadog
   class RateByServiceSamplerTest < Minitest::Test
-    MAX_DEVIATION = 0.3
-    ITERATIONS_PER_SERVICE = 1_000
+    MAX_DEVIATION = 0.2
+    ITERATIONS_PER_SERVICE = 10_000
     DEFAULT_RATE = 0.5
 
     def setup


### PR DESCRIPTION
We have this flaky test in our suite:
```
  1) Failure:
Datadog::RateByServiceSamplerTest#test_sampling [test/rate_by_service_sampler_test.rb:35]:
Expected |132 - 100.0| (32.0) to be <= 30.0.
```

This failure happens because our sampling size is too small for the assertions we are trying to make.

This PR changes the sampling sample size from 1.000 to 10.000 runs. I also reduced the allowed deviation as it should go down with the increased sample size.