### PR TITLE
fix: add improved lograge auto patching support and improve docs

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2046,6 +2046,10 @@ Datadog.configure do |c|
 end
 ```
 
+_Note:_ For `lograge` users who have also defined `lograge.custom_options` in their `initializers/lograge.rb` configuration file, due to the order that Rails loads initializers (alphabetical), automatic trace correlation may not take effect, since `initializers/datadog.rb` would be overwritten by the `initializers/lograge.rb` initializer. To support automatic trace correlation with _existing_ `lograge.custom_options`, either: 
+  - ensure your `initializers/lograge.rb` has a filename that alphabetically precedes `initializers/datadog.rb`, e.g. `initializers/01_lograge.rb`, or 
+  - use the [Manual (Lograge)](#manual-lograge) configuration below.
+
 ##### Manual (Lograge)
 
 After [setting up Lograge in a Rails application](https://docs.datadoghq.com/logs/log_collection/ruby/), manually modify the `custom_options` block in your environment configuration file (e.g. `config/environments/production.rb`) to add the trace IDs. 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2046,9 +2046,7 @@ Datadog.configure do |c|
 end
 ```
 
-_Note:_ For `lograge` users who have also defined `lograge.custom_options` in their `initializers/lograge.rb` configuration file, due to the order that Rails loads initializers (alphabetical), automatic trace correlation may not take effect, since `initializers/datadog.rb` would be overwritten by the `initializers/lograge.rb` initializer. To support automatic trace correlation with _existing_ `lograge.custom_options`, either: 
-  - ensure your `initializers/lograge.rb` has a filename that alphabetically precedes `initializers/datadog.rb`, e.g. `initializers/01_lograge.rb`, or 
-  - use the [Manual (Lograge)](#manual-lograge) configuration below.
+_Note:_ For `lograge` users who have also defined `lograge.custom_options` in an `initializers/lograge.rb` configuration file, due to the order that Rails loads initializers (alphabetical), automatic trace correlation may not take effect, since `initializers/datadog.rb` would be overwritten by the `initializers/lograge.rb` initializer. To support automatic trace correlation with _existing_ `lograge.custom_options`, use the [Manual (Lograge)](#manual-lograge) configuration below.
 
 ##### Manual (Lograge)
 

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -66,7 +66,10 @@ module Datadog
 
           # if lograge isn't set, check if tagged logged is enabled.
           # if so, add proc that injects trace identifiers for tagged logging.
-          if (logger = app.config.logger) && defined?(::ActiveSupport::TaggedLogging) && logger.is_a?(::ActiveSupport::TaggedLogging)
+          if (logger = app.config.logger) &&
+             defined?(::ActiveSupport::TaggedLogging) &&
+             logger.is_a?(::ActiveSupport::TaggedLogging)
+
             Datadog::Contrib::Rails::LogInjection.add_as_tagged_logging_logger(app)
           else
             Datadog.logger.warn("Unable to enable Datadog Trace context, Logger #{logger} is not supported")

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -54,14 +54,22 @@ module Datadog
 
         def add_logger(app)
           # check if lograge key exists
-          if app.config.respond_to?(:lograge) && app.config.lograge.enabled
+          # Note: Rails executes initializers sequentially based on alphabetical order,
+          # and lograge config could occur after dd config.
+          # Checking for `app.config.lograge.enabled` may yield a false negative.
+          # Instead we should naively add custom options if `config.lograge` exists from the lograge Railtie,
+          # since the custom options get ignored without lograge explicitly being enabled.
+          # See: https://github.com/roidrage/lograge/blob/1729eab7956bb95c5992e4adab251e4f93ff9280/lib/lograge/railtie.rb#L7-L12
+          if app.config.respond_to?(:lograge)
             Datadog::Contrib::Rails::LogInjection.add_lograge_logger(app)
-          # if lograge isn't set, check if tagged logged is enabed.
+          end
+
+          # if lograge isn't set, check if tagged logged is enabled.
           # if so, add proc that injects trace identifiers for tagged logging.
-          elsif (logger = app.config.logger) && logger.is_a?(::ActiveSupport::TaggedLogging)
+          if (logger = app.config.logger) && logger.is_a?(::ActiveSupport::TaggedLogging)
             Datadog::Contrib::Rails::LogInjection.add_as_tagged_logging_logger(app)
           else
-            Datadog.logger.warn("Unabe to enable Datadog Trace context, Logger #{logger} is not supported")
+            Datadog.logger.warn("Unable to enable Datadog Trace context, Logger #{logger} is not supported")
           end
         end
 

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -66,7 +66,7 @@ module Datadog
 
           # if lograge isn't set, check if tagged logged is enabled.
           # if so, add proc that injects trace identifiers for tagged logging.
-          if (logger = app.config.logger) && logger.is_a?(::ActiveSupport::TaggedLogging)
+          if (logger = app.config.logger) && defined?(::ActiveSupport::TaggedLogging) && logger.is_a?(::ActiveSupport::TaggedLogging)
             Datadog::Contrib::Rails::LogInjection.add_as_tagged_logging_logger(app)
           else
             Datadog.logger.warn("Unable to enable Datadog Trace context, Logger #{logger} is not supported")

--- a/spec/ddtrace/contrib/rails/rails_log_auto_injection_spec.rb
+++ b/spec/ddtrace/contrib/rails/rails_log_auto_injection_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'Rails Log Auto Injection' do
         allow(ENV).to receive(:[]).with('USE_LOGRAGE').and_return(true)
       end
 
-      context 'with lograge initialized' do
+      context 'with lograge enabled' do
         context 'with Lograge setup and no custom_options' do
           it 'should inject trace_id into logs' do
             is_expected.to be_ok
@@ -151,67 +151,16 @@ RSpec.describe 'Rails Log Auto Injection' do
         end
       end
 
-      context 'with lograge not yet initialized' do
+      context 'with lograge disabled' do
         before do
-          allow(ENV).to receive(:[]).with('USE_LOGRAGE_NOT_INITIALIZED').and_return(true)
+          allow(ENV).to receive(:[]).with('LOGRAGE_DISABLED').and_return(true)
         end
 
-        context 'with Lograge setup and no custom_options' do
-          it 'should inject trace_id into logs' do
-            is_expected.to be_ok
+        it 'should not inject trace_id into logs' do
+          is_expected.to be_ok
 
-            expect(logs).to include(spans[0].trace_id.to_s)
-            expect(logs).to include('MINASWAN')
-          end
-        end
-
-        # TODO: Right now our test setup doesn't allow us to test initializer ordering
-        # In practice this may get overridden by a user's custom_option setup.
-        # For now we'll need to note in our documentation that usage of additional custom_options
-        # Along with our auto instrumentation may not succeed, and suggest manual config instead.
-
-        # context 'with Lograge and existing custom_options as a hash' do
-        #   before do
-        #     allow(ENV).to receive(:[]).with('LOGRAGE_CUSTOM_OPTIONS').and_return(
-        #       'some_hash_info' => 'test_hash_value',
-        #       'some_other_hash_info' => 'other_test_hash_value'
-        #     )
-        #   end
-
-        #   it 'should inject trace_id into logs and preserve existing hash' do
-        #     is_expected.to be_ok
-
-        #     expect(logs).to include(spans[0].trace_id.to_s)
-        #     expect(logs).to include('MINASWAN')
-        #     expect(logs).to include('some_hash_info')
-        #     expect(logs).to include('some_other_hash_info')
-        #     expect(logs).to include('test_hash_value')
-        #     expect(logs).to include('other_test_hash_value')
-        #   end
-        # end
-
-        context 'with Lograge and existing custom_options as a lambda' do
-          before do
-            allow(ENV).to receive(:[]).with('LOGRAGE_CUSTOM_OPTIONS').and_return(
-              lambda do |_event|
-                {
-                  'some_lambda_info' => 'test_lambda_value',
-                  'some_other_lambda_info' => 'other_test_lambda_value'
-                }
-              end
-            )
-          end
-
-          it 'should inject trace_id into logs and preserve existing lambda' do
-            is_expected.to be_ok
-
-            expect(logs).to include(spans[0].trace_id.to_s)
-            expect(logs).to include('MINASWAN')
-            expect(logs).to include('some_lambda_info')
-            expect(logs).to include('some_other_lambda_info')
-            expect(logs).to include('test_lambda_value')
-            expect(logs).to include('other_test_lambda_value')
-          end
+          expect(logs).not_to include(spans[0].trace_id.to_s)
+          expect(logs).to include('MINASWAN')
         end
       end
     end

--- a/spec/ddtrace/contrib/rails/rails_log_auto_injection_spec.rb
+++ b/spec/ddtrace/contrib/rails/rails_log_auto_injection_spec.rb
@@ -96,56 +96,122 @@ RSpec.describe 'Rails Log Auto Injection' do
         allow(ENV).to receive(:[]).with('USE_LOGRAGE').and_return(true)
       end
 
-      context 'with Lograge setup and no custom_options' do
-        it 'should inject trace_id into logs' do
-          is_expected.to be_ok
+      context 'with lograge initialized' do
+        context 'with Lograge setup and no custom_options' do
+          it 'should inject trace_id into logs' do
+            is_expected.to be_ok
 
-          expect(logs).to include(spans[0].trace_id.to_s)
-          expect(logs).to include('MINASWAN')
+            expect(logs).to include(spans[0].trace_id.to_s)
+            expect(logs).to include('MINASWAN')
+          end
+        end
+
+        context 'with Lograge and existing custom_options as a hash' do
+          before do
+            allow(ENV).to receive(:[]).with('LOGRAGE_CUSTOM_OPTIONS').and_return(
+              'some_hash_info' => 'test_hash_value',
+              'some_other_hash_info' => 'other_test_hash_value'
+            )
+          end
+
+          it 'should inject trace_id into logs and preserve existing hash' do
+            is_expected.to be_ok
+
+            expect(logs).to include(spans[0].trace_id.to_s)
+            expect(logs).to include('MINASWAN')
+            expect(logs).to include('some_hash_info')
+            expect(logs).to include('some_other_hash_info')
+            expect(logs).to include('test_hash_value')
+            expect(logs).to include('other_test_hash_value')
+          end
+        end
+
+        context 'with Lograge and existing custom_options as a lambda' do
+          before do
+            allow(ENV).to receive(:[]).with('LOGRAGE_CUSTOM_OPTIONS').and_return(
+              lambda do |_event|
+                {
+                  'some_lambda_info' => 'test_lambda_value',
+                  'some_other_lambda_info' => 'other_test_lambda_value'
+                }
+              end
+            )
+          end
+
+          it 'should inject trace_id into logs and preserve existing lambda' do
+            is_expected.to be_ok
+
+            expect(logs).to include(spans[0].trace_id.to_s)
+            expect(logs).to include('MINASWAN')
+            expect(logs).to include('some_lambda_info')
+            expect(logs).to include('some_other_lambda_info')
+            expect(logs).to include('test_lambda_value')
+            expect(logs).to include('other_test_lambda_value')
+          end
         end
       end
 
-      context 'with Lograge and existing custom_options as a hash' do
+      context 'with lograge not yet initialized' do
         before do
-          allow(ENV).to receive(:[]).with('LOGRAGE_CUSTOM_OPTIONS').and_return(
-            'some_hash_info' => 'test_hash_value',
-            'some_other_hash_info' => 'other_test_hash_value'
-          )
+          allow(ENV).to receive(:[]).with('USE_LOGRAGE_NOT_INITIALIZED').and_return(true)
         end
 
-        it 'should inject trace_id into logs and preserve existing hash' do
-          is_expected.to be_ok
+        context 'with Lograge setup and no custom_options' do
+          it 'should inject trace_id into logs' do
+            is_expected.to be_ok
 
-          expect(logs).to include(spans[0].trace_id.to_s)
-          expect(logs).to include('MINASWAN')
-          expect(logs).to include('some_hash_info')
-          expect(logs).to include('some_other_hash_info')
-          expect(logs).to include('test_hash_value')
-          expect(logs).to include('other_test_hash_value')
-        end
-      end
-
-      context 'with Lograge and existing custom_options as a lambda' do
-        before do
-          allow(ENV).to receive(:[]).with('LOGRAGE_CUSTOM_OPTIONS').and_return(
-            lambda do |_event|
-              {
-                'some_lambda_info' => 'test_lambda_value',
-                'some_other_lambda_info' => 'other_test_lambda_value'
-              }
-            end
-          )
+            expect(logs).to include(spans[0].trace_id.to_s)
+            expect(logs).to include('MINASWAN')
+          end
         end
 
-        it 'should inject trace_id into logs and preserve existing lambda' do
-          is_expected.to be_ok
+        # TODO: Right now our test setup doesn't allow us to test initializer ordering
+        # In practice this may get overridden by a user's custom_option setup.
+        # For now we'll need to note in our documentation that usage of additional custom_options
+        # Along with our auto instrumentation may not succeed, and suggest manual config instead.
 
-          expect(logs).to include(spans[0].trace_id.to_s)
-          expect(logs).to include('MINASWAN')
-          expect(logs).to include('some_lambda_info')
-          expect(logs).to include('some_other_lambda_info')
-          expect(logs).to include('test_lambda_value')
-          expect(logs).to include('other_test_lambda_value')
+        # context 'with Lograge and existing custom_options as a hash' do
+        #   before do
+        #     allow(ENV).to receive(:[]).with('LOGRAGE_CUSTOM_OPTIONS').and_return(
+        #       'some_hash_info' => 'test_hash_value',
+        #       'some_other_hash_info' => 'other_test_hash_value'
+        #     )
+        #   end
+
+        #   it 'should inject trace_id into logs and preserve existing hash' do
+        #     is_expected.to be_ok
+
+        #     expect(logs).to include(spans[0].trace_id.to_s)
+        #     expect(logs).to include('MINASWAN')
+        #     expect(logs).to include('some_hash_info')
+        #     expect(logs).to include('some_other_hash_info')
+        #     expect(logs).to include('test_hash_value')
+        #     expect(logs).to include('other_test_hash_value')
+        #   end
+        # end
+
+        context 'with Lograge and existing custom_options as a lambda' do
+          before do
+            allow(ENV).to receive(:[]).with('LOGRAGE_CUSTOM_OPTIONS').and_return(
+              lambda do |_event|
+                {
+                  'some_lambda_info' => 'test_lambda_value',
+                  'some_other_lambda_info' => 'other_test_lambda_value'
+                }
+              end
+            )
+          end
+
+          it 'should inject trace_id into logs and preserve existing lambda' do
+            is_expected.to be_ok
+
+            expect(logs).to include(spans[0].trace_id.to_s)
+            expect(logs).to include('MINASWAN')
+            expect(logs).to include('some_lambda_info')
+            expect(logs).to include('some_other_lambda_info')
+            expect(logs).to include('test_lambda_value')
+            expect(logs).to include('other_test_lambda_value')
+          end
         end
       end
     end

--- a/spec/ddtrace/contrib/rails/support/base.rb
+++ b/spec/ddtrace/contrib/rails/support/base.rb
@@ -53,7 +53,8 @@ RSpec.shared_context 'Rails base application' do
           config.lograge.custom_options = ENV['LOGRAGE_CUSTOM_OPTIONS']
         end
 
-        config.lograge.enabled = true
+        config.lograge.enabled = true if ENV['USE_LOGRAGE_NOT_INITIALIZED'].nil?
+
         config.lograge.base_controller_class = 'LogrageTestController'
         config.lograge.logger = logger
       # ensure no test leakage from other tests

--- a/spec/ddtrace/contrib/rails/support/base.rb
+++ b/spec/ddtrace/contrib/rails/support/base.rb
@@ -53,10 +53,13 @@ RSpec.shared_context 'Rails base application' do
           config.lograge.custom_options = ENV['LOGRAGE_CUSTOM_OPTIONS']
         end
 
-        config.lograge.enabled = true if ENV['USE_LOGRAGE_NOT_INITIALIZED'].nil?
-
-        config.lograge.base_controller_class = 'LogrageTestController'
-        config.lograge.logger = logger
+        if ENV['LOGRAGE_DISABLED'].nil?
+          config.lograge.enabled = true
+          config.lograge.base_controller_class = 'LogrageTestController'
+          config.lograge.logger = logger
+        else
+          config.lograge.enabled = false
+        end
       # ensure no test leakage from other tests
       elsif config.respond_to?(:lograge)
         config.lograge.enabled = false


### PR DESCRIPTION
## Summary

This PR addresses https://github.com/DataDog/dd-trace-rb/issues/1205. Since Rails may load lograge's initializer file sequentially _after_ datadog's (Rails loads initializer's alphabetically and datadog's _suggested config_ filename precedes lograge's _suggested config_ filename), we cannot rely on checking `lograge.enabled` to determine whether to patch lograge with our trace correlation code, as it may yield a false negative.

However, since we can _detect_ if the lograge gem has been included in the application (enabled or otherwise), and since setting `lograge.custom_options` (which we need to set as a lambda that attaches our trace correlation context) is a no-op in the case that `lograge.enabled` is, later, explicitly set to `false` after our patching code, we can "naively" add `custom_options` without impacting the log output in an unexpected way.

## Notes

One edge case we _can't_ handle at the moment is when a user has also defined `custom_options` in their lograge specific initializer. Our ideal behavior is that we merge any existing `custom_options` with our lambda, however we can't do that if our lambda is set first (and get's overwritten by a user's lograge initializer settings). Instead, what we can do is document this edge case and give users possible workarounds (use our manual trace correlation snippet instead). 

Unfortunately, this edge case is not exactly easy to explicitly test in our test suite,  and refactoring the test suite to support testing initializer sequence would be a significant undertaking, imo out of scope of this PR (which will improve reliability).

## Next Steps

This is a more brittle than i'd like, generally speaking. Rails+ Lograge present some unique challenges here. First, there's multiple ways you can configure Lograge logging. I believe the case we're solving here only really occurs with a separate initializer file for the gem (instead of having config for logging live in config/environments/production.rb, which is an option suggested by [Lograge docs too](https://github.com/roidrage/lograge/blob/04b30072063ad0463de198b0bd268881212a8529/README.md#installation) ). And Rails has strong opinions about [initializer file ordering](https://guides.rubyonrails.org/configuring.html#using-initializer-files), and does tell users that they should use file naming manage their initializer ordering. But it's probably not reasonable as a 3rd party Lib to tell users they have to change their filenames to support our features.

If we monkey patched the Lograge gem, maybe [set_lograge_log_options](https://github.com/roidrage/lograge/blob/397c830208a7ec1601c0eacc0dddd09274afff5b/lib/lograge.rb#L184), we can probably have a more robust auto trace correlation with logs, but this requires further investigation.