### PR TITLE
Add multipart-post package

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,0 +1,2 @@
+Component,Origin,License,Copyright
+ddtrace/vendor/multipart-post,https://github.com/socketry/multipart-post,MIT,"Copyright (c) 2007-2013 Nick Sieger."

--- a/lib/ddtrace/vendor/multipart-post/LICENSE
+++ b/lib/ddtrace/vendor/multipart-post/LICENSE
@@ -1,0 +1,11 @@
+Released under the MIT license.
+
+Copyright, 2007-2013, by Nick Sieger.
+Copyright, 2017, by Samuel G. D. Williams.
+Copyright, 2019, by Patrick Davey.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/ddtrace/vendor/multipart-post/multipart.rb
+++ b/lib/ddtrace/vendor/multipart-post/multipart.rb
@@ -1,0 +1,12 @@
+#--
+# Copyright (c) 2007-2013 Nick Sieger.
+# See the file README.txt included with the distribution for
+# software license details.
+#++
+
+module Datadog
+  module Vendor
+    module Multipart
+    end
+  end
+end

--- a/lib/ddtrace/vendor/multipart-post/multipart/post.rb
+++ b/lib/ddtrace/vendor/multipart-post/multipart/post.rb
@@ -1,0 +1,8 @@
+module Datadog
+  module Vendor
+    module Multipart
+      module Post
+      end
+    end
+  end
+end

