### PR TITLE
GRPCPropagator: handle metadata array values

### DIFF
--- a/lib/ddtrace/contrib/grpc/datadog_interceptor/client.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor/client.rb
@@ -8,7 +8,7 @@ module Datadog
     module GRPC
       module DatadogInterceptor
         # The DatadogInterceptor::Client implements the tracing strategy
-        # for gRPC client-side endpoitns. This middleware compoent will
+        # for gRPC client-side endpoints. This middleware component will
         # inject trace context information into gRPC metadata prior to
         # sending the request to the server.
         class Client < Base

--- a/lib/ddtrace/propagation/grpc_propagator.rb
+++ b/lib/ddtrace/propagation/grpc_propagator.rb
@@ -57,9 +57,9 @@ module Datadog
 
       def sampling_priority
         value = if @metadata[GRPC_METADATA_SAMPLING_PRIORITY].is_a?(Array)
-                  @metadata[GRPC_METADATA_SAMPLING_PRIORITY].first.to_i
+                  @metadata[GRPC_METADATA_SAMPLING_PRIORITY].first
                 else
-                  @metadata[GRPC_METADATA_SAMPLING_PRIORITY].to_i
+                  @metadata[GRPC_METADATA_SAMPLING_PRIORITY]
                 end
         value && value.to_i
       end

--- a/lib/ddtrace/propagation/grpc_propagator.rb
+++ b/lib/ddtrace/propagation/grpc_propagator.rb
@@ -60,9 +60,9 @@ module Datadog
       private
 
       def metadata_for_key(key)
-        # metadata values can be arrays (multiple headers with the same values)
-        return @metadata[key].first if @metadata[key].is_a?(Array)
-        @metadata[key]
+        # metadata values can be arrays (multiple headers with the same key)
+        value = @metadata[key]
+        value.is_a?(Array) ? value.first : value
       end
     end
   end

--- a/lib/ddtrace/propagation/grpc_propagator.rb
+++ b/lib/ddtrace/propagation/grpc_propagator.rb
@@ -38,22 +38,38 @@ module Datadog
       end
 
       def trace_id
-        value = Array(@metadata[GRPC_METADATA_TRACE_ID]).first.to_i
+        value = if @metadata[GRPC_METADATA_TRACE_ID].is_a?(Array)
+                  @metadata[GRPC_METADATA_TRACE_ID].first.to_i
+                else
+                  @metadata[GRPC_METADATA_TRACE_ID].to_i
+                end
         value if (1..Span::EXTERNAL_MAX_ID).cover? value
       end
 
       def parent_id
-        value = Array(@metadata[GRPC_METADATA_PARENT_ID]).first.to_i
+        value = if @metadata[GRPC_METADATA_PARENT_ID].is_a?(Array)
+                  @metadata[GRPC_METADATA_PARENT_ID].first.to_i
+                else
+                  @metadata[GRPC_METADATA_PARENT_ID].to_i
+                end
         value if (1..Span::EXTERNAL_MAX_ID).cover? value
       end
 
       def sampling_priority
-        value = Array(@metadata[GRPC_METADATA_SAMPLING_PRIORITY]).first
+        value = if @metadata[GRPC_METADATA_SAMPLING_PRIORITY].is_a?(Array)
+                  @metadata[GRPC_METADATA_SAMPLING_PRIORITY].first.to_i
+                else
+                  @metadata[GRPC_METADATA_SAMPLING_PRIORITY].to_i
+                end
         value && value.to_i
       end
 
       def origin
-        value = Array(@metadata[GRPC_METADATA_ORIGIN]).first
+        value = if @metadata[GRPC_METADATA_ORIGIN].is_a?(Array)
+                  @metadata[GRPC_METADATA_ORIGIN].first
+                else
+                  @metadata[GRPC_METADATA_ORIGIN]
+                end
         value if value != ''
       end
     end

--- a/lib/ddtrace/propagation/grpc_propagator.rb
+++ b/lib/ddtrace/propagation/grpc_propagator.rb
@@ -38,39 +38,31 @@ module Datadog
       end
 
       def trace_id
-        value = if @metadata[GRPC_METADATA_TRACE_ID].is_a?(Array)
-                  @metadata[GRPC_METADATA_TRACE_ID].first.to_i
-                else
-                  @metadata[GRPC_METADATA_TRACE_ID].to_i
-                end
+        value = metadata_for_key(GRPC_METADATA_TRACE_ID).to_i
         value if (1..Span::EXTERNAL_MAX_ID).cover? value
       end
 
       def parent_id
-        value = if @metadata[GRPC_METADATA_PARENT_ID].is_a?(Array)
-                  @metadata[GRPC_METADATA_PARENT_ID].first.to_i
-                else
-                  @metadata[GRPC_METADATA_PARENT_ID].to_i
-                end
+        value = metadata_for_key(GRPC_METADATA_PARENT_ID).to_i
         value if (1..Span::EXTERNAL_MAX_ID).cover? value
       end
 
       def sampling_priority
