### PR TITLE
Add string table and object sets to profiling buffer

### DIFF
--- a/lib/ddtrace/profiling/backtrace_location.rb
+++ b/lib/ddtrace/profiling/backtrace_location.rb
@@ -1,0 +1,33 @@
+module Datadog
+  module Profiling
+    # A simplified struct version of Thread::Backtrace::Location
+    class BacktraceLocation
+      attr_reader \
+        :base_label,
+        :lineno,
+        :path
+
+      def initialize(
+        base_label,
+        lineno,
+        path
+      )
+        @base_label = base_label
+        @lineno = lineno
+        @path = path
+      end
+
+      def ==(other)
+        hash == other.hash
+      end
+
+      def eql?(other)
+        hash == other.hash
+      end
+
+      def hash
+        [base_label, lineno, path].hash
+      end
+    end
+  end
+end

--- a/lib/ddtrace/profiling/buffer.rb
+++ b/lib/ddtrace/profiling/buffer.rb
@@ -1,9 +1,41 @@
 require 'ddtrace/buffer'
+require 'ddtrace/utils/string_table'
+require 'ddtrace/utils/object_set'
 
 module Datadog
   module Profiling
     # Profiling buffer that stores profiling events. The buffer has a maximum size and when
     # the buffer is full, a random event is discarded. This class is thread-safe.
-    class Buffer < Datadog::Buffer; end
+    class Buffer < Datadog::Buffer
+      def initialize(*args)
+        super
+        @caches = {}
+        @string_table = Utils::StringTable.new
+      end
+
+      def cache(cache_name)
+        synchronize do
+          @caches[cache_name] ||= Utils::ObjectSet.new
+        end
+      end
+
+      def string_table
+        synchronize do
+          @string_table
+        end
+      end
+
+      protected
+
+      def drain!
+        items = super
+
+        # Clear caches
+        @caches = {}
+        @string_table = Utils::StringTable.new
+
+        items
+      end
+    end
   end
 end

--- a/lib/ddtrace/profiling/pprof/stack_sample.rb
+++ b/lib/ddtrace/profiling/pprof/stack_sample.rb
@@ -32,7 +32,7 @@ module Datadog
           [
             stack_sample.thread_id,
             [
-              stack_sample.frames.collect(&:to_s),
+              stack_sample.frames.collect(&:hash),
               stack_sample.total_frame_count
             ]
           ].hash

--- a/lib/ddtrace/profiling/recorder.rb
+++ b/lib/ddtrace/profiling/recorder.rb
@@ -19,6 +19,10 @@ module Datadog
         end
       end
 
+      def [](event_class)
+        @buffers[event_class]
+      end
+
       def push(events)
         if events.is_a?(Array)
           # Push multiple events

--- a/lib/ddtrace/utils/object_set.rb
+++ b/lib/ddtrace/utils/object_set.rb
@@ -1,0 +1,40 @@
+require 'ddtrace/utils/sequence'
+
+module Datadog
+  module Utils
+    # Acts as a unique dictionary of objects
+    class ObjectSet
+      # You can provide a block that defines how the key
+      # for this message type is resolved.
+      def initialize(seed = 0, &block)
+        @sequence = Utils::Sequence.new(seed)
+        @items = {}
+        @key_block = block
+      end
+
+      # Submit an array of arguments that define the message.
+      # If they match an existing message, it will return the
+      # matching object. If it doesn't match, it will yield to
+      # the block with the next ID & args given.
+      def fetch(*args, &block)
+        key = @key_block ? @key_block.call(*args) : args.hash
+        # TODO: Ruby 2.0 doesn't like yielding here... switch when 2.0 is dropped.
+        # rubocop:disable Performance/RedundantBlockCall
+        @items[key] ||= block.call(@sequence.next, *args)
+      end
+
+      def length
+        @items.length
+      end
+
+      def objects
+        @items.values
+      end
+
+      def freeze
+        super
+        @items.freeze
+      end
+    end
+  end
+end

