### PR TITLE
Detect and warn about threads without CPU time instrumentation

### DIFF
--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -38,6 +38,10 @@ module Datadog
 
           # Workers::Polling settings
           self.enabled = options[:enabled] == true
+
+          @cpu_time_expected_to_work =
+            options[:cpu_time_expected_to_work] || (Thread.current.respond_to?(:cpu_time) && Thread.current.cpu_time)
+          @warned_about_missing_cpu_time_instrumentation = false
         end
 
         def start
@@ -120,8 +124,14 @@ module Datadog
 
         def get_cpu_time_interval!(thread)
           # Return if we can't get the current CPU time
-          return unless thread.respond_to?(:cpu_time)
+          return unless @cpu_time_expected_to_work
+          return warn_about_missing_cpu_time_instrumentation(thread) unless thread.cpu_time_instrumentation_installed?
+
           current_cpu_time_ns = thread.cpu_time(:nanosecond)
+
+          # Note: This can still be nil even when all of the checks above passed because of a race: there's a bit of
+          # initialization that needs to be done by the thread itself, and it's possible for us to try to sample
+          # *before* the thread had time to finish the initialization
           return unless current_cpu_time_ns
 
           last_cpu_time_ns = (thread[THREAD_LAST_CPU_TIME_KEY] || current_cpu_time_ns)
@@ -174,6 +184,23 @@ module Datadog
             lineno,
             string_table.fetch_string(path)
           )
+        end
+
+        private
+
+        def warn_about_missing_cpu_time_instrumentation(thread)
+          return if @warned_about_missing_cpu_time_instrumentation
+
+          # make sure we warn only once
+          @warned_about_missing_cpu_time_instrumentation = true
+
+          Datadog.logger.warn(
+            "Detected thread ('#{thread}') with missing CPU profiling instrumentation. " \
+            'CPU Profiling results will be inaccurate. ' \
+            'Please report this at https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug'
+          )
+
+          nil
         end
       end
     end

--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -39,8 +39,6 @@ module Datadog
           # Workers::Polling settings
           self.enabled = options[:enabled] == true
 
-          @cpu_time_expected_to_work =
-            options[:cpu_time_expected_to_work] || (Thread.current.respond_to?(:cpu_time) && Thread.current.cpu_time)
           @warned_about_missing_cpu_time_instrumentation = false
         end
 
@@ -196,7 +194,9 @@ module Datadog
           # make sure we warn only once
           @warned_about_missing_cpu_time_instrumentation = true
 
-          if @cpu_time_expected_to_work
+          # Is the profiler thread instrumented? If it is, then we know instrumentation is available, just missing in
+          # the thread being sampled
+          if Thread.current.respond_to?(:cpu_time) && Thread.current.cpu_time
             Datadog.logger.warn(
               "Detected thread ('#{thread}') with missing CPU profiling instrumentation. " \
               'CPU Profiling results will be inaccurate. ' \

--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -202,8 +202,6 @@ module Datadog
               'CPU Profiling results will be inaccurate. ' \
               'Please report this at https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug'
             )
-          else
-            # Skip warning -- CPU time instrumentation does not seem to be available
           end
 
           nil

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -253,11 +253,12 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
         let(:current_cpu_time) { last_cpu_time + cpu_interval }
         let(:last_cpu_time) { rand(1e4) }
         let(:cpu_interval) { 1000 }
-        let(:options) { { cpu_time_expected_to_work: true, **super() } }
 
         include_context 'with profiling extensions'
 
         before do
+          allow(Thread).to receive(:current).and_return(double('Current thread', cpu_time: true))
+
           allow(thread)
             .to receive(:cpu_time_instrumentation_installed?)
             .and_return(true)
@@ -334,7 +335,9 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     end
 
     context 'when CPU timing is supported' do
-      let(:options) { { cpu_time_expected_to_work: true, **super() } }
+      before do
+        allow(Thread).to receive(:current).and_return(double('Current thread', cpu_time: true))
+      end
 
       include_context 'with profiling extensions'
 

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -249,46 +249,44 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
         end
       end
 
-      if Datadog::Profiling.native_cpu_time_supported?
-        context 'and CPU timing is available' do
-          let(:current_cpu_time) { last_cpu_time + cpu_interval }
-          let(:last_cpu_time) { rand(1e4) }
-          let(:cpu_interval) { 1000 }
-          let(:options) { { cpu_time_expected_to_work: true, **super() } }
+      context 'and CPU timing is available' do
+        let(:current_cpu_time) { last_cpu_time + cpu_interval }
+        let(:last_cpu_time) { rand(1e4) }
+        let(:cpu_interval) { 1000 }
+        let(:options) { { cpu_time_expected_to_work: true, **super() } }
 
