### PR TITLE
Add Schemas to supported AWS services

### DIFF
--- a/lib/ddtrace/contrib/aws/services.rb
+++ b/lib/ddtrace/contrib/aws/services.rb
@@ -99,6 +99,7 @@ module Datadog
         STS
         SWF
         ServiceCatalog
+        Schemas
         Shield
         SimpleDB
         Snowball


### PR DESCRIPTION
Hi, I'm using ddtrace AWS integration to be able to track every interaction with AWS services in Datadog.

I've noticed that the calls to Schemas API seem to be missing though.

I think simply adding `Schemas` to the list of supported AWS services should enable that tracking.

[aws-sdk-schemas](https://github.com/aws/aws-sdk-ruby/tree/version-3/gems/aws-sdk-schemas/lib/aws-sdk-schemas) gem uses AWS Seahorse Client (like all the other AWS services), so I reckon it should "just work".

I checked that `:Schemas` exists in `::Aws.constants`, so it won't get filtered out in https://github.com/DataDog/dd-trace-rb/blob/1343922a2c5fe921c22e1482625f09679db383e5/lib/ddtrace/contrib/aws/patcher.rb#L34