### PR TITLE
Action: Fix milestone tagging not working for community PRs

### DIFF
--- a/.github/workflows/add-milestone-to-pull-requests.yml
+++ b/.github/workflows/add-milestone-to-pull-requests.yml
@@ -1,6 +1,6 @@
 name: Add milestone to pull requests
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       - master


### PR DESCRIPTION
Reference issue: https://github.com/WordPress/gutenberg/issues/17324#issuecomment-724784917

Because the GitHub Action runs on our repository, it doesn't have permission to modify a community pull request, as those belong to the original forked repository.

This PR solves that by running the Action in the context of the original repository, by triggering from the `pull_request_target` event, instead of `pull_request`.