--- a/lib/ddtrace/utils/string_table.rb
+++ b/lib/ddtrace/utils/string_table.rb
@@ -1,0 +1,45 @@
+require 'ddtrace/utils/sequence'
+
+module Datadog
+  module Utils
+    # Tracks strings and returns IDs
+    class StringTable
+      def initialize
+        @sequence = Sequence.new
+        @ids = { ''.freeze => @sequence.next }
+      end
+
+      # Returns an ID for the string
+      def fetch(string)
+        @ids[string.to_s] ||= @sequence.next
+      end
+
+      # Returns the canonical copy of this string
+      # Typically used for psuedo interning; reduce
+      # identical copies of a string to one object.
+      def fetch_string(string)
+        return nil if string.nil?
+
+        # Co-erce to string
+        string = string.to_s
+
+        # Add to string table if no match
+        @ids[string] = @sequence.next unless @ids.key?(string)
+
+        # Get and return matching string in table
+        # NOTE: Have to resolve the key and retrieve from table again
+        #       because "string" argument is not same object as string key.
+        id = @ids[string]
+        @ids.key(id)
+      end
+
+      def [](id)
+        @ids.key(id)
+      end
+
+      def strings
+        @ids.keys
+      end
+    end
+  end
+end

--- a/spec/ddtrace/buffer_spec.rb
+++ b/spec/ddtrace/buffer_spec.rb
@@ -190,6 +190,42 @@ RSpec.describe Datadog::Buffer do
     end
   end
 
+  describe '#close' do
+    subject(:close) { buffer.close }
+
+    it do
+      expect { close }
+        .to change { buffer.closed? }
+        .from(false)
+        .to(true)
+    end
+  end
+
+  describe '#closed?' do
+    subject(:closed?) { buffer.closed? }
+
+    context 'when the buffer has not been closed' do
+      it { is_expected.to be false }
+    end
+
+    context 'when the buffer is closed' do
+      before { buffer.close }
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#synchronize' do
+    it 'is re-entrant' do
+      expect do
+        buffer.synchronize do
+          buffer.synchronize do
+            true
+          end
+        end
+      end.to_not raise_error
+    end
+  end
+
   describe 'performance' do
     require 'benchmark'
     let(:n) { 10_000 }

--- a/spec/ddtrace/profiling/backtrace_location_spec.rb
+++ b/spec/ddtrace/profiling/backtrace_location_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+require 'ddtrace/profiling/backtrace_location'
+
+RSpec.describe Datadog::Profiling::BacktraceLocation do
+  subject(:backtrace_location) { new_backtrace_location(base_label, lineno, path) }
+
+  def new_backtrace_location(
+    base_label = 'to_s',
+    lineno = 15,
+    path = 'path/to/file.rb'
+  )
+    described_class.new(
+      base_label,
+      lineno,
+      path
+    )
+  end
+
+  let(:base_label) { double('base_label') }
+  let(:lineno) { double('lineno') }
+  let(:path) { double('path') }
+
+  it do
+    is_expected.to have_attributes(
+      base_label: base_label,
+      lineno: lineno,
+      path: path
+    )
+  end
+
+  shared_context 'equivalent BacktraceLocations' do
+    let(:backtrace_location_one) { new_backtrace_location }
+    let(:backtrace_location_two) { new_backtrace_location }
+  end
+
+  describe '#==' do
+    context 'for two BacktraceLocations with same content' do
+      include_context 'equivalent BacktraceLocations'
+      it { expect(backtrace_location_one == backtrace_location_two).to be true }
+    end
+  end
+
+  describe '#eql?' do
+    context 'for two BacktraceLocations with same content' do
+      include_context 'equivalent BacktraceLocations'
+      it { expect(backtrace_location_one.eql?(backtrace_location_two)).to be true }
+    end
+  end
+
+  describe '#hash' do
+    context 'for two BacktraceLocations with same content' do
+      include_context 'equivalent BacktraceLocations'
+      it { expect(backtrace_location_one.hash).to be_a_kind_of(Integer) }
+      it { expect(backtrace_location_one.hash).to eq(backtrace_location_two.hash) }
+    end
+  end
+end

