### PR TITLE
Set Ruby 2.1 as minimum version supported by Profiler

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,8 @@ namespace :spec do
     t.pattern = 'spec/**/*_spec.rb'
     t.exclude_pattern = 'spec/**/{contrib,benchmark,redis,opentracer,opentelemetry,auto_instrument}/**/*_spec.rb,'\
                         ' spec/**/auto_instrument_spec.rb'
-    t.exclude_pattern += ',spec/**/profiling/**/*_spec.rb' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1.0') # Profiler is Ruby 2.1+ only
+    # Profiler is Ruby 2.1+ only
+    t.exclude_pattern += ',spec/**/profiling/**/*_spec.rb' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1.0')
     t.rspec_opts = args.to_a.join(' ')
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,7 @@ namespace :spec do
     t.pattern = 'spec/**/*_spec.rb'
     t.exclude_pattern = 'spec/**/{contrib,benchmark,redis,opentracer,opentelemetry,auto_instrument}/**/*_spec.rb,'\
                         ' spec/**/auto_instrument_spec.rb'
+    t.exclude_pattern += ',spec/**/profiling/**/*_spec.rb' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1.0') # Profiler is Ruby 2.1+ only
     t.rspec_opts = args.to_a.join(' ')
   end
 

--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -180,9 +180,9 @@ module Datadog
             @logger.debug('Profiling started')
             profiler.start
           else
-            # Display a warning for users who expected profiling to autostart
-            protobuf = Datadog::Profiling.google_protobuf_supported?
-            logger.warn("Profiling was enabled but is not supported; profiling disabled. (google-protobuf?: #{protobuf})")
+            # Display a warning for users who expected profiling to be enabled
+            unsupported_reason = Datadog::Profiling.unsupported_reason
+            logger.warn("Profiling was requested but is not supported, profiling disabled: #{unsupported_reason}")
           end
         else
           @logger.debug('Profiling is disabled')

--- a/lib/ddtrace/profiling.rb
+++ b/lib/ddtrace/profiling.rb
@@ -23,7 +23,7 @@ module Datadog
       elsif Gem.loaded_specs['google-protobuf'].version < GOOGLE_PROTOBUF_MINIMUM_VERSION
         'Your google-protobuf is too old; ensure that you have google-protobuf >= 3.0 by ' \
         "adding `gem 'google-protobuf', '~> 3.0'` to your Gemfile or gems.rb file"
-      elsif !self.protobuf_loaded_successfully?
+      elsif !protobuf_loaded_successfully?
         'There was an error loading the google-protobuf library; see previous warning message for details'
       end
     end
@@ -73,7 +73,7 @@ module Datadog
 
       require 'ddtrace/profiling/pprof/pprof_pb'
 
-      return true
+      true
     end
 
     load_profiling if supported?

--- a/lib/ddtrace/profiling.rb
+++ b/lib/ddtrace/profiling.rb
@@ -9,11 +9,6 @@ module Datadog
       google_protobuf_supported?
     end
 
-    def native_cpu_time_supported?
-      require 'ddtrace/profiling/ext/cpu'
-      Ext::CPU.supported?
-    end
-
     def google_protobuf_supported?
       RUBY_PLATFORM != 'java' \
         && !Gem.loaded_specs['google-protobuf'].nil? \

--- a/lib/ddtrace/profiling.rb
+++ b/lib/ddtrace/profiling.rb
@@ -16,6 +16,8 @@ module Datadog
 
       if RUBY_ENGINE == 'jruby'
         'JRuby is not supported'
+      elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1')
+        'Ruby >= 2.1 is required'
       elsif Gem.loaded_specs['google-protobuf'].nil?
         "Missing google-protobuf dependency; please add `gem 'google-protobuf', '~> 3.0'` to your Gemfile or gems.rb file"
       elsif Gem.loaded_specs['google-protobuf'].version < GOOGLE_PROTOBUF_MINIMUM_VERSION

