### PR TITLE
Add Datadog::Utils::Compression

### DIFF
--- a/lib/ddtrace/transport/io/response.rb
+++ b/lib/ddtrace/transport/io/response.rb
@@ -6,14 +6,12 @@ module Datadog
       # Response from HTTP transport for traces
       class Response
         include Transport::Response
-        include Transport::Traces::Response
 
         attr_reader \
           :result
 
-        def initialize(result, trace_count = 1)
+        def initialize(result)
           @result = result
-          @trace_count = trace_count
         end
 
         def ok?

--- a/lib/ddtrace/transport/io/traces.rb
+++ b/lib/ddtrace/transport/io/traces.rb
@@ -10,6 +10,12 @@ module Datadog
       module Traces
         # Response from HTTP transport for traces
         class Response < IO::Response
+          include Transport::Traces::Response
+
+          def initialize(result, trace_count = 1)
+            super(result)
+            @trace_count = trace_count
+          end
         end
 
         # Extensions for HTTP client

--- a/lib/ddtrace/utils/compression.rb
+++ b/lib/ddtrace/utils/compression.rb
@@ -1,0 +1,27 @@
+require 'zlib'
+
+module Datadog
+  module Utils
+    # Common database-related utility functions.
+    module Compression
+      module_function
+
+      def gzip(string, level: nil, strategy: nil)
+        sio = StringIO.new
+        sio.binmode
+        gz = Zlib::GzipWriter.new(sio, level, strategy)
+        gz.write(string)
+        gz.close
+        sio.string
+      end
+
+      def gunzip(string, encoding = ::Encoding::ASCII_8BIT)
+        sio = StringIO.new(string)
+        gz = Zlib::GzipReader.new(sio, encoding: encoding)
+        gz.read
+      ensure
+        gz && gz.close
+      end
+    end
+  end
+end

--- a/spec/ddtrace/transport/io/response_spec.rb
+++ b/spec/ddtrace/transport/io/response_spec.rb
@@ -4,18 +4,12 @@ require 'ddtrace/transport/io/response'
 
 RSpec.describe Datadog::Transport::IO::Response do
   context 'when implemented by a class' do
-    subject(:response) { described_class.new(result, trace_count) }
+    subject(:response) { described_class.new(result) }
     let(:result) { double('result') }
-    let(:trace_count) { 1 }
 
     describe '#result' do
       subject(:get_result) { response.result }
       it { is_expected.to eq result }
-    end
-
-    describe '#trace_count' do
-      subject(:get_trace_count) { response.trace_count }
-      it { is_expected.to eq trace_count }
     end
 
     describe '#ok?' do

--- a/spec/ddtrace/transport/io/traces_spec.rb
+++ b/spec/ddtrace/transport/io/traces_spec.rb
@@ -2,6 +2,29 @@ require 'spec_helper'
 
 require 'ddtrace/transport/io/traces'
 
+RSpec.describe Datadog::Transport::IO::Traces::Response do
+  context 'when implemented by a class' do
+    subject(:response) { described_class.new(result, trace_count) }
+    let(:result) { double('result') }
+    let(:trace_count) { 2 }
+
+    describe '#result' do
+      subject(:get_result) { response.result }
+      it { is_expected.to eq result }
+    end
+
+    describe '#trace_count' do
+      subject(:get_trace_count) { response.trace_count }
+      it { is_expected.to eq trace_count }
+    end
+
+    describe '#ok?' do
+      subject(:ok?) { response.ok? }
+      it { is_expected.to be true }
+    end
+  end
+end
+
 RSpec.describe Datadog::Transport::IO::Client do
   subject(:client) { described_class.new(out, encoder) }
   let(:out) { instance_double(IO) }

--- a/spec/ddtrace/utils/compression_spec.rb
+++ b/spec/ddtrace/utils/compression_spec.rb
@@ -1,0 +1,26 @@
+require 'securerandom'
+require 'ddtrace/utils/compression'
+
+RSpec.describe Datadog::Utils::Compression do
+  describe '::gzip' do
+    subject(:gzip) { described_class.gzip(unzipped) }
+    let(:unzipped) { SecureRandom.uuid }
+
+    it { is_expected.to be_a_kind_of(String) }
+
+    context 'when result is unzipped' do
+      subject(:gunzip) { described_class.gunzip(gzip) }
+      it { is_expected.to eq(unzipped) }
+    end
+  end
+
+  describe '::gunzip' do
+    subject(:gunzip) { described_class.gunzip(zipped) }
+
+    context 'given a zipped string' do
+      let(:zipped) { described_class.gzip(unzipped) }
+      let(:unzipped) { SecureRandom.uuid }
+      it { is_expected.to eq(unzipped) }
+    end
+  end
+end


### PR DESCRIPTION
In order to support compressing content sent over the wire, this pull request adds a `Datadog::Utils::Compression` utility that adds support for gzip compression and decompression.