### PR TITLE
Fix "warning: instance variable @components not initialized"

### DIFF
--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -113,7 +113,7 @@ module Datadog
       return current_components if current_components || !allow_initialization
 
       safely_synchronize do |write_components|
-        @components || write_components.call(build_components(configuration))
+        (defined?(@components) && @components) || write_components.call(build_components(configuration))
       end
     end
 


### PR DESCRIPTION
The first time we go to read the `@components`, they were not
previously defined, so we get a warning:

```
lib/ddtrace/configuration.rb:116: warning: instance variable @components not initialized
```

This can be trivially triggered by running

```bash
$ bundle exec ruby -we "require 'ddtrace'; Datadog.tracer"
```