### PR TITLE
docs:Clear wording for :orm_service_name setting

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -473,7 +473,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | Key | Description | Default |
 | ---| --- | --- |
 | `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to the global setting, `false` for off. | `false` |
-| `orm_service_name` | Service name used for the Ruby ORM portion of `active_record` instrumentation. Overrides service name for ORM spans if explicitly set, which otherwise inherit their service from their parent. | `'active_record'` |
+| `orm_service_name` | Service name used for the mapping portion of query results to ActiveRecord objects. Inherits service name from parent by default. | _parent.service_name_ (e.g. `'mysql2'`) |
 | `service_name` | Service name used for database portion of `active_record` instrumentation. | Name of database adapter (e.g. `'mysql2'`) |
 
 **Configuring trace settings per database**


### PR DESCRIPTION
This PR address the wording on ActiveRecord's `orm_service_name` option, to make it clear that it refers to the Ruby object instantiation portion of ActiveRecord queries.