### PR TITLE
Revert "Workaround bug in upstream aws-partitions gem that breaks CI for 2.2"

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -379,7 +379,6 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'active_model_serializers', '>= 0.10.0'
       gem 'activerecord', '< 5.1.5'
       gem 'aws-sdk'
-      gem 'aws-partitions', '< 1.424.0' # TODO: Locked until https://github.com/aws/aws-sdk-ruby/pull/2474 gets released (1.425.0 is broken)
       gem 'concurrent-ruby'
       gem 'dalli'
       gem 'delayed_job'


### PR DESCRIPTION
No longer needed; upstream has released the fix.