### PR TITLE
Add profiling CPU time per thread

### DIFF
--- a/bin/ddtracerb
+++ b/bin/ddtracerb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+require 'ddtrace/tasks/exec'
+require 'ddtrace/tasks/help'
+
+command = ARGV.shift
+
+case command
+when 'exec'
+  Datadog::Tasks::Exec.new(ARGV).run
+when 'help', '--help'
+  Datadog::Tasks::Help.new.run
+else
+  puts "Command '#{command}' is not valid for ddtrace."
+  Datadog::Tasks::Help.new.run
+end

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -29,8 +29,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables   = ['ddtracerb']
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'msgpack'

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
 
   # Optional extensions
   spec.add_development_dependency 'dogstatsd-ruby', '>= 3.3.0'
+  spec.add_development_dependency 'ffi', '~> 1.0'
   spec.add_development_dependency 'opentracing', '>= 0.4.1'
 
   if RUBY_PLATFORM != 'java'

--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -41,7 +41,7 @@ module Datadog
       :tracer
 
     def shutdown!
-      components.teardown! if @components
+      components.teardown! if instance_variable_defined?(:@components) && @components
     end
 
     protected

--- a/lib/ddtrace/ext/profiling.rb
+++ b/lib/ddtrace/ext/profiling.rb
@@ -8,7 +8,8 @@ module Datadog
       module Pprof
         LABEL_KEY_THREAD_ID = 'thread id'.freeze
         SAMPLE_VALUE_NO_VALUE = 0
-        VALUE_TYPE_WALL = 'wall'.freeze
+        VALUE_TYPE_CPU = 'cpu-time'.freeze
+        VALUE_TYPE_WALL = 'wall-time'.freeze
         VALUE_UNIT_NANOSECONDS = 'nanoseconds'.freeze
       end
     end

--- a/lib/ddtrace/profiling.rb
+++ b/lib/ddtrace/profiling.rb
@@ -3,10 +3,18 @@ module Datadog
   module Profiling
     module_function
 
+    FFI_MINIMUM_VERSION = Gem::Version.new('1.0')
     GOOGLE_PROTOBUF_MINIMUM_VERSION = Gem::Version.new('3.0')
 
     def supported?
       google_protobuf_supported?
+    end
+
+    def native_cpu_time_supported?
+      RUBY_PLATFORM != 'java' \
+        && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1') \
+        && !Gem.loaded_specs['ffi'].nil? \
+        && Gem.loaded_specs['ffi'].version >= FFI_MINIMUM_VERSION
     end
 
     def google_protobuf_supported?
@@ -20,6 +28,7 @@ module Datadog
       require 'ddtrace/profiling/exporter'
       require 'ddtrace/profiling/recorder'
       require 'ddtrace/profiling/scheduler'
+      require 'ddtrace/profiling/tasks/setup'
       require 'ddtrace/profiling/transport/io'
 
       require 'ddtrace/profiling/pprof/pprof_pb' if google_protobuf_supported?

--- a/lib/ddtrace/profiling/events/stack.rb
+++ b/lib/ddtrace/profiling/events/stack.rb
@@ -27,6 +27,7 @@ module Datadog
       # Describes a stack sample
       class StackSample < Stack
         attr_reader \
+          :cpu_time_interval_ns,
           :wall_time_interval_ns
 
         def initialize(
@@ -34,6 +35,7 @@ module Datadog
           frames,
           total_frame_count,
           thread_id,
+          cpu_time_interval_ns,
           wall_time_interval_ns
         )
           super(
@@ -43,6 +45,7 @@ module Datadog
             thread_id
           )
 
+          @cpu_time_interval_ns = cpu_time_interval_ns
           @wall_time_interval_ns = wall_time_interval_ns
         end
       end

