### PR TITLE
Disable coverage report for benchmarks

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,13 @@ require 'rspec/collection_matchers'
 require 'webmock/rspec'
 require 'climate_control'
 
-# +SimpleCov.start+ must be invoked before any application code is loaded
-require 'simplecov'
-SimpleCov.start do
-  formatter SimpleCov::Formatter::SimpleFormatter
+# Skip for benchmarks, as coverage collection slows them down.
+unless RSpec.configuration.files_to_run.all? { |path| path.include?('/benchmark/') }
+  # +SimpleCov.start+ must be invoked before any application code is loaded
+  require 'simplecov'
+  SimpleCov.start do
+    formatter SimpleCov::Formatter::SimpleFormatter
+  end
 end
 
 require 'ddtrace/encoding'


### PR DESCRIPTION
Collecting code coverage during benchmarks slows down the execution.

This PR disables coverage collection on all tests run from a benchmark directory.