### PR TITLE
Add docker setup for TruffleRuby, and a few more bits to get us closer to running TruffleRuby in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,10 @@ test_containers:
         description: Jit enabled?
         type: boolean
         default: false
+      resource_class_to_use:
+        description: Resource class to use
+        type: string
+        default: medium
   - &container_base_environment
     BUNDLE_GEMFILE: /app/Gemfile
     JRUBY_OPTS: --dev # Faster JVM startup: https://github.com/jruby/jruby/wiki/Improving-startup-time#use-the---dev-flag
@@ -133,6 +137,7 @@ orbs:
     jobs:
       build:
         <<: *test_job_default
+        resource_class: <<parameters.resource_class_to_use>>
         steps:
           - checkout
           - restore_cache:
@@ -438,6 +443,12 @@ job_configuration:
     <<: *filters_all_branches_and_tags
     ruby_version: 'jruby-9.2'
     image: marcotc/docker-library:ddtrace_rb_jruby_9_2
+  # TruffleRuby
+  - &config-truffleruby-21_0_0
+    <<: *filters_all_branches_and_tags
+    ruby_version: 'truffleruby-21.0.0'
+    image: ivoanjo/docker-library:ddtrace_rb_truffleruby_21_0_0
+    resource_class_to_use: large
 
 workflows:
   version: 2
@@ -462,6 +473,7 @@ workflows:
             - test-2.7
             - test-3.0
             - test-jruby-9.2
+            # soon™️ - test-truffleruby-21.0.0
       - orb/changelog:
           <<: *config-2_7
           name: changelog
@@ -612,6 +624,16 @@ workflows:
           name: test-jruby-9.2
           requires:
             - build-jruby-9.2
+      # TruffleRuby
+      - orb/build:
+          <<: *config-truffleruby-21_0_0
+          name: build-truffleruby-21.0.0
+      # soon™️
+      # - orb/test:
+      #     <<: *config-truffleruby-21_0_0
+      #     name: test-truffleruby-21.0.0
+      #     requires:
+      #       - build-truffleruby-21.0.0
       # Release jobs
       - "deploy prerelease Gem":
           <<: *filters_all_branches_and_tags
@@ -628,6 +650,7 @@ workflows:
             - test-3.0
             - test-3.0-jit
             - test-jruby-9.2
+            # soon™️ - test-truffleruby-21.0.0
       - "deploy release":
           <<: *filters_only_release_tags
           requires:
@@ -643,3 +666,4 @@ workflows:
             - test-3.0
             - test-3.0-jit
             - test-jruby-9.2
+            # soon™️ - test-truffleruby-21.0.0

