### PR TITLE
feat: enable runtime metrics by default and update tests

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2218,7 +2218,7 @@ require 'datadog/statsd'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  # To enable runtime metrics collection, set `true`. Defaults to `false`
+  # To enable runtime metrics collection, set `true`. Defaults to `true`
   # You can also set DD_RUNTIME_METRICS_ENABLED=true to configure this.
   c.runtime_metrics.enabled = true
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2208,7 +2208,7 @@ To configure your application for metrics collection:
 
 #### For application runtime
 
-If runtime metrics are configured, the trace library will automatically collect and send metrics about the health of your application.
+Runtime metrics are enabled by default. When enabled, the trace library will automatically collect and send metrics about the health of your application.
 
 To configure runtime metrics, add the following configuration:
 
@@ -2218,8 +2218,9 @@ require 'datadog/statsd'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  # To enable runtime metrics collection, set `true`. Defaults to `true`
-  # You can also set DD_RUNTIME_METRICS_ENABLED=true to configure this.
+  # Runtime metrics collection is enabled by default.
+  # To disable, set `false`. Defaults to `true`
+  # You can also set DD_RUNTIME_METRICS_ENABLED=false to disable this.
   c.runtime_metrics.enabled = true
 
   # Optionally, you can configure the Statsd instance used for sending runtime metrics.

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -113,7 +113,7 @@ module Datadog
 
       settings :runtime_metrics do
         option :enabled do |o|
-          o.default { env_to_bool(Ext::Runtime::Metrics::ENV_ENABLED, false) }
+          o.default { env_to_bool(Ext::Runtime::Metrics::ENV_ENABLED, true) }
           o.lazy
         end
 

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -1,3 +1,4 @@
+
 require 'spec_helper'
 require 'securerandom'
 
@@ -389,10 +390,10 @@ RSpec.describe Datadog::Configuration::Settings do
         subject(:runtime_metrics) { settings.runtime_metrics enabled: true }
 
         it 'updates the new #enabled setting' do
-          expect { settings.runtime_metrics enabled: true }
+          expect { settings.runtime_metrics enabled: false }
             .to change { settings.runtime_metrics.enabled }
-            .from(false)
-            .to(true)
+            .from(true)
+            .to(false)
         end
       end
 
@@ -421,7 +422,7 @@ RSpec.describe Datadog::Configuration::Settings do
 
         context 'is not defined' do
           let(:environment) { nil }
-          it { is_expected.to be false }
+          it { is_expected.to be true }
         end
 
         context 'is defined' do
@@ -433,10 +434,10 @@ RSpec.describe Datadog::Configuration::Settings do
 
     describe '#enabled=' do
       it 'changes the #enabled setting' do
-        expect { settings.runtime_metrics.enabled = true }
+        expect { settings.runtime_metrics.enabled = false }
           .to change { settings.runtime_metrics.enabled }
-          .from(false)
-          .to(true)
+          .from(true)
+          .to(false)
       end
     end
 
@@ -486,10 +487,10 @@ RSpec.describe Datadog::Configuration::Settings do
 
   describe '#runtime_metrics_enabled=' do
     it 'changes the new #enabled setting' do
-      expect { settings.runtime_metrics_enabled = true }
+      expect { settings.runtime_metrics_enabled = false }
         .to change { settings.runtime_metrics.enabled }
-        .from(false)
-        .to(true)
+        .from(true)
+        .to(false)
     end
   end
 

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -363,7 +363,7 @@ RSpec.describe Datadog::Configuration do
     describe '#runtime_metrics' do
       subject(:runtime_metrics) { test_class.runtime_metrics }
       it { is_expected.to be_a_kind_of(Datadog::Workers::RuntimeMetrics) }
-      it { expect(runtime_metrics.enabled?).to be false }
+      it { expect(runtime_metrics.enabled?).to be true }
       it { expect(runtime_metrics.running?).to be false }
     end
 

--- a/spec/ddtrace/diagnostics/environment_logger_spec.rb
+++ b/spec/ddtrace/diagnostics/environment_logger_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Datadog::Diagnostics::EnvironmentLogger do
           'os_name' => include('x86_64'),
           'partial_flushing_enabled' => false,
           'priority_sampling_enabled' => false,
-          'runtime_metrics_enabled' => false,
+          'runtime_metrics_enabled' => true,
           'version' => Datadog::VERSION::STRING,
           'vm' => be_a(String)
         )
@@ -139,7 +139,7 @@ RSpec.describe Datadog::Diagnostics::EnvironmentLogger do
           os_name: include('x86_64'),
           partial_flushing_enabled: false,
           priority_sampling_enabled: false,
-          runtime_metrics_enabled: false,
+          runtime_metrics_enabled: true,
           sample_rate: nil,
           sampling_rules: nil,
           service: nil,
@@ -192,10 +192,10 @@ RSpec.describe Datadog::Diagnostics::EnvironmentLogger do
         it { is_expected.to include analytics_enabled: true }
       end
 
-      context 'with runtime metrics enabled' do
-        before { Datadog.configure { |c| c.runtime_metrics_enabled = true } }
+      context 'with runtime metrics disabled' do
+        before { Datadog.configure { |c| c.runtime_metrics_enabled = false } }
 
-        it { is_expected.to include runtime_metrics_enabled: true }
+        it { is_expected.to include runtime_metrics_enabled: false }
       end
 
       context 'with partial flushing enabled' do

--- a/spec/ddtrace/tracer_integration_spec.rb
+++ b/spec/ddtrace/tracer_integration_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe Datadog::Tracer do
         # propagate the root span, only its ID. Therefore the span reference
         # should be the first span on the other end of the distributed trace.
         it { expect(@child_root_span).to be child_span }
-        it 'does not set runtime metrics language tag' do
-          expect(lang_tag(parent_span)).to be nil
-          expect(lang_tag(child_span)).to be nil
+        it 'sets runtime metrics language tag' do
+          expect(lang_tag(parent_span)).to eq('ruby')
+          expect(lang_tag(child_span)).to eq('ruby')
         end
       end
 


### PR DESCRIPTION
This PR enables runtime metrics by default as well as updates the relevant tests