### PR TITLE
Actions: Add milestone to merged pull requests

### DIFF
--- a/.github/workflows/add-milestone-to-pull-requests.yml
+++ b/.github/workflows/add-milestone-to-pull-requests.yml
@@ -1,0 +1,42 @@
+name: Add milestone to pull requests
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+
+jobs:
+  add_milestone_to_merged:
+    if: github.event.pull_request.merged && github.event.pull_request.milestone == null
+    name: Add milestone to merged pull requests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project milestones
+        id: milestones
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const list = await github.issues.listMilestonesForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            })
+            // Need to manually sort because "sort by number" isn't part of the api
+            // highest number first
+            const milestones = list.data.sort((a,b) => (b.number - a.number))
+
+            return milestones.length == 0 ? null : milestones[0].number
+      - name: Update Pull Request
+        if: steps.milestones.outputs.result != null
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            // Confusingly, the issues api is used because pull requests are issues
+            await github.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.pull_request.number }},
+              milestone: ${{ steps.milestones.outputs.result }},
+            });


### PR DESCRIPTION
This PR adds a Github Action to automatically tag PRs with the latest milestone, if not milestone was assigned to it.

This should help us streamline our release process, as we normally have to manually do this tagging. There's no complex logic around this tagging that would require human intervention today.

This PR is basic a copy of the Java tracer's action: https://github.com/DataDog/dd-trace-java/blob/v0.67.0/.github/workflows/add-milestone-to-pull-requests.yml

The milestone chosen is the latest created milestone, not the one with the largest semantic number. This is actually very helpful in our case, given we have a 1.0.0 milestone that we don't want to automatically assign PRs to at this point. Luckily, it was created before recent release milestones were created, so PRs will correctly be assigned to the latest open milestone.