--- a/lib/ddtrace/vendor/multipart-post/multipart/post/composite_read_io.rb
+++ b/lib/ddtrace/vendor/multipart-post/multipart/post/composite_read_io.rb
@@ -1,0 +1,116 @@
+#--
+# Copyright (c) 2007-2012 Nick Sieger.
+# See the file README.txt included with the distribution for
+# software license details.
+#++
+
+# Concatenate together multiple IO objects into a single, composite IO object
+# for purposes of reading as a single stream.
+#
+# @example
+#     crio = CompositeReadIO.new(StringIO.new('one'),
+#                                StringIO.new('two'),
+#                                StringIO.new('three'))
+#     puts crio.read # => "onetwothree"
+module Datadog
+  module Vendor
+    module Multipart
+      module Post
+        class CompositeReadIO
+          # Create a new composite-read IO from the arguments, all of which should
+          # respond to #read in a manner consistent with IO.
+          def initialize(*ios)
+            @ios = ios.flatten
+            @index = 0
+          end
+
+          # Read from IOs in order until `length` bytes have been received.
+          def read(length = nil, outbuf = nil)
+            got_result = false
+            outbuf = outbuf ? outbuf.replace("") : ""
+
+            while io = current_io
+              if result = io.read(length)
+                got_result ||= !result.nil?
+                result.force_encoding("BINARY") if result.respond_to?(:force_encoding)
+                outbuf << result
+                length -= result.length if length
+                break if length == 0
+              end
+              advance_io
+            end
+            (!got_result && length) ? nil : outbuf
+          end
+
+          def rewind
+            @ios.each { |io| io.rewind }
+            @index = 0
+          end
+
+          private
+
+          def current_io
+            @ios[@index]
+          end
+
+          def advance_io
+            @index += 1
+          end
+        end
+
+        # Convenience methods for dealing with files and IO that are to be uploaded.
+        class UploadIO
+          attr_reader :content_type, :original_filename, :local_path, :io, :opts
+
+          # Create an upload IO suitable for including in the params hash of a
+          # Net::HTTP::Post::Multipart.
+          #
+          # Can take two forms. The first accepts a filename and content type, and
+          # opens the file for reading (to be closed by finalizer).
+          #
+          # The second accepts an already-open IO, but also requires a third argument,
+          # the filename from which it was opened (particularly useful/recommended if
+          # uploading directly from a form in a framework, which often save the file to
+          # an arbitrarily named RackMultipart file in /tmp).
+          #
+          # @example
+          #     UploadIO.new("file.txt", "text/plain")
+          #     UploadIO.new(file_io, "text/plain", "file.txt")
+          def initialize(filename_or_io, content_type, filename = nil, opts = {})
+            io = filename_or_io
+            local_path = ""
+            if io.respond_to? :read
+              # in Ruby 1.9.2, StringIOs no longer respond to path
+              # (since they respond to :length, so we don't need their local path, see parts.rb:41)
+              local_path = filename_or_io.respond_to?(:path) ? filename_or_io.path : "local.path"
+            else
+              io = File.open(filename_or_io)
+              local_path = filename_or_io
+            end
+            filename ||= local_path
+
+            @content_type = content_type
+            @original_filename = File.basename(filename)
+            @local_path = local_path
+            @io = io
+            @opts = opts
+          end
+
+          def self.convert!(io, content_type, original_filename, local_path)
+            raise ArgumentError, "convert! has been removed. You must now wrap IOs " \
+              "using:\nUploadIO.new(filename_or_io, content_type, " \
+              "filename=nil)\nPlease update your code."
+          end
+
+          def method_missing(*args)
+            @io.send(*args)
+          end
+
+          def respond_to?(meth, include_all = false)
+            @io.respond_to?(meth, include_all) || super(meth, include_all)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/vendor/multipart-post/multipart/post/multipartable.rb
+++ b/lib/ddtrace/vendor/multipart-post/multipart/post/multipartable.rb
@@ -1,0 +1,57 @@
+#--
+# Copyright (c) 2007-2013 Nick Sieger.
+# See the file README.txt included with the distribution for
+# software license details.
+#++
+
+require 'ddtrace/vendor/multipart-post/multipart/post/parts'
+require 'ddtrace/vendor/multipart-post/multipart/post/composite_read_io'
+require 'securerandom'
+
+module Datadog
+  module Vendor
+    module Multipart
+      module Post
+        module Multipartable
+          def self.secure_boundary
+            # https://tools.ietf.org/html/rfc7230
+            #      tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*"
+            #                     / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
+            #                     / DIGIT / ALPHA
+
+            # https://tools.ietf.org/html/rfc2046
+            #      bcharsnospace := DIGIT / ALPHA / "'" / "(" / ")" /
+            #                       "+" / "_" / "," / "-" / "." /
+            #                       "/" / ":" / "=" / "?"
+
+            "--#{SecureRandom.uuid}"
+          end
+
+          def initialize(path, params, headers={}, boundary = Multipartable.secure_boundary)
+            headers = headers.clone # don't want to modify the original variable
+            parts_headers = headers.delete(:parts) || {}
+            super(path, headers)
+            parts = params.map do |k,v|
+              case v
+              when Array
+                v.map {|item| Parts::Part.new(boundary, "#{k}[]", item, parts_headers[k]) }
+              else
+                Parts::Part.new(boundary, k, v, parts_headers[k])
+              end
+            end.flatten
+            parts << Parts::EpiloguePart.new(boundary)
+            ios = parts.map {|p| p.to_io }
+            self.set_content_type(headers["Content-Type"] || "multipart/form-data",
+                                  { "boundary" => boundary })
+            self.content_length = parts.inject(0) {|sum,i| sum + i.length }
+            self.body_stream = CompositeReadIO.new(*ios)
+
+            @boundary = boundary
+          end
+
+          attr :boundary
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/vendor/multipart-post/multipart/post/parts.rb
+++ b/lib/ddtrace/vendor/multipart-post/multipart/post/parts.rb
@@ -1,0 +1,135 @@
+#--
+# Copyright (c) 2007-2013 Nick Sieger.
+# See the file README.txt included with the distribution for
+# software license details.
+#++
+
+module Datadog
+  module Vendor
+    module Multipart
+      module Post
+        module Parts
+          module Part
+            def self.new(boundary, name, value, headers = {})
+              headers ||= {} # avoid nil values
+              if file?(value)
+                FilePart.new(boundary, name, value, headers)
+              else
+                ParamPart.new(boundary, name, value, headers)
+              end
+            end
+
+            def self.file?(value)
+              value.respond_to?(:content_type) && value.respond_to?(:original_filename)
+            end
+
+            def length
+              @part.length
+            end
+
+            def to_io
+              @io
+            end
+          end
+
+          # Represents a parametric part to be filled with given value.
+          class ParamPart
+            include Part
+
+            # @param boundary [String]
+            # @param name [#to_s]
+            # @param value [String]
+            # @param headers [Hash] Content-Type and Content-ID are used, if present.
+            def initialize(boundary, name, value, headers = {})
+              @part = build_part(boundary, name, value, headers)
+              @io = StringIO.new(@part)
+            end
+
+            def length
+              @part.bytesize
+            end
+
+            # @param boundary [String]
+            # @param name [#to_s]
+            # @param value [String]
+            # @param headers [Hash] Content-Type is used, if present.
+            def build_part(boundary, name, value, headers = {})
+              part = ''
+              part << "--#{boundary}\r\n"
+              part << "Content-ID: #{headers["Content-ID"]}\r\n" if headers["Content-ID"]
+              part << "Content-Disposition: form-data; name=\"#{name.to_s}\"\r\n"
+              part << "Content-Type: #{headers["Content-Type"]}\r\n" if headers["Content-Type"]
+              part << "\r\n"
+              part << "#{value}\r\n"
+            end
+          end
+
+          # Represents a part to be filled from file IO.
+          class FilePart
+            include Part
+
+            attr_reader :length
+
+            # @param boundary [String]
+            # @param name [#to_s]
+            # @param io [IO]
+            # @param headers [Hash]
+            def initialize(boundary, name, io, headers = {})
+              file_length = io.respond_to?(:length) ?  io.length : File.size(io.local_path)
+              @head = build_head(boundary, name, io.original_filename, io.content_type, file_length,
+                                 io.respond_to?(:opts) ? io.opts.merge(headers) : headers)
+              @foot = "\r\n"
+              @length = @head.bytesize + file_length + @foot.length
+              @io = CompositeReadIO.new(StringIO.new(@head), io, StringIO.new(@foot))
+            end
+
+            # @param boundary [String]
+            # @param name [#to_s]
+            # @param filename [String]
+            # @param type [String]
+            # @param content_len [Integer]
+            # @param opts [Hash]
+            def build_head(boundary, name, filename, type, content_len, opts = {})
+              opts = opts.clone
+
+              trans_encoding = opts.delete("Content-Transfer-Encoding") || "binary"
+              content_disposition = opts.delete("Content-Disposition") || "form-data"
+
+              part = ''
+              part << "--#{boundary}\r\n"
+              part << "Content-Disposition: #{content_disposition}; name=\"#{name.to_s}\"; filename=\"#{filename}\"\r\n"
+              part << "Content-Length: #{content_len}\r\n"
+              if content_id = opts.delete("Content-ID")
+                part << "Content-ID: #{content_id}\r\n"
+              end
+
+              if opts["Content-Type"] != nil
+                part <<  "Content-Type: " + opts["Content-Type"] + "\r\n"
+              else
+                part << "Content-Type: #{type}\r\n"
+              end
+
+              part << "Content-Transfer-Encoding: #{trans_encoding}\r\n"
+
+              opts.each do |k, v|
+                part << "#{k}: #{v}\r\n"
+              end
+
+              part << "\r\n"
+            end
+          end
+
+          # Represents the epilogue or closing boundary.
+          class EpiloguePart
+            include Part
+
+            def initialize(boundary)
+              @part = "--#{boundary}--\r\n"
+              @io = StringIO.new(@part)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/vendor/multipart-post/multipart/post/version.rb
+++ b/lib/ddtrace/vendor/multipart-post/multipart/post/version.rb
@@ -1,0 +1,9 @@
+module Datadog
+  module Vendor
+    module Multipart
+      module Post
+        VERSION = "2.1.1"
+      end
+    end
+  end
+end

