### PR TITLE
[Actions] Upgrade create-next-milestone dependencies

### DIFF
--- a/.github/workflows/create-next-milestone.yml
+++ b/.github/workflows/create-next-milestone.yml
@@ -9,11 +9,11 @@ jobs:
     steps:
       - name: Get next minor version
         id: semvers
-        uses: WyriHaximus/github-action-next-semvers@0.1.0
+        uses: WyriHaximus/github-action-next-semvers@b135abb108d66990a85e18623d906404f4350ce4
         with:
           version: ${{ github.event.milestone.title }}
       - name: Create next milestone
-        uses: WyriHaximus/github-action-create-milestone@0.1.0
+        uses: WyriHaximus/github-action-create-milestone@ab85332e3150ec018daf497a0f761fe69d52bc7d
         with:
           title: ${{ steps.semvers.outputs.minor }}
         env:


### PR DESCRIPTION
Our GitHub action that creates the next milestone failed during the last release: https://github.com/DataDog/dd-trace-rb/runs/2025927681

This happened because we are locked in an old version of one of the actions we use (`WyriHaximus/github-action-next-semvers`).

This PR upgrades that dependency to the latest release, fixing the issue (tested in my fork of `ddtrace`).

The version lock is also changed to using SHA hashes now: this is a [recommendation from the GitHub security team](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions).