### PR TITLE
Autostart profiler

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2407,33 +2407,13 @@ In addition, CPU time measurements require:
 
 2. Enable profiling flag:
 
-    Set `DD_PROFILING_ENABLED=true` in your environment, or enable it using `Datadog.configure`.
+    Set `DD_PROFILING_ENABLED=true` in your environment, OR enable it using `Datadog.configure`.
 
     For Rails applications, you can set this in `config/initializers/datadog.rb`:
 
     ```ruby
     Datadog.configure do |c|
       c.profiling.enabled = true
-    end
-    ```
-
-    Then start the profiler with:
-
-    ```ruby
-    # Start the profiler
-    Datadog.profiler.start
-    ```
-
-3. Add restart hooks, if necessary:
-
-    Additionally, some applications create forked processes. Profiling must be started in their `after_fork` callback, if available.
-
-    For example, in Puma applications, in `puma.rb`:
-
-    ```ruby
-    on_worker_boot do
-      # Start datadog profiler
-      Datadog.profiler.start
     end
     ```
 

--- a/lib/ddtrace/profiling.rb
+++ b/lib/ddtrace/profiling.rb
@@ -3,7 +3,6 @@ module Datadog
   module Profiling
     module_function
 
-    FFI_MINIMUM_VERSION = Gem::Version.new('1.0')
     GOOGLE_PROTOBUF_MINIMUM_VERSION = Gem::Version.new('3.0')
 
     def supported?
@@ -11,10 +10,8 @@ module Datadog
     end
 
     def native_cpu_time_supported?
-      RUBY_PLATFORM != 'java' \
-        && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1') \
-        && !Gem.loaded_specs['ffi'].nil? \
-        && Gem.loaded_specs['ffi'].version >= FFI_MINIMUM_VERSION
+      require 'ddtrace/profiling/ext/cpu'
+      Ext::CPU.supported?
     end
 
     def google_protobuf_supported?
@@ -24,6 +21,9 @@ module Datadog
     end
 
     def load_profiling
+      require 'ddtrace/profiling/ext/cpu'
+      require 'ddtrace/profiling/ext/forking'
+
       require 'ddtrace/profiling/collectors/stack'
       require 'ddtrace/profiling/exporter'
       require 'ddtrace/profiling/recorder'

--- a/lib/ddtrace/profiling/ext/cpu.rb
+++ b/lib/ddtrace/profiling/ext/cpu.rb
@@ -1,0 +1,24 @@
+module Datadog
+  module Profiling
+    module Ext
+      # Extensions for CPU
+      module CPU
+        FFI_MINIMUM_VERSION = Gem::Version.new('1.0')
+
+        def self.supported?
+          RUBY_PLATFORM != 'java' \
+            && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1') \
+            && !Gem.loaded_specs['ffi'].nil? \
+            && Gem.loaded_specs['ffi'].version >= FFI_MINIMUM_VERSION
+        end
+
+        def self.apply!
+          return false unless supported?
+
+          require 'ddtrace/profiling/ext/cthread'
+          ::Thread.send(:prepend, Profiling::Ext::CThread)
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/profiling/ext/cthread.rb
+++ b/lib/ddtrace/profiling/ext/cthread.rb
@@ -18,6 +18,7 @@ module Datadog
 
         def self.prepended(base)
           # Be sure to update the current thread too; as it wouldn't have been set.
+          ::Thread.current.class.send(:prepend, CThread) unless base == ::Thread.current.class
           ::Thread.current.send(:update_native_ids)
         end
 

--- a/lib/ddtrace/profiling/ext/forking.rb
+++ b/lib/ddtrace/profiling/ext/forking.rb
@@ -8,7 +8,7 @@ module Datadog
         end
 
         def self.apply!
-          return unless supported?
+          return false unless supported?
 
           modules = [::Process, ::Kernel]
           # TODO: Ruby < 2.3 doesn't support Binding#receiver.

--- a/lib/ddtrace/profiling/ext/forking.rb
+++ b/lib/ddtrace/profiling/ext/forking.rb
@@ -27,6 +27,7 @@ module Datadog
               end
             else
               mod.extend(Kernel)
+              mod.class.send(:prepend, Kernel)
             end
           end
         end

--- a/lib/ddtrace/profiling/preload.rb
+++ b/lib/ddtrace/profiling/preload.rb
@@ -1,7 +1,3 @@
-require 'ddtrace/profiling'
+require 'ddtrace/profiling/tasks/setup'
 
-if Datadog::Profiling.supported? && Datadog::Profiling.native_cpu_time_supported?
-  Datadog::Profiling::Tasks::Setup.new.run
-else
-  puts '[DDTRACE] Profiling not supported; skipping preload.'
-end
+Datadog::Profiling::Tasks::Setup.new.run

