### PR TITLE
Updated Rack/Rails span error setting behavior

### DIFF
--- a/lib/ddtrace/contrib/action_pack/action_controller/instrumentation.rb
+++ b/lib/ddtrace/contrib/action_pack/action_controller/instrumentation.rb
@@ -66,13 +66,6 @@ module Datadog
                 span.status = 1 if status.starts_with?('5')
               elsif Utils.exception_is_error?(exception)
                 span.set_error(exception)
-
-                # Some exception gets handled by Rails middleware before it can be set on Rack middleware
-                # The rack span is the root span of the request and should make sure it has the full exception
-                # set on it.
-                if env[:datadog_rack_request_span]
-                  env[:datadog_rack_request_span].set_error(exception)
-                end
               end
             ensure
               span.finish

--- a/lib/ddtrace/contrib/rails/middlewares.rb
+++ b/lib/ddtrace/contrib/rails/middlewares.rb
@@ -24,18 +24,16 @@ module Datadog
         rescue Exception => e
           tracer = Datadog.configuration[:rails][:tracer]
           span = tracer.active_span
-          unless span.nil?
+          if !span.nil? && ActionPack::Utils.exception_is_error?(e)
             # Only set error if it's supposed to be flagged as such
             # e.g. we don't want to flag 404s.
             # You can add custom errors via `config.action_dispatch.rescue_responses`
-            if ActionPack::Utils.exception_is_error?(e)
-              span.set_error(e)
+            span.set_error(e)
 
-              # Some exception gets handled by Rails middleware before it can be set on Rack middleware
-              # The rack span is the root span of the request and should make sure it has the full exception
-              # set on it.             
-              env[:datadog_rack_request_span].set_error(e) if env[:datadog_rack_request_span]
-            end
+            # Some exception gets handled by Rails middleware before it can be set on Rack middleware
+            # The rack span is the root span of the request and should make sure it has the full exception
+            # set on it.
+            env[:datadog_rack_request_span].set_error(e) if env[:datadog_rack_request_span]
           end
           raise e
         end

--- a/test/contrib/rails/apps/controllers.rb
+++ b/test/contrib/rails/apps/controllers.rb
@@ -4,6 +4,10 @@ require 'action_view/testing/resolvers'
 class ApplicationController < ActionController::Base; end
 
 class TracingController < ActionController::Base
+  rescue_from 'ActionController::RenderError' do 
+    render 'views/tracing/index.html.erb'
+  end
+
   include Rails.application.routes.url_helpers
 
   layout 'application'
@@ -30,6 +34,10 @@ class TracingController < ActionController::Base
 
   def index
     render 'views/tracing/index.html.erb'
+  end
+
+  def index_with_rescue_from
+    raise ActionController::RenderError
   end
 
   def partial

--- a/test/contrib/rails/apps/controllers.rb
+++ b/test/contrib/rails/apps/controllers.rb
@@ -4,7 +4,7 @@ require 'action_view/testing/resolvers'
 class ApplicationController < ActionController::Base; end
 
 class TracingController < ActionController::Base
-  rescue_from 'ActionController::RenderError' do 
+  rescue_from 'ActionController::RenderError' do
     render 'views/tracing/index.html.erb'
   end
 

