### PR TITLE
add url method on test adapter to prevent startup env logs from throwing exception

### DIFF
--- a/lib/ddtrace/transport/http/adapters/test.rb
+++ b/lib/ddtrace/transport/http/adapters/test.rb
@@ -33,6 +33,8 @@ module Datadog
             @status = status
           end
 
+          def url; end
+
           # Response for test adapter
           class Response
             include Datadog::Transport::Response

--- a/spec/ddtrace/transport/http/adapters/test_spec.rb
+++ b/spec/ddtrace/transport/http/adapters/test_spec.rb
@@ -109,6 +109,14 @@ RSpec.describe Datadog::Transport::HTTP::Adapters::Test do
       expect(adapter.status).to be status
     end
   end
+
+  describe '#url' do
+    subject(:url) { adapter.url }
+
+    it do
+      is_expected.to be nil
+    end
+  end
 end
 
 RSpec.describe Datadog::Transport::HTTP::Adapters::Test::Response do


### PR DESCRIPTION
This PR addresses https://github.com/DataDog/dd-trace-rb/issues/1125, in which the startup env logger attempts to record the `adapter.url`, but in test environments using the `Adapters::Test` class, this method is not defined, causing an exception to be thrown. While we catch and handle this exception, it's unintended/noisy and causes startup env logs to be lost. This PR adds a stubbed out url method on the test adapter. Long term it make might sense to have all adapters inherit from  a base adapter