### PR TITLE
Direct object_id lookup for ActiveRecord connections

### DIFF
--- a/lib/ddtrace/contrib/active_record/utils.rb
+++ b/lib/ddtrace/contrib/active_record/utils.rb
@@ -1,3 +1,5 @@
+require 'ddtrace/ext/runtime'
+
 module Datadog
   module Contrib
     module ActiveRecord
@@ -21,39 +23,73 @@ module Datadog
           connection_config[:port]
         end
 
-        # In newer Rails versions, the `payload` contains both the `connection` and its `object_id` named `connection_id`.
+        # Returns the connection configuration hash from the
+        # current connection
         #
-        # So, if rails is recent we'll have a direct access to the connection.
-        # Else, we'll find it thanks to the passed `connection_id`.
+        # Since Rails 6.0, we have direct access to the object,
+        # while older versions of Rails only provide us the
+        # connection id.
         #
-        # See this PR for more details: https://github.com/rails/rails/pull/34602
-        #
+        # @see https://github.com/rails/rails/pull/34602
         def self.connection_config(connection = nil, connection_id = nil)
           return default_connection_config if connection.nil? && connection_id.nil?
 
           conn = if !connection.nil?
+                   # Since Rails 6.0, the connection object
+                   # is directly available.
                    connection
-                 # Rails 3.0 - 3.2
-                 elsif Gem.loaded_specs['activerecord'].version < Gem::Version.new('4.0')
-                   ::ActiveRecord::Base
-                     .connection_handler
-                     .connection_pools
-                     .values
-                     .flat_map(&:connections)
-                     .find { |c| c.object_id == connection_id }
-                 # Rails 4.2+
                  else
-                   ::ActiveRecord::Base
-                     .connection_handler
-                     .connection_pool_list
-                     .flat_map(&:connections)
-                     .find { |c| c.object_id == connection_id }
+                   # For Rails < 6.0, only the `connection_id`
+                   # is available. We have to find the connection
+                   # object from it.
+                   connection_from_id(connection_id)
                  end
 
-          if conn.instance_variable_defined?(:@config)
+          if conn && conn.instance_variable_defined?(:@config)
             conn.instance_variable_get(:@config)
           else
             EMPTY_CONFIG
+          end
+        end
+
+        # DEV: JRuby responds to {ObjectSpace._id2ref}, despite raising an error
+        # DEV: when invoked. Thus, we have to explicitly check for Ruby runtime.
+        if Datadog::Ext::Runtime::RUBY_ENGINE != 'jruby'
+          # CRuby has access to {ObjectSpace._id2ref}, which allows for
+          # direct look up of the connection object.
+          def self.connection_from_id(connection_id)
+            # `connection_id` is the `#object_id` of the
+            # connection. We can perform an ObjectSpace
+            # lookup to find it.
+            #
+            # This works not only for ActiveRecord, but for
+            # extensions that might have their own connection
+            # pool (e.g. https://rubygems.org/gems/makara).
+            ObjectSpace._id2ref(connection_id)
+          rescue => e
+            # Because `connection_id` references a live connection
+            # present in the current stack, it is very unlikely that
+            # `_id2ref` will fail, but we add this safeguard just
+            # in case.
+            Datadog.logger.debug(
+              "connection_id #{connection_id} does not represent a valid object. " \
+                      "Cause: #{e.message} Source: #{e.backtrace.first}"
+            )
+          end
+        else
+          # JRuby does not enable {ObjectSpace._id2ref} by default,
+          # as it has large performance impact:
+          # https://github.com/jruby/jruby/wiki/PerformanceTuning/cf155dd9#dont-enable-objectspace
+          #
+          # This fallback code does not support the makara gem,
+          # as its connections don't live in the ActiveRecord
+          # connection pool.
+          def self.connection_from_id(connection_id)
+            ::ActiveRecord::Base
+              .connection_handler
+              .connection_pool_list
+              .flat_map(&:connections)
+              .find { |c| c.object_id == connection_id }
           end
         end
 


### PR DESCRIPTION
When an ActiveRecord event fires an ActiveSupport notification, it can provide the connection object information in two ways: a direct reference to the connection object; an indirect reference, through a `connection_id` number.

The `connection_id` is actually the result of `connection.object_id`, thus directly references the respective connection object.

Today, when receiving only the `connection_id`, we try to iterate over all ActiveRecord connection pools to find an object that matches this id. This is not necessary, as we can directly retrieve the connection from the VM by using `ObjectSpace._id2ref(connection_id)`.

Because the `connection` object is part of the caller stack frame, there's no risk that this object has been garbage collected (possibly making `connection_id` point to a different object in the VM). Despite that, we still guard against exceptions on the block that invokes `ObjectSpace._id2ref(connection_id)`.

For runtimes that don't support `ObjectSpace._id2ref` (currently JRuby), we keep the old logic of iterating over ActiveRecord connection pools.

This refactor is performed because we'd like to support connections created outside of the default ActiveRecord connection pools, like it's the case for libraries that handle primary/replica connection switching (e.g. https://rubygems.org/gems/makara). These libraries still respect the `connection_id`/`connection` contract of ActiveRecord.

As this is a refactor, no behavior was changed in the tracer. The only immediate side-effect is a performance improvement from the direct `ObjectSpace._id2ref` lookup, instead of iterating over all connections.