### PR TITLE
Fix failure to load libpthread when development package is not installed

### DIFF
--- a/lib/ddtrace/profiling/ext/cthread.rb
+++ b/lib/ddtrace/profiling/ext/cthread.rb
@@ -12,7 +12,7 @@ module Datadog
       # Extension used to enable CPU-time profiling via use of Pthread's `getcpuclockid`.
       module CThread
         extend FFI::Library
-        ffi_lib 'ruby', 'pthread'
+        ffi_lib 'ruby', ['pthread', 'libpthread.so.0']
         attach_function :rb_nativethread_self, [], :ulong
         attach_function :pthread_getcpuclockid, [:ulong, CClockId], :int
 


### PR DESCRIPTION
To search for `pthread`, FFI goes through the usual folders for system libraries (`/usr/lib`, etc...) and tries to find a file called `libpthread.so`.

This file is then parsed to find out the real name of the library .so -- in this case `libpthread.so.0` -- which can then be `dl_open`ed.

(Curiously enough, on Ubuntu 20.04, libc actually handles this lookup of `libpthread.so` -> `libpthread.so.0` automatically when `dl_open` is called, whereas on Ubuntu 16.04 it doesn't and the FFI gem implements this behavior using regular Ruby code. Nice!)

When the `libpthread.so` file is missing (on Ubuntu, this happens when the `libc6-dev` package is not installed) trying to load `pthread` will fail with the following error:

> LoadError (Could not open library 'pthread': pthread: cannot open shared object file: No such file or directory.)
> Could not open library 'libpthread.so': libpthread.so: cannot open shared object file: No such file or directory

This issue is actually documented in the FFI wiki at <https://github.com/ffi/ffi/wiki/Loading-Libraries>, where they say:

> When you install `libfoo` on a Debian or RedHat based Linux system, it will install `libfoo.so.1` but will not install `libfoo.so`. Linux package maintainers will put the `libfoo.so` file into a development package (`libfoo-dev` on Debian or `libfoo-devel` on RedHat). To prevent users from having to install both the library package _and_ the development package:
>
>     ffi_lib ['foo', 'libfoo.so.1']

This is exactly our issue -- , and the fix is then to add a second, alternative name for `pthread`: `libpthread.so.0`. With this fix, I was able to get ffi to load pthreads, even on setups without `libc6-dev` installed (such as the official gitlab docker image).

Further note: Why `.so.0`? This value is defined by the GNU C Library (at least on distributions that use it) -- in their source tree there are a few `shlib-versions` files, one of which defines `libpthread=0` which is the ABI version for this library, which hasn't changed since its introduction.