### PR TITLE
Use MINIMUM_VERSION in resque compatible? check

### DIFF
--- a/lib/ddtrace/contrib/resque/integration.rb
+++ b/lib/ddtrace/contrib/resque/integration.rb
@@ -25,7 +25,7 @@ module Datadog
 
         def self.compatible?
           super \
-            && version >= Gem::Version.new('1.0') \
+            && version >= MINIMUM_VERSION \
             && version < MAXIMUM_VERSION
         end
 


### PR DESCRIPTION
I happened to spot this while reviewing the current implementation.

`MINIMUM_VERSION` was added in 768f560216836a6a71f8a5c829661fc15f540817 but not used and presumably an oversight. 
