### PR TITLE
Make frequently allocated string a constant

### DIFF
--- a/lib/ddtrace/contrib/ethon/easy_patch.rb
+++ b/lib/ddtrace/contrib/ethon/easy_patch.rb
@@ -99,7 +99,7 @@ module Datadog
 
           def datadog_tag_request
             span = @datadog_span
-            method = 'N/A'
+            method = Ext::NOT_APPLICABLE_METHOD
             if instance_variable_defined?(:@datadog_method) && !@datadog_method.nil?
               method = @datadog_method.to_s
             end

--- a/lib/ddtrace/contrib/ethon/ext.rb
+++ b/lib/ddtrace/contrib/ethon/ext.rb
@@ -12,6 +12,7 @@ module Datadog
         SERVICE_NAME = 'ethon'.freeze
         SPAN_REQUEST = 'ethon.request'.freeze
         SPAN_MULTI_REQUEST = 'ethon.multi.request'.freeze
+        NOT_APPLICABLE_METHOD = 'N/A'.freeze
       end
     end
   end


### PR DESCRIPTION
This string appears to be allocated a lot but can be moved to a constant. This only improves memory for versions below Ruby 2.3 because I belive Ruby has optimizations going forward that allow it to re-use these immutable strings.