### PR TITLE
Ensure clean environment for RSpec integration tests

### DIFF
--- a/spec/ddtrace/contrib/rspec/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/rspec/instrumentation_spec.rb
@@ -5,36 +5,35 @@ require 'rspec'
 require 'ddtrace'
 
 RSpec.describe 'RSpec hooks' do
-  extend ConfigurationHelpers
-
   let(:configuration_options) { {} }
 
-  around do |example|
-    old_configuration = ::RSpec.configuration
-    ::RSpec.configuration = ::RSpec::Core::Configuration.new
-
+  before do
     Datadog.configure do |c|
       c.use :rspec, configuration_options
     end
-    example.run
+  end
 
-    RSpec.configuration = old_configuration
-    Datadog.configuration.reset!
+  # Yields to a block in a new RSpec global context. All RSpec
+  # test configuration and execution should be wrapped in this method.
+  def with_new_rspec_environment
+    old_configuration = ::RSpec.configuration
+    old_world = ::RSpec.world
+    ::RSpec.configuration = ::RSpec::Core::Configuration.new
+    ::RSpec.world = ::RSpec::Core::World.new
+
+    yield
+  ensure
+    ::RSpec.configuration = old_configuration
+    ::RSpec.world = old_world
   end
 
   it 'creates span for example' do
-    spans = []
-    spec = RSpec.describe 'some test' do
-      let(:active_span) { Datadog.configuration[:rspec][:tracer].active_span }
-
-      it 'foo' do
-        spans << active_span
-      end
+    spec = with_new_rspec_environment do
+      RSpec.describe 'some test' do
+        it 'foo' do; end
+      end.tap(&:run)
     end
-    spec.run
 
-    expect(spans.count).to eq(1)
-    span = spans.first
     expect(span.span_type).to eq(Datadog::Ext::AppTypes::TEST)
     expect(span.name).to eq(Datadog::Contrib::RSpec::Ext::OPERATION_NAME)
     expect(span.resource).to eq('some test foo')
@@ -47,53 +46,42 @@ RSpec.describe 'RSpec hooks' do
   end
 
   it 'creates spans for several examples' do
-    spans = []
     num_examples = 20
-    spec = RSpec.describe 'many tests' do
-      let(:active_span) { Datadog.configuration[:rspec][:tracer].active_span }
-
-      num_examples.times do |n|
-        it n do
-          spans << active_span
+    with_new_rspec_environment do
+      RSpec.describe 'many tests' do
+        num_examples.times do |n|
+          it n do; end
         end
-      end
+      end.run
     end
-    spec.run
 
-    expect(spans.count).to eq(num_examples)
+    expect(spans).to have(num_examples).items
   end
 
   it 'creates span for unnamed examples' do
-    spans = []
-    spec = RSpec.describe 'some unnamed test' do
-      let(:active_span) { Datadog.configuration[:rspec][:tracer].active_span }
-
-      it { spans << active_span }
+    with_new_rspec_environment do
+      RSpec.describe 'some unnamed test' do
+        it do; end
+      end.run
     end
-    spec.run
 
-    expect(spans.count).to eq(1)
-    span = spans.first
     expect(span.get_tag(Datadog::Ext::Test::TAG_NAME)).to match(/some unnamed test example at .+/)
   end
 
   it 'creates span for deeply nested examples' do
-    spans = []
-    spec = RSpec.describe 'some nested test' do
-      let(:active_span) { Datadog.configuration[:rspec][:tracer].active_span }
-
-      context '1' do
-        context '2' do
-          context '3' do
-            context '4' do
-              context '5' do
-                context '6' do
-                  context '7' do
-                    context '8' do
-                      context '9' do
-                        context '10' do
-                          it 'foo' do
-                            spans << active_span
+    spec = with_new_rspec_environment do
+      RSpec.describe 'some nested test' do
+        context '1' do
+          context '2' do
+            context '3' do
+              context '4' do
+                context '5' do
+                  context '6' do
+                    context '7' do
+                      context '8' do
+                        context '9' do
+                          context '10' do
+                            it 'foo' do; end
                           end
                         end
                       end
