### PR TITLE
Drop dependency on ruby2_keywords gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-# FIXME: Use release from git until 0.0.5 is released. See more details in ddtrace.gemspec
-gem 'ruby2_keywords', git: 'https://github.com/ruby/ruby2_keywords.git'
-
 # Development dependencies
 gem 'addressable', '~> 2.4.0' # locking transitive dependency of webmock
 gem 'appraisal', '~> 2.2'

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -39,14 +39,6 @@ Gem::Specification.new do |spec|
     spec.add_dependency 'msgpack', '< 1.4'
   end
 
-  # Support correct forwarding of arguments for both Ruby <= 2.6 and Ruby >= 3, see
-  # https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#a-compatible-delegation
-  # FIXME: We need to wait for version >= 0.0.5 to be released before we can use this dependency in a released version of our gem,
-  # as version 0.0.4 is incompatible with Ruby <= 2.1 (see https://github.com/ruby/ruby2_keywords/pull/14 for more details)
-  # For now we still go with the old version, to at least enable private beta customers to help us testing the profiler
-  spec.add_dependency 'ruby2_keywords', '>= 0.0.4'
-  # spec.add_dependency 'ruby2_keywords', '>= 0.0.5'
-
   # Optional extensions
   spec.add_development_dependency 'ffi', '~> 1.0'
 

--- a/lib/ddtrace/profiling/ext/cthread.rb
+++ b/lib/ddtrace/profiling/ext/cthread.rb
@@ -1,5 +1,4 @@
 require 'ffi'
-require 'ruby2_keywords'
 
 module Datadog
   module Profiling
@@ -31,7 +30,7 @@ module Datadog
         attr_reader \
           :native_thread_id
 
-        ruby2_keywords def initialize(*args)
+        def initialize(*args)
           @pid = ::Process.pid
           @native_thread_id = nil
           @clock_id = nil
@@ -42,10 +41,12 @@ module Datadog
             # Set native thread ID & clock ID
             update_native_ids
             yield(*t_args)
-          end.ruby2_keywords
+          end
+          wrapped_block.ruby2_keywords if wrapped_block.respond_to?(:ruby2_keywords, true)
 
           super(*args, &wrapped_block)
         end
+        ruby2_keywords :initialize if respond_to?(:ruby2_keywords, true)
 
         def clock_id
           update_native_ids if forked?


### PR DESCRIPTION
Inspired by <https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html> I've decided to adopt the `respond_to?` approach to only call `ruby2_keywords` on rubies that need it, and thus workaround any issues around needing an unreleased fix to support old Rubies.