### PR TITLE
Remove explicit `Logger` class verification

### DIFF
--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -91,7 +91,6 @@ module Datadog
 
       settings :logger do
         option :instance do |o|
-          o.setter { |value, old_value| value.is_a?(::Logger) ? value : old_value }
           o.on_set { |value| set_option(:level, value.level) unless value.nil? }
         end
 

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -286,7 +286,14 @@ RSpec.describe Datadog::Configuration::Settings do
     end
 
     describe '#instance=' do
-      let(:logger) { Datadog::Logger.new(STDOUT) }
+      let(:logger) do
+        double(:logger,
+               debug: true,
+               info: true,
+               warn: true,
+               error: true,
+               level: true)
+      end
 
       it 'updates the #instance setting' do
         expect { settings.logger.instance = logger }


### PR DESCRIPTION
This PR addresses problematic check in setter configuration that disallows using loggers that are not ruby `::Logger` descendants. Current behavior not only doesn't allow using certain loggers (e.g. [`semantic_logger`](https://github.com/rocketjob/semantic_logger) or [`logging`](https://github.com/TwP/logging)) without dirty hacks, but also silently ignores setting value that does not match this validation.

I tried finding common behavior of more popular logging libraries to introduce idiomatic duck-typing instead of  current class comparison, but there doesn't seem to be anything simple enough (apart from validating presence of all methods that `dd-trace` uses) -- commonly found methods `#add` and `#log` are not always present, and they are not always public.

I didn't find any test that would validate that only `Logger` descendants can be used, so I didn't introduce any changes to existing specs. Please let me know if you think, that's something worth verifying.