### PR TITLE
Skip vendored files in coverage report

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -2,6 +2,9 @@ SimpleCov.add_group 'contrib', '/lib/ddtrace/contrib'
 SimpleCov.add_group 'transport', '/lib/ddtrace/transport'
 SimpleCov.add_group 'spec', '/spec/'
 
+# Exclude code not maintained by this project
+SimpleCov.add_filter %r{/vendor/}
+
 SimpleCov.coverage_dir ENV.fetch('COVERAGE_DIR', 'coverage')
 
 # Each test run requires its own unique command_name.


### PR DESCRIPTION
We have a few files in our repository that are not maintained by us (`lib/ddtrace/vendor/active_record/connection_specification.rb`, `lib/ddtrace/contrib/redis/vendor/resolver.rb`).

Despite that, we have them as "undertested" in our coverage reports.

This PR excludes vendored files from our coverage reports.

