### PR TITLE
Fix Span#pretty_print for empty duration

### DIFF
--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -346,8 +346,8 @@ module Datadog
 
     # Return a human readable version of the span
     def pretty_print(q)
-      start_time = (start_time.to_f * 1e9).to_i rescue '-'
-      end_time = (end_time.to_f * 1e9).to_i rescue '-'
+      start_time = (self.start_time.to_f * 1e9).to_i
+      end_time = (self.end_time.to_f * 1e9).to_i
       q.group 0 do
         q.breakable
         q.text "Name: #{@name}\n"
@@ -360,7 +360,7 @@ module Datadog
         q.text "Error: #{@status}\n"
         q.text "Start: #{start_time}\n"
         q.text "End: #{end_time}\n"
-        q.text "Duration: #{duration.to_f}\n"
+        q.text "Duration: #{duration.to_f if finished?}\n"
         q.text "Allocations: #{allocations}\n"
         q.group(2, 'Tags: [', "]\n") do
           q.breakable

--- a/spec/ddtrace/span_spec.rb
+++ b/spec/ddtrace/span_spec.rb
@@ -649,4 +649,12 @@ RSpec.describe Datadog::Span do
       is_expected.to eq(Hash[span.to_hash.map { |k, v| [k.to_s, v] }])
     end
   end
+
+  describe '#pretty_print' do
+    subject(:pretty_print) { PP.pp(span) }
+
+    it 'output without errors' do
+      expect { pretty_print }.to output.to_stdout
+    end
+  end
 end


### PR DESCRIPTION
This PR ensures `Span#pretty_print` is able to handle all valid values it prints.
The required changes were around the span's timing values.

This PR also adds a smoke test to ensure `Span#pretty_print` at least outputs a string without any errors.

The main error we stated seeing
```
     NoMethodError:
       undefined method `-' for nil:NilClass
     # ./lib/ddtrace/span.rb:392:in `duration`
```
was actually addressed in a previous PR by @ericmustin, but I remove a few of the safe-guard `rescue` statements from `def duration` when making changes to improve performance. I seek forgiveness with this PR 🙇.