### PR TITLE
Use modern pry/pry-byebug on Rubies that support it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,15 @@ gem 'minitest', '= 5.10.1'
 gem 'minitest-around', '0.5.0'
 gem 'minitest-stub_any_instance', '1.0.2'
 gem 'pimpmychangelog', '>= 0.1.2'
-gem 'pry', '~> 0.12.2'
-gem 'pry-nav', '~> 0.3.0'
-gem 'pry-stack_explorer', '~> 0.4.9' if RUBY_PLATFORM != 'java'
+gem 'pry'
+if RUBY_PLATFORM != 'java'
+  # There's a few incompatibilities between pry/pry-byebug on older Rubies
+  gem 'pry-byebug' if RUBY_VERSION >= '2.6.0' && RUBY_ENGINE != 'truffleruby'
+  gem 'pry-nav' if RUBY_VERSION < '2.6.0'
+  gem 'pry-stack_explorer'
+else
+  gem 'pry-debugger-jruby'
+end
 gem 'rake', '>= 10.5'
 gem 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
 gem 'rspec', '~> 3.10'


### PR DESCRIPTION
The old `pry-nav` is basically abandoned at this point, see <https://github.com/nixme/pry-nav/issues/35> and <https://github.com/nixme/pry-nav/pull/33> and the README points to `pry-byebug`: <https://github.com/nixme/pry-nav#using-mri-we-recommend-pry-byebug-instead>.

Because of our usual support matrix of old Rubies, I've kept `pry-nav` around for older versions.

I've also added `pry-debugger-jruby`, which is a nicer alternative for JRuby.

This setup works correctly for all Rubies: 2.0 to 3.0, JRuby and even TruffleRuby.