### PR TITLE
Fix mistyped internal Pin on HTTP clients

### DIFF
--- a/lib/ddtrace/contrib/faraday/patcher.rb
+++ b/lib/ddtrace/contrib/faraday/patcher.rb
@@ -30,7 +30,7 @@ module Datadog
             .new(
               get_option(:service_name),
               app: Ext::APP,
-              app_type: Datadog::Ext::AppTypes::WEB,
+              app_type: Datadog::Ext::HTTP::TYPE_OUTBOUND,
               tracer: -> { get_option(:tracer) }
             ).onto(::Faraday)
         end

--- a/lib/ddtrace/contrib/http/instrumentation.rb
+++ b/lib/ddtrace/contrib/http/instrumentation.rb
@@ -118,7 +118,7 @@ module Datadog
             @datadog_pin ||= Datadog::Pin.new(
               service,
               app: Ext::APP,
-              app_type: Datadog::Ext::AppTypes::WEB,
+              app_type: Datadog::Ext::HTTP::TYPE_OUTBOUND,
               tracer: -> { config[:tracer] }
             )
 
@@ -146,7 +146,7 @@ module Datadog
             @default_datadog_pin ||= Datadog::Pin.new(
               service,
               app: Ext::APP,
-              app_type: Datadog::Ext::AppTypes::WEB,
+              app_type: Datadog::Ext::HTTP::TYPE_OUTBOUND,
               tracer: -> { config[:tracer] }
             )
           end

--- a/lib/ddtrace/contrib/httprb/instrumentation.rb
+++ b/lib/ddtrace/contrib/httprb/instrumentation.rb
@@ -103,7 +103,7 @@ module Datadog
               Datadog::Pin.new(
                 service,
                 app: Ext::APP,
-                app_type: Datadog::Ext::AppTypes::WEB,
+                app_type: Datadog::Ext::HTTP::TYPE_OUTBOUND,
                 tracer: -> { config[:tracer] }
               )
             end
@@ -126,7 +126,7 @@ module Datadog
               Datadog::Pin.new(
                 service,
                 app: Ext::APP,
-                app_type: Datadog::Ext::AppTypes::WEB,
+                app_type: Datadog::Ext::HTTP::TYPE_OUTBOUND,
                 tracer: -> { config[:tracer] }
               )
             end


### PR DESCRIPTION
The default `Datadog::Pin` or `Datadog::DeprecatedPin` created on the `Net::HTTP`, `Faraday` and `http.rb` integrations were erroneously typed as `web`, while they should have been of `http` type.

This actually is a non-issue for most users, as the span type eventually gets overwritten with `http` in all three integrations ([Faraday example](https://github.com/DataDog/dd-trace-rb/blob/master/lib/ddtrace/contrib/faraday/middleware.rb#L43)).

Only users that directly manipulate the `Datadog::Pin` or `Datadog::DeprecatedPin` associated with these three integrations are affected. The change from `web` to `http` will provide better classification of the spans by the backend, providing proper categorization in our front-end. There are no changes to the data contained in a tracer or to the metrics generated by traces.