### PR TITLE
Allow ability to disable Redis capturing the args

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1427,7 +1427,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | --- | ----------- | ------- |
 | `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `redis` instrumentation | `'redis'` |
-| `show_command_args` | Show the command args (e.g. `GET key`) as a resource & tag | true |
+| `command_args` | Show the command arguments (e.g. `key` in `GET key`) as resource name and tag | true |
 
 You can also set *per-instance* configuration as it follows:
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1427,6 +1427,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | --- | ----------- | ------- |
 | `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `redis` instrumentation | `'redis'` |
+| `show_command_args` | Show the command args (e.g. `GET key`) as a resource & tag | true |
 
 You can also set *per-instance* configuration as it follows:
 

--- a/lib/ddtrace/contrib/redis/configuration/resolver.rb
+++ b/lib/ddtrace/contrib/redis/configuration/resolver.rb
@@ -4,6 +4,8 @@ module Datadog
   module Contrib
     module Redis
       module Configuration
+        UNIX_SCHEME = 'unix'.freeze
+
         # Converts Symbols, Strings, and Hashes to a normalized connection settings Hash.
         class Resolver < Contrib::Configuration::Resolver
           def resolve(key_or_hash)
@@ -13,7 +15,7 @@ module Datadog
           end
 
           def normalize(hash)
-            return { url: hash[:url] } if hash[:scheme] == 'unix'
+            return { url: hash[:url] } if hash[:scheme] == UNIX_SCHEME
 
             # Connexion strings are always converted to host, port, db and scheme
             # but the host, port, db and scheme will generate the :url only after

--- a/lib/ddtrace/contrib/redis/configuration/settings.rb
+++ b/lib/ddtrace/contrib/redis/configuration/settings.rb
@@ -22,6 +22,11 @@ module Datadog
             o.lazy
           end
 
+          option :show_command_args do |o|
+            o.default { env_to_bool(Ext::ENV_SHOW_COMMAND_ARGS, true) }
+            o.lazy
+          end
+
           option :service_name, default: Ext::SERVICE_NAME
         end
       end

--- a/lib/ddtrace/contrib/redis/configuration/settings.rb
+++ b/lib/ddtrace/contrib/redis/configuration/settings.rb
@@ -22,8 +22,8 @@ module Datadog
             o.lazy
           end
 
-          option :show_command_args do |o|
-            o.default { env_to_bool(Ext::ENV_SHOW_COMMAND_ARGS, true) }
+          option :command_args do |o|
+            o.default { env_to_bool(Ext::ENV_COMMAND_ARGS, true) }
             o.lazy
           end
 

--- a/lib/ddtrace/contrib/redis/ext.rb
+++ b/lib/ddtrace/contrib/redis/ext.rb
@@ -11,7 +11,6 @@ module Datadog
         ENV_ANALYTICS_SAMPLE_RATE_OLD = 'DD_REDIS_ANALYTICS_SAMPLE_RATE'.freeze
         ENV_COMMAND_ARGS = 'DD_REDIS_COMMAND_ARGS'.freeze
         METRIC_PIPELINE_LEN = 'redis.pipeline_length'.freeze
-        PIPELINE_RESOURCE = 'PIPELINE'.freeze
         SERVICE_NAME = 'redis'.freeze
         SPAN_COMMAND = 'redis.command'.freeze
         TAG_DB = 'out.redis_db'.freeze

--- a/lib/ddtrace/contrib/redis/ext.rb
+++ b/lib/ddtrace/contrib/redis/ext.rb
@@ -11,7 +11,7 @@ module Datadog
         ENV_ANALYTICS_SAMPLE_RATE_OLD = 'DD_REDIS_ANALYTICS_SAMPLE_RATE'.freeze
         ENV_COMMAND_ARGS = 'DD_REDIS_COMMAND_ARGS'.freeze
         METRIC_PIPELINE_LEN = 'redis.pipeline_length'.freeze
