### PR TITLE
Remove type check from ThreadLocalContext#local.

### DIFF
--- a/lib/ddtrace/context_provider.rb
+++ b/lib/ddtrace/context_provider.rb
@@ -55,8 +55,6 @@ module Datadog
 
     # Return the thread-local context.
     def local(thread = Thread.current)
-      raise ArgumentError, '\'thread\' must be a Thread.' unless thread.is_a?(Thread)
-
       thread[@key] ||= Datadog::Context.new
     end
   end

--- a/spec/ddtrace/context_provider_spec.rb
+++ b/spec/ddtrace/context_provider_spec.rb
@@ -143,12 +143,6 @@ RSpec.describe Datadog::ThreadLocalContext do
         expect(local).to_not be(thread_local_context.local)
       end
     end
-
-    context 'given a bad argument' do
-      subject(:local) { thread_local_context.local('bad_arg') }
-
-      it { expect { local }.to raise_error(ArgumentError) }
-    end
   end
 
   describe '#local=' do


### PR DESCRIPTION
Thread type checking is very incompatible with some debuggers.
For example, if you are using [Debase](https://github.com/ruby-debug/debase), Thread will be replaced with `Debase::DebugThread` and the type check will fail.

I saw a [commit](https://github.com/DataDog/dd-trace-rb/commit/eebfbc89f73c46052bc76124e70baa7ad222b854) with typecheck added, but I don't feel a strong intention to do it.
Do not remove this guard condition?