### PR TITLE
Add on_fork callback

### DIFF
--- a/lib/ddtrace/profiling/ext/forking.rb
+++ b/lib/ddtrace/profiling/ext/forking.rb
@@ -1,0 +1,74 @@
+module Datadog
+  module Profiling
+    module Ext
+      # Extensions for forking.
+      module Forking
+        def self.supported?
+          RUBY_PLATFORM != 'java'
+        end
+
+        def self.apply!
+          return unless supported?
+
+          modules = [::Process, ::Kernel]
+          # TODO: Ruby < 2.3 doesn't support Binding#receiver.
+          #       Remove "else #eval" clause when Ruby < 2.3 support is dropped.
+          modules << (TOPLEVEL_BINDING.respond_to?(:receiver) ? TOPLEVEL_BINDING.receiver : TOPLEVEL_BINDING.eval('self'))
+
+          # Patch top-level binding, Kernel, Process.
+          # NOTE: We could instead do Kernel.module_eval { def fork; ... end }
+          #       however, this method rewrite is more invasive and irreversible.
+          #       It could also have collisions with other libraries that patch.
+          #       Opt to modify the inheritance of each relevant target instead.
+          modules.each do |mod|
+            if mod.class <= Module
+              mod.singleton_class.class_eval do
+                prepend Kernel
+              end
+            else
+              mod.extend(Kernel)
+            end
+          end
+        end
+
+        # Extensions for kernel
+        module Kernel
+          FORK_STAGES = [:prepare, :parent, :child].freeze
+
+          def fork
+            wrapped_block = proc do
+              # Trigger :child callback
+              at_fork_blocks[:child].each(&:call) if at_fork_blocks.key?(:child)
+              yield
+            end
+
+            # Trigger :prepare callback
+            at_fork_blocks[:prepare].each(&:call) if at_fork_blocks.key?(:prepare)
+
+            # Start fork
+            result = super(&wrapped_block)
+
+            # Trigger :parent callback and return
+            at_fork_blocks[:parent].each(&:call) if at_fork_blocks.key?(:parent)
+            result
+          end
+
+          def at_fork(stage = :prepare, &block)
+            raise ArgumentError, 'Bad \'stage\' for ::at_fork' unless FORK_STAGES.include?(stage)
+            at_fork_blocks[stage] = [] unless at_fork_blocks.key?(stage)
+            at_fork_blocks[stage] << block
+          end
+
+          module_function
+
+          def at_fork_blocks
+            # Blocks should be shared across all users of this module,
+            # e.g. Process#fork, Kernel#fork, etc. should all invoke the same callbacks.
+            # rubocop:disable Style/ClassVars
+            @@at_fork_blocks ||= {}
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/profiling/ext/thread.rb
+++ b/lib/ddtrace/profiling/ext/thread.rb
@@ -25,7 +25,7 @@ module Datadog
           :native_thread_id
 
         def initialize(*args)
-          @pid = Process.pid
+          @pid = ::Process.pid
           @native_thread_id = nil
           @clock_id = nil
 
@@ -46,19 +46,19 @@ module Datadog
         end
 
         def cpu_time(unit = :float_second)
-          return unless clock_id && Process.respond_to?(:clock_gettime)
-          Process.clock_gettime(clock_id, unit)
+          return unless clock_id && ::Process.respond_to?(:clock_gettime)
+          ::Process.clock_gettime(clock_id, unit)
         end
 
         private
 
         # Retrieves number of classes from runtime
         def forked?
-          Process.pid != (@pid ||= nil)
+          ::Process.pid != (@pid ||= nil)
         end
 
         def update_native_ids
-          @pid = Process.pid
+          @pid = ::Process.pid
           @native_thread_id = get_native_thread_id
           @clock_id = get_clock_id(@native_thread_id)
         end

--- a/lib/ddtrace/profiling/tasks/setup.rb
+++ b/lib/ddtrace/profiling/tasks/setup.rb
@@ -4,6 +4,19 @@ module Datadog
       # Sets up profiling for the application
       class Setup
         def run
+          activate_main_extensions
+          activate_thread_extensions
+        end
+
+        def activate_main_extensions
+          # Add forking extensions
+          require 'ddtrace/profiling/ext/forking'
+          Ext::Forking.apply!
+        rescue StandardError, ScriptError => e
+          puts "[DDTRACE] Forking extensions unavailable. Cause: #{e.message} Location: #{e.backtrace.first}"
+        end
+
+        def activate_thread_extensions
           # Activate CPU timings
           require 'ddtrace/profiling/ext/thread'
           ::Thread.send(:prepend, Profiling::Ext::CThread)

