### PR TITLE
Background job custom error handlers

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -636,6 +636,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `DelayedJob` instrumentation | `'delayed_job'` |
 | `client_service_name` | Service name used for client-side `DelayedJob` instrumentation | `'delayed_job-client'` |
+| `error_handler` | Custom error handler invoked when a job raises an error. Provided `span` and `error` as arguments. Sets error on the span by default. Useful for ignoring transient errors. | `proc { |span, error| span.set_error(error) unless span.nil? }` |
 
 ### Elasticsearch
 
@@ -1136,6 +1137,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `service_name` | Service name used for `que` instrumentation | `'que'` |
 | `tag_args` | Enable tagging of a job's args field. `true` for on, `false` for off. | `false` |
 | `tag_data` | Enable tagging of a job's data field. `true` for on, `false` for off. | `false` |
+| `error_handler` | Custom error handler invoked when a job raises an error. Provided `span` and `error` as arguments. Sets error on the span by default. Useful for ignoring transient errors. | `proc { |span, error| span.set_error(error) unless span.nil? }` |
 
 ### Racecar
 
@@ -1436,6 +1438,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to the global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `resque` instrumentation | `'resque'` |
 | `workers` | An array including all worker classes you want to trace (e.g. `[MyJob]`) | `[]` |
+| `error_handler` | Custom error handler invoked when a job raises an error. Provided `span` and `error` as arguments. Sets error on the span by default. Useful for ignoring transient errors. | `proc { |span, error| span.set_error(error) unless span.nil? }` |
 
 ### Rest Client
 
