### PR TITLE
Bump rubocop version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,9 +37,6 @@ Performance/Casecmp:
 Style/AccessorMethodName:
   Enabled: false
 
-Style/MethodCallWithoutArgsParentheses:
-  Enabled: false
-
 Style/RescueModifier:
   Enabled: false
 

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   # Development dependencies
   spec.add_development_dependency 'concurrent-ruby' # Leave it open as we also have it as an integration and want Appraisal to control the version under test.
   spec.add_development_dependency 'rake', '>= 10.5'
-  spec.add_development_dependency 'rubocop', '= 0.49.1' if RUBY_VERSION >= '2.1.0'
+  spec.add_development_dependency 'rubocop', '= 0.50.0' if RUBY_VERSION >= '2.1.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.1'
   spec.add_development_dependency 'ruby-prof', '~> 1.4' if RUBY_PLATFORM != 'java' && RUBY_VERSION >= '2.4.0'

--- a/lib/ddtrace/configuration/option_definition.rb
+++ b/lib/ddtrace/configuration/option_definition.rb
@@ -71,8 +71,6 @@ module Datadog
           @helpers[name] = block
         end
 
-        # rubocop:disable Style/TrivialAccessors
-        # (Rubocop erroneously thinks #lazy == #lazy= )
         def lazy(value = true)
           @lazy = value
         end

--- a/lib/ddtrace/contrib/action_view/utils.rb
+++ b/lib/ddtrace/contrib/action_view/utils.rb
@@ -23,6 +23,7 @@ module Datadog
           else
             sections_view[-1]
           end
+        # rubocop:disable Lint/RescueWithoutErrorClass
         rescue
           return name.to_s
         end

--- a/lib/ddtrace/contrib/active_record/utils.rb
+++ b/lib/ddtrace/contrib/active_record/utils.rb
@@ -66,6 +66,7 @@ module Datadog
             # extensions that might have their own connection
             # pool (e.g. https://rubygems.org/gems/makara).
             ObjectSpace._id2ref(connection_id)
+          # rubocop:disable Lint/RescueWithoutErrorClass
           rescue => e
             # Because `connection_id` references a live connection
             # present in the current stack, it is very unlikely that

--- a/lib/ddtrace/contrib/active_support/notifications/subscription.rb
+++ b/lib/ddtrace/contrib/active_support/notifications/subscription.rb
@@ -60,7 +60,7 @@ module Datadog
 
           def unsubscribe_all
             return false if subscribers.empty?
-            subscribers.keys.each { |pattern| unsubscribe(pattern) }
+            subscribers.each_key { |pattern| unsubscribe(pattern) }
             true
           end
 

--- a/lib/ddtrace/contrib/aws/parsed_context.rb
+++ b/lib/ddtrace/contrib/aws/parsed_context.rb
@@ -8,6 +8,7 @@ module Datadog
         end
 
         def safely(attr, fallback = nil)
+          # rubocop:disable Lint/RescueWithoutErrorClass
           public_send(attr) rescue fallback
         end
 

--- a/lib/ddtrace/contrib/aws/patcher.rb
+++ b/lib/ddtrace/contrib/aws/patcher.rb
@@ -35,6 +35,7 @@ module Datadog
 
           available_services.each_with_object([]) do |service, constants|
             next if ::Aws.autoload?(service)
+            # rubocop:disable Lint/RescueWithoutErrorClass
             constants << ::Aws.const_get(service, false).const_get(:Client, false) rescue next
           end
         end

--- a/lib/ddtrace/contrib/dalli/quantize.rb
+++ b/lib/ddtrace/contrib/dalli/quantize.rb
@@ -12,6 +12,7 @@ module Datadog
           command = [operation, *args].join(' ').strip
           command = Utils.utf8_encode(command, binary: true, placeholder: placeholder)
           Utils.truncate(command, Ext::QUANTIZE_MAX_CMD_LENGTH)
+        # rubocop:disable Lint/RescueWithoutErrorClass
         rescue => e
           Datadog.logger.debug("Error sanitizing Dalli operation: #{e}")
           placeholder

--- a/lib/ddtrace/contrib/rack/patcher.rb
+++ b/lib/ddtrace/contrib/rack/patcher.rb
@@ -33,6 +33,7 @@ module Datadog
 
         def patch_middleware_names
           retain_middleware_name(get_option(:application))
+        # rubocop:disable Lint/RescueWithoutErrorClass
         rescue => e
           # We can safely ignore these exceptions since they happen only in the
           # context of middleware patching outside a Rails server process (eg. a

--- a/lib/ddtrace/contrib/redis/quantize.rb
+++ b/lib/ddtrace/contrib/redis/quantize.rb
@@ -29,6 +29,7 @@ module Datadog
           str = arg.is_a?(Symbol) ? arg.to_s.upcase : arg.to_s
           str = Utils.utf8_encode(str, binary: true, placeholder: PLACEHOLDER)
           Utils.truncate(str, VALUE_MAX_LEN, TOO_LONG_MARK)
