### PR TITLE
fix:Fully populate Rake spans on exceptions

### DIFF
--- a/lib/ddtrace/contrib/rake/instrumentation.rb
+++ b/lib/ddtrace/contrib/rake/instrumentation.rb
@@ -16,7 +16,8 @@ module Datadog
             return super unless enabled?
 
             tracer.trace(Ext::SPAN_INVOKE, span_options) do |span|
-              super.tap { annotate_invoke!(span, args) }
+              annotate_invoke!(span, args)
+              super
             end
           ensure
             shutdown_tracer!
@@ -26,7 +27,8 @@ module Datadog
             return super unless enabled?
 
             tracer.trace(Ext::SPAN_EXECUTE, span_options) do |span|
-              super.tap { annotate_execute!(span, args) }
+              annotate_execute!(span, args)
+              super
             end
           ensure
             shutdown_tracer!

--- a/spec/ddtrace/contrib/rake/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/rake/instrumentation_spec.rb
@@ -60,25 +60,18 @@ RSpec.describe Datadog::Contrib::Rake::Instrumentation do
   let(:spy) { double('spy') }
 
   describe '#invoke' do
+    subject(:invoke) { task.invoke(*args) }
+
     before(:each) do
       ::Rake.application.instance_variable_set(:@top_level_tasks, [task_name.to_s])
       expect(tracer).to receive(:shutdown!).with(no_args).once.and_call_original
     end
 
+    let(:invoke_span) { spans.find { |s| s.name == Datadog::Contrib::Rake::Ext::SPAN_INVOKE } }
+    let(:execute_span) { spans.find { |s| s.name == Datadog::Contrib::Rake::Ext::SPAN_EXECUTE } }
+
     shared_examples_for 'a single task execution' do
-      before(:each) do
-        expect(spy).to receive(:call) do |invocation_task, invocation_args|
-          expect(invocation_task).to eq(task)
-          expect(invocation_args.to_hash).to eq(args_hash)
-        end
-        expect(task).to receive(:shutdown_tracer!).with(no_args).twice.and_call_original
-        task.invoke(*args)
-      end
-
-      let(:invoke_span) { spans.find { |s| s.name == Datadog::Contrib::Rake::Ext::SPAN_INVOKE } }
-      let(:execute_span) { spans.find { |s| s.name == Datadog::Contrib::Rake::Ext::SPAN_EXECUTE } }
-
-      it do
+      it 'contains invoke and execute spans' do
         expect(spans).to have(2).items
       end
 
@@ -110,14 +103,59 @@ RSpec.describe Datadog::Contrib::Rake::Instrumentation do
       end
     end
 
-    shared_examples 'an error occurrence' do
+    shared_examples 'a successful single task execution' do
       before(:each) do
-        expect(spy).to receive(:call) do
-          raise 'oops'
+        expect(spy).to receive(:call) do |invocation_task, invocation_args|
+          expect(invocation_task).to eq(task)
+          expect(invocation_args.to_hash).to eq(args_hash)
         end
         expect(task).to receive(:shutdown_tracer!).with(no_args).twice.and_call_original
+        invoke
       end
-      it { expect { task.invoke(*args) }.to raise_error('oops') }
+
+      it_behaves_like 'a single task execution' do
+        describe '\'rake.invoke\' span' do
+          it "has no error'" do
+            expect(invoke_span).to_not have_error
+          end
+        end
+
+        describe '\'rake.execute\' span' do
+          it "has no error'" do
+            expect(execute_span).to_not have_error
+          end
+        end
+      end
+    end
+
+    shared_examples 'a failed single task execution' do
+      before(:each) do
+        expect(spy).to(receive(:call)) { raise error_class, 'oops' }
+        expect(task).to receive(:shutdown_tracer!).with(no_args).twice.and_call_original
+        expect { task.invoke(*args) }.to raise_error('oops')
+      end
+
+      let(:error_class) { Class.new(StandardError) }
+
+      it_behaves_like 'a single task execution' do
+        describe '\'rake.invoke\' span' do
+          it 'has error' do
+            expect(invoke_span).to have_error
+            expect(invoke_span).to have_error_message('oops')
+            expect(invoke_span).to have_error_type(error_class.to_s)
+            expect(invoke_span).to have_error_stack
+          end
+        end
+
+        describe '\'rake.execute\' span' do
+          it 'has error' do
+            expect(execute_span).to have_error
+            expect(execute_span).to have_error_message('oops')
+            expect(execute_span).to have_error_type(error_class.to_s)
+            expect(execute_span).to have_error_stack
+          end
+        end
+      end
     end
 
     context 'for a task' do
@@ -134,11 +172,11 @@ RSpec.describe Datadog::Contrib::Rake::Instrumentation do
 
       it 'returns task return value' do
         allow(spy).to receive(:call)
-        expect(task.invoke(*args)).to contain_exactly(task_body)
+        expect(invoke).to contain_exactly(task_body)
       end
 
       context 'without args' do
-        it_behaves_like 'a single task execution' do
+        it_behaves_like 'a successful single task execution' do
           describe '\'rake.invoke\' span tags' do
             it do
               expect(invoke_span.get_tag(Datadog::Contrib::Rake::Ext::TAG_TASK_ARG_NAMES)).to eq([].to_s)
@@ -153,12 +191,27 @@ RSpec.describe Datadog::Contrib::Rake::Instrumentation do
             end
           end
         end
