### PR TITLE
Access active correlation by thread

### DIFF
--- a/lib/ddtrace/context_provider.rb
+++ b/lib/ddtrace/context_provider.rb
@@ -13,9 +13,9 @@ module Datadog
       @context.local = ctx
     end
 
-    # Return the current context.
-    def context
-      @context.local
+    # Return the local context.
+    def context(key = nil)
+      key.nil? ? @context.local : @context.local(key)
     end
   end
 
@@ -43,8 +43,9 @@ module Datadog
     end
 
     # Return the thread-local context.
-    def local
-      Thread.current[@key] ||= Datadog::Context.new
+    def local(thread = Thread.current)
+      raise ArgumentError, '\'thread\' must be a Thread.' unless thread.is_a?(Thread)
+      thread[@key] ||= Datadog::Context.new
     end
   end
 end

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -59,8 +59,8 @@ module Datadog
     #
     # This method makes use of a \ContextProvider that is automatically set during the tracer
     # initialization, or while using a library instrumentation.
-    def call_context
-      @provider.context
+    def call_context(key = nil)
+      @provider.context(key)
     end
 
     # Initialize a new \Tracer used to create, sample and submit spans that measure the
@@ -324,18 +324,18 @@ module Datadog
     end
 
     # Return the current active span or +nil+.
-    def active_span
-      call_context.current_span
+    def active_span(key = nil)
+      call_context(key).current_span
     end
 
     # Return the current active root span or +nil+.
-    def active_root_span
-      call_context.current_root_span
+    def active_root_span(key = nil)
+      call_context(key).current_root_span
     end
 
     # Return a CorrelationIdentifier for active span
-    def active_correlation
-      Datadog::Correlation.identifier_from_context(call_context)
+    def active_correlation(key = nil)
+      Datadog::Correlation.identifier_from_context(call_context(key))
     end
 
     # Send the trace to the writer to enqueue the spans list in the agent

--- a/spec/ddtrace/context_provider_spec.rb
+++ b/spec/ddtrace/context_provider_spec.rb
@@ -23,9 +23,24 @@ RSpec.describe Datadog::DefaultContextProvider do
 
     before { expect(Datadog::ThreadLocalContext).to receive(:new).and_return(local_context) }
 
-    it do
-      expect(local_context).to receive(:local)
-      subject
+    context 'when given no arguments' do
+      it do
+        expect(local_context).to receive(:local)
+        subject
+      end
+    end
+
+    context 'when given a key' do
+      subject(:context) { provider.context(key) }
+      let(:key) { double('key') }
+
+      it do
+        expect(local_context)
+          .to receive(:local)
+          .with(key)
+
+        subject
+      end
     end
   end
 
@@ -87,6 +102,21 @@ RSpec.describe Datadog::ThreadLocalContext do
 
         expect(@thread_context).to_not eq(context)
       end
+    end
+
+    context 'given a thread' do
+      subject(:local) { thread_local_context.local(thread) }
+      let(:thread) { Thread.new {} }
+
+      it 'retrieves the context for the provided thread' do
+        is_expected.to be_a_kind_of(Datadog::Context)
+        expect(local).to_not be(thread_local_context.local)
+      end
+    end
+
+    context 'given a bad argument' do
+      subject(:local) { thread_local_context.local('bad_arg') }
+      it { expect { local }.to raise_error(ArgumentError) }
     end
   end
 


### PR DESCRIPTION
Currently `Datadog.tracer.active_correlation` provides a `Datadog::Correlation::Identifier` for the current thread: it is not possible to obtain the correlation for an arbitrary thread on which a trace might be running.

This pull request allows a key (aka thread) to be provided when the active correlation is accessed, so that the correlation matching that key can be returned. This will be useful for profiling or logging when producing correlations from threads other than the current.