+        # rubocop:disable Lint/RescueWithoutErrorClass
         rescue => e
           Datadog.logger.debug("non formattable Redis arg #{str}: #{e}")
           PLACEHOLDER

--- a/lib/ddtrace/contrib/redis/vendor/resolver.rb
+++ b/lib/ddtrace/contrib/redis/vendor/resolver.rb
@@ -56,7 +56,7 @@ module Datadog
             defaults = DEFAULTS.dup
             options = options.dup
 
-            defaults.keys.each do |key|
+            defaults.each_key do |key|
               # Fill in defaults if needed
               if defaults[key].respond_to?(:call)
                 defaults[key] = defaults[key].call
@@ -90,7 +90,7 @@ module Datadog
             end
 
             # Use default when option is not specified or nil
-            defaults.keys.each do |key|
+            defaults.each_key do |key|
               options[key] = defaults[key] if options[key].nil?
             end
 

--- a/lib/ddtrace/contrib/registry.rb
+++ b/lib/ddtrace/contrib/registry.rb
@@ -19,7 +19,7 @@ module Datadog
 
       def each
         @mutex.synchronize do
-          @data.each { |_, entry| yield(entry) }
+          @data.each_value { |entry| yield(entry) }
         end
       end
 

--- a/lib/ddtrace/contrib/sidekiq/tracing.rb
+++ b/lib/ddtrace/contrib/sidekiq/tracing.rb
@@ -25,6 +25,7 @@ module Datadog
           else
             job['class'].to_s
           end
+        # rubocop:disable Lint/RescueWithoutErrorClass
         rescue => e
           Datadog.logger.debug { "Error retrieving Sidekiq job class name (jid:#{job['jid']}): #{e}" }
 

--- a/lib/ddtrace/contrib/sucker_punch/instrumentation.rb
+++ b/lib/ddtrace/contrib/sucker_punch/instrumentation.rb
@@ -31,6 +31,7 @@ module Datadog
 
                 __run_perform_without_datadog(*args)
               end
+            # rubocop:disable Lint/RescueWithoutErrorClass
             rescue => e
               ::SuckerPunch.__exception_handler.call(e, self, args)
             end

--- a/lib/ddtrace/diagnostics/environment_logger.rb
+++ b/lib/ddtrace/diagnostics/environment_logger.rb
@@ -21,6 +21,7 @@ module Datadog
 
           log_environment!(data.to_json)
           log_error!('Agent Error'.freeze, data[:agent_error]) if data[:agent_error]
+        # rubocop:disable Lint/RescueWithoutErrorClass
         rescue => e
           Datadog.logger.warn("Failed to collect environment information: #{e} location: #{e.backtrace.first}")
         end

--- a/lib/ddtrace/pin.rb
+++ b/lib/ddtrace/pin.rb
@@ -18,7 +18,6 @@ module Datadog
     attr_accessor :name
     attr_accessor :service_name
     attr_accessor :tags
-    attr_reader :tracer
     attr_accessor :writer
 
     alias service= service_name=

--- a/lib/ddtrace/pipeline.rb
+++ b/lib/ddtrace/pipeline.rb
@@ -33,6 +33,7 @@ module Datadog
       end
 
       result || []
