### PR TITLE
Minor: Fix test failing on alternative Ruby

### DIFF
--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe 'profiling integration test' do
   end
 
   shared_context 'StackSample events' do
-    let(:stack_one) { Thread.current.backtrace_locations.first(3) }
-    let(:stack_two) { Thread.current.backtrace_locations.first(3) }
+    let(:stack_one) { Thread.current.backtrace_locations[1..3] }
+    let(:stack_two) { Thread.current.backtrace_locations[1..3] }
 
     let(:trace_id) { 0 }
     let(:span_id) { 0 }
@@ -319,7 +319,7 @@ RSpec.describe 'profiling integration test' do
 
         it 'is well formed' do
           is_expected.to be_kind_of(Google::Protobuf::RepeatedField)
-          is_expected.to have(5).items
+          is_expected.to have(4).items # both stack_one and stack_two share 2 frames, and have 1 unique frame each
 
           unique_locations = (stack_one + stack_two).uniq
 


### PR DESCRIPTION
I was running our tests using TruffleRuby to better understand our
codebase, and realized that this test failed because it was relying on
the (arguably wrong) behavior that MRI has where it attributes a call
to a method like `backtrace_locations` to the caller, and not to the
callee.

Specifically, we were using two stacks:

```ruby
[1] pry> stack_one
=> ["/dd-trace-rb/spec/ddtrace/profiling/integration_spec.rb:19:in `backtrace_locations'",
 "/dd-trace-rb/spec/ddtrace/profiling/integration_spec.rb:19:in `block (3 levels) in <top (required)>'",
 "/ruby-2.7.2/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:317:in `block (2 levels) in let'"]
[2] pry> stack_two
=> ["/dd-trace-rb/spec/ddtrace/profiling/integration_spec.rb:20:in `backtrace_locations'",
 "/dd-trace-rb/spec/ddtrace/profiling/integration_spec.rb:20:in `block (3 levels) in <top (required)>'",
 "/ruby-2.7.2/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:317:in `block (2 levels) in let'"]
```

...and expecting 5 unique frames in total, because `backtrace_locations`
shows up as being on two different lines (so the two first lines of
each stack are different, and the last RSpec line is shared).

On TruffleRuby, this shows up as:

```ruby
[1] pry> stack_one
=> ["<internal:core> core/thread.rb:302:in `backtrace_locations'",
 "/dd-trace-rb/spec/ddtrace/profiling/integration_spec.rb:19:in `stack_one'",
 "/truffleruby-20.3.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:317:in `block (2 levels) in let'"]
[2] pry> stack_two
=> ["<internal:core> core/thread.rb:302:in `backtrace_locations'",
 "/dd-trace-rb/spec/ddtrace/profiling/integration_spec.rb:20:in `stack_two'",
 "/truffleruby-20.3.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:317:in `block (2 levels) in let'"]
```

...which only gives us 4 unique frames, as `backtrace_locations` is
properly attributed to `Thread`.

By tweaking our call to `backtrace_locations`, we ignore the first
element (the `backtrace_locations` frame itself) and thus make this
test more portable.

(There's a few more cases where we get bit by similar tiny differences,
but I'll save them for later, as anyways current stable TruffleRuby is
breaking in some of the tests due to oracle/truffleruby#2229 .