### PR TITLE
[CIAPP-1198] Remove APP_ANALYTICS from tests instrumentation

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -184,7 +184,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 #### Automatic instrumentation
 
 1. Install the gem with `gem install ddtrace`
-2. Requiring any [supported libraries or frameworks](#integration-instrumentation) that should be instrumented. 
+2. Requiring any [supported libraries or frameworks](#integration-instrumentation) that should be instrumented.
 3. Add `require 'ddtrace/auto_instrument'` to your application. _Note:_ This must be done _after_ requiring any supported libraries or frameworks.
 
     ```ruby
@@ -195,7 +195,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 
     require 'ddtrace/auto_instrument'
     ```
- 
+
     You can configure, override, or disable any specific integration settings by also adding a [Ruby Manual Configuration Block](#ruby-manual-configuration).
 
 #### Manual instrumentation
@@ -673,7 +673,6 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `true` |
 | `enabled` | Defines whether Cucumber tests should be traced. Useful for temporarily disabling tracing. `true` or `false` | `true` |
 | `service_name` | Service name used for `cucumber` instrumentation. | `'cucumber'` |
 | `operation_name` | Operation name used for `cucumber` instrumentation. Useful if you want rename automatic trace metrics e.g. `trace.#{operation_name}.errors`. | `'cucumber.test'` |
@@ -1621,7 +1620,6 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `true` |
 | `enabled` | Defines whether RSpec tests should be traced. Useful for temporarily disabling tracing. `true` or `false` | `true` |
 | `service_name` | Service name used for `rspec` instrumentation. | `'rspec'` |
 | `operation_name` | Operation name used for `rspec` instrumentation. Useful if you want rename automatic trace metrics e.g. `trace.#{operation_name}.errors`. | `'rspec.example'` |

--- a/lib/ddtrace/contrib/cucumber/configuration/settings.rb
+++ b/lib/ddtrace/contrib/cucumber/configuration/settings.rb
@@ -12,16 +12,6 @@ module Datadog
             o.lazy
           end
 
-          option :analytics_enabled do |o|
-            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, true) }
-            o.lazy
-          end
-
-          option :analytics_sample_rate do |o|
-            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy
-          end
-
           option :service_name do |o|
             o.default { Datadog.configuration.service || Ext::SERVICE_NAME }
             o.lazy

--- a/lib/ddtrace/contrib/cucumber/ext.rb
+++ b/lib/ddtrace/contrib/cucumber/ext.rb
@@ -4,8 +4,6 @@ module Datadog
       # Cucumber integration constants
       module Ext
         APP = 'cucumber'.freeze
-        ENV_ANALYTICS_ENABLED = 'DD_TRACE_CUCUMBER_ANALYTICS_ENABLED'.freeze
-        ENV_ANALYTICS_SAMPLE_RATE = 'DD_TRACE_CUCUMBER_ANALYTICS_SAMPLE_RATE'.freeze
         ENV_ENABLED = 'DD_TRACE_CUCUMBER_ENABLED'.freeze
         ENV_OPERATION_NAME = 'DD_TRACE_CUCUMBER_OPERATION_NAME'.freeze
         FRAMEWORK = 'cucumber'.freeze

--- a/lib/ddtrace/contrib/cucumber/formatter.rb
+++ b/lib/ddtrace/contrib/cucumber/formatter.rb
@@ -43,11 +43,6 @@ module Datadog
           @current_feature_span.set_tag(Datadog::Ext::Test::TAG_TYPE, Ext::TEST_TYPE)
           @current_feature_span.set_tag(Datadog::Ext::Test::TAG_SPAN_KIND, Datadog::Ext::AppTypes::TEST)
 
-          # Set analytics sample rate
-          if Datadog::Contrib::Analytics.enabled?(configuration[:analytics_enabled])
-            Datadog::Contrib::Analytics.set_sample_rate(@current_feature_span, configuration[:analytics_sample_rate])
-          end
-
           # Measure service stats
           Contrib::Analytics.set_measured(@current_feature_span)
         end

--- a/lib/ddtrace/contrib/rspec/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rspec/configuration/settings.rb
@@ -12,16 +12,6 @@ module Datadog
             o.lazy
           end
 
-          option :analytics_enabled do |o|
-            o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, true) }
-            o.lazy
-          end
-
-          option :analytics_sample_rate do |o|
-            o.default { env_to_float(Ext::ENV_ANALYTICS_SAMPLE_RATE, 1.0) }
-            o.lazy
-          end
-
           option :service_name do |o|
             o.default { Datadog.configuration.service || Ext::SERVICE_NAME }
             o.lazy

--- a/lib/ddtrace/contrib/rspec/example.rb
+++ b/lib/ddtrace/contrib/rspec/example.rb
@@ -29,11 +29,6 @@ module Datadog
               span.set_tag(Datadog::Ext::Test::TAG_TYPE, Ext::TEST_TYPE)
               span.set_tag(Datadog::Ext::Test::TAG_SPAN_KIND, Datadog::Ext::AppTypes::TEST)
 
-              # Set analytics sample rate
-              if Datadog::Contrib::Analytics.enabled?(configuration[:analytics_enabled])
-                Datadog::Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])
-              end
-
               # Measure service stats
               Contrib::Analytics.set_measured(span)
 

--- a/lib/ddtrace/contrib/rspec/example_group.rb
+++ b/lib/ddtrace/contrib/rspec/example_group.rb
@@ -28,11 +28,6 @@ module Datadog
               span.set_tag(Datadog::Ext::Test::TAG_TYPE, Ext::TEST_TYPE)
               span.set_tag(Datadog::Ext::Test::TAG_SPAN_KIND, Datadog::Ext::AppTypes::TEST)
 
-              # Set analytics sample rate
-              if Datadog::Contrib::Analytics.enabled?(configuration[:analytics_enabled])
-                Datadog::Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])
-              end
-
               # Measure service stats
               Contrib::Analytics.set_measured(span)
 

--- a/lib/ddtrace/contrib/rspec/ext.rb
+++ b/lib/ddtrace/contrib/rspec/ext.rb
@@ -4,8 +4,6 @@ module Datadog
       # RSpec integration constants
       module Ext
         APP = 'rspec'.freeze
-        ENV_ANALYTICS_ENABLED = 'DD_TRACE_RSPEC_ANALYTICS_ENABLED'.freeze
-        ENV_ANALYTICS_SAMPLE_RATE = 'DD_TRACE_RSPEC_ANALYTICS_SAMPLE_RATE'.freeze
         ENV_ENABLED = 'DD_TRACE_RSPEC_ENABLED'.freeze
         ENV_OPERATION_NAME = 'DD_TRACE_RSPEC_OPERATION_NAME'.freeze
         FRAMEWORK = 'rspec'.freeze

--- a/spec/ddtrace/contrib/cucumber/formatter_spec.rb
+++ b/spec/ddtrace/contrib/cucumber/formatter_spec.rb
@@ -1,5 +1,4 @@
 require 'ddtrace/contrib/support/spec_helper'
-require 'ddtrace/contrib/analytics_examples'
 require 'ddtrace/ext/integration'
 
 require 'cucumber'

--- a/spec/ddtrace/contrib/rspec/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/rspec/instrumentation_spec.rb
@@ -1,5 +1,4 @@
 require 'ddtrace/contrib/support/spec_helper'
-require 'ddtrace/contrib/analytics_examples'
 require 'ddtrace/ext/integration'
 
 require 'rspec'


### PR DESCRIPTION
We don't use this on ci-app backend and it's actually harmful due to some internals it makes use lose some tests that go to APM instead