### PR TITLE
Add Rake task to format changelog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,6 +274,38 @@ orbs:
           - store_artifacts:
               path: /tmp/workspace/coverage/report/
               destination: coverage
+      changelog:
+        <<: *job_defaults
+        parameters:
+          ruby_version:
+            description: Ruby version
+            type: string
+          image:
+            description: Docker image location
+            type: string
+        docker:
+          - <<: *container_base
+            image: <<parameters.image>>
+            environment:
+              - BUNDLE_GEMFILE: /app/Gemfile
+        steps:
+          - restore_cache:
+              keys:
+                - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-<<parameters.ruby_version>>-{{ .Environment.CIRCLE_SHA1 }}'
+          - restore_cache:
+              keys:
+                - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundle-<<parameters.ruby_version>>-{{ checksum ".circleci/bundle_checksum" }}'
+          - attach_workspace:
+              at: /tmp/workspace
+          - run:
+              name: Format changelog
+              command: bundle exec rake changelog:format
+          - run:
+              name: Check if changelog was unformatted
+              command: |
+                if ! git diff-files --quiet; then
+                  echo "Please run 'bundle exec rake changelog:format' and commit the results."
+                fi
     commands:
     executors:
 
@@ -395,6 +427,14 @@ workflows:
             - test-2.6
             - test-2.7
             - test-jruby-9.2
+      - orb/changelog:
+          <<: *config-2_7
+          name: changelog
+          requires:
+            - build-2.7
+          filters:
+            branches:
+              only: /bump_to_version_.*/
       # MRI
       - orb/checkout:
           <<: *config-2_0

--- a/Rakefile
+++ b/Rakefile
@@ -831,4 +831,12 @@ namespace :coverage do
   end
 end
 
+namespace :changelog do
+  task :format do
+    require 'pimpmychangelog'
+
+    PimpMyChangelog::CLI.run!
+  end
+end
+
 task default: :test

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -50,6 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '= 5.10.1'
   spec.add_development_dependency 'minitest-around', '0.5.0'
   spec.add_development_dependency 'minitest-stub_any_instance', '1.0.2'
+  spec.add_development_dependency 'pimpmychangelog', '>= 0.1.2'
   spec.add_development_dependency 'appraisal', '~> 2.2'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'webmock', '~> 2.0'


### PR DESCRIPTION
After our changelog was _linkified_ in https://github.com/DataDog/dd-trace-rb/pull/1267, we should have mechanisms in place to ensure it stays that way.

This PR adds a Rake task that formats the changelog with the proper GitHub links: `rake changelog:format`.

There's also a new CI that verifies the the changelog was properly formatted prior to release. This jobs runs on release branches, which we name with the pattern `bump_to_version_.*`. If we forget to format the changelog, we'll be reminded by in our version bump PR.