### PR TITLE
Gracefully handle google-protobuf require failures

### DIFF
--- a/lib/ddtrace/profiling/transport/http/client.rb
+++ b/lib/ddtrace/profiling/transport/http/client.rb
@@ -12,9 +12,13 @@ module Datadog
           def send_profiling_flush(flush)
             # Build a request
             request = Profiling::Transport::Request.new(flush)
-            response = send_payload(request)
-            Datadog.logger.debug('Successfully reported profiling data')
-            response
+            send_payload(request).tap do |response|
+              if response.ok?
+                Datadog.logger.debug('Successfully reported profiling data')
+              else
+                Datadog.logger.debug { "Failed to report profiling data -- #{response.inspect}" }
+              end
+            end
           end
 
           def send_payload(request)

--- a/spec/ddtrace/profiling/transport/http/client_spec.rb
+++ b/spec/ddtrace/profiling/transport/http/client_spec.rb
@@ -35,8 +35,36 @@ RSpec.describe Datadog::Profiling::Transport::HTTP::Client do
 
     let(:flush) { instance_double(Datadog::Profiling::Flush) }
 
-    it do
-      is_expected.to be response
+    context 'when request was successful' do
+      before do
+        allow(response).to receive(:ok?).and_return(true)
+      end
+
+      it 'returns the response object' do
+        is_expected.to be response
+      end
+
+      it 'debug logs the successful report' do
+        expect(Datadog.logger).to receive(:debug).with(/Success/)
+
+        send_profiling_flush
+      end
+    end
+
+    context 'when request was not successful' do
+      before do
+        allow(response).to receive(:ok?).and_return(nil)
+      end
+
+      it 'returns the response object' do
+        is_expected.to be response
+      end
+
+      it 'debug logs the failed report' do
+        expect(Datadog.logger).to receive(:debug) { |&block| expect(block.call).to match(/Fail/) }
+
+        send_profiling_flush
+      end
     end
   end
 
@@ -47,7 +75,7 @@ RSpec.describe Datadog::Profiling::Transport::HTTP::Client do
 
     let(:request) { instance_double(Datadog::Profiling::Transport::Request) }
 
-    it do
+    it 'returns the response object' do
       is_expected.to be response
     end
   end

--- a/spec/ddtrace/profiling_spec.rb
+++ b/spec/ddtrace/profiling_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe Datadog::Profiling do
   describe '::google_protobuf_supported?' do
     subject(:google_protobuf_supported?) { described_class.google_protobuf_supported? }
 
+    before do
+      # Ignore any actual loading failures in the local environment
+      if described_class.instance_variable_defined?(:@failed_to_load_protobuf)
+        described_class.remove_instance_variable(:@failed_to_load_protobuf)
+      end
+    end
+
     context 'when MRI Ruby is used' do
       before { stub_const('RUBY_PLATFORM', 'x86_64-linux') }
 


### PR DESCRIPTION
The `google-protobuf` gem depends on a native component, and its creators helpfully tried to provide precompiled versions of this extension on rubygems.org.

Unfortunately, for a long time, the supported Ruby versions metadata on these precompiled versions of the extension was not correctly set. (This is fixed in newer versions -- but not all Ruby versions we want to support can use these.)

As an example, if you try to use version 3.6.1 (from 2018) with Ruby 2.7 (released in December 2019) it'll happily install the precompiled version of the gem:

```
$ gem install google-protobuf -v "3.6.1"
Fetching google-protobuf-3.6.1-universal-darwin.gem
Successfully installed google-protobuf-3.6.1-universal-darwin
Parsing documentation for google-protobuf-3.6.1-universal-darwin
Installing ri documentation for google-protobuf-3.6.1-universal-darwin
Done installing documentation for google-protobuf after 0 seconds
1 gem installed
```

and then proceed to fail loading when you try to use it:

```
$ ruby -e "require 'bundler/inline'; gemfile { gem 'google-protobuf', '= 3.6.1' }"
Traceback (most recent call last):
        7: from -e:1:in `<main>'
        6: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/inline.rb:70:in `gemfile'
        5: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/runtime.rb:65:in `require'
        4: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/runtime.rb:65:in `each'
        3: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/runtime.rb:76:in `block in require'
        2: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/runtime.rb:76:in `each'
        1: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/runtime.rb:81:in `block (2 levels) in require'
/Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/runtime.rb:81:in `require': cannot load such file -- google-protobuf (LoadError)
        8: from -e:1:in `<main>'
        7: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/inline.rb:70:in `gemfile'
        6: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/runtime.rb:65:in `require'
        5: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/runtime.rb:65:in `each'
        4: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/runtime.rb:72:in `block in require'
        3: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/runtime.rb:95:in `rescue in block in require'
        2: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/runtime.rb:95:in `require'
        1: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/google-protobuf-3.6.1-universal-darwin/lib/google/protobuf.rb:48:in `<top (required)>'
/Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/google-protobuf-3.6.1-universal-darwin/lib/google/protobuf.rb:48:in `require': cannot load such file -- google/2.7/protobuf_c (LoadError)
        9: from -e:1:in `<main>'
        8: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/inline.rb:70:in `gemfile'
        7: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/runtime.rb:65:in `require'
        6: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/runtime.rb:65:in `each'
        5: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/runtime.rb:72:in `block in require'
        4: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/runtime.rb:95:in `rescue in block in require'
        3: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/bundler-1.17.3/lib/bundler/runtime.rb:95:in `require'
        2: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/google-protobuf-3.6.1-universal-darwin/lib/google/protobuf.rb:47:in `<top (required)>'
        1: from /Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/google-protobuf-3.6.1-universal-darwin/lib/google/protobuf.rb:50:in `rescue in <top (required)>'
/Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/google-protobuf-3.6.1-universal-darwin/lib/google/protobuf.rb:50:in `require': cannot load such file -- google/protobuf_c (LoadError)
```

Because we try to `require 'google/protobuf'` during gem initialization, this meant that we could break existing customer applications on environments with a broken protobuf gem.

This looked something like:

```
$ DD_TRACE_DEBUG=true DD_PROFILING_ENABLED=true be bin/ddtracerb exec ruby -e 'sleep'
/Users/ivo.anjo/.rvm/gems/ruby-3.0.0/gems/google-protobuf-3.6.1-universal-darwin/lib/google/protobuf.rb:48:in `require': cannot load such file -- google/3.0/protobuf_c (LoadError)
  from /Users/ivo.anjo/.rvm/gems/ruby-3.0.0/gems/google-protobuf-3.6.1-universal-darwin/lib/google/protobuf.rb:48:in `<top (required)>'
  from /Users/ivo.anjo/datadog/dd-trace-rb/lib/ddtrace/profiling/pprof/pprof_pb.rb:4:in `require'
  from /Users/ivo.anjo/datadog/dd-trace-rb/lib/ddtrace/profiling/pprof/pprof_pb.rb:4:in `<top (required)>'
  from /Users/ivo.anjo/datadog/dd-trace-rb/lib/ddtrace/profiling.rb:36:in `require'
  from /Users/ivo.anjo/datadog/dd-trace-rb/lib/ddtrace/profiling.rb:36:in `load_profiling'
  from /Users/ivo.anjo/datadog/dd-trace-rb/lib/ddtrace/profiling.rb:39:in `<module:Profiling>'
  from /Users/ivo.anjo/datadog/dd-trace-rb/lib/ddtrace/profiling.rb:3:in `<module:Datadog>'
  from /Users/ivo.anjo/datadog/dd-trace-rb/lib/ddtrace/profiling.rb:1:in `<top (required)>'
  from /Users/ivo.anjo/datadog/dd-trace-rb/lib/ddtrace/configuration/components.rb:3:in `require'
  from /Users/ivo.anjo/datadog/dd-trace-rb/lib/ddtrace/configuration/components.rb:3:in `<top (required)>'
  from /Users/ivo.anjo/datadog/dd-trace-rb/lib/ddtrace/configuration.rb:4:in `require'
  from /Users/ivo.anjo/datadog/dd-trace-rb/lib/ddtrace/configuration.rb:4:in `<top (required)>'
  from /Users/ivo.anjo/datadog/dd-trace-rb/lib/ddtrace.rb:14:in `require'
  from /Users/ivo.anjo/datadog/dd-trace-rb/lib/ddtrace.rb:14:in `<top (required)>'
  from /Users/ivo.anjo/datadog/dd-trace-rb/lib/ddtrace/profiling/preload.rb:1:in `require'
  from /Users/ivo.anjo/datadog/dd-trace-rb/lib/ddtrace/profiling/preload.rb:1:in `<top (required)>'
  from -e:in `require'
```

Instead, let's gracefully handle the failure and disable profiling:

```
$ DD_TRACE_DEBUG=true DD_PROFILING_ENABLED=true be bin/ddtracerb exec ruby -e 'sleep'
[DDTRACE] Error while loading google-protobuf gem. Cause: 'cannot load such file -- google/protobuf_c' Location: '/Users/ivo.anjo/.rvm/gems/ruby-2.7.2/gems/google-protobuf-3.6.1-universal-darwin/lib/google/protobuf.rb:50:in `require''. This can happen when google-protobuf is missing its native components. To fix this, try removing and reinstalling the gem, forcing it to recompile the components: `gem uninstall google-protobuf -a; BUNDLE_FORCE_RUBY_PLATFORM=true bundle install`. If the error persists, please contact support via <https://docs.datadoghq.com/help/> or file a bug at <https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug>.
W, [2021-03-22T11:13:09.129446 #1533]  WARN -- ddtrace: [ddtrace] (/Users/ivo.anjo/datadog/dd-trace-rb/lib/ddtrace/configuration/components.rb:184:in `startup!') Profiling was enabled but is not supported; profiling disabled. (google-protobuf?: false)
```