### PR TITLE
Fix log injection warn logs and b3 env vars

### DIFF
--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -69,7 +69,7 @@ module Datadog
         option :propagation_extract_style do |o|
           o.default do
             # Look for all headers by default
-            env_to_list([Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV,
+            env_to_list([Ext::DistributedTracing::PROPAGATION_STYLE_EXTRACT_ENV,
                          Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV_OLD],
                         [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG,
                          Ext::DistributedTracing::PROPAGATION_STYLE_B3,
@@ -82,7 +82,7 @@ module Datadog
         option :propagation_inject_style do |o|
           o.default do
             # Only inject Datadog headers by default
-            env_to_list([Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV,
+            env_to_list([Ext::DistributedTracing::PROPAGATION_STYLE_INJECT_ENV,
                          Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV_OLD],
                         [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG])
           end

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -69,8 +69,8 @@ module Datadog
         option :propagation_extract_style do |o|
           o.default do
             # Look for all headers by default
-            env_to_list(Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV,
-                        Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV_OLD,
+            env_to_list([Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV,
+                         Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV_OLD],
                         [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG,
                          Ext::DistributedTracing::PROPAGATION_STYLE_B3,
                          Ext::DistributedTracing::PROPAGATION_STYLE_B3_SINGLE_HEADER])
@@ -82,8 +82,8 @@ module Datadog
         option :propagation_inject_style do |o|
           o.default do
             # Only inject Datadog headers by default
-            env_to_list(Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV,
-                        Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV_OLD,
+            env_to_list([Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV,
+                         Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV_OLD],
                         [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG])
           end
 

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -70,6 +70,7 @@ module Datadog
           o.default do
             # Look for all headers by default
             env_to_list(Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV,
+                        Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV_OLD,
                         [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG,
                          Ext::DistributedTracing::PROPAGATION_STYLE_B3,
                          Ext::DistributedTracing::PROPAGATION_STYLE_B3_SINGLE_HEADER])
@@ -82,6 +83,7 @@ module Datadog
           o.default do
             # Only inject Datadog headers by default
             env_to_list(Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV,
+                        Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV_OLD,
                         [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG])
           end
 

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -53,15 +53,17 @@ module Datadog
         end
 
         def add_logger(app)
+          should_log_flag = true
           # check if lograge key exists
           # Note: Rails executes initializers sequentially based on alphabetical order,
           # and lograge config could occur after dd config.
           # Checking for `app.config.lograge.enabled` may yield a false negative.
           # Instead we should naively add custom options if `config.lograge` exists from the lograge Railtie,
           # since the custom options get ignored without lograge explicitly being enabled.
-          # See: https://github.com/roidrage/lograge/blob/1729eab7956bb95c5992e4adab251e4f93ff9280/lib/lograge/railtie.rb#L7-L12
+          # See: https://github.com/roidrage/lograge/blob/1729eab7956bb95c5992e4adab251e4f93ff9280/lib/lograge/railtie.rb#L7-L12          
           if app.config.respond_to?(:lograge)
             Datadog::Contrib::Rails::LogInjection.add_lograge_logger(app)
+            should_log_flag = false
           end
 
           # if lograge isn't set, check if tagged logged is enabled.
@@ -71,9 +73,10 @@ module Datadog
              logger.is_a?(::ActiveSupport::TaggedLogging)
 
             Datadog::Contrib::Rails::LogInjection.add_as_tagged_logging_logger(app)
-          else
-            Datadog.logger.warn("Unable to enable Datadog Trace context, Logger #{logger} is not supported")
+            should_log_flag = false
           end
+          
+          Datadog.logger.warn("Unable to enable Datadog Trace context, Logger #{logger} is not supported") if should_log_flag
         end
 
         def patch_after_intialize

--- a/lib/ddtrace/contrib/rails/patcher.rb
+++ b/lib/ddtrace/contrib/rails/patcher.rb
@@ -53,17 +53,17 @@ module Datadog
         end
 
         def add_logger(app)
-          should_log_flag = true
+          should_warn = true
           # check if lograge key exists
           # Note: Rails executes initializers sequentially based on alphabetical order,
           # and lograge config could occur after dd config.
           # Checking for `app.config.lograge.enabled` may yield a false negative.
           # Instead we should naively add custom options if `config.lograge` exists from the lograge Railtie,
           # since the custom options get ignored without lograge explicitly being enabled.
-          # See: https://github.com/roidrage/lograge/blob/1729eab7956bb95c5992e4adab251e4f93ff9280/lib/lograge/railtie.rb#L7-L12          
+          # See: https://github.com/roidrage/lograge/blob/1729eab7956bb95c5992e4adab251e4f93ff9280/lib/lograge/railtie.rb#L7-L12
           if app.config.respond_to?(:lograge)
             Datadog::Contrib::Rails::LogInjection.add_lograge_logger(app)
-            should_log_flag = false
+            should_warn = false
           end
 
           # if lograge isn't set, check if tagged logged is enabled.
@@ -73,10 +73,10 @@ module Datadog
              logger.is_a?(::ActiveSupport::TaggedLogging)
 
             Datadog::Contrib::Rails::LogInjection.add_as_tagged_logging_logger(app)
-            should_log_flag = false
+            should_warn = false
           end
-          
-          Datadog.logger.warn("Unable to enable Datadog Trace context, Logger #{logger} is not supported") if should_log_flag
+
+          Datadog.logger.warn("Unable to enable Datadog Trace context, Logger #{logger} is not supported") if should_warn
         end
 
         def patch_after_intialize

--- a/lib/ddtrace/ext/distributed.rb
+++ b/lib/ddtrace/ext/distributed.rb
@@ -20,8 +20,10 @@ module Datadog
       PROPAGATION_STYLE_DATADOG = 'Datadog'.freeze
       PROPAGATION_STYLE_B3 = 'B3'.freeze
       PROPAGATION_STYLE_B3_SINGLE_HEADER = 'B3 single header'.freeze
-      PROPAGATION_INJECT_STYLE_ENV = 'DD_PROPAGATION_INJECT_STYLE'.freeze
-      PROPAGATION_EXTRACT_STYLE_ENV = 'DD_PROPAGATION_EXTRACT_STYLE'.freeze
+      PROPAGATION_INJECT_STYLE_ENV = 'DD_PROPAGATION_STYLE_INJECT'.freeze
+      PROPAGATION_EXTRACT_STYLE_ENV = 'DD_PROPAGATION_STYLE_EXTRACT'.freeze
+      PROPAGATION_INJECT_STYLE_ENV_OLD = 'DD_PROPAGATION_INJECT_STYLE'.freeze
+      PROPAGATION_EXTRACT_STYLE_ENV_OLD = 'DD_PROPAGATION_EXTRACT_STYLE'.freeze
 
       # gRPC metadata keys for distributed tracing. https://github.com/grpc/grpc-go/blob/v1.10.x/Documentation/grpc-metadata.md
       GRPC_METADATA_TRACE_ID = 'x-datadog-trace-id'.freeze

--- a/lib/ddtrace/ext/distributed.rb
+++ b/lib/ddtrace/ext/distributed.rb
@@ -20,8 +20,12 @@ module Datadog
       PROPAGATION_STYLE_DATADOG = 'Datadog'.freeze
       PROPAGATION_STYLE_B3 = 'B3'.freeze
       PROPAGATION_STYLE_B3_SINGLE_HEADER = 'B3 single header'.freeze
-      PROPAGATION_INJECT_STYLE_ENV = 'DD_PROPAGATION_STYLE_INJECT'.freeze
-      PROPAGATION_EXTRACT_STYLE_ENV = 'DD_PROPAGATION_STYLE_EXTRACT'.freeze
+      PROPAGATION_STYLE_INJECT_ENV = 'DD_PROPAGATION_STYLE_INJECT'.freeze
+      PROPAGATION_STYLE_EXTRACT_ENV = 'DD_PROPAGATION_STYLE_EXTRACT'.freeze
+      # Note: the below inject/extract values are deprecated and were defined erronously
+      # they were never part of the datadog language client standard or documentation
+      # some users may already be relying on them, but we should look to remove these in the future
+      # or before 1.0.
       PROPAGATION_INJECT_STYLE_ENV_OLD = 'DD_PROPAGATION_INJECT_STYLE'.freeze
       PROPAGATION_EXTRACT_STYLE_ENV_OLD = 'DD_PROPAGATION_EXTRACT_STYLE'.freeze
 

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -232,6 +232,39 @@ RSpec.describe Datadog::Configuration::Settings do
           end
         end
       end
+
+      context "when #{Datadog::Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV_OLD}" do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV_OLD => environment) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:environment) { nil }
+          it do
+            is_expected.to eq(
+              [
+                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG,
+                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_B3,
+                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_B3_SINGLE_HEADER
+              ]
+            )
+          end
+        end
+
+        context 'is defined' do
+          let(:environment) { 'B3,B3 single header' }
+          it do
+            is_expected.to eq(
+              [
+                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_B3,
+                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_B3_SINGLE_HEADER
+              ]
+            )
+          end
+        end
+      end
     end
 
     describe '#propagation_inject_style' do
@@ -240,6 +273,31 @@ RSpec.describe Datadog::Configuration::Settings do
       context "when #{Datadog::Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV}" do
         around do |example|
           ClimateControl.modify(Datadog::Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV => environment) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:environment) { nil }
+          it { is_expected.to eq([Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG]) }
+        end
+
+        context 'is defined' do
+          let(:environment) { 'Datadog,B3' }
+          it do
+            is_expected.to eq(
+              [
+                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG,
+                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_B3
+              ]
+            )
+          end
+        end
+      end
+
+      context "when #{Datadog::Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV_OLD}" do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV_OLD => environment) do
             example.run
           end
         end

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -200,9 +200,9 @@ RSpec.describe Datadog::Configuration::Settings do
     describe '#propagation_extract_style' do
       subject(:propagation_extract_style) { settings.distributed_tracing.propagation_extract_style }
 
-      context "when #{Datadog::Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV}" do
+      context "when #{Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_EXTRACT_ENV}" do
         around do |example|
-          ClimateControl.modify(Datadog::Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV => environment) do
+          ClimateControl.modify(Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_EXTRACT_ENV => environment) do
             example.run
           end
         end
@@ -270,9 +270,9 @@ RSpec.describe Datadog::Configuration::Settings do
     describe '#propagation_inject_style' do
       subject(:propagation_inject_style) { settings.distributed_tracing.propagation_inject_style }
 
-      context "when #{Datadog::Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV}" do
+      context "when #{Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_INJECT_ENV}" do
         around do |example|
-          ClimateControl.modify(Datadog::Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV => environment) do
+          ClimateControl.modify(Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_INJECT_ENV => environment) do
             example.run
           end
         end


### PR DESCRIPTION
This PR addresses https://github.com/DataDog/dd-trace-rb/issues/1226 as well as some residual followup from https://github.com/DataDog/dd-trace-rb/issues/1205.

- It updates environment variables for B3 Header Inject and Extract to fit broader datadog specification and [what's in documentation](https://docs.datadoghq.com/tracing/custom_instrumentation/ruby/?tab=activespan#b3-headers-extraction-and-injection), updating from `DD_PROPAGATION_INJECT_STYLE` and `DD_PROPAGATION_EXTRACT_STYLE` to `DD_PROPAGATION_STYLE_INJECT` and `DD_PROPAGATION_STYLE_EXTRACT`, respectively.

- It also cleans up a case in the rails trace context auto-injection feature where a warning log would occur erroneously. 