### PR TITLE
Use correct span type for AWS SDK

### DIFF
--- a/lib/ddtrace/contrib/aws/instrumentation.rb
+++ b/lib/ddtrace/contrib/aws/instrumentation.rb
@@ -1,5 +1,6 @@
 require 'ddtrace/contrib/analytics'
 require 'ddtrace/contrib/aws/ext'
+require 'ddtrace/ext/http'
 require 'ddtrace/ext/integration'
 
 module Datadog
@@ -26,7 +27,7 @@ module Datadog
 
         def annotate!(span, context)
           span.service = configuration[:service_name]
-          span.span_type = Datadog::Ext::AppTypes::WEB
+          span.span_type = Datadog::Ext::HTTP::TYPE_OUTBOUND
           span.name = Ext::SPAN_COMMAND
           span.resource = context.safely(:resource)
 

--- a/lib/ddtrace/contrib/aws/patcher.rb
+++ b/lib/ddtrace/contrib/aws/patcher.rb
@@ -1,5 +1,4 @@
 require 'ddtrace/contrib/patcher'
-require 'ddtrace/ext/app_types'
 require 'ddtrace/contrib/aws/ext'
 
 module Datadog

--- a/spec/ddtrace/contrib/aws/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/aws/instrumentation_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'AWS instrumentation' do
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
         expect(span.service).to eq('aws')
-        expect(span.span_type).to eq('web')
+        expect(span.span_type).to eq('http')
         expect(span.resource).to eq('s3.list_buckets')
 
         expect(span.get_tag('aws.agent')).to eq('aws-sdk-ruby')


### PR DESCRIPTION
Our current AWS SDK instrumentation labels its spans as `web`, which is used to identify web servers.

This PR changes that span type to `http` instead, which is the type we use for egress HTTP requests. Given the SDK performs remote work on the large majority of its calls, out of all the types we have available, `http` labels the AWS SDK the best.