### PR TITLE
Fix JRuby builds after mimemagic license change

### DIFF
--- a/.circleci/images/primary/Dockerfile-jruby-9.2-latest
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2-latest
@@ -16,7 +16,8 @@ RUN set -ex; \
             locales sudo openssh-client ca-certificates tar gzip parallel \
             net-tools netcat unzip zip bzip2 gnupg curl wget \
             tzdata rsync vim \
-            build-essential; \
+            build-essential \
+            shared-mime-info; \
         rm -rf /var/lib/apt/lists/*;
 
 # Set timezone to UTC by default

--- a/Appraisals
+++ b/Appraisals
@@ -901,7 +901,7 @@ elsif Gem::Version.new('2.5.0') <= Gem::Version.new(RUBY_VERSION) \
     gem 'pg', platform: :ruby
     gem 'activerecord-jdbcpostgresql-adapter', '>= 60.2', platform: :jruby
     gem 'presto-client', '>=  0.5.14'
-    gem 'qless'
+    gem 'qless', (RUBY_PLATFORM == 'java' ? '0.10.0' : '>= 0') # Newer releases require `rusage`, which is not available for JRuby
     gem 'racecar', '>= 0.3.5'
     gem 'rack'
     gem 'rack-test'


### PR DESCRIPTION
After many version of `mimemagic` being yanked, some older Rails versions were affected.

This didn't affect much of our test environment, as older docker images have the required [`freedesktop.org.xml` database file](https://github.com/mimemagicrb/mimemagic/blob/af5a9b1c5b774e65fd84bd7ca4239a9f3eba2039/ext/mimemagic/Rakefile#L7-L10) available, while recently created ones, like JRuby images, do not.

This PR adds the Debian package `shared-mime-info` to our affected docker images.

This change could theoretically be added to all older docker images, but, from my experience, trying to rebuild, for example, the Ruby 2.0 docker images does not produce the same compatible environment: Debian packages have changed quite a bit since last image build, and some libraries that depend on legacy native binaries (`mysql`, for example) do not work correctly anymore.
I'm choosing to not touch them at this time.

As for not touching TruffleRuby, this will depend on what version of Rails is supported when we eventually provide full support for JRuby. Given `shared-mime-info` only needs to be installed for Rails 5 today, I'm leaning towards waiting for TruffleRuby to be ready in `ddtrace`, as Rails 5 might not be in the test matrix for TruffleRuby by then.

Regarding the change to `qless`, this is a library that does not support JRuby as of version `> 0.10.0`, because it adds a dependency to [`rusage`](https://rubygems.org/gems/rusage), which does not support JRuby. Version `0.10.0` or prior do support JRuby.