--- a/lib/ddtrace/vendor/multipart-post/net/http/post/multipart.rb
+++ b/lib/ddtrace/vendor/multipart-post/net/http/post/multipart.rb
@@ -1,0 +1,32 @@
+#--
+# Copyright (c) 2007-2012 Nick Sieger.
+# See the file README.txt included with the distribution for
+# software license details.
+#++
+
+require 'net/http'
+require 'stringio'
+require 'cgi'
+require 'ddtrace/vendor/multipart-post/multipart/post/parts'
+require 'ddtrace/vendor/multipart-post/multipart/post/composite_read_io'
+require 'ddtrace/vendor/multipart-post/multipart/post/multipartable'
+
+module Datadog
+  module Vendor
+    module Net
+      class HTTP
+        class Put
+          class Multipart < ::Net::HTTP::Put
+            include ::Datadog::Vendor::Multipart::Post::Multipartable
+          end
+        end
+
+        class Post
+          class Multipart < ::Net::HTTP::Post
+            include ::Datadog::Vendor::Multipart::Post::Multipartable
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Because our HTTP transports need the ability to send multipart forms, and `Net::HTTP` doesn't support multipart form building out of the box, we need to add support for this behavior.

In this pull request, we copy [`multipart-post`](https://github.com/socketry/multipart-post) into our `vendor` directory with some minor alterations in order to 1) avoid conflict with user's applications, and 2) avoid re-engineering form building.