### PR TITLE
Fix Sequel instrumentation when executing literal strings

### DIFF
--- a/lib/ddtrace/contrib/sequel/database.rb
+++ b/lib/ddtrace/contrib/sequel/database.rb
@@ -52,6 +52,14 @@ module Datadog
                       elsif instance_variable_defined?(:@pool) && @pool
                         @pool.db.opts
                       end
+            sql = case sql
+                  when Symbol
+                    ::Sequel.lit(sql).to_s
+                  when ::Sequel::SQL::Expression
+                    literal(sql)
+                  else
+                    sql
+                  end
             Utils.parse_opts(sql, opts, db_opts)
           end
         end

--- a/lib/ddtrace/contrib/sequel/database.rb
+++ b/lib/ddtrace/contrib/sequel/database.rb
@@ -52,14 +52,8 @@ module Datadog
                       elsif instance_variable_defined?(:@pool) && @pool
                         @pool.db.opts
                       end
-            sql = case sql
-                  when Symbol
-                    ::Sequel.lit(sql).to_s
-                  when ::Sequel::SQL::Expression
-                    literal(sql)
-                  else
-                    sql
-                  end
+            sql = sql.is_a?(::Sequel::SQL::Expression) ? literal(sql) : sql.to_s
+
             Utils.parse_opts(sql, opts, db_opts)
           end
         end

--- a/spec/ddtrace/contrib/sequel/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/sequel/instrumentation_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe 'Sequel instrumentation' do
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
     Datadog.registry[:sequel].reset_configuration!
+    Sequel::DATABASES.each(&:disconnect)
     example.run
     Datadog.registry[:sequel].reset_configuration!
   end
@@ -48,31 +49,46 @@ RSpec.describe 'Sequel instrumentation' do
 
     let(:normalized_adapter) { defined?(super) ? super() : adapter }
 
-    describe 'when queried through a Sequel::Database object' do
-      before(:each) { sequel.run(query) }
-      let(:query) { "SELECT * FROM tbl WHERE name = 'foo'" }
-      let(:span) { spans.first }
+    describe 'Sequel::Database.run' do
+      shared_context 'query executed through a Sequel::Database object' do
+        before(:each) { sequel.run(query) }
+        let(:span) { spans.first }
 
-      it 'traces the command' do
-        expect(span.name).to eq('sequel.query')
-        # Expect it to be the normalized adapter name.
-        expect(span.service).to eq(normalized_adapter)
-        expect(span.span_type).to eq('sql')
-        expect(span.get_tag('sequel.db.vendor')).to eq(normalized_adapter)
-        # Expect non-quantized query: agent does SQL quantization.
-        expect(span.resource).to eq(query)
-        expect(span.status).to eq(0)
-        expect(span.parent_id).to eq(0)
+        it 'traces the command' do
+          expect(span.name).to eq('sequel.query')
+          # Expect it to be the normalized adapter name.
+          expect(span.service).to eq(normalized_adapter)
+          expect(span.span_type).to eq('sql')
+          expect(span.get_tag('sequel.db.vendor')).to eq(normalized_adapter)
+          # Expect non-quantized query: agent does SQL quantization.
+          expect(span.resource).to eq(expected_query)
+          expect(span.status).to eq(0)
+          expect(span.parent_id).to eq(0)
+        end
+
+        it_behaves_like 'analytics for integration' do
+          let(:analytics_enabled_var) { Datadog::Contrib::Sequel::Ext::ENV_ANALYTICS_ENABLED }
+          let(:analytics_sample_rate_var) { Datadog::Contrib::Sequel::Ext::ENV_ANALYTICS_SAMPLE_RATE }
+        end
+
+        it_behaves_like 'a peer service span'
+
+        it_behaves_like 'measured span for integration', false
       end
 
-      it_behaves_like 'analytics for integration' do
-        let(:analytics_enabled_var) { Datadog::Contrib::Sequel::Ext::ENV_ANALYTICS_ENABLED }
-        let(:analytics_sample_rate_var) { Datadog::Contrib::Sequel::Ext::ENV_ANALYTICS_SAMPLE_RATE }
+      context 'with query provided as a string' do
+        it_behaves_like 'query executed through a Sequel::Database object' do
+          let(:query) { "SELECT * FROM tbl WHERE name = 'foo'" }
+          let(:expected_query) { query }
+        end
       end
 
-      it_behaves_like 'a peer service span'
-
-      it_behaves_like 'measured span for integration', false
+      context 'with query provided as complex expression' do
+        it_behaves_like 'query executed through a Sequel::Database object' do
+          let(:query) { Sequel.lit("SELECT * FROM tbl WHERE name = :var", var: 'foo') }
+          let(:expected_query) { sequel.literal(query) }
+        end
+      end
     end
 
     describe 'when queried through a Sequel::Dataset' do

--- a/spec/ddtrace/contrib/sequel/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/sequel/instrumentation_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Sequel instrumentation' do
 
       context 'with query provided as complex expression' do
         it_behaves_like 'query executed through a Sequel::Database object' do
-          let(:query) { Sequel.lit("SELECT * FROM tbl WHERE name = :var", var: 'foo') }
+          let(:query) { Sequel.lit('SELECT * FROM tbl WHERE name = :var', var: 'foo') }
           let(:expected_query) { sequel.literal(query) }
         end
       end


### PR DESCRIPTION
When instrumenting an application using the `sequel` integration, tracing was failing for a case like the following:

```ruby
query = Sequel.lit("UPDATE foo SET bar = :wat WHERE bar = :var", wat: 2, var: 1)
db.run(query)
```
```ruby
     Failure/Error: db.run(query)

     NoMethodError:
       undefined method `prepared_sql' for #<Sequel::SQL::PlaceholderLiteralString:0x00005585a864c0c0>
     # /usr/local/bundle/gems/ddtrace-0.40.0/lib/ddtrace/contrib/sequel/utils.rb:32:in `parse_opts'
     # /usr/local/bundle/gems/ddtrace-0.40.0/lib/ddtrace/contrib/sequel/database.rb:55:in `parse_opts'
     # /usr/local/bundle/gems/ddtrace-0.40.0/lib/ddtrace/contrib/sequel/database.rb:19:in `run'
     # ./app/distribution/create.rb:17:in `calculate'
     # ./app/distribution/create.rb:8:in `handle'
     # ./spec/distribution/create_spec.rb:31:in `block (3 levels) in <top (required)>'
```

When using `Sequel.lit` in this context, it returns a `Sequel::SQL::PlaceholderLiteralString`.
This object does not respond to `prepared_sql`, the method expected by `Datadog::Contrib::Sequel::Utils.parse_opts`.
To coerce a `Sequel::SQL::PlaceholderLiteralString` into a `String`, `Sequel::Database#literal` (`Sequel::Dataset#literal`) may be used.

Unfortunately, a duck-type approach for the variety of types the `sql` argument may take is not possible when `sql` is a `String` because `#literal` escapes `'`s:

```ruby
db.literal("SELECT * FROM tbl WHERE name = 'foo'") # => "'SELECT * FROM tbl WHERE name = ''foo'''"
```
As such, it is necessary to check the type of `sql` in order to coerce it.