### PR TITLE
Pin mimemagic to a working version for Ruby 2.2

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -339,6 +339,7 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'mysql2', '< 1', platform: :ruby
       gem 'sprockets', '< 4'
       gem 'lograge'
+      gem 'mimemagic', '0.3.9' # Pinned until https://github.com/mimemagicrb/mimemagic/issues/142 is resolved.
     end
 
     appraise 'rails5-postgres' do
@@ -346,6 +347,7 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'pg', '< 1.0', platform: :ruby
       gem 'sprockets', '< 4'
       gem 'lograge'
+      gem 'mimemagic', '0.3.9' # Pinned until https://github.com/mimemagicrb/mimemagic/issues/142 is resolved.
     end
 
     appraise 'rails5-postgres-redis' do
@@ -354,6 +356,7 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
       gem 'lograge'
+      gem 'mimemagic', '0.3.9' # Pinned until https://github.com/mimemagicrb/mimemagic/issues/142 is resolved.
     end
 
     appraise 'rails5-postgres-redis-activesupport' do
@@ -362,6 +365,7 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'redis', '>= 4.0.1'
       gem 'sprockets', '< 4'
       gem 'lograge'
+      gem 'mimemagic', '0.3.9' # Pinned until https://github.com/mimemagicrb/mimemagic/issues/142 is resolved.
     end
 
     appraise 'rails5-postgres-sidekiq' do
@@ -371,6 +375,7 @@ elsif Gem::Version.new('2.2.0') <= Gem::Version.new(RUBY_VERSION) \
       gem 'activejob'
       gem 'sprockets', '< 4'
       gem 'lograge'
+      gem 'mimemagic', '0.3.9' # Pinned until https://github.com/mimemagicrb/mimemagic/issues/142 is resolved.
     end
 
     appraise 'contrib' do

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ else
 end
 gem 'warning', '~> 1' if RUBY_VERSION >= '2.5.0'
 gem 'webmock', '>= 3.10.0'
+if RUBY_VERSION < '2.3.0'
+  gem 'rexml', '< 3.2.5' # Pinned due to https://github.com/ruby/rexml/issues/69
+end
 gem 'webrick', '>= 1.7.0' if RUBY_VERSION >= '3.0.0' # No longer bundled by default since Ruby 3.0
 gem 'yard', '~> 0.9'
 


### PR DESCRIPTION
This PR unblocks the build of `ddtrace` since recent updates to `mimemagic`.

Until https://github.com/mimemagicrb/mimemagic/issues/142 is solved, we are pinning `mimemagic` to an older version that still supports rubies <= 2.3.

Also, in order to the build to pass, I've pinned rexml to version < 3.2.5 for Ruby < 2.3, as the latest release does not effectively support these older Ruby runtimes: https://github.com/ruby/rexml/issues/69