### PR TITLE
Add metadata to profiling flush

### DIFF
--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -23,19 +23,19 @@ module Datadog
 
         def initialize(recorder, options = {})
           @recorder = recorder
-          @max_frames = options.fetch(:max_frames, DEFAULT_MAX_FRAMES)
-          @ignore_thread = options.fetch(:ignore_thread, nil)
-          @max_time_usage_pct = options.fetch(:max_time_usage_pct, DEFAULT_MAX_TIME_USAGE_PCT)
+          @max_frames = options[:max_frames] || DEFAULT_MAX_FRAMES
+          @ignore_thread = options[:ignore_thread]
+          @max_time_usage_pct = options[:max_time_usage_pct] || DEFAULT_MAX_TIME_USAGE_PCT
 
           # Workers::Async::Thread settings
           # Restart in forks by default
-          self.fork_policy = options.fetch(:fork_policy, Workers::Async::Thread::FORK_POLICY_RESTART)
+          self.fork_policy = options[:fork_policy] || Workers::Async::Thread::FORK_POLICY_RESTART
 
           # Workers::IntervalLoop settings
-          self.loop_base_interval = options.fetch(:interval, MIN_INTERVAL)
+          self.loop_base_interval = options[:interval] || MIN_INTERVAL
 
           # Workers::Polling settings
-          self.enabled = options.fetch(:enabled, false)
+          self.enabled = options[:enabled] == true
         end
 
         def start

--- a/lib/ddtrace/profiling/encoding/profile.rb
+++ b/lib/ddtrace/profiling/encoding/profile.rb
@@ -11,15 +11,15 @@ module Datadog
         module Protobuf
           module_function
 
-          def encode(flushes)
-            return if flushes.empty?
+          def encode(flush)
+            return unless flush
 
             # Create a pprof template from the list of event types
-            event_classes = flushes.collect(&:event_class).uniq
+            event_classes = flush.event_groups.collect(&:event_class).uniq
             template = Pprof::Template.for_event_classes(event_classes)
 
             # Add all events to the pprof
-            flushes.each { |flush| template.add_events!(flush.event_class, flush.events) }
+            flush.event_groups.each { |event_group| template.add_events!(event_group.event_class, event_group.events) }
 
             # Build the profile and encode it
             template.to_encoded_profile

--- a/lib/ddtrace/profiling/exporter.rb
+++ b/lib/ddtrace/profiling/exporter.rb
@@ -8,15 +8,15 @@ module Datadog
         :transport
 
       def initialize(transport)
-        unless transport.is_a?(Profiling::Transport::IO::Client)
+        unless transport.is_a?(Profiling::Transport::Client)
           raise ArgumentError, 'Unsupported transport for profiling exporter.'
         end
 
         @transport = transport
       end
 
-      def export(flushes)
-        transport.send_flushes(flushes)
+      def export(flush)
+        transport.send_profiling_flush(flush)
       end
     end
   end

--- a/lib/ddtrace/profiling/flush.rb
+++ b/lib/ddtrace/profiling/flush.rb
@@ -1,6 +1,39 @@
+require 'ddtrace/runtime/identity'
+require 'ddtrace/runtime/socket'
+
 module Datadog
   module Profiling
+    # Represents a flush of all profiling events
+    Flush = Struct.new(
+      :start,
+      :finish,
+      :event_groups,
+      :event_count,
+      :runtime_id,
+      :service,
+      :env,
+      :version,
+      :host,
+      :language,
+      :runtime,
+      :runtime_version,
+      :profiler_version
+    ) do
+      def initialize(*args)
+        super
+        self.runtime_id = runtime_id || Datadog::Runtime::Identity.id
+        self.service = service || Datadog.configuration.service
+        self.env = env || Datadog.configuration.env
+        self.version = version || Datadog.configuration.version
+        self.host = host || Datadog::Runtime::Socket.hostname
+        self.language = language || Datadog::Runtime::Identity.lang
+        self.runtime = runtime || Datadog::Runtime::Identity.lang_interpreter
+        self.runtime_version = runtime_version || Datadog::Runtime::Identity.lang_version
+        self.profiler_version = profiler_version || Datadog::Runtime::Identity.tracer_version
+      end
+    end
+
     # Represents a collection of events of a specific type being flushed.