+    # rubocop:disable Lint/RescueWithoutErrorClass
     rescue => e
       Datadog.logger.debug(
         "trace dropped entirely due to `Pipeline.before_flush` error: #{e}"

--- a/lib/ddtrace/pipeline/span_filter.rb
+++ b/lib/ddtrace/pipeline/span_filter.rb
@@ -31,6 +31,7 @@ module Datadog
       private
 
       def drop_it?(span)
+        # rubocop:disable Lint/RescueWithoutErrorClass
         @criteria.call(span) rescue false
       end
     end

--- a/lib/ddtrace/pipeline/span_processor.rb
+++ b/lib/ddtrace/pipeline/span_processor.rb
@@ -12,6 +12,7 @@ module Datadog
 
       def call(trace)
         trace.each do |span|
+          # rubocop:disable Lint/RescueWithoutErrorClass
           @operation.call(span) rescue next
         end
       end

--- a/lib/ddtrace/propagation/http_propagator.rb
+++ b/lib/ddtrace/propagation/http_propagator.rb
@@ -28,6 +28,7 @@ module Datadog
         propagator = PROPAGATION_STYLES[style]
         begin
           propagator.inject!(context, env) unless propagator.nil?
+        # rubocop:disable Lint/RescueWithoutErrorClass
         rescue => e
           Datadog.logger.error(
             'Error injecting propagated context into the environment. ' \

--- a/lib/ddtrace/sampling/rule.rb
+++ b/lib/ddtrace/sampling/rule.rb
@@ -27,6 +27,7 @@ module Datadog
       # @return [NilClass] if the matcher fails errs during evaluation
       def match?(span)
         @matcher.match?(span)
+      # rubocop:disable Lint/RescueWithoutErrorClass
       rescue => e
         Datadog.logger.error("Matcher failed. Cause: #{e.message} Source: #{e.backtrace.first}")
         nil

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -43,9 +43,11 @@ module Datadog
     attr_accessor :name, :service, :resource, :span_type,
                   :span_id, :trace_id, :parent_id,
                   :status, :sampled,
-                  :tracer, :context, :duration, :start_time, :end_time
+                  :tracer, :context
 
-    attr_reader :parent
+    attr_reader :parent, :start_time, :end_time
+
+    attr_writer :duration
 
     # Create a new span linked to the given tracer. Call the \Tracer method <tt>start_span()</tt>
     # and then <tt>finish()</tt> once the tracer operation is over.

--- a/lib/ddtrace/sync_writer.rb
+++ b/lib/ddtrace/sync_writer.rb
@@ -32,6 +32,7 @@ module Datadog
       perform_concurrently(
         proc { flush_trace(trace) }
       )
+    # rubocop:disable Lint/RescueWithoutErrorClass
     rescue => e
       Datadog.logger.debug(e)
     end

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -294,6 +294,7 @@ module Datadog
           if (on_error_handler = options[:on_error]) && on_error_handler.respond_to?(:call)
             begin
               on_error_handler.call(span, e)
+            # rubocop:disable Lint/RescueWithoutErrorClass
             rescue
               Datadog.logger.debug('Custom on_error handler failed, falling back to default')
               DEFAULT_ON_ERROR.call(span, e)

--- a/lib/ddtrace/utils.rb
+++ b/lib/ddtrace/utils.rb
@@ -59,6 +59,7 @@ module Datadog
       else
         str.encode(::Encoding::UTF_8)
       end
+    # rubocop:disable Lint/RescueWithoutErrorClass
     rescue => e
       Datadog.logger.debug("Error encoding string in UTF-8: #{e}")
 

--- a/spec/ddtrace/benchmark/support/benchmark_helper.rb
+++ b/spec/ddtrace/benchmark/support/benchmark_helper.rb
@@ -295,6 +295,7 @@ RSpec.shared_context 'minimal agent' do
 
   after do
     if PlatformHelpers.supports_fork?
+      # rubocop:disable Lint/RescueWithoutErrorClass
       Process.kill('TERM', @agent_runner) rescue nil
       Process.wait(@agent_runner)
     else

--- a/spec/ddtrace/contrib/action_cable/patcher_spec.rb
+++ b/spec/ddtrace/contrib/action_cable/patcher_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe 'ActionCable patcher' do
       let(:data) { { 'action' => 'foo', 'extra' => 'data' } }
       let(:channel_class) do
         stub_const('ChatChannel', Class.new(ActionCable::Channel::Base) do
-          def foo(data)
+          def foo(_data)
             transmit({ mock: 'data' }, via: 'streamed from chat_channel')
           end
         end)

--- a/spec/ddtrace/contrib/active_record/app.rb
+++ b/spec/ddtrace/contrib/active_record/app.rb
@@ -27,7 +27,7 @@ end
 # MySQL JDBC drivers require that, otherwise we get a
 # "Table '?' already exists" error
 begin
-  Article.count()
+  Article.count
 rescue ActiveRecord::StatementInvalid
   logger.info 'Executing database migrations'
   ActiveRecord::Schema.define(version: 20161003090450) do
@@ -42,4 +42,4 @@ else
 end
 
 # force an access to prevent extra spans during tests
-Article.count()
+Article.count

--- a/spec/ddtrace/contrib/faraday/middleware_spec.rb
+++ b/spec/ddtrace/contrib/faraday/middleware_spec.rb
@@ -183,6 +183,7 @@ RSpec.describe 'Faraday middleware' do
         begin
           client.get('/error')
         rescue Faraday::ConnectionFailed
+          nil
         end
       end
     end

--- a/spec/ddtrace/contrib/faraday/middleware_spec.rb
+++ b/spec/ddtrace/contrib/faraday/middleware_spec.rb
@@ -179,7 +179,12 @@ RSpec.describe 'Faraday middleware' do
     end
 
     it_behaves_like 'a peer service span' do
-      subject { client.get('/error') rescue nil }
+      subject do
+        begin
+          client.get('/error')
+        rescue Faraday::ConnectionFailed
+        end
+      end
     end
   end
 

--- a/spec/ddtrace/contrib/grape/tracer_spec.rb
+++ b/spec/ddtrace/contrib/grape/tracer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Grape instrumentation' do
 
   let(:testing_api) do
     # patch Grape before the application
-    Datadog::Contrib::Grape::Patcher.patch()
+    Datadog::Contrib::Grape::Patcher.patch
 
     stub_const('TestingAPI', Class.new(Grape::API) do
       namespace :base do
@@ -84,7 +84,7 @@ RSpec.describe 'Grape instrumentation' do
 
   let(:rack_testing_api) do
     # patch Grape before the application
-    Datadog::Contrib::Grape::Patcher.patch()
+    Datadog::Contrib::Grape::Patcher.patch
 
     stub_const('RackTestingAPI', Class.new(Grape::API) do
       desc 'Returns a success message'

--- a/spec/ddtrace/contrib/grpc/support/grpc_helper.rb
+++ b/spec/ddtrace/contrib/grpc/support/grpc_helper.rb
@@ -68,7 +68,7 @@ module GRPCHelper
     end
 
     # provide implementations for each registered rpc interface
-    def basic(request, call)
+    def basic(_request, call)
       call.output_metadata.update(@trailing_metadata)
       @received_metadata << call.metadata unless call.metadata.nil?
       TestMessage.new
@@ -85,7 +85,7 @@ module GRPCHelper
       [TestMessage.new, TestMessage.new]
     end
 
-    def stream_both_ways(requests, call)
+    def stream_both_ways(_requests, call)
       call.output_metadata.update(@trailing_metadata)
       call.each_remote_read.each { |r| r }
       [TestMessage.new, TestMessage.new]

--- a/spec/ddtrace/contrib/presto/client_spec.rb
+++ b/spec/ddtrace/contrib/presto/client_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe 'Presto::Client instrumentation' do
           begin
             client.run('SELECT banana')
           # rubocop:disable Lint/HandleExceptions
-          rescue
+          rescue Presto::Client::PrestoQueryError
             # do nothing
           end
           # rubocop:enable Lint/HandleExceptions

--- a/spec/ddtrace/contrib/qless/support/job.rb
+++ b/spec/ddtrace/contrib/qless/support/job.rb
@@ -52,7 +52,9 @@ RSpec.shared_context 'Qless job' do
   end
 
   def delete_all_redis_keys
-    client.redis.each_key { |k| client.redis.del k }
+    # rubocop:disable Performance/HashEachMethods
+    # This LOOKS like a Ruby hash but ISN'T -- so it doesn't have the `each_key` method that Rubocop suggests
+    client.redis.keys.each { |k| client.redis.del k }
   end
 
   let(:job_class) do

--- a/spec/ddtrace/contrib/qless/support/job.rb
+++ b/spec/ddtrace/contrib/qless/support/job.rb
@@ -52,7 +52,7 @@ RSpec.shared_context 'Qless job' do
   end
 
   def delete_all_redis_keys
-    client.redis.keys.each { |k| client.redis.del k }
+    client.redis.each_key { |k| client.redis.del k }
   end
 
   let(:job_class) do

--- a/spec/ddtrace/contrib/que/tracer_spec.rb
+++ b/spec/ddtrace/contrib/que/tracer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Datadog::Contrib::Que::Tracer do
   end
   let(:error_job_class) do
     stub_const('ErrorJobClass', Class.new(::Que::Job) do
-      def run(*args)
+      def run(*_args)
         raise StandardError, 'with some error'
       end
     end)

--- a/spec/ddtrace/contrib/rails/rack_spec.rb
+++ b/spec/ddtrace/contrib/rails/rack_spec.rb
@@ -33,8 +33,6 @@ RSpec.describe 'Rails Rack' do
       def full
         @value = ::Rails.cache.write('empty-key', 50)
         render 'full'
-      rescue => e
-        puts e
       end
 
       def error

--- a/spec/ddtrace/contrib/rails/support/rails3.rb
+++ b/spec/ddtrace/contrib/rails/support/rails3.rb
@@ -162,7 +162,7 @@ end
 require 'active_support/ordered_options'
 module ActiveSupport
   class OrderedOptions
-    def respond_to?(*args)
+    def respond_to?(*_args)
       true
     end
   end

--- a/spec/ddtrace/contrib/sinatra/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/tracer_spec.rb
@@ -581,7 +581,6 @@ RSpec.describe 'Sinatra instrumentation' do
   end
 
   RSpec::Matchers.define :be_request_span do |opts = {}|
-    # rubocop:disable Style/RedundantSelf
     match(notify_expectation_failures: true) do |span|
       app_name = opts[:app_name] || self.app_name
       expect(span.service).to eq(Datadog::Contrib::Sinatra::Ext::SERVICE_NAME)

--- a/spec/ddtrace/contrib/sneakers/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sneakers/tracer_spec.rb
@@ -9,7 +9,7 @@ class MiddlewareWorker
 
   from_queue 'middleware-demo', ack: false
 
-  def work_with_params(msg, delivery_info, metadata)
+  def work_with_params(msg, _delivery_info, _metadata)
     msg
   end
 end
@@ -19,7 +19,7 @@ class FailingMiddlewareWorker
 
   from_queue 'failing-middleware-demo', ack: false
 
-  def work_with_params(msg, delivery_info, metadata)
+  def work_with_params(_msg, _delivery_info, _metadata)
     raise ZeroDivisionError, 'failed'
   end
 end

--- a/spec/ddtrace/contrib/sneakers/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sneakers/tracer_spec.rb
@@ -27,8 +27,8 @@ end
 RSpec.describe Datadog::Contrib::Sneakers::Tracer do
   let(:sneakers_tracer) { described_class.new }
   let(:configuration_options) { {} }
-  let(:queue) { double() }
-  let(:exchange) { double() }
+  let(:queue) { double }
+  let(:exchange) { double }
 
   before do
     allow(queue).to receive(:name).and_return(queue_name)
@@ -59,10 +59,10 @@ RSpec.describe Datadog::Contrib::Sneakers::Tracer do
       worker.do_work(delivery_info, metadata, message, handler)
     end
 
-    let(:delivery_info) { double() }
+    let(:delivery_info) { double }
     let(:message) { Sneakers::ContentType.deserialize('{"foo":"bar"}', 'application/json') }
     let(:handler) { Object.new }
-    let(:metadata) { double() }
+    let(:metadata) { double }
     let(:routing_key) { 'something' }
     let(:consumer) { double('Consumer') }
 

--- a/spec/ddtrace/diagnostics/health_spec.rb
+++ b/spec/ddtrace/diagnostics/health_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 require 'ddtrace'
 require 'ddtrace/diagnostics/health'

--- a/spec/ddtrace/event_spec.rb
+++ b/spec/ddtrace/event_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Datadog::Event do
       it 'calls both subscribers' do
         publish
 
-        subscriptions.values.each do |block|
+        subscriptions.each_value do |block|
           expect(block).to have_received(:call).with(*args).ordered
         end
       end

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -265,6 +265,7 @@ RSpec.describe 'Tracer integration tests' do
 
         # Kill the process
         write.close
+        # rubocop:disable Lint/RescueWithoutErrorClass
         Process.kill('TERM', fork_id) rescue nil
 
         # Read and return any output

--- a/spec/ddtrace/pin_spec.rb
+++ b/spec/ddtrace/pin_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Datadog::Pin do
             @custom_attribute
           end
 
-          def datadog_pin=(pin)
+          def datadog_pin=(_pin)
             @custom_attribute = 'The PIN is set!'
           end
         end

--- a/spec/ddtrace/quantization/hash_spec.rb
+++ b/spec/ddtrace/quantization/hash_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 require 'ddtrace/quantization/hash'
 

--- a/spec/ddtrace/quantization/http_spec.rb
+++ b/spec/ddtrace/quantization/http_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 require 'ddtrace/quantization/http'

--- a/spec/ddtrace/runtime/cgroup_spec.rb
+++ b/spec/ddtrace/runtime/cgroup_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 require 'ddtrace/runtime/cgroup'
 

--- a/spec/ddtrace/runtime/class_count_spec.rb
+++ b/spec/ddtrace/runtime/class_count_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 require 'ddtrace/runtime/class_count'
 

--- a/spec/ddtrace/runtime/container_spec.rb
+++ b/spec/ddtrace/runtime/container_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 require 'ddtrace/runtime/container'
 

--- a/spec/ddtrace/runtime/gc_spec.rb
+++ b/spec/ddtrace/runtime/gc_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 require 'ddtrace/runtime/gc'
 

--- a/spec/ddtrace/runtime/identity_spec.rb
+++ b/spec/ddtrace/runtime/identity_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 require 'ddtrace/runtime/identity'
 

--- a/spec/ddtrace/runtime/metrics_spec.rb
+++ b/spec/ddtrace/runtime/metrics_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Datadog::Runtime::Metrics do
         it do
           flush
 
-          runtime_metrics.gc_metrics.each do |metric_name, _metric_value|
+          runtime_metrics.gc_metrics.each_key do |metric_name|
             expect(runtime_metrics).to have_received(:gauge)
               .with(metric_name, kind_of(Numeric))
               .once

--- a/spec/ddtrace/runtime/metrics_spec.rb
+++ b/spec/ddtrace/runtime/metrics_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 require 'ddtrace'
 require 'ddtrace/runtime/metrics'

--- a/spec/ddtrace/runtime/object_space_spec.rb
+++ b/spec/ddtrace/runtime/object_space_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 require 'ddtrace/runtime/object_space'
 

--- a/spec/ddtrace/runtime/socket_spec.rb
+++ b/spec/ddtrace/runtime/socket_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 require 'ddtrace/runtime/socket'
 

--- a/spec/ddtrace/runtime/thread_count_spec.rb
+++ b/spec/ddtrace/runtime/thread_count_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 require 'ddtrace/runtime/thread_count'
 

--- a/spec/ddtrace/transport/http/adapters/unix_socket_integration_spec.rb
+++ b/spec/ddtrace/transport/http/adapters/unix_socket_integration_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe 'Adapters::UnixSocket integration tests' do
         begin
           sock = server.accept
           http.run(sock)
+        # rubocop:disable Lint/RescueWithoutErrorClass
         rescue => e
           puts "UNIX server error!: #{e}"
         end

--- a/spec/ddtrace/transport/http_spec.rb
+++ b/spec/ddtrace/transport/http_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Datadog::Transport::HTTP do
         ]
       )
 
-      default.apis.each do |_key, api|
+      default.apis.each_value do |api|
         expect(api).to be_a_kind_of(Datadog::Transport::HTTP::API::Instance)
         expect(api.adapter).to be_a_kind_of(Datadog::Transport::HTTP::Adapters::Net)
         expect(api.adapter.hostname).to eq(described_class.default_hostname)
@@ -68,7 +68,7 @@ RSpec.describe Datadog::Transport::HTTP do
             ]
           )
 
