### PR TITLE
Multiplexing fix

### DIFF
--- a/lib/ddtrace/contrib/configurable.rb
+++ b/lib/ddtrace/contrib/configurable.rb
@@ -45,7 +45,7 @@ module Datadog
         def configure(key, options = {}, &block)
           key ||= :default
 
-          # Get or add the configurations
+          # Get or add the configuration
           config = configuration_for?(key) ? configuration(key) : add_configuration(key)
 
           # Apply the settings

--- a/lib/ddtrace/contrib/configurable.rb
+++ b/lib/ddtrace/contrib/configurable.rb
@@ -48,11 +48,7 @@ module Datadog
           # PatternResolvers maintain patterns as a Set so we can naively add
           # This is a bit hacky but otherwise `configuration_for?(key)` always returns true
           # since the resolver.resolve check will always return default
-          config = if resolver.is_a?(Configuration::Resolvers::PatternResolver)
-                     add_configuration(key)
-                   else
-                     configuration_for?(key) ? configuration(key) : add_configuration(key)
-                   end
+          config = configuration_for?(key) ? configuration(key) : add_configuration(key)
 
           # Apply the settings
           config.configure(options, &block)

--- a/lib/ddtrace/contrib/configurable.rb
+++ b/lib/ddtrace/contrib/configurable.rb
@@ -28,6 +28,8 @@ module Datadog
 
         # If the key has matching configuration explicitly defined for it,
         # then return true. Otherwise return false.
+        # Note: a resolver's resolve method should not return a fallback value
+        # See: https://github.com/DataDog/dd-trace-rb/issues/1204
         def configuration_for?(key)
           key = resolver.resolve(key) unless key == :default
           configurations.key?(key)
@@ -43,11 +45,7 @@ module Datadog
         def configure(key, options = {}, &block)
           key ||= :default
 
-          # Get or add the configuration
-
-          # PatternResolvers maintain patterns as a Set so we can naively add
-          # This is a bit hacky but otherwise `configuration_for?(key)` always returns true
-          # since the resolver.resolve check will always return default
+          # Get or add the configurations
           config = configuration_for?(key) ? configuration(key) : add_configuration(key)
 
           # Apply the settings

--- a/lib/ddtrace/contrib/configurable.rb
+++ b/lib/ddtrace/contrib/configurable.rb
@@ -44,7 +44,15 @@ module Datadog
           key ||= :default
 
           # Get or add the configuration
-          config = configuration_for?(key) ? configuration(key) : add_configuration(key)
+
+          # PatternResolvers maintain patterns as a Set so we can naively add
+          # This is a bit hacky but otherwise `configuration_for?(key)` always returns true
+          # since the resolver.resolve check will always return default
+          config = if resolver.is_a?(Configuration::Resolvers::PatternResolver)
+                     add_configuration(key)
+                   else
+                     configuration_for?(key) ? configuration(key) : add_configuration(key)
+                   end
 
           # Apply the settings
           config.configure(options, &block)

--- a/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
+++ b/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
@@ -17,9 +17,9 @@ module Datadog
               elsif pattern.is_a?(Regexp)
                 if name.is_a?(Regexp)
                   name.to_s === pattern.to_s
-                elsif name.is_a?(String)
-                  pattern.match(name)
-                else
+                elsif name.respond_to?(:to_s)
+                  pattern.match(name.to_s)
+                elsif
                   false
                 end
               else

--- a/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
+++ b/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
@@ -13,7 +13,8 @@ module Datadog
               if pattern.is_a?(Proc)
                 (pattern === name)
               else
-                (pattern === name.to_s) || (pattern == name)
+                (pattern === name.to_s) ||
+                (pattern == name) # Only required during configuration time.
               end
             end
 

--- a/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
+++ b/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
@@ -10,8 +10,10 @@ module Datadog
           def resolve(name)
             # Try to find a matching pattern
             matching_pattern = patterns.find do |pattern|
-              if pattern.respond_to?(:===)
-                (pattern === name) || (pattern === name.to_s) || (pattern == name)
+              if pattern.is_a?(Proc)
+                (pattern === name)
+              else
+                (pattern === name.to_s) || (pattern == name)
               end
             end
 

