### PR TITLE
fix:Convert custom setting value to string for startup log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.37.0...v0.38.0
 - Kafka integration (#1070) (@tjwp)
 - Span#set_tags (#1081) (@DocX)
 - retry_count tag for Sidekiq jobs (#1089) (@elyalvarado)
-- Startup environment log (#1104)
+- Startup environment log (#1104, #1109)
 - DD_SITE and DD_API_KEY configuration (#1107)
 
 ### Changed

--- a/lib/ddtrace/diagnostics/environment_logger.rb
+++ b/lib/ddtrace/diagnostics/environment_logger.rb
@@ -262,7 +262,9 @@ module Datadog
           integration.configuration.to_h.flat_map do |setting, value|
             next [] if setting == :tracer # Skip internal Ruby objects
 
-            [[:"integration_#{name}_#{setting}", value]]
+            # Convert value to a string to avoid custom #to_json
+            # handlers possibly causing errors.
+            [[:"integration_#{name}_#{setting}", value.to_s]]
           end
         end]
       end

--- a/spec/ddtrace/diagnostics/environment_logger_spec.rb
+++ b/spec/ddtrace/diagnostics/environment_logger_spec.rb
@@ -246,11 +246,19 @@ RSpec.describe Datadog::Diagnostics::EnvironmentLogger do
         context 'with integration-specific settings' do
           let(:options) { { service_name: 'my-http' } }
 
-          it { is_expected.to include integration_http_analytics_enabled: false }
-          it { is_expected.to include integration_http_analytics_sample_rate: 1.0 }
+          it { is_expected.to include integration_http_analytics_enabled: 'false' }
+          it { is_expected.to include integration_http_analytics_sample_rate: '1.0' }
           it { is_expected.to include integration_http_service_name: 'my-http' }
-          it { is_expected.to include integration_http_distributed_tracing: true }
-          it { is_expected.to include integration_http_split_by_domain: false }
+          it { is_expected.to include integration_http_distributed_tracing: 'true' }
+          it { is_expected.to include integration_http_split_by_domain: 'false' }
+        end
+
+        context 'with a complex setting value' do
+          let(:options) { { service_name: Class.new } }
+
+          it 'converts to a string' do
+            is_expected.to include integration_http_service_name: start_with('#<Class:')
+          end
         end
       end
 


### PR DESCRIPTION
This PR ensures that integration settings that can store arbitrary values, e.g. `"integration_rack_application"`, don't expand into a large payload like:
```
#<RailsApp::Application:0x00007fde60c43bc8
 @_all_autoload_paths=
  ["./rails/app/controllers",
   "./rails/app/helpers",
   "./rails/app/jobs",
   "./rails/app/models"],
 @_all_load_paths=
  ["./rails/app/controllers",
   "./rails/app/helpers",
   "./rails/app/jobs",
   "./rails/app/models"],
 @app=
  #<Datadog::Contrib::Rack::TraceMiddleware:0x00007fbfb4dda128
   @app=
    #<ActionDispatch::HostAuthorization:0x00007fbfb4dda240
     @app=
      #<Rack::Sendfile:0x00007fbfb4dda308
       @app=
        #<ActionDispatch::Executor:0x00007fbfb4dda380
         @app=
          #<ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x00007fbfb4f3e000
           @app=
            #<Rack::Runtime:0x00007fbfb4dda3d0
             @app=
              #<Rack::MethodOverride:0x00007fbfb4dda3f8
               @app=
...
```

We currently call `to_json` on our startup log hash, thus calling `to_hash` on each object.
Because objects can have custom `to_json` handlers, it is not safe to perform that call.
For a Rails application, for example, you can get a `SystemStackError` due to recursive object resolution during `to_json`.

Instead they create a less descriptive, yet safer output using `#to_s`: `"integration_rack_application":"#RailsApp::Application:0x00007fde60c43bc8"`