### PR TITLE
test:Fix leaky tracer setting

### DIFF
--- a/spec/ddtrace/diagnostics/environment_logger_spec.rb
+++ b/spec/ddtrace/diagnostics/environment_logger_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe Datadog::Diagnostics::EnvironmentLogger do
 
       context 'with tracer disabled' do
         before { Datadog.configure { |c| c.tracer.enabled = false } }
+        after { Datadog.configure { |c| c.tracer.enabled = true } }
 
         it { is_expected.to include enabled: false }
       end


### PR DESCRIPTION
We were disabling the tracer for a `environment_logger_spec.rb`, but never re-enabling it.
This could cause subsequent tests to fail, like this one: https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/1563/workflows/080116a3-5a99-45ca-a4ec-3fe67c657cb0/jobs/77623