### PR TITLE
Add better error messages when flaky tests fail

### DIFF
--- a/spec/ddtrace/workers_spec.rb
+++ b/spec/ddtrace/workers_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Datadog::Workers::AsyncTransport do
         expect { worker.callback_traces }.to_not raise_error
 
         lines = buf.string.lines
-        expect(lines.count).to eq 1
+        expect(lines.count).to eq(1), "Expected single line, got #{lines.inspect}"
       end
     end
   end

--- a/spec/ddtrace_integration_spec.rb
+++ b/spec/ddtrace_integration_spec.rb
@@ -39,20 +39,35 @@ RSpec.describe 'ddtrace integration' do
     end
 
     context 'for file descriptors' do
-      let!(:original_fd_count) { fd_count }
-
-      def fd_count
-        # Unix-specific way to get the current process' open file descriptors
-        Dir['/dev/fd/*'].size
+      def open_file_descriptors
+        # Unix-specific way to get the current process' open file descriptors and the files (if any) they correspond to
+        Dir['/dev/fd/*'].each_with_object({}) do |fd, hash|
+          hash[fd] =
+            begin
+              File.realpath(fd)
+            rescue SystemCallError # This can fail due to... reasons, and we only want it for debugging so let's ignore
+              nil
+            end
+        end
       end
 
       it 'closes tracer file descriptors' do
+        before_open_file_descriptors = open_file_descriptors
+
         start_tracer
         wait_for_tracer_sent
 
         shutdown
 
-        expect(fd_count).to eq(original_fd_count)
+        after_open_file_descriptors = open_file_descriptors
+
+        expect(after_open_file_descriptors.size)
+          .to(
+            eq(before_open_file_descriptors.size),
+            lambda {
+              "Open fds before: #{before_open_file_descriptors}\nOpen fds after:  #{after_open_file_descriptors}"
+            }
+          )
       end
     end
   end


### PR DESCRIPTION
`cat `<https://www.youtube.com/watch?v=amYzBQMT4VI>` | sed 's/snakes/flaky tests/' | sed 's/plane/CI/'`