### PR TITLE
Minor: Remove extra "hidden" default interval

### DIFF
--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -149,8 +149,7 @@ module Datadog
           Datadog::Profiling::Scheduler.new(
             recorder,
             exporters,
-            enabled: settings.profiling.enabled,
-            interval: 60
+            enabled: settings.profiling.enabled
           )
         end
       end


### PR DESCRIPTION
The `Scheduler` class already has a `DEFAULT_INTERVAL = 60` which gets
initialized to
`self.loop_base_interval = options[:interval] || DEFAULT_INTERVAL`.

By also setting it in `components.rb`, in practice we would always be
overriding the apparent default in the class itself, which is very
confusing if we ever want to change it.

Thus, let's instead let the class `Scheduler` class rely and
maintain its own defaults.