### PR TITLE
Faster TraceBuffer for CRuby

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentracing', '>= 0.4.1'
 
   # Development dependencies
+  spec.add_development_dependency 'concurrent-ruby' # Leave it open as we also have it as an integration and want Appraisal to control the version under test.
   spec.add_development_dependency 'rake', '>= 10.5'
   spec.add_development_dependency 'rubocop', '= 0.49.1' if RUBY_VERSION >= '2.1.0'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/ddtrace/buffer.rb
+++ b/lib/ddtrace/buffer.rb
@@ -2,23 +2,77 @@ require 'thread'
 require 'ddtrace/diagnostics/health'
 require 'ddtrace/runtime/object_space'
 
+# Trace buffer that accumulates traces for a consumer.
+# Consumption can happen from a different thread.
 module Datadog
-  # Trace buffer that stores application traces. The buffer has a maximum size and when
-  # the buffer is full, a random trace is discarded. This class is thread-safe and is used
-  # automatically by the ``Tracer`` instance when a ``Span`` is finished.
-  class TraceBuffer
+  # Aggregate metrics:
+  # They reflect buffer activity since last #pop.
+  # These may not be as accurate or as granular, but they
+  # don't use as much network traffic as live stats.
+  class MeasuredBuffer
+    def initialize
+      @buffer_accepted = 0
+      @buffer_accepted_lengths = 0
+      @buffer_dropped = 0
+      @buffer_spans = 0
+    end
+
+    def measure_accept(trace)
+      @buffer_spans += trace.length
+      @buffer_accepted += 1
+      @buffer_accepted_lengths += trace.length
+    rescue StandardError => e
+      Datadog.logger.debug("Failed to measure queue accept. Cause: #{e.message} Source: #{e.backtrace.first}")
+    end
+
+    def measure_drop(trace)
+      @buffer_dropped += 1
+      @buffer_spans -= trace.length
+      @buffer_accepted_lengths -= trace.length
+    rescue StandardError => e
+      Datadog.logger.debug("Failed to measure queue drop. Cause: #{e.message} Source: #{e.backtrace.first}")
+    end
+
+    def measure_pop(traces)
+      # Accepted
+      Datadog.health_metrics.queue_accepted(@buffer_accepted)
+      Datadog.health_metrics.queue_accepted_lengths(@buffer_accepted_lengths)
+
+      # Dropped
+      Datadog.health_metrics.queue_dropped(@buffer_dropped)
+
+      # Queue gauges
+      Datadog.health_metrics.queue_max_length(@max_size)
+      Datadog.health_metrics.queue_spans(@buffer_spans)
+      Datadog.health_metrics.queue_length(traces.length)
+
+      # Reset aggregated metrics
+      @buffer_accepted = 0
+      @buffer_accepted_lengths = 0
+      @buffer_dropped = 0
+      @buffer_spans = 0
+    rescue StandardError => e
+      Datadog.logger.debug("Failed to measure queue. Cause: #{e.message} Source: #{e.backtrace.first}")
+    end
+  end
+
+  # Trace buffer that stores application traces and
+  # can be safely used concurrently on any environment.
+  #
+  # This implementation uses a {Mutex} around public methods, incurring
+  # overhead in order to ensure full thread-safety.
+  #
+  # This is implementation is recommended for non-CRuby environments.
+  # If using CRuby, {Datadog::CRubyTraceBuffer} is a faster implementation with minimal compromise.
+  class ThreadSafeBuffer < MeasuredBuffer
     def initialize(max_size)
+      super()
+
       @max_size = max_size
 
       @mutex = Mutex.new()
       @traces = []
       @closed = false
-
-      # Initialize metric values
-      @buffer_accepted = 0
-      @buffer_accepted_lengths = 0
-      @buffer_dropped = 0
-      @buffer_spans = 0
     end
 
     # Add a new ``trace`` in the local queue. This method doesn't block the execution
@@ -72,48 +126,103 @@ module Datadog
         @closed = true
       end
     end
+  end
 
-    # Aggregate metrics:
-    # They reflect buffer activity since last #pop.
-    # These may not be as accurate or as granular, but they
-    # don't use as much network traffic as live stats.
+  # Trace buffer that stores application traces and
+  # can be safely used concurrently with CRuby.
+  #
+  # Under extreme concurrency scenarios, this class can exceed
+  # its +max_size+ by up to 4%.
+  #
+  # Because singular +Array+ operations are thread-safe in CRuby,
+  # we can implement the trace buffer without an explicit lock,
+  # while making the compromise of allowing the buffer to go
+  # over its maximum limit under extreme circumstances.
+  #
+  # On the following scenario:
+  # * 4.5 million spans/second.
+  # * Pushed into a single CRubyTraceBuffer from 1000 threads.
+  # The buffer can exceed its maximum size by no more than 4%.
+  #
+  # This implementation allocates 17-93% less memory and
+  # is 5-15% faster than {Datadog::ThreadSafeBuffer}.
+  #
+  # @see spec/ddtrace/benchmark/buffer_benchmark_spec.rb Buffer benchmarks
+  # @see https://github.com/ruby-concurrency/concurrent-ruby/blob/c1114a0c6891d9634f019f1f9fe58dcae8658964/lib/concurrent-ruby/concurrent/array.rb#L23-L27
+  class CRubyTraceBuffer < MeasuredBuffer
+    def initialize(max_size)
+      super()
 