--- a/spec/ddtrace/profiling/buffer_spec.rb
+++ b/spec/ddtrace/profiling/buffer_spec.rb
@@ -7,4 +7,29 @@ RSpec.describe Datadog::Profiling::Buffer do
   let(:max_size) { 0 }
 
   it { is_expected.to be_a_kind_of(Datadog::Buffer) }
+
+  describe '#cache' do
+    subject(:cache) { buffer.cache(name) }
+    let(:name) { :test }
+    it { is_expected.to be_a_kind_of(Datadog::Utils::ObjectSet) }
+  end
+
+  describe '#string_table' do
+    subject(:string_table) { buffer.string_table }
+    it { is_expected.to be_a_kind_of(Datadog::Utils::StringTable) }
+  end
+
+  describe '#pop' do
+    subject(:pop) { buffer.pop }
+
+    it 'replaces the string table' do
+      expect { pop }
+        .to(change { buffer.string_table.object_id })
+    end
+
+    it 'replaces caches' do
+      expect { pop }
+        .to(change { buffer.cache(:test).object_id })
+    end
+  end
 end

--- a/spec/ddtrace/profiling/recorder_spec.rb
+++ b/spec/ddtrace/profiling/recorder_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe Datadog::Profiling::Recorder do
     end
   end
 
+  describe '#[]' do
+    subject(:buffer) { recorder[event_class] }
+
+    context 'given an event class that is defined' do
+      let(:event_class) { Class.new }
+      let(:event_classes) { [event_class] }
+
+      it { is_expected.to be_a_kind_of(Datadog::Profiling::Buffer) }
+    end
+  end
+
   describe '#push' do
     include_context 'test buffer'
 

--- a/spec/ddtrace/utils/object_set_spec.rb
+++ b/spec/ddtrace/utils/object_set_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+require 'ddtrace/utils/object_set'
+
+RSpec.describe Datadog::Utils::ObjectSet do
+  subject(:object_set) { described_class.new }
+
+  describe '::new' do
+    context 'given a seed' do
+      let(:object_set) { described_class.new(seed) }
+      let(:seed) { 100 }
+
+      let(:args) { [rand] }
+
+      it 'yields to the build block' do
+        expect { |b| object_set.fetch(*args, &b) }
+          .to yield_with_args(seed, *args)
+      end
+    end
+
+    context 'given a custom key block' do
+      let(:object_set) { described_class.new(&key_block) }
+
+      let(:key_block) { proc { |*args| key_builder.build(*args) } }
+      let(:key_builder) { double('key_builder') }
+      let(:custom_key) { double('custom key') }
+
+      let(:args) { [rand] }
+
+      it 'invokes the block to resolve keys' do
+        expect(key_builder).to receive(:build)
+          .with(*args)
+          .and_return(custom_key)
+
+        object_set.fetch(*args) { :object }
+      end
+    end
+  end
+
+  describe '#fetch' do
+    subject(:fetch) { object_set.fetch(*args, &build_block) }
+
+    context 'and unique args are provided' do
+      let(:args) { [rand] }
+      let(:build_block) { proc { |_id, *_args| object } }
+
+      let(:next_id) { double('next ID') }
+      let(:object) { double('object') }
+
+      before do
+        expect_any_instance_of(Datadog::Utils::Sequence)
+          .to receive(:next)
+          .and_return(next_id)
+      end
+
+      it 'yields to the build block' do
+        expect { |b| object_set.fetch(*args, &b) }
+          .to yield_with_args(next_id, *args)
+      end
+
+      it 'returns the object' do
+        is_expected.to be(object)
+      end
+    end
+
+    context 'and args matching an existing object are provided' do
+      let(:args) { [rand] }
+      let(:build_block) { proc { |_id, *_args| object } }
+
+      let(:original_object) { double('original object') }
+      let(:object) { double('object') }
+
+      before do
+        # Fetch same args to cache object
+        object_set.fetch(*args) { original_object }
+
+        expect_any_instance_of(Datadog::Utils::Sequence)
+          .to_not receive(:next)
+      end
+
+      it 'does not yield to the build block' do
+        expect { |b| object_set.fetch(*args, &b) }
+          .to_not yield_control
+      end
+
+      it 'returns the object' do
+        is_expected.to be(original_object)
+      end
+    end
+  end
+
+  describe '#length' do
+    subject(:length) { object_set.length }
+    it { is_expected.to eq 0 }
+
+    context 'when objects have been added' do
+      let(:n) { 3 }
+      before { n.times { object_set.fetch(rand) { rand } } }
+      it { is_expected.to eq(n) }
+    end
+  end
+
+  describe '#objects' do
+    subject(:objects) { object_set.objects }
+
+    context 'by default' do
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when objects have been added' do
+      let(:object_count) { 3 }
+
+      before do
+        object_count.times { object_set.fetch(rand) { double('object') } }
+      end
+
+      it do
+        is_expected.to be_a_kind_of(Array)
+        is_expected.to have(object_count).items
+        is_expected.to include(RSpec::Mocks::Double)
+      end
+    end
+  end
+end

