### PR TITLE
Backport #1329 to master -- Fix potential race during initialization of ddtrace components

### DIFF
--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -18,7 +18,8 @@ module Datadog
     # Note that a Mutex **IS NOT** reentrant: the same thread cannot grab the same Mutex more than once.
     # This means below we are careful not to nest calls to methods that grab the lock.
     #
-    # Every method that directly or indirectly accesses/mutates @components should be holding the lock while doing so.
+    # Every method that directly or indirectly accesses/mutates @components should be holding the lock (through
+    # #safely_synchronize) while doing so.
     COMPONENTS_LOCK = Mutex.new
     private_constant :COMPONENTS_LOCK
 
@@ -32,7 +33,7 @@ module Datadog
       if target.is_a?(Settings)
         yield(target) if block_given?
 
-        COMPONENTS_LOCK.synchronize do
+        safely_synchronize do
           # Build immutable components from settings
           @components ||= nil
           @components = if @components
@@ -62,14 +63,7 @@ module Datadog
         @temp_logger = nil
         current_components.logger
       else
-        # Use default logger without initializing components.
-        # This prevents recursive loops while initializing.
-        # e.g. Get logger --> Build components --> Log message --> Repeat...
-        @temp_logger ||= begin
-          logger = configuration.logger.instance || Datadog::Logger.new(STDOUT)
-          logger.level = configuration.diagnostics.debug ? ::Logger::DEBUG : configuration.logger.level
-          logger
-        end
+        logger_without_components
       end
     end
 
@@ -83,7 +77,7 @@ module Datadog
     #
     # Components won't be automatically reinitialized after a shutdown.
     def shutdown!
-      COMPONENTS_LOCK.synchronize do
+      safely_synchronize do
         @components.shutdown! if components?
       end
     end
@@ -94,7 +88,7 @@ module Datadog
     # In contrast with +#shutdown!+, components will be automatically
     # reinitialized after a reset.
     def reset!
-      COMPONENTS_LOCK.synchronize do
+      safely_synchronize do
         @components.shutdown! if components?
         @components = nil
       end
@@ -103,12 +97,27 @@ module Datadog
     protected
 
     def components
-      COMPONENTS_LOCK.synchronize do
+      safely_synchronize do
         @components ||= build_components(configuration)
       end
     end
 
     private
+
+    def safely_synchronize
+      COMPONENTS_LOCK.synchronize do
+        begin
+          yield
+        rescue ThreadError => e
+          logger_without_components.warn(
+            'Detected deadlock during ddtrace initialization. ' \
+            'Please report this at https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug' \
+            "\n\tSource:\n\t#{e.backtrace.join("\n\t")}"
+          )
+          nil
+        end
+      end
+    end
 
     def components?
       # This does not need to grab the COMPONENTS_LOCK because it's not returning the components
@@ -127,6 +136,17 @@ module Datadog
       old.shutdown!(components)
       components.startup!(settings)
       components
+    end
+
+    def logger_without_components
+      # Use default logger without initializing components.
+      # This prevents recursive loops while initializing.
+      # e.g. Get logger --> Build components --> Log message --> Repeat...
+      @temp_logger ||= begin
+        logger = configuration.logger.instance || Datadog::Logger.new(STDOUT)
+        logger.level = configuration.diagnostics.debug ? ::Logger::DEBUG : configuration.logger.level
+        logger
+      end
     end
   end
 end

--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -109,7 +109,7 @@ module Datadog
         begin
           yield
         rescue ThreadError => e
