### PR TITLE
Improve CPU profiling unsupported log message

### DIFF
--- a/lib/ddtrace/profiling/ext/cpu.rb
+++ b/lib/ddtrace/profiling/ext/cpu.rb
@@ -6,10 +6,7 @@ module Datadog
         FFI_MINIMUM_VERSION = Gem::Version.new('1.0')
 
         def self.supported?
-          RUBY_PLATFORM != 'java' \
-            && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1') \
-            && !Gem.loaded_specs['ffi'].nil? \
-            && Gem.loaded_specs['ffi'].version >= FFI_MINIMUM_VERSION
+          unsupported_reason.nil?
         end
 
         def self.apply!
@@ -19,6 +16,28 @@ module Datadog
           # will provide a thread/clock ID for CPU timing.
           require 'ddtrace/profiling/ext/cthread'
           ::Thread.send(:prepend, Profiling::Ext::CThread)
+        end
+
+        def self.unsupported_reason
+          # Note: Only the first matching reason is returned, so try to keep a nice order on reasons -- e.g. tell users
+          # first that they can't use this on macOS before telling them that they have the wrong ffi version
+
+          if RUBY_ENGINE == 'jruby'
+            'JRuby is not supported'
+          elsif RUBY_PLATFORM =~ /darwin/
+            'Feature requires Linux; macOS is not supported'
+          elsif RUBY_PLATFORM =~ /(mswin|mingw)/
+            'Feature requires Linux; Windows is not supported'
+          elsif RUBY_PLATFORM !~ /linux/
+            "Feature requires Linux; #{RUBY_PLATFORM} is not supported"
+          elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1')
+            'Ruby >= 2.1 is required'
+          elsif Gem.loaded_specs['ffi'].nil?
+            "Missing ffi gem dependency; please add `gem 'ffi', '~> 1.0'` to your Gemfile or gems.rb file"
+          elsif Gem.loaded_specs['ffi'].version < FFI_MINIMUM_VERSION
+            'Your ffi gem dependency is too old; ensure that you have ffi >= 1.0 by ' \
+            "adding `gem 'ffi', '~> 1.0'` to your Gemfile or gems.rb file"
+          end
         end
       end
     end

--- a/lib/ddtrace/profiling/tasks/setup.rb
+++ b/lib/ddtrace/profiling/tasks/setup.rb
@@ -54,7 +54,7 @@ module Datadog
             Ext::CPU.apply!
           elsif Datadog.configuration.profiling.enabled
             # Log warning if profiling was supposed to be activated.
-            log '[DDTRACE] CPU profiling skipped; native CPU time is not supported.'
+            log "[DDTRACE] CPU profiling skipped because native CPU time is not supported: #{Ext::CPU.unsupported_reason}."
           end
         rescue StandardError, ScriptError => e
           log "[DDTRACE] CPU profiling unavailable. Cause: #{e.message} Location: #{e.backtrace.first}"


### PR DESCRIPTION
When attempting to use our profiler on macOS, I got a cryptic error
message:

```
$ DD_PROFILING_ENABLED=true bundle exec bin/ddtracerb exec ruby -e "1"
[DDTRACE] CPU profiling unavailable. Cause: Function 'pthread_getcpuclockid' not found in [libruby.dylib, libpthread.dylib] Location: /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/ffi-1.14.2/lib/ffi/library.rb:273:in `attach_function'
```

I had forgotten that we didn't support CPU profiling on macOs, and
had to doublecheck this in our documentation.

I thus decided to improve our error message to be as clear as
possible about any limitations:

```
$ DD_PROFILING_ENABLED=true bundle exec bin/ddtracerb exec ruby -e "1"
[DDTRACE] CPU profiling skipped because native CPU time is not supported: Feature requires Linux; macOS is not supported.
```