### PR TITLE
Reset trace context after fork

### DIFF
--- a/spec/ddtrace/context_spec.rb
+++ b/spec/ddtrace/context_spec.rb
@@ -408,6 +408,31 @@ RSpec.describe Datadog::Context do
     end
   end
 
+  describe '#fork_clone' do
+    subject(:fork_clone) { context.fork_clone }
+
+    let(:options) do
+      {
+        trace_id: SecureRandom.uuid,
+        span_id: SecureRandom.uuid,
+        sampled: true,
+        sampling_priority: Datadog::Ext::Priority::AUTO_KEEP,
+        origin: 'synthetics'
+      }
+    end
+
+    it do
+      is_expected.to be_a_kind_of(described_class)
+      is_expected.to have_attributes(
+        trace_id: context.trace_id,
+        span_id: context.span_id,
+        sampled?: context.sampled?,
+        sampling_priority: context.sampling_priority,
+        origin: context.origin
+      )
+    end
+  end
+
   describe '#length' do
     subject(:ctx) { context }
     let(:span) { new_span }


### PR DESCRIPTION
When Ruby processes fork, they copy objects from the parent process into the child process: this includes the trace context objects we've assigned to each `Thread`. As a result, child processes are copying all the spans from the parent process, which could result in redundant transmission of spans.

Instead, we'd like forked processes to act like distributed traces; they should be linked to the parent process (trace ID/parent ID/sampling, etc) but only build and transmit spans generated from its own process.

To do this, we're leveraging the forking helpers implemented in #1221 to make the `Datadog::Context` fork aware, then lazily clone the `Datadog::Context` in the `Datadog::DefaultContextProvider` whenever a context is accessed and observed to have forked.