--- a/lib/ddtrace/profiling.rb
+++ b/lib/ddtrace/profiling.rb
@@ -4,19 +4,59 @@ module Datadog
     module_function
 
     GOOGLE_PROTOBUF_MINIMUM_VERSION = Gem::Version.new('3.0')
+    private_constant :GOOGLE_PROTOBUF_MINIMUM_VERSION
 
     def supported?
-      google_protobuf_supported?
+      unsupported_reason.nil?
     end
 
-    def google_protobuf_supported?
-      RUBY_PLATFORM != 'java' \
-        && !Gem.loaded_specs['google-protobuf'].nil? \
-        && Gem.loaded_specs['google-protobuf'].version >= GOOGLE_PROTOBUF_MINIMUM_VERSION \
-        && !defined?(@failed_to_load_protobuf)
+    def unsupported_reason
+      # NOTE: Only the first matching reason is returned, so try to keep a nice order on reasons -- e.g. tell users
+      # first that they can't use this on JRuby before telling them that they are missing protobuf
+
+      if RUBY_ENGINE == 'jruby'
+        'JRuby is not supported'
+      elsif Gem.loaded_specs['google-protobuf'].nil?
+        "Missing google-protobuf dependency; please add `gem 'google-protobuf', '~> 3.0'` to your Gemfile or gems.rb file"
+      elsif Gem.loaded_specs['google-protobuf'].version < GOOGLE_PROTOBUF_MINIMUM_VERSION
+        'Your google-protobuf is too old; ensure that you have google-protobuf >= 3.0 by ' \
+        "adding `gem 'google-protobuf', '~> 3.0'` to your Gemfile or gems.rb file"
+      elsif !self.protobuf_loaded_successfully?
+        'There was an error loading the google-protobuf library; see previous warning message for details'
+      end
+    end
+
+    # The `google-protobuf` gem depends on a native component, and its creators helpfully tried to provide precompiled
+    # versions of this extension on rubygems.org.
+    #
+    # Unfortunately, for a long time, the supported Ruby versions metadata on these precompiled versions of the extension
+    # was not correctly set. (This is fixed in newer versions -- but not all Ruby versions we want to support can use
+    # these.)
+    #
+    # Thus, the gem can still be installed, but can be in a broken state. To avoid breaking customer applications, we
+    # use this helper to load it and gracefully handle failures.
+    def protobuf_loaded_successfully?
+      return @protobuf_loaded if defined?(@protobuf_loaded)
+
+      begin
+        require 'google/protobuf'
+        @protobuf_loaded = true
+      rescue LoadError => e
+        Kernel.warn(
+          "[DDTRACE] Error while loading google-protobuf gem. Cause: '#{e.message}' Location: '#{e.backtrace.first}'. " \
+          'This can happen when google-protobuf is missing its native components. ' \
+          'To fix this, try removing and reinstalling the gem, forcing it to recompile the components: ' \
+          '`gem uninstall google-protobuf -a; BUNDLE_FORCE_RUBY_PLATFORM=true bundle install`. ' \
+          'If the error persists, please contact support via <https://docs.datadoghq.com/help/> or ' \
+          'file a bug at <https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug>.'
+        )
+        @protobuf_loaded = false
+      end
     end
 
     def load_profiling
+      return false unless supported?
+
       require 'ddtrace/profiling/ext/cpu'
       require 'ddtrace/profiling/ext/forking'
 
@@ -29,19 +69,9 @@ module Datadog
       require 'ddtrace/profiling/transport/http'
       require 'ddtrace/profiling/profiler'
 
