### PR TITLE
Reduce Runtime Metrics frequency to every 10 seconds

### DIFF
--- a/lib/ddtrace/workers/runtime_metrics.rb
+++ b/lib/ddtrace/workers/runtime_metrics.rb
@@ -12,6 +12,10 @@ module Datadog
       extend Forwardable
       include Workers::Polling
 
+      # In seconds
+      DEFAULT_FLUSH_INTERVAL = 10
+      DEFAULT_BACK_OFF_MAX = 30
+
       attr_reader \
         :metrics
 
@@ -22,9 +26,9 @@ module Datadog
         self.fork_policy = options.fetch(:fork_policy, Workers::Async::Thread::FORK_POLICY_STOP)
 
         # Workers::IntervalLoop settings
-        self.interval = options[:interval] if options.key?(:interval)
-        self.back_off_ratio = options[:back_off_ratio] if options.key?(:back_off_ratio)
-        self.back_off_max = options[:back_off_max] if options.key?(:back_off_max)
+        self.loop_base_interval = options.fetch(:interval, DEFAULT_FLUSH_INTERVAL)
+        self.loop_back_off_ratio = options[:back_off_ratio] if options.key?(:back_off_ratio)
+        self.loop_back_off_max = options.fetch(:back_off_max, DEFAULT_BACK_OFF_MAX)
 
         self.enabled = options.fetch(:enabled, false)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ require 'support/platform_helpers'
 require 'support/span_helpers'
 require 'support/spy_transport'
 require 'support/synchronization_helpers'
+require 'support/test_helpers'
 require 'support/tracer_helpers'
 
 begin
@@ -54,7 +55,10 @@ RSpec.configure do |config|
   config.include NetworkHelpers
   config.include SpanHelpers
   config.include SynchronizationHelpers
+  config.include TestHelpers
   config.include TracerHelpers
+
+  config.include TestHelpers::RSpec::Integration, :integration
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -1,0 +1,31 @@
+module TestHelpers
+  module_function
+
+  # Integration tests are normally expensive (time-wise or resource-wise).
+  # They run in CI by default.
+  def run_integration_tests?
+    ENV['TEST_DATADOG_INTEGRATION']
+  end
+
+  module RSpec
+    # RSpec extension to allow for declaring integration tests
+    # using example group parameters:
+    #
+    # ```ruby
+    # describe 'end-to-end foo test', :integration do
+    # ...
+    # end
+    # ```
+    module Integration
+      def self.included(base)
+        base.class_exec do
+          before do
+            unless run_integration_tests?
+              skip('Integration tests can be enabled by setting the environment variable `TEST_DATADOG_INTEGRATION=1`')
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR reduces the Runtime Metrics (thread count, global class count, and GC statistics) reporting frequency from every second to every 10 seconds.

Reporting of these values in such fine granularity has a measurable cost, but don't provide enough value to justify the current resolution. Most reporting done across the data collected here span throughout the lifetime of the host application, which can require minutes to hours of data to provide meaningful results.

Additionally, because of the introduction of a new integration tests in this PR, I've also added an Integration Test helper, to allow for easily tagging integration tests and have them only run when appropriate, given their high execution cost.