### PR TITLE
[ci] Faster JRuby startup with dev mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ test_containers:
         default: false
   - &container_base_environment
     BUNDLE_GEMFILE: /app/Gemfile
+    JRUBY_OPTS: --dev # Faster JVM startup: https://github.com/jruby/jruby/wiki/Improving-startup-time#use-the---dev-flag
   - &container_parameters_environment
     - *container_base_environment
     - RUBY_OPT: <<# parameters.jit >>--jit<</ parameters.jit >>


### PR DESCRIPTION
Use the [`--dev`](https://github.com/jruby/jruby/wiki/Improving-startup-time#use-the---dev-flag) option for JRuby in CI.

This yields faster startup times in CircleCI:

```
# echo $JRUBY_OPTS
--dev
# hyperfine "ruby -e ''"
Benchmark #1: ruby -e ''
  Time (mean ± σ):      1.173 s ±  0.059 s    [User: 1.701 s, System: 0.145 s]
  Range (min … max):    1.095 s …  1.301 s    10 runs

# unset JRUBY_OPTS
# hyperfine "ruby -e ''"
Benchmark #1: ruby -e ''
  Time (mean ± σ):      1.411 s ±  0.073 s    [User: 3.872 s, System: 0.158 s]
  Range (min … max):    1.315 s …  1.521 s    10 runs
```

Because our CI suite runs many short-lived instances of Ruby, this reduces the JRuby CI steps execution time by 20-40%.