### PR TITLE
Add end-to-end benchmarking

### DIFF
--- a/spec/ddtrace/benchmark/microbenchmark_spec.rb
+++ b/spec/ddtrace/benchmark/microbenchmark_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Microbenchmark' do
       let(:steps) { [1, 10, 100] }
 
       let(:tracer) { Datadog::Tracer.new }
-      after { shutdown! }
+      after { tracer.shutdown! }
 
       let(:name) { 'span'.freeze }
 

--- a/spec/ddtrace/benchmark/microbenchmark_spec.rb
+++ b/spec/ddtrace/benchmark/microbenchmark_spec.rb
@@ -75,4 +75,30 @@ RSpec.describe 'Microbenchmark' do
       end
     end
   end
+
+  describe 'end-to-end' do
+    include_context 'minimal agent'
+
+    describe 'nested traces' do
+      include_examples 'benchmark'
+
+      let(:timing_runtime) { 60 }
+      let(:memory_iterations) { 1000 }
+
+      let(:steps) { [1, 10, 100] }
+
+      let(:tracer) { Datadog::Tracer.new }
+      after { shutdown! }
+
+      let(:name) { 'span'.freeze }
+
+      def trace(i, total)
+        tracer.trace(name) { trace(i + 1, total) unless i == total }
+      end
+
+      def subject(i)
+        trace(1, i)
+      end
+    end
+  end
 end

--- a/spec/ddtrace/benchmark/support/benchmark_helper.rb
+++ b/spec/ddtrace/benchmark/support/benchmark_helper.rb
@@ -28,6 +28,9 @@ RSpec.shared_context 'benchmark' do
   # the real memory culprits to surface.
   let(:memory_iterations) { defined?(super) ? super() : 100 }
 
+  # How long the program will run when calculating IPS performance, in seconds.
+  let(:timing_runtime) { defined?(super) ? super() : 5 }
+
   # Outputs human readable information to STDERR.
   # Most of the benchmarks have nicely formatted reports
   # that are by default printed to terminal.
@@ -62,7 +65,7 @@ RSpec.shared_context 'benchmark' do
   # Measure execution time
   it 'timing' do
     report = Benchmark.ips do |x|
-      x.config(time: 5, warmup: 0.5)
+      x.config(time: timing_runtime, warmup: timing_runtime / 10)
 
       steps.each do |s|
         x.report(s) do


### PR DESCRIPTION
Add an end-to-end test to our benchmarking suite.

This test generated traces (ranging from 1 to 100 nested spans), sends them to the write, which sends it by HTTP to a locally running agent.

This benchmark exercises the exact same code path that host applications will perform.

With this benchmark we should be able to report on measurable, tracer-level gains performed when optimizations on a subset of the tracer.