### PR TITLE
Ensure DD_TRACE_SAMPLE_RATE enables full RuleSampler

### DIFF
--- a/spec/ddtrace/sampling/rule_sampler_spec.rb
+++ b/spec/ddtrace/sampling/rule_sampler_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe Datadog::Sampling::RuleSampler do
     allow(rate_limiter).to receive(:allow?).with(1).and_return(allow?)
   end
 
+  shared_examples 'a simple rule that matches all spans' do |options = { sample_rate: 1.0 }|
+    it do
+      expect(rule.matcher.name).to eq(Datadog::Sampling::SimpleMatcher::MATCH_ALL)
+      expect(rule.matcher.service).to eq(Datadog::Sampling::SimpleMatcher::MATCH_ALL)
+      expect(rule.sampler.sample_rate).to eq(options[:sample_rate])
+    end
+  end
+
   describe '#initialize' do
     subject(:rule_sampler) { described_class.new(rules) }
 
@@ -41,7 +49,9 @@ RSpec.describe Datadog::Sampling::RuleSampler do
           .and_return(0.5)
       end
 
-      it { expect(rule_sampler.default_sampler).to be_a(Datadog::RateSampler) }
+      it_behaves_like 'a simple rule that matches all spans', sample_rate: 0.5 do
+        let(:rule) { rule_sampler.rules.last }
+      end
     end
 
     context 'with rate_limit' do
@@ -59,7 +69,9 @@ RSpec.describe Datadog::Sampling::RuleSampler do
     context 'with default_sample_rate' do
       subject(:rule_sampler) { described_class.new(rules, default_sample_rate: 1.0) }
 
-      it { expect(rule_sampler.default_sampler).to be_a(Datadog::RateSampler) }
+      it_behaves_like 'a simple rule that matches all spans', sample_rate: 1.0 do
+        let(:rule) { rule_sampler.rules.last }
+      end
     end
   end
 


### PR DESCRIPTION
`DD_TRACE_SAMPLE_RATE` controls the global sampling rate of traces in `ddtrace`. This settings was introduced as a newer feature, compared to our default, agent-driven, RateByServiceSampler.

Because `DD_TRACE_SAMPLE_RATE` is implemented using the new RuleSampler (instead of RateByServiceSampler), it has different semantics that affect backend behaviour: RuleSampler sets two new tags (`_dd.rule_psr` and `_dd.limit_psr`) that report application-side sampling rates to the backend for throughput extrapolation (if we sent 10 spans/sec, with a sampling rate of 0.1, the application actually generated 100 spans/sec).

This PR addresses the fact that setting a sampling rate to the new environment variable `DD_TRACE_SAMPLE_RATE` was not sending the required sampling tags.

This PR keeps intact the behaviour for users that do not enable the new `RuleSampler`, either through `DD_TRACE_SAMPLE_RATE` or programmatic configuration.