### PR TITLE
Add Ruby 3.0 support to docs

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -88,7 +88,8 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
 
 | Type  | Documentation              | Version | Support type                         | Gem version support |
 | ----- | -------------------------- | -----   | ------------------------------------ | ------------------- |
-| MRI   | https://www.ruby-lang.org/ | 2.7     | Full                                 | Latest              |
+| MRI   | https://www.ruby-lang.org/ | 3.0     | Full                                 | Latest              |
+|       |                            | 2.7     | Full                                 | Latest              |
 |       |                            | 2.6     | Full                                 | Latest              |
 |       |                            | 2.5     | Full                                 | Latest              |
 |       |                            | 2.4     | Full                                 | Latest              |
@@ -1347,6 +1348,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 |  2.4          |                |  4.2.8 - 5.2   |
 |  2.5          |                |  4.2.8 - 6.1   |
 |  2.6 - 2.7    |  9.2           |  5.0 - 6.1     |
+|  3.0          |                |  6.1           |
 
 ### Rake
 


### PR DESCRIPTION
This PR documents our support for Ruby 3.0.

It's worth noting that only Rails 6.1 is supported for Ruby 3.0, because of changes to keyword arguments that made older versions of Rails not compatible with Ruby 3.0.