### PR TITLE
Reduce generated Span ID range to fit in Fixnum

### DIFF
--- a/lib/ddtrace/opentracer/distributed_headers.rb
+++ b/lib/ddtrace/opentracer/distributed_headers.rb
@@ -44,7 +44,7 @@ module Datadog
 
       def id(header)
         value = @carrier[header].to_i
-        return if value.zero? || value >= Datadog::Span::MAX_ID
+        return if value.zero? || value >= Datadog::Span::EXTERNAL_MAX_ID
         value < 0 ? value + 0x1_0000_0000_0000_0000 : value
       end
     end

--- a/lib/ddtrace/propagation/grpc_propagator.rb
+++ b/lib/ddtrace/propagation/grpc_propagator.rb
@@ -39,12 +39,12 @@ module Datadog
 
       def trace_id
         value = @metadata[GRPC_METADATA_TRACE_ID].to_i
-        value if (1..Span::MAX_ID).cover? value
+        value if (1..Span::EXTERNAL_MAX_ID).cover? value
       end
 
       def parent_id
         value = @metadata[GRPC_METADATA_PARENT_ID].to_i
-        value if (1..Span::MAX_ID).cover? value
+        value if (1..Span::EXTERNAL_MAX_ID).cover? value
       end
 
       def sampling_priority

--- a/lib/ddtrace/sampler.rb
+++ b/lib/ddtrace/sampler.rb
@@ -61,11 +61,11 @@ module Datadog
 
     def sample_rate=(sample_rate)
       @sample_rate = sample_rate
-      @sampling_id_threshold = sample_rate * Span::MAX_ID
+      @sampling_id_threshold = sample_rate * Span::EXTERNAL_MAX_ID
     end
 
     def sample?(span)
-      ((span.trace_id * KNUTH_FACTOR) % Datadog::Span::MAX_ID) <= @sampling_id_threshold
+      ((span.trace_id * KNUTH_FACTOR) % Datadog::Span::EXTERNAL_MAX_ID) <= @sampling_id_threshold
     end
 
     def sample!(span)

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -27,16 +27,18 @@ module Datadog
     # The max value for a \Span identifier.
     # Span and trace identifiers should be strictly positive and strictly inferior to this limit.
     #
-    # Limited to 63-bit positive integers, as some other languages might be limited to this,
-    # and IDs need to be easy to port across various languages and platforms.
-    MAX_ID = 2**63
+    # Limited to +2<<62-1+ positive integers, as Ruby is able to represent such numbers "inline",
+    # inside a +VALUE+ scalar, thus not requiring memory allocation.
+    #
+    # The range of IDs also has to consider portability across different languages and platforms.
+    RUBY_MAX_ID = (1 << 62) - 1
 
     # While we only generate 63-bit integers due to limitations in other languages, we support
     # parsing 64-bit integers for distributed tracing since an upstream system may generate one
-    EXTERNAL_MAX_ID = 2**64
+    EXTERNAL_MAX_ID = 1 << 64
 
     # This limit is for numeric tags because uint64 could end up rounded.
-    NUMERIC_TAG_SIZE_RANGE = (-2**53..2**53)
+    NUMERIC_TAG_SIZE_RANGE = (-1 << 53..1 << 53)
 
     attr_accessor :name, :service, :resource, :span_type,
                   :span_id, :trace_id, :parent_id,

--- a/lib/ddtrace/utils.rb
+++ b/lib/ddtrace/utils.rb
@@ -12,7 +12,7 @@ module Datadog
     def self.next_id
       reset! if was_forked?
 
-      @rnd.rand(Datadog::Span::MAX_ID)
+      @rnd.rand(Datadog::Span::RUBY_MAX_ID)
     end
 
     def self.reset!

--- a/spec/ddtrace/distributed_tracing/headers/headers_spec.rb
+++ b/spec/ddtrace/distributed_tracing/headers/headers_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Datadog::DistributedTracing::Headers::Headers do
         ['-100', -100 + (2**64)],
 
         # Allowed values
-        [Datadog::Span::MAX_ID.to_s, Datadog::Span::MAX_ID],
+        [Datadog::Span::RUBY_MAX_ID.to_s, Datadog::Span::RUBY_MAX_ID],
         [Datadog::Span::EXTERNAL_MAX_ID.to_s, Datadog::Span::EXTERNAL_MAX_ID],
         ['1', 1],
         ['100', 100],
@@ -88,7 +88,7 @@ RSpec.describe Datadog::DistributedTracing::Headers::Headers do
         [(Datadog::Span::EXTERNAL_MAX_ID + 1).to_s(16), 1],
         [Datadog::Span::EXTERNAL_MAX_ID.to_s(16), nil],
 
-        [Datadog::Span::MAX_ID.to_s(16), Datadog::Span::MAX_ID],
+        [Datadog::Span::RUBY_MAX_ID.to_s(16), Datadog::Span::RUBY_MAX_ID],
         [(Datadog::Span::EXTERNAL_MAX_ID - 1).to_s(16), Datadog::Span::EXTERNAL_MAX_ID - 1],
 
         ['3e8', 1000],
