### PR TITLE
Avoid writer reinitialization during shutdown

### DIFF
--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -55,11 +55,27 @@ module Datadog
       end
     end
 
+    # Gracefully shuts down all components.
+    #
+    # Components will still respond to method calls as usual,
+    # but might not internally perform their work after shutdown.
+    #
+    # This avoids errors being raised across the host application
+    # during shutdown, while allowing for graceful decommission of resources.
+    #
+    # Components won't be automatically reinitialized after a shutdown.
     def shutdown!
-      if instance_variable_defined?(:@components) && @components
-        components.shutdown!
-        @components = nil
-      end
+      components.shutdown! if instance_variable_defined?(:@components) && @components
+    end
+
+    # Gracefully shuts down the tracer and disposes of component references,
+    # allowing execution to start anew.
+    #
+    # In contrast with +#shutdown!+, components will be automatically
+    # reinitialized after a reset.
+    def reset!
+      shutdown!
+      @components = nil
     end
 
     protected

--- a/spec/ddtrace/contrib/support/tracer_helpers.rb
+++ b/spec/ddtrace/contrib/support/tracer_helpers.rb
@@ -50,7 +50,7 @@ module Contrib
     RSpec.configure do |config|
       # Capture spans from the global tracer
       config.before(:each) do
-        Datadog.shutdown!
+        Datadog.reset!
 
         # DEV `*_any_instance_of` has concurrency issues when running with parallelism (e.g. JRuby).
         # DEV Single object `allow` and `expect` work as intended with parallelism.


### PR DESCRIPTION
Fixes #1235 

Changes introduced in release 0.38.0 (#1091) allowed the internal worker instance, held by the `Writer`, to be restarted on demand. This is normally ok, except during a shutdown.

With the introduction of https://github.com/DataDog/dd-trace-rb/pull/1177, in release 0.41.0, the issue has change, as a brand new `Writer` is now created. That new `Writer` is then fed a trace, which triggers the lazy initialization of it's internal worker thread.

This PR prevents the re-creation of components during shutdown, the most relevant one being the `Writer`.

Components are still responsive to method calls after `Datadog.shutdown!` (as to not surface host application errors), but they might not perform their work internally after their resources have been disposed of (e.g. `Writer` will not flush any traces after its internal worker thread has been stopped).