-    def measure_accept(trace)
-      @buffer_spans += trace.length
-      @buffer_accepted += 1
-      @buffer_accepted_lengths += trace.length
-    rescue StandardError => e
-      Datadog.logger.debug("Failed to measure queue accept. Cause: #{e.message} Source: #{e.backtrace.first}")
+      @max_size = max_size
+
+      @traces = []
+      @closed = false
     end
 
-    def measure_drop(trace)
-      @buffer_dropped += 1
-      @buffer_spans -= trace.length
-      @buffer_accepted_lengths -= trace.length
-    rescue StandardError => e
-      Datadog.logger.debug("Failed to measure queue drop. Cause: #{e.message} Source: #{e.backtrace.first}")
+    # Add a new ``trace`` in the local queue. This method doesn't block the execution
+    # even if the buffer is full. In that case, a random trace is discarded.
+    def push(trace)
+      return if @closed
+      len = @traces.length
+      if len < @max_size || @max_size <= 0
+        @traces << trace
+      else
+        # we should replace a random trace with the new one
+        replace_index = rand(len)
+        replaced_trace = @traces.delete_at(replace_index)
+        @traces << trace
+
+        # Check if we deleted the element right when the buffer
+        # was popped. In that case we didn't actually delete anything,
+        # we just inserted into a newly cleared buffer instead.
+        measure_drop(replaced_trace) if replaced_trace
+      end
+
+      measure_accept(trace)
     end
 
-    def measure_pop(traces)
-      # Accepted
-      Datadog.health_metrics.queue_accepted(@buffer_accepted)
-      Datadog.health_metrics.queue_accepted_lengths(@buffer_accepted_lengths)
-
-      # Dropped
-      Datadog.health_metrics.queue_dropped(@buffer_dropped)
-
-      # Queue gauges
-      Datadog.health_metrics.queue_max_length(@max_size)
-      Datadog.health_metrics.queue_spans(@buffer_spans)
-      Datadog.health_metrics.queue_length(traces.length)
-
-      # Reset aggregated metrics
-      @buffer_accepted = 0
-      @buffer_accepted_lengths = 0
-      @buffer_dropped = 0
-      @buffer_spans = 0
-    rescue StandardError => e
-      Datadog.logger.debug("Failed to measure queue. Cause: #{e.message} Source: #{e.backtrace.first}")
+    # Return the current number of stored traces.
+    def length
+      @traces.length
     end
+
+    # Return if the buffer is empty.
+    def empty?
+      @traces.empty?
+    end
+
+    # Return all traces stored and reset buffer.
+    def pop
+      traces = @traces.pop(VERY_LARGE_INTEGER)
+
+      measure_pop(traces)
+
+      traces
+    end
+
+    # Very large value, to ensure that we drain the whole buffer.
+    # 1<<62-1 happens to be the largest integer that can be stored inline in CRuby.
+    VERY_LARGE_INTEGER = 1 << 62 - 1
+
+    def close
+      @closed = true
+    end
+  end
+
+  # Choose default TraceBuffer implementation for current platform.
+  BUFFER_IMPLEMENTATION = if Datadog::Ext::Runtime::RUBY_ENGINE == 'ruby'
+                            CRubyTraceBuffer
+                          else
+                            ThreadSafeBuffer
+                          end
+  private_constant :BUFFER_IMPLEMENTATION
+
+  # Trace buffer that stores application traces. The buffer has a maximum size and when
+  # the buffer is full, a random trace is discarded. This class is thread-safe and is used
+  # automatically by the ``Tracer`` instance when a ``Span`` is finished.
+  #
+  # TODO We should restructure this module, so that classes are not declared at top-level ::Datadog.
+  # TODO Making such a change is potentially breaking for users manually configuring the tracer.
+  class TraceBuffer < BUFFER_IMPLEMENTATION
   end
 end

--- a/lib/ddtrace/buffer.rb
+++ b/lib/ddtrace/buffer.rb
@@ -144,8 +144,8 @@ module Datadog
   # * Pushed into a single CRubyTraceBuffer from 1000 threads.
   # The buffer can exceed its maximum size by no more than 4%.
   #
