### PR TITLE
Add Ethon transport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'builder'
 gem 'climate_control', '~> 0.2.0'
 # Leave it open as we also have it as an integration and want Appraisal to control the version under test.
 gem 'concurrent-ruby'
+gem 'ethon', '>= 0.8.0'
 gem 'memory_profiler', '~> 0.9'
 gem 'minitest', '= 5.10.1'
 gem 'minitest-around', '0.5.0'

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2361,9 +2361,27 @@ By default, the tracer submits trace data using `Net::HTTP` to `127.0.0.1:8126`,
 
 Some basic settings, such as hostname and port, can be configured using [tracer settings](#tracer-settings).
 
+#### Using the Ethon adapter
+
+The `:ethon` adapter submits traces using [`Ethon`](https://github.com/typhoeus/ethon) over TCP. It is more memory efficient than the default `Net::HTTP` adapter, and it's a recommended replacement for the default adapter.
+Requires `ethon` version `0.8.0` or later to be available in the environment.
+
+```ruby
+# Gemfile
+gem 'ethon', '>= 0.8.0'
+```
+
+```ruby
+Datadog.configure do |c|
+  c.tracer.transport_options = proc { |t|
+    t.adapter :ethon
+  }
+end
+```
+
 #### Using the Net::HTTP adapter
 
-The `Net` adapter submits traces using `Net::HTTP` over TCP. It is the default transport adapter.
+The `:net_http` adapter submits traces using `Net::HTTP` over TCP. It is the default transport adapter.
 
 ```ruby
 Datadog.configure do |c|
@@ -2376,7 +2394,7 @@ end
 
 #### Using the Unix socket adapter
 
-The `UnixSocket` adapter submits traces using `Net::HTTP` over Unix socket.
+The `:unix` adapter submits traces using `Net::HTTP` over Unix socket.
 
 To use, first configure your trace agent to listen by Unix socket, then configure the tracer with:
 
@@ -2391,7 +2409,7 @@ end
 
 #### Using the transport test adapter
 
-The `Test` adapter is a no-op transport that can optionally buffer requests. For use in test suites or other non-production environments.
+The `:test` adapter is a no-op transport that can optionally buffer requests. For use in test suites or other non-production environments.
 
 ```ruby
 Datadog.configure do |c|

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -7,6 +7,7 @@ require 'ddtrace/runtime/container'
 require 'ddtrace/transport/http/builder'
 require 'ddtrace/transport/http/api'
 
+require 'ddtrace/transport/http/adapters/ethon'
 require 'ddtrace/transport/http/adapters/net'
 require 'ddtrace/transport/http/adapters/test'
 require 'ddtrace/transport/http/adapters/unix_socket'
@@ -96,6 +97,7 @@ module Datadog
       end
 
       # Add adapters to registry
+      Builder::REGISTRY.set(Adapters::Ethon, :ethon)
       Builder::REGISTRY.set(Adapters::Net, :net_http)
       Builder::REGISTRY.set(Adapters::Test, :test)
       Builder::REGISTRY.set(Adapters::UnixSocket, :unix)

--- a/lib/ddtrace/transport/http/adapters/ethon.rb
+++ b/lib/ddtrace/transport/http/adapters/ethon.rb
@@ -1,0 +1,98 @@
+require 'ddtrace/transport/response'
+require 'ethon'
+
+module Datadog
+  module Transport
+    module HTTP
+      module Adapters
+        # Adapter for Ethon >= 0.8.0.
+        # More memory efficient than Net::HTTP.
+        class Ethon
+          attr_reader \
+            :hostname,
+            :port,
+            :timeout
+
+          DEFAULT_TIMEOUT = 10
+
+          def initialize(
+            hostname = Datadog::Transport::HTTP.default_hostname,
+            port = Datadog::Transport::HTTP.default_port,
+            options = {}
+          )
+            @hostname = hostname
+            @port = port
+            @timeout = options[:timeout] || DEFAULT_TIMEOUT
+
+            @uri = URI::HTTP.build(host: hostname, port: port).to_s
+          end
+
+          def call(env)
+            if respond_to?(env.verb)
+              send(env.verb, env)
+            else
+              raise UnknownHTTPMethod, env
+            end
+          end
+
+          def post(env)
+            client = ::Ethon::Easy.new
+
+            post = ::Ethon::Easy::Http::Post.new(@uri + env.path, headers: env.headers, body: env.body)
+            post.setup(client)
+
+            client.perform
+
+            Response.new(client.response_code, client.response_body)
+          end
+
+          def url
+            "http://#{hostname}:#{port}?timeout=#{timeout}"
+          end
+
+          # Raised when called with an unknown HTTP method
+          class UnknownHTTPMethod < StandardError
+            attr_reader :verb
+
+            def initialize(verb)
+              super("No matching Net::HTTP function for '#{verb}'!")
+              @verb = verb
+            end
+          end
+
+          # A wrapped Net::HTTP response that implements the Transport::Response interface
+          class Response
+            include Datadog::Transport::Response
+
+            attr_reader :code, :payload
+
+            def initialize(code, payload)
+              @code = code
+              @payload = payload
+            end
+
+            def ok?
+              code.between?(200, 299)
+            end
+
+            def unsupported?
+              code == 415
+            end
+
+            def not_found?
+              code == 404
+            end
+
+            def client_error?
+              code.between?(400, 499)
+            end
+
+            def server_error?
+              code.between?(500, 599)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/benchmark/support/benchmark_helper.rb
+++ b/spec/ddtrace/benchmark/support/benchmark_helper.rb
@@ -56,7 +56,7 @@ RSpec.shared_context 'benchmark' do
                   @type
                 end
 
-    warn(@test, file_name, result)
+    warn(@test, file_name, result.to_s)
 
     directory = result_directory!(subtype)
     path = File.join(directory, file_name)

--- a/spec/ddtrace/benchmark/transport_benchmark_spec.rb
+++ b/spec/ddtrace/benchmark/transport_benchmark_spec.rb
@@ -18,12 +18,24 @@ RSpec.describe 'Microbenchmark Transport' do
       # in a single method call. This would translate to
       # up to 1000 spans per second in a real application.
       let(:steps) { [1, 10, 100, 1000] }
-      let(:transport) { Datadog::Transport::HTTP.default }
-
-      include_examples 'benchmark'
+      let(:transport) { Datadog.tracer.writer.transport }
 
       def subject(i)
         transport.send_traces(span[i])
+      end
+
+      context 'with Net::HTTP adapter' do
+        include_examples 'benchmark'
+      end
+
+      context 'with Ethon adapter' do
+        before do
+          Datadog.configure do |c|
+            c.tracer.transport_options = ->(t) { t.adapter :ethon }
+          end
+        end
+
+        include_examples 'benchmark'
       end
     end
   end


### PR DESCRIPTION
> _WIP, pending:_
> _0. Update circuit-breaker_
> _1. Adapter unit specs_
> _2. Small refactor to reuse Transport::HTTP code between Net::HTTP and Ethon_

The default Net::HTTP transport shows up as one of our slowest code path under a profiler (alongside Msgpack serialization).

A lot of that overhead is due to object creation when preparing an HTTP request for sending.

### Research

While looking for a more efficient implementation, I've started from the benchmarks ran by the [`http.rb` folks](https://github.com/httprb/http#another-ruby-http-library-why-should-i-care). I went through the list, starting form the top and ended up having success with Typhoeus, which is a nicely flushed out HTTP client built on top of Ethon, which in turn is built on top of the native cURL library.

Even though Typhoeus has a much nicer interface to work with, using it would increase our dependency requirement on users, so I chose to implement an adapter in Ethon. The different in interface cleanliness is not pronounced in our use case, as we only perform one kind of HTTP operation.

### Benchmarks

Benchmarks are build on top of the existing `benchmark/transport_benchmark_spec.rb` package.
This benchmark suite sends traces of varying sizes (different span count) using the transport on a tight loop.

CPU usage and GC overhead are virtually the same with both adapters, but memory usage is significantly reduced with Ethon:

#### Net::HTTP

| Spans in trace | Total resource |
| --- | --- |
| 1   |  4.864M memsize |
| 1   | 52.510k objects |
| 10    |  5.812M memsize |
| 10    | 59.710k objects |
| 100   | 15.202M memsize |
| 100    |131.710k objects |
| 1000   |109.308M memsize |
| 1000    |851.874k objects |

#### Ethon

| Spans in trace | Total resource |
| --- | --- |
| 1 |     1.549M memsize |
| 1 | 23.900k objects |
| 10 |    2.498M memsize |
| 10 | 31.100k objects |
| 100 |   11.900M memsize |
| 100 | 103.100k objects |
| 1000 |  106.099M memsize |
| 1000 | 823.100k objects |

#### Reduction of resource usage with Ethon

| Spans in trace | Resource reduction |
| --- | --- |
| 1 | 68.2% memsize |
| 1 | 54.5% objects |
| 10 | 57.0% memsize |
| 10 | 47.9% objects |
| 100 | 21.7% memsize |
| 100 | 21.7% objects |
| 1000 | 2.9% memsize |
| 1000 | 3.4% objects |

### Implementation

Ethon is not being declared as a required dependency of `ddtrace`. This is an optional adapter, in which the user has to ensure that `ethon` >= 0.8.0 is present in their application.
This version was chosen for the minimum version as it is relatively old (September, 2015) but still respects the interface of the latest version.

If this proves successful after some time, I believe we should detect the presence of `ethon` and automatically switch to it if present.