-    Flush = Struct.new(:event_class, :events).freeze
+    EventGroup = Struct.new(:event_class, :events).freeze
   end
 end

--- a/lib/ddtrace/profiling/transport/client.rb
+++ b/lib/ddtrace/profiling/transport/client.rb
@@ -1,0 +1,12 @@
+module Datadog
+  module Profiling
+    module Transport
+      # Generic interface for profiling transports
+      module Client
+        def send_profiling_flush(flush)
+          NotImplementedError.new
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/profiling/transport/io/client.rb
+++ b/lib/ddtrace/profiling/transport/io/client.rb
@@ -1,4 +1,5 @@
 require 'ddtrace/transport/io/client'
+require 'ddtrace/profiling/transport/client'
 require 'ddtrace/profiling/transport/request'
 require 'ddtrace/profiling/transport/io/response'
 
@@ -6,11 +7,13 @@ module Datadog
   module Profiling
     module Transport
       module IO
-        # Profiling extensions for IO client
+        # IO transport for profiling
         class Client < Datadog::Transport::IO::Client
-          def send_flushes(flushes)
+          include Transport::Client
+
+          def send_profiling_flush(flush)
             # Build a request
-            request = Profiling::Transport::Request.new(flushes)
+            request = Profiling::Transport::Request.new(flush)
             send_request(request)
           end
 

--- a/spec/ddtrace/profiling/encoding/profile_spec.rb
+++ b/spec/ddtrace/profiling/encoding/profile_spec.rb
@@ -5,10 +5,11 @@ require 'ddtrace/profiling/events/stack'
 
 RSpec.describe Datadog::Profiling::Encoding::Profile::Protobuf do
   describe '::encode' do
-    subject(:encode) { described_class.encode(flushes) }
+    subject(:encode) { described_class.encode(flush) }
 
-    let(:flushes) { [flush] }
-    let(:flush) { instance_double(Datadog::Profiling::Flush, event_class: event_class, events: events) }
+    let(:flush) { instance_double(Datadog::Profiling::Flush, event_groups: event_groups) }
+    let(:event_groups) { [event_group] }
+    let(:event_group) { instance_double(Datadog::Profiling::EventGroup, event_class: event_class, events: events) }
     let(:event_class) { double('event class') }
     let(:events) { double('events') }
 
@@ -24,7 +25,7 @@ RSpec.describe Datadog::Profiling::Encoding::Profile::Protobuf do
 
       expect(template)
         .to receive(:add_events!)
-        .with(flush.event_class, flush.events)
+        .with(event_group.event_class, event_group.events)
         .ordered
 
       expect(template)

--- a/spec/ddtrace/profiling/exporter_spec.rb
+++ b/spec/ddtrace/profiling/exporter_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 require 'ddtrace/profiling/exporter'
+require 'ddtrace/profiling/flush'
 require 'ddtrace/profiling/transport/io'
 
 RSpec.describe Datadog::Profiling::Exporter do
@@ -27,13 +28,13 @@ RSpec.describe Datadog::Profiling::Exporter do
   end
 
   describe '#export' do
-    subject(:export) { exporter.export(flushes) }
-    let(:flushes) { [] }
+    subject(:export) { exporter.export(flush) }
+    let(:flush) { instance_double(Datadog::Profiling::Flush) }
     let(:result) { double('result') }
 
     before do
       allow(transport)
-        .to receive(:send_flushes)
+        .to receive(:send_profiling_flush)
         .and_return(result)
     end
 
@@ -41,8 +42,8 @@ RSpec.describe Datadog::Profiling::Exporter do
       is_expected.to be result
 
       expect(transport)