-        value = if @metadata[GRPC_METADATA_SAMPLING_PRIORITY].is_a?(Array)
-                  @metadata[GRPC_METADATA_SAMPLING_PRIORITY].first
-                else
-                  @metadata[GRPC_METADATA_SAMPLING_PRIORITY]
-                end
+        value = metadata_for_key(GRPC_METADATA_SAMPLING_PRIORITY)
         value && value.to_i
       end
 
       def origin
-        value = if @metadata[GRPC_METADATA_ORIGIN].is_a?(Array)
-                  @metadata[GRPC_METADATA_ORIGIN].first
-                else
-                  @metadata[GRPC_METADATA_ORIGIN]
-                end
+        value = metadata_for_key(GRPC_METADATA_ORIGIN)
         value if value != ''
+      end
+
+      private
+
+      def metadata_for_key(key)
+        # metadata values can be arrays (multiple headers with the same values)
+        return @metadata[key].first if @metadata[key].is_a?(Array)
+        @metadata[key]
       end
     end
   end

--- a/lib/ddtrace/propagation/grpc_propagator.rb
+++ b/lib/ddtrace/propagation/grpc_propagator.rb
@@ -38,22 +38,22 @@ module Datadog
       end
 
       def trace_id
-        value = @metadata[GRPC_METADATA_TRACE_ID].to_i
+        value = Array(@metadata[GRPC_METADATA_TRACE_ID]).first.to_i
         value if (1..Span::EXTERNAL_MAX_ID).cover? value
       end
 
       def parent_id
-        value = @metadata[GRPC_METADATA_PARENT_ID].to_i
+        value = Array(@metadata[GRPC_METADATA_PARENT_ID]).first.to_i
         value if (1..Span::EXTERNAL_MAX_ID).cover? value
       end
 
       def sampling_priority
-        value = @metadata[GRPC_METADATA_SAMPLING_PRIORITY]
+        value = Array(@metadata[GRPC_METADATA_SAMPLING_PRIORITY]).first
         value && value.to_i
       end
 
       def origin
-        value = @metadata[GRPC_METADATA_ORIGIN]
+        value = Array(@metadata[GRPC_METADATA_ORIGIN]).first
         value if value != ''
       end
     end

--- a/lib/ddtrace/propagation/grpc_propagator.rb
+++ b/lib/ddtrace/propagation/grpc_propagator.rb
@@ -62,7 +62,11 @@ module Datadog
       def metadata_for_key(key)
         # metadata values can be arrays (multiple headers with the same key)
         value = @metadata[key]
-        value.is_a?(Array) ? value.first : value
+        if value.is_a?(Array)
+          value.first
+        else
+          value
+        end
       end
     end
   end

--- a/spec/ddtrace/propagation/grpc_propagator_spec.rb
+++ b/spec/ddtrace/propagation/grpc_propagator_spec.rb
@@ -85,5 +85,23 @@ RSpec.describe Datadog::GRPCPropagator do
         expect(subject.origin).to eq 'synthetics'
       end
     end
+
+    # Metadata values can also be arrays
+    # https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md
+    context 'given populated metadata in array format' do
+      let(:metadata) do
+        { 'x-datadog-trace-id' => ['12345', '67890'],
+          'x-datadog-parent-id' => ['98765', '43210'],
+          'x-datadog-sampling-priority' => ['0'],
+          'x-datadog-origin' => ['synthetics'] }
+      end
+
+      it 'returns a populated context with the first metadata array values' do
+        expect(subject.trace_id).to eq 12345
+        expect(subject.span_id).to eq 98765
+        expect(subject.sampling_priority).to be_zero
+        expect(subject.origin).to eq 'synthetics'
+      end
+    end
   end
 end

--- a/spec/ddtrace/propagation/grpc_propagator_spec.rb
+++ b/spec/ddtrace/propagation/grpc_propagator_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe Datadog::GRPCPropagator do
     # https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md
     context 'given populated metadata in array format' do
       let(:metadata) do
-        { 'x-datadog-trace-id' => ['12345', '67890'],
-          'x-datadog-parent-id' => ['98765', '43210'],
+        { 'x-datadog-trace-id' => %w[12345 67890],
+          'x-datadog-parent-id' => %w[98765 43210],
           'x-datadog-sampling-priority' => ['0'],
           'x-datadog-origin' => ['synthetics'] }
       end


### PR DESCRIPTION
gRPC metadata values can be arrays (see https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md). In gRPC's Ruby metadata implementation, single metadata values are a singular type, and multiple values come as an array.

This library assumes a single value each time. This PR fixes this assumption to take the first value of an array, like the [Go version](https://github.com/DataDog/dd-trace-go/blob/54b73b3e126a7489ed774c98aadd301488e44123/contrib/google.golang.org/internal/grpcutil/mdcarrier.go#L27).

This bug surfaced a separate bug with dd-trace-go, which [appends values to metadata](https://github.com/DataDog/dd-trace-go/blob/54b73b3e126a7489ed774c98aadd301488e44123/contrib/google.golang.org/internal/grpcutil/mdcarrier.go#L36) rather than setting. If your trace looks like `Go -> Go -> Ruby`, the gRPC call to Ruby will contain the headers twice.