### PR TITLE
Add Forking helpers

### DIFF
--- a/lib/ddtrace/runtime/identity.rb
+++ b/lib/ddtrace/runtime/identity.rb
@@ -1,22 +1,21 @@
 require 'securerandom'
 require 'ddtrace/ext/runtime'
+require 'ddtrace/utils/forking'
 
 module Datadog
   module Runtime
     # For runtime identity
     module Identity
+      extend Datadog::Utils::Forking
+
       module_function
 
       # Retrieves number of classes from runtime
       def id
-        @pid ||= Process.pid
         @id ||= SecureRandom.uuid
 
         # Check if runtime has changed, e.g. forked.
-        if Process.pid != @pid
-          @pid = Process.pid
-          @id = SecureRandom.uuid
-        end
+        after_fork! { @id = SecureRandom.uuid }
 
         @id
       end

--- a/lib/ddtrace/utils/forking.rb
+++ b/lib/ddtrace/utils/forking.rb
@@ -1,0 +1,52 @@
+module Datadog
+  module Utils
+    # Helper methods for managing forking behavior
+    module Forking
+      def self.included(base)
+        base.send(:prepend, ClassExtensions) if base.is_a?(Class)
+      end
+
+      def self.extended(base)
+        # Explicitly update PID here because there's a case where
+        # the code path that lazily updates the PID may not be exercised
+        # until after a fork occurs, thus causing the event to be missed.
+        # By eagerly setting this, we avoid this scenario.
+        base.update_fork_pid!
+      end
+
+      def after_fork!
+        if forked?
+          yield
+          update_fork_pid!
+          true
+        else
+          false
+        end
+      end
+
+      def forked?
+        Process.pid != fork_pid
+      end
+
+      def update_fork_pid!
+        @fork_pid = Process.pid
+      end
+
+      def fork_pid
+        @fork_pid ||= Process.pid
+      end
+
+      # Adds additional functionality for Classes that implement Forking
+      module ClassExtensions
+        # Addresses an edge case where forking before invoking #update_fork_pid! on the
+        # object will cause forking to not be detected in the fork when it should have.
+        #
+        # This wrapper prevents this by initializing the fork PID when the object is created.
+        def initialize(*args, &block)
+          super
+          update_fork_pid!
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/runtime/identity_spec.rb
+++ b/spec/ddtrace/runtime/identity_spec.rb
@@ -25,12 +25,9 @@ RSpec.describe Datadog::Runtime::Identity do
         expect(before_fork_id).to be_a_kind_of(String)
 
         # Invoke in fork, make sure expectations run before continuing.
-        Timeout.timeout(1) do
-          fork do
-            expect(inside_fork_id).to be_a_kind_of(String)
-            expect(inside_fork_id).to_not eq(before_fork_id)
-          end
-          Process.wait
+        expect_in_fork do
+          expect(inside_fork_id).to be_a_kind_of(String)
+          expect(inside_fork_id).to_not eq(before_fork_id)
         end
 
         # Check after forking

--- a/spec/ddtrace/utils/forking_spec.rb
+++ b/spec/ddtrace/utils/forking_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+require 'ddtrace/utils/forking'
+
+RSpec.describe Datadog::Utils::Forking do
+  before { skip 'Java not supported' if RUBY_PLATFORM == 'java' }
+
+  shared_examples_for 'a Forking type' do
+    # Assume the module is defined in the parent process not the fork.
+    # (Invoking it "before" prevents lazy definition in the fork.)
+    before { test_object }
+
+    describe '#after_fork!' do
+      subject(:after_fork!) { test_object.after_fork!(&block) }
+      let(:block) { proc {} }
+
+      context 'when the process forks' do
+        it 'invokes the block given' do
+          expect_in_fork do
+            result = nil
+            expect { |b| result = test_object.after_fork!(&b) }.to yield_control
+            expect(result).to be true
+          end
+        end
+
+        it 'changes the fork PID' do
+          expect_in_fork do
+            expect { test_object.after_fork!(&block) }
+              .to(change { test_object.fork_pid })
+          end
+        end
+      end
+
+      context 'in the same process' do
+        it 'does not invokes the block given' do
+          result = nil
+          expect { |b| result = test_object.after_fork!(&b) }.to_not yield_control
+          expect(result).to be false
+        end
+
+        it 'does not change the fork PID' do
+          expect { test_object.after_fork!(&block) }
+            .to_not(change { test_object.fork_pid })
+        end
+      end
+    end
+
+    describe '#forked?' do
+      subject(:forked?) { test_object.forked? }
+
+      context 'when the process forks' do
+        it { expect_in_fork { is_expected.to be true } }
+      end
+
+      context 'in the same process' do
+        it { is_expected.to be false }
+      end
+    end
+
+    describe '#update_fork_pid!' do
+      subject(:update_fork_pid!) { test_object.update_fork_pid! }
+
+      context 'when the process forks' do
+        it do
+          expect_in_fork do
+            expect { test_object.update_fork_pid! }
+              .to change { test_object.fork_pid }
+              .to(Process.pid)
+          end
+        end
+      end
+
+      context 'in the same process' do
+        it do
+          # Expect it not to change because the PID should have already
+          # been set for this process, thus it should remain the same.
+          expect { test_object.update_fork_pid! }
+            .to_not(change { test_object.fork_pid })
+        end
+      end
+    end
+
+    describe '#fork_pid' do
+      subject(:fork_pid) { test_object.fork_pid }
+
+      context 'when the process forks' do
+        it { expect_in_fork { is_expected.to_not eq(Process.pid) } }
+      end
+
+      context 'in the same process' do
+        it { is_expected.to eq(Process.pid) }
+      end
+    end
+  end
+
+  describe 'when extended by a module' do
+    subject(:test_object) { Module.new { extend Datadog::Utils::Forking } }
+    it_behaves_like 'a Forking type'
+  end
+
+  describe 'when included in a class' do
+    subject(:test_object) { test_class.new }
+    let(:test_class) { Class.new { include Datadog::Utils::Forking } }
+    it_behaves_like 'a Forking type'
+  end
+end


### PR DESCRIPTION
There are a number of places in code where we need to detect whether forking has occurred, and conditionally trigger some kind of behavior when it does. (This happens in runtime ID resolution, Resque, trace and runtime metric workers, etc...)

To make this behavior more consistent and generally available, this pull request introduces a small module called `Datadog::Utils::Forking` which adds this functionality. It can be applied at the class/module or instance level. e.g.

```ruby
module Identity
  extend Datadog::Utils::Forking
end

class Worker
  include Datadog::Utils::Forking
end
```

It then provides `forked?` and `after_fork!` methods that can be used to detect forking:

```ruby
def run
  # The block is only invoked if a fork has occurred.
  # Once complete, the event will not trigger again until another fork occurs.
  after_fork! { reset! }
  do_work
end
```