### PR TITLE
Correctly synchronize @components creation and access, third try

### DIFF
--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -14,12 +14,26 @@ module Datadog
     # a threaded webserver), and we don't want their initialization to clash (for instance, starting two profilers...).
     #
     # Note that a Mutex **IS NOT** reentrant: the same thread cannot grab the same Mutex more than once.
-    # This means below we are careful not to nest calls to methods that grab the lock.
+    # This means below we are careful not to nest calls to methods that would trigger initialization and grab the lock.
     #
-    # Every method that directly or indirectly accesses/mutates @components should be holding the lock (through
+    # Every method that directly or indirectly mutates @components should be holding the lock (through
     # #safely_synchronize) while doing so.
-    COMPONENTS_LOCK = Mutex.new
-    private_constant :COMPONENTS_LOCK
+    COMPONENTS_WRITE_LOCK = Mutex.new
+    private_constant :COMPONENTS_WRITE_LOCK
+
+    # We use a separate lock when reading the @components, so that they continue to be accessible during initialization/
+    # reconfiguration. This was needed because we ran into several issues where we still needed to read the old
+    # components while the COMPONENTS_WRITE_LOCK was being held (see https://github.com/DataDog/dd-trace-rb/pull/1387
+    # and https://github.com/DataDog/dd-trace-rb/pull/1373#issuecomment-799593022 ).
+    #
+    # Technically on MRI we could get away without this lock, but on non-MRI Rubies, we may run into issues because
+    # we fall into the "UnsafeDCLFactory" case of https://shipilev.net/blog/2014/safe-public-construction/ .
+    # Specifically, on JRuby reads from the @components do have volatile semantics, and on TruffleRuby they do
+    # but just as an implementation detail, see https://github.com/jruby/jruby/wiki/Concurrency-in-jruby#volatility and
+    # https://github.com/DataDog/dd-trace-rb/pull/1329#issuecomment-776750377 .
+    # Concurrency is hard.
+    COMPONENTS_READ_LOCK = Mutex.new
+    private_constant :COMPONENTS_READ_LOCK
 
     attr_writer :configuration
 
@@ -31,14 +45,14 @@ module Datadog
       if target.is_a?(Settings)
         yield(target) if block_given?
 
-        safely_synchronize do
-          # Build immutable components from settings
-          @components ||= nil
-          @components = if @components
-                          replace_components!(target, @components)
-                        else
-                          build_components(target)
-                        end
+        safely_synchronize do |write_components|
+          write_components.call(
+            if components?
+              replace_components!(target, @components)
+            else
+              build_components(target)
+            end
+          )
         end
 
         target
@@ -56,16 +70,13 @@ module Datadog
 
     def logger
       # avoid initializing components if they didn't already exist
-      return logger_without_components unless components?
+      current_components = components(allow_initialization: false)
 
-      @temp_logger = nil
-
-      if COMPONENTS_LOCK.owned?
-        # components are in the process of being replaced by this thread, avoid a deadlock and return the old logger
-        @components.logger
+      if current_components
+        @temp_logger = nil
+        current_components.logger
       else
-        # grab the lock and retrieve the latest logger
-        components.logger
+        logger_without_components
       end
     end
 
@@ -90,26 +101,35 @@ module Datadog
     # In contrast with +#shutdown!+, components will be automatically
     # reinitialized after a reset.
     def reset!
-      safely_synchronize do
+      safely_synchronize do |write_components|
         @components.shutdown! if components?
-        @components = nil
+        write_components.call(nil)
       end
     end
 
     protected
 
-    def components
-      safely_synchronize do
-        @components ||= build_components(configuration)
+    def components(allow_initialization: true)
+      current_components = COMPONENTS_READ_LOCK.synchronize { defined?(@components) && @components }
+      return current_components if current_components || !allow_initialization
+
+      safely_synchronize do |write_components|
+        @components || write_components.call(build_components(configuration))
       end
     end
 
     private
 
     def safely_synchronize
-      COMPONENTS_LOCK.synchronize do
+      # Writes to @components should only happen through this proc. Because this proc is only accessible to callers of
+      # safely_synchronize, this forces all writers to go through this method.
+      write_components = proc do |new_value|
+        COMPONENTS_READ_LOCK.synchronize { @components = new_value }
+      end
+
+      COMPONENTS_WRITE_LOCK.synchronize do
         begin
