### PR TITLE
Fix failed integration message

### DIFF
--- a/lib/ddtrace/contrib/extensions.rb
+++ b/lib/ddtrace/contrib/extensions.rb
@@ -47,7 +47,7 @@ module Datadog
               desc += ", Compatible? #{patch_results[:compatible]}"
               desc += ", Patchable? #{patch_results[:patchable]}"
 
-              Datadog.logger.warn("Unable to patch #{patch_results['name']} (#{desc})")
+              Datadog.logger.warn("Unable to patch #{patch_results[:name]} (#{desc})")
             end
 
             target.integrations_pending_activation.clear


### PR DESCRIPTION
Currently if integration fails to load I see the following message:

```
W, [2021-03-02T19:29:57.645910 #57008]  WARN -- ddtrace: [ddtrace] Unable to patch  (Available?: true, Loaded? false, Compatible? true, Patchable? false)
```

I believe it should include name of the integration in the message like this:
```
W, [2021-03-03T17:07:12.203732 #67324]  WARN -- ddtrace: [ddtrace] Unable to patch Datadog::Contrib::Rake::Integration (Available?: true, Loaded? false, Compatible? true, Patchable? false)
```

It gets really confusing if multiple integrations fail to load.