@@ -104,12 +92,9 @@ RSpec.describe 'RSpec hooks' do
             end
           end
         end
-      end
+      end.tap(&:run)
     end
-    spec.run
 
-    expect(spans.count).to eq(1)
-    span = spans.first
     expect(span.resource).to eq('some nested test 1 2 3 4 5 6 7 8 9 10 foo')
     expect(span.get_tag(Datadog::Ext::Test::TAG_NAME)).to eq('some nested test 1 2 3 4 5 6 7 8 9 10 foo')
     expect(span.get_tag(Datadog::Ext::Test::TAG_SUITE)).to eq(spec.file_path)
@@ -117,8 +102,6 @@ RSpec.describe 'RSpec hooks' do
 
   context 'catches failures' do
     def expect_failure
-      expect(spans.count).to eq(1)
-      span = spans.first
       expect(span.get_tag(Datadog::Ext::Test::TAG_STATUS)).to eq(Datadog::Ext::Test::Status::FAIL)
       expect(span).to have_error
       expect(span).to have_error_type
@@ -127,72 +110,58 @@ RSpec.describe 'RSpec hooks' do
     end
 
     it 'within let' do
-      spans = []
-      spec = RSpec.describe 'some failed test with let' do
-        let(:active_span) { Datadog.configuration[:rspec][:tracer].active_span }
-        let(:let_failure) { raise 'failure' }
+      with_new_rspec_environment do
+        RSpec.describe 'some failed test with let' do
+          let(:let_failure) { raise 'failure' }
 
-        it 'foo' do
-          spans << active_span
-          let_failure
-        end
+          it 'foo' do
+            let_failure
+          end
+        end.run
       end
-      spec.run
 
       expect_failure
     end
 
     it 'within around' do
-      spans = []
-      spec = RSpec.describe 'some failed test with around' do
-        let(:active_span) { Datadog.configuration[:rspec][:tracer].active_span }
+      with_new_rspec_environment do
+        RSpec.describe 'some failed test with around' do
+          around do |example|
+            example.run
+            raise 'failure'
+          end
 
-        around do |example|
-          example.run
-          raise 'failure'
-        end
-
-        it 'foo' do
-          spans << active_span
-        end
+          it 'foo' do; end
+        end.run
       end
-      spec.run
 
       expect_failure
     end
 
     it 'within before' do
-      spans = []
-      spec = RSpec.describe 'some failed test with before' do
-        let(:active_span) { Datadog.configuration[:rspec][:tracer].active_span }
+      with_new_rspec_environment do
+        RSpec.describe 'some failed test with before' do
+          before do
+            raise 'failure'
+          end
 
-        before do
-          spans << active_span
-          raise 'failure'
-        end
-
-        it 'foo' do
-        end
+          it 'foo' do; end
+        end.run
       end
-      spec.run
 
       expect_failure
     end
 
     it 'within after' do
-      spans = []
-      spec = RSpec.describe 'some failed test with before' do
-        let(:active_span) { Datadog.configuration[:rspec][:tracer].active_span }
+      with_new_rspec_environment do
+        RSpec.describe 'some failed test with after' do
+          after do
+            raise 'failure'
+          end
 
-        after do
-          raise 'failure'
-        end
-
-        it 'foo' do
-          spans << active_span
-        end
+          it 'foo' do; end
+        end.run
       end
-      spec.run
 
       expect_failure
     end


### PR DESCRIPTION
When running a single example in the RSpec integration test suite (e.g. `rspec --example 'RSpec hooks creates span for example'`), I noticed that theses test would fail, but while running the whole file it would pass.

This happened because the RSpec test context created for testing was not completely isolated from the `ddtrace` RSpec test runner. We already isolated `RSpec.configuration`, but we forgot to also isolate `RSpec.world`. This PR does that. This behaviour became more apparent when working addressing issues around configuration leaks between tests.

Also, this PR refactors the code in `spec/ddtrace/contrib/rspec/instrumentation_spec.rb`, as there were a few unused variables and manual span tracking (which is already provided by https://github.com/DataDog/dd-trace-rb/blob/master/spec/support/tracer_helpers.rb).