### PR TITLE
[PROF-2807] Fix Thread#initialize patch breaks keyword args in Ruby 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+# FIXME: We need to wait for https://github.com/ruby/ruby2_keywords/pull/14 to be merged before we can remove this and
+# release a version with this new dependency
+gem 'ruby2_keywords', git: 'https://github.com/DataDog/ruby2_keywords.git', branch: 'fix-support-for-old-rubies'
+
 # Development dependencies
 gem 'addressable', '~> 2.4.0' # locking transitive dependency of webmock
 gem 'appraisal', '~> 2.2'

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -39,6 +39,10 @@ Gem::Specification.new do |spec|
     spec.add_dependency 'msgpack', '< 1.4'
   end
 
+  # Support correct forwarding of arguments for both Ruby <= 2.6 and Ruby >= 3, see
+  # https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#a-compatible-delegation
+  spec.add_dependency 'ruby2_keywords'
+
   # Optional extensions
   spec.add_development_dependency 'ffi', '~> 1.0'
 

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -41,7 +41,9 @@ Gem::Specification.new do |spec|
 
   # Support correct forwarding of arguments for both Ruby <= 2.6 and Ruby >= 3, see
   # https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#a-compatible-delegation
-  spec.add_dependency 'ruby2_keywords'
+  # FIXME: We need to wait for https://github.com/ruby/ruby2_keywords/pull/14 to be merged before we can remove this and
+  # release a version with this new dependency
+  spec.add_dependency 'ruby2_keywords', '>= 0.0.5'
 
   # Optional extensions
   spec.add_development_dependency 'ffi', '~> 1.0'

--- a/lib/ddtrace/profiling/ext/cthread.rb
+++ b/lib/ddtrace/profiling/ext/cthread.rb
@@ -1,4 +1,5 @@
 require 'ffi'
+require 'ruby2_keywords'
 
 module Datadog
   module Profiling
@@ -31,7 +32,7 @@ module Datadog
         attr_reader \
           :native_thread_id
 
-        def initialize(*args)
+        ruby2_keywords def initialize(*args)
           @pid = ::Process.pid
           @native_thread_id = nil
           @clock_id = nil
@@ -42,7 +43,7 @@ module Datadog
             # Set native thread ID & clock ID
             update_native_ids
             yield(*t_args)
-          end
+          end.ruby2_keywords
 
           super(*args, &wrapped_block)
         end

--- a/spec/ddtrace/profiling/ext/cthread_spec.rb
+++ b/spec/ddtrace/profiling/ext/cthread_spec.rb
@@ -69,6 +69,19 @@ if Datadog::Profiling::Ext::CPU.supported?
           cpu_time: kind_of(Float)
         )
       end
+
+      it 'correctly forwards all received arguments to the passed proc' do
+        received_args = nil
+        received_kwargs = nil
+
+        thread_class.new(1, 2, 3, four: 4, five: 5) do |*args, **kwargs|
+          received_args = args
+          received_kwargs = kwargs
+        end.join
+
+        expect(received_args).to eq [1, 2, 3]
+        expect(received_kwargs).to eq(four: 4, five: 5)
+      end
     end
 
     describe '#native_thread_id' do


### PR DESCRIPTION
This incompatible change in Ruby 3.0 is documented in
<https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/>
and the approach used is the one described in
<https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#a-compatible-delegation>

I believe the `ruby2_keywords` is our best option, because we want to
support all rubies from 2.0 on, so we can't use some of the more modern
alternatives (such as `...`).

For the reviewers: Would it make sense to vendor the `ruby2_keywords`
gem instead of depending on it? The license is
[2-Clause BSD](https://github.com/ruby/ruby2_keywords/blob/master/LICENSE)
so it seems like a reasonable candidate, if we'd prefer to go that
route.