### PR TITLE
Misc tidying up in profiling branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,8 @@ gem 'benchmark-ips', '~> 2.8'
 gem 'benchmark-memory', '~> 0.1'
 gem 'builder'
 gem 'climate_control', '~> 0.2.0'
-gem 'concurrent-ruby' # Leave it open; it's integration too, and we want Appraisal to set the version.
+# Leave it open as we also have it as an integration and want Appraisal to control the version under test.
+gem 'concurrent-ruby'
 gem 'memory_profiler', '~> 0.9'
 gem 'minitest', '= 5.10.1'
 gem 'minitest-around', '0.5.0'
@@ -47,3 +48,11 @@ end
 # TODO: Move this to Appraisals?
 gem 'dogstatsd-ruby', '>= 3.3.0'
 gem 'opentracing', '>= 0.4.1'
+
+# Profiler optional dependencies
+gem 'ffi', '~> 1.0'
+# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424 and the big comment in
+#       lib/ddtrace/profiling.rb: it breaks for some older rubies in CI without BUNDLE_FORCE_RUBY_PLATFORM=true.
+#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
+#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1'] if RUBY_PLATFORM != 'java'

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -38,22 +38,4 @@ Gem::Specification.new do |spec|
     # msgpack 1.4 fails for Ruby 2.0 and 2.1: https://github.com/msgpack/msgpack-ruby/issues/205
     spec.add_dependency 'msgpack', '< 1.4'
   end
-
-  # Optional extensions
-  spec.add_development_dependency 'ffi', '~> 1.0'
-
-  if RUBY_PLATFORM != 'java'
-    # NOTE: Exclude 3.7.x because the required_ruby_version mismatches
-    #       actual Ruby support. It would break Ruby < 2.3.
-    google_protobuf_versions = [
-      '~> 3.0',
-      '!= 3.7.0.rc.2',
-      '!= 3.7.0.rc.3',
-      '!= 3.7.0',
-      '!= 3.7.1',
-      '!= 3.8.0.rc.1'
-    ]
-
-    spec.add_development_dependency 'google-protobuf', *google_protobuf_versions
-  end
 end

--- a/lib/ddtrace/diagnostics/environment_logger.rb
+++ b/lib/ddtrace/diagnostics/environment_logger.rb
@@ -12,7 +12,7 @@ module Datadog
         # Outputs environment information to {Datadog.logger}.
         # Executes only for the lifetime of the program.
         def log!(transport_responses)
-          return if @executed || !log?
+          return if (defined?(@executed) && @executed) || !log?
 
           @executed = true
 

--- a/lib/ddtrace/profiling/ext/forking.rb
+++ b/lib/ddtrace/profiling/ext/forking.rb
@@ -14,6 +14,8 @@ module Datadog
           modules = [::Process, ::Kernel]
           # TODO: Ruby < 2.3 doesn't support Binding#receiver.
           #       Remove "else #eval" clause when Ruby < 2.3 support is dropped.
+          # NOTE: Modifying the "main" object as we do here is (as far as I know) irreversible. During tests, this change
+          #       will stick around even if we otherwise stub `Process` and `Kernel`.
           modules << (TOPLEVEL_BINDING.respond_to?(:receiver) ? TOPLEVEL_BINDING.receiver : TOPLEVEL_BINDING.eval('self'))
 
           # Patch top-level binding, Kernel, Process.

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 require 'ddtrace'
 require 'ddtrace/tracer'
 require 'datadog/statsd'
+
 RSpec.describe 'Tracer integration tests' do
   shared_context 'agent-based test' do
     before { skip unless ENV['TEST_DATADOG_INTEGRATION'] }

--- a/spec/ddtrace/profiling/ext/cthread_spec.rb
+++ b/spec/ddtrace/profiling/ext/cthread_spec.rb
@@ -50,7 +50,12 @@ if Datadog::Profiling::Ext::CPU.supported?
     let(:thread_class) { thread_class_with_instrumentation }
 
     # Kill any spawned threads
-    after { thread.kill if instance_variable_defined?(:@thread_started) && @thread_started }
+    after do
+      if instance_variable_defined?(:@thread_started) && @thread_started
+        thread.kill
+        thread.join
+      end
+    end
 
     shared_context 'with main thread' do
       let(:thread_class) { ::Thread }

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -115,6 +115,8 @@ RSpec.describe 'profiling integration test' do
           @current_span = span
           example.run
         end
+
+        Datadog.tracer.shutdown!
       end
 
       before do

--- a/spec/ddtrace/profiling/scheduler_spec.rb
+++ b/spec/ddtrace/profiling/scheduler_spec.rb
@@ -41,7 +41,10 @@ RSpec.describe Datadog::Profiling::Scheduler do
   describe '#perform' do
     subject(:perform) { scheduler.perform }
 
-    after { scheduler.stop(true, 0) }
+    after do
+      scheduler.stop(true, 0)
+      scheduler.join
+    end
 
     context 'when disabled' do
       before { scheduler.enabled = false }

--- a/spec/ddtrace/profiling/tasks/setup_spec.rb
+++ b/spec/ddtrace/profiling/tasks/setup_spec.rb
@@ -224,6 +224,7 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
       context 'when there is an issue starting the profiler' do
         before do
           expect(Datadog).to receive(:profiler).and_raise('Dummy exception')
+          allow($stdout).to receive(:puts) # Silence logging during tests
         end
 
         it 'does not raise any error' do
@@ -252,6 +253,7 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
           without_partial_double_verification do
             expect(Thread.current).to receive(:update_native_ids).and_raise('Dummy exception')
           end
+          allow($stdout).to receive(:puts) # Silence logging during tests
         end
 
         it 'does not raise any error' do


### PR DESCRIPTION
Clean up our changes to `.gemspec`, as well as fix all leaky threads and other misc warnings when running profiling specs.