### PR TITLE
Add retry_count tag to Sidekiq job traces

### DIFF
--- a/lib/ddtrace/contrib/sidekiq/ext.rb
+++ b/lib/ddtrace/contrib/sidekiq/ext.rb
@@ -15,6 +15,7 @@ module Datadog
         TAG_JOB_ID = 'sidekiq.job.id'.freeze
         TAG_JOB_QUEUE = 'sidekiq.job.queue'.freeze
         TAG_JOB_RETRY = 'sidekiq.job.retry'.freeze
+        TAG_JOB_RETRY_COUNT = 'sidekiq.job.retry_count'.freeze
         TAG_JOB_WRAPPER = 'sidekiq.job.wrapper'.freeze
         TAG_JOB_ARGS = 'sidekiq.job.args'.freeze
       end

--- a/lib/ddtrace/contrib/sidekiq/server_tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/server_tracer.rb
@@ -31,6 +31,7 @@ module Datadog
 
             span.set_tag(Ext::TAG_JOB_ID, job['jid'])
             span.set_tag(Ext::TAG_JOB_RETRY, job['retry'])
+            span.set_tag(Ext::TAG_JOB_RETRY_COUNT, job['retry_count'])
             span.set_tag(Ext::TAG_JOB_QUEUE, job['queue'])
             span.set_tag(Ext::TAG_JOB_WRAPPER, job['class']) if job['wrapped']
             span.set_tag(Ext::TAG_JOB_DELAY, 1000.0 * (Time.now.utc.to_f - job['enqueued_at'].to_f))


### PR DESCRIPTION
Currently the traces captured for Sidekiq jobs when using the sidekiq integration include `sidekiq.job.retry` which is just the configuration value for whether the job should be retried, or how many retries should be attempted. This information doesn't add too much value, as it can be found on the code and rarely changes for any particular job.

<img width="319" alt="image" src="https://user-images.githubusercontent.com/545352/85062762-a9b5bc00-b16e-11ea-8941-79fa03fecc89.png">

This PR adds the current retry count for each job, which is available as `retry_count` in the job payload according to [Sidekiq documentation](https://github.com/mperham/sidekiq/wiki/Job-Format). This information is useful for debugging and identifying traces of jobs that are being repeated.