### PR TITLE
Avoid declaring dependency on unreleased version of ruby2_keywords

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-# FIXME: We need to wait for https://github.com/ruby/ruby2_keywords/pull/14 to be merged before we can remove this and
-# release a version with this new dependency
-gem 'ruby2_keywords', git: 'https://github.com/DataDog/ruby2_keywords.git', branch: 'fix-support-for-old-rubies'
+# FIXME: Use release from git until 0.0.5 is released. See more details in ddtrace.gemspec
+gem 'ruby2_keywords', git: 'https://github.com/ruby/ruby2_keywords.git'
 
 # Development dependencies
 gem 'addressable', '~> 2.4.0' # locking transitive dependency of webmock

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -41,9 +41,11 @@ Gem::Specification.new do |spec|
 
   # Support correct forwarding of arguments for both Ruby <= 2.6 and Ruby >= 3, see
   # https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#a-compatible-delegation
-  # FIXME: We need to wait for https://github.com/ruby/ruby2_keywords/pull/14 to be merged before we can remove this and
-  # release a version with this new dependency
-  spec.add_dependency 'ruby2_keywords', '>= 0.0.5'
+  # FIXME: We need to wait for version >= 0.0.5 to be released before we can use this dependency in a released version of our gem,
+  # as version 0.0.4 is incompatible with Ruby <= 2.1 (see https://github.com/ruby/ruby2_keywords/pull/14 for more details)
+  # For now we still go with the old version, to at least enable private beta customers to help us testing the profiler
+  spec.add_dependency 'ruby2_keywords', '>= 0.0.4'
+  # spec.add_dependency 'ruby2_keywords', '>= 0.0.5'
 
   # Optional extensions
   spec.add_development_dependency 'ffi', '~> 1.0'


### PR DESCRIPTION
In #1345 I added the `ruby2_keyword` gems (which is maintained by the Ruby VM developers) to provide a compatibility shim that helps us support both Ruby 3.0 and older rubies in the same codebase.

During development of that PR, I discovered that the currently-released version of `ruby2_keywords` (0.0.4 as I write this) was broken for really old rubies -- 2.1 and below.

The good news is that I got in contact with upstream and submitted a PR to fix this, which was merged, but the bad news is that upstream hasn't released the fix yet.

The worse news is because I added '>= 0.0.5' as a dependency in our `gemspec`, this dependency on an unreleased version means that customers in private beta helping us test the profiler just get an error for a missing dependency when they try to import our library.

So, for now, let's declare a dependency on the latest released version. I don't believe any of our private beta customers are on such old rubies, and if they are, they will see an error coming from `ruby2_keywords` and we can work with them to get them to use the unreleased version.

Also note: This PR is targeting the profiling feature branch, so it cannot cause ANY impact on regular customers.