### PR TITLE
Fix diagnostic debug settings test

### DIFF
--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -124,13 +124,14 @@ RSpec.describe Datadog::Configuration::Settings do
     describe '#debug=' do
       context 'enabled' do
         subject(:set_debug) { settings.diagnostics.debug = true }
+        after { settings.diagnostics.debug = false }
 
         it 'updates the #debug setting' do
           expect { set_debug }.to change { settings.diagnostics.debug }.from(false).to(true)
         end
 
         it 'requires debug dependencies' do
-          expect_any_instance_of(Kernel).to receive(:require).with('pp')
+          expect_any_instance_of(Object).to receive(:require).with('pp')
           set_debug
         end
       end
@@ -139,7 +140,7 @@ RSpec.describe Datadog::Configuration::Settings do
         subject(:set_debug) { settings.diagnostics.debug = false }
 
         it 'does not require debug dependencies' do
-          expect_any_instance_of(Kernel).to_not receive(:require)
+          expect_any_instance_of(Object).to_not receive(:require)
           set_debug
         end
       end


### PR DESCRIPTION
We were previously trying to match on `expect_any_instance_of(Kernel)`, which is a very blunt matcher that doesn't work reliably: it failed to intercept mocked method calls depending on test execution order.

This PR changes that matcher to `expect_any_instance_of(Object)`, which seems to behave nicely regardless of our execution patterns.

Overall, `expect_any_instance_of` has many corner cases we've stumbled upon recently, and it has proven flaky ([RSpec team doesn't recommend it either](https://relishapp.com/rspec/rspec-mocks/docs/working-with-legacy-code/any-instance)), but I don't see a better way to this `require` statements like in this test.