--- a/lib/ddtrace/profiling/ext/thread.rb
+++ b/lib/ddtrace/profiling/ext/thread.rb
@@ -1,0 +1,88 @@
+require 'ffi'
+
+module Datadog
+  module Profiling
+    module Ext
+      # C-struct for retrieving clock ID from pthread
+      class CClockId < FFI::Struct
+        layout :value, :int
+      end
+
+      # Extensions for pthread-backed Ruby threads, to retrieve
+      # the thread ID, clock ID, and CPU time.
+      module CThread
+        extend FFI::Library
+        ffi_lib 'ruby', 'pthread'
+        attach_function :rb_nativethread_self, [], :ulong
+        attach_function :pthread_getcpuclockid, [:ulong, CClockId], :int
+
+        def self.prepended(base)
+          # Be sure to update the current thread too; as it wouldn't have been set.
+          ::Thread.current.send(:update_native_ids)
+        end
+
+        attr_reader \
+          :native_thread_id
+
+        def initialize(*args)
+          @pid = Process.pid
+          @native_thread_id = nil
+          @clock_id = nil
+
+          # Wrap the work block with our own
+          # so we can retrieve the native thread ID within the thread's context.
+          wrapped_block = proc do |*t_args|
+            # Set native thread ID & clock ID
+            update_native_ids
+            yield(*t_args)
+          end
+
+          super(*args, &wrapped_block)
+        end
+
+        def clock_id
+          update_native_ids if forked?
+          @clock_id ||= nil
+        end
+
+        def cpu_time(unit = :float_second)
+          return unless clock_id && Process.respond_to?(:clock_gettime)
+          Process.clock_gettime(clock_id, unit)
+        end
+
+        private
+
+        # Retrieves number of classes from runtime
+        def forked?
+          Process.pid != (@pid ||= nil)
+        end
+
+        def update_native_ids
+          @pid = Process.pid
+          @native_thread_id = get_native_thread_id
+          @clock_id = get_clock_id(@native_thread_id)
+        end
+
+        def get_native_thread_id
+          # Only run if invoked from same thread, otherwise
+          # it will receive incorrect thread ID.
+          return unless ::Thread.current == self
+
+          # NOTE: Only returns thread ID for thread that evaluates this call.
+          #       a.k.a. evaluating `thread_a.get_native_thread_id` from within
+          #       `thread_b` will return `thread_b`'s thread ID, not `thread_a`'s.
+          rb_nativethread_self
+        end
+
+        def get_clock_id(pthread_id)
+          return unless pthread_id && alive?
+
+          # Build a struct, pass it to Pthread's getcpuclockid function.
+          clock = CClockId.new
+          clock[:value] = 0
+          pthread_getcpuclockid(pthread_id, clock).zero? ? clock[:value] : nil
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/profiling/pprof/converter.rb
+++ b/lib/ddtrace/profiling/pprof/converter.rb
@@ -58,7 +58,7 @@ module Datadog
         def build_sample_values(stack_sample)
           # Build a value array that matches the length of the sample types
           # Populate all values with "no value" by default
-          Array.new(@sample_type_mappings.length, Ext::Profiling::Pprof::SAMPLE_VALUE_NO_VALUE)
+          Array.new(@sample_type_mappings.length, Datadog::Ext::Profiling::Pprof::SAMPLE_VALUE_NO_VALUE)
         end
 
         # Represents a grouped event

--- a/lib/ddtrace/profiling/pprof/stack_sample.rb
+++ b/lib/ddtrace/profiling/pprof/stack_sample.rb
@@ -10,8 +10,8 @@ module Datadog
       class StackSample < Converter
         SAMPLE_TYPES = {
           wall_time_ns: [
-            Ext::Profiling::Pprof::VALUE_TYPE_WALL,
-            Ext::Profiling::Pprof::VALUE_UNIT_NANOSECONDS
+            Datadog::Ext::Profiling::Pprof::VALUE_TYPE_WALL,
+            Datadog::Ext::Profiling::Pprof::VALUE_UNIT_NANOSECONDS
           ]
         }.freeze
 
@@ -63,7 +63,7 @@ module Datadog
         def build_sample_labels(stack_sample)
           [
             Perftools::Profiles::Label.new(
-              key: builder.string_table.fetch(Ext::Profiling::Pprof::LABEL_KEY_THREAD_ID),
+              key: builder.string_table.fetch(Datadog::Ext::Profiling::Pprof::LABEL_KEY_THREAD_ID),
               str: builder.string_table.fetch(stack_sample.thread_id.to_s)
             )
           ]

