### PR TITLE
Make max frames taken during sampling configurable and raise default to 400

### DIFF
--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -118,7 +118,8 @@ module Datadog
         def build_profiler_collectors(settings, recorder)
           [
             Datadog::Profiling::Collectors::Stack.new(
-              recorder
+              recorder,
+              max_frames: settings.profiling.max_frames
               # TODO: Provide proc that identifies Datadog worker threads?
               # ignore_thread: settings.profiling.ignore_profiler
             )

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -123,6 +123,13 @@ module Datadog
 
         option :max_events, default: 32768
 
+        # Controls the maximum number of frames for each thread sampled. Can be tuned to avoid omitted frames in the
+        # produced profiles. Increasing this may increase the overhead of profiling.
+        option :max_frames do |o|
+          o.default { env_to_int(Ext::Profiling::ENV_MAX_FRAMES, 400) }
+          o.lazy
+        end
+
         settings :upload do
           option :timeout do |o|
             o.setter { |value| value.nil? ? 30.0 : value.to_f }

--- a/lib/ddtrace/ext/profiling.rb
+++ b/lib/ddtrace/ext/profiling.rb
@@ -3,6 +3,7 @@ module Datadog
     module Profiling
       ENV_ENABLED = 'DD_PROFILING_ENABLED'.freeze
       ENV_UPLOAD_TIMEOUT = 'DD_PROFILING_UPLOAD_TIMEOUT'.freeze
+      ENV_MAX_FRAMES = 'DD_PROFILING_MAX_FRAMES'.freeze
 
       module Pprof
         LABEL_KEY_SPAN_ID = 'span id'.freeze

--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -11,11 +11,9 @@ module Datadog
       # Collects stack trace samples from Ruby threads for both CPU-time (if available) and wall-clock.
       # Runs on its own background thread.
       #
-      # rubocop:disable Metrics/ClassLength
       class Stack < Worker
         include Workers::Polling
 
-        DEFAULT_MAX_FRAMES = 128
         DEFAULT_MAX_TIME_USAGE_PCT = 2.0
         MIN_INTERVAL = 0.01
         THREAD_LAST_CPU_TIME_KEY = :datadog_profiler_last_cpu_time
@@ -29,7 +27,7 @@ module Datadog
 
         def initialize(
           recorder,
-          max_frames: DEFAULT_MAX_FRAMES,
+          max_frames: nil,
           ignore_thread: nil,
           max_time_usage_pct: DEFAULT_MAX_TIME_USAGE_PCT,
           thread_api: Thread,
@@ -38,7 +36,8 @@ module Datadog
           enabled: true
         )
           @recorder = recorder
-          @max_frames = max_frames
+          # TODO: Make this a required named argument after we drop support for Ruby 2.0
+          @max_frames = max_frames || raise(ArgumentError, 'missing keyword :max_frames')
           @ignore_thread = ignore_thread
           @max_time_usage_pct = max_time_usage_pct
           @thread_api = thread_api
@@ -249,7 +248,6 @@ module Datadog
           end
         end
       end
-      # rubocop:enable Metrics/ClassLength
     end
   end
 end

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -659,7 +659,7 @@ RSpec.describe Datadog::Configuration::Components do
             enabled?: true,
             started?: false,
             ignore_thread: nil,
-            max_frames: 128,
+            max_frames: settings.profiling.max_frames,
             max_time_usage_pct: 2.0
           )
         end

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -538,6 +538,39 @@ RSpec.describe Datadog::Configuration::Settings do
       end
     end
 
+    describe '#max_frames' do
+      subject(:max_frames) { settings.profiling.max_frames }
+
+      context "when #{Datadog::Ext::Profiling::ENV_MAX_FRAMES}" do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::Profiling::ENV_MAX_FRAMES => environment) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:environment) { nil }
+
+          it { is_expected.to eq(400) }
+        end
+
+        context 'is defined' do
+          let(:environment) { '123' }
+
+          it { is_expected.to eq(123) }
+        end
+      end
+    end
+
+    describe '#max_frames=' do
+      it 'updates the #max_frames setting' do
+        expect { settings.profiling.max_frames = 456 }
+          .to change { settings.profiling.max_frames }
+          .from(400)
+          .to(456)
+      end
+    end
+
     describe '#upload' do
       describe '#timeout' do
         subject(:timeout) { settings.profiling.upload.timeout }

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe 'profiling integration test' do
     let(:collector) do
       Datadog::Profiling::Collectors::Stack.new(
         recorder,
-        enabled: true
+        enabled: true,
+        max_frames: 400
       )
     end
     let(:exporter) do


### PR DESCRIPTION
In internal testing with GitLab, as well as in feedback from private beta customers, the default maximum frames sampled from a thread (128) has not been enough for most apps, and it's common to see "broken" flamegraphs where there are a bunch of mismatched stack depths that then don't merge as expected.

So let's do two things:

* Raise it to 400 as a default (I've arrived at this number after observing a few applications that got their stacks cut off; the number of cut frames seems to be between 100 and 300).

  Since we dynamically adjust our sampling rate depending on our overhead, I do not expect this to have a big impact on the overhead, but I'll validate this new value along with my ongoing experiments on the reliability environment.

* Make this a configurable toggle, similar to how dd-trace-py exposes this. (We even use the same `DD_PROFILING_MAX_FRAMES` environment variable name).

  I don't quite like giving users too many buttons and knobs to tweak, but I'm not sure if we can get away from this one. Feedback welcome.