### PR TITLE
Actions: Create next milestone after closing

### DIFF
--- a/.github/workflows/create-next-milestone.yml
+++ b/.github/workflows/create-next-milestone.yml
@@ -1,0 +1,20 @@
+name: Create next milestone
+on:
+  milestone:
+    types: [closed]
+
+jobs:
+  create_next_milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get next minor version
+        id: semvers
+        uses: WyriHaximus/github-action-next-semvers@0.1.0
+        with:
+          version: ${{ github.event.milestone.title }}
+      - name: Create next milestone
+        uses: WyriHaximus/github-action-create-milestone@0.1.0
+        with:
+          title: ${{ steps.semvers.outputs.minor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a Github Action to automatically create a milestone for the next release, after the current release milestone is closed.

This PR is basicaly a copy of the Java tracer's action: https://github.com/DataDog/dd-trace-java/blob/v0.68.0/.github/workflows/create-next-milestone.yml

Example of this workflow creating milestone 0.6.0 after 0.5.0 was closed: https://github.com/marcotc/dd-trace-rb/runs/1414428349?check_suite_focus=true#step:5:3