--- a/spec/ddtrace/utils/string_table_spec.rb
+++ b/spec/ddtrace/utils/string_table_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+require 'ddtrace/utils/string_table'
+
+RSpec.describe Datadog::Utils::StringTable do
+  subject(:string_table) { described_class.new }
+
+  describe '#fetch' do
+    subject(:fetch) { string_table.fetch(string) }
+
+    context 'given an empty string' do
+      let(:string) { '' }
+      it { is_expected.to be 0 }
+    end
+
+    context 'given different strings' do
+      it 'returns different IDs' do
+        3.times do |i|
+          expect(string_table.fetch(i.to_s)).to be(i + 1)
+        end
+      end
+    end
+
+    context 'given the same string' do
+      let(:string) { 'foo' }
+
+      it 'returns the same ID' do
+        is_expected.to be 1
+
+        3.times do
+          expect(string_table.fetch(string)).to be(1)
+        end
+      end
+    end
+  end
+
+  describe '#fetch_string' do
+    subject(:fetch_string) { string_table.fetch_string(string) }
+    let(:string) { 'string' }
+
+    it { is_expected.to eq(string) }
+
+    it 'returns the same string object' do
+      strings = []
+      strings << string_table.fetch_string(string)
+      strings << string_table.fetch_string(string)
+      strings << string_table.fetch_string(string.dup)
+
+      expect(strings.collect(&:object_id).uniq).to have(1).item
+    end
+  end
+
+  describe '#[]' do
+    subject(:get_string) { string_table[id] }
+
+    context 'when ID doesn\'t exist in the string table' do
+      let(:id) { double('unknown ID') }
+      it { is_expected.to be nil }
+    end
+
+    context 'when the ID exsits in the string table' do
+      let(:string) { 'string' }
+      let(:id) { string_table.fetch(string) }
+      it { is_expected.to eq(string) }
+    end
+  end
+
+  describe '#strings' do
+    subject(:strings) { string_table.strings }
+
+    context 'when IDs have been added' do
+      before do
+        string_table.fetch('foo')
+        string_table.fetch('bar')
+        string_table.fetch('bar')
+      end
+
+      it 'returns all the unique strings' do
+        is_expected.to eq(['', 'foo', 'bar'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently the profiler produces a `Profiling::Events::StackSample` object per thread per sample, and within each of these samples, they have up to 128 `Thread::Backtrace::Location` objects that represent the stack. Given the buffer flushes these samples once every 60 seconds, these samples can have a significant memory footprint.

To reduce this footprint, we'd like to re-use equivalent objects wherever possible, including `StackSample`, `Backtrace::Location` and `String` objects.

In this pull request, we add secondary "string table" and "object sets" to the `Profiling::Buffer`. The idea is that before a sample is pushed to the buffer, the stack collector would use these tables to see if there's already a `BacktraceLocation` or `String` in the buffer that is equivalent. If there is, simply retrieve and re-use that object. Otherwise build or use a new object and add it to the buffer. When the buffer flushes, the string table and object sets are cleared as well, so references don't persist permanently and memory is released.