--- a/lib/ddtrace/profiling/pprof/stack_sample.rb
+++ b/lib/ddtrace/profiling/pprof/stack_sample.rb
@@ -9,6 +9,10 @@ module Datadog
       # Builds a profile from a StackSample
       class StackSample < Converter
         SAMPLE_TYPES = {
+          cpu_time_ns: [
+            Datadog::Ext::Profiling::Pprof::VALUE_TYPE_CPU,
+            Datadog::Ext::Profiling::Pprof::VALUE_UNIT_NANOSECONDS
+          ],
           wall_time_ns: [
             Datadog::Ext::Profiling::Pprof::VALUE_TYPE_WALL,
             Datadog::Ext::Profiling::Pprof::VALUE_UNIT_NANOSECONDS
@@ -55,8 +59,10 @@ module Datadog
         end
 
         def build_sample_values(stack_sample)
+          no_value = Datadog::Ext::Profiling::Pprof::SAMPLE_VALUE_NO_VALUE
           values = super(stack_sample)
-          values[sample_value_index(:wall_time_ns)] = stack_sample.wall_time_interval_ns
+          values[sample_value_index(:cpu_time_ns)] = stack_sample.cpu_time_interval_ns || no_value
+          values[sample_value_index(:wall_time_ns)] = stack_sample.wall_time_interval_ns || no_value
           values
         end
 

--- a/lib/ddtrace/profiling/preload.rb
+++ b/lib/ddtrace/profiling/preload.rb
@@ -1,0 +1,2 @@
+require 'ddtrace/profiling/tasks/setup'
+Datadog::Profiling::Tasks::Setup.new.execute

--- a/lib/ddtrace/profiling/preload.rb
+++ b/lib/ddtrace/profiling/preload.rb
@@ -1,2 +1,7 @@
-require 'ddtrace/profiling/tasks/setup'
-Datadog::Profiling::Tasks::Setup.new.execute
+require 'ddtrace/profiling'
+
+if Datadog::Profiling.supported? && Datadog::Profiling.native_cpu_time_supported?
+  Datadog::Profiling::Tasks::Setup.new.run
+else
+  puts '[DDTRACE] Profiling not supported; skipping preload.'
+end

--- a/lib/ddtrace/profiling/tasks/setup.rb
+++ b/lib/ddtrace/profiling/tasks/setup.rb
@@ -1,9 +1,14 @@
 module Datadog
   module Profiling
     module Tasks
+      # Sets up profiling for the application
       class Setup
-        def execute
-          # TODO
+        def run
+          # Activate CPU timings
+          require 'ddtrace/profiling/ext/thread'
+          ::Thread.send(:prepend, Profiling::Ext::CThread)
+        rescue StandardError, ScriptError => e
+          puts "[DDTRACE] CPU profiling unavailable. Cause: #{e.message} Location: #{e.backtrace.first}"
         end
       end
     end

--- a/lib/ddtrace/profiling/tasks/setup.rb
+++ b/lib/ddtrace/profiling/tasks/setup.rb
@@ -1,0 +1,11 @@
+module Datadog
+  module Profiling
+    module Tasks
+      class Setup
+        def execute
+          # TODO
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/tasks/exec.rb
+++ b/lib/ddtrace/tasks/exec.rb
@@ -1,0 +1,33 @@
+module Datadog
+  module Tasks
+    # Wraps command with Datadog tracing
+    class Exec
+      attr_reader :args
+
+      def initialize(args)
+        @args = args
+      end
+
+      def run
+        set_rubyopt!
+        Kernel.exec(*args)
+      end
+
+      def rubyopts
+        [
+          '-rddtrace/profiling/preload'
+        ]
+      end
+
+      private
+
+      def set_rubyopt!
+        if ENV.key?('RUBYOPT')
+          ENV['RUBYOPT'] += " #{rubyopts.join(' ')}"
+        else
+          ENV['RUBYOPT'] = rubyopts.join(' ')
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/tasks/help.rb
+++ b/lib/ddtrace/tasks/help.rb
@@ -1,0 +1,14 @@
+module Datadog
+  module Tasks
+    # Prints help message for usage of `ddtrace`
+    class Help
+      def run
+        puts %(
+Usage: ddtrace [command] [arguments]
+  exec [command]: Executes command with tracing & profiling preloaded.
+  help:           Prints this help message.
+        )
+      end
+    end
+  end
+end

--- a/spec/ddtrace/profiling/events/stack_spec.rb
+++ b/spec/ddtrace/profiling/events/stack_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Datadog::Profiling::Events::StackSample do
         frames,
         total_frame_count,
         thread_id,
+        cpu_time_interval_ns,
         wall_time_interval_ns
       )
     end
@@ -45,6 +46,7 @@ RSpec.describe Datadog::Profiling::Events::StackSample do
     let(:frames) { double('frames') }
     let(:total_frame_count) { double('total_frame_count') }
     let(:thread_id) { double('thread_id') }
+    let(:cpu_time_interval_ns) { double('cpu_time_interval_ns') }
     let(:wall_time_interval_ns) { double('wall_time_interval_ns') }
 
     it do
@@ -53,6 +55,7 @@ RSpec.describe Datadog::Profiling::Events::StackSample do
         frames: frames,
         total_frame_count: total_frame_count,
         thread_id: thread_id,
+        cpu_time_interval_ns: cpu_time_interval_ns,
         wall_time_interval_ns: wall_time_interval_ns
       )
     end

