### PR TITLE
Pretty inspect for Datadog components

### DIFF
--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -440,6 +440,22 @@ module Datadog
       @sampler = base_sampler || Datadog::AllSampler.new if @sampler.is_a?(PrioritySampler)
     end
 
+    def to_h
+      {
+        :__class => self.class.name,
+        context_flush: context_flush,
+        enabled: enabled,
+        provider: provider,
+        sampler: sampler,
+        tags: tags,
+        writer: writer.to_h
+      }
+    end
+
+    def inspect
+      JSON.pretty_generate(to_h)
+    end
+
     private \
       :activate_priority_sampling!,
       :configure_writer,

--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -102,6 +102,25 @@ module Datadog
         @trace_buffer.push(trace)
       end
 
+      def to_h
+        {
+          :__class => self.class.name,
+          :@back_off => @back_off,
+          :@flush_interval => @flush_interval,
+          :@mutex => @mutex,
+          :@run => @run,
+          :@shutdown => @shutdown,
+          :@trace_buffer => @trace_buffer,
+          :@trace_task => @trace_task,
+          :@transport => @transport,
+          :@worker => @worker
+        }
+      end
+
+      def inspect
+        JSON.pretty_generate(to_h)
+      end
+
       private
 
       alias flush_data callback_traces

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -169,6 +169,25 @@ module Datadog
       }
     end
 
+    def to_h
+      {
+        :__class => self.class.name,
+        :@buff_size => @buff_size,
+        :@flush_interval => @flush_interval,
+        :@mutex_after_fork => @mutex_after_fork,
+        :@pid => @pid,
+        :@stopped => @stopped,
+        :@traces_flushed => @traces_flushed,
+        :priority_sampler => priority_sampler,
+        :transport => transport,
+        :worker => worker.to_h
+      }
+    end
+
+    def inspect
+      JSON.pretty_generate(to_h)
+    end
+
     private
 
     def inject_hostname!(traces)


### PR DESCRIPTION
In order to make debugging/inspecting a little bit easier when working with Datadog components, this PR decorates existing components with `inspect` and `to_h` to provide prettier, programmatic debug output.

e.g. when inspecting a tracer with `Datadog.tracer`, instead of printing:

