### PR TITLE
Minor: Add debug log message when sending profiling data

### DIFF
--- a/lib/ddtrace/profiling/transport/http/client.rb
+++ b/lib/ddtrace/profiling/transport/http/client.rb
@@ -12,7 +12,9 @@ module Datadog
           def send_profiling_flush(flush)
             # Build a request
             request = Profiling::Transport::Request.new(flush)
-            send_payload(request)
+            response = send_payload(request)
+            Datadog.logger.debug('Successfully reported profiling data')
+            response
           end
 
           def send_payload(request)


### PR DESCRIPTION
Sometimes I just stare thinking "is this damn thing on?!", so the answer is using `DD_TRACE_DEBUG=true` and this new amazing log message to confirm that yes, indeed, the damn thing is on.