--- a/spec/ddtrace/profiling/ext/thread_spec.rb
+++ b/spec/ddtrace/profiling/ext/thread_spec.rb
@@ -1,0 +1,162 @@
+require 'spec_helper'
+require 'ddtrace/profiling'
+
+if Datadog::Profiling.native_cpu_time_supported?
+  require 'ddtrace/profiling/ext/thread'
+
+  RSpec.describe Datadog::Profiling::Ext::CThread do
+    subject(:thread) do
+      thread_class.new(&block).tap do
+        # Give thread a chance to start,
+        # which will set native IDs.
+        @thread_started = true
+        sleep(0.05)
+      end
+    end
+
+    let(:block) { proc { loop { sleep(1) } } }
+
+    let(:thread_class) do
+      Thread.send(:prepend, described_class)
+      Thread
+    end
+
+    # Leave Thread class in a clean state before and after tests
+    around do |example|
+      expect(::Thread.ancestors).to_not include(described_class)
+      unmodified_class = ::Thread.dup
+
+      example.run
+
+      Object.send(:remove_const, :Thread)
+      Object.const_set('Thread', unmodified_class)
+    end
+
+    # Kill any spawned threads
+    after { thread.kill if instance_variable_defined?(:@thread_started) && @thread_started }
+
+    describe 'prepend' do
+      it 'sets native thread IDs on current thread' do
+        expect(thread_class.current).to have_attributes(
+          clock_id: kind_of(Integer),
+          native_thread_id: kind_of(Integer),
+          cpu_time: kind_of(Float)
+        )
+      end
+    end
+
+    describe '::new' do
+      it 'has native thread IDs available' do
+        is_expected.to have_attributes(
+          clock_id: kind_of(Integer),
+          native_thread_id: kind_of(Integer),
+          cpu_time: kind_of(Float)
+        )
+      end
+    end
+
+    describe '#native_thread_id' do
+      subject(:native_thread_id) { thread.native_thread_id }
+
+      it { is_expected.to be_a_kind_of(Integer) }
+
+      context 'main thread' do
+        context 'when forked' do
+          it 'returns a new native thread ID' do
+            # Get main thread clock ID
+            original_native_thread_id = thread_class.current.native_thread_id
+
+            expect_in_fork do
+              # Expect main thread native ID to not change
+              expect(thread_class.current.native_thread_id).to be_a_kind_of(Integer)
+              expect(thread_class.current.native_thread_id).to eq(original_native_thread_id)
+            end
+          end
+        end
+      end
+    end
+
+    describe '#clock_id' do
+      subject(:clock_id) { thread.clock_id }
+
+      it { is_expected.to be_a_kind_of(Integer) }
+
+      context 'main thread' do
+        context 'when forked' do
+          it 'returns a new clock ID' do
+            # Get main thread clock ID
+            original_clock_id = thread_class.current.clock_id
+
+            expect_in_fork do
+              # Expect main thread clock ID to change (to match fork's main thread)
+              expect(thread_class.current.clock_id).to be_a_kind_of(Integer)
+              expect(thread_class.current.clock_id).to_not eq(original_clock_id)
+            end
+          end
+        end
+      end
+    end
+
+    describe '#cpu_time' do
+      subject(:cpu_time) { thread.cpu_time }
+
+      context 'when clock ID' do
+        before { allow(thread).to receive(:clock_id).and_return(clock_id) }
+
+        context 'is not available' do
+          let(:clock_id) { nil }
+          it { is_expected.to be nil }
+        end
+
+        context 'is available' do
+          let(:clock_id) { double('clock ID') }
+
+          if Process.respond_to?(:clock_gettime)
+            let(:cpu_time_measurement) { double('cpu time measurement') }
+
+            context 'when not given a unit' do
+              it 'gets time in CPU seconds' do
+                expect(Process)
+                  .to receive(:clock_gettime)
+                  .with(clock_id, :float_second)
+                  .and_return(cpu_time_measurement)
+
+                is_expected.to be cpu_time_measurement
+              end
+            end
+
+            context 'given a unit' do
+              subject(:cpu_time) { thread.cpu_time(unit) }
+              let(:unit) { double('unit') }
+
+              it 'gets time in specified unit' do
+                expect(Process)
+                  .to receive(:clock_gettime)
+                  .with(clock_id, unit)
+                  .and_return(cpu_time_measurement)
+
+                is_expected.to be cpu_time_measurement
+              end
+            end
+          else
+            context 'but #clock_gettime is not' do
+              it { is_expected.to be nil }
+            end
+          end
+        end
+      end
+
+      context 'main thread' do
+        context 'when forked' do
+          it 'returns a CPU time' do
+            expect(thread_class.current.cpu_time).to be_a_kind_of(Float)
+
+            expect_in_fork do
+              expect(thread_class.current.cpu_time).to be_a_kind_of(Float)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/profiling/pprof/template_spec.rb
+++ b/spec/ddtrace/profiling/pprof/template_spec.rb
@@ -81,7 +81,14 @@ RSpec.describe Datadog::Profiling::Pprof::Template do
         it 'has all the expected sample types' do
           is_expected.to eq(
             [
-              { type: string_id_for('wall'), unit: string_id_for('nanoseconds') }
+              {
+                type: string_id_for(Datadog::Ext::Profiling::Pprof::VALUE_TYPE_CPU),
+                unit: string_id_for(Datadog::Ext::Profiling::Pprof::VALUE_UNIT_NANOSECONDS)
+              },
+              {
+                type: string_id_for(Datadog::Ext::Profiling::Pprof::VALUE_TYPE_WALL),
+                unit: string_id_for(Datadog::Ext::Profiling::Pprof::VALUE_UNIT_NANOSECONDS)
+              }
             ]
           )
         end

