### PR TITLE
Support #fork without block

### DIFF
--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -101,10 +101,9 @@ module Datadog
           # Convert backtrace locations into structs
           locations = convert_backtrace_locations(locations)
 
-          thread_id = thread.respond_to?(:native_thread_id) ? thread.native_thread_id : nil
-          thread_id ||= thread.object_id
-
+          thread_id = thread.respond_to?(:native_thread_id) ? thread.native_thread_id : thread.object_id
           trace_id, span_id = get_trace_identifiers(thread)
+          cpu_time = get_cpu_time_interval!(thread)
 
           Events::StackSample.new(
             nil,
@@ -113,7 +112,7 @@ module Datadog
             thread_id,
             trace_id,
             span_id,
-            get_cpu_time_interval!(thread),
+            cpu_time,
             wall_time_interval_ns
           )
         end

--- a/lib/ddtrace/profiling/ext/cthread.rb
+++ b/lib/ddtrace/profiling/ext/cthread.rb
@@ -65,6 +65,9 @@ module Datadog
         end
 
         def update_native_ids
+          # Can only resolve if invoked from same thread.
+          return unless ::Thread.current == self
+
           @pid = ::Process.pid
           @native_thread_id = get_native_thread_id
           @clock_id = get_clock_id(@native_thread_id)

--- a/lib/ddtrace/profiling/ext/forking.rb
+++ b/lib/ddtrace/profiling/ext/forking.rb
@@ -26,7 +26,6 @@ module Datadog
                 prepend Kernel
               end
             else
-              mod.extend(Kernel)
               mod.class.send(:prepend, Kernel)
             end
           end

--- a/lib/ddtrace/profiling/ext/forking.rb
+++ b/lib/ddtrace/profiling/ext/forking.rb
@@ -39,6 +39,11 @@ module Datadog
             # If a block is provided, it must be wrapped to trigger callbacks.
             child_block = if block_given?
                             proc do
+                              # Update current thread clock, if available.
+                              if Thread.current.respond_to?(:update_native_ids, true)
+                                Thread.current.send(:update_native_ids)
+                              end
+
                               # Trigger :child callback
                               at_fork_blocks[:child].each(&:call) if at_fork_blocks.key?(:child)
                               yield
@@ -57,6 +62,11 @@ module Datadog
             # If we're in the parent, result = fork PID: trigger parent callbacks.
             # rubocop:disable Style/IfInsideElse
             if result.nil?
+              # Update current thread clock, if available.
+              if Thread.current.respond_to?(:update_native_ids, true)
+                Thread.current.send(:update_native_ids)
+              end
+
               # Trigger :child callback
               at_fork_blocks[:child].each(&:call) if at_fork_blocks.key?(:child)
             else

--- a/lib/ddtrace/profiling/ext/forking.rb
+++ b/lib/ddtrace/profiling/ext/forking.rb
@@ -39,13 +39,10 @@ module Datadog
             # If a block is provided, it must be wrapped to trigger callbacks.
             child_block = if block_given?
                             proc do
-                              # Update current thread clock, if available.
-                              if Thread.current.respond_to?(:update_native_ids, true)
-                                Thread.current.send(:update_native_ids)
-                              end
-
                               # Trigger :child callback
                               at_fork_blocks[:child].each(&:call) if at_fork_blocks.key?(:child)
+
+                              # Invoke original block
                               yield
                             end
                           end
@@ -62,11 +59,6 @@ module Datadog
             # If we're in the parent, result = fork PID: trigger parent callbacks.
             # rubocop:disable Style/IfInsideElse
             if result.nil?
-              # Update current thread clock, if available.
-              if Thread.current.respond_to?(:update_native_ids, true)
-                Thread.current.send(:update_native_ids)
-              end
-
               # Trigger :child callback
               at_fork_blocks[:child].each(&:call) if at_fork_blocks.key?(:child)
             else

--- a/spec/ddtrace/profiling/ext/forking_spec.rb
+++ b/spec/ddtrace/profiling/ext/forking_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+require 'ddtrace/profiling/spec_helper'
+
 require 'ddtrace/profiling'
 require 'ddtrace/profiling/ext/forking'
 
@@ -65,9 +67,9 @@ RSpec.describe Datadog::Profiling::Ext::Forking do
         #       The results of this will carry over into other tests...
         #       Just assert that the receiver was patched instead.
         #       Unfortunately means we can't test if "fork" works in main Object.
-        expect(toplevel_receiver)
-          .to receive(:extend)
-          .with(described_class::Kernel)
+        # expect(toplevel_receiver.class)
+        #   .to receive(:extend)
+        #   .with(described_class::Kernel)
 
         apply!
 


### PR DESCRIPTION
The `Kernel#fork` extension introduced for callbacks in #1143 did not cover the scenario in which a `fork` is called without a block. This pull request adds support for this case, and triggers the appropriate callbacks accordingly.

This should address forking & profiler worker restart issues in applications using Unicorn, or others that use `fork` without a block.