### PR TITLE
Ensure OpenTracer test does not leak writer thread

### DIFF
--- a/spec/ddtrace/opentracer/propagation_integration_spec.rb
+++ b/spec/ddtrace/opentracer/propagation_integration_spec.rb
@@ -11,6 +11,11 @@ if Datadog::OpenTracer.supported?
     let(:datadog_tracer) { tracer.datadog_tracer }
     let(:datadog_spans) { datadog_tracer.writer.spans(:keep) }
 
+    after do
+      # Ensure tracer is shutdown between test, as to not leak threads.
+      datadog_tracer.shutdown!
+    end
+
     def sampling_priority_metric(span)
       span.get_metric(Datadog::OpenTracer::TextMapPropagator::SAMPLING_PRIORITY_KEY)
     end


### PR DESCRIPTION
Fixes [this CI issue](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/1807/workflows/d231dc3a-567b-44cc-b380-c3e5191b263f/jobs/84823):
```
Failures:

  1) OpenTracer context propagation via OpenTracing::FORMAT_RACK when receiving a carrier with no headers 
     Failure/Error: Datadog::Statsd.new(default_hostname, default_port)
     
     ArgumentError:
       wrong number of arguments (given 2, expected 0)
     # ./lib/ddtrace/metrics.rb:47:in `initialize'
     # ./lib/ddtrace/metrics.rb:47:in `new'
     # ./lib/ddtrace/metrics.rb:47:in `default_statsd_client'
     # ./lib/ddtrace/metrics.rb:16:in `block in initialize'
```

This error happens because the OpenTracing test was not properly closing the worker thread crated by its write, causing it to interfere with subsequent test runs. This PR fixes that by properly shutting down the tracer after each run.

This error can be reproduced with the following command:
`bundle exec rspec ./spec/ddtrace/opentracer/propagation_integration_spec.rb --seed=42061`
You might have to run it a few times to it to fail.