### PR TITLE
Use latest JDBC drivers for new versions of Rails

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -838,9 +838,9 @@ elsif Gem::Version.new('2.5.0') <= Gem::Version.new(RUBY_VERSION) \
     gem 'http'
     gem 'mongo', '>= 2.8.0'
     gem 'mysql2', '< 1', platform: :ruby
-    gem 'activerecord-jdbcmysql-adapter', platform: :jruby
+    gem 'activerecord-jdbcmysql-adapter', '>= 60.2', platform: :jruby
     gem 'pg', platform: :ruby
-    gem 'activerecord-jdbcpostgresql-adapter', platform: :jruby
+    gem 'activerecord-jdbcpostgresql-adapter', '>= 60.2', platform: :jruby
     gem 'presto-client', '>=  0.5.14'
     gem 'qless'
     gem 'racecar', '>= 0.3.5'


### PR DESCRIPTION
This PR fixes the CI build failure:
```
Failure/Error: Article.count()

FrozenError:
  can't modify frozen Hash
# /usr/local/bundle/jruby/2.5.0/gems/activerecord-jdbc-adapter-50.0/lib/arjdbc/mysql/connection_methods.rb:3:in `mysql_connection'
```

This happens because there's no hard version requirement in our Appraisal gemfile for the JDBC driver.

This PR ensures that we are using at least the latest version.