### PR TITLE
Get our test suite passing on TruffleRuby

### DIFF
--- a/spec/ddtrace/benchmark/support/benchmark_helper.rb
+++ b/spec/ddtrace/benchmark/support/benchmark_helper.rb
@@ -286,7 +286,7 @@ RSpec.shared_context 'minimal agent' do
   before do
     # Initializes server in a fork, to allow for true concurrency.
     # In JRuby, threads are not supported, but true thread concurrency is.
-    @agent_runner = if PlatformHelpers.supports_fork?
+    @agent_runner = if Process.respond_to?(:fork)
                       fork { server_runner }
                     else
                       Thread.new { server_runner }
@@ -294,7 +294,7 @@ RSpec.shared_context 'minimal agent' do
   end
 
   after do
-    if PlatformHelpers.supports_fork?
+    if Process.respond_to?(:fork)
       Process.kill('TERM', @agent_runner) rescue nil
       Process.wait(@agent_runner)
     else

--- a/spec/ddtrace/context_provider_spec.rb
+++ b/spec/ddtrace/context_provider_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Datadog::DefaultContextProvider do
   end
 
   context 'when fork occurs' do
-    before { skip 'Java not supported' if RUBY_PLATFORM == 'java' }
+    before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
 
     it 'clones the context and returns the clone' do
       # Initialize a context for the current process

--- a/spec/ddtrace/context_provider_spec.rb
+++ b/spec/ddtrace/context_provider_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Datadog::DefaultContextProvider do
   end
 
   context 'when fork occurs' do
-    before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
+    before { skip 'Fork not supported on current platform' unless Process.respond_to?(:fork) }
 
     it 'clones the context and returns the clone' do
       # Initialize a context for the current process

--- a/spec/ddtrace/contrib/qless/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/qless/instrumentation_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'Qless instrumentation' do
 
   context 'with forking' do
     before do
-      skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork?
+      skip 'Fork not supported on current platform' unless Process.respond_to?(:fork)
 
       # Ensures worker is using forking
       expect(worker.class).to eq(Qless::Workers::ForkingWorker)

--- a/spec/ddtrace/contrib/qless/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/qless/instrumentation_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'Qless instrumentation' do
 
   context 'with forking' do
     before do
-      skip unless PlatformHelpers.supports_fork?
+      skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork?
 
       # Ensures worker is using forking
       expect(worker.class).to eq(Qless::Workers::ForkingWorker)

--- a/spec/ddtrace/contrib/resque/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/resque/instrumentation_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'Resque instrumentation' do
   end
 
   context 'with forking' do
-    before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
+    before { skip 'Fork not supported on current platform' unless Process.respond_to?(:fork) }
 
     it_behaves_like 'job execution tracing'
 

--- a/spec/ddtrace/contrib/resque/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/resque/instrumentation_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'Resque instrumentation' do
   end
 
   context 'with forking' do
-    before { skip unless PlatformHelpers.supports_fork? }
+    before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
 
     it_behaves_like 'job execution tracing'
 

--- a/spec/ddtrace/diagnostics/environment_logger_spec.rb
+++ b/spec/ddtrace/diagnostics/environment_logger_spec.rb
@@ -281,6 +281,12 @@ RSpec.describe Datadog::Diagnostics::EnvironmentLogger do
 
         it { is_expected.to include vm: start_with('jruby') }
       end
+
+      context 'with TruffleRuby' do
+        before { skip unless PlatformHelpers.truffleruby? }
+
+        it { is_expected.to include vm: start_with('truffleruby') }
+      end
     end
   end
 end

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe 'Tracer integration tests' do
     end
 
     context 'when sent TERM' do
-      before { skip unless PlatformHelpers.supports_fork? }
+      before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
 
       subject(:terminated_process) do
         # Initiate IO pipe

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe 'Tracer integration tests' do
     end
 
     context 'when sent TERM' do
-      before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
+      before { skip 'Fork not supported on current platform' unless Process.respond_to?(:fork) }
 
       subject(:terminated_process) do
         # Initiate IO pipe

--- a/spec/ddtrace/runtime/class_count_spec.rb
+++ b/spec/ddtrace/runtime/class_count_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Datadog::Runtime::ClassCount do
   end
 
   describe '::value' do
-    before { skip 'Not supported on current platform' if PlatformHelpers.jruby? || PlatformHelpers.truffleruby? }
+    before { skip 'Not supported on current platform' unless described_class.available? }
 
     subject(:value) { described_class.value }
 

