### PR TITLE
DD_SITE and DD_API_KEY configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+# Ignore local variables
+.envrc
 
 # lock files
 Gemfile.lock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -281,11 +281,11 @@ services:
       - bundle-jruby-9.2:/usr/local/bundle
       - gemfiles-jruby-9.2:/app/gemfiles
   ddagent:
-    image: datadog/docker-dd-agent
+    image: datadog/agent
     environment:
       - DD_APM_ENABLED=true
       - DD_BIND_HOST=0.0.0.0
-      - DD_API_KEY=invalid_key_but_this_is_fine
+      - DD_API_KEY=00000000000000000000000000000000
     expose:
       - "8125/udp"
       - "8126"

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -31,6 +31,11 @@ module Datadog
         end
       end
 
+      option :api_key do |o|
+        o.default { ENV.fetch(Ext::Environment::ENV_API_KEY, nil) }
+        o.lazy
+      end
+
       settings :diagnostics do
         option :debug, default: false
 
@@ -143,6 +148,11 @@ module Datadog
 
       option :service do |o|
         o.default { ENV.fetch(Ext::Environment::ENV_SERVICE, nil) }
+        o.lazy
+      end
+
+      option :site do |o|
+        o.default { ENV.fetch(Ext::Environment::ENV_SITE, nil) }
         o.lazy
       end
 

--- a/lib/ddtrace/environment.rb
+++ b/lib/ddtrace/environment.rb
@@ -6,7 +6,11 @@ module Datadog
     # Defines helper methods for environment
     module Helpers
       def env_to_bool(var, default = nil)
-        ENV.key?(var) ? ENV[var].to_s.downcase == 'true' : default
+        ENV.key?(var) ? ENV[var].to_s.strip.downcase == 'true' : default
+      end
+
+      def env_to_int(var, default = nil)
+        ENV.key?(var) ? ENV[var].to_i : default
       end
 
       def env_to_float(var, default = nil)

--- a/lib/ddtrace/ext/environment.rb
+++ b/lib/ddtrace/ext/environment.rb
@@ -1,8 +1,10 @@
 module Datadog
   module Ext
     module Environment
+      ENV_API_KEY = 'DD_API_KEY'.freeze
       ENV_ENVIRONMENT = 'DD_ENV'.freeze
       ENV_SERVICE = 'DD_SERVICE'.freeze
+      ENV_SITE = 'DD_SITE'.freeze
       ENV_TAGS = 'DD_TAGS'.freeze
       ENV_VERSION = 'DD_VERSION'.freeze
 

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'securerandom'
 
 require 'ddtrace'
 require 'ddtrace/configuration/settings'
@@ -56,6 +57,38 @@ RSpec.describe Datadog::Configuration::Settings do
         .to change { settings.analytics.enabled }
         .from(nil)
         .to(true)
+    end
+  end
+
+  describe '#api_key' do
+    subject(:api_key) { settings.api_key }
+
+    context "when #{Datadog::Ext::Environment::ENV_API_KEY}" do
+      around do |example|
+        ClimateControl.modify(Datadog::Ext::Environment::ENV_API_KEY => api_key_env) do
+          example.run
+        end
+      end
+
+      context 'is not defined' do
+        let(:api_key_env) { nil }
+        it { is_expected.to be nil }
+      end
+
+      context 'is defined' do
+        let(:api_key_env) { SecureRandom.uuid.delete('-') }
+        it { is_expected.to eq(api_key_env) }
+      end
+    end
+  end
+
+  describe '#api_key=' do
+    subject(:set_api_key) { settings.api_key = api_key }
+
+    context 'when given a value' do
+      let(:api_key) { SecureRandom.uuid.delete('-') }
+      before { set_api_key }
+      it { expect(settings.api_key).to eq(api_key) }
     end
   end
 
@@ -481,6 +514,38 @@ RSpec.describe Datadog::Configuration::Settings do
       let(:service) { 'custom-service' }
       before { set_service }
       it { expect(settings.service).to eq(service) }
+    end
+  end
+
+  describe '#site' do
+    subject(:site) { settings.site }
+
+    context "when #{Datadog::Ext::Environment::ENV_SITE}" do
+      around do |example|
+        ClimateControl.modify(Datadog::Ext::Environment::ENV_SITE => site_env) do
+          example.run
+        end
+      end
+
+      context 'is not defined' do
+        let(:site_env) { nil }
+        it { is_expected.to be nil }
+      end
+
+      context 'is defined' do
+        let(:site_env) { 'datadoghq.com' }
+        it { is_expected.to eq(site_env) }
+      end
+    end
+  end
+
+  describe '#site=' do
+    subject(:set_site) { settings.site = site }
+
+    context 'when given a value' do
+      let(:site) { 'datadoghq.com' }
+      before { set_site }
+      it { expect(settings.site).to eq(site) }
     end
   end
 

--- a/spec/ddtrace/diagnostics/environment_logger_spec.rb
+++ b/spec/ddtrace/diagnostics/environment_logger_spec.rb
@@ -226,6 +226,8 @@ RSpec.describe Datadog::Diagnostics::EnvironmentLogger do
           end
         end
 