-        it_behaves_like 'an error occurrence'
+
+        it_behaves_like 'a failed single task execution' do
+          describe '\'rake.invoke\' span tags' do
+            it do
+              expect(invoke_span.get_tag(Datadog::Contrib::Rake::Ext::TAG_TASK_ARG_NAMES)).to eq([].to_s)
+              expect(invoke_span.get_tag(Datadog::Contrib::Rake::Ext::TAG_INVOKE_ARGS)).to eq(['?'].to_s)
+            end
+          end
+
+          describe '\'rake.execute\' span tags' do
+            it do
+              expect(execute_span.get_tag(Datadog::Contrib::Rake::Ext::TAG_TASK_ARG_NAMES)).to be nil
+              expect(execute_span.get_tag(Datadog::Contrib::Rake::Ext::TAG_EXECUTE_ARGS)).to eq({}.to_s)
+            end
+          end
+        end
       end
 
       context 'with args' do
         let(:args_hash) { { one: 1, two: 2, three: 3 } }
-        it_behaves_like 'a single task execution' do
+        it_behaves_like 'a successful single task execution' do
           describe '\'rake.invoke\' span tags' do
             it do
               expect(invoke_span.get_tag(Datadog::Contrib::Rake::Ext::TAG_TASK_ARG_NAMES)).to eq([:one, :two, :three].to_s)
@@ -175,7 +228,23 @@ RSpec.describe Datadog::Contrib::Rake::Instrumentation do
             end
           end
         end
-        it_behaves_like 'an error occurrence'
+        it_behaves_like 'a failed single task execution' do
+          describe '\'rake.invoke\' span tags' do
+            it do
+              expect(invoke_span.get_tag(Datadog::Contrib::Rake::Ext::TAG_TASK_ARG_NAMES)).to eq([:one, :two, :three].to_s)
+              expect(invoke_span.get_tag(Datadog::Contrib::Rake::Ext::TAG_INVOKE_ARGS)).to eq(['?'].to_s)
+            end
+          end
+
+          describe '\'rake.execute\' span tags' do
+            it do
+              expect(execute_span.get_tag(Datadog::Contrib::Rake::Ext::TAG_TASK_ARG_NAMES)).to be nil
+              expect(execute_span.get_tag(Datadog::Contrib::Rake::Ext::TAG_EXECUTE_ARGS)).to eq(
+                { one: '?', two: '?', three: '?' }.to_s
+              )
+            end
+          end
+        end
       end
 
       context 'with a prerequisite task' do
@@ -205,24 +274,23 @@ RSpec.describe Datadog::Contrib::Rake::Instrumentation do
           expect(task).to receive(:shutdown_tracer!).with(no_args).twice.and_call_original
           expect(prerequisite_task).to receive(:shutdown_tracer!).with(no_args).once.and_call_original
 
-          task.invoke(*args)
+          invoke
         end
 
-        let(:invoke_span) { spans.find { |s| s.name == Datadog::Contrib::Rake::Ext::SPAN_INVOKE } }
         let(:prerequisite_task_execute_span) do
           spans.find do |s|
             s.name == Datadog::Contrib::Rake::Ext::SPAN_EXECUTE \
             && s.resource == prerequisite_task_name.to_s
           end
         end
-        let(:task_execute_span) do
+        let(:execute_span) do
           spans.find do |s|
             s.name == Datadog::Contrib::Rake::Ext::SPAN_EXECUTE \
             && s.resource == task_name.to_s
           end
         end
 
-        it do
+        it 'contains invoke, execute, and prerequisite spans' do
           expect(spans).to have(3).items
         end
 
@@ -248,11 +316,11 @@ RSpec.describe Datadog::Contrib::Rake::Instrumentation do
 
         describe 'task \'rake.execute\' span' do
           it do
-            expect(task_execute_span.name).to eq(Datadog::Contrib::Rake::Ext::SPAN_EXECUTE)
-            expect(task_execute_span.resource).to eq(task_name.to_s)
-            expect(task_execute_span.parent_id).to eq(invoke_span.span_id)
-            expect(task_execute_span.get_tag(Datadog::Contrib::Rake::Ext::TAG_TASK_ARG_NAMES)).to be nil
-            expect(task_execute_span.get_tag(Datadog::Contrib::Rake::Ext::TAG_EXECUTE_ARGS)).to eq({}.to_s)
+            expect(execute_span.name).to eq(Datadog::Contrib::Rake::Ext::SPAN_EXECUTE)
+            expect(execute_span.resource).to eq(task_name.to_s)
+            expect(execute_span.parent_id).to eq(invoke_span.span_id)
+            expect(execute_span.get_tag(Datadog::Contrib::Rake::Ext::TAG_TASK_ARG_NAMES)).to be nil
+            expect(execute_span.get_tag(Datadog::Contrib::Rake::Ext::TAG_EXECUTE_ARGS)).to eq({}.to_s)
           end
         end
       end
@@ -263,8 +331,8 @@ RSpec.describe Datadog::Contrib::Rake::Instrumentation do
           task_class.new(task_name, *task_arg_names)
         end
 
-        it_behaves_like 'a single task execution'
-        it_behaves_like 'an error occurrence'
+        it_behaves_like 'a successful single task execution'
+        it_behaves_like 'a failed single task execution'
       end
     end
   end


### PR DESCRIPTION
Rake spans were missing many properties when an error was raised in a Rake task.

This happened because we failed to call `annotate_invoke!` and `annotate_execute!` in error scenarios.

This PR ensures annotations happens regardless of the outcome of the Rake task execution. It also increases coverage of the Rake integration, by ensuring that all properties are tested in both the error and non-error path.