### PR TITLE
Improved prepared statement support for Sequel

### DIFF
--- a/lib/ddtrace/contrib/sequel/dataset.rb
+++ b/lib/ddtrace/contrib/sequel/dataset.rb
@@ -38,7 +38,7 @@ module Datadog
           private
 
           def trace_execute(super_method, sql, options, &block)
-            opts = Utils.parse_opts(sql, options, db.opts)
+            opts = Utils.parse_opts(sql, options, db.opts, self)
             response = nil
 
             datadog_pin.tracer.trace(Ext::SPAN_QUERY) do |span|
@@ -47,6 +47,7 @@ module Datadog
               span.span_type = Datadog::Ext::SQL::TYPE
               Utils.set_common_tags(span)
               span.set_tag(Ext::TAG_DB_VENDOR, adapter_name)
+              span.set_tag(Ext::TAG_PREPARED_NAME, opts[:prepared_name]) if opts[:prepared_name]
               response = super_method.call(sql, options, &block)
             end
             response

--- a/lib/ddtrace/contrib/sequel/ext.rb
+++ b/lib/ddtrace/contrib/sequel/ext.rb
@@ -12,6 +12,7 @@ module Datadog
         SERVICE_NAME = 'sequel'.freeze
         SPAN_QUERY = 'sequel.query'.freeze
         TAG_DB_VENDOR = 'sequel.db.vendor'.freeze
+        TAG_PREPARED_NAME = 'sequel.prepared.name'.freeze
       end
     end
   end

--- a/lib/ddtrace/contrib/sequel/utils.rb
+++ b/lib/ddtrace/contrib/sequel/utils.rb
@@ -28,15 +28,20 @@ module Datadog
             Datadog::Utils::Database.normalize_vendor(database.database_type.to_s)
           end
 
-          def parse_opts(sql, opts, db_opts)
-            if ::Sequel::VERSION >= '4.37.0' && !sql.is_a?(String)
-              # In 4.37.0, sql was converted to a prepared statement object
-              sql = sql.prepared_sql unless sql.is_a?(Symbol)
+          def parse_opts(sql, opts, db_opts, dataset = nil)
+            # Prepared statements don't provide their sql query in the +sql+ parameter.
+            unless sql.is_a?(String)
+              if dataset && dataset.respond_to?(:prepared_sql) && (resolved_sql = dataset.prepared_sql)
+                # The dataset contains the resolved SQL query and prepared statement name.
+                prepared_name = dataset.opts[:prepared_statement_name]
+                sql = resolved_sql
+              end
             end
 
             {
               name: opts[:type],
               query: sql,
+              prepared_name: prepared_name,
               database: db_opts[:database],
               host: db_opts[:host]
             }

--- a/lib/ddtrace/contrib/sequel/utils.rb
+++ b/lib/ddtrace/contrib/sequel/utils.rb
@@ -33,7 +33,7 @@ module Datadog
             unless sql.is_a?(String)
               if dataset && dataset.respond_to?(:prepared_sql) && (resolved_sql = dataset.prepared_sql)
                 # The dataset contains the resolved SQL query and prepared statement name.
-                prepared_name = dataset.opts[:prepared_statement_name]
+                prepared_name = dataset.prepared_statement_name
                 sql = resolved_sql
               end
             end

--- a/spec/ddtrace/contrib/support/matchers.rb
+++ b/spec/ddtrace/contrib/support/matchers.rb
@@ -8,7 +8,10 @@
 #   expect('SELECT * FROM `tbl` LIMIT 1').to match_normalized_sql(include 'LIMIT')
 RSpec::Matchers.define :match_normalized_sql do |expected|
   match do |actual|
-    @actual = actual.gsub(/[`"]/, '')
+    @actual = actual
+              .gsub(/[`"]/, '') # Remove all query token quotations. String quotations are left untouched.
+              .gsub(/\$\d+/, '?') # Convert Postgres placeholder '$1' to '?'
+              .gsub(/:\w+/, '?') # Convert Sqlite placeholder ':value' to '?'
 
     values_match?(expected, @actual)
   end


### PR DESCRIPTION
While reviewing a recent Sequel PR, I noticed that we did not have coverage for Sequel prepared statements.

This PR adds such coverage, as well as an additional span tag containing the name of the prepared statement. This name is a developer assigned internal alias for the prepared statement, which might be helpful in identifying where the query was stemmed from.