### PR TITLE
Improve error message and set exit status when ddtracerb fails

### DIFF
--- a/lib/ddtrace/tasks/exec.rb
+++ b/lib/ddtrace/tasks/exec.rb
@@ -10,7 +10,7 @@ module Datadog
 
       def run
         set_rubyopt!
-        Kernel.exec(*args)
+        exec_with_error_handling(args)
       end
 
       def rubyopts
@@ -27,6 +27,21 @@ module Datadog
         else
           ENV['RUBYOPT'] = rubyopts.join(' ')
         end
+      end
+
+      # If there's an error here, rather than throwing a cryptic stack trace, let's instead have clearer messages, and
+      # follow the same status codes as the shell uses
+      # See also:
+      # * https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
+      # * https://github.com/rubygems/rubygems/blob/dd93966cac224532035deda533cba2685dfa30cc/bundler/lib/bundler/cli/exec.rb#L45
+      def exec_with_error_handling(args)
+        Kernel.exec(*args)
+      rescue Errno::ENOENT => e
+        STDERR.puts "ddtracerb exec failed: #{e.message} (command was '#{args.join(' ')}')"
+        Kernel.exit 127
+      rescue Errno::EACCES, Errno::ENOEXEC => e
+        STDERR.puts "ddtracerb exec failed: #{e.message} (command was '#{args.join(' ')}')"
+        Kernel.exit 126
       end
     end
   end


### PR DESCRIPTION
When for some reason `ddtracerb exec` failed, we were just letting Ruby handle it as usual:

```
$ bin/ddtracerb exec does-not-exist
Traceback (most recent call last):
	2: from bin/ddtracerb:9:in `<main>'
	1: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/ddtrace-0.43.0.feature.profiling.98496/lib/ddtrace/tasks/exec.rb:13:in `run'
/Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/ddtrace-0.43.0.feature.profiling.98496/lib/ddtrace/tasks/exec.rb:13:in `exec': No such file or directory - does-not-exist (Errno::ENOENT)
```

which is not very user-friendly.

I've taken a bit of inspiration from [`bundler exec`](https://github.com/rubygems/rubygems/blob/dd93966cac224532035deda533cba2685dfa30cc/bundler/lib/bundler/cli/exec.rb#L45) and improved the error messages, as well as outputting the same exit status as used by the shell.

An error now looks like:

```
$ bin/ddtracerb exec does-not-exist foo
ddtracerb exec failed: No such file or directory - does-not-exist (command was 'does-not-exist foo')
```