### PR TITLE
test:Report when test exhausts wait timeout

### DIFF
--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -33,9 +33,11 @@ module SynchronizationHelpers
     backoff = options.fetch(:backoff, 0.1)
 
     loop do
-      break if attempts <= 0 || yield(attempts)
+      break if yield(attempts)
       sleep(backoff)
       attempts -= 1
+
+      raise StandardError, 'Wait time exhausted!' if attempts <= 0
     end
   end
 

--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -28,8 +28,9 @@ module SynchronizationHelpers
     expect(status).to be true
   end
 
+  # Defaults to 5 second timeout
   def try_wait_until(options = {})
-    attempts = options.fetch(:attempts, 10)
+    attempts = options.fetch(:attempts, 50)
     backoff = options.fetch(:backoff, 0.1)
 
     loop do

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -225,9 +225,11 @@ def try_wait_until(options = {})
   backoff = options.fetch(:backoff, 0.1)
 
   loop do
-    break if attempts <= 0 || yield
+    break if yield
     sleep(backoff)
     attempts -= 1
+
+    raise StandardError, 'Wait time exhausted!' if attempts <= 0
   end
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -220,8 +220,9 @@ def test_repeat
   30
 end
 
+# Defaults to 5 second timeout
 def try_wait_until(options = {})
-  attempts = options.fetch(:attempts, 10)
+  attempts = options.fetch(:attempts, 50)
   backoff = options.fetch(:backoff, 0.1)
 
   loop do


### PR DESCRIPTION
While trying to debug flaky tests that wait for an asynchronous condition (by invoking `try_wait_until`), I found that it is possible that some of these tests are timing out while waiting for the condition to be met.

We currently don't provide any signal that a timeout happened, we just return and move along the test execution. This can cause assertions to be performed on incomplete data, causing seemly random failures.

This PR adds clear information (in the for of an exception) that a timeout was reached when calling `try_wait_until`, meaning the required condition might not have been reached.