+        after { Datadog.configure { |c| c.tracer.transport_options = {} } }
+
         it { is_expected.to include agent_url: include('unix') }
         it { is_expected.to include agent_url: include('/tmp/trace.sock') }
       end

--- a/spec/ddtrace/environment_spec.rb
+++ b/spec/ddtrace/environment_spec.rb
@@ -1,0 +1,185 @@
+require 'spec_helper'
+
+require 'ddtrace/environment'
+
+RSpec.describe Datadog::Environment do
+  let(:var) { 'TEST_VAR' }
+
+  shared_context 'env var' do
+    around do |example|
+      ClimateControl.modify(var => env_value) do
+        example.run
+      end
+    end
+  end
+
+  describe '::env_to_bool' do
+    subject(:env_to_bool) { described_class.env_to_bool(var) }
+
+    context 'when env var is not defined' do
+      context 'and default is not defined' do
+        it { is_expected.to be nil }
+      end
+
+      context 'and default is defined' do
+        subject(:env_to_bool) { described_class.env_to_bool(var, default) }
+        let(:default) { double('default') }
+        it { is_expected.to be default }
+      end
+    end
+
+    context 'when env var is set as' do
+      include_context 'env var'
+
+      # True values
+      %w[
+        true
+        TRUE
+      ].each do |value|
+        context value.to_s do
+          let(:env_value) { value.to_s }
+          it { is_expected.to be true }
+        end
+      end
+
+      # False values
+      [
+        '',
+        'false',
+        'FALSE',
+        0,
+        1
+      ].each do |value|
+        context value.to_s do
+          let(:env_value) { value.to_s }
+          it { is_expected.to be false }
+        end
+      end
+    end
+  end
+
+  describe '::env_to_int' do
+    subject(:env_to_int) { described_class.env_to_int(var) }
+
+    context 'when env var is not defined' do
+      context 'and default is not defined' do
+        it { is_expected.to be nil }
+      end
+
+      context 'and default is defined' do
+        subject(:env_to_int) { described_class.env_to_int(var, default) }
+        let(:default) { double('default') }
+        it { is_expected.to be default }
+      end
+    end
+
+    context 'when env var is set as' do
+      include_context 'env var'
+
+      context '0' do
+        let(:env_value) { '0' }
+        it { is_expected.to eq 0 }
+      end
+
+      context '1' do
+        let(:env_value) { '1' }
+        it { is_expected.to eq 1 }
+      end
+
+      context '1.5' do
+        let(:env_value) { '1.5' }
+        it { is_expected.to eq 1 }
+      end
+
+      context 'test' do
+        let(:env_value) { 'test' }
+        it { is_expected.to eq 0 }
+      end
+    end
+  end
+
+  describe '::env_to_float' do
+    subject(:env_to_float) { described_class.env_to_float(var) }
+
+    context 'when env var is not defined' do
+      context 'and default is not defined' do
+        it { is_expected.to be nil }
+      end
+
+      context 'and default is defined' do
+        subject(:env_to_float) { described_class.env_to_float(var, default) }
+        let(:default) { double('default') }
+        it { is_expected.to be default }
+      end
+    end
+
+    context 'when env var is set as' do
+      include_context 'env var'
+
+      context '0' do
+        let(:env_value) { '0' }
+        it { is_expected.to eq 0.0 }
+      end
+
+      context '1' do
+        let(:env_value) { '1' }
+        it { is_expected.to eq 1.0 }
+      end
+
+      context '1.5' do
+        let(:env_value) { '1.5' }
+        it { is_expected.to eq 1.5 }
+      end
+
+      context 'test' do
+        let(:env_value) { 'test' }
+        it { is_expected.to eq 0.0 }
+      end
+    end
+  end
+
+  describe '::env_to_list' do
+    subject(:env_to_list) { described_class.env_to_list(var) }
+
+    context 'when env var is not defined' do
+      context 'and default is not defined' do
+        it { is_expected.to eq([]) }
+      end
+
+      context 'and default is defined' do
+        subject(:env_to_list) { described_class.env_to_list(var, default) }
+        let(:default) { double('default') }
+        it { is_expected.to be default }
+      end
+    end
+
+    context 'when env var is set as' do
+      include_context 'env var'
+
+      context '\'\'' do
+        let(:env_value) { '' }
+        it { is_expected.to eq([]) }
+      end
+
+      context ',' do
+        let(:env_value) { ',' }
+        it { is_expected.to eq([]) }
+      end
+
+      context '1' do
+        let(:env_value) { '1' }
+        it { is_expected.to eq(['1']) }
+      end
+
+      context '1,2' do
+        let(:env_value) { '1,2' }
+        it { is_expected.to eq(%w[1 2]) }
+      end
+
+      context ' 1 , 2 , 3 ' do
+        let(:env_value) { ' 1 , 2 , 3 ' }
+        it { is_expected.to eq(%w[1 2 3]) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds `DD_SITE` and `DD_API_KEY` configuration settings, which can be set via either ENV or via `Datadog.configure`. These settings are used for submitting trace and profile data to Datadog.