--- a/spec/ddtrace/runtime/class_count_spec.rb
+++ b/spec/ddtrace/runtime/class_count_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Datadog::Runtime::ClassCount do
   end
 
   describe '::value' do
-    before { skip 'Not supported on current platform' if (PlatformHelpers.jruby? || PlatformHelpers.truffleruby?) }
+    before { skip 'Not supported on current platform' if PlatformHelpers.jruby? || PlatformHelpers.truffleruby? }
 
     subject(:value) { described_class.value }
 

--- a/spec/ddtrace/runtime/class_count_spec.rb
+++ b/spec/ddtrace/runtime/class_count_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe Datadog::Runtime::ClassCount do
   describe '::available?' do
     subject(:available?) { described_class.available? }
 
-    it { is_expected.to be !PlatformHelpers.jruby? }
+    it { is_expected.to be !(PlatformHelpers.jruby? || PlatformHelpers.truffleruby?) }
   end
 
   describe '::value' do
-    before { skip if PlatformHelpers.jruby? }
+    before { skip 'Not supported on current platform' if (PlatformHelpers.jruby? || PlatformHelpers.truffleruby?) }
 
     subject(:value) { described_class.value }
 

--- a/spec/ddtrace/runtime/identity_spec.rb
+++ b/spec/ddtrace/runtime/identity_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Datadog::Runtime::Identity do
     end
 
     context 'when invoked around a fork' do
-      before { skip unless PlatformHelpers.supports_fork? }
+      before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
 
       let(:before_fork_id) { described_class.id }
       let(:inside_fork_id) { described_class.id }

--- a/spec/ddtrace/runtime/identity_spec.rb
+++ b/spec/ddtrace/runtime/identity_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Datadog::Runtime::Identity do
     end
 
     context 'when invoked around a fork' do
-      before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
+      before { skip 'Fork not supported on current platform' unless Process.respond_to?(:fork) }
 
       let(:before_fork_id) { described_class.id }
       let(:inside_fork_id) { described_class.id }

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Datadog::Tracer do
         end
 
         context 'with forking' do
-          before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
+          before { skip 'Fork not supported on current platform' unless Process.respond_to?(:fork) }
 
           it 'only the top most span per process has a runtime ID tag' do
             tracer.trace(name) do |parent_span|

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Datadog::Tracer do
         end
 
         context 'with forking' do
-          before { skip 'Java not supported' if RUBY_PLATFORM == 'java' }
+          before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
 
           it 'only the top most span per process has a runtime ID tag' do
             tracer.trace(name) do |parent_span|

--- a/spec/ddtrace/utils/forking_spec.rb
+++ b/spec/ddtrace/utils/forking_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 require 'ddtrace/utils/forking'
 
 RSpec.describe Datadog::Utils::Forking do
-  before { skip 'Java not supported' if RUBY_PLATFORM == 'java' }
+  before do
+    skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork?
+  end
 
   shared_examples_for 'a Forking type' do
     # Assume the module is defined in the parent process not the fork.

--- a/spec/ddtrace/utils/forking_spec.rb
+++ b/spec/ddtrace/utils/forking_spec.rb
@@ -4,7 +4,7 @@ require 'ddtrace/utils/forking'
 
 RSpec.describe Datadog::Utils::Forking do
   before do
-    skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork?
+    skip 'Fork not supported on current platform' unless Process.respond_to?(:fork)
   end
 
   shared_examples_for 'a Forking type' do

--- a/spec/ddtrace/workers/async_spec.rb
+++ b/spec/ddtrace/workers/async_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe Datadog::Workers::Async::Thread do
     end
 
     describe '#forked?' do
-      before { skip unless PlatformHelpers.supports_fork? }
+      before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
 
       subject(:forked?) { worker.forked? }
 
@@ -398,7 +398,7 @@ RSpec.describe Datadog::Workers::Async::Thread do
 
     describe 'integration tests' do
       describe 'forking' do
-        before { skip unless PlatformHelpers.supports_fork? }
+        before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
 
         context 'when the process forks' do
           context 'with FORK_POLICY_STOP fork policy' do

--- a/spec/ddtrace/workers/async_spec.rb
+++ b/spec/ddtrace/workers/async_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe Datadog::Workers::Async::Thread do
     end
 
     describe '#forked?' do
