### PR TITLE
[PROF-2796] Fix profiler starting without extensions

### DIFF
--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -71,6 +71,9 @@ module Datadog
         def build_profiler(settings)
           return unless Datadog::Profiling.supported?
 
+          # Load extensions needed to support some of the Profiling features
+          Datadog::Profiling::Tasks::Setup.new.run
+
           # Note: Please update the Initialization section of ProfilingDevelopment.md with any changes to this method
 
           recorder = build_profiler_recorder(settings)
@@ -184,12 +187,15 @@ module Datadog
       def startup!(settings)
         if settings.profiling.enabled
           if profiler
+            @logger.debug('Profiling started')
             profiler.start
           else
             # Display a warning for users who expected profiling to autostart
             protobuf = Datadog::Profiling.google_protobuf_supported?
             logger.warn("Profiling was enabled but is not supported; profiling disabled. (google-protobuf?: #{protobuf})")
           end
+        else
+          @logger.debug('Profiling not enabled')
         end
       end
 

--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -69,7 +69,7 @@ module Datadog
         end
 
         def build_profiler(settings)
-          return unless Datadog::Profiling.supported?
+          return unless Datadog::Profiling.supported? && settings.profiling.enabled
 
           # Load extensions needed to support some of the Profiling features
           Datadog::Profiling::Tasks::Setup.new.run
@@ -110,22 +110,15 @@ module Datadog
         end
 
         def build_profiler_recorder(settings)
-          event_classes = []
-
-          if settings.profiling.enabled && settings.profiling.cpu.enabled
-            event_classes << Datadog::Profiling::Events::StackSample
-          end
+          event_classes = [Datadog::Profiling::Events::StackSample]
 
           Datadog::Profiling::Recorder.new(event_classes, settings.profiling.max_events)
         end
 
         def build_profiler_collectors(settings, recorder)
