### PR TITLE
Change `profiling.exporter.timeout` --> `profiling.upload.timeout`

### DIFF
--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -137,7 +137,7 @@ module Datadog
                           transport_options = settings.profiling.exporter.transport_options.dup
                           transport_options[:site] ||= settings.site if settings.site
                           transport_options[:api_key] ||= settings.api_key if settings.api_key
-                          transport_options[:timeout] ||= settings.profiling.exporter.timeout
+                          transport_options[:timeout] ||= settings.profiling.upload.timeout
                           Datadog::Profiling::Transport::HTTP.default(transport_options)
                         end
 

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -121,18 +121,19 @@ module Datadog
 
         settings :exporter do
           option :instances
-
-          option :timeout do |o|
-            o.setter { |value| value.nil? ? 30.0 : value.to_f }
-            o.default { env_to_float(Ext::Profiling::ENV_UPLOAD_TIMEOUT, 30.0) }
-            o.lazy
-          end
-
           option :transport
           option :transport_options, default: ->(_o) { {} }, lazy: true
         end
 
         option :max_events, default: 32768
+
+        settings :upload do
+          option :timeout do |o|
+            o.setter { |value| value.nil? ? 30.0 : value.to_f }
+            o.default { env_to_float(Ext::Profiling::ENV_UPLOAD_TIMEOUT, 30.0) }
+            o.lazy
+          end
+        end
       end
 
       option :report_hostname do |o|

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -698,7 +698,7 @@ RSpec.describe Datadog::Configuration::Components do
             hostname: Datadog::Profiling::Transport::HTTP.default_hostname,
             port: Datadog::Profiling::Transport::HTTP.default_port,
             ssl: false,
-            timeout: settings.profiling.exporter.timeout
+            timeout: settings.profiling.upload.timeout
           )
         end
       end
@@ -821,7 +821,7 @@ RSpec.describe Datadog::Configuration::Components do
                 hostname: "intake.profile.#{site}",
                 port: 443,
                 ssl: true,
-                timeout: settings.profiling.exporter.timeout
+                timeout: settings.profiling.upload.timeout
               )
             end
           end

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -469,45 +469,6 @@ RSpec.describe Datadog::Configuration::Settings do
         end
       end
 
-      describe '#timeout' do
-        subject(:timeout) { settings.profiling.exporter.timeout }
-
-        context "when #{Datadog::Ext::Profiling::ENV_UPLOAD_TIMEOUT}" do
-          around do |example|
-            ClimateControl.modify(Datadog::Ext::Profiling::ENV_UPLOAD_TIMEOUT => environment) do
-              example.run
-            end
-          end
-
-          context 'is not defined' do
-            let(:environment) { nil }
-            it { is_expected.to eq(30.0) }
-          end
-
-          context 'is defined' do
-            let(:environment) { '10.0' }
-            it { is_expected.to eq(10.0) }
-          end
-        end
-      end
-
-      describe '#timeout=' do
-        it 'updates the #timeout setting' do
-          expect { settings.profiling.exporter.timeout = 10 }
-            .to change { settings.profiling.exporter.timeout }
-            .from(30.0)
-            .to(10.0)
-        end
-
-        context 'given nil' do
-          it 'uses the default setting' do
-            expect { settings.profiling.exporter.timeout = nil }
-              .to_not change { settings.profiling.exporter.timeout }
-              .from(30.0)
-          end
-        end
-      end
-
       describe '#transport' do
         subject(:transport) { settings.profiling.exporter.transport }
         it { is_expected.to be nil }
@@ -552,6 +513,47 @@ RSpec.describe Datadog::Configuration::Settings do
           .to change { settings.profiling.max_events }
           .from(32768)
           .to(1234)
+      end
+    end
+
+    describe '#upload' do
+      describe '#timeout' do
+        subject(:timeout) { settings.profiling.upload.timeout }
+
+        context "when #{Datadog::Ext::Profiling::ENV_UPLOAD_TIMEOUT}" do
+          around do |example|
+            ClimateControl.modify(Datadog::Ext::Profiling::ENV_UPLOAD_TIMEOUT => environment) do
+              example.run
+            end
+          end
+
+          context 'is not defined' do
+            let(:environment) { nil }
+            it { is_expected.to eq(30.0) }
+          end
+
+          context 'is defined' do
+            let(:environment) { '10.0' }
+            it { is_expected.to eq(10.0) }
+          end
+        end
+      end
+
+      describe '#timeout=' do
+        it 'updates the #timeout setting' do
+          expect { settings.profiling.upload.timeout = 10 }
+            .to change { settings.profiling.upload.timeout }
+            .from(30.0)
+            .to(10.0)
+        end
+
+        context 'given nil' do
+          it 'uses the default setting' do
+            expect { settings.profiling.upload.timeout = nil }
+              .to_not change { settings.profiling.upload.timeout }
+              .from(30.0)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
To make configuration slightly nicer, this pull request effectively renames the `profiling.exporter.timeout` option to `profiling.upload.timeout`.