### PR TITLE
Extract generic fixes and additions from profiling branch

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -86,10 +86,9 @@ Lint/MissingCopEnableDirective:
     - 'test/contrib/rails/errors_test.rb'
     - 'test/tracer_test.rb'
 
-# Offense count: 25
+# Offense count: 24
 Lint/MissingSuper:
   Exclude:
-    - 'lib/ddtrace/contrib/active_record/configuration/resolver.rb'
     - 'lib/ddtrace/contrib/grpc/datadog_interceptor.rb'
     - 'lib/ddtrace/opentracer/scope.rb'
     - 'lib/ddtrace/opentracer/span.rb'
@@ -371,6 +370,8 @@ RSpec/VerifiedDoubles:
     - 'spec/ddtrace/transport/io/traces_spec.rb'
     - 'spec/ddtrace/transport/parcel_spec.rb'
     - 'spec/ddtrace/transport/traces_spec.rb'
+    - 'spec/ddtrace/utils/object_set_spec.rb'
+    - 'spec/ddtrace/utils/string_table_spec.rb'
     - 'spec/ddtrace/worker_spec.rb'
     - 'spec/ddtrace/workers/async_spec.rb'
     - 'spec/ddtrace/workers/loop_spec.rb'

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,0 +1,2 @@
+Component,Origin,License,Copyright
+ddtrace/vendor/multipart-post,https://github.com/socketry/multipart-post,MIT,"Copyright (c) 2007-2013 Nick Sieger."

--- a/lib/ddtrace/ext/runtime.rb
+++ b/lib/ddtrace/ext/runtime.rb
@@ -5,7 +5,9 @@ module Datadog
     module Runtime
       # Identity
       LANG = 'ruby'.freeze
+      LANG_ENGINE = RUBY_ENGINE
       LANG_INTERPRETER = "#{RUBY_ENGINE}-#{RUBY_PLATFORM}".freeze
+      LANG_PLATFORM = RUBY_PLATFORM
       LANG_VERSION = RUBY_VERSION
       RUBY_ENGINE =  ::RUBY_ENGINE # e.g. 'ruby', 'jruby', 'truffleruby'
       TRACER_VERSION = Datadog::VERSION::STRING

--- a/lib/ddtrace/runtime/identity.rb
+++ b/lib/ddtrace/runtime/identity.rb
@@ -24,8 +24,16 @@ module Datadog
         Ext::Runtime::LANG
       end
 
+      def lang_engine
+        Ext::Runtime::LANG_ENGINE
+      end
+
       def lang_interpreter
         Ext::Runtime::LANG_INTERPRETER
+      end
+
+      def lang_platform
+        Ext::Runtime::LANG_PLATFORM
       end
 
       def lang_version

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -27,7 +27,7 @@ module Datadog
       # Pass a block to override any settings.
       def default(options = {})
         new do |transport|
-          transport.adapter default_adapter, default_hostname, default_port
+          transport.adapter default_adapter, default_hostname, default_port, timeout: 1
           transport.headers default_headers
 
           apis = API.defaults
@@ -43,7 +43,7 @@ module Datadog
               hostname = options[:hostname] || default_hostname
               port = options[:port] || default_port
 
-              adapter_options = {}
+              adapter_options = { timeout: 1 }
               adapter_options[:timeout] = options[:timeout] if options.key?(:timeout)
               adapter_options[:ssl] = options[:ssl] if options.key?(:ssl)
 

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -27,7 +27,7 @@ module Datadog
       # Pass a block to override any settings.
       def default(options = {})
         new do |transport|
-          transport.adapter :net_http, default_hostname, default_port
+          transport.adapter default_adapter, default_hostname, default_port
           transport.headers default_headers
 
           apis = API.defaults
@@ -39,10 +39,15 @@ module Datadog
           # Apply any settings given by options
           unless options.empty?
             # Change hostname/port
-            if options.key?(:hostname) || options.key?(:port)
-              hostname = options.fetch(:hostname, default_hostname)
-              port = options.fetch(:port, default_port)
-              transport.adapter :net_http, hostname, port
+            if [:hostname, :port, :timeout, :ssl].any? { |key| options.key?(key) }
+              hostname = options[:hostname] || default_hostname
+              port = options[:port] || default_port
+
+              adapter_options = {}
+              adapter_options[:timeout] = options[:timeout] if options.key?(:timeout)
+              adapter_options[:ssl] = options[:ssl] if options.key?(:ssl)
+
+              transport.adapter default_adapter, hostname, port, adapter_options
             end
 
             # Change default API
@@ -71,6 +76,10 @@ module Datadog
           container_id = Datadog::Runtime::Container.container_id
           headers[Datadog::Ext::Transport::HTTP::HEADER_CONTAINER_ID] = container_id unless container_id.nil?
         end
+      end
+
+      def default_adapter
+        :net_http
       end
 
       def default_hostname

--- a/lib/ddtrace/transport/http/adapters/net.rb
+++ b/lib/ddtrace/transport/http/adapters/net.rb
@@ -13,7 +13,7 @@ module Datadog
             :timeout,
             :ssl
 
-          DEFAULT_TIMEOUT = 1
+          DEFAULT_TIMEOUT = 30
 
           def initialize(hostname, port, options = {})
             @hostname = hostname

--- a/lib/ddtrace/transport/http/adapters/net.rb
+++ b/lib/ddtrace/transport/http/adapters/net.rb
@@ -1,4 +1,5 @@
 require 'ddtrace/transport/response'
+require 'ddtrace/vendor/multipart-post/net/http/post/multipart'
 
 module Datadog
   module Transport
@@ -9,7 +10,8 @@ module Datadog
           attr_reader \
             :hostname,
             :port,
-            :timeout
+            :timeout,
+            :ssl
 
           DEFAULT_TIMEOUT = 1
 
@@ -17,6 +19,7 @@ module Datadog
             @hostname = hostname
             @port = port
             @timeout = options[:timeout] || DEFAULT_TIMEOUT
+            @ssl = options.key?(:ssl) ? options[:ssl] == true : false
           end
 
           def open(&block)
@@ -25,6 +28,7 @@ module Datadog
             # https://github.com/ruby/ruby/blob/b2d96abb42abbe2e01f010ffc9ac51f0f9a50002/lib/net/http.rb#L614-L618
             req = ::Net::HTTP.new(hostname, port, nil)
 
+            req.use_ssl = ssl
             req.open_timeout = req.read_timeout = timeout
 
             req.start(&block)
@@ -39,8 +43,18 @@ module Datadog
           end
 
           def post(env)
-            post = ::Net::HTTP::Post.new(env.path, env.headers)
-            post.body = env.body
+            post = nil
+
+            if env.form.nil? || env.form.empty?
+              post = ::Net::HTTP::Post.new(env.path, env.headers)
+              post.body = env.body
+            else
+              post = ::Datadog::Vendor::Net::HTTP::Post::Multipart.new(
+                env.path,
+                env.form,
+                env.headers
+              )
+            end
 
             # Connect and send the request
             http_response = open do |http|

--- a/lib/ddtrace/transport/http/builder.rb
+++ b/lib/ddtrace/transport/http/builder.rb
@@ -95,7 +95,7 @@ module Datadog
               api_options[:headers] = @default_headers.merge((api_options[:headers] || {}))
 
               # Add API::Instance with all settings
