### PR TITLE
Add a single top level span for Racecar consumers

### DIFF
--- a/lib/ddtrace/contrib/racecar/events.rb
+++ b/lib/ddtrace/contrib/racecar/events.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/contrib/racecar/events/batch'
 require 'ddtrace/contrib/racecar/events/message'
+require 'ddtrace/contrib/racecar/events/consume'
 
 module Datadog
   module Contrib
@@ -7,6 +8,7 @@ module Datadog
       # Defines collection of instrumented Racecar events
       module Events
         ALL = [
+          Events::Consume,
           Events::Batch,
           Events::Message
         ].freeze

--- a/lib/ddtrace/contrib/racecar/events/consume.rb
+++ b/lib/ddtrace/contrib/racecar/events/consume.rb
@@ -1,0 +1,27 @@
+require 'ddtrace/contrib/racecar/ext'
+require 'ddtrace/contrib/racecar/event'
+
+module Datadog
+  module Contrib
+    module Racecar
+      module Events
+        # Defines instrumentation for main_loop.racecar event
+        module Consume
+          include Racecar::Event
+
+          EVENT_NAME = 'main_loop.racecar'.freeze
+
+          module_function
+
+          def event_name
+            self::EVENT_NAME
+          end
+
+          def span_name
+            Ext::SPAN_CONSUME
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/racecar/ext.rb
+++ b/lib/ddtrace/contrib/racecar/ext.rb
@@ -10,6 +10,7 @@ module Datadog
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_TRACE_RACECAR_ANALYTICS_SAMPLE_RATE'.freeze
         ENV_ANALYTICS_SAMPLE_RATE_OLD = 'DD_RACECAR_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'racecar'.freeze
+        SPAN_CONSUME = 'racecar.consume'.freeze
         SPAN_BATCH = 'racecar.batch'.freeze
         SPAN_MESSAGE = 'racecar.message'.freeze
         TAG_CONSUMER = 'kafka.consumer'.freeze


### PR DESCRIPTION
Right now, Racecar consumer processes use one of two top level span names based on the mode of operation: `racecar.message` or`racecar.batch`. Because of this, the Datadog interface cannot show single message consumers and batch consumers in the same list.

This change subscribes to the `main_loop` event which wraps both of these more specific events. The new span is called `racecar.consume` since that is the logical operation.