### PR TITLE
Add trace ID/span ID to profile labels

### DIFF
--- a/lib/ddtrace/ext/profiling.rb
+++ b/lib/ddtrace/ext/profiling.rb
@@ -5,7 +5,9 @@ module Datadog
       ENV_UPLOAD_TIMEOUT = 'DD_PROFILING_UPLOAD_TIMEOUT'.freeze
 
       module Pprof
+        LABEL_KEY_SPAN_ID = 'span id'.freeze
         LABEL_KEY_THREAD_ID = 'thread id'.freeze
+        LABEL_KEY_TRACE_ID = 'trace id'.freeze
         SAMPLE_VALUE_NO_VALUE = 0
         VALUE_TYPE_CPU = 'cpu-time'.freeze
         VALUE_TYPE_WALL = 'wall-time'.freeze

--- a/lib/ddtrace/ext/profiling.rb
+++ b/lib/ddtrace/ext/profiling.rb
@@ -31,6 +31,7 @@ module Datadog
           FORM_FIELD_TAG_PROFILER_VERSION = 'profiler_version'.freeze
           FORM_FIELD_TAG_RUNTIME = 'runtime'.freeze
           FORM_FIELD_TAG_RUNTIME_ENGINE = 'runtime_engine'.freeze
+          FORM_FIELD_TAG_RUNTIME_ID = 'runtime-id'.freeze
           FORM_FIELD_TAG_RUNTIME_PLATFORM = 'runtime_platform'.freeze
           FORM_FIELD_TAG_RUNTIME_VERSION = 'runtime_version'.freeze
           FORM_FIELD_TAG_SERVICE = 'service'.freeze

--- a/lib/ddtrace/profiling/events/stack.rb
+++ b/lib/ddtrace/profiling/events/stack.rb
@@ -7,24 +7,32 @@ module Datadog
       class Stack < Event
         attr_reader \
           :frames,
-          :total_frame_count,
+          :hash,
+          :span_id,
           :thread_id,
-          :hash
+          :total_frame_count,
+          :trace_id
 
         def initialize(
           timestamp,
           frames,
           total_frame_count,
-          thread_id
+          thread_id,
+          trace_id,
+          span_id
         )
           super(timestamp)
 
           @frames = frames
           @total_frame_count = total_frame_count
           @thread_id = thread_id
+          @trace_id = trace_id
+          @span_id = span_id
 
           @hash = [
             thread_id,
+            trace_id,
+            span_id,
             [
               frames.collect(&:hash),
               total_frame_count
@@ -44,6 +52,8 @@ module Datadog
           frames,
           total_frame_count,
           thread_id,
+          trace_id,
+          span_id,
           cpu_time_interval_ns,
           wall_time_interval_ns
         )
@@ -51,7 +61,9 @@ module Datadog
             timestamp,
             frames,
             total_frame_count,
-            thread_id
+            thread_id,
+            trace_id,
+            span_id
           )
 
           @cpu_time_interval_ns = cpu_time_interval_ns
@@ -69,6 +81,8 @@ module Datadog
           frames,
           total_frame_count,
           thread_id,
+          trace_id,
+          span_id,
           exception
         )
           super(
@@ -76,6 +90,8 @@ module Datadog
             frames,
             total_frame_count,
             thread_id,
+            trace_id,
+            span_id
           )
 
           @exception = exception

--- a/lib/ddtrace/profiling/pprof/stack_sample.rb
+++ b/lib/ddtrace/profiling/pprof/stack_sample.rb
@@ -61,12 +61,28 @@ module Datadog
         end
 
         def build_sample_labels(stack_sample)
