### PR TITLE
Publish profiling gem test builds to separate folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,7 +353,9 @@ jobs:
             sed lib/ddtrace/version.rb -i -e "s/^\([\t ]*PRE\) *=*/\1 = \'${PRE}\' #/g"
       - run:
           name: Upload prereleas Gem and rebuild index
-          command: S3_DIR=prerelease bundle exec rake release:gem
+          # TODO: Temporarily changed as a workaround (see commit message for more details). Should be undone before we merge
+          # the profiling feature back into master.
+          command: S3_DIR=profiling-prerelease bundle exec rake release:gem
       - store_artifacts:
           path: pkg/
           destination: gem

--- a/Appraisals
+++ b/Appraisals
@@ -379,6 +379,7 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'active_model_serializers', '>= 0.10.0'
       gem 'activerecord', '< 5.1.5'
       gem 'aws-sdk'
+      gem 'aws-partitions', '< 1.424.0' # TODO: Locked until https://github.com/aws/aws-sdk-ruby/pull/2474 gets released (1.425.0 is broken)
       gem 'concurrent-ruby'
       gem 'dalli'
       gem 'delayed_job'


### PR DESCRIPTION
In certain situations (example below), when consuming a gem build from
our test builds source, bundler will decide to start pulling A LOT of
metadata, which makes `bundle install` so slow that it just seems to
hang (`bundle install -V` reveals that it's not hung).

@pawelchcki suggested that we try publishing to a new, separate folder,
so that there's less metadata to pull, until we find a real fix.

So let's try it out!

The issue can currently be reproduced using the following `Dockerfile`:

```
FROM alpine:3 AS base
RUN echo -e "source 'https://rubygems.org'\n \
\n \
source 'http://gems.datadoghq.com/prerelease' do \n\
  gem 'ddtrace', '0.45.0.feature.profiling.109457' \n\
end \n\
" > Gemfile && \
echo -e "GEM\n\
  remote: https://rubygems.org/\n\
  specs:\n\
\n\
PLATFORMS\n\
  ruby\n\
\n\
DEPENDENCIES\n\
\n\
BUNDLED WITH\n\
   2.1.4\n\
\n\
" > Gemfile.lock
FROM ruby:2.7 AS ruby27
COPY --from=base Gemfile Gemfile.lock .
RUN bundle install -V 2>&1 | tee log
FROM alpine:3 as fin
COPY --from=ruby27 log ./ruby27.log
```

(The trigger for this issue seems to be an existing `Gemfile.lock`.
Without it, bundler is speedy and works as expected)