-          default.apis.each do |_key, api|
+          default.apis.each_value do |api|
             expect(api).to be_a_kind_of(Datadog::Transport::HTTP::API::Instance)
             expect(api.adapter).to be_a_kind_of(Datadog::Transport::HTTP::Adapters::Net)
             expect(api.adapter.hostname).to eq(described_class.default_hostname)
@@ -84,7 +84,7 @@ RSpec.describe Datadog::Transport::HTTP do
         let(:port) { double('port') }
 
         it 'returns an HTTP transport with default configuration' do
-          default.apis.each do |_key, api|
+          default.apis.each_value do |api|
             expect(api.adapter).to be_a_kind_of(Datadog::Transport::HTTP::Adapters::Net)
             expect(api.adapter.hostname).to eq(hostname)
             expect(api.adapter.port).to eq(port)
@@ -111,7 +111,7 @@ RSpec.describe Datadog::Transport::HTTP do
         let(:headers) { { 'Test-Header' => 'foo' } }
 
         it do
-          default.apis.each do |_key, api|
+          default.apis.each_value do |api|
             expect(api.headers).to include(described_class.default_headers)
             expect(api.headers).to include(headers)
           end

--- a/spec/support/health_metric_helpers.rb
+++ b/spec/support/health_metric_helpers.rb
@@ -44,7 +44,7 @@ module HealthMetricHelpers
     include_context 'metrics'
 
     let(:health_metrics) { Datadog.health_metrics }
