### PR TITLE
Include process pid when reporting profile

### DIFF
--- a/lib/ddtrace/ext/profiling.rb
+++ b/lib/ddtrace/ext/profiling.rb
@@ -29,6 +29,7 @@ module Datadog
           FORM_FIELD_TAG_ENV = 'env'.freeze
           FORM_FIELD_TAG_HOST = 'host'.freeze
           FORM_FIELD_TAG_LANGUAGE = 'language'.freeze
+          FORM_FIELD_TAG_PID = 'pid'.freeze
           FORM_FIELD_TAG_PROFILER_VERSION = 'profiler_version'.freeze
           FORM_FIELD_TAG_RUNTIME = 'runtime'.freeze
           FORM_FIELD_TAG_RUNTIME_ENGINE = 'runtime_engine'.freeze

--- a/lib/ddtrace/profiling/transport/http/api/endpoint.rb
+++ b/lib/ddtrace/profiling/transport/http/api/endpoint.rb
@@ -48,6 +48,7 @@ module Datadog
                   "#{FORM_FIELD_TAG_RUNTIME_ENGINE}:#{flush.runtime_engine}",
                   "#{FORM_FIELD_TAG_RUNTIME_PLATFORM}:#{flush.runtime_platform}",
                   "#{FORM_FIELD_TAG_RUNTIME_VERSION}:#{flush.runtime_version}",
+                  "#{FORM_FIELD_TAG_PID}:#{Process.pid}",
                   "#{FORM_FIELD_TAG_PROFILER_VERSION}:#{flush.profiler_version}",
                   # NOTE: Redundant w/ 'runtime'; may want to remove this later.
                   "#{FORM_FIELD_TAG_LANGUAGE}:#{flush.language}",

--- a/spec/ddtrace/profiling/transport/http/api/endpoint_spec.rb
+++ b/spec/ddtrace/profiling/transport/http/api/endpoint_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe Datadog::Profiling::Transport::HTTP::API::Endpoint do
             "#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_RUNTIME_ENGINE}:#{flush.runtime_engine}",
             "#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_RUNTIME_PLATFORM}:#{flush.runtime_platform}",
             "#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_RUNTIME_VERSION}:#{flush.runtime_version}",
+            "#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_PID}:#{Process.pid}",
             "#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_PROFILER_VERSION}:#{flush.profiler_version}",
             "#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_LANGUAGE}:#{flush.language}",
             "#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_HOST}:#{flush.host}"


### PR DESCRIPTION
This behavior is already present in both the Python and Go profilers, and can be quite useful when understanding services that employ multiple processes.