-        PIPELINE_RESOURCE = "PIPELINE".freeze
+        PIPELINE_RESOURCE = 'PIPELINE'.freeze
         SERVICE_NAME = 'redis'.freeze
         SPAN_COMMAND = 'redis.command'.freeze
         TAG_DB = 'out.redis_db'.freeze

--- a/lib/ddtrace/contrib/redis/ext.rb
+++ b/lib/ddtrace/contrib/redis/ext.rb
@@ -9,6 +9,7 @@ module Datadog
         ENV_ANALYTICS_ENABLED_OLD = 'DD_REDIS_ANALYTICS_ENABLED'.freeze
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_TRACE_REDIS_ANALYTICS_SAMPLE_RATE'.freeze
         ENV_ANALYTICS_SAMPLE_RATE_OLD = 'DD_REDIS_ANALYTICS_SAMPLE_RATE'.freeze
+        ENV_SHOW_COMMAND_ARGS = 'DD_REDIS_SHOW_COMMAND_ARGS'.freeze
         METRIC_PIPELINE_LEN = 'redis.pipeline_length'.freeze
         SERVICE_NAME = 'redis'.freeze
         SPAN_COMMAND = 'redis.command'.freeze

--- a/lib/ddtrace/contrib/redis/ext.rb
+++ b/lib/ddtrace/contrib/redis/ext.rb
@@ -9,8 +9,9 @@ module Datadog
         ENV_ANALYTICS_ENABLED_OLD = 'DD_REDIS_ANALYTICS_ENABLED'.freeze
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_TRACE_REDIS_ANALYTICS_SAMPLE_RATE'.freeze
         ENV_ANALYTICS_SAMPLE_RATE_OLD = 'DD_REDIS_ANALYTICS_SAMPLE_RATE'.freeze
-        ENV_SHOW_COMMAND_ARGS = 'DD_REDIS_SHOW_COMMAND_ARGS'.freeze
+        ENV_COMMAND_ARGS = 'DD_REDIS_COMMAND_ARGS'.freeze
         METRIC_PIPELINE_LEN = 'redis.pipeline_length'.freeze
+        PIPELINE_RESOURCE = "PIPELINE".freeze
         SERVICE_NAME = 'redis'.freeze
         SPAN_COMMAND = 'redis.command'.freeze
         TAG_DB = 'out.redis_db'.freeze

--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -40,11 +40,11 @@ module Datadog
               pin.tracer.trace(Datadog::Contrib::Redis::Ext::SPAN_COMMAND) do |span|
                 span.service = pin.service
                 span.span_type = Datadog::Contrib::Redis::Ext::TYPE
-                if datadog_configuration[:command_args]
-                  span.resource = Datadog::Contrib::Redis::Quantize.format_command_args(*args)
-                else
-                  span.resource = Datadog::Contrib::Redis::Quantize.get_verb(*args)
-                end
+                span.resource = if datadog_configuration[:command_args]
+                                  Datadog::Contrib::Redis::Quantize.format_command_args(*args)
+                                else
+                                  Datadog::Contrib::Redis::Quantize.get_verb(*args)
+                                end
                 Datadog::Contrib::Redis::Tags.set_common_tags(self, span)
 
                 response = call_without_datadog(*args, &block)

--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -66,11 +66,11 @@ module Datadog
                 if datadog_configuration[:command_args]
                   commands = args[0].commands.map { |c| Datadog::Contrib::Redis::Quantize.format_command_args(c) }
                   span.resource = commands.join("\n")
+                  span.set_metric Datadog::Contrib::Redis::Ext::METRIC_PIPELINE_LEN, commands.length
                 else
                   span.resource = Ext::PIPELINE_RESOURCE
                 end
                 Datadog::Contrib::Redis::Tags.set_common_tags(self, span)
-                span.set_metric Datadog::Contrib::Redis::Ext::METRIC_PIPELINE_LEN, commands.length
 
                 response = call_pipeline_without_datadog(*args, &block)
               end

