### PR TITLE
Add CPU profiling auto instrumentation

### DIFF
--- a/lib/ddtrace/profiling/ext/cpu.rb
+++ b/lib/ddtrace/profiling/ext/cpu.rb
@@ -4,6 +4,7 @@ module Datadog
       # Extensions for CPU
       module CPU
         FFI_MINIMUM_VERSION = Gem::Version.new('1.0')
+        THREAD_HOOK = :datadog_profiling_cpu_hook
 
         def self.supported?
           RUBY_PLATFORM != 'java' \
@@ -19,6 +20,65 @@ module Datadog
           # will provide a thread/clock ID for CPU timing.
           require 'ddtrace/profiling/ext/cthread'
           ::Thread.send(:prepend, Profiling::Ext::CThread)
+
+          # Applying hooks will allow any existing threads to update
+          # their thread/clock IDs so their CPU timings can be measured.
+          apply_hooks!
+        end
+
+        def self.apply_hooks!
+          # Threads that have already been created, will not have resolved
+          # a thread/clock ID. This is because these IDs can only be resolved
+          # from within the thread's execution context, which we do not control.
+          #
+          # We can work around this by applying trace hooks to capture each thread
+          # from within its own execution context, resolving the thread/clock IDs,
+          # then disabling the hook so it doesn't re-run needlessly.
+          Thread.list.each do |thread|
+            # Only attempt to hook into threads that are instrumented
+            next unless thread.is_a?(CThread)
+
+            # TracePoint supports filtering by thread for Ruby 2.7+
+            if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7') && defined?(TracePoint)
+              thread[THREAD_HOOK] = TracePoint.new(:line) do |tp|
+                current_thread = Thread.current
+
+                begin
+                  current_thread.send(:update_native_ids)
+                rescue StandardError => e
+                  log "ERROR: Failed to update thread/clock IDs for Thread #{current_thread.object_id}.\nCause: #{e.message}\nLocation: #{e.backtrace.first}"
+                ensure
+                  current_thread[THREAD_HOOK].disable
+                end
+              end
+
+              thread[THREAD_HOOK].enable(target_thread: thread)
+            # Otherwise use Thread#set_trace_func to scope per thread
+            else
+              thread[THREAD_HOOK] = proc {
+                current_thread = Thread.current
+
+                begin
+                  current_thread.send(:update_native_ids)
+                rescue StandardError => e
+                  log "ERROR: Failed to update thread/clock IDs for Thread #{current_thread.object_id}.\nCause: #{e.message}\nLocation: #{e.backtrace.first}"
+                ensure
+                  # Disable hook no matter what, to prevent loops
+                  # if an error is encountered.
+                  current_thread.set_trace_func(nil)
+                end
+              }
+
+              thread.set_trace_func(thread[THREAD_HOOK])
+            end
+          end
+        end
+
+        private
+
+        def self.log(message)
+          # Print to STDOUT for now because logging may not be setup yet...
+          puts message
         end
       end
     end

--- a/lib/ddtrace/profiling/ext/cthread.rb
+++ b/lib/ddtrace/profiling/ext/cthread.rb
@@ -12,21 +12,10 @@ module Datadog
       # the thread ID, clock ID, and CPU time.
       module CThread
         extend FFI::Library
+
         ffi_lib 'ruby', 'pthread'
         attach_function :rb_nativethread_self, [], :ulong
         attach_function :pthread_getcpuclockid, [:ulong, CClockId], :int
-
-        def self.prepended(base)
-          # Threads that have already been created, will not have resolved
-          # a thread/clock ID. This is because these IDs can only be resolved
-          # from within the thread's execution context, which we do not control.
-          #
-          # We can mitigate this for the current thread via #update_native_ids,
-          # since we are currently running within its execution context. We cannot
-          # do this for any other threads that may have been created already.
-          # (This is why it's important that CThread is applied before anything else runs.)
-          base.current.send(:update_native_ids) if base.current.is_a?(CThread)
-        end
 
         attr_reader \
           :native_thread_id


### PR DESCRIPTION
## Overview

This pull request improves the setup process for CPU profiling by using trace hooks, making it possible to enable CPU instrumentation after the Ruby process has started.

Ultimately, users will be able to add the following anywhere in their codebase to get CPU profiling:

```
require 'ddtrace/profiling/preload'
```

## Background

To implement CPU profiling, we need to get the thread/clock ID for each thread in a Ruby process. Unfortunately, these IDs can only be resolved when running within the context of the thread itself.

Previously, the strategy has been to have the profiling code load first in the application, before any thread loads, so it can patch `Thread#initialize` and thus resolve the IDs from within the context of each thread. This only works for threads that have not started yet, so it requires wrapping the processor with our preloader `ddtracerb exec`. This has downsides, as it requires modifying how the Ruby process starts, which is not always easy to do (say for example, if you're running a Docker image of a Ruby process you did not build or do not manage.)

## Strategy

To improve upon this, this pull request implements the use of `TracePoint` and `Thread#set_trace_func`. When a specific Ruby event occurs, these debugger hooks will invoke a block within the context of the thread its attached to. Because its running in the thread's context, we can use this to resolve the IDs for the thread, even after the thread has already started.

## Considerations

- `Thread#set_trace_func` works on all versions of Ruby, but is deprecated.
- `TracePoint` with thread filtering works only on Ruby 2.7+, and is the preferred API.
- Because we anticipate this API could be expensive or have a significant impact on performance, the implementation should be as minimal and temporary as possible.
    - Once the IDs are resolved, we want to remove any trace hooks to reduce cost.
- There is a number of events (e.g. `:call, :line`) that can be used to trigger the hook; some call more often than others. We probably want to be careful to call the right event(s) such that we call the hook quick enough, without being too aggressive.
- This code is failure sensitive; if a trace hook triggers and isn't removed (say because of an error), then it can create an overwhelming number of calls because the hook wasn't removed. Errors must be handled gracefully.
- Might want warnings or debug statements to aid diagnosing whether auto instrumentation applied correctly or not?

## TODO

- [ ] Implement `Thread#set_trace_func` for Ruby 2.1+
- [ ] Implement `TracePoint` for Ruby 2.7+
- [ ] Add tests
- [ ] Update documentation
- [ ] Performance & function test in real applications