### PR TITLE
Allow tracer components to be cleanly restarted after shutdown

### DIFF
--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -56,7 +56,10 @@ module Datadog
     end
 
     def shutdown!
-      components.shutdown! if instance_variable_defined?(:@components) && @components
+      if instance_variable_defined?(:@components) && @components
+        components.shutdown!
+        @components = nil
+      end
     end
 
     protected

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -372,5 +372,17 @@ RSpec.describe Datadog::Configuration do
       it { is_expected.to be_a_kind_of(Datadog::Tracer) }
       it { expect(tracer.context_flush).to be_a_kind_of(Datadog::ContextFlush::Finished) }
     end
+
+    describe '#shutdown!' do
+      subject(:shutdown!) { test_class.shutdown! }
+
+      it 'allows for a clean component restart' do
+        original_components = test_class.send(:components)
+
+        shutdown!
+
+        expect(test_class.send(:components)).to_not be(original_components)
+      end
+    end
   end
 end

--- a/spec/ddtrace/contrib/support/tracer_helpers.rb
+++ b/spec/ddtrace/contrib/support/tracer_helpers.rb
@@ -50,32 +50,24 @@ module Contrib
     RSpec.configure do |config|
       # Capture spans from the global tracer
       config.before(:each) do
-        Datadog.shutdown!
+        clear_spans!
 
-        # DEV `*_any_instance_of` has concurrency issues when running with parallelism (e.g. JRuby).
-        # DEV Single object `allow` and `expect` work as intended with parallelism.
-        allow(Datadog::Tracer).to receive(:new).and_wrap_original do |method, *args, &block|
-          instance = method.call(*args, &block)
-
-          # The mutex must be eagerly initialized to prevent race conditions on lazy initialization
-          write_lock = Mutex.new
-          allow(instance).to receive(:write) do |trace|
-            instance.instance_exec do
-              write_lock.synchronize do
-                @spans ||= []
-                @spans << trace
-              end
+        # The mutex must be eagerly initialized to prevent race conditions on lazy initialization
+        write_lock = Mutex.new
+        allow_any_instance_of(Datadog::Tracer).to receive(:write) do |tracer, trace|
+          tracer.instance_exec do
+            write_lock.synchronize do
+              @spans ||= []
+              @spans << trace
             end
           end
-
-          instance
         end
       end
     end
 
     # Useful for integration testing.
     def use_real_tracer!
-      allow(Datadog::Tracer).to receive(:new).and_call_original
+      allow_any_instance_of(Datadog::Tracer).to receive(:write).and_call_original
     end
   end
 end

--- a/spec/ddtrace/contrib/support/tracer_helpers.rb
+++ b/spec/ddtrace/contrib/support/tracer_helpers.rb
@@ -50,7 +50,7 @@ module Contrib
     RSpec.configure do |config|
       # Capture spans from the global tracer
       config.before(:each) do
-        clear_spans!
+        Datadog.shutdown!
 
         # DEV `*_any_instance_of` has concurrency issues when running with parallelism (e.g. JRuby).
         # DEV Single object `allow` and `expect` work as intended with parallelism.
@@ -70,10 +70,6 @@ module Contrib
 
           instance
         end
-      end
-
-      config.after(:each) do
-        Datadog.shutdown!
       end
     end
 

--- a/spec/ddtrace/contrib/support/tracer_helpers.rb
+++ b/spec/ddtrace/contrib/support/tracer_helpers.rb
@@ -52,22 +52,30 @@ module Contrib
       config.before(:each) do
         clear_spans!
 
-        # The mutex must be eagerly initialized to prevent race conditions on lazy initialization
-        write_lock = Mutex.new
-        allow_any_instance_of(Datadog::Tracer).to receive(:write) do |tracer, trace|
-          tracer.instance_exec do
-            write_lock.synchronize do
-              @spans ||= []
-              @spans << trace
+        # DEV `*_any_instance_of` has concurrency issues when running with parallelism (e.g. JRuby).
+        # DEV Single object `allow` and `expect` work as intended with parallelism.
+        allow(Datadog::Tracer).to receive(:new).and_wrap_original do |method, *args, &block|
+          instance = method.call(*args, &block)
+
+          # The mutex must be eagerly initialized to prevent race conditions on lazy initialization
+          write_lock = Mutex.new
+          allow(instance).to receive(:write) do |trace|
+            instance.instance_exec do
+              write_lock.synchronize do
+                @spans ||= []
+                @spans << trace
+              end
             end
           end
+
+          instance
         end
       end
     end
 
     # Useful for integration testing.
     def use_real_tracer!
-      allow_any_instance_of(Datadog::Tracer).to receive(:write).and_call_original
+      allow(Datadog::Tracer).to receive(:new).and_call_original
     end
   end
 end

--- a/spec/ddtrace/contrib/support/tracer_helpers.rb
+++ b/spec/ddtrace/contrib/support/tracer_helpers.rb
@@ -71,6 +71,10 @@ module Contrib
           instance
         end
       end
+
+      config.after(:each) do
+        Datadog.shutdown!
+      end
     end
 
     # Useful for integration testing.


### PR DESCRIPTION
We have inconsistent behaviour with `Configuration#shutdown!` where we shut down our components object (`        components.shutdown!`), but we keep its lingering instance in an instance variable (`@components`), with partially living references.

This prevented us from ever being able to restart the tracer, only ever returning dirty instances of the tracer on every call to `Datadog.tracer` after a shutdown.

This PR now allows the tracer components to be cleanly `shutdown!` and restarted, without lingering references.