-  # This implementation allocates 17-93% less memory and
-  # is 5-15% faster than {Datadog::ThreadSafeBuffer}.
+  # This implementation allocates less memory and is faster
+  # than {Datadog::ThreadSafeBuffer}.
   #
   # @see spec/ddtrace/benchmark/buffer_benchmark_spec.rb Buffer benchmarks
   # @see https://github.com/ruby-concurrency/concurrent-ruby/blob/c1114a0c6891d9634f019f1f9fe58dcae8658964/lib/concurrent-ruby/concurrent/array.rb#L23-L27

--- a/lib/ddtrace/ext/runtime.rb
+++ b/lib/ddtrace/ext/runtime.rb
@@ -7,6 +7,7 @@ module Datadog
       LANG = 'ruby'.freeze
       LANG_INTERPRETER = (RUBY_ENGINE + '-' + RUBY_PLATFORM).freeze
       LANG_VERSION = RUBY_VERSION
+      RUBY_ENGINE =  ::RUBY_ENGINE # e.g. 'ruby', 'jruby', 'truffleruby'
       TRACER_VERSION = Datadog::VERSION::STRING
 
       TAG_LANG = 'language'.freeze

--- a/spec/ddtrace/benchmark/buffer_benchmark_spec.rb
+++ b/spec/ddtrace/benchmark/buffer_benchmark_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+require_relative 'support/benchmark_helper'
+
+RSpec.describe 'Microbenchmark Buffer' do
+  let(:max_size) { Datadog::Workers::AsyncTransport::DEFAULT_BUFFER_MAX_SIZE }
+  let(:span) { get_test_traces(1).flatten }
+
+  let(:steps) { [max_size / 100, max_size / 10, max_size, max_size * 2] } # Number of elements pushed to buffer
+
+  def subject(pushes)
+    i = 0
+    while i < pushes
+      buffer.push(span)
+      i += 1
+    end
+
+    buffer.pop
+  end
+
+  describe 'CRubyTraceBuffer' do
+    before { skip unless PlatformHelpers.mri? }
+
+    include_examples 'benchmark'
+    let(:buffer) { Datadog::CRubyTraceBuffer.new(max_size) }
+  end
+
+  describe 'ThreadSafeBuffer' do
+    include_examples 'benchmark'
+    let(:buffer) { Datadog::ThreadSafeBuffer.new(max_size) }
+  end
+end


### PR DESCRIPTION
**_tl;dr: reduction of 17-93% of allocated bytes, 5-15% faster._**

Leveraging the fact that the native Ruby `Array` ["is thread-safe in practice because CRuby runs threads one at a time and does not do context switching during the execution of C functions"](https://github.com/ruby-concurrency/concurrent-ruby/blob/c1114a0c6891d9634f019f1f9fe58dcae8658964/lib/concurrent-ruby/concurrent/array.rb#L23-L27), this PR implements a version of the `TraceBuffer` that does not use explicit locking.

The buffer is one of the tracer hot-stops, being a sync point between the application critical path and the tracer's worker thread. All traces will eventually be pushed into the buffer, so improvements to it affect all instrumentations.

This version works correctly on CRuby, but will not maintain the same guarantees under other runtimes, like JRuby. For this reason, we kept the existing implementation, which utilizes explicit locking, for non-CRuby environments.

The benchmarks below (also included in the PR) use the default buffer size of 1000 traces.
When pushing over 1000 traces into the buffer, our fair eviction policy will take place. The 2000 traces benchmark covers this case. Increasing the number of traces pushed even more yielded the same performance results, so we stop at 2000.

The reduction in memory usage is the most notable improvement, with memory usage being constant for the new implementation:
```
Before(ThreadSafeBuffer) [bytes allocated (objects created)]
    10 traces:   91840.00 (   1900.00)
   100 traces:  177376.00 (   1900.00)
  1000 traces: 1244200.00 (   1900.00)
  2000 traces: 1244200.00 (   1900.00)

After(CRubyTraceBuffer)  [bytes allocated (objects created)]
    10 traces:   76000.00 (   1900.00)
   100 traces:   76000.00 (   1900.00)
  1000 traces:   76000.00 (   1900.00)
  2000 traces:   76000.00 (   1900.00)

Comparison (% reduction, increase negative)
    10 traces:      17.25 (      0.00)
   100 traces:      57.15 (      0.00)
  1000 traces:      93.89 (      0.00)
  2000 traces:      93.89 (      0.00)
```

While wall time has had a modest improvement:
```
Before(ThreadSafeBuffer) [operations/sec]
    10 spans:   74676.66
   100 spans:   11465.74
  1000 spans:    1208.54
  2000 spans:     486.27

After(CRubyTraceBuffer)  [operations/sec]
    10 spans:   82571.16
   100 spans:   13084.07
  1000 spans:    1397.91
  2000 spans:     512.44

Comparison (% faster; slower if negative)
    10 spans:      10.57
   100 spans:      14.11
  1000 spans:      15.67
  2000 spans:       5.38

Process finished with exit code 0
```