### PR TITLE
Simpily git checkout in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,18 +91,6 @@ filters_only_release_tags: &filters_only_release_tags
 orbs:
   orb:
     jobs:
-      checkout:
-        <<: *job_defaults
-        docker:
-          - image: alpine/git:v2.26.2 # Minimal image with git available
-            user: root # We currently require root to write to `/app`
-        resource_class: small
-        steps:
-          - checkout
-          - save_cache:
-              key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-{{ .Environment.CIRCLE_SHA1 }}'
-              paths:
-                - /app
       build:
         <<: *job_defaults
         parameters:
@@ -116,6 +104,7 @@ orbs:
           - <<: *container_base
             image: <<parameters.image>>
         steps:
+          - checkout
           - restore_cache:
               keys:
                 - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-<<parameters.ruby_version>>-{{ .Environment.CIRCLE_SHA1 }}'
@@ -406,9 +395,6 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - orb/checkout:
-          <<: *filters_all_branches_and_tags
-          name: checkout
       - orb/lint:
           <<: *config-2_6
           name: lint
@@ -439,8 +425,6 @@ workflows:
       - orb/build:
           <<: *config-2_0
           name: build-2.0
-          requires:
-            - checkout
       - orb/test:
           <<: *config-2_0
           name: test-2.0
@@ -449,8 +433,6 @@ workflows:
       - orb/build:
           <<: *config-2_1
           name: build-2.1
-          requires:
-            - checkout
       - orb/test:
           <<: *config-2_1
           name: test-2.1
@@ -459,8 +441,6 @@ workflows:
       - orb/build:
           <<: *config-2_2
           name: build-2.2
-          requires:
-            - checkout
       - orb/test:
           <<: *config-2_2
           name: test-2.2
@@ -469,8 +449,6 @@ workflows:
       - orb/build:
           <<: *config-2_3
           name: build-2.3
-          requires:
-            - checkout
       - orb/test:
           <<: *config-2_3
           name: test-2.3
@@ -484,8 +462,6 @@ workflows:
       - orb/build:
           <<: *config-2_4
           name: build-2.4
-          requires:
-            - checkout
       - orb/test:
           <<: *config-2_4
           name: test-2.4
@@ -494,8 +470,6 @@ workflows:
       - orb/build:
           <<: *config-2_5
           name: build-2.5
-          requires:
-            - checkout
       - orb/test:
           <<: *config-2_5
           name: test-2.5
@@ -504,8 +478,6 @@ workflows:
       - orb/build:
           <<: *config-2_6
           name: build-2.6
-          requires:
-            - checkout
       - orb/test:
           <<: *config-2_6
           name: test-2.6
@@ -514,8 +486,6 @@ workflows:
       - orb/build:
           <<: *config-2_7
           name: build-2.7
-          requires:
-            - checkout
       - orb/test:
           <<: *config-2_7
           name: test-2.7
@@ -525,8 +495,6 @@ workflows:
       - orb/build:
           <<: *config-jruby-9_2
           name: build-jruby-9.2
-          requires:
-            - checkout
       - orb/test:
           <<: *config-jruby-9_2
           name: test-jruby-9.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,6 @@ orbs:
           - restore_cache:
               keys:
                 - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-<<parameters.ruby_version>>-{{ .Environment.CIRCLE_SHA1 }}'