-      begin
-        require 'ddtrace/profiling/pprof/pprof_pb' if google_protobuf_supported?
-      rescue LoadError => e
-        @failed_to_load_protobuf = true
-        Kernel.warn(
-          "[DDTRACE] Error while loading google-protobuf gem. Cause: '#{e.message}' Location: '#{e.backtrace.first}'. " \
-          'This can happen when google-protobuf is missing its native components. ' \
-          'To fix this, try removing and reinstalling the gem, forcing it to recompile the components: ' \
-          '`gem uninstall google-protobuf -a; BUNDLE_FORCE_RUBY_PLATFORM=true bundle install`. ' \
-          'If the error persists, please contact support via <https://docs.datadoghq.com/help/> or ' \
-          'file a bug at <https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug>.'
-        )
-      end
+      require 'ddtrace/profiling/pprof/pprof_pb'
+
+      return true
     end
 
     load_profiling if supported?

--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -27,7 +27,7 @@ module Datadog
 
         def initialize(
           recorder,
-          max_frames: nil,
+          max_frames:,
           ignore_thread: nil,
           max_time_usage_pct: DEFAULT_MAX_TIME_USAGE_PCT,
           thread_api: Thread,
@@ -36,8 +36,7 @@ module Datadog
           enabled: true
         )
           @recorder = recorder
-          # TODO: Make this a required named argument after we drop support for Ruby 2.0
-          @max_frames = max_frames || raise(ArgumentError, 'missing keyword :max_frames')
+          @max_frames = max_frames
           @ignore_thread = ignore_thread
           @max_time_usage_pct = max_time_usage_pct
           @thread_api = thread_api

--- a/lib/ddtrace/profiling/ext/cpu.rb
+++ b/lib/ddtrace/profiling/ext/cpu.rb
@@ -40,8 +40,6 @@ module Datadog
             'Feature requires Linux; Windows is not supported'
           elsif !RUBY_PLATFORM.include?('linux')
             "Feature requires Linux; #{RUBY_PLATFORM} is not supported"
-          elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1')
-            'Ruby >= 2.1 is required'
           elsif Gem::Specification.find_all_by_name('rollbar', ROLLBAR_INCOMPATIBLE_VERSIONS).any?
             'You have an incompatible rollbar gem version installed; ensure that you have rollbar >= 3.1.2 by ' \
             "adding `gem 'rollbar', '>= 3.1.2'` to your Gemfile or gems.rb file. " \

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -904,8 +904,8 @@ RSpec.describe Datadog::Configuration::Components do
       context 'is unsupported' do
         before do
           allow(Datadog::Profiling)
-            .to receive(:supported?)
-            .and_return(false)
+            .to receive(:unsupported_reason)
+            .and_return('Disabled for testing')
         end
 
         context 'and enabled' do

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe Datadog::Configuration::Components do
 
   let(:settings) { Datadog::Configuration::Settings.new }
 
-  let(:profiler_setup_task) { instance_double(Datadog::Profiling::Tasks::Setup) }
+  let(:profiler_setup_task) { Datadog::Profiling.supported? ? instance_double(Datadog::Profiling::Tasks::Setup) : nil }
 
   before do
     # Ensure the real task never gets run (so it doesn't apply our thread patches and other extensions to our test env)
-    allow(Datadog::Profiling::Tasks::Setup).to receive(:new).and_return(profiler_setup_task)
+    if Datadog::Profiling.supported?
+      allow(Datadog::Profiling::Tasks::Setup).to receive(:new).and_return(profiler_setup_task)
+    end
   end
 
   describe '::new' do

--- a/spec/ddtrace/profiling/ext/cpu_spec.rb
+++ b/spec/ddtrace/profiling/ext/cpu_spec.rb
@@ -54,40 +54,30 @@ RSpec.describe Datadog::Profiling::Ext::CPU do
       context 'when running on Linux' do
         before { stub_const('RUBY_PLATFORM', 'x86_64-linux-gnu') }
 
-        context 'when running on MRI < 2.1' do
-          before { stub_const('RUBY_VERSION', '2.0.0') }
+        let(:last_version_of_rollbar_affected) { '3.1.1' }
 
