### PR TITLE
Add ability to easily remove long paths from backtrace

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1865,6 +1865,7 @@ Available options are:
  - `diagnostics.startup_logs.enabled`: Startup configuration and diagnostic log. Defaults to `true`. Can be configured through the `DD_TRACE_STARTUP_LOGS` environment variable.
  - `diagnostics.debug`: set to true to enable debug logging. Can be configured through the `DD_TRACE_DEBUG` environment variable. Defaults to `false`.
  - `time_now_provider`: when testing, it might be helpful to use a different time provider. For Timecop, for example, `->{ Time.now_without_mock_time }` allows the tracer to use the real wall time. Span duration calculation will still use the system monotonic clock when available, thus not being affected by this setting. Defaults to `->{ Time.now }`.
+ - `error_backtrace_strip`: to avoid verbose error backtraces including long Rails install or Bundler path names you can provide a String or Regexp to have removed. This defaults to removing the Rails root path and the Bundler bundle path (`/(Rails.root|Bundler.bundle_path)/`). Set to `nil` to disable.
 
 #### Custom logging
 

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -241,6 +241,24 @@ module Datadog
         option :transport_options, default: ->(_i) { {} }, lazy: true # TODO: Deprecate
         option :writer # TODO: Deprecate
         option :writer_options, default: ->(_i) { {} }, lazy: true # TODO: Deprecate
+
+        option :error_backtrace_strip do |o|
+          o.default do
+            paths = []
+            if defined?(Rails) && Rails.respond_to?(:root)
+              paths << Rails.root.to_s
+            end
+            if defined?(Bundler) && Bundler.respond_to?(:bundle_path)
+              paths << Bundler.bundle_path.to_s
+            end
+
+            next if paths.empty?
+
+            group = paths.map { |p| Regexp.escape(p) }.join("|")
+            /(#{group})\/?/
+          end
+          o.lazy
+        end
       end
 
       # Backwards compatibility for configuring tracer e.g. `c.tracer debug: true`


### PR DESCRIPTION
This adds the ability to automatically strip long paths from `Rails.root` and `Bundler.bundle_path` from the error backtrace tag allowing for more readable backtraces when view in the Datadog trace view. Originally we implemented this as a span processor but I figured it might be worthwhile to A) provide this with some sensible stripping out of the box B) expose a simple configuration option so people don't need to roll their own.