@@ -123,8 +123,8 @@ RSpec.describe Datadog::DistributedTracing::Headers::Headers do
         ['2', 2],
 
         # Allowed values
-        [Datadog::Span::MAX_ID.to_s, Datadog::Span::MAX_ID],
-        [(Datadog::Span::MAX_ID + 1).to_s, Datadog::Span::MAX_ID + 1],
+        [Datadog::Span::RUBY_MAX_ID.to_s, Datadog::Span::RUBY_MAX_ID],
+        [(Datadog::Span::RUBY_MAX_ID + 1).to_s, Datadog::Span::RUBY_MAX_ID + 1],
         [Datadog::Span::EXTERNAL_MAX_ID.to_s, Datadog::Span::EXTERNAL_MAX_ID],
         [(Datadog::Span::EXTERNAL_MAX_ID + 1).to_s, Datadog::Span::EXTERNAL_MAX_ID + 1],
         ['-100', -100],
@@ -144,8 +144,8 @@ RSpec.describe Datadog::DistributedTracing::Headers::Headers do
         [Datadog::Span::EXTERNAL_MAX_ID.to_s(16), 0],
         [(Datadog::Span::EXTERNAL_MAX_ID + 1).to_s(16), 1],
 
-        [Datadog::Span::MAX_ID.to_s(16), Datadog::Span::MAX_ID],
-        [(Datadog::Span::MAX_ID + 1).to_s(16), Datadog::Span::MAX_ID + 1],
+        [Datadog::Span::RUBY_MAX_ID.to_s(16), Datadog::Span::RUBY_MAX_ID],
+        [(Datadog::Span::RUBY_MAX_ID + 1).to_s(16), Datadog::Span::RUBY_MAX_ID + 1],
 
         ['3e8', 1000],
         ['3E8', 1000],

--- a/spec/ddtrace/distributed_tracing/headers/helpers_spec.rb
+++ b/spec/ddtrace/distributed_tracing/headers/helpers_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Datadog::DistributedTracing::Headers::Helpers do
       [((2**64) - 1).to_s(16), 'ffffffffffffffff'],
 
       # Our max generated id
-      [Datadog::Span::MAX_ID.to_s(16), '8000000000000000'],
+      [Datadog::Span::RUBY_MAX_ID.to_s(16), '3fffffffffffffff'],
       # Our max external id
       # DEV: This is the same as (2**64) above, but use the constant to be sure
       [Datadog::Span::EXTERNAL_MAX_ID.to_s(16), '0'],

--- a/spec/ddtrace/opentracer/distributed_headers_spec.rb
+++ b/spec/ddtrace/opentracer/distributed_headers_spec.rb
@@ -25,19 +25,19 @@ if Datadog::OpenTracer.supported?
 
       context 'when #trace_id is missing' do
         let(:trace_id) { nil }
-        let(:parent_id) { (Datadog::Span::MAX_ID + 1).to_s }
+        let(:parent_id) { (Datadog::Span::EXTERNAL_MAX_ID + 1).to_s }
         it { is_expected.to be false }
       end
 
       context 'when #parent_id is missing' do
-        let(:trace_id) { (Datadog::Span::MAX_ID + 1).to_s }
+        let(:trace_id) { (Datadog::Span::EXTERNAL_MAX_ID + 1).to_s }
         let(:parent_id) { nil }
         it { is_expected.to be false }
       end
 
       context 'when both #trace_id and #parent_id are present' do
-        let(:trace_id) { (Datadog::Span::MAX_ID - 1).to_s }
-        let(:parent_id) { (Datadog::Span::MAX_ID - 1).to_s }
+        let(:trace_id) { (Datadog::Span::EXTERNAL_MAX_ID - 1).to_s }
+        let(:parent_id) { (Datadog::Span::EXTERNAL_MAX_ID - 1).to_s }
         it { is_expected.to be true }
       end
     end
@@ -57,12 +57,12 @@ if Datadog::OpenTracer.supported?
 
       context 'when the header is present' do
         context 'but the value is out of range' do
-          let(:value) { (Datadog::Span::MAX_ID + 1).to_s }
+          let(:value) { (Datadog::Span::EXTERNAL_MAX_ID + 1).to_s }
           it { is_expected.to be nil }
         end
 
         context 'and the value is in range' do
-          let(:value) { (Datadog::Span::MAX_ID - 1).to_s }
+          let(:value) { (Datadog::Span::EXTERNAL_MAX_ID - 1).to_s }
           it { is_expected.to eq value.to_i }
 
           context 'as a negative signed integer' do
@@ -89,12 +89,12 @@ if Datadog::OpenTracer.supported?
 
       context 'when the header is present' do
         context 'but the value is out of range' do
-          let(:value) { (Datadog::Span::MAX_ID + 1).to_s }
+          let(:value) { (Datadog::Span::EXTERNAL_MAX_ID + 1).to_s }
           it { is_expected.to be nil }
         end
 
         context 'and the value is in range' do
