### PR TITLE
Add topic tag to kafka producer events

### DIFF
--- a/lib/ddtrace/contrib/kafka/events/produce_operation/send_messages.rb
+++ b/lib/ddtrace/contrib/kafka/events/produce_operation/send_messages.rb
@@ -15,6 +15,7 @@ module Datadog
             def self.process(span, _event, _id, payload)
               super
 
+              span.set_tag(Ext::TAG_TOPIC, payload[:topic]) if payload.key?(:topic)
               span.set_tag(Ext::TAG_MESSAGE_COUNT, payload[:message_count]) if payload.key?(:message_count)
               span.set_tag(Ext::TAG_SENT_MESSAGE_COUNT, payload[:sent_message_count]) if payload.key?(:sent_message_count)
             end

--- a/lib/ddtrace/contrib/kafka/events/producer/deliver_messages.rb
+++ b/lib/ddtrace/contrib/kafka/events/producer/deliver_messages.rb
@@ -16,6 +16,7 @@ module Datadog
               super
 
               span.set_tag(Ext::TAG_ATTEMPTS, payload[:attempts]) if payload.key?(:attempts)
+              span.set_tag(Ext::TAG_TOPIC, payload[:topic]) if payload.key?(:topic)
               span.set_tag(Ext::TAG_MESSAGE_COUNT, payload[:message_count]) if payload.key?(:message_count)
               if payload.key?(:delivered_message_count)
                 span.set_tag(Ext::TAG_DELIVERED_MESSAGE_COUNT, payload[:delivered_message_count])

--- a/spec/ddtrace/contrib/kafka/patcher_spec.rb
+++ b/spec/ddtrace/contrib/kafka/patcher_spec.rb
@@ -517,11 +517,13 @@ RSpec.describe 'Kafka patcher' do
   end
 
   describe 'producer.send_messages' do
+    let(:topic) { 'my-topic' }
     let(:message_count) { rand(10..100) }
     let(:sent_message_count) { rand(1..message_count) }
     let(:payload) do
       {
         client_id: client_id,
+        topic: topic,
         message_count: message_count,
         sent_message_count: sent_message_count
       }
@@ -538,6 +540,7 @@ RSpec.describe 'Kafka patcher' do
           expect(span.name).to eq('kafka.producer.send_messages')
           expect(span.resource).to eq(span.name)
           expect(span.get_tag('kafka.client')).to eq(client_id)
+          expect(span.get_tag('kafka.topic')).to eq(topic)
           expect(span.get_tag('kafka.message_count')).to eq(message_count)
           expect(span.get_tag('kafka.sent_message_count')).to eq(sent_message_count)
           expect(span).to_not have_error

--- a/spec/ddtrace/contrib/kafka/patcher_spec.rb
+++ b/spec/ddtrace/contrib/kafka/patcher_spec.rb
@@ -587,12 +587,14 @@ RSpec.describe 'Kafka patcher' do
 
   describe 'producer.deliver_messages' do
     let(:attempts) { rand(1..10) }
+    let(:topic) { 'my-topic' }
     let(:message_count) { rand(10..100) }
     let(:delivered_message_count) { rand(1..message_count) }
     let(:payload) do
       {
         client_id: client_id,
         attempts: attempts,
+        topic: topic,
         message_count: message_count,
         delivered_message_count: delivered_message_count
       }
@@ -610,6 +612,7 @@ RSpec.describe 'Kafka patcher' do
           expect(span.resource).to eq(span.name)
           expect(span.get_tag('kafka.client')).to eq(client_id)
           expect(span.get_tag('kafka.attempts')).to eq(attempts)
+          expect(span.get_tag('kafka.topic')).to eq(topic)
           expect(span.get_tag('kafka.message_count')).to eq(message_count)
           expect(span.get_tag('kafka.delivered_message_count')).to eq(delivered_message_count)
           expect(span).to_not have_error


### PR DESCRIPTION
Hi again. This is a feature request to improve Kafka monitoring. Consumer events (`process_message` & `process_batch`) are already tagged with the topic from the payload, but producer events (`send_messages` & `deliver_messages`) are not. This is an important piece of info for understanding traces, especially when the producer and consumer event spans are spread across separate traces.

I also ran into some failing specs before making any changes. Not sure if this is a local environment problem or real failures, but I was able to fix them by updating the tracer/writer initialization to use the newer methods from `Contrib::TracerHelpers`. I noticed `rake spec:kafka` is missing from the `ci` task, leading me to believe they might be legitimate failures that were missed in an earlier update.

Thanks for reviewing!