-              instances[key] = API::Instance.new(
+              instances[key] = api_instance_class.new(
                 spec,
                 adapter,
                 api_options
@@ -105,6 +105,10 @@ module Datadog
               instances.with_fallbacks(key => fallback) unless fallback.nil?
             end
           end
+        end
+
+        def api_instance_class
+          API::Instance
         end
 
         # Raised when the API key does not match known APIs.

--- a/lib/ddtrace/transport/http/env.rb
+++ b/lib/ddtrace/transport/http/env.rb
@@ -42,6 +42,14 @@ module Datadog
         def headers=(value)
           self[:headers] = value
         end
+
+        def form
+          self[:form] ||= {}
+        end
+
+        def form=(value)
+          self[:form] = value
+        end
       end
     end
   end

--- a/lib/ddtrace/transport/io/response.rb
+++ b/lib/ddtrace/transport/io/response.rb
@@ -6,14 +6,12 @@ module Datadog
       # Response from HTTP transport for traces
       class Response
         include Transport::Response
-        include Transport::Traces::Response
 
         attr_reader \
           :result
 
-        def initialize(result, trace_count = 1)
+        def initialize(result)
           @result = result
-          @trace_count = trace_count
         end
 
         def ok?

--- a/lib/ddtrace/transport/io/traces.rb
+++ b/lib/ddtrace/transport/io/traces.rb
@@ -10,6 +10,12 @@ module Datadog
       module Traces
         # Response from HTTP transport for traces
         class Response < IO::Response
+          include Transport::Traces::Response
+
+          def initialize(result, trace_count = 1)
+            super(result)
+            @trace_count = trace_count
+          end
         end
 
         # Extensions for HTTP client

--- a/lib/ddtrace/utils/compression.rb
+++ b/lib/ddtrace/utils/compression.rb
@@ -1,0 +1,27 @@
+require 'zlib'
+
+module Datadog
+  module Utils
+    # Common database-related utility functions.
+    module Compression
+      module_function
+
+      def gzip(string, level: nil, strategy: nil)
+        sio = StringIO.new
+        sio.binmode
+        gz = Zlib::GzipWriter.new(sio, level, strategy)
+        gz.write(string)
+        gz.close
+        sio.string
+      end
+
+      def gunzip(string, encoding = ::Encoding::ASCII_8BIT)
+        sio = StringIO.new(string)
+        gz = Zlib::GzipReader.new(sio, encoding: encoding)
+        gz.read
+      ensure
+        gz && gz.close
+      end
+    end
+  end
+end

--- a/lib/ddtrace/utils/object_set.rb
+++ b/lib/ddtrace/utils/object_set.rb
@@ -1,0 +1,40 @@
+require 'ddtrace/utils/sequence'
+
+module Datadog
+  module Utils
+    # Acts as a unique dictionary of objects
+    class ObjectSet
+      # You can provide a block that defines how the key
+      # for this message type is resolved.
+      def initialize(seed = 0, &block)
+        @sequence = Utils::Sequence.new(seed)
+        @items = {}
+        @key_block = block
+      end
+
+      # Submit an array of arguments that define the message.
+      # If they match an existing message, it will return the
+      # matching object. If it doesn't match, it will yield to
+      # the block with the next ID & args given.
+      def fetch(*args, &block)
+        key = @key_block ? @key_block.call(*args) : args.hash
+        # TODO: Ruby 2.0 doesn't like yielding here... switch when 2.0 is dropped.
+        # rubocop:disable Performance/RedundantBlockCall
+        @items[key] ||= block.call(@sequence.next, *args)
+      end
+
+      def length
+        @items.length
+      end
+
+      def objects
+        @items.values
+      end
+
+      def freeze
+        super
+        @items.freeze
+      end
+    end
+  end
+end

--- a/lib/ddtrace/utils/object_set.rb
+++ b/lib/ddtrace/utils/object_set.rb
@@ -21,6 +21,7 @@ module Datadog
         # TODO: Ruby 2.0 doesn't like yielding here... switch when 2.0 is dropped.
         # rubocop:disable Performance/RedundantBlockCall
         @items[key] ||= block.call(@sequence.next, *args)
+        # rubocop:enable Performance/RedundantBlockCall
       end
 
       def length

--- a/lib/ddtrace/utils/sequence.rb
+++ b/lib/ddtrace/utils/sequence.rb
@@ -1,0 +1,17 @@
+module Datadog
+  module Utils
+    # Generates values from a consistent sequence
+    class Sequence
+      def initialize(seed = 0, &block)
+        @current = seed
+        @next_item = block
+      end
+
+      def next
+        next_item = @next_item ? @next_item.call(@current) : @current
+        @current += 1
+        next_item
+      end
+    end
+  end
+end

--- a/lib/ddtrace/utils/string_table.rb
+++ b/lib/ddtrace/utils/string_table.rb
@@ -1,0 +1,45 @@
+require 'ddtrace/utils/sequence'
+
+module Datadog
+  module Utils
+    # Tracks strings and returns IDs
+    class StringTable
+      def initialize
+        @sequence = Sequence.new
+        @ids = { ''.freeze => @sequence.next }
+      end
+
+      # Returns an ID for the string
+      def fetch(string)
+        @ids[string.to_s] ||= @sequence.next
+      end
+
+      # Returns the canonical copy of this string
+      # Typically used for psuedo interning; reduce
+      # identical copies of a string to one object.
+      def fetch_string(string)
+        return nil if string.nil?
+
+        # Co-erce to string
+        string = string.to_s
+
+        # Add to string table if no match
+        @ids[string] = @sequence.next unless @ids.key?(string)
+
+        # Get and return matching string in table
+        # NOTE: Have to resolve the key and retrieve from table again
+        #       because "string" argument is not same object as string key.
+        id = @ids[string]
+        @ids.key(id)
+      end
+
+      def [](id)
+        @ids.key(id)
+      end
+
+      def strings
+        @ids.keys
+      end
+    end
+  end
+end

--- a/lib/ddtrace/utils/time.rb
+++ b/lib/ddtrace/utils/time.rb
@@ -33,6 +33,13 @@ module Datadog
       def now_provider=(block)
         define_singleton_method(:now, &block)
       end
+
+      def measure
+        before = get_time
+        yield
+        after = get_time
+        after - before
+      end
     end
   end
 end

--- a/lib/ddtrace/vendor/multipart-post/LICENSE
+++ b/lib/ddtrace/vendor/multipart-post/LICENSE
@@ -1,0 +1,11 @@
+Released under the MIT license.
+
+Copyright, 2007-2013, by Nick Sieger.
+Copyright, 2017, by Samuel G. D. Williams.
+Copyright, 2019, by Patrick Davey.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/ddtrace/vendor/multipart-post/multipart.rb
+++ b/lib/ddtrace/vendor/multipart-post/multipart.rb
@@ -1,0 +1,12 @@
+#--
+# Copyright (c) 2007-2013 Nick Sieger.
+# See the file README.txt included with the distribution for
+# software license details.
+#++
+
+module Datadog
+  module Vendor
+    module Multipart
+    end
+  end
+end

--- a/lib/ddtrace/vendor/multipart-post/multipart/post.rb
+++ b/lib/ddtrace/vendor/multipart-post/multipart/post.rb
@@ -1,0 +1,8 @@
+module Datadog
+  module Vendor
+    module Multipart
+      module Post
+      end
+    end
+  end
+end

--- a/lib/ddtrace/vendor/multipart-post/multipart/post/composite_read_io.rb
+++ b/lib/ddtrace/vendor/multipart-post/multipart/post/composite_read_io.rb
@@ -1,0 +1,116 @@
+#--
+# Copyright (c) 2007-2012 Nick Sieger.
+# See the file README.txt included with the distribution for
+# software license details.
+#++
+
+# Concatenate together multiple IO objects into a single, composite IO object
+# for purposes of reading as a single stream.
+#
+# @example
+#     crio = CompositeReadIO.new(StringIO.new('one'),
+#                                StringIO.new('two'),
+#                                StringIO.new('three'))
+#     puts crio.read # => "onetwothree"
+module Datadog
+  module Vendor
+    module Multipart
+      module Post
+        class CompositeReadIO
+          # Create a new composite-read IO from the arguments, all of which should
+          # respond to #read in a manner consistent with IO.
+          def initialize(*ios)
+            @ios = ios.flatten
+            @index = 0
+          end
+
+          # Read from IOs in order until `length` bytes have been received.
+          def read(length = nil, outbuf = nil)
+            got_result = false
+            outbuf = outbuf ? outbuf.replace("") : ""
+
+            while io = current_io
+              if result = io.read(length)
+                got_result ||= !result.nil?
+                result.force_encoding("BINARY") if result.respond_to?(:force_encoding)
+                outbuf << result
+                length -= result.length if length
+                break if length == 0
+              end
+              advance_io
+            end
+            (!got_result && length) ? nil : outbuf
+          end
+
+          def rewind
+            @ios.each { |io| io.rewind }
+            @index = 0
+          end
+
+          private
+
+          def current_io
+            @ios[@index]
+          end
+
+          def advance_io
+            @index += 1
+          end
+        end
+
+        # Convenience methods for dealing with files and IO that are to be uploaded.
+        class UploadIO
+          attr_reader :content_type, :original_filename, :local_path, :io, :opts
+
+          # Create an upload IO suitable for including in the params hash of a
+          # Net::HTTP::Post::Multipart.
+          #
+          # Can take two forms. The first accepts a filename and content type, and
+          # opens the file for reading (to be closed by finalizer).
+          #
+          # The second accepts an already-open IO, but also requires a third argument,
+          # the filename from which it was opened (particularly useful/recommended if
+          # uploading directly from a form in a framework, which often save the file to
+          # an arbitrarily named RackMultipart file in /tmp).
+          #
+          # @example
+          #     UploadIO.new("file.txt", "text/plain")
+          #     UploadIO.new(file_io, "text/plain", "file.txt")
+          def initialize(filename_or_io, content_type, filename = nil, opts = {})
+            io = filename_or_io
+            local_path = ""
+            if io.respond_to? :read
+              # in Ruby 1.9.2, StringIOs no longer respond to path
+              # (since they respond to :length, so we don't need their local path, see parts.rb:41)
+              local_path = filename_or_io.respond_to?(:path) ? filename_or_io.path : "local.path"
+            else
+              io = File.open(filename_or_io)
+              local_path = filename_or_io
+            end
+            filename ||= local_path
+
+            @content_type = content_type
+            @original_filename = File.basename(filename)
+            @local_path = local_path
+            @io = io
+            @opts = opts
+          end
+
+          def self.convert!(io, content_type, original_filename, local_path)
+            raise ArgumentError, "convert! has been removed. You must now wrap IOs " \
+              "using:\nUploadIO.new(filename_or_io, content_type, " \
+              "filename=nil)\nPlease update your code."
+          end
+
+          def method_missing(*args)
+            @io.send(*args)
+          end
+
+          def respond_to?(meth, include_all = false)
+            @io.respond_to?(meth, include_all) || super(meth, include_all)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/vendor/multipart-post/multipart/post/multipartable.rb
+++ b/lib/ddtrace/vendor/multipart-post/multipart/post/multipartable.rb
@@ -1,0 +1,57 @@
+#--
+# Copyright (c) 2007-2013 Nick Sieger.
+# See the file README.txt included with the distribution for
+# software license details.
+#++
+
+require 'ddtrace/vendor/multipart-post/multipart/post/parts'
+require 'ddtrace/vendor/multipart-post/multipart/post/composite_read_io'
+require 'securerandom'
+
+module Datadog
+  module Vendor
+    module Multipart
+      module Post
+        module Multipartable
+          def self.secure_boundary
+            # https://tools.ietf.org/html/rfc7230
+            #      tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*"
+            #                     / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
+            #                     / DIGIT / ALPHA
+
+            # https://tools.ietf.org/html/rfc2046
+            #      bcharsnospace := DIGIT / ALPHA / "'" / "(" / ")" /
+            #                       "+" / "_" / "," / "-" / "." /
+            #                       "/" / ":" / "=" / "?"
+
+            "--#{SecureRandom.uuid}"
+          end
+
+          def initialize(path, params, headers={}, boundary = Multipartable.secure_boundary)
+            headers = headers.clone # don't want to modify the original variable
+            parts_headers = headers.delete(:parts) || {}
+            super(path, headers)
+            parts = params.map do |k,v|
+              case v
+              when Array
+                v.map {|item| Parts::Part.new(boundary, "#{k}[]", item, parts_headers[k]) }
+              else
+                Parts::Part.new(boundary, k, v, parts_headers[k])
+              end
+            end.flatten
+            parts << Parts::EpiloguePart.new(boundary)
+            ios = parts.map {|p| p.to_io }
+            self.set_content_type(headers["Content-Type"] || "multipart/form-data",
+                                  { "boundary" => boundary })
+            self.content_length = parts.inject(0) {|sum,i| sum + i.length }
+            self.body_stream = CompositeReadIO.new(*ios)
+
+            @boundary = boundary
+          end
+
+          attr :boundary
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/vendor/multipart-post/multipart/post/parts.rb
+++ b/lib/ddtrace/vendor/multipart-post/multipart/post/parts.rb
@@ -1,0 +1,135 @@
+#--
+# Copyright (c) 2007-2013 Nick Sieger.
+# See the file README.txt included with the distribution for
+# software license details.
+#++
+
+module Datadog
+  module Vendor
+    module Multipart
+      module Post
+        module Parts
+          module Part
+            def self.new(boundary, name, value, headers = {})
+              headers ||= {} # avoid nil values
+              if file?(value)
+                FilePart.new(boundary, name, value, headers)
+              else
+                ParamPart.new(boundary, name, value, headers)
+              end
+            end
+
+            def self.file?(value)
+              value.respond_to?(:content_type) && value.respond_to?(:original_filename)
+            end
+
+            def length
+              @part.length
+            end
+
+            def to_io
+              @io
+            end
+          end
+
+          # Represents a parametric part to be filled with given value.
+          class ParamPart
+            include Part
+
+            # @param boundary [String]
+            # @param name [#to_s]
+            # @param value [String]
+            # @param headers [Hash] Content-Type and Content-ID are used, if present.
+            def initialize(boundary, name, value, headers = {})
+              @part = build_part(boundary, name, value, headers)
+              @io = StringIO.new(@part)
+            end
+
+            def length
+              @part.bytesize
+            end
+
+            # @param boundary [String]
+            # @param name [#to_s]
+            # @param value [String]
+            # @param headers [Hash] Content-Type is used, if present.
+            def build_part(boundary, name, value, headers = {})
+              part = ''
+              part << "--#{boundary}\r\n"
+              part << "Content-ID: #{headers["Content-ID"]}\r\n" if headers["Content-ID"]
+              part << "Content-Disposition: form-data; name=\"#{name.to_s}\"\r\n"
+              part << "Content-Type: #{headers["Content-Type"]}\r\n" if headers["Content-Type"]
+              part << "\r\n"
+              part << "#{value}\r\n"
+            end
+          end
+
+          # Represents a part to be filled from file IO.
+          class FilePart
+            include Part
+
+            attr_reader :length
+
+            # @param boundary [String]
+            # @param name [#to_s]
+            # @param io [IO]
+            # @param headers [Hash]
+            def initialize(boundary, name, io, headers = {})
+              file_length = io.respond_to?(:length) ?  io.length : File.size(io.local_path)
+              @head = build_head(boundary, name, io.original_filename, io.content_type, file_length,
+                                 io.respond_to?(:opts) ? io.opts.merge(headers) : headers)
+              @foot = "\r\n"
+              @length = @head.bytesize + file_length + @foot.length
+              @io = CompositeReadIO.new(StringIO.new(@head), io, StringIO.new(@foot))
+            end
+
+            # @param boundary [String]
+            # @param name [#to_s]
+            # @param filename [String]
+            # @param type [String]
+            # @param content_len [Integer]
+            # @param opts [Hash]
+            def build_head(boundary, name, filename, type, content_len, opts = {})
+              opts = opts.clone
+
+              trans_encoding = opts.delete("Content-Transfer-Encoding") || "binary"
+              content_disposition = opts.delete("Content-Disposition") || "form-data"
+
+              part = ''
+              part << "--#{boundary}\r\n"
+              part << "Content-Disposition: #{content_disposition}; name=\"#{name.to_s}\"; filename=\"#{filename}\"\r\n"
+              part << "Content-Length: #{content_len}\r\n"
+              if content_id = opts.delete("Content-ID")
+                part << "Content-ID: #{content_id}\r\n"
+              end
+
+              if opts["Content-Type"] != nil
+                part <<  "Content-Type: " + opts["Content-Type"] + "\r\n"
+              else
+                part << "Content-Type: #{type}\r\n"
+              end
+
+              part << "Content-Transfer-Encoding: #{trans_encoding}\r\n"
+
+              opts.each do |k, v|
+                part << "#{k}: #{v}\r\n"
+              end
+
+              part << "\r\n"
+            end
+          end
+
+          # Represents the epilogue or closing boundary.
+          class EpiloguePart
+            include Part
+
+            def initialize(boundary)
+              @part = "--#{boundary}--\r\n"
+              @io = StringIO.new(@part)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/vendor/multipart-post/multipart/post/version.rb
+++ b/lib/ddtrace/vendor/multipart-post/multipart/post/version.rb
@@ -1,0 +1,9 @@
+module Datadog
+  module Vendor
+    module Multipart
+      module Post
+        VERSION = "2.1.1"
+      end
+    end
+  end
+end

--- a/lib/ddtrace/vendor/multipart-post/net/http/post/multipart.rb
+++ b/lib/ddtrace/vendor/multipart-post/net/http/post/multipart.rb
@@ -1,0 +1,32 @@
+#--
+# Copyright (c) 2007-2012 Nick Sieger.
+# See the file README.txt included with the distribution for
+# software license details.
+#++
+
+require 'net/http'
+require 'stringio'
+require 'cgi'
+require 'ddtrace/vendor/multipart-post/multipart/post/parts'
+require 'ddtrace/vendor/multipart-post/multipart/post/composite_read_io'
+require 'ddtrace/vendor/multipart-post/multipart/post/multipartable'
+
+module Datadog
+  module Vendor
+    module Net
+      class HTTP
+        class Put
+          class Multipart < ::Net::HTTP::Put
+            include ::Datadog::Vendor::Multipart::Post::Multipartable
+          end
+        end
+
+        class Post
+          class Multipart < ::Net::HTTP::Post
+            include ::Datadog::Vendor::Multipart::Post::Multipartable
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/workers/async.rb
+++ b/lib/ddtrace/workers/async.rb
@@ -18,7 +18,7 @@ module Datadog
         # Methods that must be prepended
         module PrependedMethods
           def perform(*args)
-            start { self.result = super(*args) } unless started?
+            start_async { self.result = super(*args) } unless started?
           end
         end
 
@@ -105,7 +105,7 @@ module Datadog
           @worker ||= nil
         end
 
-        def start(&block)
+        def start_async(&block)
           mutex.synchronize do
             return if running?
 

--- a/lib/ddtrace/workers/async.rb
+++ b/lib/ddtrace/workers/async.rb
@@ -126,7 +126,7 @@ module Datadog
           @run_async = true
           @pid = Process.pid
           @error = nil
-          Datadog.logger.debug("Starting thread in the process: #{Process.pid}")
+          Datadog.logger.debug("Starting thread in the process: #{Process.pid} for: #{self}")
 
           @worker = ::Thread.new do
             begin

--- a/lib/ddtrace/workers/loop.rb
+++ b/lib/ddtrace/workers/loop.rb
@@ -55,12 +55,21 @@ module Datadog
         @loop_wait_time ||= loop_base_interval
       end
 
+      def loop_wait_time=(value)
+        @loop_wait_time = value
+      end
+
+      def reset_loop_wait_time
+        self.loop_wait_time = loop_base_interval
+      end
+
+      # Should the loop "back off" when there's no work?
       def loop_back_off?
         false
       end
 
-      def loop_back_off!(amount = nil)
-        @loop_wait_time = amount || [loop_wait_time * BACK_OFF_RATIO, BACK_OFF_MAX].min
+      def loop_back_off!
+        self.loop_wait_time = [loop_wait_time * BACK_OFF_RATIO, BACK_OFF_MAX].min
       end
 
       protected
@@ -81,12 +90,14 @@ module Datadog
 
         loop do
           if work_pending?
+            # There's work to do...
             # Run the task
             yield
 
             # Reset the wait interval
-            loop_back_off!(loop_base_interval)
+            reset_loop_wait_time if loop_back_off?
           elsif loop_back_off?
+            # There's no work to do...
             # Back off the wait interval a bit
             loop_back_off!
           end

--- a/spec/ddtrace/runtime/identity_spec.rb
+++ b/spec/ddtrace/runtime/identity_spec.rb
@@ -33,4 +33,34 @@ RSpec.describe Datadog::Runtime::Identity do
       end
     end
   end
+
+  describe '::lang' do
+    subject(:lang) { described_class.lang }
+    it { is_expected.to eq(Datadog::Ext::Runtime::LANG) }
+  end
+
+  describe '::lang_engine' do
+    subject(:lang_engine) { described_class.lang_engine }
+    it { is_expected.to eq(Datadog::Ext::Runtime::LANG_ENGINE) }
+  end
+
+  describe '::lang_interpreter' do
+    subject(:lang_interpreter) { described_class.lang_interpreter }
+    it { is_expected.to eq(Datadog::Ext::Runtime::LANG_INTERPRETER) }
+  end
+
+  describe '::lang_platform' do
+    subject(:lang_platform) { described_class.lang_platform }
+    it { is_expected.to eq(Datadog::Ext::Runtime::LANG_PLATFORM) }
+  end
+
+  describe '::lang_version' do
+    subject(:lang_version) { described_class.lang_version }
+    it { is_expected.to eq(Datadog::Ext::Runtime::LANG_VERSION) }
+  end
+
+  describe '::tracer_version' do
+    subject(:tracer_version) { described_class.tracer_version }
+    it { is_expected.to eq(Datadog::Ext::Runtime::TRACER_VERSION) }
+  end
 end

--- a/spec/ddtrace/runtime/identity_spec.rb
+++ b/spec/ddtrace/runtime/identity_spec.rb
@@ -36,31 +36,37 @@ RSpec.describe Datadog::Runtime::Identity do
 
   describe '::lang' do
     subject(:lang) { described_class.lang }
+
     it { is_expected.to eq(Datadog::Ext::Runtime::LANG) }
   end
 
   describe '::lang_engine' do
     subject(:lang_engine) { described_class.lang_engine }
+
     it { is_expected.to eq(Datadog::Ext::Runtime::LANG_ENGINE) }
   end
 
   describe '::lang_interpreter' do
     subject(:lang_interpreter) { described_class.lang_interpreter }
+
     it { is_expected.to eq(Datadog::Ext::Runtime::LANG_INTERPRETER) }
   end
 
   describe '::lang_platform' do
     subject(:lang_platform) { described_class.lang_platform }
+
     it { is_expected.to eq(Datadog::Ext::Runtime::LANG_PLATFORM) }
   end
 
   describe '::lang_version' do
     subject(:lang_version) { described_class.lang_version }
+
     it { is_expected.to eq(Datadog::Ext::Runtime::LANG_VERSION) }
   end
 
   describe '::tracer_version' do
     subject(:tracer_version) { described_class.tracer_version }
+
     it { is_expected.to eq(Datadog::Ext::Runtime::TRACER_VERSION) }
   end
 end

--- a/spec/ddtrace/transport/http/adapters/net_integration_spec.rb
+++ b/spec/ddtrace/transport/http/adapters/net_integration_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Adapters::Net integration tests' do
     let(:access_log) { [[log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]] }
     let(:server_proc) do
       proc do |req, res|
-        messages << req
+        messages << req.tap { req.body } # Read body, store message before socket closes.
         res.body = '{}'
       end
     end
@@ -80,6 +80,7 @@ RSpec.describe 'Adapters::Net integration tests' do
         end
 
         expect(http_request.header['content-length'].first.to_i).to be > 0
+        expect(http_request.body.length).to be > 0
       end
     end
   end

--- a/spec/ddtrace/transport/http/adapters/net_spec.rb
+++ b/spec/ddtrace/transport/http/adapters/net_spec.rb
@@ -73,11 +73,13 @@ RSpec.describe Datadog::Transport::HTTP::Adapters::Net do
 
       context 'with nil' do
         let(:ssl) { nil }
+
         it { is_expected.to have_attributes(ssl: false) }
       end
 
       context 'with true' do
         let(:ssl) { true }
+
         it { is_expected.to have_attributes(ssl: true) }
       end
     end

--- a/spec/ddtrace/transport/http/adapters/net_spec.rb
+++ b/spec/ddtrace/transport/http/adapters/net_spec.rb
@@ -24,9 +24,27 @@ RSpec.describe Datadog::Transport::HTTP::Adapters::Net do
 
       allow(http_connection).to receive(:open_timeout=).with(adapter.timeout)
       allow(http_connection).to receive(:read_timeout=).with(adapter.timeout)
+      allow(http_connection).to receive(:use_ssl=).with(adapter.ssl)
 
       allow(http_connection).to receive(:start).and_yield(http_connection)
     end
+  end
+
+  shared_context 'HTTP Env' do
+    let(:env) do
+      instance_double(
+        Datadog::Transport::HTTP::Env,
+        path: path,
+        body: body,
+        headers: headers,
+        form: form
+      )
+    end
+
+    let(:path) { '/foo' }
+    let(:body) { '{}' }
+    let(:headers) { {} }
+    let(:form) { {} }
   end
 
   describe '#initialize' do
@@ -37,16 +55,31 @@ RSpec.describe Datadog::Transport::HTTP::Adapters::Net do
         is_expected.to have_attributes(
           hostname: hostname,
           port: port,
-          timeout: Datadog::Transport::HTTP::Adapters::Net::DEFAULT_TIMEOUT
+          timeout: Datadog::Transport::HTTP::Adapters::Net::DEFAULT_TIMEOUT,
+          ssl: false
         )
       end
     end
 
-    context 'given a timeout option' do
+    context 'given a :timeout option' do
       let(:options) { { timeout: timeout } }
       let(:timeout) { double('timeout') }
 
       it { is_expected.to have_attributes(timeout: timeout) }
+    end
+
+    context 'given a :ssl option' do
+      let(:options) { { ssl: ssl } }
+
+      context 'with nil' do
+        let(:ssl) { nil }
+        it { is_expected.to have_attributes(ssl: false) }
+      end
+
+      context 'with true' do
+        let(:ssl) { true }
+        it { is_expected.to have_attributes(ssl: true) }
+      end
     end
   end
 
@@ -59,12 +92,9 @@ RSpec.describe Datadog::Transport::HTTP::Adapters::Net do
   end
 
   describe '#call' do
-    subject(:call) { adapter.call(env) }
+    include_context 'HTTP Env'
 
-    let(:env) { instance_double(Datadog::Transport::HTTP::Env, path: path, body: body, headers: headers) }
-    let(:path) { '/foo' }
-    let(:body) { '{}' }
-    let(:headers) { {} }
+    subject(:call) { adapter.call(env) }
 
     context 'given an HTTP::Env with a verb' do
       before { allow(env).to receive(:verb).and_return(verb) }
@@ -80,11 +110,48 @@ RSpec.describe Datadog::Transport::HTTP::Adapters::Net do
         let(:verb) { :post }
         let(:http_response) { double('http_response') }
 
-        before { expect(http_connection).to receive(:request).and_return(http_response) }
+        context 'and an empty form body' do
+          let(:form) { {} }
+          let(:post) { instance_double(Net::HTTP::Post) }
 
-        it 'produces a response' do
-          is_expected.to be_a_kind_of(described_class::Response)
-          expect(call.http_response).to be(http_response)
+          it 'makes a POST and produces a response' do
+            expect(Net::HTTP::Post)
+              .to receive(:new)
+              .with(env.path, env.headers)
+              .and_return(post)
+
+            expect(post)
+              .to receive(:body=)
+              .with(env.body)
+
+            expect(http_connection)
+              .to receive(:request)
+              .with(post)
+              .and_return(http_response)
+
+            is_expected.to be_a_kind_of(described_class::Response)
+            expect(call.http_response).to be(http_response)
+          end
+        end
+
+        context 'and a form with fields' do
+          let(:form) { { 'id' => '1234', 'type' => 'Test' } }
+          let(:multipart_post) { instance_double(Datadog::Vendor::Net::HTTP::Post::Multipart) }
+
+          it 'makes a multipart POST and produces a response' do
+            expect(Datadog::Vendor::Net::HTTP::Post::Multipart)
+              .to receive(:new)
+              .with(env.path, env.form, env.headers)
+              .and_return(multipart_post)
+
+            expect(http_connection)
+              .to receive(:request)
+              .with(multipart_post)
+              .and_return(http_response)
+
+            is_expected.to be_a_kind_of(described_class::Response)
+            expect(call.http_response).to be(http_response)
+          end
         end
       end
     end
@@ -92,13 +159,9 @@ RSpec.describe Datadog::Transport::HTTP::Adapters::Net do
 
   describe '#post' do
     include_context 'HTTP connection stub'
+    include_context 'HTTP Env'
 
     subject(:post) { adapter.post(env) }
-
-    let(:env) { instance_double(Datadog::Transport::HTTP::Env, path: path, body: body, headers: headers) }
-    let(:path) { '/foo' }
-    let(:body) { '{}' }
-    let(:headers) { {} }
 
     let(:http_response) { double('http_response') }
 

--- a/spec/ddtrace/transport/http/builder_spec.rb
+++ b/spec/ddtrace/transport/http/builder_spec.rb
@@ -288,6 +288,7 @@ RSpec.describe Datadog::Transport::HTTP::Builder do
 
   describe '#api_instance_class' do
     subject(:api_instance_class) { builder.api_instance_class }
+
     it { is_expected.to be(Datadog::Transport::HTTP::API::Instance) }
   end
 end

--- a/spec/ddtrace/transport/http/builder_spec.rb
+++ b/spec/ddtrace/transport/http/builder_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe Datadog::Transport::HTTP::Builder do
         include_context 'default adapter'
 
         it 'configures the API instance with the default adapter' do
-          expect(api_instances).to include(key => kind_of(Datadog::Transport::HTTP::API::Instance))
+          expect(api_instances).to include(key => kind_of(builder.api_instance_class))
           expect(api_instances[key].adapter).to be adapter
         end
       end
@@ -190,7 +190,7 @@ RSpec.describe Datadog::Transport::HTTP::Builder do
         let(:adapter) { double('adapter') }
 
         it 'configures the API instance with the given adapter' do
-          expect(api_instances).to include(key => kind_of(Datadog::Transport::HTTP::API::Instance))
+          expect(api_instances).to include(key => kind_of(builder.api_instance_class))
           expect(api_instances[key].adapter).to be adapter
         end
       end
@@ -202,13 +202,13 @@ RSpec.describe Datadog::Transport::HTTP::Builder do
         let(:options) { { foo: :bar } }
 
         before do
-          expect(Datadog::Transport::HTTP::API::Instance).to receive(:new)
+          expect(builder.api_instance_class).to receive(:new)
             .with(spec, adapter, foo: :bar, headers: {})
             .and_call_original
         end
 
         it 'configures the API instance with custom options' do
-          expect(api_instances).to include(key => kind_of(Datadog::Transport::HTTP::API::Instance))
+          expect(api_instances).to include(key => kind_of(builder.api_instance_class))
         end
       end
 
@@ -224,8 +224,8 @@ RSpec.describe Datadog::Transport::HTTP::Builder do
 
         it 'configures the map with a fallback' do
           expect(api_instances).to include(
-            key => kind_of(Datadog::Transport::HTTP::API::Instance),
-            fallback_key => kind_of(Datadog::Transport::HTTP::API::Instance)
+            key => kind_of(builder.api_instance_class),
+            fallback_key => kind_of(builder.api_instance_class)
           )
           expect(api_instances.fallbacks[key]).to eq(fallback_key)
         end
@@ -240,7 +240,7 @@ RSpec.describe Datadog::Transport::HTTP::Builder do
 
         context 'and there are no default headers defined' do
           it 'configures the API instance with the given adapter' do
-            expect(api_instances).to include(key => kind_of(Datadog::Transport::HTTP::API::Instance))
+            expect(api_instances).to include(key => kind_of(builder.api_instance_class))
             expect(api_instances[key].headers).to eq(api_headers)
           end
         end
@@ -251,7 +251,7 @@ RSpec.describe Datadog::Transport::HTTP::Builder do
           before { builder.headers('X-Test-One' => 'foo', 'X-Test-Two' => 'bar') }
 
           it 'configures the API instance with the given adapter' do
-            expect(api_instances).to include(key => kind_of(Datadog::Transport::HTTP::API::Instance))
+            expect(api_instances).to include(key => kind_of(builder.api_instance_class))
             expect(api_instances[key].headers).to eq(
               'X-Test-One' => 'foo',
               'X-Test-Two' => 'blah',
@@ -284,5 +284,10 @@ RSpec.describe Datadog::Transport::HTTP::Builder do
         expect(transport.apis).to include(v2: kind_of(Datadog::Transport::HTTP::API::Instance))
       end
     end
+  end
+
+  describe '#api_instance_class' do
+    subject(:api_instance_class) { builder.api_instance_class }
+    it { is_expected.to be(Datadog::Transport::HTTP::API::Instance) }
   end
 end

--- a/spec/ddtrace/transport/http/env_spec.rb
+++ b/spec/ddtrace/transport/http/env_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Datadog::Transport::HTTP::Env do
     it do
       is_expected.to have_attributes(
         request: request,
-        headers: {}
+        headers: {},
+        form: {}
       )
     end
 
@@ -34,5 +35,7 @@ RSpec.describe Datadog::Transport::HTTP::Env do
     is_expected.to respond_to(:body=)
     is_expected.to respond_to(:headers)
     is_expected.to respond_to(:headers=)
+    is_expected.to respond_to(:form)
+    is_expected.to respond_to(:form=)
   end
 end

--- a/spec/ddtrace/transport/http_spec.rb
+++ b/spec/ddtrace/transport/http_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe Datadog::Transport::HTTP do
         expect(api.adapter).to be_a_kind_of(Datadog::Transport::HTTP::Adapters::Net)
         expect(api.adapter.hostname).to eq(described_class.default_hostname)
         expect(api.adapter.port).to eq(described_class.default_port)
+        expect(api.adapter.timeout).to eq(1)
+        expect(api.adapter.ssl).to be false
         expect(api.headers).to include(described_class.default_headers)
       end
     end
@@ -74,21 +76,35 @@ RSpec.describe Datadog::Transport::HTTP do
             expect(api.adapter).to be_a_kind_of(Datadog::Transport::HTTP::Adapters::Net)
             expect(api.adapter.hostname).to eq(described_class.default_hostname)
             expect(api.adapter.port).to eq(described_class.default_port)
+            expect(api.adapter.timeout).to eq(1)
+            expect(api.adapter.ssl).to be false
             expect(api.headers).to include(described_class.default_headers)
           end
         end
       end
 
-      context 'that specify hostname and port' do
-        let(:options) { { hostname: hostname, port: port } }
+      context 'that specify host, port, timeout or ssl' do
+        let(:options) do
+          {
+            hostname: hostname,
+            port: port,
+            timeout: timeout,
+            ssl: ssl
+          }
+        end
+
         let(:hostname) { double('hostname') }
         let(:port) { double('port') }
+        let(:timeout) { double('timeout') }
+        let(:ssl) { true }
 
-        it 'returns an HTTP transport with default configuration' do
+        it 'returns a transport with provided options' do
           default.apis.each_value do |api|
             expect(api.adapter).to be_a_kind_of(Datadog::Transport::HTTP::Adapters::Net)
             expect(api.adapter.hostname).to eq(hostname)
             expect(api.adapter.port).to eq(port)
+            expect(api.adapter.timeout).to be(timeout)
+            expect(api.adapter.ssl).to be true
           end
         end
       end
@@ -158,6 +174,11 @@ RSpec.describe Datadog::Transport::HTTP do
         it { is_expected.to_not include(Datadog::Ext::Transport::HTTP::HEADER_CONTAINER_ID) }
       end
     end
+  end
+
+  describe '.default_adapter' do
+    subject(:default_adapter) { described_class.default_adapter }
+    it { is_expected.to be(:net_http) }
   end
 
   describe '.default_hostname' do

--- a/spec/ddtrace/transport/http_spec.rb
+++ b/spec/ddtrace/transport/http_spec.rb
@@ -178,6 +178,7 @@ RSpec.describe Datadog::Transport::HTTP do
 
   describe '.default_adapter' do
     subject(:default_adapter) { described_class.default_adapter }
+
     it { is_expected.to be(:net_http) }
   end
 

--- a/spec/ddtrace/transport/io/response_spec.rb
+++ b/spec/ddtrace/transport/io/response_spec.rb
@@ -4,21 +4,14 @@ require 'ddtrace/transport/io/response'
 
 RSpec.describe Datadog::Transport::IO::Response do
   context 'when implemented by a class' do
-    subject(:response) { described_class.new(result, trace_count) }
+    subject(:response) { described_class.new(result) }
 
     let(:result) { double('result') }
-    let(:trace_count) { 1 }
 
     describe '#result' do
       subject(:get_result) { response.result }
 
       it { is_expected.to eq result }
-    end
-
-    describe '#trace_count' do
-      subject(:get_trace_count) { response.trace_count }
-
-      it { is_expected.to eq trace_count }
     end
 
     describe '#ok?' do

--- a/spec/ddtrace/transport/io/traces_spec.rb
+++ b/spec/ddtrace/transport/io/traces_spec.rb
@@ -2,6 +2,29 @@ require 'spec_helper'
 
 require 'ddtrace/transport/io/traces'
 
+RSpec.describe Datadog::Transport::IO::Traces::Response do
+  context 'when implemented by a class' do
+    subject(:response) { described_class.new(result, trace_count) }
+    let(:result) { double('result') }
+    let(:trace_count) { 2 }
+
+    describe '#result' do
+      subject(:get_result) { response.result }
+      it { is_expected.to eq result }
+    end
+
+    describe '#trace_count' do
+      subject(:get_trace_count) { response.trace_count }
+      it { is_expected.to eq trace_count }
+    end
+
+    describe '#ok?' do
+      subject(:ok?) { response.ok? }
+      it { is_expected.to be true }
+    end
+  end
+end
+
 RSpec.describe Datadog::Transport::IO::Client do
   subject(:client) { described_class.new(out, encoder) }
 

--- a/spec/ddtrace/transport/io/traces_spec.rb
+++ b/spec/ddtrace/transport/io/traces_spec.rb
@@ -5,21 +5,25 @@ require 'ddtrace/transport/io/traces'
 RSpec.describe Datadog::Transport::IO::Traces::Response do
   context 'when implemented by a class' do
     subject(:response) { described_class.new(result, trace_count) }
+
     let(:result) { double('result') }
     let(:trace_count) { 2 }
 
     describe '#result' do
       subject(:get_result) { response.result }
+
       it { is_expected.to eq result }
     end
 
     describe '#trace_count' do
       subject(:get_trace_count) { response.trace_count }
+
       it { is_expected.to eq trace_count }
     end
 
     describe '#ok?' do
       subject(:ok?) { response.ok? }
+
       it { is_expected.to be true }
     end
   end

--- a/spec/ddtrace/utils/compression_spec.rb
+++ b/spec/ddtrace/utils/compression_spec.rb
@@ -1,0 +1,26 @@
+require 'securerandom'
+require 'ddtrace/utils/compression'
+
+RSpec.describe Datadog::Utils::Compression do
+  describe '::gzip' do
+    subject(:gzip) { described_class.gzip(unzipped) }
+    let(:unzipped) { SecureRandom.uuid }
+
+    it { is_expected.to be_a_kind_of(String) }
+
+    context 'when result is unzipped' do
+      subject(:gunzip) { described_class.gunzip(gzip) }
+      it { is_expected.to eq(unzipped) }
+    end
+  end
+
+  describe '::gunzip' do
+    subject(:gunzip) { described_class.gunzip(zipped) }
+
+    context 'given a zipped string' do
+      let(:zipped) { described_class.gzip(unzipped) }
+      let(:unzipped) { SecureRandom.uuid }
+      it { is_expected.to eq(unzipped) }
+    end
+  end
+end

--- a/spec/ddtrace/utils/compression_spec.rb
+++ b/spec/ddtrace/utils/compression_spec.rb
@@ -4,12 +4,14 @@ require 'ddtrace/utils/compression'
 RSpec.describe Datadog::Utils::Compression do
   describe '::gzip' do
     subject(:gzip) { described_class.gzip(unzipped) }
+
     let(:unzipped) { SecureRandom.uuid }
 
     it { is_expected.to be_a_kind_of(String) }
 
     context 'when result is unzipped' do
       subject(:gunzip) { described_class.gunzip(gzip) }
+
       it { is_expected.to eq(unzipped) }
     end
   end
@@ -20,6 +22,7 @@ RSpec.describe Datadog::Utils::Compression do
     context 'given a zipped string' do
       let(:zipped) { described_class.gzip(unzipped) }
       let(:unzipped) { SecureRandom.uuid }
+
       it { is_expected.to eq(unzipped) }
     end
   end

--- a/spec/ddtrace/utils/object_set_spec.rb
+++ b/spec/ddtrace/utils/object_set_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+require 'ddtrace/utils/object_set'
+
+RSpec.describe Datadog::Utils::ObjectSet do
+  subject(:object_set) { described_class.new }
+
+  describe '::new' do
+    context 'given a seed' do
+      let(:object_set) { described_class.new(seed) }
+      let(:seed) { 100 }
+
+      let(:args) { [rand] }
+
+      it 'yields to the build block' do
+        expect { |b| object_set.fetch(*args, &b) }
+          .to yield_with_args(seed, *args)
+      end
+    end
+
+    context 'given a custom key block' do
+      let(:object_set) { described_class.new(&key_block) }
+
+      let(:key_block) { proc { |*args| key_builder.build(*args) } }
+      let(:key_builder) { double('key_builder') }
+      let(:custom_key) { double('custom key') }
+
+      let(:args) { [rand] }
+
+      it 'invokes the block to resolve keys' do
+        expect(key_builder).to receive(:build)
+          .with(*args)
+          .and_return(custom_key)
+
+        object_set.fetch(*args) { :object }
+      end
+    end
+  end
+
+  describe '#fetch' do
+    subject(:fetch) { object_set.fetch(*args, &build_block) }
+
+    context 'and unique args are provided' do
+      let(:args) { [rand] }
+      let(:build_block) { proc { |_id, *_args| object } }
+
+      let(:next_id) { double('next ID') }
+      let(:object) { double('object') }
+
+      before do
+        expect_any_instance_of(Datadog::Utils::Sequence)
+          .to receive(:next)
+          .and_return(next_id)
+      end
+
+      it 'yields to the build block' do
+        expect { |b| object_set.fetch(*args, &b) }
+          .to yield_with_args(next_id, *args)
+      end
+
+      it 'returns the object' do
+        is_expected.to be(object)
+      end
+    end
+
+    context 'and args matching an existing object are provided' do
+      let(:args) { [rand] }
+      let(:build_block) { proc { |_id, *_args| object } }
+
+      let(:original_object) { double('original object') }
+      let(:object) { double('object') }
+
+      before do
+        # Fetch same args to cache object
+        object_set.fetch(*args) { original_object }
+
+        expect_any_instance_of(Datadog::Utils::Sequence)
+          .to_not receive(:next)
+      end
+
+      it 'does not yield to the build block' do
+        expect { |b| object_set.fetch(*args, &b) }
+          .to_not yield_control
+      end
+
+      it 'returns the object' do
+        is_expected.to be(original_object)
+      end
+    end
+  end
+
+  describe '#length' do
+    subject(:length) { object_set.length }
+    it { is_expected.to eq 0 }
+
+    context 'when objects have been added' do
+      let(:n) { 3 }
+      before { n.times { object_set.fetch(rand) { rand } } }
+      it { is_expected.to eq(n) }
+    end
+  end
+
+  describe '#objects' do
+    subject(:objects) { object_set.objects }
+
+    context 'by default' do
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when objects have been added' do
+      let(:object_count) { 3 }
+
+      before do
+        object_count.times { object_set.fetch(rand) { double('object') } }
+      end
+
+      it do
+        is_expected.to be_a_kind_of(Array)
+        is_expected.to have(object_count).items
+        is_expected.to include(RSpec::Mocks::Double)
+      end
+    end
+  end
+end

--- a/spec/ddtrace/utils/object_set_spec.rb
+++ b/spec/ddtrace/utils/object_set_spec.rb
@@ -91,11 +91,14 @@ RSpec.describe Datadog::Utils::ObjectSet do
 
   describe '#length' do
     subject(:length) { object_set.length }
+
     it { is_expected.to eq 0 }
 
     context 'when objects have been added' do
       let(:n) { 3 }
+
       before { n.times { object_set.fetch(rand) { rand } } }
+
       it { is_expected.to eq(n) }
     end
   end

--- a/spec/ddtrace/utils/sequence_spec.rb
+++ b/spec/ddtrace/utils/sequence_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+require 'ddtrace/utils/sequence'
+
+RSpec.describe Datadog::Utils::Sequence do
+  describe '#next' do
+    context 'for a sequence' do
+      context 'with default settings' do
+        let(:sequence) { described_class.new }
+
+        it 'produces an integer sequence' do
+          expect(sequence.next).to eq 0
+          expect(sequence.next).to eq 1
+          expect(sequence.next).to eq 2
+        end
+      end
+
+      context 'with a seed' do
+        let(:sequence) { described_class.new(seed) }
+        let(:seed) { 10 }
+
+        it 'produces an integer sequence starting at the seed' do
+          expect(sequence.next).to eq 10
+          expect(sequence.next).to eq 11
+          expect(sequence.next).to eq 12
+        end
+      end
+
+      context 'with a block' do
+        let(:sequence) { described_class.new(&block) }
+        let(:block) { ->(i) { i.to_s } }
+
+        it 'returns the block value for each iteration' do
+          expect(sequence.next).to eq '0'
+          expect(sequence.next).to eq '1'
+          expect(sequence.next).to eq '2'
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/utils/string_table_spec.rb
+++ b/spec/ddtrace/utils/string_table_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+require 'ddtrace/utils/string_table'
+
+RSpec.describe Datadog::Utils::StringTable do
+  subject(:string_table) { described_class.new }
+
+  describe '#fetch' do
+    subject(:fetch) { string_table.fetch(string) }
+
+    context 'given an empty string' do
+      let(:string) { '' }
+      it { is_expected.to be 0 }
+    end
+
+    context 'given different strings' do
+      it 'returns different IDs' do
+        3.times do |i|
+          expect(string_table.fetch(i.to_s)).to be(i + 1)
+        end
+      end
+    end
+
+    context 'given the same string' do
+      let(:string) { 'foo' }
+
+      it 'returns the same ID' do
+        is_expected.to be 1
+
+        3.times do
+          expect(string_table.fetch(string)).to be(1)
+        end
+      end
+    end
+  end
+
+  describe '#fetch_string' do
+    subject(:fetch_string) { string_table.fetch_string(string) }
+    let(:string) { 'string' }
+
+    it { is_expected.to eq(string) }
+
+    it 'returns the same string object' do
+      strings = []
+      strings << string_table.fetch_string(string)
+      strings << string_table.fetch_string(string)
+      strings << string_table.fetch_string(string.dup)
+
+      expect(strings.collect(&:object_id).uniq).to have(1).item
+    end
+  end
+
+  describe '#[]' do
+    subject(:get_string) { string_table[id] }
+
+    context 'when ID doesn\'t exist in the string table' do
+      let(:id) { double('unknown ID') }
+      it { is_expected.to be nil }
+    end
+
+    context 'when the ID exsits in the string table' do
+      let(:string) { 'string' }
+      let(:id) { string_table.fetch(string) }
+      it { is_expected.to eq(string) }
+    end
+  end
+
+  describe '#strings' do
+    subject(:strings) { string_table.strings }
+
+    context 'when IDs have been added' do
+      before do
+        string_table.fetch('foo')
+        string_table.fetch('bar')
+        string_table.fetch('bar')
+      end
+
+      it 'returns all the unique strings' do
+        is_expected.to eq(['', 'foo', 'bar'])
+      end
+    end
+  end
+end

--- a/spec/ddtrace/utils/string_table_spec.rb
+++ b/spec/ddtrace/utils/string_table_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Datadog::Utils::StringTable do
 
     context 'given an empty string' do
       let(:string) { '' }
+
       it { is_expected.to be 0 }
     end
 
@@ -36,6 +37,7 @@ RSpec.describe Datadog::Utils::StringTable do
 
   describe '#fetch_string' do
     subject(:fetch_string) { string_table.fetch_string(string) }
+
     let(:string) { 'string' }
 
     it { is_expected.to eq(string) }
@@ -55,12 +57,14 @@ RSpec.describe Datadog::Utils::StringTable do
 
     context 'when ID doesn\'t exist in the string table' do
       let(:id) { double('unknown ID') }
+
       it { is_expected.to be nil }
     end
 
     context 'when the ID exsits in the string table' do
       let(:string) { 'string' }
       let(:id) { string_table.fetch(string) }
+
       it { is_expected.to eq(string) }
     end
   end

--- a/spec/ddtrace/utils/time_spec.rb
+++ b/spec/ddtrace/utils/time_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+require 'ddtrace/utils/time'
+
+RSpec.describe Datadog::Utils::Time do
+  describe '#get_time' do
+    subject(:get_time) { described_class.get_time }
+    it { is_expected.to be_a_kind_of(Float) }
+  end
+
+  describe '#measure' do
+    it { expect { |b| described_class.measure(&b) }.to yield_control }
+
+    context 'given a block' do
+      subject(:measure) { described_class.measure(&block) }
+      let(:block) { proc { sleep(run_time) } }
+      let(:run_time) { 0.01 }
+
+      it do
+        is_expected.to be_a_kind_of(Float)
+        is_expected.to be >= run_time
+      end
+    end
+  end
+end

--- a/spec/ddtrace/utils/time_spec.rb
+++ b/spec/ddtrace/utils/time_spec.rb
@@ -5,6 +5,7 @@ require 'ddtrace/utils/time'
 RSpec.describe Datadog::Utils::Time do
   describe '#get_time' do
     subject(:get_time) { described_class.get_time }
+
     it { is_expected.to be_a_kind_of(Float) }
   end
 
@@ -13,6 +14,7 @@ RSpec.describe Datadog::Utils::Time do
 
     context 'given a block' do
       subject(:measure) { described_class.measure(&block) }
+
       let(:block) { proc { sleep(run_time) } }
       let(:run_time) { 0.01 }
 

--- a/spec/ddtrace/workers/loop_spec.rb
+++ b/spec/ddtrace/workers/loop_spec.rb
@@ -196,6 +196,7 @@ RSpec.describe Datadog::Workers::IntervalLoop do
     describe '#reset_loop_wait_time' do
       context 'when the loop time has been changed' do
         let(:value) { rand }
+
         before { worker.loop_wait_time = value }
 
         it do

--- a/spec/ddtrace/workers/loop_spec.rb
+++ b/spec/ddtrace/workers/loop_spec.rb
@@ -180,15 +180,29 @@ RSpec.describe Datadog::Workers::IntervalLoop do
       context 'default' do
         it { is_expected.to eq(described_class::BASE_INTERVAL) }
       end
+    end
 
-      context 'when set' do
+    describe '#loop_wait_time=' do
+      let(:value) { rand }
+
+      it do
+        expect { worker.loop_wait_time = value }
+          .to change { worker.loop_wait_time }
+          .from(described_class::BASE_INTERVAL)
+          .to(value)
+      end
+    end
+
+    describe '#reset_loop_wait_time' do
+      context 'when the loop time has been changed' do
         let(:value) { rand }
+        before { worker.loop_wait_time = value }
 
         it do
-          expect { worker.send(:loop_base_interval=, value) }
-            .to change { worker.loop_base_interval }
-            .from(described_class::BASE_INTERVAL)
-            .to(value)
+          expect { worker.reset_loop_wait_time }
+            .to change { worker.loop_wait_time }
+            .from(value)
+            .to(described_class::BASE_INTERVAL)
         end
       end
     end
@@ -200,33 +214,17 @@ RSpec.describe Datadog::Workers::IntervalLoop do
     end
 
     describe '#loop_back_off!' do
-      subject(:loop_back_off!) { worker.loop_back_off! }
+      it do
+        expect { worker.loop_back_off! }
+          .to change { worker.loop_wait_time }
+          .from(described_class::BASE_INTERVAL)
+          .to(described_class::BASE_INTERVAL * described_class::BACK_OFF_RATIO)
 
-      context 'given no arguments' do
-        it do
-          expect { loop_back_off! }
-            .to change { worker.loop_wait_time }
-            .from(described_class::BASE_INTERVAL)
-            .to(described_class::BASE_INTERVAL * described_class::BACK_OFF_RATIO)
-
-          expect { worker.loop_back_off! }
-            .to change { worker.loop_wait_time }
-            .from(described_class::BASE_INTERVAL * described_class::BACK_OFF_RATIO)
-            .to(described_class::BASE_INTERVAL * described_class::BACK_OFF_RATIO * described_class::BACK_OFF_RATIO)
-        end
-      end
-
-      context 'given an amount to back off' do
-        subject(:loop_back_off!) { worker.loop_back_off!(value) }
-
-        let(:value) { rand }
-
-        it do
-          expect { loop_back_off! }
-            .to change { worker.loop_wait_time }
-            .from(described_class::BASE_INTERVAL)
-            .to(value)
-        end
+        # Call again to see back-off increase
+        expect { worker.loop_back_off! }
+          .to change { worker.loop_wait_time }
+          .from(described_class::BASE_INTERVAL * described_class::BACK_OFF_RATIO)
+          .to(described_class::BASE_INTERVAL * described_class::BACK_OFF_RATIO * described_class::BACK_OFF_RATIO)
       end
     end
   end

--- a/spec/support/container_helpers.rb
+++ b/spec/support/container_helpers.rb
@@ -2,6 +2,10 @@ require 'stringio'
 
 # rubocop:disable Metrics/ModuleLength
 module ContainerHelpers
+  def uuid_regex
+    /[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/
+  end
+
   shared_context 'cgroup file' do
     let(:cgroup_file) { StringIO.new }
 


### PR DESCRIPTION
I've extracted these commits from the `feature/profiling` branch because they are entirely independent of profiling, so we can review them separately and have them in `master` to reduce the overall diff with that branch.

Hopefully once we get to the point where `feature/profiling` will be ready to be merged into `master`, it'll contain only profiling-related changes, increasing our confidence in such a big code dump :)