### PR TITLE
Add Ruby integration test app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -473,50 +473,50 @@ workflows:
       # Integration
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.0
-          integration_apps: 'rack'
+          integration_apps: 'ruby rack'
           ruby_version: '2.0'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.1
-          integration_apps: 'rack'
+          integration_apps: 'ruby rack'
           ruby_version: '2.1'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.2
-          integration_apps: 'rack'
+          integration_apps: 'ruby rack'
           ruby_version: '2.2'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.3
-          integration_apps: 'rack rails-five'
+          integration_apps: 'ruby rack rails-five'
           ruby_version: '2.3'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.4
-          integration_apps: 'rack rails-five'
+          integration_apps: 'ruby rack rails-five'
           ruby_version: '2.4'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.5
-          integration_apps: 'rack rails-five'
+          integration_apps: 'ruby rack rails-five'
           ruby_version: '2.5'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.6
-          integration_apps: 'rack rails-five'
+          integration_apps: 'ruby rack rails-five'
           ruby_version: '2.6'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.7
-          integration_apps: 'rack rails-five'
+          integration_apps: 'ruby rack rails-five'
           ruby_version: '2.7'
           <<: *filters_all_branches_and_tags
-      # TODO: Get apps working with Ruby 3.0
-      # - orb/build_and_test_integration:
-      #     name: build_and_test_integration-3.0
-      #     integration_apps: 'rack rails-five'
-      #     ruby_version: '3.0'
-      #     <<: *filters_all_branches_and_tags
+      - orb/build_and_test_integration:
+          name: build_and_test_integration-3.0
+          # TODO: Get Rack & Rails apps working with Ruby 3.0
+          integration_apps: 'ruby'
+          ruby_version: '3.0'
+          <<: *filters_all_branches_and_tags
       # MRI
       - orb/build:
           <<: *config-2_0

--- a/integration/apps/rack/README.md
+++ b/integration/apps/rack/README.md
@@ -38,7 +38,6 @@ Within the container, run `bin/run <process>` where `<process>` is one of the fo
 
  - `puma`: Puma web server
  - `unicorn`: Unicorn web server
- - `console`: Rails console
  - `irb`: IRB session
 
  Alternatively, set `DD_DEMO_ENV_PROCESS` to run a particular process by default when `bin/run` is run.

--- a/integration/apps/ruby/.dockerignore
+++ b/integration/apps/ruby/.dockerignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/integration/apps/ruby/.envrc.sample
+++ b/integration/apps/ruby/.envrc.sample
@@ -1,0 +1,1 @@
+export DD_API_KEY=<Your Datadog API key here>

--- a/integration/apps/ruby/.gitignore
+++ b/integration/apps/ruby/.gitignore
@@ -1,0 +1,2 @@
+.envrc
+.byebug_history

--- a/integration/apps/ruby/Dockerfile
+++ b/integration/apps/ruby/Dockerfile
@@ -1,0 +1,25 @@
+# Select base image
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+# Setup directory
+RUN mkdir /app
+WORKDIR /app
+
+# Setup specific version of ddtrace, if specified.
+ARG ddtrace_git
+ENV DD_DEMO_ENV_GEM_GIT_DDTRACE ${ddtrace_git}
+
+ARG ddtrace_ref
+ENV DD_DEMO_ENV_GEM_REF_DDTRACE ${ddtrace_ref}
+
+# Install dependencies
+COPY Gemfile /app/Gemfile
+RUN bundle install
+
+# Add files
+COPY . /app
+
+# Set entrypoint
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["bin/setup && bin/run"]

--- a/integration/apps/ruby/Dockerfile-ci
+++ b/integration/apps/ruby/Dockerfile-ci
@@ -1,0 +1,11 @@
+# Select base image
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+# Add gem
+COPY . /vendor/dd-trace-rb
+
+# Install dependencies
+# Setup specific version of ddtrace, if specified.
+ENV DD_DEMO_ENV_GEM_LOCAL_DDTRACE /vendor/dd-trace-rb
+RUN bundle install

--- a/integration/apps/ruby/Gemfile
+++ b/integration/apps/ruby/Gemfile
@@ -1,0 +1,11 @@
+require 'datadog/demo_env'
+
+source 'https://rubygems.org' do
+  gem 'ffi'
+  gem 'google-protobuf'
+
+  # Choose correct specs for 'ddtrace' demo environment
+  gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
+
+  gem 'byebug'
+end

