### PR TITLE
Fix broken test due to bug in JRuby 9.2.0.0 by skipping `around` block too

### DIFF
--- a/spec/ddtrace/profiling/ext/forking_spec.rb
+++ b/spec/ddtrace/profiling/ext/forking_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe Datadog::Profiling::Ext::Forking do
 
     context 'when forking is supported' do
       around do |example|
+        # NOTE: Do not move this to a before, since we also want to skip the around as well
+        skip 'Forking not supported' unless described_class.supported?
+
         if ::Process.singleton_class.ancestors.include?(Datadog::Profiling::Ext::Forking::Kernel)
           skip 'Unclean Process class state.'
         end
@@ -45,8 +48,6 @@ RSpec.describe Datadog::Profiling::Ext::Forking do
         # Can't assert this because top level can't be reverted; can't guarantee pristine state.
         # expect(toplevel_receiver.method(:fork).source_location).to be nil
       end
-
-      before { skip 'Forking not supported' unless described_class.supported? }
 
       it 'applies the Kernel patch' do
         # NOTE: There's no way to undo a modification of the TOPLEVEL_BINDING.


### PR DESCRIPTION
The `forking_spec.rb` doesn't make sense to run on JRuby, since JRuby does not support the `fork` API, and we had a `skip` to avoid running the test.

But there was a bit of clean-up code in the `around` block that seems to be broken on JRuby 9.2.0.0 (but not on later versions).

The broken part seems to be replacing the `::Kernel` constant:

```ruby
# ...
unmodified_kernel_class = ::Kernel.dup
# ...
Object.send(:remove_const, :Kernel)
Object.const_set('Kernel', unmodified_kernel_class)
```

This caused an unrelated test in the test suite to later break with

```
NoMethodError: private method `require' called for Kernel:Module
                           require_relative at uri:classloader:/jruby/kernel/kernel.rb:13
                           block in Support at /usr/local/bundle/gems/rspec-support-3.10.2/lib/rspec/support.rb:33
             block in require_rspec_support at /usr/local/bundle/gems/rspec-support-3.10.2/lib/rspec/support.rb:24
                           source_from_file at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/world.rb:148
                           source_from_file at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/formatters/snippet_extractor.rb:18
                            extract_line_at at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/formatters/snippet_extractor.rb:10
                extract_expression_lines_at at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/formatters/snippet_extractor.rb:123
                          read_failed_lines at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/formatters/exception_presenter.rb:231
                  failure_slash_error_lines at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/formatters/exception_presenter.rb:166
                     block in failure_lines at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/formatters/exception_presenter.rb:153
                                        tap at org/jruby/RubyKernel.java:1876
                              failure_lines at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/formatters/exception_presenter.rb:152
                    colorized_message_lines at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/formatters/exception_presenter.rb:34
            formatted_message_and_backtrace at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/formatters/exception_presenter.rb:253
                      fully_formatted_lines at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/formatters/exception_presenter.rb:88
                            fully_formatted at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/formatters/exception_presenter.rb:80
                            fully_formatted at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/notifications.rb:200
  block in fully_formatted_pending_examples at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/notifications.rb:126
                                       each at org/jruby/RubyArray.java:1801
                            each_with_index at org/jruby/RubyEnumerable.java:1180
           fully_formatted_pending_examples at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/notifications.rb:125
                               dump_pending at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/formatters/base_text_formatter.rb:49
                            block in notify at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:209
                                       each at org/jruby/RubyArray.java:1801
                                     notify at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:208
                            block in finish at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:177
                                close_after at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:194
                                     finish at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:174
                                     report at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:76
                                  run_specs at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:115
                                        run at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:89
                                        run at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:71
                                     invoke at /usr/local/bundle/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:45
                                     <main> at /usr/local/bundle/gems/rspec-core-3.10.1/exe/rspec:4
```

To avoid this, I just moved the `skip` to the top of the `around` block, making sure we only run the `around` if we're  actually going to need it.