-          it { is_expected.to include 'Ruby >= 2.1' }
+        context 'when incompatible rollbar gem is installed' do
+          before do
+            expect(Gem::Specification)
+              .to receive(:find_all_by_name)
+              .with('rollbar', Gem::Requirement.new("<= #{last_version_of_rollbar_affected}"))
+              .and_return([instance_double(Gem::Specification), instance_double(Gem::Specification)])
+          end
+
+          it { is_expected.to include 'rollbar >= 3.1.2' }
         end
 
-        context 'when running on MRI >= 2.1' do
-          before { stub_const('RUBY_VERSION', '2.1.0') }
-
-          let(:last_version_of_rollbar_affected) { '3.1.1' }
-
-          context 'when incompatible rollbar gem is installed' do
-            before do
-              expect(Gem::Specification)
-                .to receive(:find_all_by_name)
-                .with('rollbar', Gem::Requirement.new("<= #{last_version_of_rollbar_affected}"))
-                .and_return([instance_double(Gem::Specification), instance_double(Gem::Specification)])
-            end
-
-            it { is_expected.to include 'rollbar >= 3.1.2' }
+        context 'when compatible rollbar gem is installed or no version at all is installed' do
+          before do
+            # Because we search with a <= requirement, both not installed as well as only compatible versions
+            # installed show up in the API in the same way -- an empty return
+            expect(Gem::Specification)
+              .to receive(:find_all_by_name)
+              .with('rollbar', Gem::Requirement.new("<= #{last_version_of_rollbar_affected}"))
+              .and_return([])
           end
 
-          context 'when compatible rollbar gem is installed or no version at all is installed' do
-            before do
-              # Because we search with a <= requirement, both not installed as well as only compatible versions
-              # installed show up in the API in the same way -- an empty return
-              expect(Gem::Specification)
-                .to receive(:find_all_by_name)
-                .with('rollbar', Gem::Requirement.new("<= #{last_version_of_rollbar_affected}"))
-                .and_return([])
-            end
-
-            it { is_expected.to be nil }
-          end
+          it { is_expected.to be nil }
         end
       end
     end

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -93,7 +93,9 @@ RSpec.describe 'profiling integration test' do
       end
     end
 
-    if Datadog::Profiling.native_cpu_time_supported?
+    require 'ddtrace/profiling/ext/cpu'
+
+    if Datadog::Profiling::Ext::CPU.supported?
       context 'with CPU profiling' do
         # include_context 'with profiling extensions'
         include_context 'end-to-end profiler'

--- a/spec/ddtrace/profiling_spec.rb
+++ b/spec/ddtrace/profiling_spec.rb
@@ -7,58 +7,93 @@ RSpec.describe Datadog::Profiling do
   describe '::supported?' do
     subject(:supported?) { described_class.supported? }
 
-    let(:google_protobuf_supported) { double('google-protobuf supported') }
+    context 'when there is an unsupported_reason' do
+      before { allow(described_class).to receive(:unsupported_reason).and_return('Unsupported, sorry :(') }
 
-    before do
-      allow(described_class)
-        .to receive(:google_protobuf_supported?)
-        .and_return(google_protobuf_supported)
+      it { is_expected.to be false }
     end
 
-    it { is_expected.to be(google_protobuf_supported) }
+    context 'when there is no unsupported_reason' do
+      before { allow(described_class).to receive(:unsupported_reason).and_return(nil) }
+
+      it { is_expected.to be true }
+    end
   end
 
-  describe '::google_protobuf_supported?' do
-    subject(:google_protobuf_supported?) { described_class.google_protobuf_supported? }
+  describe '::unsupported_reason' do
+    subject(:unsupported_reason) { described_class.unsupported_reason }
 
-    before do
-      # Ignore any actual loading failures in the local environment
-      if described_class.instance_variable_defined?(:@failed_to_load_protobuf)
-        described_class.remove_instance_variable(:@failed_to_load_protobuf)
-      end
+    context 'when JRuby is used' do
+      before { stub_const('RUBY_ENGINE', 'jruby') }
+
+      it { is_expected.to include 'JRuby' }
     end
 
