### PR TITLE
Cache hashes for BacktraceLocation and Stack events

### DIFF
--- a/lib/ddtrace/profiling/backtrace_location.rb
+++ b/lib/ddtrace/profiling/backtrace_location.rb
@@ -5,7 +5,8 @@ module Datadog
       attr_reader \
         :base_label,
         :lineno,
-        :path
+        :path,
+        :hash
 
       def initialize(
         base_label,
@@ -15,6 +16,7 @@ module Datadog
         @base_label = base_label
         @lineno = lineno
         @path = path
+        @hash = [base_label, lineno, path].hash
       end
 
       def ==(other)
@@ -23,10 +25,6 @@ module Datadog
 
       def eql?(other)
         hash == other.hash
-      end
-
-      def hash
-        [base_label, lineno, path].hash
       end
     end
   end

--- a/lib/ddtrace/profiling/events/stack.rb
+++ b/lib/ddtrace/profiling/events/stack.rb
@@ -8,7 +8,8 @@ module Datadog
         attr_reader \
           :frames,
           :total_frame_count,
-          :thread_id
+          :thread_id,
+          :hash
 
         def initialize(
           timestamp,
@@ -21,6 +22,14 @@ module Datadog
           @frames = frames
           @total_frame_count = total_frame_count
           @thread_id = thread_id
+
+          @hash = [
+            thread_id,
+            [
+              frames.collect(&:hash),
+              total_frame_count
+            ]
+          ].hash
         end
       end
 

--- a/lib/ddtrace/profiling/pprof/stack_sample.rb
+++ b/lib/ddtrace/profiling/pprof/stack_sample.rb
@@ -29,13 +29,7 @@ module Datadog
         end
 
         def stack_sample_group_key(stack_sample)
-          [
-            stack_sample.thread_id,
-            [
-              stack_sample.frames.collect(&:hash),
-              stack_sample.total_frame_count
-            ]
-          ].hash
+          stack_sample.hash
         end
 
         def build_samples(stack_samples)

--- a/spec/ddtrace/profiling/events/stack_spec.rb
+++ b/spec/ddtrace/profiling/events/stack_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Datadog::Profiling::Events::Stack do
     end
 
     let(:timestamp) { double('timestamp') }
-    let(:frames) { double('frames') }
+    let(:frames) { double('frames', collect: []) }
     let(:total_frame_count) { double('total_frame_count') }
     let(:thread_id) { double('thread_id') }
 
@@ -43,7 +43,7 @@ RSpec.describe Datadog::Profiling::Events::StackSample do
     end
 
     let(:timestamp) { double('timestamp') }
-    let(:frames) { double('frames') }
+    let(:frames) { double('frames', collect: []) }
     let(:total_frame_count) { double('total_frame_count') }
     let(:thread_id) { double('thread_id') }
     let(:cpu_time_interval_ns) { double('cpu_time_interval_ns') }
@@ -75,7 +75,7 @@ RSpec.describe Datadog::Profiling::Events::StackExceptionSample do
     end
 
     let(:timestamp) { double('timestamp') }
-    let(:frames) { double('frames') }
+    let(:frames) { double('frames', collect: []) }
     let(:total_frame_count) { double('total_frame_count') }
     let(:thread_id) { double('thread_id') }
     let(:exception) { double('exception') }


### PR DESCRIPTION
In an effort to improve performance of the profiling exporter, which spends some significant resources on grouping and encoding profiling samples, this pull request caches hash values for `BacktraceLocation` and `Stack` event objects.

In the exporter, profiling samples are compared and grouped where their stacks are identical. To do this, it must compute the hash of each stack, then compare those to decide whether to keep or merge that sample. Computing this hash can be expensive, as it must compile each file & line number of every frame in each stack into a Hash.

Although this pull request doesn't reduce the complexity, it instead aims to amortize the cost, and prevent having to pay it more than once, by computing the hash of `BacktraceLocation` and `Stack` event objects at initialization time. (This relies on the assumption that these objects are effectively immutable.) As a result, it smoothes out CPU usage prevent large spikes during profile export, and reduces memory by a small amount as well.