### PR TITLE
feat:Startup environment log

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1586,6 +1586,7 @@ Available options are:
  - `partial_flush.enabled`: set to `true` to enable partial trace flushing (for long running traces.) Disabled by default. *Experimental.*
  - `port`: set the port the trace agent is listening on.
  - `sampler`: set to a custom `Datadog::Sampler` instance. If provided, the tracer will use this sampler to determine sampling behavior.
+ - `diagnostics.startup_logs.enabled`: Startup configuration and diagnostic log. Defaults to `true`. Can be configured through the `DD_TRACE_STARTUP_LOGS` environment variable.
 
 #### Custom logging
 

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -42,6 +42,14 @@ module Datadog
 
           option :statsd
         end
+
+        settings :startup_logs do
+          option :enabled do |o|
+            # Defaults to nil as we want to know when the default value is being used
+            o.default { env_to_bool(Datadog::Ext::Diagnostics::DD_TRACE_STARTUP_LOGS, nil) }
+            o.lazy
+          end
+        end
       end
 
       settings :distributed_tracing do

--- a/lib/ddtrace/contrib/extensions.rb
+++ b/lib/ddtrace/contrib/extensions.rb
@@ -60,6 +60,7 @@ module Datadog
               configuration_name = options[:describes] || :default
               filtered_options = options.reject { |k, _v| k == :describes }
               integration.configure(configuration_name, filtered_options, &block)
+              instrumented_integrations[integration_name] = integration
 
               # Add to activation list
               integrations_pending_activation << integration
@@ -70,6 +71,15 @@ module Datadog
 
           def integrations_pending_activation
             @integrations_pending_activation ||= Set.new
+          end
+
+          def instrumented_integrations
+            @instrumented_integrations ||= {}
+          end
+
+          def reset!
+            instrumented_integrations.clear
+            super
           end
 
           def fetch_integration(name)