-    before { METRICS.eack_key { |metric| allow(health_metrics).to receive(metric) } }
+    before { METRICS.each_key { |metric| allow(health_metrics).to receive(metric) } }
 
     def have_received_lazy_health_metric(metric, *expected_args)
       have_received(metric) do |&block|

--- a/spec/support/health_metric_helpers.rb
+++ b/spec/support/health_metric_helpers.rb
@@ -44,7 +44,7 @@ module HealthMetricHelpers
     include_context 'metrics'
 
     let(:health_metrics) { Datadog.health_metrics }
-    before { METRICS.each { |metric, _attrs| allow(health_metrics).to receive(metric) } }
+    before { METRICS.eack_key { |metric| allow(health_metrics).to receive(metric) } }
 
     def have_received_lazy_health_metric(metric, *expected_args)
       have_received(metric) do |&block|
@@ -58,7 +58,7 @@ module HealthMetricHelpers
       end
     end
 
-    METRICS.each do |metric, _attributes|
+    METRICS.each_key do |metric|
       define_method(:"have_received_#{metric}") do |value = kind_of(Numeric), options = {}|
         options = metric_options(options)
         check_options!(options)

--- a/spec/support/log_helpers.rb
+++ b/spec/support/log_helpers.rb
@@ -56,7 +56,7 @@ module LogHelpers
         # Scans each pattern against each line, increments count if it matches.
         lines = buffer.string.lines
         lines.each do |line|
