### PR TITLE
Introduce Span#set_tags

### DIFF
--- a/lib/ddtrace/contrib/grpc/datadog_interceptor/client.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor/client.rb
@@ -30,9 +30,7 @@ module Datadog
           private
 
           def annotate!(span, metadata)
-            metadata.each do |header, value|
-              span.set_tag(header, value)
-            end
+            span.set_tags(metadata)
 
             # Set analytics sample rate
             Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -107,6 +107,16 @@ module Datadog
       Datadog.logger.debug("Unable to set the tag #{key}, ignoring it. Caused by: #{e}")
     end
 
+    # Sets tags from given hash, for each key in hash it sets the tag with that key
+    # and associated value from the hash. It is shortcut for `set_tag`. Keys and values
+    # of the hash must be strings. Note that nested hashes are not supported.
+    # A valid example is:
+    #
+    #   span.set_tags({ "http.method" => "GET", "user.id" => "234" })
+    def set_tags(tags)
+      tags.each { |k, v| set_tag(k, v) }
+    end
+
     # This method removes a tag for the given key.
     def clear_tag(key)
       @meta.delete(key)

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -212,8 +212,8 @@ module Datadog
         # child span
         span.parent = parent # sets service, trace_id, parent_id, sampled
       end
-      @tags.each { |k, v| span.set_tag(k, v) } unless @tags.empty?
-      tags.each { |k, v| span.set_tag(k, v) } unless tags.empty?
+      span.set_tags(@tags) unless @tags.empty?
+      span.set_tags(tags) unless tags.empty?
       span.start_time = start_time
 
       # this could at some point be optional (start_active_span vs start_manual_span)


### PR DESCRIPTION
In many places it is reasonable to set span tags from a hash. Currently the only way was to iterate thru the hash and call `set_tag`. `set_tags` implements this directly in Span so user code does not need to repeat it everytime tags are set from a hash.