### PR TITLE
Test suite fixes for TruffleRuby support for the profiling branch

### DIFF
--- a/lib/ddtrace/profiling/ext/forking.rb
+++ b/lib/ddtrace/profiling/ext/forking.rb
@@ -5,7 +5,7 @@ module Datadog
       # profiling abilities after the VM forks.
       module Forking
         def self.supported?
-          RUBY_PLATFORM != 'java'
+          Process.respond_to?(:fork)
         end
 
         def self.apply!

--- a/spec/ddtrace/profiling/ext/forking_spec.rb
+++ b/spec/ddtrace/profiling/ext/forking_spec.rb
@@ -16,36 +16,36 @@ RSpec.describe Datadog::Profiling::Ext::Forking do
       end
     end
 
-    around do |example|
-      if ::Process.singleton_class.ancestors.include?(Datadog::Profiling::Ext::Forking::Kernel)
-        skip 'Unclean Process class state.'
+    context 'when forking is supported' do
+      around do |example|
+        if ::Process.singleton_class.ancestors.include?(Datadog::Profiling::Ext::Forking::Kernel)
+          skip 'Unclean Process class state.'
+        end
+
+        unmodified_process_class = ::Process.dup
+        unmodified_kernel_class = ::Kernel.dup
+
+        example.run
+
+        # Clean up classes
+        Object.send(:remove_const, :Process)
+        Object.const_set('Process', unmodified_process_class)
+
+        Object.send(:remove_const, :Kernel)
+        Object.const_set('Kernel', unmodified_kernel_class)
+
+        # Check for leaks (make sure test is properly cleaned up)
+        expect(::Process.ancestors.include?(described_class::Kernel)).to be false
+        expect(::Kernel.ancestors.include?(described_class::Kernel)).to be false
+        # Can't assert this because top level can't be reverted; can't guarantee pristine state.
+        # expect(toplevel_receiver.class.ancestors.include?(described_class::Kernel)).to be false
+
+        expect(::Process.method(:fork).source_location).to be nil
+        expect(::Kernel.method(:fork).source_location).to be nil
+        # Can't assert this because top level can't be reverted; can't guarantee pristine state.
+        # expect(toplevel_receiver.method(:fork).source_location).to be nil
       end
 
-      unmodified_process_class = ::Process.dup
-      unmodified_kernel_class = ::Kernel.dup
-
-      example.run
-
-      # Clean up classes
-      Object.send(:remove_const, :Process)
-      Object.const_set('Process', unmodified_process_class)
-
-      Object.send(:remove_const, :Kernel)
-      Object.const_set('Kernel', unmodified_kernel_class)
-
-      # Check for leaks (make sure test is properly cleaned up)
-      expect(::Process.ancestors.include?(described_class::Kernel)).to be false
-      expect(::Kernel.ancestors.include?(described_class::Kernel)).to be false
-      # Can't assert this because top level can't be reverted; can't guarantee pristine state.
-      # expect(toplevel_receiver.class.ancestors.include?(described_class::Kernel)).to be false
-
-      expect(::Process.method(:fork).source_location).to be nil
-      expect(::Kernel.method(:fork).source_location).to be nil
-      # Can't assert this because top level can't be reverted; can't guarantee pristine state.
-      # expect(toplevel_receiver.method(:fork).source_location).to be nil
-    end
-
-    context 'when forking is supported' do
       before { skip 'Forking not supported' unless described_class.supported? }
 
       it 'applies the Kernel patch' do

--- a/spec/ddtrace/profiling/ext/forking_spec.rb
+++ b/spec/ddtrace/profiling/ext/forking_spec.rb
@@ -5,20 +5,6 @@ require 'ddtrace/profiling'
 require 'ddtrace/profiling/ext/forking'
 
 RSpec.describe Datadog::Profiling::Ext::Forking do
-  describe '::supported?' do
-    subject(:supported?) { described_class.supported? }
-
-    context 'when MRI Ruby is used' do
-      before { stub_const('RUBY_PLATFORM', 'x86_64-linux') }
-      it { is_expected.to be true }
-    end
-
-    context 'when JRuby is used' do
-      before { stub_const('RUBY_PLATFORM', 'java') }
-      it { is_expected.to be false }
-    end
-  end
-
   describe '::apply!' do
     subject(:apply!) { described_class.apply! }
 

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -16,8 +16,16 @@ RSpec.describe 'profiling integration test' do
   end
 
   shared_context 'StackSample events' do
-    let(:stack_one) { Thread.current.backtrace_locations[1..3] }
-    let(:stack_two) { Thread.current.backtrace_locations[1..3] }
+    # Note: Please do not convert stack_one or stack_two to let, because
+    # we want the method names on the resulting stacks to be stack_one or
+    # stack_two, not block in ... when showing up in the stack traces
+    def stack_one
+      @stack_one ||= Thread.current.backtrace_locations[1..3]
+    end
+
+    def stack_two
+      @stack_two ||= Thread.current.backtrace_locations[1..3]
+    end
 
     let(:trace_id) { 0 }
     let(:span_id) { 0 }
@@ -343,7 +351,7 @@ RSpec.describe 'profiling integration test' do
 
         it 'is well formed' do
           is_expected.to be_kind_of(Google::Protobuf::RepeatedField)
-          is_expected.to have(3).items
+          is_expected.to have(4).items
 
           unique_functions = (stack_one + stack_two).uniq { |f| [f.base_label, f.path] }
 
@@ -364,7 +372,7 @@ RSpec.describe 'profiling integration test' do
 
         it 'is well formed' do
           is_expected.to be_kind_of(Google::Protobuf::RepeatedField)
-          is_expected.to have(13).items
+          is_expected.to have(14).items
           expect(string_table.first).to eq('')
         end
       end


### PR DESCRIPTION
This is a collection of fixes for our profiling-specific specs to make them work on TruffleRuby.