--- a/lib/ddtrace/diagnostics/environment_logger.rb
+++ b/lib/ddtrace/diagnostics/environment_logger.rb
@@ -1,0 +1,268 @@
+require 'date'
+require 'json'
+require 'rbconfig'
+
+module Datadog
+  module Diagnostics
+    # A holistic collection of the environment in which ddtrace is running.
+    # This logger should allow for easy reporting by users to Datadog support.
+    #
+    # rubocop:disable Style/DoubleNegation
+    module EnvironmentLogger
+      class << self
+        # Outputs environment information to {Datadog.logger}.
+        # Executes only for the lifetime of the program.
+        def log!(transport_responses)
+          return if @executed || !log?
+          @executed = true
+
+          data = EnvironmentCollector.new.collect!(transport_responses)
+          data.reject! { |_, v| v.nil? } # Remove empty values from hash output
+
+          log_environment!(data.to_json)
+          log_error!('Agent Error'.freeze, data[:agent_error]) if data[:agent_error]
+        rescue => e
+          Datadog.logger.warn("Failed to collect environment information: #{e} location: #{e.backtrace.first}")
+        end
+
+        private
+
+        def log_environment!(line)
+          Datadog.logger.warn("DATADOG TRACER CONFIGURATION - #{line}")
+        end
+
+        def log_error!(type, error)
+          Datadog.logger.warn("DATADOG TRACER DIAGNOSTIC - #{type}: #{error}")
+        end
+
+        # Are we logging the environment data?
+        def log?
+          startup_logs_enabled = Datadog.configuration.diagnostics.startup_logs.enabled
+          if startup_logs_enabled.nil?
+            !repl? # Suppress logs if we running in a REPL
+          else
+            startup_logs_enabled
+          end
+        end
+
+        REPL_PROGRAM_NAMES = %w[irb pry].freeze
+
+        def repl?
+          REPL_PROGRAM_NAMES.include?($PROGRAM_NAME)
+        end
+      end
+    end
+
+    # Collects environment information for diagnostic logging
+    class EnvironmentCollector
+      # @return [String] current time in ISO8601 format
+      def date
+        DateTime.now.iso8601
+      end
+
+      # Best portable guess of OS information.
+      # @return [String] platform string
+      def os_name
+        RbConfig::CONFIG['host'.freeze]
+      end
+
+      # @return [String] ddtrace version
+      def version
+        VERSION::STRING
+      end
+
+      # @return [String] "ruby"
+      def lang
+        Ext::Runtime::LANG
+      end
+
+      # Supported Ruby language version.
+      # Will be distinct from VM version for non-MRI environments.
+      # @return [String]
+      def lang_version
+        Ext::Runtime::LANG_VERSION
+      end
+
+      # @return [String] configured application environment
+      def env
+        Datadog.configuration.env
+      end
+
+      # @return [Boolean, nil]
+      def enabled
+        Datadog.configuration.tracer.enabled
+      end
+
+      # @return [String] configured application service name
+      def service
+        Datadog.configuration.service
+      end
+
+      # @return [String] configured application version
+      def dd_version
+        Datadog.configuration.version
+      end
+
+      # @return [String] target agent URL for trace flushing
+      def agent_url
+        # Retrieve the effect agent URL, regardless of how it was configured
+        transport = Datadog.tracer.writer.transport
+        adapter = transport.client.api.adapter
+        adapter.url
+      end
+
+      # Error returned by Datadog agent during a tracer flush attempt
+      # @return [String] concatenated list of transport errors
+      def agent_error(transport_responses)
+        error_responses = transport_responses.reject(&:ok?)
+
+        return nil if error_responses.empty?
+
+        error_responses.map(&:inspect).join(','.freeze)
+      end
+
+      # @return [Boolean, nil] debug mode enabled in configuration
+      def debug
+        !!Datadog.configuration.diagnostics.debug
+      end
+
+      # @return [Boolean, nil] analytics enabled in configuration
+      def analytics_enabled
+        !!Datadog.configuration.analytics.enabled
+      end
+
+      # @return [Numeric, nil] tracer sample rate configured
+      def sample_rate
+        sampler = Datadog.configuration.tracer.sampler
+        return nil unless sampler
+
+        sampler.sample_rate(nil) rescue nil
+      end
+
+      # DEV: We currently only support SimpleRule instances.
+      # DEV: These are the most commonly used rules.
+      # DEV: We should expand support for other rules in the future,
+      # DEV: although it is tricky to serialize arbitrary rules.
+      #
+      # @return [Hash, nil] sample rules configured
+      def sampling_rules
+        sampler = Datadog.configuration.tracer.sampler
+        return nil unless sampler.is_a?(Datadog::PrioritySampler) &&
+                          sampler.priority_sampler.is_a?(Datadog::Sampling::RuleSampler)
+
+        sampler.priority_sampler.rules.map do |rule|
+          next unless rule.is_a?(Datadog::Sampling::SimpleRule)
+
+          {
+            name: rule.matcher.name,
+            service: rule.matcher.service,
+            sample_rate: rule.sampler.sample_rate(nil)
+          }
+        end.compact
+      end
+
+      # @return [Hash, nil] concatenated list of global tracer tags configured
+      def tags
+        tags = Datadog.configuration.tags
+        return nil if tags.empty?
+        hash_serializer(tags)
+      end
+
+      # @return [Boolean, nil] runtime metrics enabled in configuration
+      def runtime_metrics_enabled
+        Datadog.configuration.runtime_metrics.enabled
+      end
+
+      # Concatenated list of integrations activated, with their gem version.
+      # Example: "rails@6.0.3,rack@2.2.3"
+      #
+      # @return [String, nil]
+      def integrations_loaded
+        integrations = instrumented_integrations
+        return if integrations.empty?
+
+        integrations.map { |name, integration| "#{name}@#{integration.class.version}" }.join(','.freeze)
+      end
+
+      # Ruby VM name and version.
+      # Examples: "ruby-2.7.1", "jruby-9.2.11.1", "truffleruby-20.1.0"
+      # @return [String, nil]
+      def vm
+        # RUBY_ENGINE_VERSION returns the VM version, which
+        # will differ from RUBY_VERSION for non-mri VMs.
+        if defined?(RUBY_ENGINE_VERSION)
+          "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}"
+        else
+          # Ruby < 2.3 doesn't support RUBY_ENGINE_VERSION
+          "#{RUBY_ENGINE}-#{RUBY_VERSION}"
+        end
+      end
+
+      # @return [Boolean, nil] partial flushing enabled in configuration
+      def partial_flushing_enabled
+        !!Datadog.configuration.tracer.partial_flush.enabled
+      end
+
+      # @return [Boolean, nil] priority sampling enabled in configuration
+      def priority_sampling_enabled
+        !!Datadog.configuration.tracer.priority_sampling
+      end
+
+      # @return [Boolean, nil] health metrics enabled in configuration
+      def health_metrics_enabled
+        !!Datadog.configuration.diagnostics.health_metrics.enabled
+      end
+
+      # @return [Hash] environment information available at call time
+      def collect!(transport_responses)
+        {
+          date: date,
+          os_name: os_name,
+          version: version,
+          lang: lang,
+          lang_version: lang_version,
+          env: env,
+          enabled: enabled,
+          service: service,
+          dd_version: dd_version,
+          agent_url: agent_url,
+          agent_error: agent_error(transport_responses),
+          debug: debug,
+          analytics_enabled: analytics_enabled,
+          sample_rate: sample_rate,
+          sampling_rules: sampling_rules,
+          tags: tags,
+          runtime_metrics_enabled: runtime_metrics_enabled,
+          integrations_loaded: integrations_loaded,
+          vm: vm,
+          partial_flushing_enabled: partial_flushing_enabled,
+          priority_sampling_enabled: priority_sampling_enabled,
+          health_metrics_enabled: health_metrics_enabled,
+          **instrumented_integrations_settings
+        }
+      end
+
+      private
+
+      def instrumented_integrations
+        Datadog.configuration.instrumented_integrations
+      end
+
+      # Capture all active integration settings into "integrationName_settingName: value" entries.
+      def instrumented_integrations_settings
+        Hash[instrumented_integrations.flat_map do |name, integration|
+          integration.configuration.to_h.flat_map do |setting, value|
+            next [] if setting == :tracer # Skip internal Ruby objects
+
+            [[:"#{name}_#{setting}", value]]
+          end
+        end]
+      end
+
+      # Outputs "k1:v1,k2:v2,..."
+      def hash_serializer(h)
+        h.map { |k, v| "#{k}:#{v}" }.join(','.freeze)
+      end
+    end
+  end
+end