--- a/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
+++ b/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
@@ -10,18 +10,8 @@ module Datadog
           def resolve(name)
             # Try to find a matching pattern
             matching_pattern = patterns.find do |pattern|
-              if pattern.is_a?(Proc)
-                pattern === name
-              elsif pattern.is_a?(Regexp)
-                if name.is_a?(Regexp)
-                  name.to_s === pattern.to_s
-                elsif name.respond_to?(:to_s)
-                  pattern.match(name.to_s)
-                else
-                  false
-                end
-              else
-                pattern === name.to_s # Co-erce to string
+              if pattern.respond_to?(:===)
+                (pattern === name) || (pattern === name.to_s) || (pattern == name)
               end
             end
 

--- a/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
+++ b/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
@@ -14,6 +14,14 @@ module Datadog
               # rubocop:disable Style/ConditionalAssignment
               if pattern.is_a?(Proc)
                 pattern === name
+              elsif pattern.is_a?(Regexp)
+                if name.is_a?(Regexp)
+                  name.to_s === pattern.to_s
+                elsif name.is_a?(String)
+                  pattern.match(name)
+                else
+                  false
+                end
               else
                 pattern === name.to_s # Co-erce to string
               end

--- a/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
+++ b/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
@@ -14,7 +14,7 @@ module Datadog
                 (pattern === name)
               else
                 (pattern === name.to_s) ||
-                (pattern == name) # Only required during configuration time.
+                  (pattern == name) # Only required during configuration time.
               end
             end
 

--- a/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
+++ b/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
@@ -10,8 +10,6 @@ module Datadog
           def resolve(name)
             # Try to find a matching pattern
             matching_pattern = patterns.find do |pattern|
-              # Rubocop incorrectly thinks assignment is done here...
-              # rubocop:disable Style/ConditionalAssignment
               if pattern.is_a?(Proc)
                 pattern === name
               elsif pattern.is_a?(Regexp)
@@ -19,7 +17,7 @@ module Datadog
                   name.to_s === pattern.to_s
                 elsif name.respond_to?(:to_s)
                   pattern.match(name.to_s)
-                elsif
+                else
                   false
                 end
               else

--- a/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
+++ b/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
@@ -20,7 +20,7 @@ module Datadog
             end
 
             # Return match or default
-            matching_pattern || :default
+            matching_pattern
           end
 
           def add(pattern)

--- a/lib/ddtrace/contrib/excon/middleware.rb
+++ b/lib/ddtrace/contrib/excon/middleware.rb
@@ -63,6 +63,12 @@ module Datadog
               @options
             end
 
+            # default_options in this case contains our specific middleware options
+            # so we want it to take precedence in build_request_options
+            def build_request_options!(datum)
+              datadog_configuration(datum[:host]).options_hash.merge(@default_options)
+            end
+
             def initialize(stack)
               super(stack, self.class.options)
             end
@@ -149,7 +155,7 @@ module Datadog
         end
 
         def build_request_options!(datum)
-          datadog_configuration(datum[:host]).options_hash.merge(@default_options)
+          @default_options.merge(datadog_configuration(datum[:host]).options_hash)
         end
 
         def datadog_configuration(host = :default)

--- a/spec/ddtrace/contrib/configuration/resolvers/pattern_resolver_spec.rb
+++ b/spec/ddtrace/contrib/configuration/resolvers/pattern_resolver_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Datadog::Contrib::Configuration::Resolvers::PatternResolver do
     context 'when non-matching Regexp has been added' do
       let(:name) { 'my-name' }
       before { resolver.add(/not_found/) }
-      it { is_expected.to be :default }
+      it { is_expected.to be nil }
     end
 
     context 'when matching Proc has been added' do
@@ -49,7 +49,7 @@ RSpec.describe Datadog::Contrib::Configuration::Resolvers::PatternResolver do
     context 'when non-matching Proc has been added' do
       let(:name) { 'my-name' }
       before { resolver.add(proc { |n| n == 'not_found' }) }
