### PR TITLE
Add Datadog::Profiler

### DIFF
--- a/lib/ddtrace/profiling.rb
+++ b/lib/ddtrace/profiling.rb
@@ -30,6 +30,7 @@ module Datadog
       require 'ddtrace/profiling/scheduler'
       require 'ddtrace/profiling/tasks/setup'
       require 'ddtrace/profiling/transport/io'
+      require 'ddtrace/profiling/profiler'
 
       require 'ddtrace/profiling/pprof/pprof_pb' if google_protobuf_supported?
     end

--- a/lib/ddtrace/profiling/profiler.rb
+++ b/lib/ddtrace/profiling/profiler.rb
@@ -1,0 +1,28 @@
+module Datadog
+  # Generates profiles and transmits them to Datadog
+  class Profiler
+    attr_reader \
+      :collectors,
+      :scheduler
+
+    def initialize(collectors, scheduler)
+      @collectors = collectors
+      @scheduler = scheduler
+    end
+
+    def start
+      collectors.each(&:start)
+      scheduler.start
+    end
+
+    def shutdown!
+      collectors.each do |collector|
+        collector.enabled = false
+        collector.stop(true)
+      end
+
+      scheduler.enabled = false
+      scheduler.stop(true)
+    end
+  end
+end

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe 'profiling integration test' do
         enabled: true
       )
     end
-    let(:profiler) { Datadog::Profiling::Profiler.new }
 
     it 'produces a profile' do
       expect(out).to receive(:puts)

--- a/spec/ddtrace/profiling/profiler_spec.rb
+++ b/spec/ddtrace/profiling/profiler_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+require 'ddtrace/profiling'
+require 'ddtrace/profiling/profiler'
+
+RSpec.describe Datadog::Profiler do
+  subject(:profiler) { described_class.new(collectors, scheduler) }
+  let(:collectors) { Array.new(2) { instance_double(Datadog::Profiling::Collectors::Stack) } }
+  let(:scheduler) { instance_double(Datadog::Profiling::Scheduler) }
+
+  describe '::new' do
+    it do
+      is_expected.to have_attributes(
+        collectors: collectors,
+        scheduler: scheduler
+      )
+    end
+  end
+
+  describe '#start' do
+    subject(:start) { profiler.start }
+
+    it 'signals collectors and scheduler to start' do
+      collectors.each { |c| expect(c).to receive(:start) }
+      expect(scheduler).to receive(:start)
+      start
+    end
+  end
+
+  describe '#shutdown!' do
+    subject(:shutdown!) { profiler.shutdown! }
+    it 'signals collectors and scheduler to disable and stop' do
+      collectors.each do |c|
+        expect(c).to receive(:enabled=).with(false)
+        expect(c).to receive(:stop).with(true)
+      end
+
+      expect(scheduler).to receive(:enabled=).with(false)
+      expect(scheduler).to receive(:stop).with(true)
+
+      shutdown!
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds the `Datadog::Profiler`, which holds the collectors and scheduler for profiling, which can be collectively started or shutdown.