--- a/lib/ddtrace/diagnostics/environment_logger.rb
+++ b/lib/ddtrace/diagnostics/environment_logger.rb
@@ -213,6 +213,14 @@ module Datadog
         !!Datadog.configuration.diagnostics.health_metrics.enabled
       end
 
+      # TODO: Populate when profiling is implemented
+      # def profiling_enabled
+      # end
+
+      # TODO: Populate when automatic log correlation is implemented
+      # def logs_correlation_enabled
+      # end
+
       # @return [Hash] environment information available at call time
       def collect!(transport_responses)
         {

--- a/lib/ddtrace/diagnostics/environment_logger.rb
+++ b/lib/ddtrace/diagnostics/environment_logger.rb
@@ -254,7 +254,7 @@ module Datadog
           integration.configuration.to_h.flat_map do |setting, value|
             next [] if setting == :tracer # Skip internal Ruby objects
 
-            [[:"#{name}_#{setting}", value]]
+            [[:"integration_#{name}_#{setting}", value]]
           end
         end]
       end

--- a/lib/ddtrace/ext/diagnostics.rb
+++ b/lib/ddtrace/ext/diagnostics.rb
@@ -1,6 +1,8 @@
 module Datadog
   module Ext
     module Diagnostics
+      DD_TRACE_STARTUP_LOGS = 'DD_TRACE_STARTUP_LOGS'.freeze
+
       # Health
       module Health
         # Metrics