-      it { is_expected.to be :default }
+      it { is_expected.to be nil }
     end
 
     context 'when a matching String has been added' do
@@ -72,7 +72,7 @@ RSpec.describe Datadog::Contrib::Configuration::Resolvers::PatternResolver do
     context 'when a non-matching String has been added' do
       let(:name) { 'name' }
       before { resolver.add('my-name') }
-      it { is_expected.to be :default }
+      it { is_expected.to be nil }
     end
   end
 
@@ -84,7 +84,7 @@ RSpec.describe Datadog::Contrib::Configuration::Resolvers::PatternResolver do
 
       it 'allows any string matching the pattern to resolve' do
         expect { add }.to change { resolver.resolve('my-name') }
-          .from(:default)
+          .from(nil)
           .to(pattern)
       end
     end
@@ -94,7 +94,7 @@ RSpec.describe Datadog::Contrib::Configuration::Resolvers::PatternResolver do
 
       it 'allows any string matching the pattern to resolve' do
         expect { add }.to change { resolver.resolve('my-name') }
-          .from(:default)
+          .from(nil)
           .to(pattern)
       end
     end
@@ -104,7 +104,7 @@ RSpec.describe Datadog::Contrib::Configuration::Resolvers::PatternResolver do
 
       it 'allows identical strings to resolve' do
         expect { add }.to change { resolver.resolve(pattern) }
-          .from(:default)
+          .from(nil)
           .to(pattern)
       end
     end
@@ -115,7 +115,7 @@ RSpec.describe Datadog::Contrib::Configuration::Resolvers::PatternResolver do
       it 'allows its #to_s value to match identical strings when resolved' do
         expect(pattern).to respond_to(:to_s)
         expect { add }.to change { resolver.resolve('http://localhost') }
-          .from(:default)
+          .from(nil)
           .to('http://localhost')
       end
     end

--- a/spec/ddtrace/contrib/ethon/easy_patch_spec.rb
+++ b/spec/ddtrace/contrib/ethon/easy_patch_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Datadog::Contrib::Ethon::EasyPatch do
       context 'and the host matches a specific configuration' do
         before do
           Datadog.configure do |c|
-            c.use :ethon, describe: /example\.com/ do |ethon|
+            c.use :ethon, describes: /example\.com/ do |ethon|
               ethon.service_name = 'baz'
               ethon.split_by_domain = false
             end

--- a/spec/ddtrace/contrib/ethon/easy_patch_spec.rb
+++ b/spec/ddtrace/contrib/ethon/easy_patch_spec.rb
@@ -71,10 +71,15 @@ RSpec.describe Datadog::Contrib::Ethon::EasyPatch do
               ethon.service_name = 'baz'
               ethon.split_by_domain = false
             end
+
+            c.use :ethon, describes: /badexample\.com/ do |ethon|
+              ethon.service_name = 'baz_bad'
+              ethon.split_by_domain = false
+            end
           end
         end
 
-        it 'uses the configured service name over the domain name' do
+        it 'uses the configured service name over the domain name and the correct describes block' do
           subject
           expect(span.service).to eq('baz')
         end

--- a/spec/ddtrace/contrib/excon/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/excon/instrumentation_spec.rb
@@ -173,14 +173,19 @@ RSpec.describe Datadog::Contrib::Excon::Middleware do
     context 'and the host matches a specific configuration' do
       before do
         Datadog.configure do |c|
-          c.use :excon, describes: /example\.com/ do |faraday|
-            faraday.service_name = 'bar'
-            faraday.split_by_domain = false
+          c.use :excon, describes: /example\.com/ do |excon|
+            excon.service_name = 'bar'
+            excon.split_by_domain = false
+          end
+
+          c.use :excon, describes: /badexample\.com/ do |excon|
+            excon.service_name = 'bar_bad'
+            excon.split_by_domain = false
           end
         end
       end
 
-      it 'uses the configured service name over the domain name' do
+      it 'uses the configured service name over the domain name and the correct describes block' do
         response
         expect(request_span.service).to eq('bar')
       end

