### PR TITLE
Draft: Experiments with CPU-time profiling for macOS

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -51,7 +51,8 @@ Gem::Specification.new do |spec|
       '!= 3.7.0.rc.3',
       '!= 3.7.0',
       '!= 3.7.1',
-      '!= 3.8.0.rc.1'
+      '!= 3.8.0.rc.1',
+      '~> 3.14.0',
     ]
 
     spec.add_development_dependency 'google-protobuf', *google_protobuf_versions

--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -102,7 +102,7 @@ module Datadog
           locations = locations[0..(max_frames - 1)]
 
           # Convert backtrace locations into structs
-          locations = convert_backtrace_locations(locations)
+          locations = convert_backtrace_locations(locations, thread)
 
           thread_id = thread.respond_to?(:native_thread_id) ? thread.native_thread_id : thread.object_id
           trace_id, span_id = get_trace_identifiers(thread)
@@ -160,12 +160,15 @@ module Datadog
 
         # Convert backtrace locations into structs
         # Re-use old backtrace location objects if they already exist in the buffer
-        def convert_backtrace_locations(locations)
+        def convert_backtrace_locations(locations, thread)
           locations.collect do |location|
             # Re-use existing BacktraceLocation if identical copy, otherwise build a new one.
+
+
             recorder[Events::StackSample].cache(:backtrace_locations).fetch(
               # Function name
-              location.base_label,
+              #location.base_label,
+              thread.to_s.include?('reference-processor') ? "FIXME-WIP-TRUFFLERUBY" : location.base_label,
               # Line number
               location.lineno,
               # Filename

--- a/lib/ddtrace/profiling/exporter.rb
+++ b/lib/ddtrace/profiling/exporter.rb
@@ -16,6 +16,7 @@ module Datadog
       end
 
       def export(flush)
+        puts "DEBUG: Sending profiling flush"
         transport.send_profiling_flush(flush)
       end
     end

--- a/lib/ddtrace/profiling/ext/cpu.rb
+++ b/lib/ddtrace/profiling/ext/cpu.rb
@@ -35,12 +35,12 @@ module Datadog
 
           if RUBY_ENGINE == 'jruby'
             'JRuby is not supported'
-          elsif RUBY_PLATFORM =~ /darwin/
-            'Feature requires Linux; macOS is not supported'
+          # elsif RUBY_PLATFORM =~ /darwin/
+          #   'Feature requires Linux; macOS is not supported'
           elsif RUBY_PLATFORM =~ /(mswin|mingw)/
             'Feature requires Linux; Windows is not supported'
-          elsif RUBY_PLATFORM !~ /linux/
-            "Feature requires Linux; #{RUBY_PLATFORM} is not supported"
+          # elsif RUBY_PLATFORM !~ /linux/
+          #   "Feature requires Linux; #{RUBY_PLATFORM} is not supported"
           elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1')
             'Ruby >= 2.1 is required'
           elsif Gem.loaded_specs['ffi'].nil?

--- a/lib/ddtrace/profiling/ext/cthread.rb
+++ b/lib/ddtrace/profiling/ext/cthread.rb
@@ -55,7 +55,12 @@ module Datadog
 
         def cpu_time(unit = :float_second)
           return unless clock_id && ::Process.respond_to?(:clock_gettime)
-          ::Process.clock_gettime(clock_id, unit)
+          begin
+            ::Process.clock_gettime(clock_id, unit)
+          rescue ::Errno::EINVAL
+            puts "Failed to get clock_id for thread #{Thread.current} clock_id #{clock_id}"
+            nil # ¯\_(ツ)_/¯
+          end
         end
 
         def cpu_time_instrumentation_installed?

--- a/lib/ddtrace/profiling/ext/cthread.rb
+++ b/lib/ddtrace/profiling/ext/cthread.rb
@@ -11,8 +11,8 @@ module Datadog
       # Extension used to enable CPU-time profiling via use of Pthread's `getcpuclockid`.
       module CThread
         extend FFI::Library
-        ffi_lib 'ruby', ['pthread', 'libpthread.so.0']
-        attach_function :rb_nativethread_self, [], :ulong
+        ffi_lib FFI::CURRENT_PROCESS
+        attach_function :pthread_self, [], :ulong
         attach_function :pthread_getcpuclockid, [:ulong, CClockId], :int
 
         def self.prepended(base)
@@ -92,7 +92,7 @@ module Datadog
           # NOTE: Only returns thread ID for thread that evaluates this call.
           #       a.k.a. evaluating `thread_a.get_native_thread_id` from within
           #       `thread_b` will return `thread_b`'s thread ID, not `thread_a`'s.
-          rb_nativethread_self
+          pthread_self
         end
 
         def get_clock_id(pthread_id)

--- a/lib/ddtrace/profiling/ext/cthread.rb
+++ b/lib/ddtrace/profiling/ext/cthread.rb
@@ -4,8 +4,47 @@ module Datadog
   module Profiling
     module Ext
       # C-struct for retrieving clock ID from pthread
-      class CClockId < FFI::Struct
-        layout :value, :int
+      if RUBY_PLATFORM =~ /darwin/
+        MACOS_INTEGER_T = :int      # https://github.com/apple/darwin-xnu/blob/main/osfmk/mach/i386/vm_types.h#L93
+        MACOS_POLICY_T = :int       # https://github.com/apple/darwin-xnu/blob/main/osfmk/mach/policy.h#L79
+
+        class MachMsgTypeNumberT < FFI::Struct
+          layout(
+            fixme: :uint,
+          )
+        end
+
+        class StructThreadExtendedInfo < FFI::Struct
+          layout(
+            pth_user_time: :uint64, # time in nanoseconds
+            pth_system_time: :uint64, # time in nanoseconds
+            pth_cpu_usage: :int32,
+            pth_policy: :int32,
+            pth_run_state: :int32,
+            pth_flags: :int32,
+            pth_sleep_time: :int32,
+            pth_curpri: :int32,
+            pth_priority: :int32,
+            pth_maxpriority: :int32,
+            pth_name: [:char, 64],
+          )
+
+          def to_h
+            members.map { |member| [member, self[member]] }.to_h
+          end
+
+          def inspect
+            to_h.to_s
+          end
+        end
+
+        THREAD_EXTENDED_INFO = 5
+
+        THREAD_EXTENDED_INFO_COUNT = StructThreadExtendedInfo.size / FFI::TypeDefs[:uint].size
+      elsif RUBY_PLATFORM =~ /linux/
+        class CClockId < FFI::Struct
+          layout :value, :int
+        end
       end
 
       # Extension used to enable CPU-time profiling via use of Pthread's `getcpuclockid`.
@@ -13,7 +52,27 @@ module Datadog
         extend FFI::Library
         ffi_lib FFI::CURRENT_PROCESS
         attach_function :pthread_self, [], :ulong
-        attach_function :pthread_getcpuclockid, [:ulong, CClockId], :int
+        if RUBY_PLATFORM =~ /darwin/
+          attach_function(
+            :mach_thread_self, # http://web.mit.edu/darwin/src/modules/xnu/osfmk/man/mach_thread_self.html
+                               # https://github.com/apple/darwin-xnu/blob/8f02f2a044b9bb1ad951987ef5bab20ec9486310/libsyscall/mach/mach/mach_init.h#L73
+            [],                # no args
+            :uint,             # mach_port_t => __darwin_mach_port_t => __darwin_mach_port_name_t => __darwin_natural_t => unsigned int
+          )
+          attach_function(
+            :thread_info,      # https://github.com/apple/darwin-xnu/blob/main/osfmk/mach/thread_act.defs#L241
+                               # https://developer.apple.com/documentation/kernel/1418630-thread_info
+            [
+              :uint,           # thread_inspect_it => mach_port_t => (see above)
+              :uint,           # thread_flavor_t => natural_t => __darwin_natural_t => (see above)
+              StructThreadExtendedInfo.by_ref,
+              MachMsgTypeNumberT.by_ref,         # mach_msg_type_number_t *thread_info_outCnt
+            ],
+            :int,              # kern_return_t
+          )
+        elsif RUBY_PLATFORM =~ /linux/
+          attach_function :pthread_getcpuclockid, [:ulong, CClockId], :int
+        end
 
         def self.prepended(base)
           # Threads that have already been created, will not have resolved
@@ -33,6 +92,7 @@ module Datadog
         def initialize(*args)
           @pid = ::Process.pid
           @native_thread_id = nil
+          @thread_port = nil
           @clock_id = nil
 
           # Wrap the work block with our own
@@ -53,10 +113,37 @@ module Datadog
           defined?(@clock_id) && @clock_id
         end
 
-        def cpu_time(unit = :float_second)
-          return unless clock_id && ::Process.respond_to?(:clock_gettime)
+        def thread_port
+          update_native_ids if forked?
+          defined?(@thread_port) && @thread_port
+        end
+
+        def cpu_time(unit = :float_second) # FIXME: CHANGE THIS DEFAULT TO NANOS
+          if RUBY_PLATFORM =~ /darwin/
+            return unless thread_port
+          else
+            return unless clock_id && ::Process.respond_to?(:clock_gettime)
+          end
+
+          raise "Only supports nanosecond" if unit != :nanosecond
+
           begin
-            ::Process.clock_gettime(clock_id, unit)
+            if RUBY_PLATFORM =~ /darwin/
+              thread_info = StructThreadExtendedInfo.new
+              thread_info_out_cnt = MachMsgTypeNumberT.new
+              thread_info_out_cnt[:fixme] = THREAD_EXTENDED_INFO_COUNT
+              thread_info_result = thread_info(thread_port, THREAD_EXTENDED_INFO, thread_info, thread_info_out_cnt)
+
+              #raise "Kernel call failed with error #{thread_info_result}" unless thread_info_result.zero?
+              unless thread_info_result.zero?
+                puts "Kernel call failed with error #{thread_info_result}"
+                return
+              end
+
+              thread_info[:pth_user_time] + thread_info[:pth_system_time]
+            elsif RUBY_PLATFORM =~ /linux/
+              ::Process.clock_gettime(clock_id, unit)
+            end
           rescue ::Errno::EINVAL
             puts "Failed to get clock_id for thread #{Thread.current} clock_id #{clock_id}"
             nil # ¯\_(ツ)_/¯
@@ -70,7 +157,11 @@ module Datadog
           #
           # Thus, we can use @clock_id as a canary to detect a thread that has missing instrumentation, because we
           # know that in initialize above we always set this variable to nil.
-          defined?(@clock_id) != nil
+          if RUBY_PLATFORM =~ /darwin/
+            defined?(@thread_port) != nil
+          else
+            defined?(@clock_id) != nil
+          end
         end
 
         private
@@ -86,7 +177,12 @@ module Datadog
 
           @pid = ::Process.pid
           @native_thread_id = get_native_thread_id
-          @clock_id = get_clock_id(@native_thread_id)
+          if RUBY_PLATFORM =~ /darwin/
+            @thread_port = mach_thread_self()
+            #puts "Setting thread port for #{Thread.current} to #{@thread_port}"
+          elsif RUBY_PLATFORM =~ /linux/
+            @clock_id = get_clock_id(@native_thread_id)
+          end
         end
 
         def get_native_thread_id

--- a/lib/ddtrace/profiling/tasks/setup.rb
+++ b/lib/ddtrace/profiling/tasks/setup.rb
@@ -56,7 +56,8 @@ module Datadog
             log "[DDTRACE] CPU profiling skipped because native CPU time is not supported: #{Ext::CPU.unsupported_reason}."
           end
         rescue StandardError, ScriptError => e
-          log "[DDTRACE] CPU profiling unavailable. Cause: #{e.message} Location: #{e.backtrace.first}"
+          log "[DDTRACE] CPU profiling unavailable. Cause: #{e.message} Location:"
+          log e.backtrace.join("\n\t")
         end
 
         def autostart_profiler

--- a/mac-ffi-time.rb
+++ b/mac-ffi-time.rb
@@ -1,0 +1,172 @@
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+
+  gem 'ffi'
+  gem 'pry'
+end
+
+require 'ffi'
+require 'pry'
+
+module MacStuff
+  extend FFI::Library
+  ffi_lib FFI::CURRENT_PROCESS
+
+  MACOS_INTEGER_T = :int      # https://github.com/apple/darwin-xnu/blob/main/osfmk/mach/i386/vm_types.h#L93
+  MACOS_POLICY_T = :int       # https://github.com/apple/darwin-xnu/blob/main/osfmk/mach/policy.h#L79
+
+  class StructTimeValue < FFI::Struct
+    layout(
+      seconds: MACOS_INTEGER_T,
+      microseconds: MACOS_INTEGER_T,
+    )
+
+    def to_h
+      members.map { |member| [member, self[member]] }.to_h
+    end
+
+    def inspect
+      to_h.to_s
+    end
+  end
+
+  class MachMsgTypeNumberT < FFI::Struct
+    layout(
+      fixme: :uint,
+    )
+
+    def to_h
+      members.map { |member| [member, self[member]] }.to_h
+    end
+
+    def inspect
+      to_h.to_s
+    end
+  end
+
+  MACOS_TIME_VALUE_T = StructTimeValue
+
+  class StructThreadBasicInfo < FFI::Struct
+    # https://github.com/apple/darwin-xnu/blob/main/osfmk/mach/thread_info.h#L92
+    layout(
+      user_time:     MACOS_TIME_VALUE_T,
+      system_time:   MACOS_TIME_VALUE_T,
+      cpu_usage:     MACOS_INTEGER_T,
+      policy:        MACOS_POLICY_T,
+      run_state:     MACOS_INTEGER_T,
+      flags:         MACOS_INTEGER_T,
+      suspend_count: MACOS_INTEGER_T,
+      sleep_time:    MACOS_INTEGER_T,
+    )
+
+    def to_h
+      members.map { |member| [member, self[member]] }.to_h
+    end
+
+    def inspect
+      to_h.to_s
+    end
+  end
+
+  attach_function(
+    :mach_thread_self, # http://web.mit.edu/darwin/src/modules/xnu/osfmk/man/mach_thread_self.html
+                       # https://github.com/apple/darwin-xnu/blob/8f02f2a044b9bb1ad951987ef5bab20ec9486310/libsyscall/mach/mach/mach_init.h#L73
+    [],                # no args
+    :uint,             # mach_port_t => __darwin_mach_port_t => __darwin_mach_port_name_t => __darwin_natural_t => unsigned int
+  )
+  attach_function(
+    :thread_basic_info,
+    :thread_info,      # https://github.com/apple/darwin-xnu/blob/main/osfmk/mach/thread_act.defs#L241
+                       # https://developer.apple.com/documentation/kernel/1418630-thread_info
+    [
+      :uint,           # thread_inspect_it => mach_port_t => (see above)
+      :uint,           # thread_flavor_t => natural_t => __darwin_natural_t => (see above)
+      StructThreadBasicInfo.by_ref,
+      MachMsgTypeNumberT.by_ref,         # mach_msg_type_number_t *thread_info_outCnt
+    ],
+    :int,              # kern_return_t
+  )
+
+  THREAD_BASIC_INFO = 3 # https://github.com/apple/darwin-xnu/blob/main/osfmk/mach/thread_info.h#L90
+
+  THREAD_BASIC_INFO_COUNT = MacStuff::StructThreadBasicInfo.size / FFI::TypeDefs[:uint].size
+
+  class StructThreadExtendedInfo < FFI::Struct
+    layout(
+      pth_user_time: :uint64,
+      pth_system_time: :uint64,
+      pth_cpu_usage: :int32,
+      pth_policy: :int32,
+      pth_run_state: :int32,
+      pth_flags: :int32,
+      pth_sleep_time: :int32,
+      pth_curpri: :int32,
+      pth_priority: :int32,
+      pth_maxpriority: :int32,
+      pth_name: [:char, 64],
+    )
+
+    def to_h
+      members.map { |member| [member, self[member]] }.to_h
+    end
+
+    def inspect
+      to_h.to_s
+    end
+  end
+
+  THREAD_EXTENDED_INFO = 5
+  THREAD_EXTENDED_INFO_COUNT = MacStuff::StructThreadExtendedInfo.size / FFI::TypeDefs[:uint].size
+
+  attach_function(
+    :thread_extended_info,
+    :thread_info,      # https://github.com/apple/darwin-xnu/blob/main/osfmk/mach/thread_act.defs#L241
+                       # https://developer.apple.com/documentation/kernel/1418630-thread_info
+    [
+      :uint,           # thread_inspect_it => mach_port_t => (see above)
+      :uint,           # thread_flavor_t => natural_t => __darwin_natural_t => (see above)
+      StructThreadExtendedInfo.by_ref,
+      MachMsgTypeNumberT.by_ref,         # mach_msg_type_number_t *thread_info_outCnt
+    ],
+    :int,              # kern_return_t
+  )
+end
+
+# We can also get the port from the pthread id using pthread_mach_thread_np(pthread), see https://opensource.apple.com/source/Libc/Libc-498/pthreads/pthread.c
+current_thread_port = MacStuff.mach_thread_self
+
+thread_basic_info = MacStuff::StructThreadBasicInfo.new
+
+thread_info_out_cnt = MacStuff::MachMsgTypeNumberT.new
+thread_info_out_cnt[:fixme] = MacStuff::THREAD_BASIC_INFO_COUNT
+
+start_time = Time.now
+finish_time = start_time + 5
+
+rand while (Time.now < finish_time)
+
+thread_info_result = MacStuff.thread_basic_info(current_thread_port, MacStuff::THREAD_BASIC_INFO, thread_basic_info, thread_info_out_cnt)
+
+if thread_info_result == 0
+  puts "Success!"
+else
+  puts "Call failed with error #{thread_info_result}" # see kern_return.h
+end
+
+thread_extended_info = MacStuff::StructThreadExtendedInfo.new
+thread_extended_info_out_cnt = MacStuff::MachMsgTypeNumberT.new
+thread_extended_info_out_cnt[:fixme] = MacStuff::THREAD_EXTENDED_INFO_COUNT
+
+thread_extended_info_result = MacStuff.thread_extended_info(current_thread_port, MacStuff::THREAD_EXTENDED_INFO, thread_extended_info, thread_extended_info_out_cnt)
+
+if thread_extended_info_result == 0
+  puts "Success!"
+else
+  puts "Call failed with error #{thread_extended_info_result}" # see kern_return.h
+end
+
+puts "This thread took #{(thread_extended_info[:pth_user_time] + thread_extended_info[:pth_system_time]).to_f / 1_000_000_000}s to run"
+
+binding.pry


### PR DESCRIPTION
This branch contains the experiments me and @P403n1x87 did to support CPU-time profiling on macOS. This was testing to be working-ish with both MRI Ruby and TruffleRuby.

Of course this code looks awful (we were just trying to see if it works), but I decided to open leave behind this draft PR so we wouldn't lose the experiments.

TL:DR This is just for later reference. Please DO NOT USE THIS. THIS WILL EAT UP YOUR MAC AND MAKE STEVE CRY SOMEWHERE IN HEAVEN.