### PR TITLE
Reset existing cpu time tracking state when starting Stack collector

### DIFF
--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -24,21 +24,28 @@ module Datadog
           :max_time_usage_pct,
           :recorder
 
-        def initialize(recorder, options = {})
+        def initialize(
+          recorder,
+          max_frames: DEFAULT_MAX_FRAMES,
+          ignore_thread: nil,
+          max_time_usage_pct: DEFAULT_MAX_TIME_USAGE_PCT,
+          fork_policy: Workers::Async::Thread::FORK_POLICY_RESTART, # Restart in forks by default
+          interval: MIN_INTERVAL,
+          enabled: true
+        )
           @recorder = recorder
-          @max_frames = options[:max_frames] || DEFAULT_MAX_FRAMES
-          @ignore_thread = options[:ignore_thread]
-          @max_time_usage_pct = options[:max_time_usage_pct] || DEFAULT_MAX_TIME_USAGE_PCT
+          @max_frames = max_frames
+          @ignore_thread = ignore_thread
+          @max_time_usage_pct = max_time_usage_pct
 
           # Workers::Async::Thread settings
-          # Restart in forks by default
-          self.fork_policy = options[:fork_policy] || Workers::Async::Thread::FORK_POLICY_RESTART
+          self.fork_policy = fork_policy
 
           # Workers::IntervalLoop settings
-          self.loop_base_interval = options[:interval] || MIN_INTERVAL
+          self.loop_base_interval = interval
 
           # Workers::Polling settings
-          self.enabled = options.key?(:enabled) ? options[:enabled] == true : true
+          self.enabled = enabled
 
           @warn_about_missing_cpu_time_instrumentation_only_once = Datadog::Utils::OnlyOnce.new
         end

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -63,7 +63,10 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   describe '#perform' do
     subject(:perform) { collector.perform }
 
-    after { collector.stop(true, 0) }
+    after do
+      collector.stop(true, 0)
+      collector.join
+    end
 
     context 'when disabled' do
       before { collector.enabled = false }

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -452,6 +452,10 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
 
     let(:thread) { Thread.new {} }
 
+    after do
+      thread && thread.join
+    end
+
     context 'given a non-thread' do
       let(:thread) { nil }
 

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -5,7 +5,7 @@ require 'ddtrace/profiling/collectors/stack'
 require 'ddtrace/profiling/recorder'
 
 RSpec.describe Datadog::Profiling::Collectors::Stack do
-  subject(:collector) { described_class.new(recorder, options) }
+  subject(:collector) { described_class.new(recorder, **options) }
 
   let(:recorder) { instance_double(Datadog::Profiling::Recorder) }
   let(:options) { {} }


### PR DESCRIPTION
If the profiler is started for a while, stopped and then restarted OR whenever the process forks, we need to clean up the per-thread cpu time counters we keep, so that the first sample after starting doesn't end up with:

1. negative time: At least on my test docker container, and on the reliability environment, after the process forks, the clock reference changes and (old cpu time - new cpu time) can be < 0

2. large amount of time: if the profiler was started, then stopped for some amount of time, and then restarted, we don't want the first sample to be "blamed" for multiple minutes of CPU time

By resetting the last cpu time seen, we start with a clean slate every time we start the stack collector.

I also did a few clean-ups while I was touching this class and the specs. I've separated them out into commits, so it's probably easy to review commit-by-commit.

Finally, this PR is on top of #1434, I'll change it to target `feature/profiling` once that one is merged.