### PR TITLE
Ensure public apis don't fail after shutdown

### DIFF
--- a/spec/ddtrace_integration_spec.rb
+++ b/spec/ddtrace_integration_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'ddtrace integration' do
       end
 
       it 'does not error on logging' do
-        expect(Datadog.logger.info('test')).to be_truthy
+        expect(Datadog.logger.info('test')).to be true
       end
 
       it 'does not error on configuration access' do

--- a/spec/ddtrace_integration_spec.rb
+++ b/spec/ddtrace_integration_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe 'ddtrace integration' do
 
       context 'with OpenTracer' do
         before do
+          skip 'OpenTracing not supported' unless Datadog::OpenTracer.supported?
+
           OpenTracing.global_tracer = Datadog::OpenTracer::Tracer.new
         end
 

--- a/spec/ddtrace_integration_spec.rb
+++ b/spec/ddtrace_integration_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+require 'ddtrace/opentracer'
+require 'datadog/statsd'
+
+RSpec.describe 'ddtrace integration' do
+  context 'after shutdown' do
+    subject(:shutdown!) { Datadog.shutdown! }
+
+    before do
+      Datadog.configure do |c|
+        c.diagnostics.health_metrics.enabled = true
+      end
+
+      shutdown!
+    end
+
+    after do
+      Datadog.configuration.diagnostics.health_metrics.reset!
+    end
+
+    context 'calling public apis' do
+      it 'does not error on tracing' do
+        span = Datadog.tracer.trace('test')
+
+        expect(span.finish).to be_truthy
+      end
+
+      it 'does not error on tracing with block' do
+        value = Datadog.tracer.trace('test') do |span|
+          expect(span).to be_a(Datadog::Span)
+          :return
+        end
+
+        expect(value).to be(:return)
+      end
+
+      it 'does not error on logging' do
+        expect(Datadog.logger.info('test')).to be_truthy
+      end
+
+      it 'does not error on configuration access' do
+        expect(Datadog.configuration.diagnostics.debug).to be(false)
+      end
+
+      it 'does not error on reporting health metrics' do
+        expect(Datadog.health_metrics.queue_accepted(1)).to be_a(Integer)
+      end
+
+      context 'with OpenTracer' do
+        before do
+          OpenTracing.global_tracer = Datadog::OpenTracer::Tracer.new
+        end
+
+        let(:tracer) do
+          OpenTracing.global_tracer
+        end
+
+        it 'does not error on tracing' do
+          span = tracer.start_span('test')
+
+          expect { span.finish }.to_not raise_error
+        end
+
+        it 'does not error on tracing with block' do
+          scope = tracer.start_span('test') do |scp|
+            expect(scp).to be_a(OpenTracing::Scope)
+          end
+
+          expect(scope).to be_a(OpenTracing::Span)
+        end
+
+        it 'does not error on registered scope tracing' do
+          span = tracer.start_active_span('test')
+
+          expect { span.close }.to_not raise_error
+        end
+
+        it 'does not error on registered scope tracing with block' do
+          scope = tracer.start_active_span('test') do |scp|
+            expect(scp).to be_a(OpenTracing::Scope)
+          end
+
+          expect(scope).to be_a(OpenTracing::Scope)
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace_integration_spec.rb
+++ b/spec/ddtrace_integration_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'ddtrace integration' do
       end
 
       it 'does not error on configuration access' do
-        expect(Datadog.configuration.diagnostics.debug).to be(false)
+        expect(Datadog.configuration.runtime_metrics.enabled).to be(true).or be(false)
       end
 
       it 'does not error on reporting health metrics' do


### PR DESCRIPTION
Our public API can be use permissively across the host application. During the event of a Ruby process shutdown, `ddtrace` will invoke `Datadog.shutdown!` (though an `at_exit` hook) to gracefully flush any pending traces and decommission resources.

When this shutdown happens, internal parts of the tracer won't work anymore (new traces won't be captured), which is acceptable, but we must still ensure that calls out public API methods do not raise errors and still behave predictably during a shutdown. We don't want the tracer to interfere with any of the host application's own shutdown routines by introducing uncertain behavior in our tracer public methods.

This PR ensures that our publicly exposed API does not change their interface, nor raise errors after the tracer has been shutdown.