### PR TITLE
Ensure profile gets reported on application shutdown

### DIFF
--- a/lib/ddtrace/profiling/profiler.rb
+++ b/lib/ddtrace/profiling/profiler.rb
@@ -16,6 +16,8 @@ module Datadog
     end
 
     def shutdown!
+      Datadog.logger.debug("Shutting down profiler")
+
       collectors.each do |collector|
         collector.enabled = false
         collector.stop(true)

--- a/lib/ddtrace/profiling/profiler.rb
+++ b/lib/ddtrace/profiling/profiler.rb
@@ -16,7 +16,7 @@ module Datadog
     end
 
     def shutdown!
-      Datadog.logger.debug("Shutting down profiler")
+      Datadog.logger.debug('Shutting down profiler')
 
       collectors.each do |collector|
         collector.enabled = false

--- a/lib/ddtrace/profiling/recorder.rb
+++ b/lib/ddtrace/profiling/recorder.rb
@@ -59,6 +59,11 @@ module Datadog
         )
       end
 
+      # NOTE: Remember that if the recorder is being accessed by multiple threads, this is an inherently racy operation.
+      def empty?
+        @buffers.values.all?(&:empty?)
+      end
+
       # Error when event of an unknown type is used with the Recorder
       class UnknownEventError < StandardError
         attr_reader :event_class

--- a/lib/ddtrace/profiling/scheduler.rb
+++ b/lib/ddtrace/profiling/scheduler.rb
@@ -65,6 +65,10 @@ module Datadog
         true
       end
 
+      def work_pending?
+        skip_next_flush? || !recorder.empty?
+      end
+
       private
 
       def flush_and_wait

--- a/lib/ddtrace/profiling/scheduler.rb
+++ b/lib/ddtrace/profiling/scheduler.rb
@@ -66,7 +66,7 @@ module Datadog
       end
 
       def work_pending?
-        skip_next_flush? || !recorder.empty?
+        !recorder.empty?
       end
 
       private

--- a/spec/ddtrace/profiling/recorder_spec.rb
+++ b/spec/ddtrace/profiling/recorder_spec.rb
@@ -164,4 +164,21 @@ RSpec.describe Datadog::Profiling::Recorder do
       end
     end
   end
+
+  describe '#empty?' do
+    let(:event_classes) { [event_class] }
+    let(:event_class) { Class.new(Datadog::Profiling::Event) }
+
+    context 'when there are no events recorded' do
+      it { is_expected.to be_empty }
+    end
+
+    context 'when there are recorded events' do
+      before do
+        recorder.push(event_class.new)
+      end
+
+      it { is_expected.to_not be_empty }
+    end
+  end
 end

--- a/spec/ddtrace/profiling/scheduler_spec.rb
+++ b/spec/ddtrace/profiling/scheduler_spec.rb
@@ -196,26 +196,16 @@ RSpec.describe Datadog::Profiling::Scheduler do
   describe '#work_pending?' do
     subject(:work_pending?) { scheduler.work_pending? }
 
-    context 'when scheduler will skip_next_flush?' do
-      let(:options) { { **super(), skip_next_flush: true } }
+    context 'when the recorder has no events' do
+      before { expect(recorder).to receive(:empty?).and_return(true) }
 
-      it { is_expected.to be true }
+      it { is_expected.to be false }
     end
 
-    context 'when skip_next_flush? is false' do
-      let(:options) { { **super(), skip_next_flush: false } }
+    context 'when the recorder has events' do
+      before { expect(recorder).to receive(:empty?).and_return(false) }
 
-      context 'when the recorder has no events' do
-        before { expect(recorder).to receive(:empty?).and_return(true) }
-
-        it { is_expected.to be false }
-      end
-
-      context 'when the recorder has events' do
-        before { expect(recorder).to receive(:empty?).and_return(false) }
-
-        it { is_expected.to be true }
-      end
+      it { is_expected.to be true }
     end
   end
 end

--- a/spec/ddtrace/profiling/scheduler_spec.rb
+++ b/spec/ddtrace/profiling/scheduler_spec.rb
@@ -192,4 +192,30 @@ RSpec.describe Datadog::Profiling::Scheduler do
       expect(scheduler.loop_wait_before_first_iteration?).to be true
     end
   end
+
+  describe '#work_pending?' do
+    subject(:work_pending?) { scheduler.work_pending? }
+
+    context 'when scheduler will skip_next_flush?' do
+      let(:options) { { **super(), skip_next_flush: true } }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when skip_next_flush? is false' do
+      let(:options) { { **super(), skip_next_flush: false } }
+
+      context 'when the recorder has no events' do
+        before { expect(recorder).to receive(:empty?).and_return(true) }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the recorder has events' do
+        before { expect(recorder).to receive(:empty?).and_return(false) }
+
+        it { is_expected.to be true }
+      end
+    end
+  end
 end


### PR DESCRIPTION
The `#work_pending?` callback is used to signal to `Datadog::Workers::IntervalLoop` when there is more work to be done.

During shutdown, when `#stop` is called on the `Scheduler`, this flag is used to determine if there is still work to do before `Scheduler` stops.

Thus, by correctly setting it to reflect the state of the recorder, we ensure that on application shutdown, any pending events are still reported; previously they would just be dropped.

Finally, the `#work_pending?` also needs to take into account the `#skip_next_flush?` so that we still preserve the behavior introduced in #1462 where we want the first `#flush_event` to always execute, but do nothing.

(Note: Current base branch is `fix/avoid-flush-after-start` since this builds off the change in #1462)