-          [
+          labels = [
             Perftools::Profiles::Label.new(
               key: builder.string_table.fetch(Datadog::Ext::Profiling::Pprof::LABEL_KEY_THREAD_ID),
               str: builder.string_table.fetch(stack_sample.thread_id.to_s)
             )
           ]
+
+          unless stack_sample.trace_id.nil? || stack_sample.trace_id.zero?
+            labels << Perftools::Profiles::Label.new(
+              key: builder.string_table.fetch(Datadog::Ext::Profiling::Pprof::LABEL_KEY_TRACE_ID),
+              str: builder.string_table.fetch(stack_sample.trace_id.to_s)
+            )
+          end
+
+          unless stack_sample.span_id.nil? || stack_sample.span_id.zero?
+            labels << Perftools::Profiles::Label.new(
+              key: builder.string_table.fetch(Datadog::Ext::Profiling::Pprof::LABEL_KEY_SPAN_ID),
+              str: builder.string_table.fetch(stack_sample.span_id.to_s)
+            )
+          end
+
+          labels
         end
       end
     end

--- a/lib/ddtrace/profiling/transport/http/api/endpoint.rb
+++ b/lib/ddtrace/profiling/transport/http/api/endpoint.rb
@@ -38,11 +38,13 @@ module Datadog
               pprof_file, types = build_pprof(flush)
 
               form = {
+                # NOTE: Redundant w/ 'runtime-id' tag below; may want to remove this later.
                 FORM_FIELD_RUNTIME_ID => flush.runtime_id,
                 FORM_FIELD_RECORDING_START => flush.start.utc.iso8601,
                 FORM_FIELD_RECORDING_END => flush.finish.utc.iso8601,
                 FORM_FIELD_TAGS => [
                   "#{FORM_FIELD_TAG_RUNTIME}:#{flush.language}",
+                  "#{FORM_FIELD_TAG_RUNTIME_ID}:#{flush.runtime_id}",
                   "#{FORM_FIELD_TAG_RUNTIME_ENGINE}:#{flush.runtime_engine}",
                   "#{FORM_FIELD_TAG_RUNTIME_PLATFORM}:#{flush.runtime_platform}",
                   "#{FORM_FIELD_TAG_RUNTIME_VERSION}:#{flush.runtime_version}",

--- a/spec/ddtrace/profiling/events/stack_spec.rb
+++ b/spec/ddtrace/profiling/events/stack_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe Datadog::Profiling::Events::Stack do
         timestamp,
         frames,
         total_frame_count,
-        thread_id
+        thread_id,
+        trace_id,
+        span_id
       )
     end
 
@@ -17,13 +19,17 @@ RSpec.describe Datadog::Profiling::Events::Stack do
     let(:frames) { double('frames', collect: []) }
     let(:total_frame_count) { double('total_frame_count') }
     let(:thread_id) { double('thread_id') }
+    let(:trace_id) { double('trace_id') }
+    let(:span_id) { double('span_id') }
 
     it do
       is_expected.to have_attributes(
         timestamp: timestamp,
         frames: frames,
         total_frame_count: total_frame_count,
-        thread_id: thread_id
+        thread_id: thread_id,
+        trace_id: trace_id,
+        span_id: span_id
       )
     end
   end
@@ -37,6 +43,8 @@ RSpec.describe Datadog::Profiling::Events::StackSample do
         frames,
         total_frame_count,
         thread_id,
+        trace_id,
+        span_id,
         cpu_time_interval_ns,
         wall_time_interval_ns
       )
@@ -46,6 +54,8 @@ RSpec.describe Datadog::Profiling::Events::StackSample do
     let(:frames) { double('frames', collect: []) }
     let(:total_frame_count) { double('total_frame_count') }
     let(:thread_id) { double('thread_id') }
+    let(:trace_id) { double('trace_id') }
+    let(:span_id) { double('span_id') }
     let(:cpu_time_interval_ns) { double('cpu_time_interval_ns') }
     let(:wall_time_interval_ns) { double('wall_time_interval_ns') }
 
@@ -55,6 +65,8 @@ RSpec.describe Datadog::Profiling::Events::StackSample do
         frames: frames,
         total_frame_count: total_frame_count,
         thread_id: thread_id,
+        trace_id: trace_id,
+        span_id: span_id,
         cpu_time_interval_ns: cpu_time_interval_ns,
         wall_time_interval_ns: wall_time_interval_ns
       )
@@ -70,6 +82,8 @@ RSpec.describe Datadog::Profiling::Events::StackExceptionSample do
         frames,
         total_frame_count,
         thread_id,
+        trace_id,
+        span_id,
         exception
       )
     end
@@ -78,6 +92,8 @@ RSpec.describe Datadog::Profiling::Events::StackExceptionSample do
     let(:frames) { double('frames', collect: []) }
     let(:total_frame_count) { double('total_frame_count') }
     let(:thread_id) { double('thread_id') }
+    let(:trace_id) { double('trace_id') }
+    let(:span_id) { double('span_id') }
     let(:exception) { double('exception') }
 
     it do