```
#<Datadog::Tracer:0x0000560f0e81a740 @context_flush=#<Datadog::ContextFlush::Finished:0x0000560f0e81a4e8>, @default_service="rspec", @enabled=true, @provider=#<Datadog::DefaultContextProvider:0x0000560f0e81a3f8 @context=#<Datadog::ThreadLocalContext:0x0000560f0e81a128 @key=:datadog_context_47311333937300>>, @sampler=#<Datadog::PrioritySampler:0x0000560f0e7bac28 @pre_sampler=#<Datadog::AllSampler:0x0000560f0e8196d8>, @priority_sampler=#<Datadog::Sampling::RuleSampler:0x0000560f0e7dd318 @rules=[], @rate_limiter=#<Datadog::Sampling::TokenBucket:0x0000560f0e7bb4c0 @rate=100, @max_tokens=100, @tokens=100, @total_messages=0, @conforming_messages=0, @prev_conforming_messages=nil, @prev_total_messages=nil, @current_window=nil, @last_refill=22694.252760073>, @default_sampler=#<Datadog::RateByServiceSampler:0x0000560f0e7bb380 @default_key="service:,env:", @resolver=#<Proc:0x0000560f0e7bb038 (lambda)>, @mutex=#<Thread::Mutex:0x0000560f0e7bae58>, @samplers={"service:,env:"=>#<Datadog::RateSampler:0x0000560f0e7bacc8 @sample_rate=1.0, @sampling_id_threshold=1.8446744073709552e+19>}, @env=#<Proc:0x0000560f0e7bb420@/app/lib/ddtrace/sampling/rule_sampler.rb:58 (lambda)>>>>, @tags={}, @writer=#<Datadog::Writer:0x0000560f0e8195e8 @buff_size=1000, @flush_interval=1, @transport=#<Datadog::Transport::Traces::Transport:0x0000560f0e7dd638 @apis={"v0.4"=>#<Datadog::Transport::HTTP::API::Instance:0x0000560f0e7de9e8 @spec=#<Datadog::Transport::HTTP::API::Spec:0x0000560f0e7e82e0 @traces=#<Datadog::Transport::HTTP::Traces::API::Endpoint:0x0000560f0e7e8268 @verb=:post, @path="/v0.4/traces", @encoder=Datadog::Encoding::MsgpackEncoder, @service_rates=true>>, @adapter=#<Datadog::Transport::HTTP::Adapters::Net:0x0000560f0e818fa8 @hostname="ddagent", @port=8126, @timeout=1>, @headers={"Datadog-Meta-Lang"=>"ruby", "Datadog-Meta-Lang-Version"=>"2.4.6", "Datadog-Meta-Lang-Interpreter"=>"ruby-x86_64-linux", "Datadog-Meta-Tracer-Version"=>"0.45.0", "Datadog-Container-ID"=>"672885e52afa57b1b453bf78b2c5fb9e0463737d1051e3a549eaa882e0c8f964"}>, "v0.3"=>#<Datadog::Transport::HTTP::API::Instance:0x0000560f0e7de1a0 @spec=#<Datadog::Transport::HTTP::API::Spec:0x0000560f0e7e8470 @traces=#<Datadog::Transport::HTTP::Traces::API::Endpoint:0x0000560f0e7e8dd0 @verb=:post, @path="/v0.3/traces", @encoder=Datadog::Encoding::MsgpackEncoder, @service_rates=false>>, @adapter=#<Datadog::Transport::HTTP::Adapters::Net:0x0000560f0e818fa8 @hostname="ddagent", @port=8126, @timeout=1>, @headers={"Datadog-Meta-Lang"=>"ruby", "Datadog-Meta-Lang-Version"=>"2.4.6", "Datadog-Meta-Lang-Interpreter"=>"ruby-x86_64-linux", "Datadog-Meta-Tracer-Version"=>"0.45.0", "Datadog-Container-ID"=>"672885e52afa57b1b453bf78b2c5fb9e0463737d1051e3a549eaa882e0c8f964"}>, "v0.2"=>#<Datadog::Transport::HTTP::API::Instance:0x0000560f0e7dd8b8 @spec=#<Datadog::Transport::HTTP::API::Spec:0x0000560f0e7dfdc0 @traces=#<Datadog::Transport::HTTP::Traces::API::Endpoint:0x0000560f0e7dfd98 @verb=:post, @path="/v0.2/traces", @encoder=Datadog::Encoding::JSONEncoder, @service_rates=false>>, @adapter=#<Datadog::Transport::HTTP::Adapters::Net:0x0000560f0e818fa8 @hostname="ddagent", @port=8126, @timeout=1>, @headers={"Datadog-Meta-Lang"=>"ruby", "Datadog-Meta-Lang-Version"=>"2.4.6", "Datadog-Meta-Lang-Interpreter"=>"ruby-x86_64-linux", "Datadog-Meta-Tracer-Version"=>"0.45.0", "Datadog-Container-ID"=>"672885e52afa57b1b453bf78b2c5fb9e0463737d1051e3a549eaa882e0c8f964"}>}, @default_api="v0.4", @current_api_id="v0.4", @client=#<Datadog::Transport::HTTP::Client:0x0000560f0e7dd548 @api=#<Datadog::Transport::HTTP::API::Instance:0x0000560f0e7de9e8 @spec=#<Datadog::Transport::HTTP::API::Spec:0x0000560f0e7e82e0 @traces=#<Datadog::Transport::HTTP::Traces::API::Endpoint:0x0000560f0e7e8268 @verb=:post, @path="/v0.4/traces", @encoder=Datadog::Encoding::MsgpackEncoder, @service_rates=true>>, @adapter=#<Datadog::Transport::HTTP::Adapters::Net:0x0000560f0e818fa8 @hostname="ddagent", @port=8126, @timeout=1>, @headers={"Datadog-Meta-Lang"=>"ruby", "Datadog-Meta-Lang-Version"=>"2.4.6", "Datadog-Meta-Lang-Interpreter"=>"ruby-x86_64-linux", "Datadog-Meta-Tracer-Version"=>"0.45.0", "Datadog-Container-ID"=>"672885e52afa57b1b453bf78b2c5fb9e0463737d1051e3a549eaa882e0c8f964"}>, @stats=#<Datadog::Transport::Statistics::Counts:0x0000560f0f15a710 @success=1, @client_error=0, @server_error=0, @internal_error=0, @consecutive_errors=0>>>, @mutex_after_fork=#<Thread::Mutex:0x0000560f0e7dd458>, @pid=162, @traces_flushed=1, @worker=#<Datadog::Workers::AsyncTransport:0x0000560f0f0b6958 @transport=#<Datadog::Transport::Traces::Transport:0x0000560f0e7dd638 @apis={"v0.4"=>#<Datadog::Transport::HTTP::API::Instance:0x0000560f0e7de9e8 @spec=#<Datadog::Transport::HTTP::API::Spec:0x0000560f0e7e82e0 @traces=#<Datadog::Transport::HTTP::Traces::API::Endpoint:0x0000560f0e7e8268 @verb=:post, @path="/v0.4/traces", @encoder=Datadog::Encoding::MsgpackEncoder, @service_rates=true>>, @adapter=#<Datadog::Transport::HTTP::Adapters::Net:0x0000560f0e818fa8 @hostname="ddagent", @port=8126, @timeout=1>, @headers={"Datadog-Meta-Lang"=>"ruby", "Datadog-Meta-Lang-Version"=>"2.4.6", "Datadog-Meta-Lang-Interpreter"=>"ruby-x86_64-linux", "Datadog-Meta-Tracer-Version"=>"0.45.0", "Datadog-Container-ID"=>"672885e52afa57b1b453bf78b2c5fb9e0463737d1051e3a549eaa882e0c8f964"}>, "v0.3"=>#<Datadog::Transport::HTTP::API::Instance:0x0000560f0e7de1a0 @spec=#<Datadog::Transport::HTTP::API::Spec:0x0000560f0e7e8470 @traces=#<Datadog::Transport::HTTP::Traces::API::Endpoint:0x0000560f0e7e8dd0 @verb=:post, @path="/v0.3/traces", @encoder=Datadog::Encoding::MsgpackEncoder, @service_rates=false>>, @adapter=#<Datadog::Transport::HTTP::Adapters::Net:0x0000560f0e818fa8 @hostname="ddagent", @port=8126, @timeout=1>, @headers={"Datadog-Meta-Lang"=>"ruby", "Datadog-Meta-Lang-Version"=>"2.4.6", "Datadog-Meta-Lang-Interpreter"=>"ruby-x86_64-linux", "Datadog-Meta-Tracer-Version"=>"0.45.0", "Datadog-Container-ID"=>"672885e52afa57b1b453bf78b2c5fb9e0463737d1051e3a549eaa882e0c8f964"}>, "v0.2"=>#<Datadog::Transport::HTTP::API::Instance:0x0000560f0e7dd8b8 @spec=#<Datadog::Transport::HTTP::API::Spec:0x0000560f0e7dfdc0 @traces=#<Datadog::Transport::HTTP::Traces::API::Endpoint:0x0000560f0e7dfd98 @verb=:post, @path="/v0.2/traces", @encoder=Datadog::Encoding::JSONEncoder, @service_rates=false>>, @adapter=#<Datadog::Transport::HTTP::Adapters::Net:0x0000560f0e818fa8 @hostname="ddagent", @port=8126, @timeout=1>, @headers={"Datadog-Meta-Lang"=>"ruby", "Datadog-Meta-Lang-Version"=>"2.4.6", "Datadog-Meta-Lang-Interpreter"=>"ruby-x86_64-linux", "Datadog-Meta-Tracer-Version"=>"0.45.0", "Datadog-Container-ID"=>"672885e52afa57b1b453bf78b2c5fb9e0463737d1051e3a549eaa882e0c8f964"}>}, @default_api="v0.4", @current_api_id="v0.4", @client=#<Datadog::Transport::HTTP::Client:0x0000560f0e7dd548 @api=#<Datadog::Transport::HTTP::API::Instance:0x0000560f0e7de9e8 @spec=#<Datadog::Transport::HTTP::API::Spec:0x0000560f0e7e82e0 @traces=#<Datadog::Transport::HTTP::Traces::API::Endpoint:0x0000560f0e7e8268 @verb=:post, @path="/v0.4/traces", @encoder=Datadog::Encoding::MsgpackEncoder, @service_rates=true>>, @adapter=#<Datadog::Transport::HTTP::Adapters::Net:0x0000560f0e818fa8 @hostname="ddagent", @port=8126, @timeout=1>, @headers={"Datadog-Meta-Lang"=>"ruby", "Datadog-Meta-Lang-Version"=>"2.4.6", "Datadog-Meta-Lang-Interpreter"=>"ruby-x86_64-linux", "Datadog-Meta-Tracer-Version"=>"0.45.0", "Datadog-Container-ID"=>"672885e52afa57b1b453bf78b2c5fb9e0463737d1051e3a549eaa882e0c8f964"}>, @stats=#<Datadog::Transport::Statistics::Counts:0x0000560f0f15a710 @success=1, @client_error=0, @server_error=0, @internal_error=0, @consecutive_errors=0>>>, @trace_task=#<Proc:0x0000560f0f0b69a8@/app/lib/ddtrace/writer.rb:69 (lambda)>, @flush_interval=1, @back_off=1, @trace_buffer=#<Datadog::CRubyTraceBuffer:0x0000560f0f0b68b8 @max_size=1000, @items=[], @closed=false, @buffer_accepted=0, @buffer_accepted_lengths=0, @buffer_dropped=0, @buffer_spans=0>, @shutdown=#<Thread::ConditionVariable:0x0000560f0f0b67a0>, @mutex=#<Thread::Mutex:0x0000560f0f0b6750>, @worker=#<Thread:0x0000560f0f0b6610@Datadog::Workers::AsyncTransport@/app/spec/spec_helper.rb:176 sleep>, @run=true>, @stopped=false, @trace_handler=#<Proc:0x0000560f0f0b69a8@/app/lib/ddtrace/writer.rb:69 (lambda)>>, @mutex=#<Thread::Mutex:0x0000560f0e7dd340>>
```

