### PR TITLE
ci: Ensure Appraisal fetches latest version of dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,9 @@ step_rubocop: &step_rubocop
 step_appraisal_install: &step_appraisal_install
   run:
     name: Install Appraisal gems
-    command: bundle exec appraisal install
+    command: |
+      bundle exec appraisal clean # Ensure we fetch the latest version of dependencies
+      bundle exec appraisal install
 step_compute_bundle_checksum: &step_compute_bundle_checksum
   run:
     name: Compute bundle checksum


### PR DESCRIPTION
`appraisal install` runs `bundle check` first, then `bundle install` if `bundle check` returned false:

```
bundle exec appraisal install
>> bundle check --gemfile='gemfiles/rails5_mysql2.gemfile' || bundle install --gemfile='gemfiles/rails5_mysql2.gemfile'
 ```

`bundle check` returns true if the gems currently installed in the system can fulfill the `Gemfile.lock` (or simply the `Gemfile`, if a lock file is absent).

When `bundle check` runs the for first time in our CI, there is no `Gemfile.lock` available, so it tries to satisfy the `Gemfile` dependencies, which are lenient (e.g. `gem 'excon'`), and `bundle check` will  consider that dependency fulfilled as long as a version that satisfies the version constraint is installed.

In contrast, `bundle install` will always try to fetch the latest version from the remote, and will skip downloading it if it is already present.

Unfortunately, there's no API to invoke `appraisal install` without `bundle check`.

This PR cleans up any existing `appraisal` `Gemfile`s, with `appraisal clean`, which ensures `bundle check` returns false (without a `Gemfile`, `bundle check` fails), and ensuring `bundle install` runs for all Appraisal combinations.
