### PR TITLE
Add ffi as a required ddtrace dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,6 @@ gem 'dogstatsd-ruby', '>= 3.3.0'
 gem 'opentracing', '>= 0.4.1'
 
 # Profiler optional dependencies
-gem 'ffi', '~> 1.0'
 # NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424 and the big comment in
 #       lib/ddtrace/profiling.rb: it breaks for some older rubies in CI without BUNDLE_FORCE_RUBY_PLATFORM=true.
 #       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -38,4 +38,7 @@ Gem::Specification.new do |spec|
     # msgpack 1.4 fails for Ruby 2.0 and 2.1: https://github.com/msgpack/msgpack-ruby/issues/205
     spec.add_dependency 'msgpack', '< 1.4'
   end
+
+  # Used by the profiler
+  spec.add_dependency 'ffi', '~> 1.0'
 end

--- a/lib/ddtrace/profiling/ext/cpu.rb
+++ b/lib/ddtrace/profiling/ext/cpu.rb
@@ -3,8 +3,6 @@ module Datadog
     module Ext
       # Monkey patches Ruby's `Thread` with our `Ext::CThread` to enable CPU-time profiling
       module CPU
-        FFI_MINIMUM_VERSION = Gem::Version.new('1.0')
-
         # We cannot apply our CPU extension if a broken rollbar is around because that can cause customer apps to fail
         # with a SystemStackError: stack level too deep.
         #
@@ -44,11 +42,6 @@ module Datadog
             "Feature requires Linux; #{RUBY_PLATFORM} is not supported"
           elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1')
             'Ruby >= 2.1 is required'
-          elsif Gem.loaded_specs['ffi'].nil?
-            "Missing ffi gem dependency; please add `gem 'ffi', '~> 1.0'` to your Gemfile or gems.rb file"
-          elsif Gem.loaded_specs['ffi'].version < FFI_MINIMUM_VERSION
-            'Your ffi gem dependency is too old; ensure that you have ffi >= 1.0 by ' \
-            "adding `gem 'ffi', '~> 1.0'` to your Gemfile or gems.rb file"
           elsif Gem::Specification.find_all_by_name('rollbar', ROLLBAR_INCOMPATIBLE_VERSIONS).any?
             'You have an incompatible rollbar gem version installed; ensure that you have rollbar >= 3.1.2 by ' \
             "adding `gem 'rollbar', '>= 3.1.2'` to your Gemfile or gems.rb file. " \

--- a/spec/ddtrace/profiling/ext/cpu_spec.rb
+++ b/spec/ddtrace/profiling/ext/cpu_spec.rb
@@ -63,51 +63,30 @@ RSpec.describe Datadog::Profiling::Ext::CPU do
         context 'when running on MRI >= 2.1' do
           before { stub_const('RUBY_VERSION', '2.1.0') }
 
-          context 'and \'ffi\'' do
-            context 'is not available' do
-              include_context 'loaded gems', ffi: nil
-              it { is_expected.to include 'Missing ffi' }
+          let(:last_version_of_rollbar_affected) { '3.1.1' }
+
+          context 'when incompatible rollbar gem is installed' do
+            before do
+              expect(Gem::Specification)
+                .to receive(:find_all_by_name)
+                .with('rollbar', Gem::Requirement.new("<= #{last_version_of_rollbar_affected}"))
+                .and_return([instance_double(Gem::Specification), instance_double(Gem::Specification)])
             end
 
-            context 'is available' do
-              context 'but is below the minimum version' do
-                include_context 'loaded gems',
-                                ffi: decrement_gem_version(described_class::FFI_MINIMUM_VERSION)
+            it { is_expected.to include 'rollbar >= 3.1.2' }
+          end
 
-                it { is_expected.to include 'ffi >= 1.0' }
-              end
-
-              context 'and meeting the minimum version' do
-                include_context 'loaded gems',
-                                ffi: described_class::FFI_MINIMUM_VERSION
-
-                let(:last_version_of_rollbar_affected) { '3.1.1' }
-
-                context 'when incompatible rollbar gem is installed' do
-                  before do
-                    expect(Gem::Specification)
-                      .to receive(:find_all_by_name)
-                      .with('rollbar', Gem::Requirement.new("<= #{last_version_of_rollbar_affected}"))
-                      .and_return([instance_double(Gem::Specification), instance_double(Gem::Specification)])
-                  end
-
-                  it { is_expected.to include 'rollbar >= 3.1.2' }
-                end
-
-                context 'when compatible rollbar gem is installed or no version at all is installed' do
-                  before do
-                    # Because we search with a <= requirement, both not installed as well as only compatible versions
-                    # installed show up in the API in the same way -- an empty return
-                    expect(Gem::Specification)
-                      .to receive(:find_all_by_name)
-                      .with('rollbar', Gem::Requirement.new("<= #{last_version_of_rollbar_affected}"))
-                      .and_return([])
-                  end
-
-                  it { is_expected.to be nil }
-                end
-              end
+          context 'when compatible rollbar gem is installed or no version at all is installed' do
+            before do
+              # Because we search with a <= requirement, both not installed as well as only compatible versions
+              # installed show up in the API in the same way -- an empty return
+              expect(Gem::Specification)
+                .to receive(:find_all_by_name)
+                .with('rollbar', Gem::Requirement.new("<= #{last_version_of_rollbar_affected}"))
+                .and_return([])
             end
+
+            it { is_expected.to be nil }
           end
         end
       end


### PR DESCRIPTION
Ffi is needed to enable cpu-time profiling and possibly other features in the future. I want to move it to a real required dependency.

I claim that this has a low impact on our existing customers:

* ffi has been around for a long time (version 1.0.0 was released back in 2010) and has regular fixes and maintenance; the JRuby and TruffleRuby developers are amongst its biggest contributors

* ffi is supported on CRuby, JRuby and TruffleRuby

* ffi is a native extension, **but so is msgpack**, our sole other dependency. msgpack provides only pre-compiled versions for windows (see <https://rubygems.org/gems/msgpack/versions>), which means that any of our customers on Linux/macOS already need to have a working compiler to install it. ffi is in the exact same boat: it provides pre-compiled versions for windows, and builds from source on install on Linux/macOS (see <https://rubygems.org/gems/ffi/versions>)

* ffi is a very core dependency for the Ruby ecosystem. I just ran `rails new foo` and the auto-generated `Gemfile` included TWO different gems that depended on ffi (`sassc` and `rb-inotify`, if you're curious). It's also a dependency of `ethon`/`typhoeus`, `spoon`, `rdkafka`, and many other gems with millions of downloads (<https://rubygems.org/gems/ffi/reverse_dependencies>).

Having it as a dependency means one less potential source for issues and confusion for our customers.