-    context 'when MRI Ruby is used' do
-      before { stub_const('RUBY_PLATFORM', 'x86_64-linux') }
+    context 'when not using JRuby' do
+      before { stub_const('RUBY_ENGINE', 'ruby') }
 
       context 'and \'google-protobuf\'' do
         context 'is not available' do
-          include_context 'loaded gems', :'google-protobuf' => nil
-          it { is_expected.to be false }
+          include_context 'loaded gems', 'google-protobuf': nil
+
+          it { is_expected.to include 'Missing google-protobuf' }
         end
 
         context 'is available' do
-          context 'and meeting the minimum version' do
-            include_context 'loaded gems',
-                            :'google-protobuf' => described_class::GOOGLE_PROTOBUF_MINIMUM_VERSION
+          context 'but is below the minimum version' do
+            include_context 'loaded gems', 'google-protobuf': Gem::Version.new('2.9')
 
-            it { is_expected.to be true }
+            it { is_expected.to include 'google-protobuf >= 3.0' }
           end
 
-          context 'but is below the minimum version' do
-            include_context 'loaded gems',
-                            :'google-protobuf' => decrement_gem_version(described_class::GOOGLE_PROTOBUF_MINIMUM_VERSION)
+          context 'and meeting the minimum version' do
+            include_context 'loaded gems', 'google-protobuf': Gem::Version.new('3.0')
 
-            it { is_expected.to be false }
+            context 'when protobuf does not load correctly' do
+              before { allow(described_class).to receive(:protobuf_loaded_successfully?).and_return(false) }
+
+              it { is_expected.to include 'error loading' }
+            end
+
+            context 'when protobuf loads successfully' do
+              before { allow(described_class).to receive(:protobuf_loaded_successfully?).and_return(true) }
+
+              it { is_expected.to be nil }
+            end
           end
         end
       end
     end
+  end
 
-    context 'when JRuby is used' do
-      before { stub_const('RUBY_PLATFORM', 'java') }
+  describe '::protobuf_loaded_successfully?' do
+    subject(:protobuf_loaded_successfully?) { described_class.protobuf_loaded_successfully? }
+
+    before do
+      # Remove any previous state
+      if described_class.instance_variable_defined?(:@protobuf_loaded)
+        described_class.remove_instance_variable(:@protobuf_loaded)
+      end
+
+      allow(Kernel).to receive(:warn)
+    end
+
+    context 'when there is an issue requiring protobuf' do
+      before { allow(described_class).to receive(:require).and_raise(LoadError.new('Simulated require failure')) }
 
       it { is_expected.to be false }
+
+      it 'logs a warning' do
+        expect(Kernel).to receive(:warn).with(/Error while loading/)
+
+        protobuf_loaded_successfully?
+      end
+    end
+
+    context 'when requiring protobuf is successful' do
+      before { allow(described_class).to receive(:require).and_return(true) }
+
+      it { is_expected.to be true }
     end
   end
 end

--- a/spec/ddtrace/profiling_spec.rb
+++ b/spec/ddtrace/profiling_spec.rb
@@ -18,30 +18,6 @@ RSpec.describe Datadog::Profiling do
     it { is_expected.to be(google_protobuf_supported) }
   end
 
-  describe 'native_cpu_time_supported?' do
-    subject(:native_cpu_time_supported?) { described_class.native_cpu_time_supported? }
-
-    context 'when the CPU extension is supported' do
-      before do
-        allow(Datadog::Profiling::Ext::CPU)
-          .to receive(:supported?)
-          .and_return(true)
-      end
-
-      it { is_expected.to be true }
-    end
-
-    context 'when the CPU extension is not supported' do
-      before do
-        allow(Datadog::Profiling::Ext::CPU)
-          .to receive(:supported?)
-          .and_return(false)
-      end
-
-      it { is_expected.to be false }
-    end
-  end
-
   describe '::google_protobuf_supported?' do
     subject(:google_protobuf_supported?) { described_class.google_protobuf_supported? }
 

