### PR TITLE
Add AWS Textract to the list of AWS services Datadog provides traces for

### DIFF
--- a/lib/ddtrace/contrib/aws/services.rb
+++ b/lib/ddtrace/contrib/aws/services.rb
@@ -104,6 +104,7 @@ module Datadog
         States
         StorageGateway
         Support
+        Textract
         WAF
         WAFRegional
         WorkDocs


### PR DESCRIPTION
## Goal & Description
My team at Square uses Datadog for tracing. We currently use the Datadog Ruby SDK to provide metrics for our S3 and DynamoDB integrations. We would like to also use Datadog to provide metrics for our upcoming [Textract](https://aws.amazon.com/textract/) integration. After taking a look at their [Textract SDK](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Textract.html), it seems like they also use the AWS Seahorse Client to make calls to their endpoints. I figured we can add `Textract` to the list of services traced by Datadog and things should "just work". We were hoping to have metrics like latency and whatnot for Textract in our Datadog AWS dashboard. Currently we see metrics for S3 and DynamoDB.

## Test Coverage
It seems after I made my change, all main specs are passing:
```
bundle exec rake spec:main
...
=> 2014 examples, 0 failures, 31 pending
```