### PR TITLE
Fix Fargate 1.4 container ID not being read

### DIFF
--- a/spec/ddtrace/runtime/cgroup_spec.rb
+++ b/spec/ddtrace/runtime/cgroup_spec.rb
@@ -83,8 +83,18 @@ RSpec.describe Datadog::Runtime::Cgroup do
         end
       end
 
-      context 'in a Fargate environment' do
-        include_context 'Fargate environment'
+      context 'in a Fargate 1.3- environment' do
+        include_context 'Fargate 1.3- environment'
+
+        it do
+          is_expected.to be_a_kind_of(Array)
+          is_expected.to have(11).items
+          is_expected.to include(be_a_kind_of(described_class::Descriptor))
+        end
+      end
+
+      context 'in a Fargate 1.4+ environment' do
+        include_context 'Fargate 1.4+ environment'
 
         it do
           is_expected.to be_a_kind_of(Array)
@@ -219,7 +229,7 @@ RSpec.describe Datadog::Runtime::Cgroup do
         end
       end
 
-      context 'in Fargate format' do
+      context 'in Fargate format 1.3-' do
         let(:line) { '1:name=systemd:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da' }
 
         it { is_expected.to be_a_kind_of(described_class::Descriptor) }
@@ -229,6 +239,21 @@ RSpec.describe Datadog::Runtime::Cgroup do
             id: '1',
             groups: 'name=systemd',
             path: '/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da',
+            controllers: ['name=systemd']
+          )
+        end
+      end
+
+      context 'in Fargate format 1.4+' do
+        let(:line) { '1:name=systemd:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890' }
+
+        it { is_expected.to be_a_kind_of(described_class::Descriptor) }
+
+        it do
+          is_expected.to have_attributes(
+            id: '1',
+            groups: 'name=systemd',
+            path: '/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890',
             controllers: ['name=systemd']
           )
         end

--- a/spec/ddtrace/runtime/container_spec.rb
+++ b/spec/ddtrace/runtime/container_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe Datadog::Runtime::Container do
       end
     end
 
-    context 'when in a Fargate environment' do
-      include_context 'Fargate environment'
+    context 'when in a Fargate 1.3- environment' do
+      include_context 'Fargate 1.3- environment'
 
       it do
         is_expected.to be_a_kind_of(described_class::Descriptor)
@@ -73,6 +73,21 @@ RSpec.describe Datadog::Runtime::Container do
           platform: 'ecs',
           container_id: container_id,
           task_uid: task_arn
+        )
+      end
+    end
+
+    context 'when in a Fargate 1.4+ environment' do
+      include_context 'Fargate 1.4+ environment'
+
+      it do
+        # allow(File).to receive(:exist?)
+
+        is_expected.to be_a_kind_of(described_class::Descriptor)
+        is_expected.to have_attributes(
+          platform: 'ecs',
+          container_id: container_id,
+          task_uid: nil
         )
       end
     end

--- a/spec/support/container_helpers.rb
+++ b/spec/support/container_helpers.rb
@@ -107,7 +107,7 @@ module ContainerHelpers
     end
   end
 
-  shared_context 'Fargate environment' do
+  shared_context 'Fargate 1.3- environment' do
     include_context 'cgroup file'
 
     let(:container_id) { '432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da' }
@@ -125,6 +125,27 @@ module ContainerHelpers
       cgroup_file.puts "3:blkio:/ecs/#{task_arn}/#{container_id}"
       cgroup_file.puts "2:memory:/ecs/#{task_arn}/#{container_id}"
       cgroup_file.puts "1:name=systemd:/ecs/#{task_arn}/#{container_id}"
+      cgroup_file.rewind
+    end
+  end
+
+  shared_context 'Fargate 1.4+ environment' do
+    include_context 'cgroup file'
+
+    let(:container_id) { '34dc0b5e626f2c5c4c5170e34b10e765-1234567890' }
+
+    before do
+      cgroup_file.puts "11:hugetlb:/ecs/#{container_id}"
+      cgroup_file.puts "10:pids:/ecs/#{container_id}"
+      cgroup_file.puts "9:cpuset:/ecs/#{container_id}"
+      cgroup_file.puts "8:net_cls,net_prio:/ecs/#{container_id}"
+      cgroup_file.puts "7:cpu,cpuacct:/ecs/#{container_id}"
+      cgroup_file.puts "6:perf_event:/ecs/#{container_id}"
+      cgroup_file.puts "5:freezer:/ecs/#{container_id}"
+      cgroup_file.puts "4:devices:/ecs/#{container_id}"
+      cgroup_file.puts "3:blkio:/ecs/#{container_id}"
+      cgroup_file.puts "2:memory:/ecs/#{container_id}"
+      cgroup_file.puts "1:name=systemd:/ecs/#{container_id}"
       cgroup_file.rewind
     end
   end


### PR DESCRIPTION
AWS Fargate 1.4 changed its `cgroup` scheme from `/ecs/<arn>/<container-id>` to `/ecs/<container-id>` and the format of the container ID itself, which causes container ID to not be extracted or tagged properly. This pull request detects and fixes this tagging.