### PR TITLE
Export RSpec results metadata to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,13 @@ step_compute_bundle_checksum: &step_compute_bundle_checksum
 step_run_all_tests: &step_run_all_tests
   run:
     name: Run tests
-    command: bundle exec rake ci
+    command: |
+        echo "
+        --format=progress
+        --format=RspecJunitFormatter
+        --out='/tmp/rspec/-<%= ARGV.join.gsub('/', '-') %>.xml'
+        " > .rspec-local # Configure RSpec metadata exporter
+        bundle exec rake ci
 step_release_docs: &step_release_docs
   run:
     name: Upload release docs
@@ -173,6 +179,8 @@ orbs:
                 # Create a unique coverage directory for this job, to avoid conflicts when merging all results
                 echo 'export COVERAGE_DIR="$COVERAGE_BASE_DIR/versions/$CIRCLE_JOB/$CIRCLE_NODE_INDEX"' >> $BASH_ENV
           - *step_run_all_tests
+          - store_test_results:
+              path: /tmp/rspec
           - persist_to_workspace:
               root: .
               paths:

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -56,6 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '>= 3.10.0'
   spec.add_development_dependency 'builder'
   spec.add_development_dependency 'climate_control', '~> 0.2.0'
+  spec.add_development_dependency 'rspec_junit_formatter', '>= 0.4.1'
 
   # locking transitive dependency of webmock
   spec.add_development_dependency 'addressable', '~> 2.4.0'


### PR DESCRIPTION
This PR [exports RSpec of test results to CircleCI](https://circleci.com/docs/2.0/collect-test-data/).

This allows CircleCI to properly record and display test failures, instead of us having to dig around the plain text output: (from [Ruby 2.0 test failure](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/2563/workflows/d627ea4b-fa40-47ef-bc75-6ee7f747730f/jobs/107079))
![Screen Shot 2021-01-21 at 5 56 23 PM](https://user-images.githubusercontent.com/583503/105423286-3d72cd80-5c13-11eb-923d-9464882545fe.png)

There's also a way to get historically flaky and slow tests, but it's only available [through CircleCI API calls](https://circleci.com/docs/2.0/collect-test-data/). I haven't had the time to do this API work yet, but it's good to start collecting data already for such report.