-          pattern_matches.keys.each do |pattern|
+          pattern_matches.each_key do |pattern|
             pattern_matches[pattern] += 1 if line.match(pattern)
           end
         end

--- a/spec/support/tracer_helpers.rb
+++ b/spec/support/tracer_helpers.rb
@@ -111,8 +111,8 @@ module TracerHelpers
     }
 
     n.times do
-      span1 = Datadog::Span.new(nil, 'client.testing', defaults).start().finish()
-      span2 = Datadog::Span.new(nil, 'client.testing', defaults).start().finish()
+      span1 = Datadog::Span.new(nil, 'client.testing', defaults).start.finish
+      span2 = Datadog::Span.new(nil, 'client.testing', defaults).start.finish
       span2.set_parent(span1)
       traces << [span1, span2]
     end

--- a/test/benchmark_test.rb
+++ b/test/benchmark_test.rb
@@ -13,12 +13,12 @@ class TraceBufferTest < Minitest::Test
 
   def test_benchmark_create_traces
     # create and finish a huge number of spans with a single thread
-    tracer = get_test_tracer()
-    tracer.writer.start()
+    tracer = get_test_tracer
+    tracer.writer.start
 
     Benchmark.benchmark(CAPTION, 7, FORMAT, '>total:', '>avg:') do |x|
       x.report("create #{N} traces:") do