--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -68,7 +68,7 @@ module Datadog
                   span.resource = commands.join("\n")
                   span.set_metric Datadog::Contrib::Redis::Ext::METRIC_PIPELINE_LEN, commands.length
                 else
-                  span.resource = Ext::PIPELINE_RESOURCE
+                  commands = args[0].commands.map { |c| Datadog::Contrib::Redis::Quantize.get_verb(c) }
                 end
                 Datadog::Contrib::Redis::Tags.set_common_tags(self, span)
 

--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -40,8 +40,10 @@ module Datadog
               pin.tracer.trace(Datadog::Contrib::Redis::Ext::SPAN_COMMAND) do |span|
                 span.service = pin.service
                 span.span_type = Datadog::Contrib::Redis::Ext::TYPE
-                if datadog_configuration[:show_command_args]
+                if datadog_configuration[:command_args]
                   span.resource = Datadog::Contrib::Redis::Quantize.format_command_args(*args)
+                else
+                  span.resource = Datadog::Contrib::Redis::Quantize.get_verb(*args)
                 end
                 Datadog::Contrib::Redis::Tags.set_common_tags(self, span)
 
@@ -61,9 +63,11 @@ module Datadog
               pin.tracer.trace(Datadog::Contrib::Redis::Ext::SPAN_COMMAND) do |span|
                 span.service = pin.service
                 span.span_type = Datadog::Contrib::Redis::Ext::TYPE
-                if datadog_configuration[:show_command_args]
+                if datadog_configuration[:command_args]
                   commands = args[0].commands.map { |c| Datadog::Contrib::Redis::Quantize.format_command_args(c) }
                   span.resource = commands.join("\n")
+                else
+                  span.resource = Ext::PIPELINE_RESOURCE
                 end
                 Datadog::Contrib::Redis::Tags.set_common_tags(self, span)
                 span.set_metric Datadog::Contrib::Redis::Ext::METRIC_PIPELINE_LEN, commands.length

--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -40,7 +40,9 @@ module Datadog
               pin.tracer.trace(Datadog::Contrib::Redis::Ext::SPAN_COMMAND) do |span|
                 span.service = pin.service
                 span.span_type = Datadog::Contrib::Redis::Ext::TYPE
-                span.resource = Datadog::Contrib::Redis::Quantize.format_command_args(*args)
+                if datadog_configuration[:show_command_args]
+                  span.resource = Datadog::Contrib::Redis::Quantize.format_command_args(*args)
+                end
                 Datadog::Contrib::Redis::Tags.set_common_tags(self, span)
 
                 response = call_without_datadog(*args, &block)
@@ -59,8 +61,10 @@ module Datadog
               pin.tracer.trace(Datadog::Contrib::Redis::Ext::SPAN_COMMAND) do |span|
                 span.service = pin.service
                 span.span_type = Datadog::Contrib::Redis::Ext::TYPE
-                commands = args[0].commands.map { |c| Datadog::Contrib::Redis::Quantize.format_command_args(c) }
-                span.resource = commands.join("\n")
+                if datadog_configuration[:show_command_args]
+                  commands = args[0].commands.map { |c| Datadog::Contrib::Redis::Quantize.format_command_args(c) }
+                  span.resource = commands.join("\n")
+                end
                 Datadog::Contrib::Redis::Tags.set_common_tags(self, span)
                 span.set_metric Datadog::Contrib::Redis::Ext::METRIC_PIPELINE_LEN, commands.length
 

--- a/lib/ddtrace/contrib/redis/patcher.rb
+++ b/lib/ddtrace/contrib/redis/patcher.rb
@@ -28,6 +28,7 @@ module Datadog
 
         # rubocop:disable Metrics/MethodLength
         # rubocop:disable Metrics/BlockLength
+        # rubocop:disable Metrics/AbcSize
         def patch_redis_client
           ::Redis::Client.class_eval do
             alias_method :call_without_datadog, :call

