### PR TITLE
Stub all relevant IO calls for cgroup mocking

### DIFF
--- a/spec/support/container_helpers.rb
+++ b/spec/support/container_helpers.rb
@@ -6,6 +6,10 @@ module ContainerHelpers
     let(:cgroup_file) { StringIO.new }
 
     before do
+      expect(File).to receive(:exist?)
+        .with('/proc/self/cgroup')
+        .and_return(true)
+
       allow(File).to receive(:open).and_call_original
       allow(File).to receive(:open)
         .with('/proc/self/cgroup')


### PR DESCRIPTION
When testing container ID detection, we would stub `File.open('/proc/self/cgroup')`, but not `File.exist?('/proc/self/cgroup')`, which we call before reading the file.

This causes the tracer to check if the testing process itself (RSpec) has a `/proc/self/cgroup` file defined. This incidentally works on Linux environment, but is not the intention of the test.

This change also allows tests to run successfully on MacOS.