--- a/lib/ddtrace/sampler.rb
+++ b/lib/ddtrace/sampler.rb
@@ -193,6 +193,8 @@ module Datadog
   class PrioritySampler
     extend Forwardable
 
+    attr_reader :pre_sampler, :priority_sampler
+
     SAMPLE_RATE_METRIC_KEY = '_sample_rate'.freeze
 
     def initialize(opts = {})

--- a/lib/ddtrace/transport/http/adapters/net.rb
+++ b/lib/ddtrace/transport/http/adapters/net.rb
@@ -47,6 +47,10 @@ module Datadog
             Response.new(http_response)
           end
 
+          def url
+            "http://#{hostname}:#{port}?timeout=#{timeout}"
+          end
+
           # Raised when called with an unknown HTTP method
           class UnknownHTTPMethod < StandardError
             attr_reader :verb
@@ -103,6 +107,10 @@ module Datadog
             def server_error?
               return super if http_response.nil?
               code.between?(500, 599)
+            end
+
+            def inspect
+              "#{super}, http_response:#{http_response}"
             end
           end
         end

--- a/lib/ddtrace/transport/http/adapters/test.rb
+++ b/lib/ddtrace/transport/http/adapters/test.rb
@@ -69,6 +69,10 @@ module Datadog
             def server_error?
               code.between?(500, 599)
             end
+
+            def inspect
+              "#{super}, code:#{code}"
+            end
           end
         end
       end

--- a/lib/ddtrace/transport/http/adapters/unix_socket.rb
+++ b/lib/ddtrace/transport/http/adapters/unix_socket.rb
@@ -31,6 +31,10 @@ module Datadog
             end
           end
 
+          def url
+            "http+unix://#{filepath}?timeout=#{timeout}"
+          end
+
           # Re-implements Net:HTTP with underlying Unix socket
           class HTTP < ::Net::HTTP
             DEFAULT_TIMEOUT = 1

--- a/lib/ddtrace/transport/response.rb
+++ b/lib/ddtrace/transport/response.rb
@@ -29,6 +29,13 @@ module Datadog
       def internal_error?
         nil
       end
+
+      def inspect
+        "#{self.class} ok?:#{ok?} unsupported?:#{unsupported?}, " \
+        "not_found?:#{not_found?}, client_error?:#{client_error?}, " \
+        "server_error?:#{server_error?}, internal_error?:#{internal_error?}, " \
+        "payload:#{payload}"
+      end
     end
 
     # A generic error response for internal errors
@@ -43,6 +50,10 @@ module Datadog
 
       def internal_error?
         true
+      end
+
+      def inspect
+        "#{super}, error_type:#{error.class} error:#{error}"
       end
     end
   end

--- a/lib/ddtrace/workers/trace_writer.rb
+++ b/lib/ddtrace/workers/trace_writer.rb
@@ -72,6 +72,9 @@ module Datadog
         end
       end
 
+      # TODO: Register `Datadog::Diagnostics::EnvironmentLogger.log!`
+      # TODO: as a flush_completed subscriber when the `TraceWriter`
+      # TODO: instantiation code is implemented.
       def flush_completed
         @flush_completed ||= FlushCompleted.new
       end

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -7,6 +7,7 @@ require 'ddtrace/transport/http'
 require 'ddtrace/transport/io'
 require 'ddtrace/encoding'
 require 'ddtrace/workers'
+require 'ddtrace/diagnostics/environment_logger'
 
 module Datadog
   # Processor that sends traces and metadata to the agent
