### PR TITLE
Fix deadlock when trying to log during component replacement

### DIFF
--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -58,13 +58,16 @@ module Datadog
 
     def logger
       # avoid initializing components if they didn't already exist
-      current_components = components? && components
+      return logger_without_components unless components?
 
-      if current_components
-        @temp_logger = nil
-        current_components.logger
+      @temp_logger = nil
+
+      if COMPONENTS_LOCK.owned?
+        # components are in the process of being replaced by this thread, avoid a deadlock and return the old logger
+        @components.logger
       else
-        logger_without_components
+        # grab the lock and retrieve the latest logger
+        components.logger
       end
     end
 

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -399,6 +399,28 @@ RSpec.describe Datadog::Configuration do
           expect(test_class.send(:components?)).to be false
         end
       end
+
+      context 'when components are being replaced' do
+        before do
+          test_class.configure
+          allow(test_class.send(:components)).to receive(:shutdown!)
+        end
+
+        it 'returns the old logger' do
+          old_logger = test_class.logger
+          logger_during_component_replacement = nil
+
+          allow(Datadog::Configuration::Components).to receive(:new) do
+            # simulate getting the logger during reinitialization
+            logger_during_component_replacement = test_class.logger
+            instance_double(Datadog::Configuration::Components, startup!: nil)
+          end
+
+          test_class.configure
+
+          expect(logger_during_component_replacement).to be old_logger
+        end
+      end
     end
 
     describe '#profiler' do


### PR DESCRIPTION
In #1329 we added locking to component initialization and made sure that the logger method would:

a) not trigger component initialization
b) grab the lock to access the components after components were initialized

Unfortunately, b) has a corner case -- what happens when components are being replaced (e.g. during reconfiguration) if a component being replaced tries to log?

The answer is -- a deadlock:

```
E, [2021-03-01T09:43:26.970633 #18619] ERROR -- ddtrace: [ddtrace]
(lib/ddtrace/configuration.rb:113:in `rescue in block in
safely_synchronize') Detected deadlock during ddtrace initialization.
Please report this at https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug
  Source:
  lib/ddtrace/configuration.rb:109:in `synchronize' # <-- boom
  lib/ddtrace/configuration.rb:109:in `safely_synchronize'
  lib/ddtrace/configuration.rb:101:in `components'
  lib/ddtrace/configuration.rb:61:in `logger' # <-- new component tries to log
  lib/ddtrace/workers/async.rb:124:in `start_worker'
  lib/ddtrace/workers/async.rb:115:in `block in start_async'
  lib/ddtrace/workers/async.rb:105:in `synchronize'
  lib/ddtrace/workers/async.rb:105:in `start_async'
  lib/ddtrace/workers/async.rb:21:in `perform'
  lib/ddtrace/workers/polling.rb:19:in `perform'
  lib/ddtrace/profiling/collectors/stack.rb:47:in `start'
  lib/ddtrace/profiling/profiler.rb:14:in `each'
  lib/ddtrace/profiling/profiler.rb:14:in `start'
  lib/ddtrace/configuration/components.rb:187:in `startup!'
  lib/ddtrace/configuration.rb:138:in `replace_components!' # <-- components are being replaced
  lib/ddtrace/configuration.rb:40:in `block in configure'
  lib/ddtrace/configuration.rb:111:in `block in safely_synchronize'
  lib/ddtrace/configuration.rb:109:in `synchronize'
  lib/ddtrace/configuration.rb:109:in `safely_synchronize'
  lib/ddtrace/configuration.rb:36:in `configure'
  lib/ddtrace/contrib/extensions.rb:26:in `configure' # <-- configuration requested
```

To avoid this issue, we detect when the logger is being requested by a thread that owns the COMPONENTS_LOCK (and thus is in the process of modifying the components) and in that case we skip locking and directly grab the existing components and logger.