### PR TITLE
Close /proc/self/cgroup file after reading

### DIFF
--- a/lib/ddtrace/runtime/cgroup.rb
+++ b/lib/ddtrace/runtime/cgroup.rb
@@ -21,7 +21,7 @@ module Datadog
             filepath = "/proc/#{process}/cgroup"
 
             if File.exist?(filepath)
-              File.open("/proc/#{process}/cgroup").each do |line|
+              File.foreach("/proc/#{process}/cgroup") do |line|
                 line = line.strip
                 descriptors << parse(line) unless line.empty?
               end

--- a/spec/ddtrace/runtime/cgroup_spec.rb
+++ b/spec/ddtrace/runtime/cgroup_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Datadog::Runtime::Cgroup do
         let(:error) { stub_const('TestError', Class.new(StandardError)) }
 
         before do
-          expect(File).to receive(:open)
+          expect(File).to receive(:foreach)
             .with('/proc/self/cgroup')
             .and_raise(error)
 

--- a/spec/support/container_helpers.rb
+++ b/spec/support/container_helpers.rb
@@ -14,10 +14,10 @@ module ContainerHelpers
         .with('/proc/self/cgroup')
         .and_return(true)
 
-      allow(File).to receive(:open).and_call_original
-      allow(File).to receive(:open)
-        .with('/proc/self/cgroup')
-        .and_return(cgroup_file)
+      allow(File).to receive(:foreach)
+        .with('/proc/self/cgroup') do |&block|
+          cgroup_file.each { |line| block.call(line) }
+        end
     end
   end
 


### PR DESCRIPTION
While working on https://github.com/DataDog/dd-trace-rb/pull/1334, I noticed the test that checks if no file descriptions have been left open was failing intermittently.

This was happening because the Linux cgroups parsing code never closed the `/proc` file it opens. The real-world impact is small, as this file is only open once per application execution and its result cached after that. But there's no reason to keep the file open after its contents have been read.

This PR ensures that the file reading closes the file when it's done.