@@ -83,6 +84,8 @@ module Datadog
       # Update priority sampler
       update_priority_sampler(responses.last)
 
+      record_environment_information!(responses)
+
       # Return if server error occurred.
       !responses.find(&:server_error?)
     end
@@ -149,6 +152,10 @@ module Datadog
       return unless response && !response.internal_error? && priority_sampler && response.service_rates
 
       priority_sampler.update(response.service_rates)
+    end
+
+    def record_environment_information!(responses)
+      Diagnostics::EnvironmentLogger.log!(responses)
     end
   end
 end

--- a/spec/ddtrace/contrib/extensions_spec.rb
+++ b/spec/ddtrace/contrib/extensions_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe Datadog::Contrib::Extensions do
           it do
             expect { result }.to_not raise_error
             expect(settings.integrations_pending_activation).to include(integration)
+            expect(settings.instrumented_integrations).to include(integration_name => integration)
           end
         end
 

--- a/spec/ddtrace/diagnostics/environment_logger_spec.rb
+++ b/spec/ddtrace/diagnostics/environment_logger_spec.rb
@@ -244,11 +244,11 @@ RSpec.describe Datadog::Diagnostics::EnvironmentLogger do
         context 'with integration-specific settings' do
           let(:options) { { service_name: 'my-http' } }
 
-          it { is_expected.to include http_analytics_enabled: false }
-          it { is_expected.to include http_analytics_sample_rate: 1.0 }
-          it { is_expected.to include http_service_name: 'my-http' }
-          it { is_expected.to include http_distributed_tracing: true }
-          it { is_expected.to include http_split_by_domain: false }
+          it { is_expected.to include integration_http_analytics_enabled: false }
+          it { is_expected.to include integration_http_analytics_sample_rate: 1.0 }
+          it { is_expected.to include integration_http_service_name: 'my-http' }
+          it { is_expected.to include integration_http_distributed_tracing: true }
+          it { is_expected.to include integration_http_split_by_domain: false }
         end
       end
 

