### PR TITLE
Correctly force resolution of Appraisal gems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,8 +91,7 @@ step_appraisal_install: &step_appraisal_install
   run:
     name: Install Appraisal gems
     command: |
-      bundle exec appraisal clean # Ensure we fetch the latest version of dependencies
-      bundle exec appraisal install
+      bundle exec appraisal update
 step_compute_bundle_checksum: &step_compute_bundle_checksum
   run:
     name: Compute bundle checksum


### PR DESCRIPTION
We tried a few ways to ensure that we always resolve the gem dependency graph again on every CI run.

Our current approach is to clean all Appraisal files and install gems again.
Unfortunately, this is not enough to force a remote gem resolution.

Turns our there's a single command that does exactly what we need. From `appraisal --help`:
```
  appraisal update  # Remove all generated gemfiles and lockfiles, resolve, and install dependencies again
```

This PR now uses `appraisal update` for CI.