@@ -86,6 +102,8 @@ RSpec.describe Datadog::Profiling::Events::StackExceptionSample do
         frames: frames,
         total_frame_count: total_frame_count,
         thread_id: thread_id,
+        trace_id: trace_id,
+        span_id: span_id,
         exception: exception
       )
     end

--- a/spec/ddtrace/profiling/spec_helper.rb
+++ b/spec/ddtrace/profiling/spec_helper.rb
@@ -38,11 +38,11 @@ module ProfileHelpers
     stack_two = Thread.current.backtrace_locations.first(3)
 
     stack_samples = [
-      build_stack_sample(stack_one, 100, 100, 100),
-      build_stack_sample(stack_two, 100, 200, 200),
-      build_stack_sample(stack_one, 101, 400, 400),
-      build_stack_sample(stack_two, 101, 800, 800),
-      build_stack_sample(stack_two, 101, 1600, 1600)
+      build_stack_sample(stack_one, 100, 0, 0, 100, 100),
+      build_stack_sample(stack_two, 100, 0, 0, 200, 200),
+      build_stack_sample(stack_one, 101, 0, 0, 400, 400),
+      build_stack_sample(stack_two, 101, 0, 0, 800, 800),
+      build_stack_sample(stack_two, 101, 0, 0, 1600, 1600)
     ]
 
     start = Time.now.utc
@@ -61,7 +61,14 @@ module ProfileHelpers
     Datadog::Profiling::Encoding::Profile::Protobuf.encode(get_test_profiling_flush)
   end
 
-  def build_stack_sample(locations = nil, thread_id = nil, cpu_time_ns = nil, wall_time_ns = nil)
+  def build_stack_sample(
+    locations = nil,
+    thread_id = nil,
+    trace_id = nil,
+    span_id = nil,
+    cpu_time_ns = nil,
+    wall_time_ns = nil
+  )
     locations ||= Thread.current.backtrace_locations
 
     Datadog::Profiling::Events::StackSample.new(
@@ -69,6 +76,8 @@ module ProfileHelpers
       locations,
       locations.length,
       thread_id || rand(1e9),
+      trace_id || rand(1e9),
+      span_id || rand(1e9),
       cpu_time_ns || rand(1e9),
       wall_time_ns || rand(1e9)
     )

--- a/spec/ddtrace/profiling/transport/http/adapters/net_integration_spec.rb
+++ b/spec/ddtrace/profiling/transport/http/adapters/net_integration_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe 'Adapters::Net profiling integration tests' do
         expect(tags).to be_a_kind_of(Array)
         expect(tags).to include(
           /#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_RUNTIME}:#{Datadog::Ext::Runtime::LANG}/,
+          /#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_RUNTIME_ID}:#{uuid_regex.source}/,
           /#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_RUNTIME_ENGINE}:#{Datadog::Ext::Runtime::LANG_ENGINE}/,
           /#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_RUNTIME_PLATFORM}:#{Datadog::Ext::Runtime::LANG_PLATFORM}/,
           /#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_RUNTIME_VERSION}:#{Datadog::Ext::Runtime::LANG_VERSION}/,

--- a/spec/ddtrace/profiling/transport/http/api/endpoint_spec.rb
+++ b/spec/ddtrace/profiling/transport/http/api/endpoint_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe Datadog::Profiling::Transport::HTTP::API::Endpoint do
           Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_RUNTIME_ID => flush.runtime_id,
           Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAGS => array_including(
             "#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_RUNTIME}:#{flush.language}",
+            "#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_RUNTIME_ID}:#{flush.runtime_id}",
             "#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_RUNTIME_ENGINE}:#{flush.runtime_engine}",
             "#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_RUNTIME_PLATFORM}:#{flush.runtime_platform}",
             "#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_RUNTIME_VERSION}:#{flush.runtime_version}",

--- a/spec/support/container_helpers.rb
+++ b/spec/support/container_helpers.rb
@@ -2,6 +2,10 @@ require 'stringio'
 
 # rubocop:disable Metrics/ModuleLength
 module ContainerHelpers
+  def uuid_regex
+    /[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/
+  end
+
   shared_context 'cgroup file' do
     let(:cgroup_file) { StringIO.new }
 


### PR DESCRIPTION
We'd like profiles to reference active traces so that we can link between the two.

In this pull request, we leverage the correlation API in #1200 to access the active trace for each thread, add their IDs respectively to each `StackSample`, then serialize these as labels on the pprof file.