### PR TITLE
Fix HTTP::StateError on http.rb tracer

### DIFF
--- a/lib/ddtrace/contrib/httprb/instrumentation.rb
+++ b/lib/ddtrace/contrib/httprb/instrumentation.rb
@@ -83,7 +83,7 @@ module Datadog
             case response.code.to_i
             when 400...599
               begin
-                message = response.parse['message']
+                message = JSON.parse(response.body.to_s)['message']
               rescue
                 message = 'Error'
               end

--- a/lib/ddtrace/contrib/httprb/instrumentation.rb
+++ b/lib/ddtrace/contrib/httprb/instrumentation.rb
@@ -83,7 +83,7 @@ module Datadog
             case response.code.to_i
             when 400...599
               begin
-                message = JSON.parse(response.body)['message']
+                message = response.parse['message']
               rescue
                 message = 'Error'
               end


### PR DESCRIPTION
This PR fixes the issue originally reported in #1116 

Using `JSON.parse(response.body)` will lock the body as `streaming` and prevent subsequent attempts to parse the `body` outside of `ddtrace`

~~Using `parse` on `HTTP::Response` will prevent this behavior and allow you to parse the response body any number of times.~~

### Update

By calling `to_s` on the `body` before parsing, will prevent this behavior and allow you to parse the response body any number of times. This is similar to how `HTTP::Response#parse` handles it with out depending on a MIME-Type.

https://github.com/httprb/http/blob/4-x-stable/lib/http/response.rb#L158