### PR TITLE
Use doc formatter when running a single spec file

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,6 +74,13 @@ RSpec.configure do |config|
   config.order = :random
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = 'doc'
+  end
 end
 
 # Helper matchers


### PR DESCRIPTION
By default, rspec uses the "progress formatter" to output the status
of running our test suite -- this is the one that outputs a single
character for each executed test: ./F/*. This is the correct default
to avoid a deluge of text whenever we run the test suite.

But when developing some specific component, it's common that you run
rspec only for a single spec file. In that case, there's not a lot of
tests so it's nice to switch to the documentation formatter that
prints a nice looking description for each test.

So there's a nice trick that rspec itself adds to the `spec_helper.rb`
when you initialize it on a new project with `rspec --init`, which is
to switch to the documentation formatter only when there's a single
spec file to run.

I claim this gives us the best of both worlds :)