### PR TITLE
Correctly close all StatsD clients

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -107,6 +107,10 @@ elsif Gem::Version.new('2.0.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'timers', '< 4.2'
       gem 'typhoeus'
     end
+
+    appraise 'core-old' do
+      gem 'dogstatsd-ruby', '~> 4'
+    end
   end
 elsif Gem::Version.new('2.1.0') <= Gem::Version.new(RUBY_VERSION) \
       && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.0')
@@ -233,6 +237,10 @@ elsif Gem::Version.new('2.1.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'sucker_punch'
       gem 'timers', '< 4.2'
       gem 'typhoeus'
+    end
+
+    appraise 'core-old' do
+      gem 'dogstatsd-ruby', '~> 4'
     end
   end
 elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
@@ -421,6 +429,10 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'sucker_punch'
       gem 'typhoeus'
       gem 'que', '>= 1.0.0.beta2'
+    end
+
+    appraise 'core-old' do
+      gem 'dogstatsd-ruby', '~> 4'
     end
   end
 elsif Gem::Version.new('2.3.0') <= Gem::Version.new(RUBY_VERSION) \
@@ -622,6 +634,10 @@ elsif Gem::Version.new('2.3.0') <= Gem::Version.new(RUBY_VERSION) \
     appraise 'contrib-old' do
       gem 'faraday', '0.17'
     end
+
+    appraise 'core-old' do
+      gem 'dogstatsd-ruby', '~> 4'
+    end
   end
 elsif Gem::Version.new('2.4.0') <= Gem::Version.new(RUBY_VERSION) \
       && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5.0')
@@ -726,6 +742,10 @@ elsif Gem::Version.new('2.4.0') <= Gem::Version.new(RUBY_VERSION) \
 
     appraise 'contrib-old' do
       gem 'faraday', '0.17'
+    end
+
+    appraise 'core-old' do
+      gem 'dogstatsd-ruby', '~> 4'
     end
   end
 elsif Gem::Version.new('2.5.0') <= Gem::Version.new(RUBY_VERSION) \
@@ -931,6 +951,10 @@ elsif Gem::Version.new('2.5.0') <= Gem::Version.new(RUBY_VERSION) \
   appraise 'contrib-old' do
     gem 'faraday', '0.17'
   end
+
+  appraise 'core-old' do
+    gem 'dogstatsd-ruby', '~> 4'
+  end
 elsif Gem::Version.new('2.6.0') <= Gem::Version.new(RUBY_VERSION) \
       && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
   if RUBY_PLATFORM != 'java'
@@ -1102,6 +1126,10 @@ elsif Gem::Version.new('2.6.0') <= Gem::Version.new(RUBY_VERSION) \
 
     appraise 'contrib-old' do
       gem 'faraday', '0.17'
+    end
+
+    appraise 'core-old' do
+      gem 'dogstatsd-ruby', '~> 4'
     end
   end
 elsif Gem::Version.new('2.7.0') <= Gem::Version.new(RUBY_VERSION) \
@@ -1279,6 +1307,10 @@ elsif Gem::Version.new('2.7.0') <= Gem::Version.new(RUBY_VERSION) \
     appraise 'contrib-old' do
       gem 'faraday', '0.17'
     end
+
+    appraise 'core-old' do
+      gem 'dogstatsd-ruby', '~> 4'
+    end
   end
 elsif Gem::Version.new('3.0.0') <= Gem::Version.new(RUBY_VERSION)
   appraise 'rails61-mysql2' do
@@ -1366,5 +1398,9 @@ elsif Gem::Version.new('3.0.0') <= Gem::Version.new(RUBY_VERSION)
     gem 'sucker_punch'
     gem 'typhoeus'
     gem 'que', '>= 1.0.0.beta2'
+  end
+
+  appraise 'core-old' do
+    gem 'dogstatsd-ruby', '~> 4'
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -58,5 +58,7 @@ end
 
 # Optional extensions
 # TODO: Move this to Appraisals?
-gem 'dogstatsd-ruby', '>= 3.3.0'
+
+# Unpin when https://github.com/DataDog/dogstatsd-ruby/pull/175 is released
+gem 'dogstatsd-ruby', git: 'https://github.com/marcotc/dogstatsd-ruby.git', ref: 'dd7ef5dfe4ff9336ec27dc3736e0bbd2acede767'
 gem 'opentracing', '>= 0.4.1'

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,5 @@ end
 
 # Optional extensions
 # TODO: Move this to Appraisals?
-
-# Unpin when https://github.com/DataDog/dogstatsd-ruby/pull/175 is released
-gem 'dogstatsd-ruby', git: 'https://github.com/marcotc/dogstatsd-ruby.git', ref: 'dd7ef5dfe4ff9336ec27dc3736e0bbd2acede767'
+gem 'dogstatsd-ruby', '>= 3.3.0'
 gem 'opentracing', '>= 0.4.1'

--- a/Rakefile
+++ b/Rakefile
@@ -209,6 +209,7 @@ task :ci do
     # Main library
     declare 'bundle exec rake test:main'
     declare 'bundle exec rake spec:main'
+    declare 'bundle exec appraisal core-old rake spec:main'
     declare 'bundle exec rake spec:contrib'
 
     if RUBY_PLATFORM != 'java'
@@ -265,6 +266,7 @@ task :ci do
     # Main library
     declare 'bundle exec rake test:main'
     declare 'bundle exec rake spec:main'
+    declare 'bundle exec appraisal core-old rake spec:main'
     declare 'bundle exec rake spec:contrib'
     declare 'bundle exec rake spec:opentracer'
 
@@ -331,6 +333,7 @@ task :ci do
     # Main library
     declare 'bundle exec rake test:main'
     declare 'bundle exec rake spec:main'
+    declare 'bundle exec appraisal core-old rake spec:main'
     declare 'bundle exec rake spec:contrib'
     declare 'bundle exec rake spec:opentracer'
 
@@ -413,6 +416,7 @@ task :ci do
     # Main library
     declare 'bundle exec rake test:main'
     declare 'bundle exec rake spec:main'
+    declare 'bundle exec appraisal core-old rake spec:main'
     declare 'bundle exec rake spec:contrib'
     declare 'bundle exec rake spec:opentracer'
 
@@ -500,6 +504,7 @@ task :ci do
     # Main library
     declare 'bundle exec rake test:main'
     declare 'bundle exec rake spec:main'
+    declare 'bundle exec appraisal core-old rake spec:main'
     declare 'bundle exec rake spec:contrib'
     declare 'bundle exec rake spec:opentracer'
     declare 'bundle exec rake spec:opentelemetry'
@@ -574,6 +579,7 @@ task :ci do
     # Main library
     declare 'bundle exec rake test:main'
     declare 'bundle exec rake spec:main'
+    declare 'bundle exec appraisal core-old rake spec:main'
     declare 'bundle exec rake spec:contrib'
     declare 'bundle exec rake spec:opentracer'
     declare 'bundle exec rake spec:opentelemetry'
@@ -667,6 +673,7 @@ task :ci do
     # Main library
     declare 'bundle exec rake test:main'
     declare 'bundle exec rake spec:main'
+    declare 'bundle exec appraisal core-old rake spec:main'
     declare 'bundle exec rake spec:contrib'
     declare 'bundle exec rake spec:opentracer'
     declare 'bundle exec rake spec:opentelemetry'
@@ -764,6 +771,7 @@ task :ci do
     # Main library
     declare 'bundle exec rake test:main'
     declare 'bundle exec rake spec:main'
+    declare 'bundle exec appraisal core-old rake spec:main'
     declare 'bundle exec rake spec:contrib'
     declare 'bundle exec rake spec:opentracer'
     declare 'bundle exec rake spec:opentelemetry'
@@ -859,6 +867,7 @@ task :ci do
     # Main library
     declare 'bundle exec rake test:main'
     declare 'bundle exec rake spec:main'
+    declare 'bundle exec appraisal core-old rake spec:main'
     declare 'bundle exec rake spec:contrib'
     declare 'bundle exec rake spec:opentracer'
     declare 'bundle exec rake spec:opentelemetry'

--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -125,10 +125,16 @@ module Datadog
 
         # Shutdown workers
         runtime_metrics.enabled = false
-        runtime_metrics.stop(true)
+        runtime_metrics.stop(true, close_metrics: false)
 
         # Shutdown the old metrics, unless they are still being used.
         # (e.g. custom Statsd instances.)
+        #
+        # TODO: This violates the encapsulation created by Runtime::Metrics and
+        # Health::Metrics, by directly manipulating `statsd` and changing
+        # it's lifecycle management.
+        # If we need to directly have ownership of `statsd` lifecycle, we should
+        # have direct ownership of it.
         old_statsd = [
           runtime_metrics.metrics.statsd,
           health_metrics.statsd

--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -124,7 +124,6 @@ module Datadog
         tracer.shutdown! unless replacement && tracer == replacement.tracer
 
         # Shutdown workers
-        runtime_metrics.enabled = false
         runtime_metrics.stop(true, close_metrics: false)
 
         # Shutdown the old metrics, unless they are still being used.

--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -120,6 +120,10 @@ module Datadog
       metrics.each { |m| send(m.type, *[m.name, m.value, m.options].compact) }
     end
 
+    def close
+      @statsd.close if @statsd && @statsd.respond_to?(:close)
+    end
+
     Metric = Struct.new(:type, :name, :value, :options) do
       def initialize(*args)
         super

--- a/lib/ddtrace/workers/runtime_metrics.rb
+++ b/lib/ddtrace/workers/runtime_metrics.rb
@@ -50,8 +50,9 @@ module Datadog
       # ensuring correct resource decommission of its internal
       # dependencies.
       def stop(*args, close_metrics: true)
+        result = super(*args)
         @metrics.close if close_metrics
-        super(*args)
+        result
       end
 
       def_delegators \

--- a/lib/ddtrace/workers/runtime_metrics.rb
+++ b/lib/ddtrace/workers/runtime_metrics.rb
@@ -50,6 +50,7 @@ module Datadog
       # ensuring correct resource decommission of its internal
       # dependencies.
       def stop(*args, close_metrics: true)
+        self.enabled = false
         result = super(*args)
         @metrics.close if close_metrics
         result

--- a/lib/ddtrace/workers/runtime_metrics.rb
+++ b/lib/ddtrace/workers/runtime_metrics.rb
@@ -20,7 +20,7 @@ module Datadog
         :metrics
 
       def initialize(options = {})
-        @metrics = options.fetch(:metrics, Runtime::Metrics.new)
+        @metrics = options.fetch(:metrics) { Runtime::Metrics.new }
 
         # Workers::Async::Thread settings
         self.fork_policy = options.fetch(:fork_policy, Workers::Async::Thread::FORK_POLICY_STOP)
@@ -41,6 +41,17 @@ module Datadog
       def associate_with_span(*args)
         # Start the worker
         metrics.associate_with_span(*args).tap { perform }
+      end
+
+      # TODO: `close_metrics` is only needed because
+      # Datadog::Components directly manipulates the lifecycle of
+      # Runtime::Metrics.statsd instances.
+      # This should be avoided, as it prevents this class from
+      # ensuring correct resource decommission of its internal
+      # dependencies.
+      def stop(*args, close_metrics: true)
+        @metrics.close if close_metrics
+        super(*args)
       end
 
       def_delegators \

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -615,8 +615,6 @@ RSpec.describe Datadog::Configuration::Components do
 
       it 'shuts down all components' do
         expect(components.tracer).to receive(:shutdown!)
-        expect(components.runtime_metrics).to receive(:enabled=)
-          .with(false)
         expect(components.runtime_metrics).to receive(:stop)
           .with(true, close_metrics: false)
         expect(components.runtime_metrics.metrics.statsd).to receive(:close)
@@ -647,8 +645,6 @@ RSpec.describe Datadog::Configuration::Components do
 
         it 'shuts down all components' do
           expect(components.tracer).to receive(:shutdown!)
-          expect(components.runtime_metrics).to receive(:enabled=)
-            .with(false)
           expect(components.runtime_metrics).to receive(:stop)
             .with(true, close_metrics: false)
           expect(components.runtime_metrics.metrics.statsd).to receive(:close)
@@ -666,8 +662,6 @@ RSpec.describe Datadog::Configuration::Components do
 
           it 'shuts down all components' do
             expect(components.tracer).to receive(:shutdown!)
-            expect(components.runtime_metrics).to receive(:enabled=)
-              .with(false)
             expect(components.runtime_metrics).to receive(:stop)
               .with(true, close_metrics: false)
             expect(components.health_metrics.statsd).to receive(:close)
@@ -684,8 +678,6 @@ RSpec.describe Datadog::Configuration::Components do
 
         it 'shuts down all components but the tracer' do
           expect(components.tracer).to_not receive(:shutdown!)
-          expect(components.runtime_metrics).to receive(:enabled=)
-            .with(false)
           expect(components.runtime_metrics).to receive(:stop)
             .with(true, close_metrics: false)
           expect(components.runtime_metrics.metrics.statsd).to receive(:close)
@@ -702,8 +694,6 @@ RSpec.describe Datadog::Configuration::Components do
 
         it 'shuts down all components but the tracer' do
           expect(components.tracer).to receive(:shutdown!)
-          expect(components.runtime_metrics).to receive(:enabled=)
-            .with(false)
           expect(components.runtime_metrics).to receive(:stop)
             .with(true, close_metrics: false)
           expect(components.runtime_metrics.metrics.statsd).to_not receive(:close)
@@ -721,8 +711,6 @@ RSpec.describe Datadog::Configuration::Components do
 
         it 'shuts down all components but the tracer' do
           expect(components.tracer).to receive(:shutdown!)
-          expect(components.runtime_metrics).to receive(:enabled=)
-            .with(false)
           expect(components.runtime_metrics).to receive(:stop)
             .with(true, close_metrics: false)
           expect(components.runtime_metrics.metrics.statsd).to_not receive(:close)

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -618,7 +618,7 @@ RSpec.describe Datadog::Configuration::Components do
         expect(components.runtime_metrics).to receive(:enabled=)
           .with(false)
         expect(components.runtime_metrics).to receive(:stop)
-          .with(true)
+          .with(true, close_metrics: false)
         expect(components.runtime_metrics.metrics.statsd).to receive(:close)
         expect(components.health_metrics.statsd).to receive(:close)
 
@@ -650,7 +650,7 @@ RSpec.describe Datadog::Configuration::Components do
           expect(components.runtime_metrics).to receive(:enabled=)
             .with(false)
           expect(components.runtime_metrics).to receive(:stop)
-            .with(true)
+            .with(true, close_metrics: false)
           expect(components.runtime_metrics.metrics.statsd).to receive(:close)
           expect(components.health_metrics.statsd).to receive(:close)
 
@@ -669,7 +669,7 @@ RSpec.describe Datadog::Configuration::Components do
             expect(components.runtime_metrics).to receive(:enabled=)
               .with(false)
             expect(components.runtime_metrics).to receive(:stop)
-              .with(true)
+              .with(true, close_metrics: false)
             expect(components.health_metrics.statsd).to receive(:close)
 
             shutdown!
@@ -687,7 +687,7 @@ RSpec.describe Datadog::Configuration::Components do
           expect(components.runtime_metrics).to receive(:enabled=)
             .with(false)
           expect(components.runtime_metrics).to receive(:stop)
-            .with(true)
+            .with(true, close_metrics: false)
           expect(components.runtime_metrics.metrics.statsd).to receive(:close)
           expect(components.health_metrics.statsd).to receive(:close)
 
@@ -705,7 +705,7 @@ RSpec.describe Datadog::Configuration::Components do
           expect(components.runtime_metrics).to receive(:enabled=)
             .with(false)
           expect(components.runtime_metrics).to receive(:stop)
-            .with(true)
+            .with(true, close_metrics: false)
           expect(components.runtime_metrics.metrics.statsd).to_not receive(:close)
           expect(components.health_metrics.statsd).to receive(:close)
 
@@ -724,7 +724,7 @@ RSpec.describe Datadog::Configuration::Components do
           expect(components.runtime_metrics).to receive(:enabled=)
             .with(false)
           expect(components.runtime_metrics).to receive(:stop)
-            .with(true)
+            .with(true, close_metrics: false)
           expect(components.runtime_metrics.metrics.statsd).to_not receive(:close)
           expect(components.health_metrics.statsd).to_not receive(:close)
 

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -337,7 +337,7 @@ RSpec.describe Datadog::Configuration do
             end
           end
 
-          it 'deactivates the old runtime metrics worker' do
+          it 'stops the old runtime metrics worker' do
             expect(@old_runtime_metrics.enabled?).to be false
             expect(@old_runtime_metrics.running?).to be false
 

--- a/spec/ddtrace/metrics_spec.rb
+++ b/spec/ddtrace/metrics_spec.rb
@@ -678,6 +678,28 @@ RSpec.describe Datadog::Metrics do
       end
     end
   end
+
+  describe '#close' do
+    subject(:close) { metrics.close }
+
+    context 'with a closeable statsd instance' do
+      let(:statsd) { instance_double(Datadog::Statsd, close: nil) }
+
+      it 'closes statsd' do
+        close
+
+        expect(statsd).to have_received(:close)
+      end
+    end
+
+    context 'without a non-closeable statsd instance' do
+      let(:statsd) { double }
+
+      it 'does not call nonexistent method #close' do
+        close
+      end
+    end
+  end
 end
 
 RSpec.describe Datadog::Metrics::Options do

--- a/spec/ddtrace/workers/runtime_metrics_spec.rb
+++ b/spec/ddtrace/workers/runtime_metrics_spec.rb
@@ -217,6 +217,7 @@ RSpec.describe Datadog::Workers::RuntimeMetrics do
     it 'closes metrics and stops worker' do
       stop
 
+      expect(worker.enabled?).to be(false)
       expect(worker.running?).to be(false)
       expect(worker.metrics).to have_received(:close)
     end
@@ -229,6 +230,19 @@ RSpec.describe Datadog::Workers::RuntimeMetrics do
 
         expect(worker.running?).to be(false)
         expect(worker.metrics).to_not have_received(:close)
+      end
+    end
+
+    context 'with async thread not started'do
+      it 'does not lazily initialize stopped worker' do
+        expect(worker.running?).to be(false)
+
+        stop
+
+        # Try to initialize async thread
+        worker.perform
+
+        expect(worker.running?).to be(false)
       end
     end
   end

--- a/spec/ddtrace/workers/runtime_metrics_spec.rb
+++ b/spec/ddtrace/workers/runtime_metrics_spec.rb
@@ -6,7 +6,7 @@ require 'ddtrace/workers/runtime_metrics'
 RSpec.describe Datadog::Workers::RuntimeMetrics do
   subject(:worker) { described_class.new(options) }
 
-  let(:metrics) { instance_double(Datadog::Runtime::Metrics) }
+  let(:metrics) { instance_double(Datadog::Runtime::Metrics, close: nil) }
   let(:options) { { metrics: metrics, enabled: true } }
 
   before { allow(metrics).to receive(:flush) }
@@ -201,6 +201,35 @@ RSpec.describe Datadog::Workers::RuntimeMetrics do
       expect(worker.metrics).to have_received(:associate_with_span)
         .with(span)
       expect(worker).to have_received(:perform)
+    end
+  end
+
+  describe '#stop' do
+    subject(:stop) { worker.stop(*args, **kwargs) }
+
+    let(:args) { %w[foo bar] }
+    let(:kwargs) { {} }
+
+    before do
+      allow(worker.metrics).to receive(:close)
+    end
+
+    it 'closes metrics and stops worker' do
+      stop
+
+      expect(worker.running?).to be(false)
+      expect(worker.metrics).to have_received(:close)
+    end
+
+    context 'with close_metrics: false' do
+      let(:kwargs) { { close_metrics: false } }
+
+      it 'does not close metrics, but stops worker' do
+        stop
+
+        expect(worker.running?).to be(false)
+        expect(worker.metrics).to_not have_received(:close)
+      end
     end
   end
 

--- a/spec/ddtrace/workers/runtime_metrics_spec.rb
+++ b/spec/ddtrace/workers/runtime_metrics_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe Datadog::Workers::RuntimeMetrics do
       end
     end
 
-    context 'with async thread not started'do
+    context 'with async thread not started' do
       it 'does not lazily initialize stopped worker' do
         expect(worker.running?).to be(false)
 

--- a/spec/ddtrace_integration_spec.rb
+++ b/spec/ddtrace_integration_spec.rb
@@ -112,8 +112,12 @@ RSpec.describe 'ddtrace integration' do
         expect(Datadog.configuration.runtime_metrics.enabled).to be(true).or be(false)
       end
 
-      it 'does not error on reporting health metrics' do
+      it 'does not error on reporting health metrics', if: Datadog::Statsd::VERSION >= '5.0.0' do
         expect(Datadog.health_metrics.queue_accepted(1)).to be(true)
+      end
+
+      it 'does not error on reporting health metrics', if: Datadog::Statsd::VERSION < '5.0.0' do
+        expect(Datadog.health_metrics.queue_accepted(1)).to be_a(Integer)
       end
 
       context 'with OpenTracer' do

--- a/spec/ddtrace_integration_spec.rb
+++ b/spec/ddtrace_integration_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'ddtrace integration' do
       end
 
       it 'does not error on reporting health metrics' do
-        expect(Datadog.health_metrics.queue_accepted(1)).to be_a(Integer)
+        expect(Datadog.health_metrics.queue_accepted(1)).to be(true)
       end
 
       context 'with OpenTracer' do

--- a/spec/ddtrace_integration_spec.rb
+++ b/spec/ddtrace_integration_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'ddtrace integration' do
       end
 
       it 'does not error on reporting health metrics', if: Datadog::Statsd::VERSION >= '5.0.0' do
-        expect(Datadog.health_metrics.queue_accepted(1)).to be(true)
+        expect(Datadog.health_metrics.queue_accepted(1)).to be_truthy
       end
 
       it 'does not error on reporting health metrics', if: Datadog::Statsd::VERSION < '5.0.0' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -173,11 +173,14 @@ end
 # To allow for leaky threads to be traced
 # back to their creation point.
 module DatadogThreadDebugger
-  def initialize(*args)
+  # DEV: we have to use an explicit `block`, argument
+  # instead of the implicit `yield` call, as calling
+  # `yield` here crashes the Ruby VM in Ruby < 2.2.
+  def initialize(*args, &block)
     caller_ = caller
     wrapped = lambda do |*thread_args|
       Thread.current.instance_variable_set(:@caller, caller_)
-      yield(*thread_args)
+      block.call(*thread_args) # rubocop:disable Performance/RedundantBlockCall
     end
     wrapped.ruby2_keywords if wrapped.respond_to?(:ruby2_keywords, true)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,6 +91,10 @@ RSpec.configure do |config|
   # with the test execution.
   config.around do |example|
     example.run.tap do
+      # Background thread leak checking is currently too verbose for CI,
+      # slowing down builds to the point of causing CircleCI timeouts.
+      next if ENV.key?('CI')
+
       # Exclude acceptable background threads
       background_threads = Thread.list.reject do |t|
         group_name = t.group.instance_variable_get(:@group_name) if t.group.instance_variable_defined?(:@group_name)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,14 +90,21 @@ RSpec.configure do |config|
   # put this code inside the test scope, interfering
   # with the test execution.
   #
-  # rubocop:disable Style/ClassVars
+  # rubocop:disable Style/GlobalVars
   config.around do |example|
     example.run.tap do
       # Stop reporting on background thread leaks after too many
       # successive failures. The output is very verbose and, at that point,
       # it's better to work on fixing the very first occurrences.
-      @@background_thread_leak_reports ||= 0
-      next if @@background_thread_leak_reports > 10
+      $background_thread_leak_reports ||= 0
+      if $background_thread_leak_reports >= 10
+        if $background_thread_leak_reports == 10
+          warn "Too many leak thread reports! Suppressing further reports.\n" \
+               'Consider addressing the previously reported leaks before proceeding.'
+        end
+
+        next
+      end
 
       # Exclude acceptable background threads
       background_threads = Thread.list.reject do |t|
@@ -159,11 +166,11 @@ RSpec.configure do |config|
           :red
         )
 
-        @@background_thread_leak_reports += 1
+        $background_thread_leak_reports += 1
       end
     end
   end
-  # rubocop:enable Style/ClassVars
+  # rubocop:enable Style/GlobalVars
 
   # Closes the global testing tracer.
   #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,9 +98,14 @@ RSpec.configure do |config|
       # it's better to work on fixing the very first occurrences.
       $background_thread_leak_reports ||= 0
       if $background_thread_leak_reports >= 10
-        if $background_thread_leak_reports == 10
-          warn "Too many leak thread reports! Suppressing further reports.\n" \
-               'Consider addressing the previously reported leaks before proceeding.'
+        unless $background_thread_leak_warned ||= false
+          warn RSpec::Core::Formatters::ConsoleCodes.wrap(
+            "Too many leaky thread reports! Suppressing further reports.\n" \
+            'Consider addressing the previously reported leaks before proceeding.',
+            :red
+          )
+
+          $background_thread_leak_warned = true
         end
 
         next
@@ -163,7 +168,7 @@ RSpec.configure do |config|
           "For help fixing this issue, see \"Ensuring tests don't leak resources\" in docs/DevelopmentGuide.md.\n" \
           "\n" \
           "#{info}",
-          :red
+          :yellow
         )
 
         $background_thread_leak_reports += 1

--- a/spec/support/tracer_helpers.rb
+++ b/spec/support/tracer_helpers.rb
@@ -156,11 +156,11 @@ module TracerHelpers
   def tracer_shutdown!
     if defined?(@use_real_tracer) && @use_real_tracer
       Datadog.tracer.shutdown!
-    else
-      return unless defined?(@tracer) && @tracer
-
+    elsif defined?(@tracer) && @tracer
       @tracer.shutdown!
       @tracer = nil
     end
+
+    Datadog.send(:reset!)
   end
 end


### PR DESCRIPTION
The new version of [`dogstatsd-ruby`, v4.9.0,](https://github.com/DataDog/dogstatsd-ruby/releases/tag/v4.9.0) creates a background thread, which needs to be properly closed by calling the previously existing method `#close`.

In a few parts of our tracer and test suite we fail to call `#close` on all instances of the StatsD client. This PR addresses that.

The configuration of Runtime Metric and Health Metrics components reuse the existing `statsd` client from previous configurations, thus directly manipulating the lifecycle of `statsd`. This doesn't seem like a natural relationship, as the `statsd` client is nested inside the Runtime Metrics Worker object, and trying to manipulate its lifecycle from outside creates a few complications. These are documented inline. This also gives us another reason to "flatten" our internal tracer components, in this case the `statsd` client, as that will restore the natural ownership of its lifecycle to the global Components manager.