### PR TITLE
fix:Race condition on instance variable assignment

### DIFF
--- a/lib/ddtrace/workers/async.rb
+++ b/lib/ddtrace/workers/async.rb
@@ -42,7 +42,7 @@ module Datadog
         end
 
         def run_async?
-          @run_async = false unless instance_variable_defined?(:@run_async)
+          return false unless instance_variable_defined?(:@run_async)
           @run_async == true
         end
 
@@ -55,7 +55,7 @@ module Datadog
         end
 
         def error?
-          @error = nil unless instance_variable_defined?(:@error)
+          return false unless instance_variable_defined?(:@error)
           !@error.nil?
         end
 

--- a/lib/ddtrace/workers/loop.rb
+++ b/lib/ddtrace/workers/loop.rb
@@ -33,7 +33,7 @@ module Datadog
       end
 
       def run_loop?
-        @run_loop = false unless instance_variable_defined?(:@run_loop)
+        return false unless instance_variable_defined?(:@run_loop)
         @run_loop == true
       end
 

--- a/lib/ddtrace/workers/polling.rb
+++ b/lib/ddtrace/workers/polling.rb
@@ -34,7 +34,7 @@ module Datadog
       end
 
       def enabled?
-        @enabled = true unless instance_variable_defined?(:@enabled)
+        return true unless instance_variable_defined?(:@enabled)
         @enabled
       end
 


### PR DESCRIPTION
This PR fixes most recent CI timeouts, specially the ones seen for JRuby:
```
Failures:

  1) Datadog::Workers::Polling when included into a worker #perform by default 
     Failure/Error: raise StandardError, 'Wait time exhausted!' if attempts <= 0
     
     StandardError:
       Wait time exhausted!
     # ./spec/support/synchronization_helpers.rb:41:in `block in try_wait_until'
     # ./spec/support/synchronization_helpers.rb:36:in `try_wait_until'
     # ./spec/ddtrace/workers/polling_spec.rb:27:in `block in <main>'
```

These timeouts happen because probing `worker.run_loop?` can have the non-thread-safe side-effect of setting `@run_loop = false`:
```ruby
def run_async?
  @run_async = false unless instance_variable_defined?(:@run_async)
  @run_async == true
end
```

If the check for `instance_variable_defined?(:@run_async)` is executed then the Ruby VM context switches to:
```ruby
def perform_loop
  @run_loop = true

  loop do
    # ...
    return unless run_loop? || work_pending?
  end
end
```

which sets it to true: `@run_loop = true`.

Then context switches back and executes the assignment part of:
```ruby
@run_async = false unless instance_variable_defined?(:@run_async)
```

`@run_async` will be set to `false` prematurely, effectively terminating the worker.

One alternative solution to the changes in this PR is to wrap `#run_async?` in a mutex, but this is not necessary, as the changes introduced here respect strict **Happened-before** semantics: we wait until `instance_variable_defined?(:@run_async)` returns `true` for us to ever evaluate `@run_async`, and assigning a value to `@run_async` is guaranteed to happen before `instance_variable_defined?(:@run_async)` returns `true`, so we now only read it when it's guaranteed to be available.
Also we stop assigning a value `@run_async`, which means this method does not have to worry about read/write race conditions that it could cause.

I've applied this fix to all instances of such pattern I could find in our code base.