### PR TITLE
disable tracing mongo endSessions event

### DIFF
--- a/lib/ddtrace/contrib/mongodb/subscribers.rb
+++ b/lib/ddtrace/contrib/mongodb/subscribers.rb
@@ -9,7 +9,14 @@ module Datadog
       # `MongoCommandSubscriber` listens to all events from the `Monitoring`
       # system available in the Mongo driver.
       class MongoCommandSubscriber
+        END_SESSIONS_EVENT = 'endSessions'.freeze
+
         def started(event)
+          # workaround for https://github.com/DataDog/dd-trace-rb/issues/1235
+          # This event gets emmitted on disconnect
+          # https://github.com/mongodb/mongo-ruby-driver/blob/20748bbf1d1c69ee97833098bb2ff959beceb0dd/lib/mongo/cluster.rb#L486
+          return if event.command_name == END_SESSIONS_EVENT
+
           pin = Datadog::Pin.get_from(event.address)
           return unless pin && pin.enabled?
 


### PR DESCRIPTION
This PR temporarily addresses https://github.com/DataDog/dd-trace-rb/issues/1235. There are segfaults occurring as a result of the Mongo instrumentation and it's interaction with system exit.

After some time spent debugging, the event that causes the segfault consistently seems to be the `endSessions` event. From adding some basic debug logs, this event gets emitted after the Tracer is `shutdown!` from [the at_exit hook ](https://github.com/DataDog/dd-trace-rb/blob/817a0827d0c6edeb41b37d7ea8d321ce09e1547a/lib/ddtrace.rb#L37). Beside the timing, the only other thing that sticks out with this event is that it's `id` is a `bson` collection, but I'm not sure if that has any significance. More specifically, The segfault consistently happens after attempting to call `span.finish` and enqueue the trace in the trace buffer. I haven't been able to nail down why that's the case, broadly it seems like `Tracer.shutdown!` puts our Writer and Buffer in an unexpected state. Occasionally in testing, everything writes/flushes without issue, so there may be a race condition at work. More investigation is required.

In the meantime, simply not tracing this `endSessions` event seems like the fastest patch to ensuring Mongo instrumentation can continue to be used by users, while we investigate the more complex root causes