### PR TITLE
[PROF-2711] Fix multiple profilers starting in the same process

### DIFF
--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -110,7 +110,7 @@ module Datadog
         begin
           yield
         rescue ThreadError => e
-          logger_without_components.warn(
+          logger_without_components.error(
             'Detected deadlock during ddtrace initialization. ' \
             'Please report this at https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug' \
             "\n\tSource:\n\t#{e.backtrace.join("\n\t")}"

--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'thread'
 
 require 'ddtrace/configuration/pin_setup'
 require 'ddtrace/configuration/settings'
@@ -8,6 +9,18 @@ module Datadog
   # Configuration provides a unique access point for configurations
   module Configuration
     extend Forwardable
+
+    # Used to ensure that @components initialization/reconfiguration is performed one-at-a-time, by a single thread.
+    #
+    # This is important because components can end up being accessed from multiple application threads (for instance on
+    # a threaded webserver), and we don't want their initialization to clash (for instance, starting two profilers...).
+    #
+    # Note that a Mutex **IS NOT** reentrant: the same thread cannot grab the same Mutex more than once.
+    # This means below we are careful not to nest calls to methods that grab the lock.
+    #
+    # Every method that directly or indirectly accesses/mutates @components should be holding the lock while doing so.
+    COMPONENTS_LOCK = Mutex.new
+    private_constant :COMPONENTS_LOCK
 
     attr_writer :configuration
 
@@ -19,13 +32,15 @@ module Datadog
       if target.is_a?(Settings)
         yield(target) if block_given?
 
-        # Build immutable components from settings
-        @components ||= nil
-        @components = if @components
-                        replace_components!(target, @components)
-                      else
-                        build_components(target)
-                      end
+        COMPONENTS_LOCK.synchronize do
+          # Build immutable components from settings
+          @components ||= nil
+          @components = if @components
+                          replace_components!(target, @components)
+                        else
+                          build_components(target)
+                        end
+        end
 
         target
       else
@@ -41,9 +56,12 @@ module Datadog
       :tracer
 
     def logger
-      if instance_variable_defined?(:@components) && @components
+      # avoid initializing components if they didn't already exist
+      current_components = components? && components
+
+      if current_components
         @temp_logger = nil
-        components.logger
+        current_components.logger
       else
         # Use default logger without initializing components.
         # This prevents recursive loops while initializing.
@@ -66,7 +84,9 @@ module Datadog
     #
     # Components won't be automatically reinitialized after a shutdown.
     def shutdown!
-      components.shutdown! if instance_variable_defined?(:@components) && @components
+      COMPONENTS_LOCK.synchronize do
+        @components.shutdown! if components?
+      end
     end
 
     # Gracefully shuts down the tracer and disposes of component references,
@@ -75,17 +95,26 @@ module Datadog
     # In contrast with +#shutdown!+, components will be automatically
     # reinitialized after a reset.
     def reset!
-      shutdown!
-      @components = nil
+      COMPONENTS_LOCK.synchronize do
+        @components.shutdown! if components?
+        @components = nil
+      end
     end
 
     protected
 
     def components
-      @components ||= build_components(configuration)
+      COMPONENTS_LOCK.synchronize do
+        @components ||= build_components(configuration)
+      end
     end
 
     private
+
+    def components?
+      # This does not need to grab the COMPONENTS_LOCK because it's not returning the components
+      (defined?(@components) && @components) != nil
+    end
 
     def build_components(settings)
       components = Components.new(settings)

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -460,5 +460,44 @@ RSpec.describe Datadog::Configuration do
         expect(test_class.send(:components)).to_not be(original_components)
       end
     end
+
+    describe '#safely_synchronize' do
+      it 'runs the given block while holding the COMPONENTS_LOCK' do
+        block_ran = false
+
+        test_class.send(:safely_synchronize) do
+          block_ran = true
+          expect(described_class.const_get(:COMPONENTS_LOCK)).to be_owned
+        end
+
+        expect(block_ran).to be true
+      end
+
+      it 'returns the value of the given block' do
+        expect(test_class.send(:safely_synchronize) { :returned_value }).to be :returned_value
+      end
+
+      context 'when recursive execution triggers a deadlock' do
+        subject(:safely_synchronize) { test_class.send(:safely_synchronize) { test_class.send(:safely_synchronize) } }
+
+        before do
+          allow(test_class.send(:logger_without_components)).to receive(:warn)
+        end
+
+        it 'logs an error' do
+          expect(test_class.send(:logger_without_components)).to receive(:warn).with(/Detected deadlock/)
+
+          safely_synchronize
+        end
+
+        it 'does not let the exception propagate' do
+          expect { safely_synchronize }.to_not raise_error
+        end
+
+        it 'returns nil' do
+          expect(safely_synchronize).to be nil
+        end
+      end
+    end
   end
 end

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -391,6 +391,14 @@ RSpec.describe Datadog::Configuration do
       subject(:logger) { test_class.logger }
       it { is_expected.to be_a_kind_of(Datadog::Logger) }
       it { expect(logger.level).to be default_log_level }
+
+      context 'when components are not initialized' do
+        it 'does not cause them to be initialized' do
+          logger
+
+          expect(test_class.send(:components?)).to be false
+        end
+      end
     end
 
     describe '#profiler' do
@@ -441,7 +449,7 @@ RSpec.describe Datadog::Configuration do
       let!(:original_components) { test_class.send(:components) }
 
       it 'gracefully shuts down components' do
-        expect(test_class).to receive(:shutdown!)
+        expect(original_components).to receive(:shutdown!)
 
         reset!
       end

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -481,11 +481,11 @@ RSpec.describe Datadog::Configuration do
         subject(:safely_synchronize) { test_class.send(:safely_synchronize) { test_class.send(:safely_synchronize) } }
 
         before do
-          allow(test_class.send(:logger_without_components)).to receive(:warn)
+          allow(test_class.send(:logger_without_components)).to receive(:error)
         end
 
         it 'logs an error' do
-          expect(test_class.send(:logger_without_components)).to receive(:warn).with(/Detected deadlock/)
+          expect(test_class.send(:logger_without_components)).to receive(:error).with(/Detected deadlock/)
 
           safely_synchronize
         end


### PR DESCRIPTION
While experimenting with Ruby profiler, I noticed that sometimes more
than one profiler was being started.

Upon closer investigation, I identified this as a race between the
profiler's sampling thread and the thread that was initializing the
Datadog APM: If initialization of components was not "fast enough",
the Datadog::Profiling::Collectors::Stack would run and try to access
`Datadog.tracer` (stack.rb:140), which would trigger a new
initialization of the components, including starting a second profiler.

This can be triggered reliably by injecting an artificial slow down
into component initialization -- change configuration.rb from

```ruby
    def components
      @components ||= build_components(configuration)
    end
```

to

```ruby
    def components
      @components ||= build_components(configuration).tap { sleep 0.1 }
    end
```

and then by running a trivial application:

```ruby
$ DD_PROFILING_ENABLED=true bundle exec bin/ddtracerb exec ruby -e 'sleep 1; puts Thread.list.count'
203
$ DD_PROFILING_ENABLED=true bundle exec bin/ddtracerb exec ruby -e 'sleep 1; puts Thread.list.count'
195
```

Every initialization starts a new profiler, which starts two new
threads, and due to the race, many more threads get started than
expected -- and the value is not deterministic.

To fix this, I've added a mutex to protect all access to the
`@components`. Thus, adding the same `.tap { sleep 0.1 }` now
yields the three expected threads (one user code, two for the
profiler):

```ruby
$ DD_PROFILING_ENABLED=true bundle exec bin/ddtracerb exec ruby -e 'sleep 1; puts Thread.list.count'
3
```