### PR TITLE
Do not use Enumerable#find if Set is empty

### DIFF
--- a/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
+++ b/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb
@@ -8,6 +8,8 @@ module Datadog
         # Matches strings against Regexps.
         class PatternResolver < Datadog::Contrib::Configuration::Resolver
           def resolve(name)
+            return if patterns.empty?
+
             # Try to find a matching pattern
             matching_pattern = patterns.find do |pattern|
               if pattern.is_a?(Proc)


### PR DESCRIPTION
`Enumerable#find` occurs a penalty because it allocates an Array (because `Set` is internally a hash) - this is very wasteful if the Set is empty. Alternative is make `@patterns` an Array and pay the `contains?` tax at `add` time - open to either.

Profiling of `dd-trace-rb`:

```
allocated memory by location
-----------------------------------
      7392  /mnt/airlab/rbenv/versions/2.1.8/gems/gems/ddtrace-0.42.0/lib/ddtrace/span.rb:412
      1680  /mnt/airlab/rbenv/versions/2.1.8/gems/gems/ddtrace-0.42.0/lib/ddtrace/span.rb:73
      1512  /mnt/airlab/rbenv/versions/2.1.8/gems/gems/ddtrace-0.42.0/lib/ddtrace/contrib/configuration/resolvers/pattern_resolver.rb:12
       720  /mnt/airlab/rbenv/versions/2.1.8/gems/gems/ddtrace-0.42.0/lib/ddtrace/span.rb:74
       720  /mnt/airlab/rbenv/versions/2.1.8/gems/gems/ddtrace-0.42.0/lib/ddtrace/tracer.rb:191
       600  /mnt/airlab/rbenv/versions/2.1.8/gems/gems/ddtrace-0.42.0/lib/ddtrace/tracer.rb:199
```