-          return [] unless settings.profiling.enabled && settings.profiling.cpu.enabled
-
           [
             Datadog::Profiling::Collectors::Stack.new(
               recorder,
-              enabled: settings.profiling.cpu.enabled
               # TODO: Provide proc that identifies Datadog worker threads?
               # ignore_thread: settings.profiling.ignore_profiler
             )
@@ -151,11 +144,7 @@ module Datadog
         end
 
         def build_profiler_scheduler(settings, recorder, exporters)
-          Datadog::Profiling::Scheduler.new(
-            recorder,
-            exporters,
-            enabled: settings.profiling.enabled
-          )
+          Datadog::Profiling::Scheduler.new(recorder, exporters)
         end
       end
 
@@ -195,7 +184,7 @@ module Datadog
             logger.warn("Profiling was enabled but is not supported; profiling disabled. (google-protobuf?: #{protobuf})")
           end
         else
-          @logger.debug('Profiling not enabled')
+          @logger.debug('Profiling is disabled')
         end
       end
 

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -110,10 +110,6 @@ module Datadog
       end
 
       settings :profiling do
-        settings :cpu do
-          option :enabled, default: true
-        end
-
         option :enabled do |o|
           o.default { env_to_bool(Ext::Profiling::ENV_ENABLED, false) }
           o.lazy

--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -37,7 +37,7 @@ module Datadog
           self.loop_base_interval = options[:interval] || MIN_INTERVAL
 
           # Workers::Polling settings
-          self.enabled = options[:enabled] == true
+          self.enabled = options.key?(:enabled) ? options[:enabled] == true : true
 
           @warned_about_missing_cpu_time_instrumentation = false
         end

--- a/lib/ddtrace/profiling/preload.rb
+++ b/lib/ddtrace/profiling/preload.rb
@@ -1,3 +1,3 @@
-require 'ddtrace/profiling/tasks/setup'
+require 'ddtrace'
 
-Datadog::Profiling::Tasks::Setup.new.run
+Datadog.profiler.start if Datadog.profiler

--- a/lib/ddtrace/profiling/scheduler.rb
+++ b/lib/ddtrace/profiling/scheduler.rb
@@ -29,7 +29,7 @@ module Datadog
         self.loop_base_interval = options[:interval] || DEFAULT_INTERVAL
 
         # Workers::Polling settings
-        self.enabled = options[:enabled] == true
+        self.enabled = options.key?(:enabled) ? options[:enabled] == true : true
       end
 
       def start

--- a/lib/ddtrace/workers/async.rb
+++ b/lib/ddtrace/workers/async.rb
@@ -121,7 +121,7 @@ module Datadog
           @run_async = true
           @pid = Process.pid
           @error = nil
-          Datadog.logger.debug("Starting thread in the process: #{Process.pid}")
+          Datadog.logger.debug("Starting thread in the process: #{Process.pid} for: #{self}")
 
           @worker = ::Thread.new do
             begin

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -725,6 +725,12 @@ RSpec.describe Datadog::Configuration::Components do
           it_behaves_like 'profiler with default scheduler'
           it_behaves_like 'profiler with default recorder'
           it_behaves_like 'profiler with default exporters'
+
+          it 'runs the setup task to set up any needed extensions for profiling' do
+            expect_any_instance_of(Datadog::Profiling::Tasks::Setup).to receive(:run)
+
+            build_profiler
+          end
         end
 
         context 'and :cpu.enabled' do

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -405,22 +405,6 @@ RSpec.describe Datadog::Configuration::Settings do
   end
 
   describe '#profiling' do
-    describe '#cpu' do
-      describe '#enabled' do
-        subject(:enabled) { settings.profiling.cpu.enabled }
-        it { is_expected.to be true }
-      end
-
-      describe '#enabled=' do
-        it 'updates the #enabled setting' do
-          expect { settings.profiling.cpu.enabled = false }
-            .to change { settings.profiling.cpu.enabled }
-            .from(true)
-            .to(false)
-        end
-      end
-    end
-
     describe '#enabled' do
       subject(:enabled) { settings.profiling.enabled }
 

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -325,18 +325,6 @@ RSpec.describe Datadog::Configuration do
       context 'when the profiler' do
         context 'is not changed' do
           before { skip 'Profiling is not supported.' unless Datadog::Profiling.supported? }
-
-          before do
-            @original_profiler = test_class.profiler
-            expect(@original_profiler).to receive(:shutdown!)
-          end
-
-          it 'shuts down the old profiler' do
-            configure
-            expect(test_class.profiler).to be_a_kind_of(Datadog::Profiler)
-            expect(test_class.profiler).to_not be(@original_profiler)
-          end
-
           context 'and profiling is enabled' do
             before do
               allow(test_class.configuration.profiling)
@@ -345,6 +333,8 @@ RSpec.describe Datadog::Configuration do
 
               allow_any_instance_of(Datadog::Profiler)
                 .to receive(:start)
+              allow_any_instance_of(Datadog::Profiling::Tasks::Setup)
+                .to receive(:run)
             end
 
             it 'starts the profiler' do
@@ -397,17 +387,6 @@ RSpec.describe Datadog::Configuration do
           logger
 
           expect(test_class.send(:components?)).to be false
-        end
-      end
-    end
-
-    describe '#profiler' do
-      subject(:profiler) { test_class.profiler }
-      it do
-        if Datadog::Profiling.supported?
-          is_expected.to be_a_kind_of(Datadog::Profiler)
-        else
-          is_expected.to be nil
         end
       end
     end

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   describe '::new' do
     it 'with default settings' do
       is_expected.to have_attributes(
-        enabled?: false,
+        enabled?: true,
         fork_policy: Datadog::Workers::Async::Thread::FORK_POLICY_RESTART,
         ignore_thread: nil,
         loop_base_interval: described_class::MIN_INTERVAL,

--- a/spec/ddtrace/profiling/preload_spec.rb
+++ b/spec/ddtrace/profiling/preload_spec.rb
@@ -3,14 +3,21 @@ require 'ddtrace/profiling'
 
 RSpec.describe 'Profiling preloading' do
   subject(:preload) { load 'ddtrace/profiling/preload.rb' }
-  let(:setup_task) { instance_double(Datadog::Profiling::Tasks::Setup) }
 
-  before do
-    allow(Datadog::Profiling::Tasks::Setup).to receive(:new).and_return(setup_task)
+  it 'starts the profiler' do
+    profiler = instance_double(Datadog::Profiler)
+
+    expect(Datadog).to receive(:profiler).and_return(profiler).at_least(:once)
+    expect(profiler).to receive(:start)
+
+    preload
   end
 
-  it 'runs the Profiling::Tasks::Setup task' do
-    expect(setup_task).to receive(:run)
-    preload
+  context 'when the profiler is not available' do
+    it 'does not raise any error' do
+      expect(Datadog).to receive(:profiler).and_return(nil)
+
+      preload
+    end
   end
 end

--- a/spec/ddtrace/profiling/scheduler_spec.rb
+++ b/spec/ddtrace/profiling/scheduler_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Datadog::Profiling::Scheduler do
   describe '::new' do
     it 'with default settings' do
       is_expected.to have_attributes(
-        enabled?: false,
+        enabled?: true,
         exporters: exporters,
         fork_policy: Datadog::Workers::Async::Thread::FORK_POLICY_RESTART,
         loop_base_interval: described_class::DEFAULT_INTERVAL,

--- a/spec/ddtrace/profiling/spec_helper.rb
+++ b/spec/ddtrace/profiling/spec_helper.rb
@@ -10,6 +10,7 @@ module ProfilingFeatureHelpers
       stub_const('Kernel', ::Kernel.dup)
 
       require 'ddtrace/profiling/tasks/setup'
+      Datadog::Profiling::Tasks::Setup.const_get(:ONLY_ONCE).send(:reset_ran_once_state_for_tests)
       Datadog::Profiling::Tasks::Setup.new.run
     end
   end
@@ -26,6 +27,7 @@ module ProfilingFeatureHelpers
     # Apply extensions in a fork so we don't modify the original Thread class
     expect_in_fork do
       require 'ddtrace/profiling/tasks/setup'
+      Datadog::Profiling::Tasks::Setup.const_get(:ONLY_ONCE).send(:reset_ran_once_state_for_tests)
       Datadog::Profiling::Tasks::Setup.new.run
       yield
     end


### PR DESCRIPTION
Previously, if a customer onboarded via code and forgot to `require 'ddtrace/profiling/preload'` the profiler would still start, but would be missing the CPU and fork extensions.

```ruby
require 'ddtrace'
# require 'ddtrace/profiling/preload' <-- this never gets loaded

Datadog.configure do |c|
  c.profiling.enabled = true
end
```

At least one customer ran into this issue.

To fix this, I've refactored the profiler start code-paths so that the `Setup` task only does extension initialization (does not start the profiler), and then the `Datadog::Components` becomes responsible for calling the `Setup` task as well as starting the profiler.

Because the `Setup` task is now called every time the profiler is starting up, I've added a tiny helper that ensures that it only applies the monkey patches and other setups only once per Ruby VM execution.

I've also tweaked the profiler components creation to avoid creating and initializing any profiler components when profiler is disabled -- previously we would still empty instances of a few components which made them really hard to debug.