-        N.times { tracer.trace('benchmark.test').finish() }
+        N.times { tracer.trace('benchmark.test').finish }
       end
     end
 

--- a/test/concurrent_test.rb
+++ b/test/concurrent_test.rb
@@ -9,7 +9,7 @@ class ConcurrentTest < Minitest::Test
 
   def traced_task
     @tracer.trace('a-root-task') do |_root_span|
-      delay = rand()
+      delay = rand
       @tracer.trace('a-sub-task') do |sub_span|
         sub_span.set_tag('delay', delay)
       end
@@ -17,7 +17,7 @@ class ConcurrentTest < Minitest::Test
       # and the instant the root span is done.
       sleep delay
     end
-    @tracer.writer.trace0_spans()
+    @tracer.writer.trace0_spans
   end
 
   def test_parallel_tasks

--- a/test/contrib/rails/apps/rails4.rb
+++ b/test/contrib/rails/apps/rails4.rb
@@ -7,7 +7,7 @@ module Rails4
 end
 
 def initialize_rails!
-  Rails4::Application.test_config()
+  Rails4::Application.test_config
 end
 
 def rails_initialized?

--- a/test/contrib/rails/apps/rails5.rb
+++ b/test/contrib/rails/apps/rails5.rb
@@ -6,7 +6,7 @@ module Rails5
 end
 
 def initialize_rails!
-  Rails5::Application.test_config()
+  Rails5::Application.test_config
 end
 
 def rails_initialized?

--- a/test/contrib/rails/apps/rails6.rb
+++ b/test/contrib/rails/apps/rails6.rb
@@ -17,7 +17,7 @@ module Rails6
 end
 
 def initialize_rails!
-  Rails6::Application.test_config()
+  Rails6::Application.test_config
 end
 
 def rails_initialized?

--- a/test/contrib/rails/controller_test.rb
+++ b/test/contrib/rails/controller_test.rb
@@ -181,7 +181,7 @@ class TracingControllerTest < ActionController::TestCase
     err = false
     begin
       get :error
-    rescue
+    rescue ZeroDivisionError
       err = true
     end
     assert_equal(true, err, 'should have raised an error')
@@ -198,7 +198,7 @@ class TracingControllerTest < ActionController::TestCase
     err = false
     begin
       get :not_found
-    rescue
+    rescue ActionController::RoutingError
       err = true
     end
     assert_equal(true, err, 'should have raised an error')

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -94,8 +94,8 @@ def get_test_traces(n)
   }
 
   n.times do
-    span1 = Datadog::Span.new(nil, 'client.testing', defaults).finish()
-    span2 = Datadog::Span.new(nil, 'client.testing', defaults).finish()
+    span1 = Datadog::Span.new(nil, 'client.testing', defaults).finish
+    span2 = Datadog::Span.new(nil, 'client.testing', defaults).finish
     span2.set_parent(span1)
     traces << [span1, span2]
   end

--- a/test/rate_by_service_sampler_test.rb
+++ b/test/rate_by_service_sampler_test.rb
@@ -22,7 +22,7 @@ module Datadog
     def test_sampling
       counter = Hash.new(0)
 
-      @rates.each do |service_key, _|
+      @rates.each_key do |service_key|
         ITERATIONS_PER_SERVICE.times do
           span = span_for(service_key)
           @sampler.sample!(span)

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -138,7 +138,7 @@ class TracerTest < Minitest::Test
   def test_disabled_tracer
     tracer = get_test_tracer
     tracer.enabled = false
-    tracer.trace('something').finish()
+    tracer.trace('something').finish
 
     spans = tracer.writer.spans()
     assert_equal(0, spans.length)
@@ -287,8 +287,8 @@ class TracerTest < Minitest::Test
 
     main = tracer.trace('main_call')
     detached = tracer.start_span('detached_trace')
-    detached.finish()
-    main.finish()
+    detached.finish
+    main.finish
 
     spans = tracer.writer.spans()
     assert_equal(2, spans.length)

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -13,7 +13,7 @@ class UtilsTest < Minitest::Test
     threads = []
     n.times do |_i|
       thread = Thread.new do
-        r = Datadog::Utils.next_id()
+        r = Datadog::Utils.next_id
         mutex.synchronize do
           @numbers[r] = true
         end
@@ -28,7 +28,7 @@ class UtilsTest < Minitest::Test
   end
 
   def test_rand_no_side_effect
-    tracer = get_test_tracer()
+    tracer = get_test_tracer
 
     srand 1234
     tracer.trace('random') do # this creates span, so calls our PRNG