-          let(:value) { (Datadog::Span::MAX_ID - 1).to_s }
+          let(:value) { (Datadog::Span::EXTERNAL_MAX_ID - 1).to_s }
           it { is_expected.to eq value.to_i }
 
           context 'as a negative signed integer' do

--- a/spec/ddtrace/opentracer/propagation_integration_spec.rb
+++ b/spec/ddtrace/opentracer/propagation_integration_spec.rb
@@ -87,8 +87,8 @@ if Datadog::OpenTracer.supported?
             )
           end
 
-          let(:trace_id) { Datadog::Span::MAX_ID - 1 }
-          let(:parent_id) { Datadog::Span::MAX_ID - 2 }
+          let(:trace_id) { Datadog::Span::EXTERNAL_MAX_ID - 1 }
+          let(:parent_id) { Datadog::Span::EXTERNAL_MAX_ID - 2 }
           let(:sampling_priority) { 2 }
           let(:origin) { 'synthetics' }
 
@@ -229,8 +229,8 @@ if Datadog::OpenTracer.supported?
             )
           end
 
-          let(:trace_id) { Datadog::Span::MAX_ID - 1 }
-          let(:parent_id) { Datadog::Span::MAX_ID - 2 }
+          let(:trace_id) { Datadog::Span::EXTERNAL_MAX_ID - 1 }
+          let(:parent_id) { Datadog::Span::EXTERNAL_MAX_ID - 2 }
           let(:sampling_priority) { 2 }
           let(:origin) { 'synthetics' }
 

--- a/spec/ddtrace/sampler_spec.rb
+++ b/spec/ddtrace/sampler_spec.rb
@@ -81,7 +81,11 @@ RSpec.describe Datadog::RateSampler do
       let(:span_count) { 1000 }
       let(:rng) { Random.new(123) }
 
-      let(:spans) { Array.new(span_count) { Datadog::Span.new(nil, '', trace_id: rng.rand(Datadog::Span::MAX_ID)) } }
+      let(:spans) do
+        Array.new(span_count) do
+          Datadog::Span.new(nil, '', trace_id: rng.rand(Datadog::Span::EXTERNAL_MAX_ID))
+        end
+      end
       let(:expected_num_of_sampled_spans) { span_count * sample_rate }
 
       it 'samples an appropriate proportion of spans' do


### PR DESCRIPTION
Ruby transparently handles small and large integers using the [Integer](https://ruby-doc.org/core-2.5.0/Integer.html) object. Behind the scenes, a number could either be a [Fixnum](https://ruby-doc.org/core-2.2.10/Fixnum.html) or [Bignum](https://ruby-doc.org/core-2.2.10/Bignum.html).

A Fixnum ["Holds Integer values that can be represented in a native machine word (minus 1 bit)"](https://ruby-doc.org/core-2.2.10/Fixnum.html), and thus requiring no auxiliary memory to be represented.
Fixnums are faster to create and manipulate.

The transparent boundary between Fixnums and Bignums, in the positive integer range, is around `2**62`:
```ruby
require 'objspace'
ObjectSpace.memsize_of(2**62-1)
# => 0
ObjectSpace.memsize_of(2**62)
# => 40
```

In the tracer, we were generating random span ids up to `2**63`, meaning half the generated ids were internally Bignums.

This PR reduces the range of internally generated span ids** to up to `2**62-1`. The limit of this new range is still sufficient to produce unique ids for the purpose of tracing.

This does not affect spans received from external sources: those are still handled as-is, without modification.

Also, this PR fixes our sampling logic that performs Knuth's sampling algorithm to use the correct maximum range: before we were using `2**63`, but our specs require our sampling to be consistent across languages, specially when possibly handling externally provided span ids. The specs require `2**64` to be the sampling range limit. This fix can be seen in "Datadog::RateSampler#sample?".

#### Benchmark results

For our [critical path benchmark](https://github.com/DataDog/dd-trace-rb/blob/0ce05a75307e0aec2f3376c8d78a74f9a0880761/spec/ddtrace/benchmark/microbenchmark_spec.rb#L14-L31), that measures span creation up until the hand-off to the background worker:

* **1-6% wall time reduction**
* **4-6% memory reduction**
* **11-22% fewer objects created**

```
Before [operations/sec]
     1 spans:   41298.16
    10 spans:    9982.20
   100 spans:    1239.96

After [operations/sec]
     1 spans:   41898.30
    10 spans:   10466.44
   100 spans:    1322.01

Comparison (% faster; slower if negative)
     1 spans:       1.45
    10 spans:       4.85
   100 spans:       6.62
```

```
Before [bytes allocated (objects created)]
     1 traces:   251760.00 (   2784.00)
    10 traces:  1825600.00 (  14464.00)
   100 traces: 17502136.00 ( 131539.00)

After  [bytes allocated (objects created)]
     1 traces:   239400.00 (   2475.00)
    10 traces:  1705920.00 (  11472.00)
   100 traces: 16299616.00 ( 101476.00)

Comparison (% reduction, increase negative)
     1 traces:       4.91 (     11.10)
    10 traces:       6.56 (     20.69)
   100 traces:       6.87 (     22.85)
```