### PR TITLE
Add Components#startup! hook

### DIFF
--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -22,9 +22,9 @@ module Datadog
         # Build immutable components from settings
         @components ||= nil
         @components = if @components
-                        Components.replace!(@components, target)
+                        replace_components!(target, @components)
                       else
-                        Components.new(target)
+                        build_components(target)
                       end
 
         target
@@ -41,13 +41,29 @@ module Datadog
       :tracer
 
     def shutdown!
-      components.teardown! if @components
+      components.shutdown! if instance_variable_defined?(:@components) && @components
     end
 
     protected
 
     def components
-      @components ||= Components.new(configuration)
+      @components ||= build_components(configuration)
+    end
+
+    private
+
+    def build_components(settings)
+      components = Components.new(settings)
+      components.startup!(settings)
+      components
+    end
+
+    def replace_components!(settings, old)
+      components = Components.new(settings)
+
+      old.shutdown!(components)
+      components.startup!(settings)
+      components
     end
   end
 end

--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -10,12 +10,6 @@ module Datadog
     # rubocop:disable Metrics/LineLength
     class Components
       class << self
-        def replace!(old, settings)
-          replacement = new(settings)
-          old.teardown!(replacement)
-          replacement
-        end
-
         def build_health_metrics(settings)
           settings = settings.diagnostics.health_metrics
           options = { enabled: settings.enabled }
@@ -118,10 +112,13 @@ module Datadog
         @health_metrics = self.class.build_health_metrics(settings)
       end
 
+      # Starts up components
+      def startup!(settings); end
+
       # Shuts down all the components in use.
       # If it has another instance to compare to, it will compare
       # and avoid tearing down parts still in use.
-      def teardown!(replacement = nil)
+      def shutdown!(replacement = nil)
         # Shutdown the old tracer, unless it's still being used.
         # (e.g. a custom tracer instance passed in.)
         tracer.shutdown! unless replacement && tracer == replacement.tracer

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -40,24 +40,6 @@ RSpec.describe Datadog::Configuration::Components do
     end
   end
 
-  describe '::replace!' do
-    subject(:replace!) { described_class.replace!(old, settings) }
-    let(:old) { instance_double(described_class) }
-    let(:replacement) { instance_double(described_class) }
-    let(:settings) { instance_double(Datadog::Configuration::Settings) }
-
-    it do
-      expect(described_class).to receive(:new)
-        .with(settings)
-        .and_return(replacement)
-
-      expect(old).to receive(:teardown!)
-        .with(replacement)
-
-      is_expected.to be replacement
-    end
-  end
-
   describe '::build_health_metrics' do
     subject(:build_health_metrics) { described_class.build_health_metrics(settings) }
 
@@ -624,8 +606,8 @@ RSpec.describe Datadog::Configuration::Components do
     end
   end
 
-  describe '#teardown!' do
-    subject(:teardown!) { components.teardown!(replacement) }
+  describe '#shutdown!' do
+    subject(:shutdown!) { components.shutdown!(replacement) }
 
     context 'given no replacement' do
       let(:replacement) { nil }
@@ -639,7 +621,7 @@ RSpec.describe Datadog::Configuration::Components do
         expect(components.runtime_metrics.metrics.statsd).to receive(:close)
         expect(components.health_metrics.statsd).to receive(:close)
 
-        teardown!
+        shutdown!
       end
     end
 
@@ -671,7 +653,7 @@ RSpec.describe Datadog::Configuration::Components do
           expect(components.runtime_metrics.metrics.statsd).to receive(:close)
           expect(components.health_metrics.statsd).to receive(:close)
 
-          teardown!
+          shutdown!
         end
 
         context 'and Statsd is not initialized' do
@@ -689,7 +671,7 @@ RSpec.describe Datadog::Configuration::Components do
               .with(true)
             expect(components.health_metrics.statsd).to receive(:close)
 
-            teardown!
+            shutdown!
           end
         end
       end
@@ -708,7 +690,7 @@ RSpec.describe Datadog::Configuration::Components do
           expect(components.runtime_metrics.metrics.statsd).to receive(:close)
           expect(components.health_metrics.statsd).to receive(:close)
 
-          teardown!
+          shutdown!
         end
       end
 
@@ -726,7 +708,7 @@ RSpec.describe Datadog::Configuration::Components do
           expect(components.runtime_metrics.metrics.statsd).to_not receive(:close)
           expect(components.health_metrics.statsd).to receive(:close)
 
-          teardown!
+          shutdown!
         end
       end
 
@@ -745,7 +727,7 @@ RSpec.describe Datadog::Configuration::Components do
           expect(components.runtime_metrics.metrics.statsd).to_not receive(:close)
           expect(components.health_metrics.statsd).to_not receive(:close)
 
-          teardown!
+          shutdown!
         end
       end
     end


### PR DESCRIPTION
Some parts of `Datadog::Configuration::Components` require startup (namely worker threads); this pull request adds a `Components#startup!` method which defines this behavior. It also does some minor refactoring of how components are built/replaced in the configuration cycle (original behavior should be largely unaffected though.)

This hook isn't employed in this PR but will become necessary for profiling and other auto-starting processes.