### PR TITLE
ext: remove invalid Jenkins URL

### DIFF
--- a/lib/ddtrace/ext/ci.rb
+++ b/lib/ddtrace/ext/ci.rb
@@ -221,7 +221,6 @@ module Datadog
           Git::TAG_COMMIT_SHA => env['GIT_COMMIT'],
           Git::TAG_REPOSITORY_URL => env['GIT_URL'],
           Git::TAG_TAG => tag,
-          TAG_JOB_URL => env['JOB_URL'],
           TAG_PIPELINE_ID => env['BUILD_TAG'],
           TAG_PIPELINE_NAME => name,
           TAG_PIPELINE_NUMBER => env['BUILD_NUMBER'],

--- a/spec/ddtrace/ext/fixtures/ci/jenkins.json
+++ b/spec/ddtrace/ext/fixtures/ci/jenkins.json
@@ -12,7 +12,6 @@
       "JOB_URL": "jenkins-job-url"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -37,7 +36,6 @@
       "JOB_URL": "jenkins-job-url"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -63,7 +61,6 @@
       "WORKSPACE": "foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -90,7 +87,6 @@
       "WORKSPACE": "/foo/bar~"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -117,7 +113,6 @@
       "WORKSPACE": "/foo/~/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -146,7 +141,6 @@
       "WORKSPACE": "~/foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -175,7 +169,6 @@
       "WORKSPACE": "~foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -204,7 +197,6 @@
       "WORKSPACE": "~"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -231,7 +223,6 @@
       "WORKSPACE": "/foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -258,7 +249,6 @@
       "WORKSPACE": "/foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -285,7 +275,6 @@
       "WORKSPACE": "/foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName/another",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -312,7 +301,6 @@
       "WORKSPACE": "/foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -339,7 +327,6 @@
       "WORKSPACE": "/foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -366,7 +353,6 @@
       "WORKSPACE": "/foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -393,7 +379,6 @@
       "WORKSPACE": "/foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName/another-branch",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -419,7 +404,6 @@
       "WORKSPACE": "/foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
@@ -444,7 +428,6 @@
       "WORKSPACE": "/foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
@@ -470,7 +453,6 @@
       "WORKSPACE": "/foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -497,7 +479,6 @@
       "WORKSPACE": "/foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -524,7 +505,6 @@
       "WORKSPACE": "/foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -551,7 +531,6 @@
       "WORKSPACE": "/foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",
@@ -578,7 +557,6 @@
       "WORKSPACE": "/foo/bar"
     },
     {
-      "ci.job.url": "jenkins-job-url",
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.name": "jobName",
       "ci.pipeline.number": "jenkins-pipeline-number",


### PR DESCRIPTION
Removes invalid Jenkins URL from CI env detection.

related https://github.com/DataDog/dd-trace-py/pull/1875