--- a/spec/ddtrace/contrib/excon/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/excon/instrumentation_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe Datadog::Contrib::Excon::Middleware do
     context 'and the host matches a specific configuration' do
       before do
         Datadog.configure do |c|
-          c.use :excon, describe: /example\.com/ do |faraday|
+          c.use :excon, describes: /example\.com/ do |faraday|
             faraday.service_name = 'bar'
             faraday.split_by_domain = false
           end

--- a/spec/ddtrace/contrib/faraday/middleware_spec.rb
+++ b/spec/ddtrace/contrib/faraday/middleware_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe 'Faraday middleware' do
     context 'and the host matches a specific configuration' do
       before do
         Datadog.configure do |c|
-          c.use :faraday, describe: /example\.com/ do |faraday|
+          c.use :faraday, describes: /example\.com/ do |faraday|
             faraday.service_name = 'bar'
             faraday.split_by_domain = false
           end

--- a/spec/ddtrace/contrib/faraday/middleware_spec.rb
+++ b/spec/ddtrace/contrib/faraday/middleware_spec.rb
@@ -218,10 +218,15 @@ RSpec.describe 'Faraday middleware' do
             faraday.service_name = 'bar'
             faraday.split_by_domain = false
           end
+
+          c.use :faraday, describes: /badexample\.com/ do |faraday|
+            faraday.service_name = 'bar_bad'
+            faraday.split_by_domain = false
+          end
         end
       end
 
-      it 'uses the configured service name over the domain name' do
+      it 'uses the configured service name over the domain name and the correct describes block' do
         response
         expect(request_span.service).to eq('bar')
       end

--- a/spec/ddtrace/contrib/http/request_spec.rb
+++ b/spec/ddtrace/contrib/http/request_spec.rb
@@ -231,7 +231,8 @@ RSpec.describe 'net/http requests' do
     context 'and the host matches a specific configuration' do
       before do
         Datadog.configure do |c|
-          c.use :http, describes: /example\.com/ do |http|
+          c.use :http, configuration_options
+          c.use :http, describes: /127.0.0.1/ do |http|
             http.service_name = 'bar'
             http.split_by_domain = false
           end

--- a/spec/ddtrace/contrib/http/request_spec.rb
+++ b/spec/ddtrace/contrib/http/request_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe 'net/http requests' do
     context 'and the host matches a specific configuration' do
       before do
         Datadog.configure do |c|
-          c.use :http, describe: /example\.com/ do |http|
+          c.use :http, describes: /example\.com/ do |http|
             http.service_name = 'bar'
             http.split_by_domain = false
           end

--- a/spec/ddtrace/contrib/http/request_spec.rb
+++ b/spec/ddtrace/contrib/http/request_spec.rb
@@ -235,10 +235,15 @@ RSpec.describe 'net/http requests' do
             http.service_name = 'bar'
             http.split_by_domain = false
           end
+
+          c.use :http, describes: /badexample\.com/ do |http|
+            http.service_name = 'bar_bad'
+            http.split_by_domain = false
+          end
         end
       end
 
-      it 'uses the configured service name over the domain name' do
+      it 'uses the configured service name over the domain name and the correct describes block' do
         response
         expect(span.service).to eq('bar')
       end

--- a/spec/ddtrace/contrib/httprb/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/httprb/instrumentation_spec.rb
@@ -222,10 +222,15 @@ RSpec.describe Datadog::Contrib::Httprb::Instrumentation do
                   httprb.service_name = 'bar'
                   httprb.split_by_domain = false
                 end
+
+                c.use :httprb, describes: /random/ do |httprb|
+                  httprb.service_name = 'barz'
+                  httprb.split_by_domain = false
+                end
               end
             end
 
-            it 'uses the configured service name over the domain name' do
+            it 'uses the configured service name over the domain name and the correct describes block' do
               http_response
               expect(span.service).to eq('bar')
             end

