### PR TITLE
Publish prerelease builds to prerelease-v2 folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,10 +390,10 @@ jobs:
             echo PRE=$PRE
             sed lib/ddtrace/version.rb -i -e "s/^\([\t ]*PRE\) *=*/\1 = \'${PRE}\' #/g"
       - run:
-          name: Upload prereleas Gem and rebuild index
-          # TODO: Temporarily changed as a workaround (see commit message for more details). Should be undone before we merge
-          # the profiling feature back into master.
-          command: S3_DIR=profiling-prerelease bundle exec rake release:gem
+          name: Upload prerelease Gem and rebuild index
+          # This was bumped from prerelease to prerelease-v2 to avoid the issue documented in
+          # https://github.com/DataDog/dd-trace-rb/pull/1358
+          command: S3_DIR=prerelease-v2 bundle exec rake release:gem
       - store_artifacts:
           path: pkg/
           destination: gem


### PR DESCRIPTION
As discussed in <https://github.com/DataDog/dd-trace-rb/pull/1358>, it seems like under certain situations, `bundle install` tries to read A TON of metadata for all the existing prerelease builds, making it seem like `bundle install` just hung.

Initially, we changed this to a `profiling-prelease` for the profiling branch and it solved the issue, and now that we're getting
ready to merge profiling into master, let's permanently adopt a new folder, so that customers trying out prerelease builds don't run into this issue.