### PR TITLE
test:Fix sucker_punch flaky test

### DIFF
--- a/spec/ddtrace/contrib/sucker_punch/patcher_spec.rb
+++ b/spec/ddtrace/contrib/sucker_punch/patcher_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe 'sucker_punch instrumentation' do
     end
 
     it 'should instrument enqueuing for a delayed job' do
-      is_expected.to be true
+      dummy_worker_delay
       try_wait_until { fetch_spans.any? }
 
       expect(enqueue_span.service).to eq('sucker_punch')


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/1691/workflows/ebaf9777-0229-49e2-9172-438841cea5d4/jobs/81378:
```
  1) sucker_punch instrumentation delayed job should instrument enqueuing for a delayed job
     Failure/Error: is_expected.to be true
     
       expected true
            got false
     # ./spec/ddtrace/contrib/sucker_punch/patcher_spec.rb:118:in `block in <main>'
     # ./spec/ddtrace/contrib/sucker_punch/patcher_spec.rb:23:in `block in <main>'
```

This error happens because `SuckerPunch::Job#perform_in` schedules the job to be performed and then checks if the job status is `:pending` right before returning. If the job finishes too quickly, it might have already been moved into a `:fulfilled`, thus making `#perform_in` return false.

This PR does not verify the return value of `#perform_in` anymore, as it is unimportant to our tests, but maintains the verification that the job has finished and that the correct spans have been generated.