--- a/spec/ddtrace/profiling/preload_spec.rb
+++ b/spec/ddtrace/profiling/preload_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'ddtrace/profiling'
+
+RSpec.describe 'Profiling preloading' do
+  subject(:preload) { load 'ddtrace/profiling/preload.rb' }
+
+  shared_examples_for 'skipped preloading' do
+    it 'displays a warning' do
+      expect(STDOUT).to receive(:puts) do |message|
+        expect(message).to include('Profiling not supported')
+      end
+
+      preload
+    end
+  end
+
+  context 'when profiling is not supported' do
+    before { allow(Datadog::Profiling).to receive(:supported?).and_return(false) }
+    it_behaves_like 'skipped preloading'
+  end
+
+  context 'when native CPU time is not supported' do
+    before { allow(Datadog::Profiling).to receive(:native_cpu_time_supported?).and_return(false) }
+    it_behaves_like 'skipped preloading'
+  end
+
+  context 'when profiling and native CPU time is supported' do
+    let(:setup_task) { instance_double(Datadog::Profiling::Tasks::Setup) }
+
+    before do
+      allow(Datadog::Profiling).to receive(:supported?).and_return(true)
+      allow(Datadog::Profiling).to receive(:native_cpu_time_supported?).and_return(true)
+      allow(Datadog::Profiling::Tasks::Setup).to receive(:new).and_return(setup_task)
+    end
+
+    it 'preloads without warning' do
+      expect(setup_task).to receive(:run)
+      expect(STDOUT).to_not receive(:puts)
+      preload
+    end
+  end
+end

