### PR TITLE
Promote request_queuing out of experimental

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2116,9 +2116,7 @@ end
 
 Traces that originate from HTTP requests can be configured to include the time spent in a frontend web server or load balancer queue before the request reaches the Ruby application.
 
-This functionality is **experimental** and deactivated by default.
-
-To activate this feature, you must add an `X-Request-Start` or `X-Queue-Start` header from your web server (i.e., Nginx). The following is an Nginx configuration example:
+This feature is disabled by default. To activate it, you must add an `X-Request-Start` or `X-Queue-Start` header from your web server (i.e., Nginx). The following is an Nginx configuration example:
 
 ```
 # /etc/nginx/conf.d/ruby_service.conf
@@ -2132,9 +2130,7 @@ server {
 }
 ```
 
-Then you must enable the request queuing feature in the integration handling the request.
-
-For Rack-based applications, see the [documentation](#rack) for details for enabling this feature.
+Then you must enable the request queuing feature, by setting `request_queuing: true`, in the integration handling the request. For Rack-based applications, see the [documentation](#rack) for details.
 
 ### Processing Pipeline
 

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -53,7 +53,7 @@ module Datadog
             tracer.provider.context = context if context.trace_id
           end
 
-          # [experimental] create a root Span to keep track of frontend web servers
+          # Create a root Span to keep track of frontend web servers
           # (i.e. Apache, nginx) if the header is properly set
           frontend_span = compute_queue_time(env, tracer)
 

--- a/lib/ddtrace/contrib/rack/request_queue.rb
+++ b/lib/ddtrace/contrib/rack/request_queue.rb
@@ -1,7 +1,12 @@
 module Datadog
   module Contrib
     module Rack
-      # QueueTime simply...
+      # Retrieves the time spent in an upstream proxy
+      # for the current Rack request.
+      #
+      # This time captures the request delay introduced but
+      # such proxy before the request made it to the Ruby
+      # process.
       module QueueTime
         REQUEST_START = 'HTTP_X_REQUEST_START'.freeze
         QUEUE_START = 'HTTP_X_QUEUE_START'.freeze


### PR DESCRIPTION
This PR removes the experimental status of the `request_queuing` option for web servers.

This option has been stable for quite a while across multiple production environemtns, thus we are confident that it can be enabled without concern.