-          include_context 'with profiling extensions'
+        include_context 'with profiling extensions'
 
-          before do
-            allow(thread)
-              .to receive(:cpu_time_instrumentation_installed?)
-              .and_return(true)
-            allow(thread)
-              .to receive(:cpu_time)
-              .with(:nanosecond)
-              .and_return(current_cpu_time)
+        before do
+          allow(thread)
+            .to receive(:cpu_time_instrumentation_installed?)
+            .and_return(true)
+          allow(thread)
+            .to receive(:cpu_time)
+            .with(:nanosecond)
+            .and_return(current_cpu_time)
 
-            allow(thread)
-              .to receive(:[])
-              .with(described_class::THREAD_LAST_CPU_TIME_KEY)
-              .and_return(last_cpu_time)
+          allow(thread)
+            .to receive(:[])
+            .with(described_class::THREAD_LAST_CPU_TIME_KEY)
+            .and_return(last_cpu_time)
 
-            expect(thread)
-              .to receive(:[]=)
-              .with(described_class::THREAD_LAST_CPU_TIME_KEY, current_cpu_time)
-          end
+          expect(thread)
+            .to receive(:[]=)
+            .with(described_class::THREAD_LAST_CPU_TIME_KEY, current_cpu_time)
+        end
 
-          it 'builds an event with CPU time' do
-            is_expected.to be_a_kind_of(Datadog::Profiling::Events::StackSample)
+        it 'builds an event with CPU time' do
+          is_expected.to be_a_kind_of(Datadog::Profiling::Events::StackSample)
 
-            is_expected.to have_attributes(
-              timestamp: kind_of(Float),
-              frames: array_including(kind_of(Datadog::Profiling::BacktraceLocation)),
-              total_frame_count: backtrace.length,
-              thread_id: thread.object_id,
-              cpu_time_interval_ns: cpu_interval,
-              wall_time_interval_ns: wall_time_interval_ns
-            )
-          end
+          is_expected.to have_attributes(
+            timestamp: kind_of(Float),
+            frames: array_including(kind_of(Datadog::Profiling::BacktraceLocation)),
+            total_frame_count: backtrace.length,
+            thread_id: thread.object_id,
+            cpu_time_interval_ns: cpu_interval,
+            wall_time_interval_ns: wall_time_interval_ns
+          )
         end
       end
 
@@ -335,100 +333,98 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       end
     end
 
-    if Datadog::Profiling.native_cpu_time_supported?
-      context 'when CPU timing is supported' do
-        let(:options) { { cpu_time_expected_to_work: true, **super() } }
+    context 'when CPU timing is supported' do
+      let(:options) { { cpu_time_expected_to_work: true, **super() } }
 
-        include_context 'with profiling extensions'
+      include_context 'with profiling extensions'
 
-        context 'but thread is not properly instrumented' do
-          before do
-            allow(thread)
-              .to receive(:cpu_time_instrumentation_installed?)
-              .and_return(false)
-            allow(Datadog.logger).to receive(:warn)
-          end
-
-          it { is_expected.to be nil }
-
-          it 'logs a warning' do
-            expect(Datadog.logger).to receive(:warn).with(/missing CPU profiling instrumentation/)
-
-            get_cpu_time_interval!
-          end
-
-          it 'logs a warning only once' do
-            expect(Datadog.logger).to receive(:warn).once
-
-            get_cpu_time_interval!
-            get_cpu_time_interval!
-          end
+      context 'but thread is not properly instrumented' do
+        before do
+          allow(thread)
+            .to receive(:cpu_time_instrumentation_installed?)
+            .and_return(false)
+          allow(Datadog.logger).to receive(:warn)
         end
 
-        context 'but yields nil' do
+        it { is_expected.to be nil }
+
+        it 'logs a warning' do
+          expect(Datadog.logger).to receive(:warn).with(/missing CPU profiling instrumentation/)
+
+          get_cpu_time_interval!
+        end
+
+        it 'logs a warning only once' do
+          expect(Datadog.logger).to receive(:warn).once
+
+          get_cpu_time_interval!
+          get_cpu_time_interval!
+        end
+      end
+
+      context 'but yields nil' do
+        before do
+          allow(thread)
+            .to receive(:cpu_time_instrumentation_installed?)
+            .and_return(true)
+          allow(thread)
+            .to receive(:cpu_time)
+            .and_return(nil)
+        end
+
+        it { is_expected.to be nil }
+
+        it 'does not log any warnings' do
+          expect(Datadog).to_not receive(:logger)
+
+          get_cpu_time_interval!
+        end
+      end
+
+      context 'and returns time' do
+        let(:current_cpu_time) { last_cpu_time + cpu_interval }
+        let(:last_cpu_time) { rand(1e4) }
+        let(:cpu_interval) { 1000 }
+
+        before do
+          allow(thread)
+            .to receive(:cpu_time_instrumentation_installed?)
+            .and_return(true)
+          allow(thread)
+            .to receive(:cpu_time)
+            .with(:nanosecond)
+            .and_return(current_cpu_time)
+
+          expect(thread)
+            .to receive(:[]=)
+            .with(described_class::THREAD_LAST_CPU_TIME_KEY, current_cpu_time)
+        end
+
+        context 'and the thread CPU time has not been retrieved before' do
           before do
             allow(thread)