It will print something like:

```
{
  "__class": "Datadog::Tracer",
  "context_flush": "#<Datadog::ContextFlush::Finished:0x00005585d2c6bb20>",
  "enabled": true,
  "provider": "#<Datadog::DefaultContextProvider:0x00005585d2c6baf8>",
  "sampler": "#<Datadog::PrioritySampler:0x00005585d2c12f20>",
  "tags": {
  },
  "writer": {
    "__class": "Datadog::Writer",
    "@buff_size": 1000,
    "@flush_interval": 1,
    "@mutex_after_fork": "#<Thread::Mutex:0x00005585d2c26048>",
    "@pid": 152,
    "@stopped": false,
    "@traces_flushed": 1,
    "priority_sampler": null,
    "transport": "#<Datadog::Transport::Traces::Transport:0x00005585d2c26138>",
    "worker": {
      "__class": "Datadog::Workers::AsyncTransport",
      "@back_off": 1,
      "@flush_interval": 1,
      "@mutex": "#<Thread::Mutex:0x00005585d34bc068>",
      "@run": true,
      "@shutdown": "#<Thread::ConditionVariable:0x00005585d34bc0e0>",
      "@trace_buffer": "#<Datadog::CRubyTraceBuffer:0x00005585d34bc1a8>",
      "@trace_task": "#<Proc:0x00005585d34bc220@/app/lib/ddtrace/writer.rb:69 (lambda)>",
      "@transport": "#<Datadog::Transport::Traces::Transport:0x00005585d2c26138>",
      "@worker": "#<Thread:0x00005585d34bc838>"
    }
  }
}
```

We can also use this data structure as data for diagnostic dumps (e.g. `EnvironmentLogger`) or other such purposes.