--- a/lib/ddtrace/contrib/redis/quantize.rb
+++ b/lib/ddtrace/contrib/redis/quantize.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module Datadog
   module Contrib
     module Redis
@@ -7,6 +9,17 @@ module Datadog
         TOO_LONG_MARK = '...'.freeze
         VALUE_MAX_LEN = 50
         CMD_MAX_LEN = 500
+
+        MULTI_VERB_COMMANDS = Set.new(%w[
+          ACL
+          CLIENT
+          CLUSTER
+          COMMAND
+          CONFIG
+          DEBUG
+          LATENCY
+          MEMORY
+        ]).freeze
 
         module_function
 
@@ -25,6 +38,18 @@ module Datadog
 
           cmd = command_args.map { |x| format_arg(x) }.join(' ')
           Utils.truncate(cmd, CMD_MAX_LEN, TOO_LONG_MARK)
+        end
+
+        def get_verb(command_args)
+          return unless command_args.is_a?(Array)
+
+          return get_verb(command_args.first) if command_args.first.is_a?(Array)
+
+          arg = command_args.first
+          verb = arg.is_a?(Symbol) ? arg.to_s.upcase : arg.to_s
+          return verb unless MULTI_VERB_COMMANDS.include?(verb) && command_args[1]
+
+          "#{verb} #{command_args[1]}"
         end
 
         def auth_command?(command_args)

--- a/lib/ddtrace/contrib/redis/quantize.rb
+++ b/lib/ddtrace/contrib/redis/quantize.rb
@@ -10,16 +10,18 @@ module Datadog
         VALUE_MAX_LEN = 50
         CMD_MAX_LEN = 500
 
-        MULTI_VERB_COMMANDS = Set.new(%w[
-          ACL
-          CLIENT
-          CLUSTER
-          COMMAND
-          CONFIG
-          DEBUG
-          LATENCY
-          MEMORY
-        ]).freeze
+        MULTI_VERB_COMMANDS = Set.new(
+          %w[
+            ACL
+            CLIENT
+            CLUSTER
+            COMMAND
+            CONFIG
+            DEBUG
+            LATENCY
+            MEMORY
+          ]
+        ).freeze
 
         module_function
 

--- a/lib/ddtrace/contrib/redis/tags.rb
+++ b/lib/ddtrace/contrib/redis/tags.rb
@@ -19,7 +19,7 @@ module Datadog
             span.set_tag Datadog::Ext::NET::TARGET_HOST, client.host
             span.set_tag Datadog::Ext::NET::TARGET_PORT, client.port
             span.set_tag Ext::TAG_DB, client.db
-            span.set_tag Ext::TAG_RAW_COMMAND, span.resource
+            span.set_tag Ext::TAG_RAW_COMMAND, span.resource if show_command_args?
           end
 
           private
@@ -34,6 +34,10 @@ module Datadog
 
           def analytics_sample_rate
             datadog_configuration[:analytics_sample_rate]
+          end
+
+          def show_command_args?
+            datadog_configuration[:show_command_args]
           end
         end
       end

--- a/lib/ddtrace/contrib/redis/tags.rb
+++ b/lib/ddtrace/contrib/redis/tags.rb
@@ -37,7 +37,7 @@ module Datadog
           end
 
           def show_command_args?
-            datadog_configuration[:show_command_args]
+            datadog_configuration[:command_args]
           end
         end
       end

--- a/spec/ddtrace/contrib/redis/quantize_spec.rb
+++ b/spec/ddtrace/contrib/redis/quantize_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Datadog::Contrib::Redis::Quantize do
     end
 
     context 'given an multi verb commands' do
-      let(:args) { [:acl, "HELP"] }
+      let(:args) { [:acl, 'HELP'] }
       it { is_expected.to eq('ACL HELP') }
     end
 

--- a/spec/ddtrace/contrib/redis/quantize_spec.rb
+++ b/spec/ddtrace/contrib/redis/quantize_spec.rb
@@ -80,4 +80,28 @@ RSpec.describe Datadog::Contrib::Redis::Quantize do
       it { is_expected.to eq('SET KEY VALUE') }
     end
   end