--- a/spec/ddtrace/profiling/spec_helper.rb
+++ b/spec/ddtrace/profiling/spec_helper.rb
@@ -1,0 +1,54 @@
+require 'ddtrace/profiling'
+
+module ProfilingFeatureHelpers
+  RSpec.shared_context 'with profiling extensions' do
+    around do |example|
+      unmodified_class = ::Thread.dup
+
+      # Setup profiling to add
+      require 'ddtrace/profiling/tasks/setup'
+      Datadog::Profiling::Tasks::Setup.new.run
+
+      example.run
+      Object.send(:remove_const, :Thread)
+      Object.const_set('Thread', unmodified_class)
+    end
+  end
+end
+
+module ProfileHelpers
+  def get_test_profiling_flushes
+    stack_one = Thread.current.backtrace_locations.first(3)
+    stack_two = Thread.current.backtrace_locations.first(3)
+
+    stack_samples = [
+      build_stack_sample(stack_one, 100, 100, 100),
+      build_stack_sample(stack_two, 100, 200, 200),
+      build_stack_sample(stack_one, 101, 400, 400),
+      build_stack_sample(stack_two, 101, 800, 800),
+      build_stack_sample(stack_two, 101, 1600, 1600)
+    ]
+
+    [
+      Datadog::Profiling::Flush.new(Datadog::Profiling::Events::StackSample, stack_samples)
+    ]
+  end
+
+  def build_stack_sample(locations = nil, thread_id = nil, cpu_time_ns = nil, wall_time_ns = nil)
+    locations ||= Thread.current.backtrace_locations
+
+    Datadog::Profiling::Events::StackSample.new(
+      nil,
+      locations,
+      locations.length,
+      thread_id || rand(1e9),
+      cpu_time_ns || rand(1e9),
+      wall_time_ns || rand(1e9)
+    )
+  end
+end
+
+RSpec.configure do |config|
+  config.include ProfileHelpers
+  config.include ProfilingFeatureHelpers
+end

