### PR TITLE
Ensure fatal exceptions are propagated

### DIFF
--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -98,23 +98,26 @@ module Datadog
           request_span.set_error(e) unless request_span.nil?
           raise e
         ensure
-          # Rack is a really low level interface and it doesn't provide any
-          # advanced functionality like routers. Because of that, we assume that
-          # the underlying framework or application has more knowledge about
-          # the result for this request; `resource` and `tags` are expected to
-          # be set in another level but if they're missing, reasonable defaults
-          # are used.
-          set_request_tags!(request_span, env, status, headers, response, original_env)
+          if request_span
+            # Rack is a really low level interface and it doesn't provide any
+            # advanced functionality like routers. Because of that, we assume that
+            # the underlying framework or application has more knowledge about
+            # the result for this request; `resource` and `tags` are expected to
+            # be set in another level but if they're missing, reasonable defaults
+            # are used.
+            set_request_tags!(request_span, env, status, headers, response, original_env || env)
 
-          # ensure the request_span is finished and the context reset;
-          # this assumes that the Rack middleware creates a root span
-          request_span.finish
+            # ensure the request_span is finished and the context reset;
+            # this assumes that the Rack middleware creates a root span
+            request_span.finish
+          end
+
           frontend_span.finish unless frontend_span.nil?
 
           # TODO: Remove this once we change how context propagation works. This
           # ensures we clean thread-local variables on each HTTP request avoiding
           # memory leaks.
-          tracer.provider.context = Datadog::Context.new
+          tracer.provider.context = Datadog::Context.new if tracer
         end
 
         def resource_name_for(env, status)

--- a/lib/ddtrace/contrib/rest_client/request_patch.rb
+++ b/lib/ddtrace/contrib/rest_client/request_patch.rb
@@ -62,11 +62,11 @@ module Datadog
             # rubocop:disable Lint/RescueException
           rescue Exception => e
             # rubocop:enable Lint/RescueException
-            span.set_error(e)
+            span.set_error(e) if span
 
             raise e
           ensure
-            span.finish
+            span.finish if span
           end
 
           private

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -269,11 +269,10 @@ module Datadog
         begin
           begin
             span = start_span(name, options)
-          # rubocop:disable Lint/UselessAssignment
           rescue StandardError => e
-            Datadog.logger.debug('Failed to start span: #{e}')
+            Datadog.logger.debug("Failed to start span: #{e}")
           ensure
-            return_value = yield(span)
+            return_value = yield(span) if span
           end
         # rubocop:disable Lint/RescueException
         # Here we really want to catch *any* exception, not only StandardError,

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -272,7 +272,7 @@ module Datadog
           rescue StandardError => e
             Datadog.logger.debug("Failed to start span: #{e}")
           ensure
-            return_value = yield(span) if span
+            return_value = yield(span) if span || e.is_a?(StandardError)
           end
         # rubocop:disable Lint/RescueException
         # Here we really want to catch *any* exception, not only StandardError,

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -272,6 +272,12 @@ module Datadog
           rescue StandardError => e
             Datadog.logger.debug("Failed to start span: #{e}")
           ensure
+            # We should yield to the provided block when possible, as this
+            # block is application code that we don't want to hinder. We call:
+            # * `yield(span)` during normal execution.
+            # * `yield(nil)` if `start_span` fails with a runtime error.
+            # * We don't yield during a fatal error, as the application is likely trying to
+            #   end its execution (either due to a system error or graceful shutdown).
             return_value = yield(span) if span || e.is_a?(StandardError)
           end
         # rubocop:disable Lint/RescueException

--- a/spec/ddtrace/contrib/rack/middlewares_spec.rb
+++ b/spec/ddtrace/contrib/rack/middlewares_spec.rb
@@ -71,5 +71,18 @@ RSpec.describe Datadog::Contrib::Rack::TraceMiddleware do
         end
       end
     end
+
+    context 'with fatal exception' do
+      let(:fatal_error) { stub_const('FatalError', Class.new(Exception)) }
+
+      before do
+        # Raise error at first line of #call
+        expect(Datadog.configuration[:rack]).to receive(:[]).and_raise(fatal_error)
+      end
+
+      it 'reraises exception' do
+        expect { middleware_call }.to raise_error(fatal_error)
+      end
+    end
   end
 end

--- a/spec/ddtrace/contrib/rest_client/request_patch_spec.rb
+++ b/spec/ddtrace/contrib/rest_client/request_patch_spec.rb
@@ -128,6 +128,19 @@ RSpec.describe Datadog::Contrib::RestClient::RequestPatch do
             expect(span).to_not have_error_message
           end
         end
+
+        context 'with fatal error' do
+          let(:fatal_error) { stub_const('FatalError', Class.new(Exception)) }
+
+          before do
+            # Raise error at first line of #datadog_trace_request
+            expect(tracer).to receive(:trace).and_raise(fatal_error)
+          end
+
+          it 'reraises exception' do
+            expect { request }.to raise_error(fatal_error)
+          end
+        end
       end
     end
 

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Datadog::Tracer do
             allow(tracer).to receive(:start_span).and_raise(fatal_error)
           end
 
-          it 'reraises exception' do
+          it 'does not yield to block and reraises exception' do
             expect do |b|
               expect do
                 tracer.trace(name, &b)

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -152,6 +152,23 @@ RSpec.describe Datadog::Tracer do
             end.to yield_with_args(nil)
           end.to_not raise_error
         end
+
+        context 'with fatal exception' do
+          let(:fatal_error) { stub_const('FatalError', Class.new(Exception)) }
+
+          before(:each) do
+            # Raise error at first line of begin block
+            allow(tracer).to receive(:start_span).and_raise(fatal_error)
+          end
+
+          it 'reraises exception' do
+            expect do |b|
+              expect do
+                tracer.trace(name, &b)
+              end.to raise_error(fatal_error)
+            end.to_not yield_control
+          end
+        end
       end
 
       context 'when the block raises an error' do


### PR DESCRIPTION
When a Ruby application raises a fatal (non-`StandardError`) exception our tracer might intercept that error in one of our `being/rescue` blocks. We should make sure that we properly propagate such errors, as they are normally important signals of an unrescuable situation.

This PR addresses the remaining code blocks that could intercept fatal exceptions and not correctly propagate them, normally due to these blocks erroring themselves during edge cases.

The most common case this PR will alleviate is the proper handling of graceful shutdowns in the form of fatal `SignalException`s.