### PR TITLE
test:Ensure worker thread waits for test assertion

### DIFF
--- a/spec/ddtrace/workers/async_spec.rb
+++ b/spec/ddtrace/workers/async_spec.rb
@@ -257,6 +257,8 @@ RSpec.describe Datadog::Workers::Async::Thread do
     describe '#running?' do
       subject(:running?) { worker.running? }
 
+      before { allow(worker_spy).to(receive(:perform)) { sleep 5 } }
+
       context 'by default' do
         it { is_expected.to be false }
       end


### PR DESCRIPTION
While testing `Datadog::Workers::Async::Thread#running?`, we could encounter a race condition where we start a background task but that task finishes before we can check the result of `#running?`:
https://github.com/DataDog/dd-trace-rb/blob/6e326cce76c0b6130d5bb936f6ba71a924b15850/spec/ddtrace/workers/async_spec.rb#L266-L274

This happens because the task we schedule to run is empty, finishing very quickly.

This PR changes the background task to wait for some time, so we can assert on it. The thread won't hold our test suite back because we call `worker#terminal`, which forcefully terminates the thread.