--- a/spec/ddtrace/profiling/tasks/setup_spec.rb
+++ b/spec/ddtrace/profiling/tasks/setup_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'ddtrace/profiling'
+require 'ddtrace/profiling/tasks/setup'
+
+RSpec.describe Datadog::Profiling::Tasks::Setup do
+  subject(:task) { described_class.new }
+
+  describe '#run' do
+    subject(:run) { task.run }
+
+    if Datadog::Profiling.native_cpu_time_supported?
+      context 'when native CPU time is supported' do
+        around do |example|
+          unmodified_class = ::Thread.dup
+
+          example.run
+
+          Object.send(:remove_const, :Thread)
+          Object.const_set('Thread', unmodified_class)
+        end
+
+        before { expect(STDOUT).to_not receive(:puts) }
+
+        it 'adds Thread extensions' do
+          run
+          expect(Thread.ancestors).to include(Datadog::Profiling::Ext::CThread)
+        end
+      end
+    else
+      context 'when native CPU time is not supported' do
+        it 'displays a warning to STDOUT' do
+          expect(STDOUT).to receive(:puts) do |message|
+            expect(message).to include('CPU profiling unavailable')
+          end
+
+          task.run
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/profiling_spec.rb
+++ b/spec/ddtrace/profiling_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+require 'ddtrace/profiling'
+
+RSpec.describe Datadog::Profiling do
+  extend ConfigurationHelpers
+
+  describe '::supported?' do
+    subject(:supported?) { described_class.supported? }
+    let(:google_protobuf_supported) { double('google-protobuf supported') }
+
+    before do
+      allow(described_class)
+        .to receive(:google_protobuf_supported?)
+        .and_return(google_protobuf_supported)
+    end
+
+    it { is_expected.to be(google_protobuf_supported) }
+  end
+
+  describe 'native_cpu_time_supported?' do
+    subject(:native_cpu_time_supported?) { described_class.native_cpu_time_supported? }
+
+    context 'when MRI Ruby is used' do
+      before { stub_const('RUBY_PLATFORM', 'x86_64-linux') }
+
+      context 'of version < 2.1' do
+        before { stub_const('RUBY_VERSION', '2.0') }
+        it { is_expected.to be false }
+      end
+
+      context 'of version >= 2.1' do
+        before { stub_const('RUBY_VERSION', '2.1') }
+
+        context 'and \'ffi\'' do
+          context 'is not available' do
+            include_context 'loaded gems', ffi: nil
+            it { is_expected.to be false }
+          end
+
+          context 'is available' do
+            context 'and meeting the minimum version' do
+              include_context 'loaded gems',
+                              ffi: described_class::FFI_MINIMUM_VERSION
+
+              it { is_expected.to be true }
+            end
+
+            context 'but is below the minimum version' do
+              include_context 'loaded gems',
+                              ffi: decrement_gem_version(described_class::FFI_MINIMUM_VERSION)
+
+              it { is_expected.to be false }
+            end
+          end
+        end
+      end
+    end
+
+    context 'when JRuby is used' do
+      before { stub_const('RUBY_PLATFORM', 'java') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '::google_protobuf_supported?' do
+    subject(:google_protobuf_supported?) { described_class.google_protobuf_supported? }
+
+    context 'when MRI Ruby is used' do
+      before { stub_const('RUBY_PLATFORM', 'x86_64-linux') }
+
+      context 'and \'google-protobuf\'' do
+        context 'is not available' do
+          include_context 'loaded gems', :'google-protobuf' => nil
+          it { is_expected.to be false }
+        end
+
+        context 'is available' do
+          context 'and meeting the minimum version' do
+            include_context 'loaded gems',
+                            :'google-protobuf' => described_class::GOOGLE_PROTOBUF_MINIMUM_VERSION
+
+            it { is_expected.to be true }
+          end
+
+          context 'but is below the minimum version' do
+            include_context 'loaded gems',
+                            :'google-protobuf' => decrement_gem_version(described_class::GOOGLE_PROTOBUF_MINIMUM_VERSION)
+
+            it { is_expected.to be false }
+          end
+        end
+      end
+    end
+
+    context 'when JRuby is used' do
+      before { stub_const('RUBY_PLATFORM', 'java') }
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/spec/ddtrace/tasks/exec_spec.rb
+++ b/spec/ddtrace/tasks/exec_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require 'ddtrace/tasks/exec'
+
+RSpec.describe Datadog::Tasks::Exec do
+  subject(:task) { described_class.new(args) }
+  let(:args) { ['ruby', '-e', '"RUBY_VERSION"'] }
+
+  describe '::new' do
+    it { is_expected.to have_attributes(args: args) }
+  end
+
+  describe '#run' do
+    subject(:run) { task.run }
+    let(:result) { double('result') }
+
+    around do |example|
+      # Make sure RUBYOPT is returned to its original state.
+      original_opts = ENV['RUBYOPT']
+      example.run
+      ENV['RUBYOPT'] = original_opts
+    end
+
+    before do
+      # Must stub the call out or test will prematurely terminate.
+      expect(Kernel).to receive(:exec)
+        .with(*args)
+        .and_return(result)
+    end
+
+    context 'when RUBOPT is not defined' do
+      it 'runs the task with preloads' do
+        is_expected.to be(result)
+
+        # Expect preloading to have been attached
+        task.rubyopts.each do |opt|
+          expect(ENV['RUBYOPT']).to include(opt)
+        end
+      end
+    end
+
+    context 'when RUBYOPT is defined' do
+      before { ENV['RUBYOPT'] = start_opts }
+      let(:start_opts) { 'start_opts' }
+
+      it 'runs the task with additional preloads' do
+        is_expected.to be(result)
+
+        # Expect original RUBYOPT to have been preserved
+        expect(ENV['RUBYOPT']).to include(start_opts)
+
+        # Expect preloading to have been attached
+        task.rubyopts.each do |opt|
+          expect(ENV['RUBYOPT']).to include(opt)
+        end
+      end
+    end
+  end
+
+  describe '#rubyopts' do
+    subject(:rubyopts) { task.rubyopts }
+    it { is_expected.to eq(['-rddtrace/profiling/preload']) }
+  end
+end

--- a/spec/ddtrace/tasks/help_spec.rb
+++ b/spec/ddtrace/tasks/help_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+require 'ddtrace/tasks/help'
+
+RSpec.describe Datadog::Tasks::Help do
+  subject(:task) { described_class.new }
+
+  describe '#run' do
+    it 'prints a help message to STDOUT' do
+      expect(STDOUT).to receive(:puts) do |message|
+        expect(message).to include('Usage: ddtrace')
+      end
+
+      task.run
+    end
+  end
+end


### PR DESCRIPTION
Out of the box, Ruby is unable to provide CPU time per thread, because the Ruby API does not expose either the native thread ID or the clock ID for which to get the time from. Although there is a C API for getting the current native thread, getting the clock for that thread, and getting the time for that clock, this is not accessible from another thread (our profiling thread.)

To work around this, this pull request:

1. Adds a `bin/ddtrace` executable that can be used to wrap any Ruby process to preload a patch to `Thread`...
2. ...which hijacks the `Thread`'s execution block, and uses it to obtain and store the native thread ID from within the thread, and store it on the `Thread` object.
3. Then the "stack" profiler can call `cpu_time` against the patched `Thread` object to get the CPU time, and add it to the profile.

Currently, this only works for MRI Ruby 2.1+ with `ffi` running on a *nix system that uses pthread for Ruby threads... additionally the process in question is wrapped with `ddtrace exec <command>` when run.