### PR DESCRIPTION
We are running a really really old Rubocop version: (keep scrolling)

1.9.0 - January 28, 2021 (466 KB)
1.8.1 - January 11, 2021 (459 KB)
1.8.0 - January 07, 2021 (459 KB)
1.7.0 - December 25, 2020 (456 KB)
1.6.1 - December 10, 2020 (451 KB)
1.6.0 - December 09, 2020 (451 KB)
1.5.2 - December 04, 2020 (448 KB)
1.5.1 - December 02, 2020 (446 KB)
1.5.0 - December 01, 2020 (446 KB)
1.4.2 - November 25, 2020 (441 KB)
1.4.1 - November 23, 2020 (441 KB)
1.4.0 - November 23, 2020 (433 KB)
1.3.1 - November 16, 2020 (440 KB)
1.3.0 - November 12, 2020 (440 KB)
1.2.0 - November 05, 2020 (436 KB)
1.1.0 - October 29, 2020 (432 KB)
1.0.0 - October 21, 2020 (424 KB)
0.93.1 - October 12, 2020 (422 KB)
0.93.0 - October 08, 2020 (421 KB)
0.92.0 - September 25, 2020 (420 KB)
0.91.1 - September 23, 2020 (419 KB)
0.91.0 - September 15, 2020 (419 KB)
0.90.0 - September 01, 2020 (415 KB)
0.89.1 - August 10, 2020 (408 KB)
0.89.0 - August 05, 2020 (408 KB)
0.88.0 - July 13, 2020 (396 KB)
0.87.1 - July 07, 2020 (392 KB)
0.87.0 - July 06, 2020 (391 KB)
0.86.0 - June 22, 2020 (386 KB)
0.85.1 - June 07, 2020 (382 KB)
0.85.0 - June 01, 2020 (381 KB)
0.84.0 - May 21, 2020 (377 KB)
0.83.0 - May 11, 2020 (405 KB)
0.82.0 - April 16, 2020 (403 KB)
0.81.0 - April 01, 2020 (400 KB)
0.80.1 - February 29, 2020 (398 KB)
0.80.0 - February 18, 2020 (397 KB)
0.79.0 - January 06, 2020 (394 KB)
0.78.0 - December 18, 2019 (392 KB)
0.77.0 - November 27, 2019 (391 KB)
0.76.0 - October 28, 2019 (388 KB)
0.75.1 - October 14, 2019 (387 KB)
0.75.0 - September 30, 2019 (387 KB)
0.74.0 - July 31, 2019 (382 KB)
0.73.0 - July 16, 2019 (380 KB)
0.72.0 - June 25, 2019 (378 KB)
0.71.0 - May 30, 2019 (414 KB)
0.70.0 - May 21, 2019 (413 KB)
0.69.0 - May 13, 2019 (412 KB)
0.68.1 - April 30, 2019 (412 KB)
0.68.0 - April 29, 2019 (412 KB)
0.67.2 - April 05, 2019 (421 KB)
0.67.1 - April 04, 2019 (421 KB)
0.67.0 - April 04, 2019 (421 KB)
0.66.0 - March 18, 2019 (417 KB)
0.65.0 - February 19, 2019 (413 KB)
0.64.0 - February 10, 2019 (411 KB)
0.63.1 - January 22, 2019 (410 KB)
0.63.0 - January 16, 2019 (410 KB)
0.62.0 - January 01, 2019 (406 KB)
0.61.1 - December 06, 2018 (405 KB)
0.61.0 - December 05, 2018 (405 KB)
0.60.0 - October 26, 2018 (401 KB)
0.59.2 - September 24, 2018 (400 KB)
0.59.1 - September 15, 2018 (399 KB)
0.59.0 - September 09, 2018 (399 KB)
0.58.2 - July 23, 2018 (394 KB)
0.58.1 - July 10, 2018 (394 KB)
0.58.0 - July 07, 2018 (393 KB)
0.57.2 - June 12, 2018 (391 KB)
0.57.1 - June 06, 2018 (391 KB)
0.57.0 - June 06, 2018 (391 KB)
0.56.0 - May 14, 2018 (387 KB)
0.55.0 - April 16, 2018 (383 KB)
0.54.0 - March 21, 2018 (380 KB)
0.53.0 - March 05, 2018 (377 KB)
0.52.1 - December 27, 2017 (363 KB)
0.52.0 - December 12, 2017 (358 KB)
0.51.0 - October 18, 2017 (333 KB)
0.50.0 - September 14, 2017 (328 KB) <-- this PR brings us to here
0.49.1 - May 29, 2017 (314 KB) <-- we were here

In the spirit of incremental improvements, I've bumped forward one version and fixed what came up.

Individual commit messages have more details on each change. **I recommend reviewing this commit-by-commit, as it makes a lot more sense**.