+
+  describe '#get_verb' do
+    subject(:output) { described_class.get_verb(args) }
+
+    context 'given an array' do
+      let(:args) { [:set, 'KEY', 'VALUE'] }
+      it { is_expected.to eq('SET') }
+    end
+
+    context 'given an multi verb commands' do
+      let(:args) { [:acl, 'CAT', 'categoryname'] }
+      it { is_expected.to eq('ACL CAT') }
+    end
+
+    context 'given an multi verb commands' do
+      let(:args) { [:acl, "HELP"] }
+      it { is_expected.to eq('ACL HELP') }
+    end
+
+    context 'given a nested array' do
+      let(:args) { [[:set, 'KEY', 'VALUE']] }
+      it { is_expected.to eq('SET') }
+    end
+  end
 end

--- a/spec/ddtrace/contrib/redis/redis_spec.rb
+++ b/spec/ddtrace/contrib/redis/redis_spec.rb
@@ -175,6 +175,19 @@ RSpec.describe 'Redis test' do
         it_behaves_like 'a span with common tags'
         it_behaves_like 'a peer service span'
       end
+
+      describe 'command_args disabled' do
+        subject(:span) { spans[-1] }
+        let(:configuration_options) { { command_args: false } }
+
+        it 'hides the sensitive params' do
+          expect(span.get_metric('redis.pipeline_length')).to eq(5)
+          expect(span.name).to eq('redis.command')
+          expect(span.service).to eq('redis')
+          expect(span.resource).to eq("SET\nSET\nINCR\nINCR\nINCR")
+          expect(span.get_tag('redis.raw_command')).to be_nil
+        end
+      end
     end
 
     context 'error' do

--- a/spec/ddtrace/contrib/redis/redis_spec.rb
+++ b/spec/ddtrace/contrib/redis/redis_spec.rb
@@ -125,6 +125,24 @@ RSpec.describe 'Redis test' do
       end
     end
 
+    context 'show_command_args disabled' do
+      let(:configuration_options) { { show_command_args: false } }
+      before(:each) do
+        expect(redis.call([:set, 'FOO', 'bar'])).to eq('OK')
+      end
+
+      it { expect(spans).to have(1).item }
+
+      describe 'span' do
+        subject(:span) { spans[-1] }
+
+        it do
+          expect(span.resource).to be_nil
+          expect(span.get_tag('redis.raw_command')).to be_nil
+        end
+      end
+    end
+
     context 'pipeline' do
       before(:each) do
         redis.pipelined do

--- a/spec/ddtrace/contrib/redis/redis_spec.rb
+++ b/spec/ddtrace/contrib/redis/redis_spec.rb
@@ -125,8 +125,8 @@ RSpec.describe 'Redis test' do
       end
     end
 
-    context 'show_command_args disabled' do
-      let(:configuration_options) { { show_command_args: false } }
+    context 'command_args disabled' do
+      let(:configuration_options) { { command_args: false } }
       before(:each) do
         expect(redis.call([:set, 'FOO', 'bar'])).to eq('OK')
       end
@@ -137,7 +137,7 @@ RSpec.describe 'Redis test' do
         subject(:span) { spans[-1] }
 
         it do
-          expect(span.resource).to eq('redis.command')
+          expect(span.resource).to eq('SET')
           expect(span.get_tag('redis.raw_command')).to be_nil
         end
       end

--- a/spec/ddtrace/contrib/redis/redis_spec.rb
+++ b/spec/ddtrace/contrib/redis/redis_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe 'Redis test' do
         subject(:span) { spans[-1] }
 
         it do
-          expect(span.resource).to be_nil
+          expect(span.resource).to eq('redis.command')
           expect(span.get_tag('redis.raw_command')).to be_nil
         end
       end


### PR DESCRIPTION
For security (& memory allocation reasons) we want to disable this as the keys could contain sensitive information. Allow for this to be disabled.