### PR TITLE
Add tag_body configuration option for Shoryuken

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1739,6 +1739,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | --- | ----------- | ------- |
 | `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `shoryuken` instrumentation | `'shoryuken'` |
+| `tag_body` | Enable tagging of the SQS message body. `true` or `false` | `false` |
 | `error_handler` | Custom error handler invoked when a job raises an error. Provided `span` and `error` as arguments. Sets error on the span by default. Useful for ignoring transient errors. | `proc { |span, error| span.set_error(error) unless span.nil? }` |
 
 ### Sidekiq

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1739,7 +1739,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | --- | ----------- | ------- |
 | `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `shoryuken` instrumentation | `'shoryuken'` |
-| `tag_body` | Enable tagging of the SQS message body. `true` or `false` | `false` |
+| `tag_body` | Tag spans with the SQS message body `true` or `false` | `false` |
 | `error_handler` | Custom error handler invoked when a job raises an error. Provided `span` and `error` as arguments. Sets error on the span by default. Useful for ignoring transient errors. | `proc { |span, error| span.set_error(error) unless span.nil? }` |
 
 ### Sidekiq

--- a/lib/ddtrace/contrib/shoryuken/configuration/settings.rb
+++ b/lib/ddtrace/contrib/shoryuken/configuration/settings.rb
@@ -23,6 +23,7 @@ module Datadog
 
           option :service_name, default: Ext::SERVICE_NAME
           option :error_handler, default: Datadog::Tracer::DEFAULT_ON_ERROR
+          option :tag_body, default: true
         end
       end
     end

--- a/lib/ddtrace/contrib/shoryuken/configuration/settings.rb
+++ b/lib/ddtrace/contrib/shoryuken/configuration/settings.rb
@@ -23,7 +23,7 @@ module Datadog
 
           option :service_name, default: Ext::SERVICE_NAME
           option :error_handler, default: Datadog::Tracer::DEFAULT_ON_ERROR
-          option :tag_body, default: true
+          option :tag_body, default: false
         end
       end
     end

--- a/lib/ddtrace/contrib/shoryuken/tracer.rb
+++ b/lib/ddtrace/contrib/shoryuken/tracer.rb
@@ -12,8 +12,12 @@ module Datadog
         end
 
         def call(worker_instance, queue, sqs_msg, body)
-          @tracer.trace(Ext::SPAN_JOB, service: @shoryuken_service, span_type: Datadog::Ext::AppTypes::WORKER,
-                                       on_error: @error_handler) do |span|
+          @tracer.trace(
+            Ext::SPAN_JOB,
+            service: @shoryuken_service,
+            span_type: Datadog::Ext::AppTypes::WORKER,
+            on_error: @error_handler
+          ) do |span|
             # Set analytics sample rate
             if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
               Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])

--- a/lib/ddtrace/contrib/shoryuken/tracer.rb
+++ b/lib/ddtrace/contrib/shoryuken/tracer.rb
@@ -26,7 +26,7 @@ module Datadog
             span.set_tag(Ext::TAG_JOB_ID, sqs_msg.message_id)
             span.set_tag(Ext::TAG_JOB_QUEUE, queue)
             span.set_tag(Ext::TAG_JOB_ATTRIBUTES, sqs_msg.attributes) if sqs_msg.respond_to?(:attributes)
-            span.set_tag(Ext::TAG_JOB_BODY, body)
+            span.set_tag(Ext::TAG_JOB_BODY, body) if configuration[:tag_body]
 
             yield
           end

--- a/spec/ddtrace/contrib/shoryuken/tracer_spec.rb
+++ b/spec/ddtrace/contrib/shoryuken/tracer_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe Datadog::Contrib::Shoryuken::Tracer do
       end
     end
 
-    # TODO: Convert this to an instance double, to verify stub.
-    let(:sqs_msg) { double('sqs_msg', message_id: message_id, attributes: attributes) }
+    let(:sqs_msg) { instance_double('Shoryuken::Message', message_id: message_id, attributes: attributes) }
     let(:message_id) { SecureRandom.uuid }
     let(:attributes) { {} }
+    let(:body) { 'message body' }
 
     include_context 'Shoryuken::Worker'
 
@@ -90,27 +90,23 @@ RSpec.describe Datadog::Contrib::Shoryuken::Tracer do
       end
 
       context 'that is a String' do
-        let(:body) { 'my body' }
-
         it { expect(span.resource).to eq('TestWorker') }
       end
     end
 
-    describe 'span tagging' do
-      let(:body) { 'message body' }
+    context 'when tag_body is true' do
+      let(:configuration_options) { { tag_body: true } }
 
-      context 'with default configuration options' do
-        it 'includes the body in the span' do
-          expect(span.get_tag(Datadog::Contrib::Shoryuken::Ext::TAG_JOB_BODY)).to eq(body)
-        end
+      it 'includes the body in the span' do
+        expect(span.get_tag(Datadog::Contrib::Shoryuken::Ext::TAG_JOB_BODY)).to eq(body)
       end
+    end
 
-      context 'when tag_body is false' do
-        let(:configuration_options) { { tag_body: false } }
+    context 'when tag_body is false' do
+      let(:configuration_options) { { tag_body: false } }
 
-        it 'does not include the message body in the span' do
-          expect(span.get_tag(Datadog::Contrib::Shoryuken::Ext::TAG_JOB_BODY)).to be_nil
-        end
+      it 'does not include the message body in the span' do
+        expect(span.get_tag(Datadog::Contrib::Shoryuken::Ext::TAG_JOB_BODY)).to be_nil
       end
     end
   end

--- a/spec/ddtrace/contrib/shoryuken/tracer_spec.rb
+++ b/spec/ddtrace/contrib/shoryuken/tracer_spec.rb
@@ -95,6 +95,24 @@ RSpec.describe Datadog::Contrib::Shoryuken::Tracer do
         it { expect(span.resource).to eq('TestWorker') }
       end
     end
+
+    describe 'span tagging' do
+      let(:body) { 'message body' }
+
+      context 'with default configuration options' do
+        it 'includes the body in the span' do
+          expect(span.get_tag(Datadog::Contrib::Shoryuken::Ext::TAG_JOB_BODY)).to eq(body)
+        end
+      end
+
+      context 'when tag_body is false' do
+        let(:configuration_options) { { tag_body: false } }
+
+        it 'does not include the message body in the span' do
+          expect(span.get_tag(Datadog::Contrib::Shoryuken::Ext::TAG_JOB_BODY)).to be_nil
+        end
+      end
+    end
   end
 
   context 'when a Shoryuken::Worker class' do


### PR DESCRIPTION
This PR adds the option to configure tagging of Shoryuken jobs with the SQS message body.

I've made it default to `false`, which changes the default behaviour. However, I think this is probably the best option as:

1. This brings the configuration in line with the other job library instrumentations (Sidekiq, Sneakers, Que etc.)
2. It's a secure default (I think it's a reasonable expectation that the SQS message can/will contain sensitive data)