-                - '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-{{ .Environment.CIRCLE_SHA1 }}'
           - restore_cache:
               keys:
                 - bundle-{{ .Environment.CIRCLE_CACHE_VERSION }}-<<parameters.ruby_version>>-{{ checksum "lib/ddtrace/version.rb" }}-{{ .Branch }}-{{ checksum "Gemfile" }}-{{ checksum "Appraisals" }}-{{ checksum "ddtrace.gemspec" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,9 @@ version: 2.1
 
 # Common variables, containers, jobs and steps.
 job_defaults: &job_defaults
+  # TODO: We should move away from using a directory
+  # TODO: that requires root permission to be created.
+  # TODO: Changing this requires rebuilding all docker images.
   working_directory: /app
   shell: /bin/bash --login
 
@@ -90,20 +93,14 @@ orbs:
     jobs:
       checkout:
         <<: *job_defaults
-        parameters:
-          ruby_version:
-            description: Ruby version
-            type: string
-          image:
-            description: Docker image location
-            type: string
         docker:
-          - <<: *container_base
-            image: <<parameters.image>>
+          - image: alpine/git:v2.26.2 # Minimal image with git available
+            user: root # We currently require root to write to `/app`
+        resource_class: small
         steps:
           - checkout
           - save_cache:
-              key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-<<parameters.ruby_version>>-{{ .Environment.CIRCLE_SHA1 }}'
+              key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-{{ .Environment.CIRCLE_SHA1 }}'
               paths:
                 - /app
       build:
@@ -122,7 +119,7 @@ orbs:
           - restore_cache:
               keys:
                 - '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-<<parameters.ruby_version>>-{{ .Environment.CIRCLE_SHA1 }}'
-                - '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-<<parameters.ruby_version>>-{{ .Environment.CIRCLE_SHA1 }}'
+                - '{{ .Environment.CIRCLE_CACHE_VERSION }}-repo-{{ .Environment.CIRCLE_SHA1 }}'
           - restore_cache:
               keys:
                 - bundle-{{ .Environment.CIRCLE_CACHE_VERSION }}-<<parameters.ruby_version>>-{{ checksum "lib/ddtrace/version.rb" }}-{{ .Branch }}-{{ checksum "Gemfile" }}-{{ checksum "Appraisals" }}-{{ checksum "ddtrace.gemspec" }}
@@ -409,6 +406,9 @@ workflows:
   version: 2
   build-and-test:
     jobs:
+      - orb/checkout:
+          <<: *filters_all_branches_and_tags
+          name: checkout
       - orb/lint:
           <<: *config-2_6
           name: lint
@@ -436,53 +436,41 @@ workflows:
             branches:
               only: /bump_to_version_.*/
       # MRI
-      - orb/checkout:
-          <<: *config-2_0
-          name: checkout-2.0
       - orb/build:
           <<: *config-2_0
           name: build-2.0
           requires:
-            - checkout-2.0
+            - checkout
       - orb/test:
           <<: *config-2_0
           name: test-2.0
           requires:
             - build-2.0
-      - orb/checkout:
-          <<: *config-2_1
-          name: checkout-2.1
       - orb/build:
           <<: *config-2_1
           name: build-2.1
           requires:
-            - checkout-2.1
+            - checkout
       - orb/test:
           <<: *config-2_1
           name: test-2.1
           requires:
             - build-2.1
-      - orb/checkout:
-          <<: *config-2_2
-          name: checkout-2.2
       - orb/build:
           <<: *config-2_2
           name: build-2.2
           requires:
-            - checkout-2.2
+            - checkout
       - orb/test:
           <<: *config-2_2
           name: test-2.2
           requires:
             - build-2.2
-      - orb/checkout:
-          <<: *config-2_3
-          name: checkout-2.3
       - orb/build:
           <<: *config-2_3
           name: build-2.3
           requires:
-            - checkout-2.3
+            - checkout
       - orb/test:
           <<: *config-2_3
           name: test-2.3
@@ -493,67 +481,52 @@ workflows:
           name: benchmark-2.3
           requires:
             - build-2.3
-      - orb/checkout:
-          <<: *config-2_4
-          name: checkout-2.4
       - orb/build:
           <<: *config-2_4
           name: build-2.4
           requires:
-            - checkout-2.4
+            - checkout
       - orb/test:
           <<: *config-2_4
           name: test-2.4
           requires:
             - build-2.4
-      - orb/checkout:
-          <<: *config-2_5
-          name: checkout-2.5
       - orb/build:
           <<: *config-2_5
           name: build-2.5
           requires:
-            - checkout-2.5
+            - checkout
       - orb/test:
           <<: *config-2_5
           name: test-2.5
           requires:
             - build-2.5
-      - orb/checkout:
-          <<: *config-2_6
-          name: checkout-2.6
       - orb/build:
           <<: *config-2_6
           name: build-2.6
           requires:
-            - checkout-2.6
+            - checkout
       - orb/test:
           <<: *config-2_6
           name: test-2.6
           requires:
             - build-2.6
-      - orb/checkout:
-          <<: *config-2_7
-          name: checkout-2.7
       - orb/build:
           <<: *config-2_7
           name: build-2.7
           requires:
-            - checkout-2.7
+            - checkout
       - orb/test:
           <<: *config-2_7
           name: test-2.7
           requires:
             - build-2.7
       # JRuby
-      - orb/checkout:
-          <<: *config-jruby-9_2
-          name: checkout-jruby-9.2
       - orb/build:
           <<: *config-jruby-9_2
           name: build-jruby-9.2
           requires:
-            - checkout-jruby-9.2
+            - checkout
       - orb/test:
           <<: *config-jruby-9_2
           name: test-jruby-9.2


### PR DESCRIPTION
While working on Ruby 3.0, I noticed that our `checkout` CI job didn't perform any meaningful Ruby work. Additionally, all `checkout-2.*` jobs performed the same work: checkout this repo, save files to cache to be restored in `build-2.*` jobs. All cached copies are effectively the same, but we had them as a separate jobs per Ruby version.

This PR removes the standalone `checkout-2.*` jobs and instead performs the builtin `checkout` step. The checkout step takes around 1 second to execute, compared to the existing `checkout-2.*` jobs that take from 15 seconds to over 1 minute.

This replaces these jobs:
  
![Screen Shot 2020-12-16 at 5 36 08 PM](https://user-images.githubusercontent.com/583503/102418234-544a5280-3fcb-11eb-8ce9-fcc423c8642c.png)

With this step on each `build-2.*` job:

<img width="500" alt="Screen Shot 2020-12-17 at 11 17 49 AM" src="https://user-images.githubusercontent.com/583503/102513688-873b2780-4059-11eb-97ae-5f44ed8d3ae3.png">
