### PR TITLE
change:Default logger level from WARN to INFO

### DIFF
--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -92,7 +92,7 @@ module Datadog
           o.on_set { |value| set_option(:level, value.level) unless value.nil? }
         end
 
-        option :level, default: ::Logger::WARN
+        option :level, default: ::Logger::INFO
       end
 
       def logger=(logger)

--- a/lib/ddtrace/diagnostics/environment_logger.rb
+++ b/lib/ddtrace/diagnostics/environment_logger.rb
@@ -28,7 +28,7 @@ module Datadog
         private
 
         def log_environment!(line)
-          Datadog.logger.warn("DATADOG TRACER CONFIGURATION - #{line}")
+          Datadog.logger.info("DATADOG TRACER CONFIGURATION - #{line}")
         end
 
         def log_error!(type, error)

--- a/lib/ddtrace/logger.rb
+++ b/lib/ddtrace/logger.rb
@@ -10,7 +10,7 @@ module Datadog
     def initialize(*args, &block)
       super
       self.progname = PREFIX
-      self.level = ::Logger::WARN
+      self.level = ::Logger::INFO
     end
 
     def add(severity, message = nil, progname = nil, &block)

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -275,16 +275,16 @@ RSpec.describe Datadog::Configuration::Settings do
 
     describe '#level' do
       subject(:level) { settings.logger.level }
-      it { is_expected.to be ::Logger::WARN }
+      it { is_expected.to be ::Logger::INFO }
     end
 
     describe 'level=' do
-      let(:level) { ::Logger::INFO }
+      let(:level) { ::Logger::DEBUG }
 
       it 'changes the #statsd setting' do
         expect { settings.logger.level = level }
           .to change { settings.logger.level }
-          .from(::Logger::WARN)
+          .from(::Logger::INFO)
           .to(level)
       end
     end

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -5,6 +5,8 @@ require 'ddtrace/patcher'
 require 'ddtrace/configuration'
 
 RSpec.describe Datadog::Configuration do
+  let(:default_log_level) { ::Logger::INFO }
+
   context 'when extended by a class' do
     subject(:test_class) { stub_const('TestClass', Class.new { extend Datadog::Configuration }) }
 
@@ -14,7 +16,7 @@ RSpec.describe Datadog::Configuration do
       context 'when debug mode' do
         it 'is toggled with default settings' do
           # Assert initial state
-          expect(test_class.logger.level).to be ::Logger::WARN
+          expect(test_class.logger.level).to be default_log_level
 
           # Enable
           test_class.configure do |c|
@@ -30,7 +32,7 @@ RSpec.describe Datadog::Configuration do
           end
 
           # Assert final state
-          expect(test_class.logger.level).to be ::Logger::WARN
+          expect(test_class.logger.level).to be default_log_level
         end
 
         context 'is disabled with a custom logger in use' do
@@ -276,7 +278,7 @@ RSpec.describe Datadog::Configuration do
     describe '#logger' do
       subject(:logger) { test_class.logger }
       it { is_expected.to be_a_kind_of(Datadog::Logger) }
-      it { expect(logger.level).to be ::Logger::WARN }
+      it { expect(logger.level).to be default_log_level }
     end
 
     describe '#runtime_metrics' do

--- a/spec/ddtrace/logger_spec.rb
+++ b/spec/ddtrace/logger_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Datadog::Logger do
   describe '::new' do
     subject(:logger) { described_class.new(STDOUT) }
     it { is_expected.to be_a_kind_of(::Logger) }
-    it { expect(logger.level).to be ::Logger::WARN }
+    it { expect(logger.level).to be ::Logger::INFO }
     it { expect(logger.progname).to eq(Datadog::Logger::PREFIX) }
   end
 
@@ -29,21 +29,23 @@ RSpec.describe Datadog::Logger do
     end
 
     context 'with default settings' do
-      it { is_expected.to have(4).items }
+      it { is_expected.to have(5).items }
       it 'produces log messages with expected format' do
-        expect(lines[0]).to match(
+        expect(lines[0]).to match(/I,.*INFO -- ddtrace: \[ddtrace\] Info message/)
+
+        expect(lines[1]).to match(
           /W,.*WARN -- ddtrace: \[ddtrace\] Warning message/
         )
 
-        expect(lines[1]).to match(
+        expect(lines[2]).to match(
           /E,.*ERROR -- ddtrace: \[ddtrace\] \(.*logger_spec.rb.*\) Error message #1/
         )
 
-        expect(lines[2]).to match(
+        expect(lines[3]).to match(
           /E,.*ERROR -- my-progname: \[ddtrace\] \(.*logger_spec.rb.*\) Error message #2/
         )
 
-        expect(lines[3]).to match(
+        expect(lines[4]).to match(
           /E,.*ERROR -- ddtrace: \[ddtrace\] \(.*logger_spec.rb.*\) Error message #3/
         )
       end


### PR DESCRIPTION
Fixes #1112

This PR changes the default `Datadog.logger` default level to `INFO`.
This allows us to reduce the log level of #1104 down from `WARN` to `INFO`, which was the original plan.

The change to the default log level does not affect any internal usage of `Datadog.logger`: we don't have any active path emitting `INFO` level messages.

We **do** have an undocumented [alternative implementation of `Datadog::Statsd`](https://github.com/DataDog/dd-trace-rb/blob/9c73f569ed973631f8113a360f159422005c80b9/lib/ddtrace/metrics.rb#L185-L214), which needs to be explicitly instantiated by the user, which outputs `INFO` level messages. This use case is not common, and only recommended for developing/debugging environments.