--- a/spec/ddtrace/contrib/httprb/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/httprb/instrumentation_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe Datadog::Contrib::Httprb::Instrumentation do
           context 'and the host matches a specific configuration' do
             before do
               Datadog.configure do |c|
-                c.use :httprb, describe: /localhost/ do |httprb|
+                c.use :httprb, describes: /localhost/ do |httprb|
                   httprb.service_name = 'bar'
                   httprb.split_by_domain = false
                 end

--- a/spec/ddtrace/contrib/httprb/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/httprb/instrumentation_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe Datadog::Contrib::Httprb::Instrumentation do
   end
   after(:all) { @server.shutdown }
 
-  # let(:tracer) { get_test_tracer }
   let(:configuration_options) { {} }
 
   before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,6 +68,8 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.warnings = true
   config.order = :random
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
 end
 
 # Helper matchers


### PR DESCRIPTION
Updated:

This PR is a first step at addressing https://github.com/DataDog/dd-trace-rb/issues/1204 .

As far as I can tell our multiplexing code that relied on `describes` blocks for http clients was never really functional. It appears that, due to the way our PatternResolver attempts to `resolve` a key, we woulld always "fallback" to `:default` configuration if that `describes` pattern has not yet been added, which leads to methods like `configuration_for?(key)` to _always_ return true. And since `configuration_for?(key)` always returns true when using a PatternResolver, we never add the `describes` pattern to the configurations, instead always just overwriting the default, [seen here](https://github.com/DataDog/dd-trace-rb/pull/1227/files#diff-5404a32ad5b25528f6b0702fa60b7ab6fad0e5883e1604b7164a4efc04339bbcR49):

`config = configuration_for?(key) ? configuration(key) : add_configuration(key)`  

~I'm a bit hesitant to modify too much here, as it's unclear to me whether the root issue here is that~ The root issue here is that

A: our `PatternResolver` is returning an unexpected [`:default` as a fallback](https://github.com/DataDog/dd-trace-rb/blob/069cb0ee583b3ff00357ba6da363f047d8171821/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb#L23) incorrectly.

~B: Or, our `configuration_for?(key)` method is incorrectly using `resolver.resolve` to [determine whether configuration explicitly exists](https://github.com/DataDog/dd-trace-rb/blob/0c39fecbec95a554958bbf821ee986f634c580f0/lib/ddtrace/contrib/configurable.rb#L29-L30).~

~So in the meantime I've put in a patch, i'd like to see how this runs against the whole test suite as well. Open to feedback as well, just wanted to start the conversation here.~

B: Additionally, the test suite for integations that relied on `PatternResolver` were testing with a `describe` block, not a `describes` block. an incorrectly spelled key effectively functions as overwriting the defaults.

C: And, lastly, even with the above issues fixed, the `PatternResolver` `resolve` method was not properly accounting for Regex patterns, which is the only pattern we document as being accepted by `describes`

So, needless to say there were a few things at work here. Here's what i've done in this PR to clean this up going forward.

1. `PatternResolver` `resolve` method now explicitly returns nil in the event the pattern has not yet been added. While a resolver's `resolve` method could hypothetically have a fallback value, given the way it's being used in practice within our configuration code, having it return a fallback value is problematic.

2. the `resolve` method also now has logic to correctly resolve against Regexp patterns.

3. Tests are updated to test against the appropriate `describes` block, and i've added "non-matching" describes blocks to prevent a regression from what is happening in https://github.com/DataDog/dd-trace-rb/issues/1204 where the last `describes` block to be configured "wins".

4. The Excon integration had some unusual behavior for how it was determining precedence for it's default configuration code vs it's `middleware` configuration code vs it's `describes` configuration code. I've fixed this to support both `describes` taking precedence over `default` and `middleware` taking precedence over `default`.

I think technically this constitutes a breaking change since it's possible some users have been relying on `describes` code that otherwise wouldn't have "matched" to set config details. So, for example, even if the user put `describes: localHoost, {service_name: xyz}` instead of `describes: localhost, {service_name: xyz}`, the `service_name` would still be set to `xyz` while this would now be fixed, we should make sure to not this in release notes.

Lmk what you think