### PR TITLE
Memoize URI to cut down multiple parsing

### DIFF
--- a/lib/ddtrace/contrib/ethon/easy_patch.rb
+++ b/lib/ddtrace/contrib/ethon/easy_patch.rb
@@ -123,7 +123,7 @@ module Datadog
           end
 
           def uri
-            URI.parse(url)
+            @uri ||= URI.parse(url)
           # rubocop:disable Lint/HandleExceptions
           rescue URI::InvalidURIError
           end

--- a/lib/ddtrace/contrib/ethon/easy_patch.rb
+++ b/lib/ddtrace/contrib/ethon/easy_patch.rb
@@ -109,11 +109,12 @@ module Datadog
             # Set analytics sample rate
             Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
 
-            return unless uri
-            span.set_tag(Datadog::Ext::HTTP::URL, uri.path)
+            this_uri = uri
+            return unless this_uri
+            span.set_tag(Datadog::Ext::HTTP::URL, this_uri.path)
             span.set_tag(Datadog::Ext::HTTP::METHOD, method)
-            span.set_tag(Datadog::Ext::NET::TARGET_HOST, uri.host)
-            span.set_tag(Datadog::Ext::NET::TARGET_PORT, uri.port)
+            span.set_tag(Datadog::Ext::NET::TARGET_HOST, this_uri.host)
+            span.set_tag(Datadog::Ext::NET::TARGET_PORT, this_uri.port)
           end
 
           def set_span_error_message(message)
@@ -123,7 +124,7 @@ module Datadog
           end
 
           def uri
-            @uri ||= URI.parse(url)
+            URI.parse(url)
           # rubocop:disable Lint/HandleExceptions
           rescue URI::InvalidURIError
           end


### PR DESCRIPTION
I've noticed that `datadog_tag_request` makes multiple calls to `uri` but because it isn't memoized we're re-parsing it 3 times.