-          yield
+          yield write_components
         rescue ThreadError => e
           logger_without_components.error(
             'Detected deadlock during ddtrace initialization. ' \
@@ -122,7 +142,7 @@ module Datadog
     end
 
     def components?
-      # This does not need to grab the COMPONENTS_LOCK because it's not returning the components
+      # This does not need to grab the COMPONENTS_READ_LOCK because it's not returning the components
       (defined?(@components) && @components) != nil
     end
 

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -468,13 +468,43 @@ RSpec.describe Datadog::Configuration do
       end
     end
 
+    describe '#components' do
+      context 'when components are not initialized' do
+        it 'initializes the components' do
+          test_class.send(:components)
+
+          expect(test_class.send(:components?)).to be true
+        end
+
+        context 'when allow_initialization is false' do
+          it 'does not initialize the components' do
+            test_class.send(:components, allow_initialization: false)
+
+            expect(test_class.send(:components?)).to be false
+          end
+        end
+      end
+
+      context 'when components are initialized' do
+        before { test_class.send(:components) }
+
+        after { described_class.const_get(:COMPONENTS_WRITE_LOCK).tap { |lock| lock.unlock if lock.owned? } }
+
+        it 'returns the components without touching the COMPONENTS_WRITE_LOCK' do
+          described_class.const_get(:COMPONENTS_WRITE_LOCK).lock
+
+          expect(test_class.send(:components)).to_not be_nil
+        end
+      end
+    end
+
     describe '#safely_synchronize' do
-      it 'runs the given block while holding the COMPONENTS_LOCK' do
+      it 'runs the given block while holding the COMPONENTS_WRITE_LOCK' do
         block_ran = false
 
         test_class.send(:safely_synchronize) do
           block_ran = true
-          expect(described_class.const_get(:COMPONENTS_LOCK)).to be_owned
+          expect(described_class.const_get(:COMPONENTS_WRITE_LOCK)).to be_owned
         end
 
         expect(block_ran).to be true
@@ -482,6 +512,14 @@ RSpec.describe Datadog::Configuration do
 
       it 'returns the value of the given block' do
         expect(test_class.send(:safely_synchronize) { :returned_value }).to be :returned_value
+      end
+
+      it 'provides a write_components callback that can be used to update the components' do
+        test_class.send(:safely_synchronize) do |write_components|
+          write_components.call(:updated_components)
+        end
+
+        expect(test_class.send(:components)).to be :updated_components
       end
 
       context 'when recursive execution triggers a deadlock' do


### PR DESCRIPTION
In #1329, after running into issues where background threads caused the `@components` to be initialized multiple times, we decided to add locking to prevent this from happening.

By design, we forced every access to `@components` to go through a lock (even reads) with the intent that:

1. during configuration (e.g. `@components` was previously `nil`) other    threads would block until the `@components` were available

2. during reconfiguration (e.g. `@components` was not `nil`) other    threads would still block until the new `@components` were available

The first issue we ran into was #1387, where the thread doing reconfiguration could try to access the `@components` (e.g. to log) and ran into a deadlock.

And then in <https://github.com/DataDog/dd-trace-rb/pull/1373#issuecomment-799593022> we discovered that due to the way the `@components` can be accessed in background threads, we could cause deadlocks if we blocked those background threads during reconfiguration (case 2 above).

Hence, we arrive at the third attempt to get this correct. We change the semantics so that threads that are competing to write the `@components` still block and those operations are sequential, but we allow concurrent reads of existing `@components` to proceed.

This means that **during reconfiguration** (case 2 above) background threads can still access all the components as needed (these components may be in the process of shutting down, but that was always a possibility).

This avoids the deadlock observed in <https://github.com/DataDog/dd-trace-rb/pull/1373#issuecomment-799593022> because the background thread would be able to get the `Datadog.health_metrics` and finish its work.

Note that there's still two possible issues lying in hiding here, regarding the case 1 above.
Because there is nothing to read when `@components` was previously `nil`, we're still making threads block in the write lock.

This means that:
1. If the thread that is initializing the components tries to access    a component, we're still going to to fail. Basically the same issue    we ran into in #1387 can happen with any other component, e.g.    trying to use `health_metrics` during initialization.

2. If for some reason during initialization there's more than one    thread trying to access the `@components`, and there are multiple     locks involved, we can still fail. (For instance consider that     a background thread got initialized, grabbed a lock on itself   and then tries to grab the `health_metrics`, and then the main   thread is still doing initialization and tries to grab the lock   that the background thread holds).

To solve the issues above, I think we'd need to go in a separate direction: either have a lock-per-component OR go in the dependency injection direction.

(Note: this PR is targeting the wrong branch until #1410 gets merged; I'll then merge it to `feature/profiling` and backport to master as well)