### PR TITLE
Fix leaky configuration failure in integration test

### DIFF
--- a/spec/ddtrace_integration_spec.rb
+++ b/spec/ddtrace_integration_spec.rb
@@ -6,7 +6,14 @@ RSpec.describe 'ddtrace integration' do
     subject(:shutdown) { Datadog.shutdown! }
 
     let(:start_tracer) do
-      Datadog.configure {}
+      # TODO: We manually unset the tracer instance here as
+      # we don't have a mechanism to deeply reset the
+      # `Datadog.configuration` object.
+
+      # Ensure we terminate the existing tracer instance, if any
+      Datadog.configuration.tracer.instance.shutdown! if Datadog.configuration.tracer.instance
+      Datadog.configure { |c| c.tracer.instance = nil }
+
       Datadog.tracer.trace('test.op') {}
     end
 


### PR DESCRIPTION
Since #1334 was merged, we noticed flaky tests affecting the `master` branch.

This PR unblocks the `master` branch build.

This happens because we don't have a clean `Datadog.configuration` object for each test run.

For this specific case, we want a clean tracer instance for this test, but this value is normally populated from previous runs. Because `Datadog.configuration` has not deep reset feature, we always try to reset parts of it during tests, but we can forget those.

As a follow up, we should always correctly reset the components and configuration between each test run.