--- a/test/contrib/rails/apps/routes.rb
+++ b/test/contrib/rails/apps/routes.rb
@@ -1,5 +1,6 @@
 routes = {
   '/' => 'tracing#index',
+  '/index_with_rescue_from' => 'tracing#index_with_rescue_from',
   '/nested_partial' => 'tracing#nested_partial',
   '/partial' => 'tracing#partial',
   '/full' => 'tracing#full',

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -154,7 +154,7 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_match(/\n/, request_span.get_tag('error.stack'))
   end
 
-  test 'the rack.request span does not has the Rails exception when its handled' do
+  test 'the rack.request span does not have the Rails exception when its handled with rescue_from' do
     # make a request that throws an error but is handled
     get '/index_with_rescue_from'
 
@@ -163,14 +163,14 @@ class FullStackTest < ActionDispatch::IntegrationTest
     request_span, controller_span = spans
 
     assert_equal(controller_span.name, 'rails.action_controller')
-    assert_equal(controller_span.status, 1)
+    assert_equal(controller_span.status, 1, 'rails controller span should be flagged as an error')
     assert_equal(controller_span.get_tag('error.type'), 'ActionController::RenderError')
 
     assert_equal('rack.request', request_span.name)
     assert_equal(request_span.span_type, 'web')
     assert_equal(request_span.get_tag('http.method'), 'GET')
     assert_equal(request_span.get_tag('http.status_code'), '200')
-    assert_equal(request_span.status, 0, 'span should not be flagged as an error')
+    assert_equal(request_span.status, 0, 'rack span should not be flagged as an error')
     assert_nil(request_span.get_tag('error.type'))
     assert_nil(request_span.get_tag('error.msg'))
     assert_nil(request_span.get_tag('error.stack'))    

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -154,6 +154,29 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_match(/\n/, request_span.get_tag('error.stack'))
   end
 
+  test 'the rack.request span does not has the Rails exception when its handled' do
+    # make a request that throws an error but is handled
+    get '/index_with_rescue_from'
+
+    # get spans
+    assert_operator(spans.length, :>=, 2, 'there should be at least 2 spans')
+    request_span, controller_span = spans
+
+    assert_equal(controller_span.name, 'rails.action_controller')
+    assert_equal(controller_span.status, 1)
+    assert_equal(controller_span.get_tag('error.type'), 'ActionController::RenderError')
+
+    assert_equal('rack.request', request_span.name)
+    assert_equal(request_span.span_type, 'web')
+    assert_equal(request_span.get_tag('http.method'), 'GET')
+    assert_equal(request_span.get_tag('http.status_code'), '200')
+    assert_equal(request_span.status, 0, 'span should not be flagged as an error')
+    assert_nil(request_span.get_tag('error.type'))
+    assert_nil(request_span.get_tag('error.msg'))
+    assert_nil(request_span.get_tag('error.stack'))    
+  end
+
+
   test 'custom error controllers should not override trace resource names' do
     # Simulate an error being passed to the exception controller
     # (Syntax depends on Rails integration test version)

--- a/test/contrib/rails/rack_middleware_test.rb
+++ b/test/contrib/rails/rack_middleware_test.rb
@@ -173,9 +173,8 @@ class FullStackTest < ActionDispatch::IntegrationTest
     assert_equal(request_span.status, 0, 'rack span should not be flagged as an error')
     assert_nil(request_span.get_tag('error.type'))
     assert_nil(request_span.get_tag('error.msg'))
-    assert_nil(request_span.get_tag('error.stack'))    
+    assert_nil(request_span.get_tag('error.stack'))
   end
-
 
   test 'custom error controllers should not override trace resource names' do
     # Simulate an error being passed to the exception controller


### PR DESCRIPTION
This PR addresses https://github.com/DataDog/dd-trace-rb/issues/1155 , when a user modifies or handles a Rails Controller exception in a `rescue_from` block.  Since adding https://github.com/DataDog/dd-trace-rb/pull/1124, the instrumentation has been setting any rails errors upstream on the rack span. However, in cases where these exceptions get swallowed, or re-raised with a different exception, in a `rescue_from`, this causes the rack span to contain stale information, since we haven't been accounting for `rescue_from` in our current rails instrumentation.

By moving the rails => rack span upstream error propagation from the `action_controller` instrumentation, and into the datadog rails `exception_middleware`, we ensure we're modifying the rack span as late as possible before the exception information is swallowed by rails internal  exception handling. This means that we are not going to incorrectly set a handled exception on the rack span.

Long term, adding more explicit instrumentation of the `rescue_from` code blocks (perhaps by patching `ActionController::Rescue.process_action`) and Controller before/after hooks would also cover the above use case, but it's a little unclear what that would look like (are they child spans of the controller? part of the controller? child spans of rack? etc) and how to safely test and handle all the edge cases that come with that in a way we could release reliably. For now, the priority of this PR is to ensure the rack spans are not receiving stale error information.