--- a/spec/ddtrace/diagnostics/environment_logger_spec.rb
+++ b/spec/ddtrace/diagnostics/environment_logger_spec.rb
@@ -1,0 +1,268 @@
+require 'spec_helper'
+
+require 'ddtrace/diagnostics/environment_logger'
+
+RSpec.describe Datadog::Diagnostics::EnvironmentLogger do
+  subject(:env_logger) { Datadog::Diagnostics::EnvironmentLogger }
+
+  before { allow(DateTime).to receive(:now).and_return(DateTime.new(2020)) }
+
+  # Reading DD_AGENT_HOST allows this to work in CI
+  let(:agent_hostname) { ENV['DD_AGENT_HOST'] || '127.0.0.1' }
+
+  before do
+    # Resets "only-once" execution pattern of `log!`
+    env_logger.instance_variable_set(:@executed, nil)
+
+    Datadog.configure.reset!
+  end
+
+  context '#log!' do
+    subject(:log!) { env_logger.log!([response]) }
+    let(:logger) do
+      log!
+      tracer_logger
+    end
+
+    let(:response) { instance_double(Datadog::Transport::Response, ok?: true) }
+    let(:tracer_logger) { instance_double(Datadog::Logger) }
+
+    before do
+      allow(Datadog).to receive(:logger).and_return(tracer_logger)
+      allow(tracer_logger).to receive(:warn)
+    end
+
+    it 'with a default tracer settings' do
+      expect(logger).to have_received(:warn).with start_with('DATADOG TRACER CONFIGURATION') do |msg|
+        json = JSON.parse(msg.partition('-')[2].strip)
+        expect(json).to match(
+          'agent_url' => "http://#{agent_hostname}:8126?timeout=1",
+          'analytics_enabled' => false,
+          'date' => '2020-01-01T00:00:00+00:00',
+          'debug' => false,
+          'enabled' => true,
+          'health_metrics_enabled' => false,
+          'lang' => 'ruby',
+          'lang_version' => start_with('2.'),
+          'os_name' => include('x86_64'),
+          'partial_flushing_enabled' => false,
+          'priority_sampling_enabled' => false,
+          'runtime_metrics_enabled' => false,
+          'version' => Datadog::VERSION::STRING,
+          'vm' => be_a(String)
+        )
+      end
+    end
+
+    context 'with multiple invocations' do
+      it 'executes only once' do
+        env_logger.log!([response])
+        env_logger.log!([response])
+
+        expect(logger).to have_received(:warn).once
+      end
+    end
+
+    context 'with agent error' do
+      let(:response) { Datadog::Transport::InternalErrorResponse.new(ZeroDivisionError.new('msg')) }
+
+      it do
+        expect(logger).to have_received(:warn).with start_with('DATADOG TRACER DIAGNOSTIC') do |msg|
+          error_line = msg.partition('-')[2].strip
+          error = error_line.partition(':')[2].strip
+
+          expect(error_line).to start_with('Agent Error')
+          expect(error).to include('ZeroDivisionError')
+          expect(error).to include('msg')
+        end
+      end
+    end
+
+    context 'under a REPL' do
+      around do |example|
+        begin
+          original = $PROGRAM_NAME
+          $0 = 'irb'
+          example.run
+        ensure
+          $0 = original
+        end
+      end
+
+      context 'with default settings' do
+        it { expect(logger).to_not have_received(:warn) }
+      end
+
+      context 'with explicit setting' do
+        before do
+          Datadog.configure { |c| c.diagnostics.startup_logs.enabled = true }
+        end
+
+        it { expect(logger).to have_received(:warn) }
+      end
+    end
+
+    context 'with error collecting information' do
+      before do
+        expect_any_instance_of(Datadog::Diagnostics::EnvironmentCollector).to receive(:collect!).and_raise
+      end
+
+      it 'rescues error and logs exception' do
+        expect(logger).to have_received(:warn).with start_with('Failed to collect environment information')
+      end
+    end
+  end
+
+  describe Datadog::Diagnostics::EnvironmentCollector do
+    context '#collect!' do
+      subject(:collect!) { collector.collect!([response]) }
+      let(:collector) { described_class.new }
+      let(:response) { instance_double(Datadog::Transport::Response, ok?: true) }
+
+      it 'with a default tracer' do
+        is_expected.to match(
+          agent_error: nil,
+          agent_url: "http://#{agent_hostname}:8126?timeout=1",
+          analytics_enabled: false,
+          date: '2020-01-01T00:00:00+00:00',
+          dd_version: nil,
+          debug: false,
+          enabled: true,
+          env: nil,
+          health_metrics_enabled: false,
+          integrations_loaded: nil,
+          lang: 'ruby',
+          lang_version: start_with('2.'),
+          os_name: include('x86_64'),
+          partial_flushing_enabled: false,
+          priority_sampling_enabled: false,
+          runtime_metrics_enabled: false,
+          sample_rate: nil,
+          sampling_rules: nil,
+          service: nil,
+          tags: nil,
+          version: Datadog::VERSION::STRING,
+          vm: be_a(String)
+        )
+      end
+
+      context 'with tracer disabled' do
+        before { Datadog.configure { |c| c.tracer.enabled = false } }
+
+        it { is_expected.to include enabled: false }
+      end
+
+      context 'with env configured' do
+        before { Datadog.configure { |c| c.env = 'env' } }
+
+        it { is_expected.to include env: 'env' }
+      end
+
+      context 'with tags configured' do
+        before { Datadog.configure { |c| c.tags = { 'k1' => 'v1', 'k2' => 'v2' } } }
+
+        it { is_expected.to include tags: 'k1:v1,k2:v2' }
+      end
+
+      context 'with service configured' do
+        before { Datadog.configure { |c| c.service = 'svc' } }
+
+        it { is_expected.to include service: 'svc' }
+      end
+
+      context 'with version configured' do
+        before { Datadog.configure { |c| c.version = '1.2' } }
+
+        it { is_expected.to include dd_version: '1.2' }
+      end
+
+      context 'with debug enabled' do
+        before { Datadog.configure { |c| c.diagnostics.debug = true } }
+
+        it { is_expected.to include debug: true }
+      end
+
+      context 'with analytics enabled' do
+        before { Datadog.configure { |c| c.analytics_enabled = true } }
+
+        it { is_expected.to include analytics_enabled: true }
+      end
+
+      context 'with runtime metrics enabled' do
+        before { Datadog.configure { |c| c.runtime_metrics_enabled = true } }
+
+        it { is_expected.to include runtime_metrics_enabled: true }
+      end
+
+      context 'with partial flushing enabled' do
+        before { Datadog.configure { |c| c.tracer.partial_flush.enabled = true } }
+
+        it { is_expected.to include partial_flushing_enabled: true }
+      end
+
+      context 'with priority sampling enabled' do
+        before { Datadog.configure { |c| c.tracer.priority_sampling = true } }
+
+        it { is_expected.to include priority_sampling_enabled: true }
+      end
+
+      context 'with health metrics enabled' do
+        before { Datadog.configure { |c| c.diagnostics.health_metrics.enabled = true } }
+
+        it { is_expected.to include health_metrics_enabled: true }
+      end
+
+      context 'with agent connectivity issues' do
+        let(:response) { Datadog::Transport::InternalErrorResponse.new(ZeroDivisionError.new('msg')) }
+
+        it { is_expected.to include agent_error: include('ZeroDivisionError') }
+        it { is_expected.to include agent_error: include('msg') }
+      end
+
+      context 'with unix socket transport' do
+        before do
+          Datadog.configure do |c|
+            c.tracer.transport_options = ->(t) { t.adapter :unix, '/tmp/trace.sock' }
+          end
+        end
+
+        it { is_expected.to include agent_url: include('unix') }
+        it { is_expected.to include agent_url: include('/tmp/trace.sock') }
+      end
+
+      context 'with integrations loaded' do
+        before { Datadog.configure { |c| c.use :http, options } }
+        let(:options) { {} }
+
+        it { is_expected.to include integrations_loaded: start_with('http') }
+
+        it do
+          # Because net/http is default gem, we use the Ruby version as the library version.
+          is_expected.to include integrations_loaded: end_with("@#{RUBY_VERSION}")
+        end
+
+        context 'with integration-specific settings' do
+          let(:options) { { service_name: 'my-http' } }
+
+          it { is_expected.to include http_analytics_enabled: false }
+          it { is_expected.to include http_analytics_sample_rate: 1.0 }
+          it { is_expected.to include http_service_name: 'my-http' }
+          it { is_expected.to include http_distributed_tracing: true }
+          it { is_expected.to include http_split_by_domain: false }
+        end
+      end
+
+      context 'with MRI' do
+        before { skip unless PlatformHelpers.mri? }
+
+        it { is_expected.to include vm: start_with('ruby') }
+      end
+
+      context 'with JRuby' do
+        before { skip unless PlatformHelpers.jruby? }
+
+        it { is_expected.to include vm: start_with('jruby') }
+      end
+    end
+  end
+end

