### PR TITLE
Temporarily lock graphql due to breaking changes

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -583,7 +583,7 @@ elsif Gem::Version.new('2.3.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'excon'
       gem 'faraday'
       gem 'grape'
-      gem 'graphql'
+      gem 'graphql', '< 1.12.0' # TODO: Pending ddtrace support for breaking changes in >= 1.12.0
       gem 'grpc'
       gem 'google-protobuf', '~> 3.11.0' # Last version to support Ruby < 2.5
       gem 'hiredis'
@@ -688,7 +688,7 @@ elsif Gem::Version.new('2.4.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'excon'
       gem 'faraday'
       gem 'grape'
-      gem 'graphql'
+      gem 'graphql', '< 1.12.0' # TODO: Pending ddtrace support for breaking changes in >= 1.12.0
       gem 'grpc'
       gem 'google-protobuf', '~> 3.11.0' # Last version to support Ruby < 2.5
       gem 'hiredis'
@@ -875,7 +875,7 @@ elsif Gem::Version.new('2.5.0') <= Gem::Version.new(RUBY_VERSION) \
     gem 'excon'
     gem 'faraday'
     gem 'grape'
-    gem 'graphql'
+    gem 'graphql', '< 1.12.0' # TODO: Pending ddtrace support for breaking changes in >= 1.12.0
     gem 'grpc', platform: :ruby
     gem 'hiredis'
     gem 'http'
@@ -1050,7 +1050,7 @@ elsif Gem::Version.new('2.6.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'excon'
       gem 'faraday'
       gem 'grape'
-      gem 'graphql'
+      gem 'graphql', '< 1.12.0' # TODO: Pending ddtrace support for breaking changes in >= 1.12.0
       gem 'grpc'
       gem 'hiredis'
       gem 'http'
@@ -1226,7 +1226,7 @@ elsif Gem::Version.new('2.7.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'ethon'
       gem 'excon'
       gem 'grape'
-      gem 'graphql'
+      gem 'graphql', '< 1.12.0' # TODO: Pending ddtrace support for breaking changes in >= 1.12.0
       gem 'grpc'
       gem 'hiredis'
       gem 'http'
@@ -1318,7 +1318,7 @@ elsif Gem::Version.new('3.0.0') <= Gem::Version.new(RUBY_VERSION)
     gem 'ethon'
     gem 'excon'
     gem 'grape'
-    gem 'graphql'
+    gem 'graphql', '< 1.12.0' # TODO: Pending ddtrace support for breaking changes in >= 1.12.0
     # gem 'grpc' # Pending 3.0 support by transient protobuf dependency https://github.com/protocolbuffers/protobuf/issues/7922
     gem 'hiredis'
     gem 'http'


### PR DESCRIPTION
[Breaking changes in `graphql` `1.12.0`](https://github.com/rmosolgo/graphql-ruby/blob/a9a7373a1fbf91cbcc10a1385cc4cf8c2af8254d/CHANGELOG.md#breaking-changes-1) are causing our `master` build to fail, this will block any work in `ddtrace` currently.

This PR unblocks us from doing `ddtrace` work by locking the version of `graphql` until we address changes introduced in `1.12.0`.

At first glance, it seems like extra spans are now produced in our tests, but doesn't seem like anything major.