### PR TITLE
Add EventBridge to supported AWS services

### DIFF
--- a/lib/ddtrace/contrib/aws/services.rb
+++ b/lib/ddtrace/contrib/aws/services.rb
@@ -52,6 +52,7 @@ module Datadog
         ElasticLoadBalancingV2
         ElasticTranscoder
         ElasticsearchService
+        EventBridge
         Firehose
         GameLift
         Glacier


### PR DESCRIPTION
Hi, I'm using ddtrace AWS integration to be able to track every interaction with AWS services in Datadog.

I've noticed that the calls to EventBridge API seem to be missing though.

I think simply adding `EventBridge` to the list of supported AWS services should enable that tracking.

[aws-sdk-eventbridge](https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge) gem uses AWS Seahorse Client (like all the other AWS services), so I reckon it should "just work".

I checked that `:EventBridge` exists in `::Aws.constants`, so it won't get filtered out in https://github.com/DataDog/dd-trace-rb/blob/1343922a2c5fe921c22e1482625f09679db383e5/lib/ddtrace/contrib/aws/patcher.rb#L34