### PR TITLE
Lint changes for latest Rubocop minor release

### DIFF
--- a/lib/ddtrace/configuration/options.rb
+++ b/lib/ddtrace/configuration/options.rb
@@ -14,10 +14,8 @@ module Datadog
       # Class behavior for a configuration object with options
       module ClassMethods
         def options
-          @options ||= begin
-            # Allows for class inheritance of option definitions
-            superclass <= Options ? superclass.options.dup : OptionDefinitionSet.new
-          end
+          # Allows for class inheritance of option definitions
+          @options ||= superclass <= Options ? superclass.options.dup : OptionDefinitionSet.new
         end
 
         protected

--- a/lib/ddtrace/contrib/active_record/configuration/resolver.rb
+++ b/lib/ddtrace/contrib/active_record/configuration/resolver.rb
@@ -87,17 +87,17 @@ module Datadog
           end
 
           def connection_resolver
-            @resolver ||= begin
-              if defined?(::ActiveRecord::Base.configurations.resolve)
-                ::ActiveRecord::DatabaseConfigurations.new(active_record_configuration)
-              elsif defined?(::ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver)
-                ::ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(active_record_configuration)
-              else
-                ::Datadog::Vendor::ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(
-                  active_record_configuration
-                )
-              end
-            end
+            @resolver ||= if defined?(::ActiveRecord::Base.configurations.resolve)
+                            ::ActiveRecord::DatabaseConfigurations.new(active_record_configuration)
+                          elsif defined?(::ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver)
+                            ::ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(
+                              active_record_configuration
+                            )
+                          else
+                            ::Datadog::Vendor::ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(
+                              active_record_configuration
+                            )
+                          end
           end
 
           def resolve_connection_key(key)

--- a/lib/ddtrace/contrib/httpclient/instrumentation.rb
+++ b/lib/ddtrace/contrib/httpclient/instrumentation.rb
@@ -88,14 +88,12 @@ module Datadog
             service = config[:service_name]
             tracer = config[:tracer]
 
-            @datadog_pin ||= begin
-              Datadog::Pin.new(
-                service,
-                app: Ext::APP,
-                app_type: Datadog::Ext::HTTP::TYPE_OUTBOUND,
-                tracer: -> { config[:tracer] }
-              )
-            end
+            @datadog_pin ||= Datadog::Pin.new(
+              service,
+              app: Ext::APP,
+              app_type: Datadog::Ext::HTTP::TYPE_OUTBOUND,
+              tracer: -> { config[:tracer] }
+            )
 
             if @datadog_pin.service_name == default_datadog_pin.service_name && @datadog_pin.service_name != service
               @datadog_pin.service = service
@@ -111,14 +109,12 @@ module Datadog
             config = Datadog.configuration[:httpclient]
             service = config[:service_name]
 
-            @default_datadog_pin ||= begin
-              Datadog::Pin.new(
-                service,
-                app: Ext::APP,
-                app_type: Datadog::Ext::HTTP::TYPE_OUTBOUND,
-                tracer: -> { config[:tracer] }
-              )
-            end
+            @default_datadog_pin ||= Datadog::Pin.new(
+              service,
+              app: Ext::APP,
+              app_type: Datadog::Ext::HTTP::TYPE_OUTBOUND,
+              tracer: -> { config[:tracer] }
+            )
           end
 
           def datadog_configuration(host = :default)

--- a/lib/ddtrace/contrib/httprb/instrumentation.rb
+++ b/lib/ddtrace/contrib/httprb/instrumentation.rb
@@ -16,7 +16,6 @@ module Datadog
         end
 
         # Instance methods for configuration
-        # rubocop:disable Metrics/ModuleLength
         module InstanceMethods
           include Datadog::Contrib::HttpAnnotationHelper
 
@@ -99,14 +98,12 @@ module Datadog
             service = config[:service_name]
             tracer = config[:tracer]
 
-            @datadog_pin ||= begin
-              Datadog::Pin.new(
-                service,
-                app: Ext::APP,
-                app_type: Datadog::Ext::HTTP::TYPE_OUTBOUND,
-                tracer: -> { config[:tracer] }
-              )
-            end
+            @datadog_pin ||= Datadog::Pin.new(
+              service,
+              app: Ext::APP,
+              app_type: Datadog::Ext::HTTP::TYPE_OUTBOUND,
+              tracer: -> { config[:tracer] }
+            )
 
             if @datadog_pin.service_name == default_datadog_pin.service_name && @datadog_pin.service_name != service
               @datadog_pin.service = service
@@ -122,14 +119,12 @@ module Datadog
             config = Datadog.configuration[:httprb]
             service = config[:service_name]
 
-            @default_datadog_pin ||= begin
-              Datadog::Pin.new(
-                service,
-                app: Ext::APP,
-                app_type: Datadog::Ext::HTTP::TYPE_OUTBOUND,
-                tracer: -> { config[:tracer] }
-              )
-            end
+            @default_datadog_pin ||= Datadog::Pin.new(
+              service,
+              app: Ext::APP,
+              app_type: Datadog::Ext::HTTP::TYPE_OUTBOUND,
+              tracer: -> { config[:tracer] }
+            )
           end
 
           def datadog_configuration(host = :default)

--- a/lib/ddtrace/runtime/container.rb
+++ b/lib/ddtrace/runtime/container.rb
@@ -32,39 +32,37 @@ module Datadog
       end
 
       def descriptor
-        @descriptor ||= begin
-          Descriptor.new.tap do |descriptor|
-            begin
-              Cgroup.descriptors.each do |cgroup_descriptor|
-                # Parse container data from cgroup descriptor
-                path = cgroup_descriptor.path
-                next if path.nil?
+        @descriptor ||= Descriptor.new.tap do |descriptor|
+          begin
+            Cgroup.descriptors.each do |cgroup_descriptor|
+              # Parse container data from cgroup descriptor
+              path = cgroup_descriptor.path
+              next if path.nil?
 
-                # Split path into parts
-                parts = path.split('/')
-                parts.shift # Remove leading empty part
-                next if parts.length < 2
+              # Split path into parts
+              parts = path.split('/')
+              parts.shift # Remove leading empty part
+              next if parts.length < 2
 
-                # Read info from path
-                platform = parts[0]
-                container_id = parts[-1][CONTAINER_REGEX]
-                task_uid = parts[-2][POD_REGEX]
+              # Read info from path
+              platform = parts[0]
+              container_id = parts[-1][CONTAINER_REGEX]
+              task_uid = parts[-2][POD_REGEX]
 
-                # If container ID wasn't found, ignore.
-                # Path might describe a non-container environment.
-                next if container_id.nil?
+              # If container ID wasn't found, ignore.
+              # Path might describe a non-container environment.
+              next if container_id.nil?
 
-                descriptor.platform = platform
-                descriptor.container_id = container_id
-                descriptor.task_uid = task_uid
+              descriptor.platform = platform
+              descriptor.container_id = container_id
+              descriptor.task_uid = task_uid
 
-                break
-              end
-            rescue StandardError => e
-              Datadog.logger.error(
-                "Error while parsing container info. Cause: #{e.message} Location: #{e.backtrace.first}"
-              )
+              break
             end
+          rescue StandardError => e
+            Datadog.logger.error(
+              "Error while parsing container info. Cause: #{e.message} Location: #{e.backtrace.first}"
+            )
           end
         end
       end


### PR DESCRIPTION
> Makes CI green, alongside https://github.com/DataDog/dd-trace-rb/pull/1429

Rubocop recently changed the existing `Style/RedundantBegin` cop to identify additional cases.

This PR addresses the newly discovered infractors and addresses them.