--- a/.circleci/images/primary/Dockerfile-truffleruby-21.0.0
+++ b/.circleci/images/primary/Dockerfile-truffleruby-21.0.0
@@ -1,0 +1,73 @@
+FROM flavorjones/truffleruby:21.0.0-buster
+
+# Make apt non-interactive
+RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
+  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install required packages
+RUN set -ex; \
+        apt-get update; \
+        mkdir -p /usr/share/man/man1; \
+        apt-get install -y --no-install-recommends \
+            git mercurial xvfb \
+            locales sudo openssh-client ca-certificates tar gzip parallel \
+            net-tools netcat unzip zip bzip2 gnupg curl wget \
+            tzdata rsync vim; \
+        rm -rf /var/lib/apt/lists/*;
+
+# Set timezone to UTC by default
+RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
+
+# Set language
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+
+# Install jq
+RUN JQ_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/jq-latest" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/jq $JQ_URL \
+  && chmod +x /usr/bin/jq \
+  && jq --version
+
+# Install Docker
+RUN set -ex \
+  && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/x86_64/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
+  && DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/${DOCKER_VERSION}" \
+  && echo Docker URL: $DOCKER_URL \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
+  && ls -lha /tmp/docker.tgz \
+  && tar -xz -C /tmp -f /tmp/docker.tgz \
+  && mv /tmp/docker/* /usr/bin \
+  && rm -rf /tmp/docker /tmp/docker.tgz \
+  && which docker \
+  && (docker version || true)
+
+# Install Docker Compose
+RUN COMPOSE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/docker-compose-latest" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
+  && chmod +x /usr/bin/docker-compose \
+  && docker-compose version
+
+# Install Dockerize
+RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/dockerize-latest.tar.gz" \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/dockerize-linux-amd64.tar.gz $DOCKERIZE_URL \
+  && tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64.tar.gz \
+  && rm -rf /tmp/dockerize-linux-amd64.tar.gz \
+  && dockerize --version
+
+# Install RubyGems
+RUN gem update --system
+RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
+
+# Upgrade RubyGems and Bundler
+RUN gem update --system
+RUN gem install bundler
+ENV BUNDLE_SILENCE_ROOT_WARNING 1
+
+RUN mkdir /app
+WORKDIR /app
+
+CMD ["/bin/sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -308,6 +308,38 @@ services:
       - .:/app
       - bundle-jruby-9.2:/usr/local/bundle
       - gemfiles-jruby-9.2:/app/gemfiles
+  # TruffleRuby
+  tracer-truffleruby-21.0.0:
+    image: ivoanjo/docker-library:ddtrace_rb_truffleruby_21_0_0
+    command: /bin/bash
+    depends_on:
+      - ddagent
+      - elasticsearch
+      - memcached
+      - mongodb
+      - mysql
+      - postgres
+      - presto
+      - redis
+    env_file: ./.env
+    environment:
+      - BUNDLE_GEMFILE=/app/Gemfile
+      - DD_AGENT_HOST=ddagent
+      - TEST_DATADOG_INTEGRATION=1
+      - TEST_ELASTICSEARCH_HOST=elasticsearch
+      - TEST_MEMCACHED_HOST=memcached
+      - TEST_MONGODB_HOST=mongodb
+      - TEST_MYSQL_HOST=mysql
+      - TEST_POSTGRES_HOST=postgres
+      - TEST_PRESTO_HOST=presto
+      - TEST_PRESTO_PORT=8080
+      - TEST_REDIS_HOST=redis
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/app
+      - bundle-truffleruby-21.0.0:/usr/local/bundle
+      - gemfiles-truffleruby-21.0.0:/app/gemfiles
   ddagent:
     image: datadog/agent
     environment:
@@ -388,6 +420,7 @@ volumes:
   bundle-2.7:
   bundle-3.0:
   bundle-jruby-9.2:
+  bundle-truffleruby-21.0.0:
   gemfiles-2.0:
   gemfiles-2.1:
   gemfiles-2.2:
@@ -398,3 +431,4 @@ volumes:
   gemfiles-2.7:
   gemfiles-3.0:
   gemfiles-jruby-9.2:
+  gemfiles-truffleruby-21.0.0:

--- a/spec/ddtrace/contrib/rails/rails_auto_instrument_spec.rb
+++ b/spec/ddtrace/contrib/rails/rails_auto_instrument_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Datadog::Contrib::AutoInstrument' do
 
   context 'when auto patching is included' do
     before do
-      skip if PlatformHelpers.jruby?
+      skip 'Fork not supported on current platform' unless Process.respond_to?(:fork)
     end
 
     let(:config) { Datadog.configuration[:rails] }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -112,7 +112,10 @@ RSpec.configure do |config|
           # Ruby JetBrains debugger
           t.class.name.include?('DebugThread') ||
           # Categorized as a known leaky thread
-          !group_name.nil?
+          !group_name.nil? ||
+          # Internal TruffleRuby thread, defined in
+          # https://github.com/oracle/truffleruby/blob/02f568556ca4dd9056b0114b750ab848ac52943b/src/main/java/org/truffleruby/core/ReferenceProcessingService.java#L221
+          RUBY_ENGINE == 'truffleruby' && t.to_s.include?('Ruby-reference-processor')
       end
 
       unless background_threads.empty?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,7 @@ require 'rspec/collection_matchers'
 require 'webmock/rspec'
 require 'climate_control'
 
-# Skip for benchmarks, as coverage collection slows them down.
-unless RSpec.configuration.files_to_run.all? { |path| path.include?('/benchmark/') }
+if (ENV['SKIP_SIMPLECOV'] != '1') && !RSpec.configuration.files_to_run.all? { |path| path.include?('/benchmark/') }
   # +SimpleCov.start+ must be invoked before any application code is loaded
   require 'simplecov'
   SimpleCov.start do


### PR DESCRIPTION
Due to the issues documented in #1383 we're not yet ready to run TruffleRuby in our CI, but here's a few more improvements to get us closer to that goal.