### PR TITLE
Temporarily lock msgpack version for Ruby 2.0 and 2.1

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -33,7 +33,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'msgpack'
+  if RUBY_VERSION >= '2.2.0'
+    spec.add_dependency 'msgpack'
+  else
+    # msgpack 1.4 fails for Ruby 2.0 and 2.1: https://github.com/msgpack/msgpack-ruby/issues/205
+    spec.add_dependency 'msgpack', '< 1.4'
+  end
 
   # Optional extensions
   # TODO: Move this to Appraisals?


### PR DESCRIPTION
The newest release of msgpack (1.4) is not currently compatible with Ruby 2.0 and 2.1.

This PR locks the msgpack version to < 1.4 until we know if support will be restored and completely dropped for these old rubies.