--- a/lib/ddtrace/profiling/tasks/setup.rb
+++ b/lib/ddtrace/profiling/tasks/setup.rb
@@ -1,3 +1,8 @@
+require 'ddtrace'
+require 'ddtrace/profiling'
+require 'ddtrace/profiling/ext/cpu'
+require 'ddtrace/profiling/ext/forking'
+
 module Datadog
   module Profiling
     module Tasks
@@ -5,23 +10,36 @@ module Datadog
       class Setup
         def run
           activate_main_extensions
-          activate_thread_extensions
+          activate_cpu_extensions
         end
 
         def activate_main_extensions
-          # Add forking extensions
-          require 'ddtrace/profiling/ext/forking'
-          Ext::Forking.apply!
+          if Ext::Forking.supported?
+            Ext::Forking.apply!
+          elsif Datadog.configuration.profiling.enabled
+            # Log warning if profiling was supposed to be activated.
+            log '[DDTRACE] Forking extensions skipped; forking not supported.'
+          end
         rescue StandardError, ScriptError => e
-          puts "[DDTRACE] Forking extensions unavailable. Cause: #{e.message} Location: #{e.backtrace.first}"
+          log "[DDTRACE] Forking extensions unavailable. Cause: #{e.message} Location: #{e.backtrace.first}"
         end
 
-        def activate_thread_extensions
-          # Activate CPU timings
-          require 'ddtrace/profiling/ext/thread'
-          ::Thread.send(:prepend, Profiling::Ext::CThread)
+        def activate_cpu_extensions
+          if Ext::CPU.supported?
+            Ext::CPU.apply!
+          elsif Datadog.configuration.profiling.enabled
+            # Log warning if profiling was supposed to be activated.
+            log '[DDTRACE] CPU profiling skipped; native CPU time is not supported.'
+          end
         rescue StandardError, ScriptError => e
-          puts "[DDTRACE] CPU profiling unavailable. Cause: #{e.message} Location: #{e.backtrace.first}"
+          log "[DDTRACE] CPU profiling unavailable. Cause: #{e.message} Location: #{e.backtrace.first}"
+        end
+
+        private
+
+        def log(message)
+          # Print to STDOUT for now because logging may not be setup yet...
+          puts message
         end
       end
     end

