### PR TITLE
Prevent revealing secure params in README

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2138,7 +2138,6 @@ config.lograge.custom_options = lambda do |event|
       :version => correlation.version.to_s
     },
     :ddsource => ["ruby"],
-    :params => event.payload[:params].reject { |k| %w(controller action).include? k }
   }
 end
 ```

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2138,6 +2138,7 @@ config.lograge.custom_options = lambda do |event|
       :version => correlation.version.to_s
     },
     :ddsource => ["ruby"],
+    :status => event.payload[:status]
   }
 end
 ```


### PR DESCRIPTION
Suggesting folks emit their params in logs will lead to passwords and tokens being revealed. There are other mechanisms in lograge and rails for doing this well.