### PR TITLE
Use string table when building BacktraceLocations

### DIFF
--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -140,17 +140,15 @@ module Datadog
         # Convert backtrace locations into structs
         # Re-use old backtrace location objects if they already exist in the buffer
         def convert_backtrace_locations(locations)
-          string_table = recorder[Events::StackSample].string_table
-
           locations.collect do |location|
             # Re-use existing BacktraceLocation if identical copy, otherwise build a new one.
             recorder[Events::StackSample].cache(:backtrace_locations).fetch(
               # Function name
-              string_table.fetch_string(location.base_label),
+              location.base_label,
               # Line number
               location.lineno,
               # Filename
-              string_table.fetch_string(location.path),
+              location.path,
               # Build function
               &method(:build_backtrace_location)
             )
@@ -158,10 +156,12 @@ module Datadog
         end
 
         def build_backtrace_location(_id, base_label, lineno, path)
+          string_table = recorder[Events::StackSample].string_table
+
           Profiling::BacktraceLocation.new(
-            base_label,
+            string_table.fetch_string(base_label),
             lineno,
-            path
+            string_table.fetch_string(path)
           )
         end
       end

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -524,10 +524,23 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
 
     it do
       is_expected.to have_attributes(
-        base_label: base_label,
+        base_label: base_label.to_s,
         lineno: lineno,
-        path: path
+        path: path.to_s
       )
+    end
+
+    context 'when strings' do
+      context 'exist in the string table' do
+        let!(:string_table_base_label) { string_table.fetch_string(base_label.to_s) }
+        let!(:string_table_path) { string_table.fetch_string(path.to_s) }
+
+        it 'reuses strings' do
+          backtrace_location = build_backtrace_location
+          expect(backtrace_location.base_label).to be string_table_base_label
+          expect(backtrace_location.path).to be string_table_path
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Instead of using the string table when looping through each sample, we can use it only when we're creating the new `BacktraceLocation`. This is a small optimization that should save a few extra lookups/CPU per sample in the collector thread.