### PR TITLE
[PROF-2710] Fix missing instrumentation when using Thread.start/fork

### DIFF
--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -188,6 +188,9 @@ module Datadog
 
         private
 
+        # FIXME: Threads started with `start`/`fork` can wrongly trigger this warning, because unlike with Thread#new
+        # we can't distinguish between missing instrumentation and "thread was just started and hasn't had time to
+        # run update_native_ids"
         def warn_about_missing_cpu_time_instrumentation(thread)
           return if @warned_about_missing_cpu_time_instrumentation
 

--- a/lib/ddtrace/profiling/ext/cpu.rb
+++ b/lib/ddtrace/profiling/ext/cpu.rb
@@ -27,6 +27,7 @@ module Datadog
           # will provide a thread/clock ID for CPU timing.
           require 'ddtrace/profiling/ext/cthread'
           ::Thread.send(:prepend, Profiling::Ext::CThread)
+          ::Thread.singleton_class.send(:prepend, Datadog::Profiling::Ext::WrapThreadStartFork)
         end
 
         def self.unsupported_reason

--- a/lib/ddtrace/profiling/ext/cthread.rb
+++ b/lib/ddtrace/profiling/ext/cthread.rb
@@ -104,6 +104,30 @@ module Datadog
           pthread_getcpuclockid(pthread_id, clock).zero? ? clock[:value] : nil
         end
       end
+
+      # Threads in Ruby can be started by creating a new instance of `Thread` (or a subclass) OR by calling
+      # `start`/`fork` on `Thread` (or a subclass).
+      #
+      # This module intercepts calls to `start`/`fork`, ensuring that the `update_native_ids` operation is correctly
+      # called once the new thread starts.
+      #
+      # Note that unlike CThread above, this module should be prepended to the `Thread`'s singleton class, not to
+      # the class.
+      module WrapThreadStartFork
+        def start(*args)
+          # Wrap the work block with our own
+          # so we can retrieve the native thread ID within the thread's context.
+          wrapped_block = proc do |*t_args|
+            # Set native thread ID & clock ID
+            ::Thread.current.send(:update_native_ids)
+            yield(*t_args)
+          end
+
+          super(*args, &wrapped_block)
+        end
+
+        alias fork start
+      end
     end
   end
 end

--- a/lib/ddtrace/profiling/ext/cthread.rb
+++ b/lib/ddtrace/profiling/ext/cthread.rb
@@ -122,9 +122,11 @@ module Datadog
             ::Thread.current.send(:update_native_ids)
             yield(*t_args)
           end
+          wrapped_block.ruby2_keywords if wrapped_block.respond_to?(:ruby2_keywords, true)
 
           super(*args, &wrapped_block)
         end
+        ruby2_keywords :start if respond_to?(:ruby2_keywords, true)
 
         alias fork start
       end

--- a/spec/ddtrace/profiling/ext/cpu_spec.rb
+++ b/spec/ddtrace/profiling/ext/cpu_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe Datadog::Profiling::Ext::CPU do
       it 'adds Thread extensions' do
         apply!
         expect(Thread.ancestors).to include(Datadog::Profiling::Ext::CThread)
+        expect(Thread.singleton_class.ancestors).to include(Datadog::Profiling::Ext::WrapThreadStartFork)
       end
     end
 


### PR DESCRIPTION
When a `Thread` is started with either `start` or `fork` (they are aliases), then our `CThread#initialize` patch never gets run and thus these threads are not properly instrumented.

This API is used in Ruby's own built-in `timeout` gem (see <https://github.com/ruby/timeout/blob/14d421252b54027108da183783a7a26d0cf5aac1/lib/timeout.rb#L87>) although I'm not entirely sure how common it is in the community.

The behavior of skipping `#initialize` is by design, but it seems a rather weird API; here's what the docs say:

> Basically the same as ::new. However, if class Thread is subclassed,
> then calling start in that subclass will not invoke the subclass's
> initialize method.

(<https://rubyapi.org/3.0/o/thread#method-c-start>)

To fix this, we introduce a new module, which wraps these two operations to provide the expected behavior of installing the CPU instrumentation.

**NOTE**:
Due to the way the missing cpu time instrumentation warning works, Thread.start/fork will still trigger it, even if Threads are
instrumented correctly.

Since https://github.com/DataDog/dd-trace-rb/pull/1310 is still under review, for now I'm leaving it as a `FIXME` (and marking this PR as a draft), but this should be fixed before merging.

(I can't think of a 100% accurate way of fixing it, so possibly the fix will be along the lines of "track how long the thread
has lived, and if it was just created, don't warn yet -- wait a few seconds before considering it as missing instrumentation").

Hopefully at some point https://github.com/DataDog/dd-trace-rb/pull/1333 will become a better solution to all this messing around.