--- a/integration/apps/ruby/README.md
+++ b/integration/apps/ruby/README.md
@@ -1,0 +1,70 @@
+# Ruby: Demo application for Datadog APM
+
+A generic Ruby application with some common use scenarios.
+
+For generating Datadog APM traces and profiles.
+
+## Installation
+
+Install [direnv](https://github.com/direnv/direnv) for applying local settings.
+
+1. `cp .envrc.sample .envrc` and add your Datadog API key.
+2. `direnv allow` to load the env var.
+4. `docker-compose run --rm app bin/setup`
+
+## Running the application
+
+### To monitor performance of Docker containers with Datadog
+
+```sh
+docker run --rm --name dd-agent  -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e API_KEY=$DD_API_KEY datadog/docker-dd-agent:latest
+```
+
+### Starting the application
+
+Run `docker-compose up` to auto-start the application.
+
+Alternatively, you can run it manually with:
+
+```sh
+docker-compose run --rm app bin/run <process>
+```
+
+The `<process>` argument is optional, and will default to `DD_DEMO_ENV_PROCESS` if not provided. See [Processes](#processes) for more details.
+
+##### Processes
+
+Within the container, run `bin/run <process>` where `<process>` is one of the following values:
+
+ - `fibonacci`: Fibonacci number generator
+ - `irb`: IRB session
+
+ Alternatively, set `DD_DEMO_ENV_PROCESS` to run a particular process by default when `bin/run` is run.
+
+##### Features
+
+Set `DD_DEMO_ENV_PROCESS` to a comma-delimited list of any of the following values to activate the feature:
+
+ - `tracing`: Tracing instrumentation
+ - `profiling`: Profiling (NOTE: Must also set `DD_PROFILING_ENABLED` to match.)
+ - `debug`: Enable diagnostic debug mode
+ - `analytics`: Enable trace analytics
+ - `runtime_metrics`: Enable runtime metrics
+ - `pprof_to_file`: Dump profiling pprof to file instead of agent.
+
+e.g. `DD_DEMO_ENV_PROCESS=tracing,profiling`
+
+### Running integration tests
+
+You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`)
+
+```sh
+./script/build-images -v <RUBY_VERSION>
+./script/ci -v <RUBY_VERSION>
+```
+
+Or inside a running container:
+
+```sh
+./bin/test
+```

--- a/integration/apps/ruby/agent.yaml
+++ b/integration/apps/ruby/agent.yaml
@@ -1,0 +1,3 @@
+use_dogstatsd: true
+dogstatsd_port: 8125
+dogstatsd_non_local_traffic: true

--- a/integration/apps/ruby/app/datadog.rb
+++ b/integration/apps/ruby/app/datadog.rb
@@ -1,0 +1,13 @@
+require 'datadog/demo_env'
+require 'ddtrace'
+
+Datadog.configure do |c|
+  c.diagnostics.debug = true if Datadog::DemoEnv.feature?('debug')
+  c.analytics_enabled = true if Datadog::DemoEnv.feature?('analytics')
+  c.runtime_metrics.enabled = true if Datadog::DemoEnv.feature?('runtime_metrics')
+
+  if Datadog::DemoEnv.feature?('pprof_to_file')
+    # Reconfigure transport to write pprof to file
+    c.profiling.exporter.transport = Datadog::DemoEnv.profiler_file_transport
+  end
+end

--- a/integration/apps/ruby/app/fibonacci.rb
+++ b/integration/apps/ruby/app/fibonacci.rb
@@ -1,0 +1,58 @@
+require_relative 'datadog'
+
+def fib(n)
+  n <= 1 ? n : fib(n-1) + fib(n-2)
+end
+
+def trace(*options, &block)
+  raise ArgumentError('Must provide trace block') unless block_given?
+
+  if Datadog::DemoEnv.feature?('tracing')
+    Datadog.tracer.trace(*options, &block)
+  else
+    yield
+  end
+end
+
+def generate_fib
+  loop do
+    n = rand(25..35)
+
+    trace('compute.fibonacci') do |span|
+      result = fib(n)
+      span.set_metric('operation.fibonacci.n', n)
+      span.set_metric('operation.fibonacci.result', result)
+      yield(span) if block_given?
+    end
+
+    sleep(0.1)
+  end
+end
+
+if defined?(Ractor)
+  # Ractor version
+  # DEV: Disabled for now because Ractors cannot access ENV.
+  #      This results in a shareable-object violation.
+  #      Enable when we figure out how to make DemoEnv ractor-safe.
+
+  # require 'securerandom'
+  # ractors = []
+
+  # 3.times do |i|
+  #   ractors << Ractor.new do
+  #     ractor_id = SecureRandom.uuid
+  #     generate_fib { |span| span.set_tag('ractor.id', ractor_id) }
+  #   end
+  # end
+
+  # # Wait indefinitely for ractors
+  # loop do
+  #   ractors.collect(&:take)
+  # end
+  
+  # DEV: Use single-threaded version instead for now...
+  generate_fib
+else
+  # Single-threaded version
+  generate_fib
+end

--- a/integration/apps/ruby/bin/run
+++ b/integration/apps/ruby/bin/run
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+# Start application process
+puts "\n== Starting application process =="
+
+profiling = Datadog::DemoEnv.feature?('profiling') ? 'DD_PROFILING_ENABLED=true ddtracerb exec ' : ''
+process = (ARGV[0] || Datadog::DemoEnv.process)
+command = case process
+          when 'fibonacci'
+            "bundle exec ruby app/fibonacci.rb"
+          when 'irb'
+            "bundle exec #{profiling}irb"
+          when nil, ''
+            abort("\n== ERROR: Must specify a application process! ==")
+          else
+            abort("\n== ERROR: Unknown application process '#{process}' ==")
+          end
+
+puts "Run: #{command}"
+Kernel.exec(command)

--- a/integration/apps/ruby/bin/setup
+++ b/integration/apps/ruby/bin/setup
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+require 'fileutils'
+include FileUtils
+
+# path to your application root.
+APP_ROOT = File.expand_path('..', __dir__)
+
+def system!(*args)
+  puts "Run: #{args.join(' ')}"
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+chdir APP_ROOT do
+  puts "\n== Installing dependencies =="
+  system! 'gem install bundler --conservative'
+  system('bundle check') || system!('bundle install')
+end

--- a/integration/apps/ruby/bin/test
+++ b/integration/apps/ruby/bin/test
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+require 'fileutils'
+include FileUtils
+
+# path to your application root.
+APP_ROOT = File.expand_path('..', __dir__)
+
+def system!(*args)
+  puts "Run: #{args.join(' ')}"
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+chdir APP_ROOT do
+  puts "\n== Performing setup =="
+  system!('./bin/setup')
+
+  puts "\n== Run test suite =="
+  # DEV: There are no RSpec tests right now.
+  #      Re-enable this when we have something worth testing.
+  # system!('rspec')
+end

--- a/integration/apps/ruby/docker-compose.ci.yml
+++ b/integration/apps/ruby/docker-compose.ci.yml
@@ -1,0 +1,51 @@
+version: '3.4'
+services:
+  app:
+    # Build at dd-trace-rb level to copy in current code
+    # and use it as the `ddtrace` gem.
+    build:
+      context: ../../..
+      dockerfile: integration/apps/ruby/Dockerfile-ci
+      args:
+        BASE_IMAGE: ${APP_IMAGE}
+    depends_on:
+      - ddagent
+    environment:
+      - BUNDLE_GEMFILE=/app/Gemfile
+      - DD_AGENT_HOST=ddagent
+      - DD_METRIC_AGENT_PORT=8125
+      - DD_TRACE_AGENT_PORT=8126
+      - DD_HEALTH_METRICS_ENABLED=true
+      - DD_SERVICE=acme-ruby
+      - DD_PROFILING_ENABLED=true
+      # Use these to choose what is run
+      - DD_DEMO_ENV_PROCESS=fibonacci
+      - DD_DEMO_ENV_FEATURES=tracing
+    stdin_open: true
+    tty: true
+  ddagent:
+    image: datadog/dd-apm-demo:agent
+    environment:
+      - DD_APM_ENABLED=true
+      - DD_PROCESS_AGENT_ENABLED=false
+      - DD_BIND_HOST=0.0.0.0
+      - DD_API_KEY=invalid_api_key
+      - LOG_LEVEL=DEBUG
+      - DD_LOGS_STDOUT=yes
+      - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
+    expose:
+      - "8125/udp"
+      - "8126"
+  # Build at dd-trace-rb level to copy in current code
+  # and use it as the `ddtrace` gem.
+  integration-tester:
+    build:
+      context: ../../..
+      dockerfile: integration/apps/ruby/Dockerfile-ci
+      args:
+        BASE_IMAGE: ${APP_IMAGE}
+    command: bin/test
+    # volumes:
+    #   - .:/app
+    #   - ../../images/include:/vendor/dd-demo
+    #   - ../../..:/vendor/dd-trace-rb

--- a/integration/apps/ruby/docker-compose.yml
+++ b/integration/apps/ruby/docker-compose.yml
@@ -1,0 +1,63 @@
+version: '3.4'
+services:
+  app:
+    build:
+      context: .
+      args:
+        BASE_IMAGE: datadog/dd-apm-demo:rb-3.0
+    depends_on:
+      - ddagent
+    environment:
+      - BUNDLE_GEMFILE=/app/Gemfile
+      - DD_AGENT_HOST=ddagent
+      - DD_METRIC_AGENT_PORT=8125
+      - DD_TRACE_AGENT_PORT=8126
+      - DD_HEALTH_METRICS_ENABLED=true
+      - DD_SERVICE=acme-ruby
+      - DD_PROFILING_ENABLED=true
+      # Use these to choose what is run
+      - DD_DEMO_ENV_PROCESS=fibonacci
+      - DD_DEMO_ENV_FEATURES=tracing
+      # Use this for a local version of ddtrace
+      - DD_DEMO_ENV_GEM_LOCAL_DDTRACE=/vendor/dd-trace-rb
+      # Use these for a specific revision of ddtrace
+      # - DD_DEMO_ENV_GEM_GIT_DDTRACE=https://github.com/DataDog/dd-trace-rb.git
+      # - DD_DEMO_ENV_GEM_REF_DDTRACE=f233336994315bfa04dac581387a8152bab8b85a
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/app
+      - ./data/app:/data/app
+      - bundle:/usr/local/bundle
+      - ../../images/include:/vendor/dd-demo
+      - ../../..:/vendor/dd-trace-rb
+  ddagent:
+    image: datadog/dd-apm-demo:agent
+    environment:
+      - DD_APM_ENABLED=true
+      - DD_PROCESS_AGENT_ENABLED=false
+      - DD_BIND_HOST=0.0.0.0
+      - DD_API_KEY
+      - LOG_LEVEL=DEBUG
+      - DD_LOGS_STDOUT=yes
+      - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
+    expose:
+      - "8125/udp"
+      - "8126"
+    volumes:
+      - ../../images/agent/agent.yaml:/etc/datadog-agent/datadog.yaml
+      # For monitoring performance of containers (e.g. CPU, Memory, etc...)
+      # - type: bind
+      #   source: ../../images/agent/agent.yaml
+      #   target: /etc/datadog-agent/datadog.yaml
+      # - type: bind
+      #   source: /var/run/docker.sock
+      #   target: /var/run/docker.sock:ro
+      # - type: bind
+      #   source: /proc/
+      #   target: /host/proc/:ro
+      # - type: bind
+      #   source: /sys/fs/cgroup/
+      #   target: /host/sys/fs/cgroup:ro
+volumes:
+  bundle:

--- a/integration/apps/ruby/script/build-images
+++ b/integration/apps/ruby/script/build-images
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+APP_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+APP_DIR=${APP_SCRIPT_DIR%/script}
+cd $APP_DIR
+
+while getopts ":v:" opt; do
+  case $opt in
+    v)
+      APP_RUBY_VERSION=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "== Building Ruby app images... =="
+if [ -v APP_RUBY_VERSION ]; then
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-$APP_RUBY_VERSION -t datadog/dd-apm-demo:rb-$APP_RUBY_VERSION-ruby .
+else
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.0 -t datadog/dd-apm-demo:rb-2.0-ruby .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.1 -t datadog/dd-apm-demo:rb-2.1-ruby .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.2 -t datadog/dd-apm-demo:rb-2.2-ruby .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.3 -t datadog/dd-apm-demo:rb-2.3-ruby .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.4 -t datadog/dd-apm-demo:rb-2.4-ruby .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.5 -t datadog/dd-apm-demo:rb-2.5-ruby .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.6 -t datadog/dd-apm-demo:rb-2.6-ruby .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.7 -t datadog/dd-apm-demo:rb-2.7-ruby .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.0 -t datadog/dd-apm-demo:rb-3.0-ruby .
+fi
+echo "== Done building Ruby app images. =="

--- a/integration/apps/ruby/script/ci
+++ b/integration/apps/ruby/script/ci
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+APP_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+APP_DIR=${APP_SCRIPT_DIR%/script}
+cd $APP_DIR
+
+# Parse options
+while getopts "v:" opt; do
+  case $opt in
+    v)
+      APP_RUBY_VERSION=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Validate options
+if [ -z ${APP_RUBY_VERSION+x} ]; then
+  echo "You must specify a Ruby version with -v. (e.g. 2.7)" >&2
+  exit 1
+fi
+
+# Set configuration
+APP_BASE_IMAGE=${APP_BASE_IMAGE:-datadog/dd-apm-demo:rb-$APP_RUBY_VERSION}
+APP_IMAGE=${APP_IMAGE:-$APP_BASE_IMAGE-ruby}
+APP_COMPOSE_FILES="-f docker-compose.ci.yml"
+
+echo "== Running integration tests... =="
+echo " - App: ruby"
+echo " - Ruby version: $APP_RUBY_VERSION"
+echo " - Base image: $APP_BASE_IMAGE"
+echo " - App image: $APP_IMAGE"
+echo ""
+
+# Pull/build any missing images
+APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES build
+
+# Run the test suite
+APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES run integration-tester
+
+# Cleanup
+APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES down -t 0 --remove-orphans


### PR DESCRIPTION
This pull request adds a new test application to the integration test suite. This application is a very simple pure Ruby application that computes Fibonacci and produces traces/profiles.

It's intended as a minimalist example of Datadog tracing/profiling in use, and a sandbox in which we can drive some more Ruby-specific scenarios (e.g. threads, Ractors, IO, etc) outside of any framework.