--- a/spec/ddtrace/profiling/ext/cpu_spec.rb
+++ b/spec/ddtrace/profiling/ext/cpu_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+require 'ddtrace/profiling'
+require 'ddtrace/profiling/ext/cpu'
+
+RSpec.describe Datadog::Profiling::Ext::CPU do
+  extend ConfigurationHelpers
+
+  describe '::supported?' do
+    subject(:supported?) { described_class.supported? }
+
+    context 'when MRI Ruby is used' do
+      before { stub_const('RUBY_PLATFORM', 'x86_64-linux') }
+
+      context 'of version < 2.1' do
+        before { stub_const('RUBY_VERSION', '2.0') }
+        it { is_expected.to be false }
+      end
+
+      context 'of version >= 2.1' do
+        before { stub_const('RUBY_VERSION', '2.1') }
+
+        context 'and \'ffi\'' do
+          context 'is not available' do
+            include_context 'loaded gems', ffi: nil
+            it { is_expected.to be false }
+          end
+
+          context 'is available' do
+            context 'and meeting the minimum version' do
+              include_context 'loaded gems',
+                              ffi: described_class::FFI_MINIMUM_VERSION
+
+              it { is_expected.to be true }
+            end
+
+            context 'but is below the minimum version' do
+              include_context 'loaded gems',
+                              ffi: decrement_gem_version(described_class::FFI_MINIMUM_VERSION)
+
+              it { is_expected.to be false }
+            end
+          end
+        end
+      end
+    end
+
+    context 'when JRuby is used' do
+      before { stub_const('RUBY_PLATFORM', 'java') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '::apply!' do
+    subject(:apply!) { described_class.apply! }
+
+    around do |example|
+      unmodified_thread_class = ::Thread.dup
+
+      example.run
+
+      Object.send(:remove_const, :Thread)
+      Object.const_set('Thread', unmodified_thread_class)
+    end
+
+    context 'when native CPU time is supported' do
+      before { skip 'CPU profiling not supported' unless described_class.supported? }
+
+      it 'adds Thread extensions' do
+        apply!
+        expect(Thread.ancestors).to include(Datadog::Profiling::Ext::CThread)
+      end
+    end
+
+    context 'when native CPU time is not supported' do
+      before do
+        allow(described_class)
+          .to receive(:supported?)
+          .and_return(false)
+      end
+
+      it 'skips adding Thread extensions' do
+        is_expected.to be false
+      end
+    end
+  end
+end

--- a/spec/ddtrace/profiling/ext/cthread_spec.rb
+++ b/spec/ddtrace/profiling/ext/cthread_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 require 'ddtrace/profiling'
 
-if Datadog::Profiling.native_cpu_time_supported?
-  require 'ddtrace/profiling/ext/thread'
+if Datadog::Profiling::Ext::CPU.supported?
+  require 'ddtrace/profiling/ext/cthread'
 
   RSpec.describe Datadog::Profiling::Ext::CThread do
     subject(:thread) do
@@ -63,7 +63,7 @@ if Datadog::Profiling.native_cpu_time_supported?
       context 'main thread' do
         context 'when forked' do
           it 'returns a new native thread ID' do
-            # Get main thread clock ID
+            # Get main thread native ID
             original_native_thread_id = thread_class.current.native_thread_id
 
             expect_in_fork do

--- a/spec/ddtrace/profiling/preload_spec.rb
+++ b/spec/ddtrace/profiling/preload_spec.rb
@@ -3,40 +3,14 @@ require 'ddtrace/profiling'
 
 RSpec.describe 'Profiling preloading' do
   subject(:preload) { load 'ddtrace/profiling/preload.rb' }
+  let(:setup_task) { instance_double(Datadog::Profiling::Tasks::Setup) }
 
-  shared_examples_for 'skipped preloading' do
-    it 'displays a warning' do
-      expect(STDOUT).to receive(:puts) do |message|
-        expect(message).to include('Profiling not supported')
-      end
-
-      preload
-    end
+  before do
+    allow(Datadog::Profiling::Tasks::Setup).to receive(:new).and_return(setup_task)
   end
 
-  context 'when profiling is not supported' do
-    before { allow(Datadog::Profiling).to receive(:supported?).and_return(false) }
-    it_behaves_like 'skipped preloading'
-  end
-
-  context 'when native CPU time is not supported' do
-    before { allow(Datadog::Profiling).to receive(:native_cpu_time_supported?).and_return(false) }
-    it_behaves_like 'skipped preloading'
-  end
-
-  context 'when profiling and native CPU time is supported' do
-    let(:setup_task) { instance_double(Datadog::Profiling::Tasks::Setup) }
-
-    before do
-      allow(Datadog::Profiling).to receive(:supported?).and_return(true)
-      allow(Datadog::Profiling).to receive(:native_cpu_time_supported?).and_return(true)
-      allow(Datadog::Profiling::Tasks::Setup).to receive(:new).and_return(setup_task)
-    end
-
-    it 'preloads without warning' do
-      expect(setup_task).to receive(:run)
-      expect(STDOUT).to_not receive(:puts)
-      preload
-    end
+  it 'runs the Profiling::Tasks::Setup task' do
+    expect(setup_task).to receive(:run)
+    preload
   end
 end

--- a/spec/ddtrace/profiling/tasks/setup_spec.rb
+++ b/spec/ddtrace/profiling/tasks/setup_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+require 'ddtrace/profiling/spec_helper'
+
 require 'ddtrace/profiling'
 require 'ddtrace/profiling/tasks/setup'
 require 'ddtrace/profiling/ext/forking'
@@ -12,6 +14,7 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
     it do
       expect(task).to receive(:activate_main_extensions).ordered
       expect(task).to receive(:activate_cpu_extensions).ordered
+      expect(task).to receive(:autostart_profiler).ordered
       run
     end
   end
@@ -161,6 +164,131 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
           expect(Datadog::Profiling::Ext::CPU).to_not receive(:apply!)
           expect(STDOUT).to_not receive(:puts)
           activate_cpu_extensions
+        end
+      end
+    end
+  end
+
+  describe '#autostart_profiler' do
+    subject(:autostart_profiler) { task.autostart_profiler }
+
+    context 'when profiling' do
+      context 'is supported' do
+        let(:profiler) { instance_double(Datadog::Profiler) }
+
+        before do
+          skip 'Profiling not supported.' unless defined?(Datadog::Profiler)
+
+          allow(Datadog::Profiling)
+            .to receive(:supported?)
+            .and_return(true)
+
+          allow(Datadog)
+            .to receive(:profiler)
+            .and_return(profiler)
+        end
+
+        context 'and Process' do
+          context 'responds to #at_fork' do
+            it do
+              without_partial_double_verification do
+                allow(Process)
+                  .to receive(:respond_to?)
+                  .and_call_original
+
+                allow(Process)
+                  .to receive(:respond_to?)
+                  .with(:at_fork)
+                  .and_return(true)
+
+                expect(profiler).to receive(:start)
+
+                expect(Process).to receive(:at_fork) do |stage, &block|
+                  expect(stage).to eq(:child)
+                  # Might be better to assert it attempts to restart the profiler here
+                  expect(block).to_not be nil
+                end
+
+                autostart_profiler
+              end
+            end
+          end
+
+          context 'does not respond to #at_fork' do
+            before do
+              allow(Process)
+                .to receive(:respond_to?)
+                .and_call_original
+
+              allow(Process)
+                .to receive(:respond_to?)
+                .with(:at_fork, any_args)
+                .and_return(false)
+            end
+
+            it do
+              without_partial_double_verification do
+                expect(Process).to_not receive(:at_fork)
+                expect(profiler).to receive(:start)
+                autostart_profiler
+              end
+            end
+          end
+        end
+
+        context 'but it fails' do
+          before do
+            expect(Datadog)
+              .to receive(:profiler)
+              .and_raise(StandardError)
+          end
+
+          it 'displays a warning to STDOUT' do
+            expect(STDOUT).to receive(:puts) do |message|
+              expect(message).to include('Could not autostart profiling')
+            end
+
+            autostart_profiler
+          end
+        end
+      end
+
+      context 'isn\'t supported' do
+        before do
+          allow(Datadog::Profiling)
+            .to receive(:supported?)
+            .and_return(false)
+        end
+
+        context 'and profiling is enabled' do
+          before do
+            allow(Datadog.configuration.profiling)
+              .to receive(:enabled)
+              .and_return(true)
+          end
+
+          it 'skips profiling autostart with warning' do
+            expect(Datadog).to_not receive(:profiler)
+            expect(STDOUT).to receive(:puts) do |message|
+              expect(message).to include('Profiling did not autostart')
+            end
+
+            autostart_profiler
+          end
+        end
+
+        context 'and profiling is disabled' do
+          before do
+            allow(Datadog.configuration.profiling)
+              .to receive(:enabled)
+              .and_return(false)
+          end
+
+          it 'skips profiling autostart without warning' do
+            expect(Datadog).to_not receive(:profiler)
+            expect(STDOUT).to_not receive(:puts)
+            autostart_profiler
+          end
         end
       end
     end

--- a/spec/ddtrace/profiling_spec.rb
+++ b/spec/ddtrace/profiling_spec.rb
@@ -20,44 +20,23 @@ RSpec.describe Datadog::Profiling do
   describe 'native_cpu_time_supported?' do
     subject(:native_cpu_time_supported?) { described_class.native_cpu_time_supported? }
 
-    context 'when MRI Ruby is used' do
-      before { stub_const('RUBY_PLATFORM', 'x86_64-linux') }
-
-      context 'of version < 2.1' do
-        before { stub_const('RUBY_VERSION', '2.0') }
-        it { is_expected.to be false }
+    context 'when the CPU extension is supported' do
+      before do
+        allow(Datadog::Profiling::Ext::CPU)
+          .to receive(:supported?)
+          .and_return(true)
       end
 
-      context 'of version >= 2.1' do
-        before { stub_const('RUBY_VERSION', '2.1') }
-
-        context 'and \'ffi\'' do
-          context 'is not available' do
-            include_context 'loaded gems', ffi: nil
-            it { is_expected.to be false }
-          end
-
-          context 'is available' do
-            context 'and meeting the minimum version' do
-              include_context 'loaded gems',
-                              ffi: described_class::FFI_MINIMUM_VERSION
-
-              it { is_expected.to be true }
-            end
-
-            context 'but is below the minimum version' do
-              include_context 'loaded gems',
-                              ffi: decrement_gem_version(described_class::FFI_MINIMUM_VERSION)
-
-              it { is_expected.to be false }
-            end
-          end
-        end
-      end
+      it { is_expected.to be true }
     end
 
-    context 'when JRuby is used' do
-      before { stub_const('RUBY_PLATFORM', 'java') }
+    context 'when the CPU extension is not supported' do
+      before do
+        allow(Datadog::Profiling::Ext::CPU)
+          .to receive(:supported?)
+          .and_return(false)
+      end
+
       it { is_expected.to be false }
     end
   end


### PR DESCRIPTION
To simplify the setup of the profiler, this pull request adds an `autostart_profiler` step to the setup task for profiling. In doing so, using `ddtracerb exec` will automatically start the profiler, and set the restart hooks when forked, if profiling is enabled. If an error is raised, or profiling is enabled but not supported, it will print warnings to STDOUT.

Some pre-requisites for this are:

 - Some refactoring of the setup task (included in this PR)
 - at_fork hook (added in #1143)
 - Logging recursion fix (#1158)