### PR TITLE
Revert "Reduce memory overhead of Tracer#trace (#1050)"

### DIFF
--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -193,15 +193,3 @@ Datadog.configure do |c|
   }
 end
 ```
-
-### Performance
-
-Writing idiomatic Ruby code should always be your first stylistic priority, but having performance considerations
-guiding your decisions is also important when writing a tracer library that is often part of an application's critical path.
-
-Here are a few performance learnings we've collected while writing `ddtrace`:
-* Freeze string literals. If not frozen, a new string is created every time the statement is evaluated.
-* Prefer `Hash[:key] || default` over `Hash#fetch`. The former is faster for both miss or hit key lookups and prevents the allocation of `default` when not needed.
-* Use mutable array operations when possible (e.g. `map!`, `select!`), as this prevents the creation of a new array.
-* If you need an empty array as a placeholder (e.g. `def foo(opt = {})`) and you won't mutate it, use `Datadog::Utils::EMPTY_HASH`. This avoids the allocation of a new hash.
- 

--- a/lib/ddtrace/context.rb
+++ b/lib/ddtrace/context.rb
@@ -234,7 +234,7 @@ module Datadog
 
     private
 
-    def reset(options = Utils::EMPTY_HASH)
+    def reset(options = {})
       @trace = []
       @parent_trace_id = options.fetch(:trace_id, nil)
       @parent_span_id = options.fetch(:span_id, nil)

--- a/lib/ddtrace/ext/system.rb
+++ b/lib/ddtrace/ext/system.rb
@@ -1,7 +1,0 @@
-module Datadog
-  module Ext
-    module System
-      PID = 'system.pid'.freeze
-    end
-  end
-end

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -11,7 +11,6 @@ require 'ddtrace/writer'
 require 'ddtrace/sampler'
 require 'ddtrace/sampling'
 require 'ddtrace/correlation'
-require 'ddtrace/ext/system'
 
 # \Datadog global namespace that includes all tracing functionality for Tracer and Span classes.
 module Datadog
@@ -178,39 +177,32 @@ module Datadog
 
     # Return a span that will trace an operation called \name. This method allows
     # parenting passing \child_of as an option. If it's missing, the newly created span is a
-    # root span.
+    # root span. Available options are:
     #
-    # @param name [String] Operation name
-    # @param options [Hash] options hash, can be mutated
-    # @option options [String] :service the service name for this span
-    # @option options [String] :resource the resource this span refers, or \name if it's missing
-    # @option options [String] :span_type the type of the span (such as \http, \db and so on)
-    # @option options [Context,Span] :child_of a \Span or a \Context instance representing the parent for this span.
-    # @option options [Time] :start_time when the span actually starts (defaults to \now)
-    # @option options [Hash<String,String>] :tags extra tags which should be added to the span.
+    # * +service+: the service name for this span
+    # * +resource+: the resource this span refers, or \name if it's missing
+    # * +span_type+: the type of the span (such as \http, \db and so on)
+    # * +child_of+: a \Span or a \Context instance representing the parent for this span.
+    # * +start_time+: when the span actually starts (defaults to \now)
+    # * +tags+: extra tags which should be added to the span.
     def start_span(name, options = {})
-      # DEV `hash[:key] || default` is a faster alternative to `#fetch`, but
-      # DEV still using as little memory as `#fetch(:key){default}`.
-      start_time = options[:start_time] || Time.now
-      tags = options[:tags] || Utils::EMPTY_HASH
+      start_time = options.fetch(:start_time, Time.now.utc)
 
-      ctx, parent = guess_context_and_parent(options[:child_of])
+      tags = options.fetch(:tags, {})
 
-      # Prepare +options+ to be forwarded to +Span.new+
-      # Mutating the provided +options+ using +select!+ allows us to save on
-      # allocating a new hash and having to copy the contents of the original
-      # hash.
-      options.select! do |k, _v|
+      span_options = options.select do |k, _v|
         # Filter options, we want no side effects with unexpected args.
         ALLOWED_SPAN_OPTIONS.include?(k)
       end
-      options[:context] = ctx unless ctx.nil?
 
-      span = Span.new(self, name, options)
+      ctx, parent = guess_context_and_parent(options[:child_of])
+      span_options[:context] = ctx unless ctx.nil?
+
+      span = Span.new(self, name, span_options)
       if parent.nil?
         # root span
         @sampler.sample!(span)
-        span.set_tag(Ext::System::PID, Process.pid)
+        span.set_tag('system.pid', Process.pid)
 
         if ctx && ctx.trace_id
           span.trace_id = ctx.trace_id
@@ -274,9 +266,6 @@ module Datadog
         span = nil
         return_value = nil
 
-        # Record this option as #start_span can modify the options hash
-        on_error = options[:on_error]
-
         begin
           begin
             span = start_span(name, options)
@@ -293,7 +282,7 @@ module Datadog
         # It's not a problem since we re-raise it afterwards so for example a
         # SignalException::Interrupt would still bubble up.
         rescue Exception => e
-          (on_error || DEFAULT_ON_ERROR).call(span, e)
+          (options[:on_error] || DEFAULT_ON_ERROR).call(span, e)
           raise e
         ensure
           span.finish unless span.nil?

--- a/lib/ddtrace/utils.rb
+++ b/lib/ddtrace/utils.rb
@@ -3,11 +3,6 @@ require 'ddtrace/utils/database'
 module Datadog
   # Utils contains low-level utilities, typically to provide pseudo-random trace IDs.
   module Utils
-    # Empty immutable hash to be used.
-    # Useful to avoid allocations when the hash won't be modified:
-    # e.g. methods with empty +options={}+ as default.
-    EMPTY_HASH = {}.freeze
-
     STRING_PLACEHOLDER = ''.encode(::Encoding::UTF_8).freeze
     # We use a custom random number generator because we want no interference
     # with the default one. Using the default prng, we could break code that


### PR DESCRIPTION
This reverts commit 0625ccc10682699d8d3a226cae65588b7d221a6b.

Ever since we've merged this change, we've noticed spikes in our internal testing environment.
We are taking a conservative approach to revert these changes for now and try to introduce them again in the future with further testing.