### PR TITLE
Load the Sidekiq client tracer on Sidekiq server

### DIFF
--- a/lib/ddtrace/contrib/sidekiq/patcher.rb
+++ b/lib/ddtrace/contrib/sidekiq/patcher.rb
@@ -26,6 +26,9 @@ module Datadog
             config.server_middleware do |chain|
               chain.add(Sidekiq::ServerTracer)
             end
+            config.client_middleware do |chain|
+              chain.add(Sidekiq::ClientTracer)
+            end
           end
         end
       end


### PR DESCRIPTION
Instrument the Sidekiq client when running a Sidekiq server, Sidekiq jobs can schedule other jobs.

See documentation here: https://github.com/mperham/sidekiq/wiki/Middleware#client-middleware-registered-in-both-places