--- a/spec/ddtrace/transport/http/adapters/net_spec.rb
+++ b/spec/ddtrace/transport/http/adapters/net_spec.rb
@@ -102,6 +102,15 @@ RSpec.describe Datadog::Transport::HTTP::Adapters::Net do
       expect(post.http_response).to be(http_response)
     end
   end
+
+  describe '#url' do
+    subject(:url) { adapter.url }
+
+    let(:hostname) { 'local.test' }
+    let(:port) { '345' }
+    let(:timeout) { 7 }
+    it { is_expected.to eq('http://local.test:345?timeout=7') }
+  end
 end
 
 RSpec.describe Datadog::Transport::HTTP::Adapters::Net::Response do

--- a/spec/ddtrace/transport/http/adapters/unix_socket_spec.rb
+++ b/spec/ddtrace/transport/http/adapters/unix_socket_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe Datadog::Transport::HTTP::Adapters::UnixSocket do
       expect { |b| adapter.open(&b) }.to yield_with_args(http_connection)
     end
   end
+
+  describe '#url' do
+    subject(:url) { adapter.url }
+
+    let(:filepath) { '/tmp/trace.sock' }
+    let(:timeout) { 7 }
+    it { is_expected.to eq('http+unix:///tmp/trace.sock?timeout=7') }
+  end
 end
 
 RSpec.describe Datadog::Transport::HTTP::Adapters::UnixSocket::HTTP do

