### PR TITLE
Add detailed CPU benchmark

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '= 0.49.1' if RUBY_VERSION >= '2.1.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.1'
-  spec.add_development_dependency 'ruby-prof', '~> 1.4'
+  spec.add_development_dependency 'ruby-prof', '~> 1.4' if RUBY_PLATFORM != 'java'
   spec.add_development_dependency 'minitest', '= 5.10.1'
   spec.add_development_dependency 'minitest-around', '0.5.0'
   spec.add_development_dependency 'minitest-stub_any_instance', '1.0.2'

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '= 0.49.1' if RUBY_VERSION >= '2.1.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.1'
-  spec.add_development_dependency 'ruby-prof', '~> 1.4' if RUBY_PLATFORM != 'java'
+  spec.add_development_dependency 'ruby-prof', '~> 1.4' if RUBY_PLATFORM != 'java' && RUBY_VERSION >= '2.4.0'
   spec.add_development_dependency 'minitest', '= 5.10.1'
   spec.add_development_dependency 'minitest-around', '0.5.0'
   spec.add_development_dependency 'minitest-stub_any_instance', '1.0.2'

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '= 0.49.1' if RUBY_VERSION >= '2.1.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.1'
+  spec.add_development_dependency 'ruby-prof', '~> 1.4'
   spec.add_development_dependency 'minitest', '= 5.10.1'
   spec.add_development_dependency 'minitest-around', '0.5.0'
   spec.add_development_dependency 'minitest-stub_any_instance', '1.0.2'

--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -124,6 +124,16 @@ The trace library uses Rubocop to enforce [code style](https://github.com/bbatso
 $ bundle exec rake rubocop
 ```
 
+### Running benchmarks
+
+If your changes can have a measurable performance impact, we recommend running our benchmark suite:
+
+```
+$ bundle exec rake spec:benchmark
+```
+
+Results are printed to STDOUT as well as written to the `./tmp/benchmark/` directory.
+
 ## Appendix
 
 ### Writing new integrations

--- a/spec/ddtrace/benchmark/microbenchmark_spec.rb
+++ b/spec/ddtrace/benchmark/microbenchmark_spec.rb
@@ -87,8 +87,10 @@ RSpec.describe 'Microbenchmark' do
 
       let(:steps) { [1, 10, 100] }
 
-      let(:tracer) { Datadog::Tracer.new }
+      let(:tracer) { Datadog::Tracer.new(writer: writer) }
       after { tracer.shutdown! }
+
+      let(:writer) { Datadog::Writer.new(buffer_size: 1000, flush_interval: 0) }
 
       let(:name) { 'span'.freeze }
 

--- a/spec/ddtrace/benchmark/support/benchmark_helper.rb
+++ b/spec/ddtrace/benchmark/support/benchmark_helper.rb
@@ -198,7 +198,11 @@ RSpec.shared_context 'benchmark' do
 
     # CPU profiling report
     context 'RubyProf report' do
-      before { skip("'ruby-prof' not supported") if PlatformHelpers.jruby? }
+      before do
+        if PlatformHelpers.jruby? || Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.0')
+          skip("'ruby-prof' not supported")
+        end
+      end
 
       before do
         require 'ruby-prof'


### PR DESCRIPTION
This PR adds CPU profiling using [ruby-prof ](https://ruby-prof.github.io/).

All our existing benchmarks only provide deep analysis for memory behavior. This PR introduces a detailed analysis tool to measure application timing.

By default, the results are output in [Cachegrind](https://www.valgrind.org/docs/manual/cg-manual.html) format, and can be analyzed with tools like [KCachegrind or QCachegrind](https://kcachegrind.github.io/html/Home.html).
Here's an example:
<img width="1436" alt="Screen Shot 2020-09-28 at 3 04 25 PM" src="https://user-images.githubusercontent.com/583503/94474690-fd876680-019b-11eb-9109-5cc595490a24.png">

When the benchmark runs, instructions are printed on how to get to this colorful screen I posted above.