### PR TITLE
Avoid stack level tool deep error when spec fails

### DIFF
--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -257,7 +257,12 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
         include_context 'with profiling extensions'
 
         before do
-          allow(Thread).to receive(:current).and_return(double('Current thread', cpu_time: true))
+          real_current_thread = Thread.current
+          mock_thread = double('Mock current thread', cpu_time: true)
+          allow(mock_thread).to receive(:[]) { |name| real_current_thread[name] }
+          allow(mock_thread).to receive(:[]=) { |name, value| real_current_thread[name] = value }
+
+          allow(Thread).to receive(:current).and_return(mock_thread)
 
           allow(thread)
             .to receive(:cpu_time_instrumentation_installed?)


### PR DESCRIPTION
While running a few experiments with this spec, I ran into a `SystemStackError: stack level too deep` (aka stack overflow) when rspec is trying to pretty print an error failure.

I tracked it down to the usage of `pp` and our mocking of `Thread.current` -- `pp` uses the fiber-local storage of the thread (<https://github.com/ruby/ruby/blob/4e32a4ab81d510b1cb3cd45f7faafc917aa071cc/lib/pp.rb#L121>) which our mock breaks.

By having our mock pass through the required methods, rspec can again print error messages when the test fails for some reason.