### PR TITLE
Temporarily disable graceful shutdown tests for JRuby

### DIFF
--- a/spec/ddtrace_integration_spec.rb
+++ b/spec/ddtrace_integration_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe 'ddtrace integration' do
     end
 
     context 'for file descriptors' do
+      before do
+        # TODO: Restore test for JRuby after further investigation on why it's flaky
+        skip('Flaky test on JRuby. Requires further investigation.') if PlatformHelpers.jruby?
+      end
+
       def open_file_descriptors
         # Unix-specific way to get the current process' open file descriptors and the files (if any) they correspond to
         Dir['/dev/fd/*'].each_with_object({}) do |fd, hash|
@@ -57,7 +62,8 @@ RSpec.describe 'ddtrace integration' do
           .to(
             eq(before_open_file_descriptors.size),
             lambda {
-              "Open fds before: #{before_open_file_descriptors}\nOpen fds after:  #{after_open_file_descriptors}"
+              "Open fds before (#{after_open_file_descriptors.size}): #{before_open_file_descriptors}\n" \
+              "Open fds after (#{after_open_file_descriptors.size}):  #{after_open_file_descriptors}"
             }
           )
       end

--- a/spec/ddtrace_integration_spec.rb
+++ b/spec/ddtrace_integration_spec.rb
@@ -4,10 +4,9 @@ require 'datadog/statsd'
 RSpec.describe 'ddtrace integration' do
   context 'graceful shutdown', :integration do
     before do
-      # TODO: Restore test for JRuby after further investigation on why it's flaky
-      # It currently breaks CI too frequently, with the only practical recourse
-      # being to rerun the build.
-      skip('Flaky test on JRuby. Requires further investigation.') if PlatformHelpers.jruby?
+      # TODO: This test is flaky, and the flakiness affects JRuby really often.
+      # Until we can investigate it, let's skip it as the constant failures impact unrelated development.
+      skip('TODO: This test is flaky, and triggers very often on JRuby. Requires further investigation.') if PlatformHelpers.jruby?
     end
 
     subject(:shutdown) { Datadog.shutdown! }

--- a/spec/ddtrace_integration_spec.rb
+++ b/spec/ddtrace_integration_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe 'ddtrace integration' do
     before do
       # TODO: This test is flaky, and the flakiness affects JRuby really often.
       # Until we can investigate it, let's skip it as the constant failures impact unrelated development.
-      skip('TODO: This test is flaky, and triggers very often on JRuby. Requires further investigation.') if PlatformHelpers.jruby?
+      if PlatformHelpers.jruby?
+        skip('TODO: This test is flaky, and triggers very often on JRuby. Requires further investigation.')
+      end
     end
 
     subject(:shutdown) { Datadog.shutdown! }

--- a/spec/ddtrace_integration_spec.rb
+++ b/spec/ddtrace_integration_spec.rb
@@ -3,6 +3,13 @@ require 'datadog/statsd'
 
 RSpec.describe 'ddtrace integration' do
   context 'graceful shutdown', :integration do
+    before do
+      # TODO: Restore test for JRuby after further investigation on why it's flaky
+      # It currently breaks CI too frequently, with the only practical recourse
+      # being to rerun the build.
+      skip('Flaky test on JRuby. Requires further investigation.') if PlatformHelpers.jruby?
+    end
+
     subject(:shutdown) { Datadog.shutdown! }
 
     let(:start_tracer) do
@@ -31,11 +38,6 @@ RSpec.describe 'ddtrace integration' do
     end
 
     context 'for file descriptors' do
-      before do
-        # TODO: Restore test for JRuby after further investigation on why it's flaky
-        skip('Flaky test on JRuby. Requires further investigation.') if PlatformHelpers.jruby?
-      end
-
       def open_file_descriptors
         # Unix-specific way to get the current process' open file descriptors and the files (if any) they correspond to
         Dir['/dev/fd/*'].each_with_object({}) do |fd, hash|


### PR DESCRIPTION
The leaky file description and leaky thread test has been flaky for JRuby for a while.
Because it depends on a clean test application of virtually all our test suite, it's easy to have this test assert that the expect file descriptors after shutdown are miscounted.

This PR disables it until we have the bandwidth for perform a thorough investigation.

This PR unblocks all builds (including master) from flaky failures.