--- a/spec/ddtrace/profiling/ext/forking_spec.rb
+++ b/spec/ddtrace/profiling/ext/forking_spec.rb
@@ -1,0 +1,272 @@
+require 'spec_helper'
+require 'ddtrace/profiling'
+require 'ddtrace/profiling/ext/forking'
+
+RSpec.describe Datadog::Profiling::Ext::Forking do
+  describe '::supported?' do
+    subject(:supported?) { described_class.supported? }
+
+    context 'when MRI Ruby is used' do
+      before { stub_const('RUBY_PLATFORM', 'x86_64-linux') }
+      it { is_expected.to be true }
+    end
+
+    context 'when JRuby is used' do
+      before { stub_const('RUBY_PLATFORM', 'java') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '::apply!' do
+    subject(:apply!) { described_class.apply! }
+
+    let(:toplevel_receiver) do
+      if TOPLEVEL_BINDING.respond_to?(:receiver)
+        TOPLEVEL_BINDING.receiver
+      else
+        TOPLEVEL_BINDING.eval('self')
+      end
+    end
+
+    around do |example|
+      expect(::Process.ancestors).to_not include(described_class::Kernel)
+      expect(::Kernel.ancestors).to_not include(described_class::Kernel)
+
+      unmodified_process_class = ::Process.dup
+      unmodified_kernel_class = ::Kernel.dup
+
+      example.run
+
+      # Clean up classes
+      Object.send(:remove_const, :Process)
+      Object.const_set('Process', unmodified_process_class)
+
+      Object.send(:remove_const, :Kernel)
+      Object.const_set('Kernel', unmodified_kernel_class)
+
+      # Check for leaks (make sure test is properly cleaned up)
+      expect(::Process.ancestors.include?(described_class::Kernel)).to be false
+      expect(::Kernel.ancestors.include?(described_class::Kernel)).to be false
+      # Can't assert this because top level can't be reverted; can't guarantee pristine state.
+      # expect(toplevel_receiver.class.ancestors.include?(described_class::Kernel)).to be false
+
+      expect(::Process.method(:fork).source_location).to be nil
+      expect(::Kernel.method(:fork).source_location).to be nil
+      # Can't assert this because top level can't be reverted; can't guarantee pristine state.
+      # expect(toplevel_receiver.method(:fork).source_location).to be nil
+    end
+
+    if described_class.supported?
+      it 'applies the Kernel patch' do
+        # NOTE: There's no way to undo a modification of the TOPLEVEL_BINDING.
+        #       The results of this will carry over into other tests...
+        #       Just assert that the receiver was patched instead.
+        #       Unfortunately means we can't test if "fork" works in main Object.
+        expect(toplevel_receiver)
+          .to receive(:extend)
+          .with(described_class::Kernel)
+
+        apply!
+
+        expect(::Process.ancestors).to include(described_class::Kernel)
+        expect(::Kernel.ancestors).to include(described_class::Kernel)
+
+        expect(::Process.method(:fork).source_location.first).to match(%r{.*ddtrace/profiling/ext/forking.rb})
+        expect(::Kernel.method(:fork).source_location.first).to match(%r{.*ddtrace/profiling/ext/forking.rb})
+      end
+    else
+      it 'skips the Kernel patch' do
+        expect(toplevel_receiver)
+          .to_not receive(:extend)
+          .with(described_class::Kernel)
+
+        apply!
+
+        expect(::Process.ancestors).to_not include(described_class::Kernel)
+        expect(::Kernel.ancestors).to_not include(described_class::Kernel)
+
+        expect(::Process.method(:fork).source_location).to be nil
+        expect(::Kernel.method(:fork).source_location).to be nil
+      end
+    end
+  end
+end
+
+RSpec.describe Datadog::Profiling::Ext::Forking::Kernel do
+  before { skip 'Forking not supported' unless Datadog::Profiling::Ext::Forking.supported? }
+
+  shared_context 'fork class' do
+    def new_fork_class
+      Class.new.tap do |c|
+        c.singleton_class.class_eval do
+          prepend Datadog::Profiling::Ext::Forking::Kernel
+
+          def fork(&block)
+            Kernel.fork(&block)
+          end
+        end
+      end
+    end
+
+    subject(:fork_class) { new_fork_class }
+
+    before do
+      # Stub out actual forking, return mock result.
+      # This also makes callback order deterministic.
+      allow(Kernel).to receive(:fork) do |*_args, &b|
+        b.call
+        :fork_result
+      end
+    end
+  end
+
+  shared_context 'at_fork callbacks' do
+    let(:prepare) { double('prepare') }
+    let(:child) { double('child') }
+    let(:parent) { double('parent') }
+
+    before do
+      fork_class.at_fork(:prepare) { prepare.call }
+      fork_class.at_fork(:child) { child.call }
+      fork_class.at_fork(:parent) { parent.call }
+    end
+
+    after do
+      described_class.at_fork_blocks.clear
+    end
+  end
+
+  context 'when applied to a class with forking' do
+    include_context 'fork class'
+
+    it do
+      is_expected.to respond_to(:fork)
+      is_expected.to respond_to(:at_fork)
+    end
+
+    describe '#fork' do
+      subject(:fork) { fork_class.fork(&block) }
+      let(:block) { proc {} }
+
+      context 'when no callbacks are configured' do
+        it 'passes through to original #fork' do
+          expect { |b| fork_class.fork(&b) }.to yield_control
+          is_expected.to be :fork_result
+        end
+      end
+
+      context 'when callbacks are configured' do
+        include_context 'at_fork callbacks'
+
+        it 'invokes all the callbacks in order' do
+          expect(prepare).to receive(:call).ordered
+          expect(child).to receive(:call).ordered
+          expect(parent).to receive(:call).ordered
+
+          is_expected.to be :fork_result
+        end
+      end
+    end
+
+    describe '#at_fork' do
+      include_context 'at_fork callbacks'
+
+      let(:callback) { double('callback') }
+      let(:block) { proc { callback.call } }
+
+      context 'by default' do
+        subject(:at_fork) do
+          fork_class.at_fork(&block)
+        end
+
+        it 'adds a :prepare callback' do
+          at_fork
+
+          expect(prepare).to receive(:call).ordered
+          expect(callback).to receive(:call).ordered
+          expect(child).to receive(:call).ordered
+          expect(parent).to receive(:call).ordered
+
+          fork_class.fork {}
+        end
+      end
+
+      context 'given a stage' do
+        subject(:at_fork) do
+          fork_class.at_fork(stage, &block)
+        end
+
+        context ':prepare' do
+          let(:stage) { :prepare }
+
+          it 'adds a prepare callback' do
+            at_fork
+
+            expect(prepare).to receive(:call).ordered
+            expect(callback).to receive(:call).ordered
+            expect(child).to receive(:call).ordered
+            expect(parent).to receive(:call).ordered
+
+            fork_class.fork {}
+          end
+        end
+
+        context ':child' do
+          let(:stage) { :child }
+
+          it 'adds a child callback' do
+            at_fork
+
+            expect(prepare).to receive(:call).ordered
+            expect(child).to receive(:call).ordered
+            expect(callback).to receive(:call).ordered
+            expect(parent).to receive(:call).ordered
+
+            fork_class.fork {}
+          end
+        end
+
+        context ':parent' do
+          let(:stage) { :parent }
+
+          it 'adds a parent callback' do
+            at_fork
+
+            expect(prepare).to receive(:call).ordered
+            expect(child).to receive(:call).ordered
+            expect(parent).to receive(:call).ordered
+            expect(callback).to receive(:call).ordered
+
+            fork_class.fork {}
+          end
+        end
+      end
+    end
+  end
+
+  context 'when applied to multiple classes with forking' do
+    include_context 'fork class'
+
+    let(:other_fork_class) { new_fork_class }
+
+    context 'and #at_fork is called in one' do
+      include_context 'at_fork callbacks'
+
+      it 'applies the callback to the original class' do
+        expect(prepare).to receive(:call).ordered
+        expect(child).to receive(:call).ordered
+        expect(parent).to receive(:call).ordered
+
+        fork_class.fork {}
+      end
+
+      it 'applies the callback to the other class' do
+        expect(prepare).to receive(:call).ordered
+        expect(child).to receive(:call).ordered
+        expect(parent).to receive(:call).ordered
+
+        other_fork_class.fork {}
+      end
+    end
+  end
+end

--- a/spec/ddtrace/profiling/spec_helper.rb
+++ b/spec/ddtrace/profiling/spec_helper.rb
@@ -3,15 +3,22 @@ require 'ddtrace/profiling'
 module ProfilingFeatureHelpers
   RSpec.shared_context 'with profiling extensions' do
     around do |example|
-      unmodified_class = ::Thread.dup
+      unmodified_thread_class = ::Thread.dup
+      unmodified_process_class = ::Process.dup
+      unmodified_kernel_class = ::Kernel.dup
 
       # Setup profiling to add
       require 'ddtrace/profiling/tasks/setup'
       Datadog::Profiling::Tasks::Setup.new.run
 
       example.run
+
       Object.send(:remove_const, :Thread)
-      Object.const_set('Thread', unmodified_class)
+      Object.const_set('Thread', unmodified_thread_class)
+      Object.send(:remove_const, :Process)
+      Object.const_set('Process', unmodified_process_class)
+      Object.send(:remove_const, :Kernel)
+      Object.const_set('Kernel', unmodified_kernel_class)
     end
   end
 end


### PR DESCRIPTION
We currently have a number of processes, background workers running on threads, which must run continuously in order to function. When Ruby forks, it terminates threads (including these workers), which must be manually restarted.

There is no Ruby-provided hook for running code at the start of new forks (see https://bugs.ruby-lang.org/issues/5446), so right now we depend upon leveraging analogous "on fork" hooks implemented within various frameworks that do the forking (e.g. Resque, Puma, etc.) This means users must manually add this configuration.

This pull request provides an `on_fork` hook, that leverages `ddtracerb` to patch `fork` to trigger callbacks. When a callback is defined, it will be invoked within the fork prior to any other code being executed.

We could use this hook to restart our worker processes automatically, so users do not have to configure their applications.