-      before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
+      before { skip 'Fork not supported on current platform' unless Process.respond_to?(:fork) }
 
       subject(:forked?) { worker.forked? }
 
@@ -398,7 +398,7 @@ RSpec.describe Datadog::Workers::Async::Thread do
 
     describe 'integration tests' do
       describe 'forking' do
-        before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
+        before { skip 'Fork not supported on current platform' unless Process.respond_to?(:fork) }
 
         context 'when the process forks' do
           context 'with FORK_POLICY_STOP fork policy' do

--- a/spec/ddtrace/workers/runtime_metrics_spec.rb
+++ b/spec/ddtrace/workers/runtime_metrics_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Datadog::Workers::RuntimeMetrics do
     end
 
     describe 'forking' do
-      before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
+      before { skip 'Fork not supported on current platform' unless Process.respond_to?(:fork) }
 
       let(:options) do
         {

--- a/spec/ddtrace/workers/runtime_metrics_spec.rb
+++ b/spec/ddtrace/workers/runtime_metrics_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Datadog::Workers::RuntimeMetrics do
     end
 
     describe 'forking' do
-      before { skip unless PlatformHelpers.supports_fork? }
+      before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
 
       let(:options) do
         {

--- a/spec/ddtrace/workers/trace_writer_spec.rb
+++ b/spec/ddtrace/workers/trace_writer_spec.rb
@@ -637,7 +637,7 @@ RSpec.describe Datadog::Workers::AsyncTraceWriter do
     let(:output) { [] }
 
     describe 'forking' do
-      before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
+      before { skip 'Fork not supported on current platform' unless Process.respond_to?(:fork) }
 
       context 'when the process forks and a trace is written' do
         let(:traces) { get_test_traces(3) }

--- a/spec/ddtrace/workers/trace_writer_spec.rb
+++ b/spec/ddtrace/workers/trace_writer_spec.rb
@@ -637,7 +637,7 @@ RSpec.describe Datadog::Workers::AsyncTraceWriter do
     let(:output) { [] }
 
     describe 'forking' do
-      before { skip unless PlatformHelpers.supports_fork? }
+      before { skip 'Fork not supported on current platform' unless PlatformHelpers.supports_fork? }
 
       context 'when the process forks and a trace is written' do
         let(:traces) { get_test_traces(3) }

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -12,8 +12,4 @@ module PlatformHelpers
   def truffleruby?
     RUBY_ENGINE == 'truffleruby'.freeze
   end
-
-  def supports_fork?
-    !(jruby? || truffleruby?)
-  end
 end

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -9,7 +9,11 @@ module PlatformHelpers
     RUBY_ENGINE == 'jruby'.freeze
   end
 
+  def truffleruby?
+    RUBY_ENGINE == 'truffleruby'.freeze
+  end
+
   def supports_fork?
-    !jruby?
+    !(jruby? || truffleruby?)
   end
 end

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -43,7 +43,7 @@ class UtilsTest < Minitest::Test
   end
 
   def test_forked_process_id_collision
-    skip 'Fork not supported on current platform' if %w[jruby truffleruby].include?(RUBY_ENGINE)
+    skip 'Fork not supported on current platform' unless Process.respond_to?(:fork)
 
     r, w = IO.pipe
 

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -43,7 +43,7 @@ class UtilsTest < Minitest::Test
   end
 
   def test_forked_process_id_collision
-    skip 'Fork not supported on current platform' if ['jruby', 'truffleruby'].include?(RUBY_ENGINE)
+    skip 'Fork not supported on current platform' if %w[jruby truffleruby].include?(RUBY_ENGINE)
 
     r, w = IO.pipe
 

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -43,7 +43,7 @@ class UtilsTest < Minitest::Test
   end
 
   def test_forked_process_id_collision
-    skip if RUBY_PLATFORM == 'java'
+    skip 'Fork not supported on current platform' if ['jruby', 'truffleruby'].include?(RUBY_ENGINE)
 
     r, w = IO.pipe
 


### PR DESCRIPTION
The minor changes in this PR are enough to run both `bundle exec rake spec:main` and `bundle exec rake test:main` on TruffleRuby with only 2 tests failing.

The 2 failing tests are due to https://github.com/oracle/truffleruby/issues/2273 so we'll need an upstream fix for them.

Thanks to @P403n1x87 for pairing with me on this.