### PR TITLE
test:Ensure worker thread waits for test assertion 2

### DIFF
--- a/spec/ddtrace/workers/polling_spec.rb
+++ b/spec/ddtrace/workers/polling_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Datadog::Workers::Polling do
       let(:task) { proc { |*args| worker_spy.perform(*args) } }
       let(:worker_spy) { double('worker spy') }
 
-      before { allow(worker_spy).to receive(:perform) }
+      before { allow(worker_spy).to receive(:perform) { sleep 5 } }
 
       context 'by default' do
         it do


### PR DESCRIPTION
Similar to #1103, this PR makes background threads in `polling_spec.rb` wait until assertions can be performed on the worker class under test.

This has manifested more clearly in [JRuby sporadic CI failures](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/1484/workflows/0f3d214c-f1da-4ba1-be8a-91fca0c519ba/jobs/75277/steps):
```c
1) Datadog::Workers::Polling when included into a worker #stop called multiple times with graceful stop is expected to equal true
   Failure/Error: expect(worker.stop).to be true
     expected true
          got false
   # ./spec/ddtrace/workers/polling_spec.rb:93:in `block in <main>'
 ```