### PR TITLE
Ensure consisten configuration in writer test

### DIFF
--- a/spec/ddtrace/writer_spec.rb
+++ b/spec/ddtrace/writer_spec.rb
@@ -257,6 +257,11 @@ RSpec.describe Datadog::Writer do
         let(:trace) { instance_double(Array) }
         let(:services) { nil }
 
+        before do
+          allow(Datadog.configuration.runtime_metrics)
+            .to receive(:enabled).and_return(false)
+        end
+
         context 'when runtime metrics are enabled' do
           before do
             allow_any_instance_of(Datadog::Workers::AsyncTransport)


### PR DESCRIPTION
In https://github.com/DataDog/dd-trace-rb/pull/1248/files#diff-ffc89a0ffd0de70be571ade8e3296d6a96c3126da82421877a6027b533d72773L260-R268, a few RSpec mock setup statements have been refactored.

This ended up leaving `Datadog.configuration.runtime_metrics.enabled` not properly mocked for all example groups in that context.

This PR ensures that `Datadog.configuration.runtime_metrics.enabled` is correctly mocked for all `#write` tests in that test file. This fixes flaky CI issues [like this one](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/2216/workflows/4944530b-4b74-42cf-877c-064abbc19087/jobs/97270/parallel-runs/2?filterBy=FAILED).