--- a/spec/ddtrace/profiling_spec.rb
+++ b/spec/ddtrace/profiling_spec.rb
@@ -32,33 +32,43 @@ RSpec.describe Datadog::Profiling do
     context 'when not using JRuby' do
       before { stub_const('RUBY_ENGINE', 'ruby') }
 
-      context 'and \'google-protobuf\'' do
-        context 'is not available' do
-          include_context 'loaded gems', 'google-protobuf': nil
+      context 'when running on MRI < 2.1' do
+        before { stub_const('RUBY_VERSION', '2.0.0') }
 
-          it { is_expected.to include 'Missing google-protobuf' }
-        end
+        it { is_expected.to include 'Ruby >= 2.1' }
+      end
 
-        context 'is available' do
-          context 'but is below the minimum version' do
-            include_context 'loaded gems', 'google-protobuf': Gem::Version.new('2.9')
+      context 'when running on MRI >= 2.1' do
+        before { stub_const('RUBY_VERSION', '2.1.0') }
 
-            it { is_expected.to include 'google-protobuf >= 3.0' }
+        context 'and \'google-protobuf\'' do
+          context 'is not available' do
+            include_context 'loaded gems', :'google-protobuf' => nil
+
+            it { is_expected.to include 'Missing google-protobuf' }
           end
 
-          context 'and meeting the minimum version' do
-            include_context 'loaded gems', 'google-protobuf': Gem::Version.new('3.0')
+          context 'is available' do
+            context 'but is below the minimum version' do
+              include_context 'loaded gems', :'google-protobuf' => Gem::Version.new('2.9')
 
-            context 'when protobuf does not load correctly' do
-              before { allow(described_class).to receive(:protobuf_loaded_successfully?).and_return(false) }
-
-              it { is_expected.to include 'error loading' }
+              it { is_expected.to include 'google-protobuf >= 3.0' }
             end
 
-            context 'when protobuf loads successfully' do
-              before { allow(described_class).to receive(:protobuf_loaded_successfully?).and_return(true) }
+            context 'and meeting the minimum version' do
+              include_context 'loaded gems', :'google-protobuf' => Gem::Version.new('3.0')
 
-              it { is_expected.to be nil }
+              context 'when protobuf does not load correctly' do
+                before { allow(described_class).to receive(:protobuf_loaded_successfully?).and_return(false) }
+
+                it { is_expected.to include 'error loading' }
+              end
+
+              context 'when protobuf loads successfully' do
+                before { allow(described_class).to receive(:protobuf_loaded_successfully?).and_return(true) }
+
+                it { is_expected.to be nil }
+              end
             end
           end
         end

--- a/spec/ddtrace/profiling_spec.rb
+++ b/spec/ddtrace/profiling_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Datadog::Profiling do
   end
 
   describe '::protobuf_loaded_successfully?' do
-    subject(:protobuf_loaded_successfully?) { described_class.protobuf_loaded_successfully? }
+    subject(:protobuf_loaded_successfully?) { described_class.send(:protobuf_loaded_successfully?) }
 
     before do
       # Remove any previous state


### PR DESCRIPTION
We've decided not to support Ruby 2.0 in the first release of the profiler.

I've piggy-backed on the existing mechanism for only loading the profiler if it is supported, and thus, on Ruby 2.0 is never even loaded (allowing us to use 2.1 features in code).

This also enables us to simplify the CPU extension support: we no longer have to separately check if we're on 2.1 or not, and we can now assume that if the extension is being loaded, then we're on a supported Ruby version.

I've tested that `ddtracerb exec` also continues to work correctly on 2.0 (it just doesn't start profiling, even if you try to
enable it).

Note: This will need a rebase once the CI madness is fixed, but otherwise should be considered complete.
Tip: The diff has some indentation level changes; hiding whitespace makes the diff clearer.