### PR TITLE
Add back actioncable rails6 specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -620,7 +620,7 @@ task :ci do
     declare 'bundle exec appraisal rails5-mysql2 rake spec:action_cable'
     declare 'bundle exec appraisal rails5-mysql2 rake spec:rails'
     declare 'bundle exec appraisal rails5-postgres rake spec:rails'
-    # declare 'bundle exec appraisal rails6-mysql2 rake spec:action_cable' # TODO: Hangs CI jobs... fix and re-enable.
+    declare 'bundle exec appraisal rails6-mysql2 rake spec:action_cable'
     declare 'bundle exec appraisal rails6-mysql2 rake spec:rails'
     declare 'bundle exec appraisal rails6-postgres rake spec:rails'
 
@@ -704,7 +704,7 @@ task :ci do
       declare 'bundle exec appraisal rails5-mysql2 rake spec:action_cable'
       declare 'bundle exec appraisal rails5-mysql2 rake spec:rails'
       declare 'bundle exec appraisal rails5-postgres rake spec:rails'
-      # declare 'bundle exec appraisal rails6-mysql2 rake spec:action_cable' # TODO: Hangs CI jobs... fix and re-enable.
+      declare 'bundle exec appraisal rails6-mysql2 rake spec:action_cable'
       declare 'bundle exec appraisal rails6-mysql2 rake spec:rails'
       declare 'bundle exec appraisal rails6-postgres rake spec:rails'
 
@@ -787,6 +787,7 @@ task :ci do
       # Rails specs
       declare 'bundle exec appraisal rails5-mysql2 rake spec:rails'
       declare 'bundle exec appraisal rails5-postgres rake spec:rails'
+      declare 'bundle exec appraisal rails6-mysql2 rake spec:action_cable'
       declare 'bundle exec appraisal rails6-mysql2 rake spec:rails'
       declare 'bundle exec appraisal rails6-postgres rake spec:rails'
 

--- a/spec/ddtrace/contrib/action_cable/patcher_spec.rb
+++ b/spec/ddtrace/contrib/action_cable/patcher_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'ActionCable patcher' do
     let(:server) do
       ActionCable::Server::Base.new.tap do |s|
         s.config.cable = { adapter: 'inline' }.with_indifferent_access
-        s.config.logger = Logger.new(nil)
+        s.config.logger = Logger.new(STDOUT)
       end
     end
 
@@ -81,7 +81,7 @@ RSpec.describe 'ActionCable patcher' do
     end
 
     let(:channel_instance) { channel_class.new(connection, '{id: 1}', id: 1) }
-    let(:connection) { double('connection', logger: Logger.new(nil), transmit: nil, identifiers: []) }
+    let(:connection) { double('connection', logger: Logger.new(STDOUT), transmit: nil, identifiers: []) }
 
     context 'on perform action' do
       subject(:perform) { channel_instance.perform_action(data) }


### PR DESCRIPTION
Previously we'd disabled action_cabled rails6 specs as they were hanging in CI. I can't recreate this locally so trying to trigger in CI again, we've also done some work on the tracer as well as test suite since these were originally disabled that may have resolved the issue (but i doubt it)

https://github.com/DataDog/dd-trace-rb/pull/951