### PR TITLE
Report fork spec failures

### DIFF
--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -9,7 +9,7 @@ module SynchronizationHelpers
       read_io.close
 
       # Capture test failures
-      STDERR.reopen(write_io)
+      $stderr.reopen(write_io)
 
       yield
     end

--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -1,16 +1,30 @@
 require 'English'
 
 module SynchronizationHelpers
-  def expect_in_fork(&block)
+  def expect_in_fork
+    read_io, write_io = IO.pipe
+
     # Start in fork
-    pid = fork(&block)
+    pid = fork do
+      read_io.close
+
+      # Capture test failures
+      STDERR.reopen(write_io)
+
+      yield
+    end
+
+    write_io.close
 
     # Wait for fork to finish, retrieve its status.
     Process.wait(pid)
     status = $CHILD_STATUS if $CHILD_STATUS && $CHILD_STATUS.pid == pid
 
+    # Read test failures
+    fork_stderr = read_io.read
+
     # Expect fork and assertions to have completed successfully.
-    expect(status && status.success?).to be true
+    expect(status && status.success?).to be(true), fork_stderr
   end
 
   def expect_in_thread(&block)


### PR DESCRIPTION
When a test running under our `expect_in_fork` test helper fails, it creates this output:

```
  1) Datadog::Workers::AsyncTraceWriter integration tests forking when the process forks and a trace is written with :async fork policy does not drop any traces
     Failure/Error: expect(status && status.success?).to be true
     
       expected true
            got false
     # ./spec/support/synchronization_helpers.rb:13:in `expect_in_fork'
     # ./spec/ddtrace/workers/trace_writer_spec.rb:688:in `block (6 levels) in <top (required)>'
     # ./spec/spec_helper.rb:164:in `block (2 levels) in <top (required)>'(required)>'
```

This message unfortunately only tells us that the child process exited with a status non-zero.
This error happens to be a flaky issue today: https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/2998/workflows/5c01a51a-b03d-4bfb-a32d-5015716207df/jobs/120042/parallel-runs/2

This PR captures the STDERR output inside the forked process and reports that output when the fork exists with a non-zero status. I introduced a fake failure (`expect(1).to be(2)`) at line `trace_writer_spec.rb:689` for this example, inside the forked block:

```
  0) Datadog::Workers::AsyncTraceWriter integration tests forking when the process forks and a trace is written with :async fork policy does not drop any traces
     Failure/Error: expect(status && status.success?).to be(true), stderr

       expected #<Integer:5> => 2
            got #<Integer:3> => 1

       	from ./spec/ddtrace/workers/trace_writer_spec.rb:689:in `block (7 levels) in <top (required)>'
       	from ./spec/support/synchronization_helpers.rb:12:in `block in expect_in_fork'
       	from ./spec/support/synchronization_helpers.rb:8:in `fork'
       	from ./spec/support/synchronization_helpers.rb:8:in `expect_in_fork'
       	from ./spec/ddtrace/workers/trace_writer_spec.rb:688:in `block (6 levels) in <top (required)>'
       	...
       	from /Users/marco.costa/.rbenv/versions/2.7.1/bin/rspec:23:in `<main>'
     # ./spec/support/synchronization_helpers.rb:24:in `expect_in_fork'
     # ./spec/ddtrace/workers/trace_writer_spec.rb:688:in `block (6 levels) in <top (required)>'
     # ./spec/spec_helper.rb:164:in `block (2 levels) in <top (required)>'

```