@@ -1526,6 +1529,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | --- | ----------- | ------- |
 | `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `shoryuken` instrumentation | `'shoryuken'` |
+| `error_handler` | Custom error handler invoked when a job raises an error. Provided `span` and `error` as arguments. Sets error on the span by default. Useful for ignoring transient errors. | `proc { |span, error| span.set_error(error) unless span.nil? }` |
 
 ### Sidekiq
 
@@ -1549,6 +1553,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `client_service_name` | Service name used for client-side `sidekiq` instrumentation | `'sidekiq-client'` |
 | `service_name` | Service name used for server-side `sidekiq` instrumentation | `'sidekiq'` |
 | `tag_args` | Enable tagging of job arguments. `true` for on, `false` for off. | `false` |
+| `error_handler` | Custom error handler invoked when a job raises an error. Provided `span` and `error` as arguments. Sets error on the span by default. Useful for ignoring transient errors. | `proc { |span, error| span.set_error(error) unless span.nil? }` |
 
 ### Sinatra
 
@@ -1636,6 +1641,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `enabled` | Defines whether Sneakers should be traced. Useful for temporarily disabling tracing. `true` or `false` | `true` |
 | `service_name` | Service name used for `sneakers` instrumentation | `'sneakers'` |
 | `tag_body` | Enable tagging of job message. `true` for on, `false` for off. | `false` |
+| `error_handler` | Custom error handler invoked when a job raises an error. Provided `span` and `error` as arguments. Sets error on the span by default. Useful for ignoring transient errors. | `proc { |span, error| span.set_error(error) unless span.nil? }` |
 
 ### Sucker Punch
 

--- a/lib/ddtrace/contrib/delayed_job/configuration/settings.rb
+++ b/lib/ddtrace/contrib/delayed_job/configuration/settings.rb
@@ -24,6 +24,7 @@ module Datadog
 
           option :service_name, default: Ext::SERVICE_NAME
           option :client_service_name, default: Ext::CLIENT_SERVICE_NAME
+          option :error_handler, default: Datadog::Tracer::DEFAULT_ON_ERROR
         end
       end
     end

--- a/lib/ddtrace/contrib/delayed_job/plugin.rb
+++ b/lib/ddtrace/contrib/delayed_job/plugin.rb
@@ -10,7 +10,9 @@ module Datadog
         def self.instrument_invoke(job, &block)
           return block.call(job) unless tracer && tracer.enabled
 
-          tracer.trace(Ext::SPAN_JOB, service: configuration[:service_name], resource: job_name(job)) do |span|
+          tracer.trace(Ext::SPAN_JOB, service: configuration[:service_name], resource: job_name(job),
+                                      on_error: configuration[:error_handler]) do |span|
+
             set_sample_rate(span)
 
             # Measure service stats

--- a/lib/ddtrace/contrib/que/configuration/settings.rb
+++ b/lib/ddtrace/contrib/que/configuration/settings.rb
@@ -35,6 +35,7 @@ module Datadog
             o.default { env_to_bool(Ext::ENV_TAG_DATA_ENABLED, false) }
             o.lazy
           end
+          option :error_handler, default: Datadog::Tracer::DEFAULT_ON_ERROR
         end
       end
     end

--- a/lib/ddtrace/contrib/que/tracer.rb
+++ b/lib/ddtrace/contrib/que/tracer.rb
@@ -10,7 +10,8 @@ module Datadog
         def call(job)
           trace_options = {
             service:   configuration[:service_name],
-            span_type: Datadog::Ext::AppTypes::WORKER
+            span_type: Datadog::Ext::AppTypes::WORKER,
+            on_error: configuration[:error_handler]
           }
 
           tracer.trace(Ext::SPAN_JOB, trace_options) do |request_span|

--- a/lib/ddtrace/contrib/resque/configuration/settings.rb
+++ b/lib/ddtrace/contrib/resque/configuration/settings.rb
@@ -24,6 +24,7 @@ module Datadog
 
           option :service_name, default: Ext::SERVICE_NAME
           option :workers, default: []
+          option :error_handler, default: Datadog::Tracer::DEFAULT_ON_ERROR
         end
       end
     end

--- a/lib/ddtrace/contrib/resque/resque_job.rb
+++ b/lib/ddtrace/contrib/resque/resque_job.rb
@@ -48,7 +48,7 @@ module Datadog
         end
 
         def span_options
-          { service: datadog_configuration[:service_name] }
+          { service: datadog_configuration[:service_name], on_error: datadog_configuration[:error_handler] }
         end
 
         def tracer

--- a/lib/ddtrace/contrib/shoryuken/configuration/settings.rb
+++ b/lib/ddtrace/contrib/shoryuken/configuration/settings.rb
@@ -22,6 +22,7 @@ module Datadog
           end
 
           option :service_name, default: Ext::SERVICE_NAME
+          option :error_handler, default: Datadog::Tracer::DEFAULT_ON_ERROR
         end
       end
     end

--- a/lib/ddtrace/contrib/shoryuken/tracer.rb
+++ b/lib/ddtrace/contrib/shoryuken/tracer.rb
@@ -8,10 +8,13 @@ module Datadog
         def initialize(options = {})
           @tracer = options[:tracer] || configuration[:tracer]
           @shoryuken_service = options[:service_name] || configuration[:service_name]
+          @error_handler = options[:error_handler] || configuration[:error_handler]
         end
 
         def call(worker_instance, queue, sqs_msg, body)
-          @tracer.trace(Ext::SPAN_JOB, service: @shoryuken_service, span_type: Datadog::Ext::AppTypes::WORKER) do |span|
+          @tracer.trace(Ext::SPAN_JOB, service: @shoryuken_service, span_type: Datadog::Ext::AppTypes::WORKER,
+                                       on_error: @error_handler) do |span|
+
             # Set analytics sample rate
             if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
               Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])

--- a/lib/ddtrace/contrib/sidekiq/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sidekiq/configuration/settings.rb
@@ -29,6 +29,7 @@ module Datadog
 
           option :service_name, default: Ext::SERVICE_NAME
           option :client_service_name, default: Ext::CLIENT_SERVICE_NAME
+          option :error_handler, default: Datadog::Tracer::DEFAULT_ON_ERROR
         end
       end
     end

--- a/lib/ddtrace/contrib/sidekiq/server_tracer.rb
+++ b/lib/ddtrace/contrib/sidekiq/server_tracer.rb
@@ -11,6 +11,7 @@ module Datadog
         def initialize(options = {})
           super
           @sidekiq_service = options[:service_name] || configuration[:service_name]
+          @error_handler = options[:error_handler] || configuration[:error_handler]
         end
 
         def call(worker, job, queue)
@@ -19,7 +20,9 @@ module Datadog
           service = worker_config(resource, :service_name) || @sidekiq_service
           tag_args = worker_config(resource, :tag_args) || configuration[:tag_args]
 
-          @tracer.trace(Ext::SPAN_JOB, service: service, span_type: Datadog::Ext::AppTypes::WORKER) do |span|
+          @tracer.trace(Ext::SPAN_JOB, service: service, span_type: Datadog::Ext::AppTypes::WORKER,
+                                       on_error: @error_handler) do |span|
+
             span.resource = resource
             # Set analytics sample rate
             if Contrib::Analytics.enabled?(configuration[:analytics_enabled])

--- a/lib/ddtrace/contrib/sneakers/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sneakers/configuration/settings.rb
@@ -24,6 +24,7 @@ module Datadog
           end
 
           option :service_name, default: Ext::SERVICE_NAME
+          option :error_handler, default: Datadog::Tracer::DEFAULT_ON_ERROR
           option :tag_body, default: false
         end
       end

--- a/lib/ddtrace/contrib/sneakers/tracer.rb
+++ b/lib/ddtrace/contrib/sneakers/tracer.rb
@@ -15,32 +15,29 @@ module Datadog
         def call(deserialized_msg, delivery_info, metadata, handler)
           trace_options = {
             service:   configuration[:service_name],
-            span_type: Datadog::Ext::AppTypes::WORKER
+            span_type: Datadog::Ext::AppTypes::WORKER,
+            on_error: configuration[:error_handler]
           }
-          request_span = tracer.trace(Ext::SPAN_JOB, trace_options)
 
-          # Set analytics sample rate
-          if Datadog::Contrib::Analytics.enabled?(configuration[:analytics_enabled])
-            Datadog::Contrib::Analytics.set_sample_rate(request_span, configuration[:analytics_sample_rate])
+          tracer.trace(Ext::SPAN_JOB, trace_options) do |request_span|
+            # Set analytics sample rate
+            if Datadog::Contrib::Analytics.enabled?(configuration[:analytics_enabled])
+              Datadog::Contrib::Analytics.set_sample_rate(request_span, configuration[:analytics_sample_rate])
+            end
+
+            # Measure service stats
+            Contrib::Analytics.set_measured(request_span)
+
+            request_span.resource = @app.to_proc.binding.eval('self.class').to_s
+            request_span.set_tag(Ext::TAG_JOB_ROUTING_KEY, delivery_info.routing_key)
+            request_span.set_tag(Ext::TAG_JOB_QUEUE, delivery_info.consumer.queue.name)
+
+            if configuration[:tag_body]
+              request_span.set_tag(Ext::TAG_JOB_BODY, deserialized_msg)
+            end
+
+            @app.call(deserialized_msg, delivery_info, metadata, handler)
           end
-
-          # Measure service stats
-          Contrib::Analytics.set_measured(request_span)
-
-          request_span.resource = @app.to_proc.binding.eval('self.class').to_s
-          request_span.set_tag(Ext::TAG_JOB_ROUTING_KEY, delivery_info.routing_key)
-          request_span.set_tag(Ext::TAG_JOB_QUEUE, delivery_info.consumer.queue.name)
-
-          if configuration[:tag_body]
-            request_span.set_tag(Ext::TAG_JOB_BODY, deserialized_msg)
-          end
-
-          @app.call(deserialized_msg, delivery_info, metadata, handler)
-        rescue StandardError => e
-          request_span.set_error(e) unless request_span.nil?
-          raise e
-        ensure
-          request_span.finish if request_span
         end
 
         private

--- a/spec/ddtrace/contrib/delayed_job/plugin_spec.rb
+++ b/spec/ddtrace/contrib/delayed_job/plugin_spec.rb
@@ -81,6 +81,24 @@ RSpec.describe Datadog::Contrib::DelayedJob::Plugin, :delayed_job_active_record 
       end
     end
 
+    context 'when job fails' do
+      let(:configuration_options) { { error_handler: error_handler } }
+      let(:error_handler) { proc {} }
+
+      let(:sample_job_object) do
+        stub_const('SampleJob', Class.new do
+          def perform
+            raise ZeroDivisionError, 'job error'
+          end
+        end)
+      end
+
+      it 'uses custom error handler' do
+        expect(error_handler).to receive(:call)
+        expect { job_run }.to raise_error
+      end
+    end
+
     shared_context 'delayed_job common tags and resource' do
       it 'has resource name equal to job name' do
         expect(span.resource).to eq('SampleJob')

--- a/spec/ddtrace/contrib/sidekiq/tracer_configure_spec.rb
+++ b/spec/ddtrace/contrib/sidekiq/tracer_configure_spec.rb
@@ -6,13 +6,15 @@ RSpec.describe 'Tracer configuration' do
 
   subject(:perform_async) { job_class.perform_async }
   let(:job_class) { EmptyWorker }
+  let(:error_handler) { nil }
 
   context 'with custom middleware configuration' do
     before do
       Sidekiq::Testing.server_middleware do |chain|
         chain.add(
           Datadog::Contrib::Sidekiq::ServerTracer,
-          service_name: 'my-service'
+          service_name: 'my-service',
+          error_handler: error_handler
         )
       end
     end
@@ -24,6 +26,27 @@ RSpec.describe 'Tracer configuration' do
 
       span, _push = spans
       expect(span.service).to eq('my-service')
+    end
+
+    context 'with custom error handler' do
+      let(:job_class) { ErrorWorker }
+
+      before do
+        stub_const('ErrorWorker', Class.new do
+          include Sidekiq::Worker
+
+          def perform
+            raise ZeroDivisionError, 'job error'
+          end
+        end)
+      end
+
+      let(:error_handler) { proc {} }
+
+      it 'uses custom error handler' do
+        expect(error_handler).to receive(:call)
+        expect { perform_async }.to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
**Goal**
Allow passing custom error handler for background job gems. Useful to retry jobs for known transient errors without reporting errors to Datadog.

Example usage:
```ruby
TRANSIENT_ERRORS = [SomeTransientError]
# This can be any callable object, provided `span` and `error` as arguments.
custom_error_handler = proc { |span, error| span.set_tag('error', true) unless TRANSIENT_ERRORS.include?(error.class) }

Datadog.configure do |c| 
  c.use :sidekiq, {
    error_handler: custom_error_handler
  }
end
```