-        .to have_received(:send_flushes)
-        .with(flushes)
+        .to have_received(:send_profiling_flush)
+        .with(flush)
     end
   end
 end

--- a/spec/ddtrace/profiling/spec_helper.rb
+++ b/spec/ddtrace/profiling/spec_helper.rb
@@ -17,7 +17,7 @@ module ProfilingFeatureHelpers
 end
 
 module ProfileHelpers
-  def get_test_profiling_flushes
+  def get_test_profiling_flush
     stack_one = Thread.current.backtrace_locations.first(3)
     stack_two = Thread.current.backtrace_locations.first(3)
 
@@ -29,9 +29,16 @@ module ProfileHelpers
       build_stack_sample(stack_two, 101, 1600, 1600)
     ]
 
-    [
-      Datadog::Profiling::Flush.new(Datadog::Profiling::Events::StackSample, stack_samples)
-    ]
+    start = Time.now.utc
+    finish = start + 10
+    event_groups = [Datadog::Profiling::EventGroup.new(Datadog::Profiling::Events::StackSample, stack_samples)]
+
+    Datadog::Profiling::Flush.new(
+      start,
+      finish,
+      event_groups,
+      stack_samples.length
+    )
   end
 
   def build_stack_sample(locations = nil, thread_id = nil, cpu_time_ns = nil, wall_time_ns = nil)

--- a/spec/ddtrace/profiling/transport/io/client_spec.rb
+++ b/spec/ddtrace/profiling/transport/io/client_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-require 'ddtrace/transport/io/client'
+require 'ddtrace/profiling/flush'
 require 'ddtrace/profiling/transport/io/client'
 
 RSpec.describe Datadog::Profiling::Transport::IO::Client do
@@ -8,30 +8,29 @@ RSpec.describe Datadog::Profiling::Transport::IO::Client do
   let(:out) { instance_double(IO) }
   let(:encoder) { instance_double(Datadog::Encoding::Encoder) }
 
-  describe '#send_flushes' do
-    context 'given events' do
-      subject(:send_flushes) { client.send_flushes(events) }
-      let(:events) { instance_double(Array) }
-      let(:encoded_events) { double('encoded events') }
-      let(:result) { double('IO result') }
+  describe '#send_profiling_flush' do
+    subject(:send_profiling_flush) { client.send_profiling_flush(flush) }
 
-      before do
-        expect(client.encoder).to receive(:encode)
-          .with(events)
-          .and_return(encoded_events)
+    let(:flush) { instance_double(Datadog::Profiling::Flush) }
+    let(:encoded_events) { double('encoded events') }
+    let(:result) { double('IO result') }
 
-        expect(client.out).to receive(:puts)
-          .with(encoded_events)
-          .and_return(result)
+    before do
+      expect(client.encoder).to receive(:encode)
+        .with(flush)
+        .and_return(encoded_events)
 
-        expect(client).to receive(:update_stats_from_response!)
-          .with(kind_of(Datadog::Profiling::Transport::IO::Response))
-      end
+      expect(client.out).to receive(:puts)
+        .with(encoded_events)
+        .and_return(result)
 
-      it do
-        is_expected.to be_a_kind_of(Datadog::Profiling::Transport::IO::Response)
-        expect(send_flushes.result).to eq(result)
-      end
+      expect(client).to receive(:update_stats_from_response!)
+        .with(kind_of(Datadog::Profiling::Transport::IO::Response))
+    end
+
+    it do
+      is_expected.to be_a_kind_of(Datadog::Profiling::Transport::IO::Response)
+      expect(send_profiling_flush.result).to eq(result)
     end
   end
 


### PR DESCRIPTION
In order to assist transport, and make "flushes" more self-contained, this pull request adds some richer metadata to the `Flush` object. This richer version of `Flush` includes the events, time stamps, and details about the environment.

This additional data can be used to produced a more robust dump of flush data to HTTP, or other channels.