### PR TITLE
Fix Tracer#trace start_time type documentation

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -229,7 +229,7 @@ And `options` is an optional `Hash` that accepts the following parameters:
 | `resource`    | `String` | Name of the resource or action being operated on. Traces with the same resource value will be grouped together for the purpose of metrics (but still independently viewable.) Usually domain specific, such as a URL, query, request, etc. (e.g. `'Article#submit'`, `http://example.com/articles/list`.) | `name` of Span. |
 | `span_type`   | `String` | The type of the span (such as `'http'`, `'db'`, etc.) | `nil` |
 | `child_of`    | `Datadog::Span` / `Datadog::Context` | Parent for this span. If not provided, will automatically become current active span. | `nil` |
-| `start_time`  | `Integer` | When the span actually starts. Useful when tracing events that have already happened. | `Time.now.utc` |
+| `start_time`  | `Time` | When the span actually starts. Useful when tracing events that have already happened. | `Time.now` |
 | `tags`        | `Hash` | Extra tags which should be added to the span. | `{}` |
 | `on_error`    | `Proc` | Handler invoked when a block is provided to trace, and it raises an error. Provided `span` and `error` as arguments. Sets error on the span by default. | `proc { |span, error| span.set_error(error) unless span.nil? }` |
 


### PR DESCRIPTION
Fixes #1264

This PR updates the required type for the `Datadog::Tracer#trace(start_time:)` option.

The type required is a Ruby [Time](https://ruby-doc.org/stdlib-2.7.2/libdoc/time/rdoc/Time.html) object, while the documentation erroneously requested an `Integer`.

As as follow up, I suggest we move most of this documentation to our published API docs: https://www.rubydoc.info/github/DataDog/dd-trace-rb/Datadog/Tracer#trace-instance_method. This allows us to keep the documentation close to implementation, and prevent information drift between the two.