### PR TITLE
[test] Wait for AsyncTraceWriter to finish sending traces

### DIFF
--- a/lib/ddtrace/workers/queue.rb
+++ b/lib/ddtrace/workers/queue.rb
@@ -26,6 +26,7 @@ module Datadog
         buffer.shift
       end
 
+      # Are there more items to be processed next?
       def work_pending?
         !buffer.empty?
       end

--- a/lib/ddtrace/workers/trace_writer.rb
+++ b/lib/ddtrace/workers/trace_writer.rb
@@ -145,6 +145,7 @@ module Datadog
         [buffer.pop]
       end
 
+      # Are there more traces to be processed next?
       def work_pending?
         !buffer.empty?
       end

--- a/spec/ddtrace/workers/trace_writer_spec.rb
+++ b/spec/ddtrace/workers/trace_writer_spec.rb
@@ -689,6 +689,7 @@ RSpec.describe Datadog::Workers::AsyncTraceWriter do
               # Queue up traces, wait for worker to process them.
               traces.each { |trace| writer.write(trace) }
               try_wait_until(attempts: 30) { !writer.work_pending? }
+              writer.stop
 
               # Verify state of the writer
               expect(writer).to have_received(:after_fork).once


### PR DESCRIPTION
This PR addresses an old, but recently more pronounced flaky test, regarding a `Datadog::Workers::AsyncTraceWriter` test.

This this was trying to wait until the writer had flushed all data, but instead, was waiting until the writer had started processing all traces (by calling `#work_pending?`).

`#work_pending?` is used internally by the writer to know if there are traces queued to be process, thus allowing the tracer to either go on a busy processing loop, or sleep for a short bit. This behaviour describes correctly if "Is there more work to be done next?", which is exactly what it represents, but does not answer "Is all the work done?".

This PR waits for the tracer to completely finish its work before verifying the desired conditions.

There's no impact on the correctness of the `AsyncTraceWriter`, as it is behaving as expected.