### PR TITLE
Temporarily remove profiling from getting started doc

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -83,7 +83,6 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
      - [Metrics](#metrics)
          - [For application runtime](#for-application-runtime)
      - [OpenTracing](#opentracing)
-     - [Profiling](#profiling)
 
 ## Compatibility
 
@@ -2498,58 +2497,3 @@ However, additional instrumentation provided by Datadog can be activated alongsi
 | `OpenTracing::FORMAT_TEXT_MAP` | Yes        |                        |
 | `OpenTracing::FORMAT_RACK`     | Yes        | Because of the loss of resolution in the Rack format, please note that baggage items with names containing either upper case characters or `-` will be converted to lower case and `_` in a round-trip respectively. We recommend avoiding these characters or accommodating accordingly on the receiving end. |
 | `OpenTracing::FORMAT_BINARY`   | No         |                        |
-
-### Profiling
-
-*Currently available as BETA feature.*
-
-`ddtrace` can produce profiles that measure method-level application resource usage within production environments. These profiles can give insight into resources spent in Ruby code outside of existing trace instrumentation.
-
-**Compatibility**
-
-Basic profiling requires:
-
-- MRI Ruby 2.0+
-- `google-protobuf` gem installed
-
-In addition, CPU time measurements require:
-
-- MRI Ruby 2.1+
-- Linux OS with `pthread` support
-- `ffi` gem installed
-
-**Setup**
-
-1. Add gems to your `Gemfile` and `bundle install`:
-
-    ```ruby
-    gem 'ddtrace'
-    gem 'google-protobuf'
-    gem 'ffi'
-    ```
-
-2. Enable profiling flag:
-
-    Set `DD_PROFILING_ENABLED=true` in your environment, OR enable it using `Datadog.configure`.
-
-    For Rails applications, you can set this in `config/initializers/datadog.rb`:
-
-    ```ruby
-    Datadog.configure do |c|
-      c.profiling.enabled = true
-    end
-    ```
-
-3. Start your application with the preloader:
-
-    ```sh
-    bundle exec ddtracerb exec rails s
-    ```
-
-    Manual alternative: If starting the application via `ddtracerb exec` is not an option (for instance, when using the
-    Phusion Passenger web server), you can alternatively start the profiler by adding the following to your application
-    entry point (such as `config.ru` for a web application):
-
-    ```ruby
-    require 'ddtrace/profiling/preload'
-    ```


### PR DESCRIPTION
Since we want to merge the profiling feature into master, but don't want customers to use it until we actually decide to release it, let's temporarily remove all mentions of the feature from the getting started doc.

We can re-add this once we're ready for public beta. And that point, we can revise the documentation to mention <https://github.com/DataDog/dd-trace-rb/pull/1439#discussion_r605026392>, as well as how to configure via code (which is something several of the private beta customers are using).