--- a/spec/ddtrace/writer_spec.rb
+++ b/spec/ddtrace/writer_spec.rb
@@ -56,6 +56,8 @@ RSpec.describe Datadog::Writer do
             .and_return(responses)
 
           allow(transport).to receive(:stats).and_return(transport_stats)
+
+          allow(Datadog::Diagnostics::EnvironmentLogger).to receive(:log!)
         end
 
         shared_examples_for 'priority sampling update' do
@@ -94,6 +96,13 @@ RSpec.describe Datadog::Writer do
           end
         end
 
+        shared_examples 'records environment information' do
+          it 'calls environment logger' do
+            subject
+            expect(Datadog::Diagnostics::EnvironmentLogger).to have_received(:log!).with(responses)
+          end
+        end
+
         context 'which returns a response that is' do
           let(:response) { instance_double(Datadog::Transport::HTTP::Traces::Response, trace_count: 1) }
 
@@ -112,6 +121,8 @@ RSpec.describe Datadog::Writer do
                 end
               end
             end
+
+            it_behaves_like 'records environment information'
           end
 
           context 'a server error' do
@@ -129,6 +140,8 @@ RSpec.describe Datadog::Writer do
                 end
               end
             end
+
+            it_behaves_like 'records environment information'
           end
 
           context 'an internal error' do
@@ -156,6 +169,8 @@ RSpec.describe Datadog::Writer do
                 end
               end
             end
+
+            it_behaves_like 'records environment information'
           end
         end
 
@@ -164,12 +179,14 @@ RSpec.describe Datadog::Writer do
             instance_double(Datadog::Transport::HTTP::Traces::Response,
                             internal_error?: false,
                             server_error?: false,
+                            ok?: true,
                             trace_count: 10)
           end
           let(:response2) do
             instance_double(Datadog::Transport::HTTP::Traces::Response,
                             internal_error?: false,
                             server_error?: false,
+                            ok?: true,
                             trace_count: 20)
           end
 
@@ -179,7 +196,8 @@ RSpec.describe Datadog::Writer do
             let(:response2) do
               instance_double(Datadog::Transport::HTTP::Traces::Response,
                               internal_error?: false,
-                              server_error?: true)
+                              server_error?: true,
+                              ok?: false)
             end
 
             it do
@@ -187,6 +205,8 @@ RSpec.describe Datadog::Writer do
               expect(writer.stats[:traces_flushed]).to eq(10)
             end
           end
+
+          it_behaves_like 'records environment information'
         end
 
         context 'with report hostname' do


### PR DESCRIPTION
### What does this PR do?
Adds standardized startup logging as soon as we have enough information to do so.

### Motivation
Help support get as much information as they can from app startup logs.

### Implementation
We collect logs when the first trace is attempted to be sent to the agent. This allows us to collect valuable information about the connectivity with the agent and any specific failure conditions, if any.

This information is logged only once for the application lifetime.