-              .to receive(:cpu_time_instrumentation_installed?)
-              .and_return(true)
-            allow(thread)
-              .to receive(:cpu_time)
+              .to receive(:[])
+              .with(described_class::THREAD_LAST_CPU_TIME_KEY)
               .and_return(nil)
           end
 
-          it { is_expected.to be nil }
-
-          it 'does not log any warnings' do
-            expect(Datadog).to_not receive(:logger)
-
-            get_cpu_time_interval!
-          end
+          let(:current_cpu_time) { rand(1e4) }
+          it { is_expected.to eq 0 }
         end
 
-        context 'and returns time' do
+        context 'and the thread CPU time has been retrieved before' do
           let(:current_cpu_time) { last_cpu_time + cpu_interval }
           let(:last_cpu_time) { rand(1e4) }
           let(:cpu_interval) { 1000 }
 
           before do
             allow(thread)
-              .to receive(:cpu_time_instrumentation_installed?)
-              .and_return(true)
-            allow(thread)
-              .to receive(:cpu_time)
-              .with(:nanosecond)
-              .and_return(current_cpu_time)
-
-            expect(thread)
-              .to receive(:[]=)
-              .with(described_class::THREAD_LAST_CPU_TIME_KEY, current_cpu_time)
+              .to receive(:[])
+              .with(described_class::THREAD_LAST_CPU_TIME_KEY)
+              .and_return(last_cpu_time)
           end
 
-          context 'and the thread CPU time has not been retrieved before' do
-            before do
-              allow(thread)
-                .to receive(:[])
-                .with(described_class::THREAD_LAST_CPU_TIME_KEY)
-                .and_return(nil)
-            end
-
-            let(:current_cpu_time) { rand(1e4) }
-            it { is_expected.to eq 0 }
-          end
-
-          context 'and the thread CPU time has been retrieved before' do
-            let(:current_cpu_time) { last_cpu_time + cpu_interval }
-            let(:last_cpu_time) { rand(1e4) }
-            let(:cpu_interval) { 1000 }
-
-            before do
-              allow(thread)
-                .to receive(:[])
-                .with(described_class::THREAD_LAST_CPU_TIME_KEY)
-                .and_return(last_cpu_time)
-            end
-
-            it { is_expected.to eq(cpu_interval) }
-          end
+          it { is_expected.to eq(cpu_interval) }
         end
       end
     end


### PR DESCRIPTION
When a thread is missing CPU instrumentation due to it being started
before our `Ext::CThread` was applied (or in a way which skips our
custom thread initialization code), the resulting CPU profile will
be incomplete -- it will be missing the CPU timing data from those
threads.

This means that regarding CPU instrumentation, we can be in one of
three cases:
1. CPU instrumentation is available AND every thread is correctly
   instrumented
2. CPU instrumentation is available BUT there are threads that are
   missing the instrumentation
3. CPU instrumentation is NOT available

Our ideal case is # 1, and then # 3. Being in # 2 is not desirable,
because it means that our profiling data is incomplete, and thus
may lead customers astray or to lose confidence in our results.

This commits adds a detector that distinguishes between case # 1
and # 2, printing a warning so that customers can report back to
us their issue, and will be aware that there can be more than
what they are seeing in our UX.
(Previously, we would silently ignore missing instrumentation).

This detector works by having the Stack collector record -- at
initialization time -- if its own thread is instrumented, because
instrumentation is always applied before starting the collector.

If no instrumentation is available, then the collector is running
in case # 3. If instrumentation is available, the collector
assumes it is running in either case # 1 or # 2.

During execution, if the Stack collector finds a thread without
instrumentation, it it will know that we are in case # 2 above,
and thus will emit a warning for missing data.

Example way of triggering warning:

```
$ DD_PROFILING_ENABLED=true bundle exec ruby -e 'Thread.start { require "ddtrace/profiling/preload"; sleep }; sleep'
W, [2021-01-15T11:15:04.621929 #506]  WARN -- ddtrace: [ddtrace] Detected thread ('#<Thread:0x0000563aa6326158>') with missing CPU profiling instrumentation. CPU Profiling results will be inaccurate. Please report this at https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug
```