### PR TITLE
PrestoSQL renamed Trino

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ test_containers:
       - POSTGRES_DB=postgres
   - &postgres_port 5432
   - &container_presto
-    image: prestosql/presto
+    image: trinodb/trino:354
   - &presto_port 8080
   - &container_mysql
     image: mysql:5.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,8 @@ test_containers:
       - POSTGRES_DB=postgres
   - &postgres_port 5432
   - &container_presto
-    image: trinodb/trino:354
+    # Move to trinodb/trino after https://github.com/treasure-data/presto-client-ruby/issues/64 is resolved.
+    image: starburstdata/presto:332-e.9
   - &presto_port 8080
   - &container_mysql
     image: mysql:5.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -429,7 +429,8 @@ services:
     ports:
       - "${TEST_POSTGRES_PORT}:5432"
   presto:
-    image:  trinodb/trino:354
+    # Move to trinodb/trino after https://github.com/treasure-data/presto-client-ruby/issues/64 is resolved.
+    image: starburstdata/presto:332-e.9
     expose:
       - "8080"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -429,7 +429,7 @@ services:
     ports:
       - "${TEST_POSTGRES_PORT}:5432"
   presto:
-    image:  prestosql/presto
+    image:  trinodb/trino:354
     expose:
       - "8080"
     ports:


### PR DESCRIPTION
[PrestoSQL has been rebranded to Trino](https://trino.io/blog/2020/12/27/announcing-trino.html), and recently yanked all their DockerHub images named `prestosql`.

This PR changes our environment to use [`starburstdata` images instead](https://hub.docker.com/r/starburstdata/presto): [Starburst is a Presto enterprise vendor](https://www.starburst.io/).

There were no query syntax changes with this rebranding, but the authentication header changed names, causing all our tests to not be able to authenticate with to the server anymore: https://github.com/treasure-data/presto-client-ruby/issues/64

This prevents use from using [TrinoDB docker images](https://hub.docker.com/r/trinodb/trino), thus why we are using Starburst for now.

We'll be able to revert to official project images when the linked issue in `presto-client-ruby` is addressed.