### PR TITLE
Fix Profiling::Transport::IO load dependency

### DIFF
--- a/lib/ddtrace/transport/io/response.rb
+++ b/lib/ddtrace/transport/io/response.rb
@@ -6,14 +6,12 @@ module Datadog
       # Response from HTTP transport for traces
       class Response
         include Transport::Response
-        include Transport::Traces::Response
 
         attr_reader \
           :result
 
-        def initialize(result, trace_count = 1)
+        def initialize(result)
           @result = result
-          @trace_count = trace_count
         end
 
         def ok?

--- a/lib/ddtrace/transport/io/traces.rb
+++ b/lib/ddtrace/transport/io/traces.rb
@@ -10,6 +10,12 @@ module Datadog
       module Traces
         # Response from HTTP transport for traces
         class Response < IO::Response
+          include Transport::Traces::Response
+
+          def initialize(result, trace_count = 1)
+            super(result)
+            @trace_count = trace_count
+          end
         end
 
         # Extensions for HTTP client

--- a/spec/ddtrace/transport/io/response_spec.rb
+++ b/spec/ddtrace/transport/io/response_spec.rb
@@ -4,18 +4,12 @@ require 'ddtrace/transport/io/response'
 
 RSpec.describe Datadog::Transport::IO::Response do
   context 'when implemented by a class' do
-    subject(:response) { described_class.new(result, trace_count) }
+    subject(:response) { described_class.new(result) }
     let(:result) { double('result') }
-    let(:trace_count) { 1 }
 
     describe '#result' do
       subject(:get_result) { response.result }
       it { is_expected.to eq result }
-    end
-
-    describe '#trace_count' do
-      subject(:get_trace_count) { response.trace_count }
-      it { is_expected.to eq trace_count }
     end
 
     describe '#ok?' do

--- a/spec/ddtrace/transport/io/traces_spec.rb
+++ b/spec/ddtrace/transport/io/traces_spec.rb
@@ -2,6 +2,29 @@ require 'spec_helper'
 
 require 'ddtrace/transport/io/traces'
 
+RSpec.describe Datadog::Transport::IO::Traces::Response do
+  context 'when implemented by a class' do
+    subject(:response) { described_class.new(result, trace_count) }
+    let(:result) { double('result') }
+    let(:trace_count) { 2 }
+
+    describe '#result' do
+      subject(:get_result) { response.result }
+      it { is_expected.to eq result }
+    end
+
+    describe '#trace_count' do
+      subject(:get_trace_count) { response.trace_count }
+      it { is_expected.to eq trace_count }
+    end
+
+    describe '#ok?' do
+      subject(:ok?) { response.ok? }
+      it { is_expected.to be true }
+    end
+  end
+end
+
 RSpec.describe Datadog::Transport::IO::Client do
   subject(:client) { described_class.new(out, encoder) }
   let(:out) { instance_double(IO) }


### PR DESCRIPTION
When `Profiling::Transport::IO` was inheriting from `Transport::IO`, the base class had a requirement for some trace-specific attribute (`trace_count`.) This pull request moves this trace specific attribute into the traces transport, so that profiling transports do not need it.