### PR TITLE
ci:Remove gitlab deployment when not applicable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ copy_to_s3:
     - if: '$CI_COMMIT_BRANCH == "master"'
       when: on_success
     - when: manual
+      allow_failure: true
   script:
     - export ACCESS_KEY_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-rb.secret_key_id --with-decryption --query "Parameter.Value" --out text)
     - export SECRET_ACCESS_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-rb.secret_sec_key_id --with-decryption --query "Parameter.Value" --out text)


### PR DESCRIPTION
This removes the Gitlab internal CI check from all Github commits, unless it's applicable: only `master` commits and manually triggered Gitlab job runs will show up here on Github.
![Screen Shot 2020-08-31 at 3 43 05 PM](https://user-images.githubusercontent.com/583503/91760065-aee8ab80-eba0-11ea-9ba8-ff595f052673.png)

This will allow our commits to come back into a ✅ state when everything passes.