### PR TITLE
Fix 1116, remove parsing of resp body from http.rb instrumentation

### DIFF
--- a/lib/ddtrace/contrib/httprb/instrumentation.rb
+++ b/lib/ddtrace/contrib/httprb/instrumentation.rb
@@ -82,12 +82,9 @@ module Datadog
 
             case response.code.to_i
             when 400...599
-              begin
-                message = JSON.parse(response.body)['message']
-              rescue
-                message = 'Error'
-              end
-              span.set_error(["Error #{response.code}", message])
+              # https://github.com/DataDog/dd-trace-rb/issues/1116
+              # parsing the response bpdy message will alter downstream application behavior
+              span.set_error(["Error #{response.code}", 'Error'])
             end
           end
 

--- a/spec/ddtrace/contrib/httprb/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/httprb/instrumentation_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Datadog::Contrib::Httprb::Instrumentation do
           end
 
           it 'has error message' do
-            expect(span).to have_error_message('Internal Server Error')
+            expect(span).to have_error_message('Error')
           end
         end
 

--- a/spec/ddtrace/contrib/httprb/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/httprb/instrumentation_spec.rb
@@ -132,6 +132,7 @@ RSpec.describe Datadog::Contrib::Httprb::Instrumentation do
             expect(span).to have_error_type('Error 500')
           end
 
+          # default error message to `Error` from https://github.com/DataDog/dd-trace-rb/issues/1116
           it 'has error message' do
             expect(span).to have_error_message('Error')
           end


### PR DESCRIPTION
Resolves https://github.com/DataDog/dd-trace-rb/issues/1116 

This piggybacks off the discussion here https://github.com/DataDog/dd-trace-rb/pull/1117

Ultimately, it is not safe to read the http.rb response body in ddtrace: we end up consuming the body reading stream, so the host application cannot properly read it. The httprb suggests usage of `.readpartial` which we would also impact.

To address this issue we should stop reading the response body message altogether. This will remove some information from our error reporting, but it's ultimately required for the safe operation of ddtrace with http.rb.