### PR TITLE
test: Add missing dependency for Excon 0.74.0

### DIFF
--- a/spec/ddtrace/contrib/excon/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/excon/instrumentation_spec.rb
@@ -2,6 +2,7 @@ require 'ddtrace/contrib/support/spec_helper'
 require 'ddtrace/contrib/analytics_examples'
 
 require 'excon'
+require 'ipaddr' # Missed by Excon 0.74.0, can be removed when https://github.com/excon/excon/pull/719 is shipped
 require 'ddtrace'
 require 'ddtrace/contrib/excon/middleware'
 


### PR DESCRIPTION
In [0.74.0](https://github.com/excon/excon/releases/tag/v0.74.0), https://github.com/excon/excon/pull/718 was shipped, which introduced a [dependency on `IPAddr`](https://github.com/excon/excon/pull/718/files#diff-93618fc68cdc1fde818cf4abd7102a14R495).

This dependency can be [transitively loaded by `excon`, through newer versions of `openssl`](https://github.com/ruby/openssl/blob/0aaf274211d4b4877b266bc1ad406db4fd8160ab/lib/openssl/ssl.rb#L15).

But older Ruby installations will load older versions of `openssl`, like the older versions of Ruby we test with.

This PR adds that missing dependency.

A PR has been submitted upstream to address this issue: https://github.com/excon/excon/pull/719