### PR TITLE
Restore clean Thread class after applying Profiling thread extensions

### DIFF
--- a/lib/ddtrace/profiling/ext/cpu.rb
+++ b/lib/ddtrace/profiling/ext/cpu.rb
@@ -15,6 +15,8 @@ module Datadog
         def self.apply!
           return false unless supported?
 
+          # Applying CThread to Thread will ensure any new threads
+          # will provide a thread/clock ID for CPU timing.
           require 'ddtrace/profiling/ext/cthread'
           ::Thread.send(:prepend, Profiling::Ext::CThread)
         end

--- a/spec/ddtrace/profiling/ext/cpu_spec.rb
+++ b/spec/ddtrace/profiling/ext/cpu_spec.rb
@@ -53,14 +53,7 @@ RSpec.describe Datadog::Profiling::Ext::CPU do
   describe '::apply!' do
     subject(:apply!) { described_class.apply! }
 
-    around do |example|
-      unmodified_thread_class = ::Thread.dup
-
-      example.run
-
-      Object.send(:remove_const, :Thread)
-      Object.const_set('Thread', unmodified_thread_class)
-    end
+    before { stub_const('Thread', ::Thread.dup) }
 
     context 'when native CPU time is supported' do
       before { skip 'CPU profiling not supported' unless described_class.supported? }

--- a/spec/ddtrace/profiling/ext/cthread_spec.rb
+++ b/spec/ddtrace/profiling/ext/cthread_spec.rb
@@ -17,31 +17,47 @@ if Datadog::Profiling::Ext::CPU.supported?
     let(:block) { proc { loop { sleep(1) } } }
 
     let(:thread_class) do
-      Thread.send(:prepend, described_class)
-      Thread
+      expect(::Thread.ancestors).to_not include(described_class)
+
+      klass = ::Thread.dup
+      klass.send(:prepend, described_class)
+      klass
     end
 
     # Leave Thread class in a clean state before and after tests
-    around do |example|
-      expect(::Thread.ancestors).to_not include(described_class)
-      unmodified_class = ::Thread.dup
-
-      example.run
-
-      Object.send(:remove_const, :Thread)
-      Object.const_set('Thread', unmodified_class)
+    before do
+      stub_const('Thread', thread_class)
     end
 
     # Kill any spawned threads
     after { thread.kill if instance_variable_defined?(:@thread_started) && @thread_started }
 
+    shared_context 'with main thread' do
+      let(:thread_class) { ::Thread }
+
+      def on_main_thread
+        # Patch thread in a fork so we don't modify the original Thread class
+        expect_in_fork do
+          thread_class.send(:prepend, described_class)
+          yield
+        end
+
+        # Ensure the patch didn't leak out of the fork.
+        expect(::Thread).to_not be_a_kind_of(described_class)
+      end
+    end
+
     describe 'prepend' do
+      let(:thread_class) { ::Thread.dup }
+
+      before { allow(thread_class).to receive(:current).and_return(thread) }
+
       it 'sets native thread IDs on current thread' do
-        expect(thread_class.current).to have_attributes(
-          clock_id: kind_of(Integer),
-          native_thread_id: kind_of(Integer),
-          cpu_time: kind_of(Float)
-        )
+        # Skip verification because the thread will not have been patched with the method yet
+        without_partial_double_verification do
+          expect(thread).to receive(:update_native_ids)
+          thread_class.send(:prepend, described_class)
+        end
       end
     end
 
@@ -64,12 +80,12 @@ if Datadog::Profiling::Ext::CPU.supported?
         context 'when forked' do
           it 'returns a new native thread ID' do
             # Get main thread native ID
-            original_native_thread_id = thread_class.current.native_thread_id
+            original_native_thread_id = thread.native_thread_id
 
             expect_in_fork do
               # Expect main thread native ID to not change
-              expect(thread_class.current.native_thread_id).to be_a_kind_of(Integer)
-              expect(thread_class.current.native_thread_id).to eq(original_native_thread_id)
+              expect(thread.native_thread_id).to be_a_kind_of(Integer)
+              expect(thread.native_thread_id).to eq(original_native_thread_id)
             end
           end
         end
@@ -82,15 +98,19 @@ if Datadog::Profiling::Ext::CPU.supported?
       it { is_expected.to be_a_kind_of(Integer) }
 
       context 'main thread' do
+        include_context 'with main thread'
+
         context 'when forked' do
           it 'returns a new clock ID' do
-            # Get main thread clock ID
-            original_clock_id = thread_class.current.clock_id
+            on_main_thread do
+              # Get main thread clock ID
+              original_clock_id = thread_class.current.clock_id
 
-            expect_in_fork do
-              # Expect main thread clock ID to change (to match fork's main thread)
-              expect(thread_class.current.clock_id).to be_a_kind_of(Integer)
-              expect(thread_class.current.clock_id).to_not eq(original_clock_id)
+              expect_in_fork do
+                # Expect main thread clock ID to change (to match fork's main thread)
+                expect(thread_class.current.clock_id).to be_a_kind_of(Integer)
+                expect(thread_class.current.clock_id).to_not eq(original_clock_id)
+              end
             end
           end
         end
@@ -147,12 +167,16 @@ if Datadog::Profiling::Ext::CPU.supported?
       end
 
       context 'main thread' do
+        include_context 'with main thread'
+
         context 'when forked' do
           it 'returns a CPU time' do
-            expect(thread_class.current.cpu_time).to be_a_kind_of(Float)
-
-            expect_in_fork do
+            on_main_thread do
               expect(thread_class.current.cpu_time).to be_a_kind_of(Float)
+
+              expect_in_fork do
+                expect(thread_class.current.cpu_time).to be_a_kind_of(Float)
+              end
             end
           end
         end


### PR DESCRIPTION
After adding a [type check](https://github.com/DataDog/dd-trace-rb/pull/1200/files#diff-62e0521325c7c05c2ca53226e748a05eff8619193dcae150f141a90cb6428620R47) in #1200, it became clear that profiling tests would leave the `Thread` in an unclean state. Specifically, `Thread` would be replaced with a duplicate of the original class. Although this was functionally similar to the original `Thread` class object, the `object_id` is different, and this was causing `Thread.current.class == Thread` to evaluate as `false`.

In this pull request, we want to leave the `Thread` constant in a pristine state after a profiling test is complete, so that subsequent tests are consistent and dependable. To do this, we leverage `stub_const` to temporarily replace the `Thread` constant with a copy of `Thread` and restore it after the test.

There's also a specific case where we must profiling on the main `Thread` object. This main thread object is an instance of the original `Thread` class, not our stubbed copy of the `Thread` class, which means in our test suite, we cannot update this object without altering the original `Thread` class (something we cannot do if we want to preserve pristine state.) Instead in these tests, we must `fork` then patch the main thread inside the fork, to allow profiling on the main thread to be tested without altering the original `Thread` class.