### PR TITLE
Fix negative assertion for custom span error matching

### DIFF
--- a/lib/ddtrace/contrib/httprb/instrumentation.rb
+++ b/lib/ddtrace/contrib/httprb/instrumentation.rb
@@ -40,7 +40,7 @@ module Datadog
                 # Add additional request specific tags to the span.
                 annotate_span_with_request!(span, req, request_options)
               rescue StandardError => e
-                logger.error("error preparing span for http.rb request: #{e}, Soure: #{e.backtrace}")
+                logger.error("error preparing span for http.rb request: #{e}, Source: #{e.backtrace}")
               ensure
                 res = super(req, options)
               end

--- a/spec/ddtrace/contrib/httprb/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/httprb/instrumentation_spec.rb
@@ -149,8 +149,17 @@ RSpec.describe Datadog::Contrib::Httprb::Instrumentation do
             expect(span.get_tag(Datadog::Ext::HTTP::STATUS_CODE)).to eq(code.to_s)
           end
 
-          it 'has no error set' do
-            expect(span).to_not have_error_message
+          it 'has error set' do
+            expect(span).to have_error
+          end
+
+          it 'has error type set' do
+            expect(span).to have_error_type('Error 404')
+          end
+
+          # default error message to `Error` from https://github.com/DataDog/dd-trace-rb/issues/1116
+          it 'has error message' do
+            expect(span).to have_error_message('Error')
           end
         end
 

--- a/spec/support/span_helpers.rb
+++ b/spec/support/span_helpers.rb
@@ -18,10 +18,25 @@ module SpanHelpers
         @tag_name = tag_name
         @actual = span.get_tag(tag)
 
+        if args.empty? && @actual
+          # This condition enables the default matcher:
+          # expect(foo).to have_error_tag
+          return true
+        end
+
+        values_match? expected, @actual
+      end
+
+      match_when_negated do |span|
+        expected = args.first
+
+        @tag_name = tag_name
+        @actual = span.get_tag(tag)
+
         if args.empty? && @actual.nil?
-          # This condition enables the negative matcher:
+          # This condition enables the default matcher:
           # expect(foo).to_not have_error_tag
-          return false
+          return true
         end
 
         values_match? expected, @actual


### PR DESCRIPTION
This PR fixes the negative matching case for our custom error matchers, e.g. `have_error_message` matcher (`is_expected.to_not have_error_message`).

There was one test that had an incorrect assertion: `http.rb` https://github.com/DataDog/dd-trace-rb/blob/774ee8e81380f746bf16e6c5023478c81096b6da/spec/ddtrace/contrib/httprb/instrumentation_spec.rb#L152-L154

This assertion is for the 404 case, which by default is considered an error by our integration. The tracer itself is correctly recording this error, but the test was broke, and was actually asserting that there was **no** error.