### PR TITLE
Minor: Revert class documentation change

### DIFF
--- a/lib/ddtrace/buffer.rb
+++ b/lib/ddtrace/buffer.rb
@@ -4,8 +4,8 @@ require 'ddtrace/runtime/object_space'
 # Trace buffer that accumulates traces for a consumer.
 # Consumption can happen from a different thread.
 module Datadog
-  # Bounded buffer used to store profiling events.
-  # The buffer has a maximum size and when the buffer is full, a random object is discarded.
+  # Buffer that stores objects. The buffer has a maximum size and when
+  # the buffer is full, a random object is discarded.
   class Buffer
     def initialize(max_size)
       @max_size = max_size


### PR DESCRIPTION
In #1339 I added and tweaked the documentation of several profiler-related classes, but completely missed that the `Buffer` class was used by the profiler but was shared with other components, so my documentation change was actually incorrect.

This reverts that change.