### PR TITLE
Add runtime ID tag to parent spans

### DIFF
--- a/lib/ddtrace/ext/runtime.rb
+++ b/lib/ddtrace/ext/runtime.rb
@@ -10,6 +10,7 @@ module Datadog
       RUBY_ENGINE =  ::RUBY_ENGINE # e.g. 'ruby', 'jruby', 'truffleruby'
       TRACER_VERSION = Datadog::VERSION::STRING
 
+      TAG_ID = 'runtime-id'.freeze
       TAG_LANG = 'language'.freeze
 
       # Metrics

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -7,6 +7,7 @@ require 'ddtrace/span'
 require 'ddtrace/context'
 require 'ddtrace/logger'
 require 'ddtrace/writer'
+require 'ddtrace/runtime/identity'
 require 'ddtrace/sampler'
 require 'ddtrace/sampling'
 require 'ddtrace/correlation'
@@ -201,6 +202,7 @@ module Datadog
         # root span
         @sampler.sample!(span)
         span.set_tag('system.pid', Process.pid)
+        span.set_tag(Datadog::Ext::Runtime::TAG_ID, Datadog::Runtime::Identity.id)
 
         if ctx && ctx.trace_id
           span.trace_id = ctx.trace_id

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -171,7 +171,7 @@ class TracerTest < Minitest::Test
                  tags: { 'tag1' => 'value1', 'tag2' => 'value2' }) do
     end
 
-    spans = tracer.writer.spans()
+    spans = tracer.writer.spans
     assert_equal(1, spans.length)
     span = spans[0]
     assert_equal('special-service', span.service)
@@ -179,7 +179,7 @@ class TracerTest < Minitest::Test
     assert_equal('my-type', span.span_type)
     # 2 tags from tracer, 2 for span, metrics for PID, and sampling priority,
     # then optionally 1 from runtime metrics if enabled.
-    expected_length = 7 # 4 tags, 3 metrics
+    expected_length = 8 # 5 tags, 3 metrics
     expected_length += 1 if Datadog.configuration.runtime_metrics_enabled
 
     assert_equal(expected_length, span.meta.length + span.metrics.length)


### PR DESCRIPTION
In order to distinguish different runtimes within a trace, this pull request adds `runtime-id` tags to the "local root span" (the top most span in a given process.)

```ruby
Datadog.tracer.trace('parent_span') do
 # Tag "runtime-id": "a3184506-bd6a-4204-b302-89dda8b95f5a"
  Datadog.tracer.trace('child_span') do
    # Tag "runtime-id": nil
    fork do
      Datadog.tracer.trace('fork_parent_span') do
        # Tag "runtime-id": "53f7622d-7db9-494d-8bc8-8cf6735b7297"
        Datadog.tracer.trace('fork_child_span') do
          # Tag "runtime-id": nil
        end
      end
    end
  end
end
```

It's based on the context reset changes in #1225, which adds the necessary auto-clearing of spans after forking.