-          logger_without_components.warn(
+          logger_without_components.error(
             'Detected deadlock during ddtrace initialization. ' \
             'Please report this at https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug' \
             "\n\tSource:\n\t#{e.backtrace.join("\n\t")}"

--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'thread'
 
 require 'ddtrace/configuration/pin_setup'
 require 'ddtrace/configuration/settings'
@@ -8,6 +9,18 @@ module Datadog
   # Configuration provides a unique access point for configurations
   module Configuration
     extend Forwardable
+
+    # Used to ensure that @components initialization/reconfiguration is performed one-at-a-time, by a single thread.
+    #
+    # This is important because components can end up being accessed from multiple application threads (for instance on
+    # a threaded webserver), and we don't want their initialization to clash (for instance, starting two profilers...).
+    #
+    # Note that a Mutex **IS NOT** reentrant: the same thread cannot grab the same Mutex more than once.
+    # This means below we are careful not to nest calls to methods that grab the lock.
+    #
+    # Every method that directly or indirectly accesses/mutates @components should be holding the lock while doing so.
+    COMPONENTS_LOCK = Mutex.new
+    private_constant :COMPONENTS_LOCK
 
     attr_writer :configuration
 
@@ -19,13 +32,15 @@ module Datadog
       if target.is_a?(Settings)
         yield(target) if block_given?
 
-        # Build immutable components from settings
-        @components ||= nil
-        @components = if @components
-                        replace_components!(target, @components)
-                      else
-                        build_components(target)
-                      end
+        COMPONENTS_LOCK.synchronize do
+          # Build immutable components from settings
+          @components ||= nil
+          @components = if @components
+                          replace_components!(target, @components)
+                        else
+                          build_components(target)
+                        end
+        end
 
         target
       else
@@ -40,9 +55,12 @@ module Datadog
       :tracer
 
     def logger
-      if instance_variable_defined?(:@components) && @components
+      # avoid initializing components if they didn't already exist
+      current_components = components? && components
+
+      if current_components
         @temp_logger = nil
-        components.logger
+        current_components.logger
       else
         # Use default logger without initializing components.
         # This prevents recursive loops while initializing.
@@ -65,7 +83,9 @@ module Datadog
     #
     # Components won't be automatically reinitialized after a shutdown.
     def shutdown!
-      components.shutdown! if instance_variable_defined?(:@components) && @components
+      COMPONENTS_LOCK.synchronize do
+        @components.shutdown! if components?
+      end
     end
 
     # Gracefully shuts down the tracer and disposes of component references,
@@ -74,17 +94,26 @@ module Datadog
     # In contrast with +#shutdown!+, components will be automatically
     # reinitialized after a reset.
     def reset!
-      shutdown!
-      @components = nil
+      COMPONENTS_LOCK.synchronize do
+        @components.shutdown! if components?
+        @components = nil
+      end
     end
 
     protected
 
     def components
-      @components ||= build_components(configuration)
+      COMPONENTS_LOCK.synchronize do
+        @components ||= build_components(configuration)
+      end
     end
 
     private
+
+    def components?
+      # This does not need to grab the COMPONENTS_LOCK because it's not returning the components
+      (defined?(@components) && @components) != nil
+    end
 
     def build_components(settings)
       components = Components.new(settings)

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -358,6 +358,14 @@ RSpec.describe Datadog::Configuration do
       subject(:logger) { test_class.logger }
       it { is_expected.to be_a_kind_of(Datadog::Logger) }
       it { expect(logger.level).to be default_log_level }
+
+      context 'when components are not initialized' do
+        it 'does not cause them to be initialized' do
+          logger
+
+          expect(test_class.send(:components?)).to be false
+        end
+      end
     end
 
     describe '#runtime_metrics' do
@@ -397,7 +405,7 @@ RSpec.describe Datadog::Configuration do
       let!(:original_components) { test_class.send(:components) }
 
       it 'gracefully shuts down components' do
-        expect(test_class).to receive(:shutdown!)
+        expect(original_components).to receive(:shutdown!)
 
         reset!
       end

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -416,5 +416,44 @@ RSpec.describe Datadog::Configuration do
         expect(test_class.send(:components)).to_not be(original_components)
       end
     end
+
+    describe '#safely_synchronize' do
+      it 'runs the given block while holding the COMPONENTS_LOCK' do
+        block_ran = false
+
+        test_class.send(:safely_synchronize) do
+          block_ran = true
+          expect(described_class.const_get(:COMPONENTS_LOCK)).to be_owned
+        end
+
+        expect(block_ran).to be true
+      end
+
+      it 'returns the value of the given block' do
+        expect(test_class.send(:safely_synchronize) { :returned_value }).to be :returned_value
+      end
+
+      context 'when recursive execution triggers a deadlock' do
+        subject(:safely_synchronize) { test_class.send(:safely_synchronize) { test_class.send(:safely_synchronize) } }
+
+        before do
+          allow(test_class.send(:logger_without_components)).to receive(:warn)
+        end
+
+        it 'logs an error' do
+          expect(test_class.send(:logger_without_components)).to receive(:warn).with(/Detected deadlock/)
+
+          safely_synchronize
+        end
+
+        it 'does not let the exception propagate' do
+          expect { safely_synchronize }.to_not raise_error
+        end
+
+        it 'returns nil' do
+          expect(safely_synchronize).to be nil
+        end
+      end
+    end
   end
 end

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -437,11 +437,11 @@ RSpec.describe Datadog::Configuration do
         subject(:safely_synchronize) { test_class.send(:safely_synchronize) { test_class.send(:safely_synchronize) } }
 
         before do
-          allow(test_class.send(:logger_without_components)).to receive(:warn)
+          allow(test_class.send(:logger_without_components)).to receive(:error)
         end
 
         it 'logs an error' do
-          expect(test_class.send(:logger_without_components)).to receive(:warn).with(/Detected deadlock/)
+          expect(test_class.send(:logger_without_components)).to receive(:error).with(/Detected deadlock/)
 
           safely_synchronize
         end


### PR DESCRIPTION
See #1329 for details. The commits are unchanged, I just cherry-picked them to master and added a note to mention they're backports.

(To avoid having these backports, I've started to target master first when I do these kinds of general fixes, but this one was started long ago and within the scope of the profiler and thus was merged to the profiling branch first)