### PR TITLE
Profiler user docs

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2529,3 +2529,9 @@ Profiling requires:
     ```ruby
     require 'ddtrace/profiling/preload'
     ```
+
+#### Profiling Resque jobs
+
+When profiling [Resque](https://github.com/resque/resque) jobs, you should set the `RUN_AT_EXIT_HOOKS=1` option described in the [Resque](https://github.com/resque/resque/blob/v2.0.0/docs/HOOKS.md#worker-hooks) documentation.
+
+Without this flag, profiles for short-lived Resque jobs will not be available as Resque kills worker processes before they have a chance to submit this information.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -85,6 +85,7 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
      - [Metrics](#metrics)
          - [For application runtime](#for-application-runtime)
      - [OpenTracing](#opentracing)
+     - [Profiling](#profiling)
 
 ## Compatibility
 
@@ -2480,3 +2481,58 @@ However, additional instrumentation provided by Datadog can be activated alongsi
 | `OpenTracing::FORMAT_TEXT_MAP` | Yes        |                        |
 | `OpenTracing::FORMAT_RACK`     | Yes        | Because of the loss of resolution in the Rack format, please note that baggage items with names containing either upper case characters or `-` will be converted to lower case and `_` in a round-trip respectively. We recommend avoiding these characters or accommodating accordingly on the receiving end. |
 | `OpenTracing::FORMAT_BINARY`   | No         |                        |
+
+### Profiling
+
+*Currently available as BETA feature.*
+
+`ddtrace` can produce profiles that measure method-level application resource usage within production environments. These profiles can give insight into resources spent in Ruby code outside of existing trace instrumentation.
+
+**Compatibility**
+
+Basic profiling requires:
+
+- MRI Ruby 2.0+
+- `google-protobuf` gem installed
+
+In addition, CPU time measurements require:
+
+- MRI Ruby 2.1+
+- Linux OS with `pthread` support
+- `ffi` gem installed
+
+**Setup**
+
+1. Add gems to your `Gemfile` and `bundle install`:
+
+    ```ruby
+    gem 'ddtrace'
+    gem 'google-protobuf'
+    gem 'ffi'
+    ```
+
+2. Enable profiling flag:
+
+    Set `DD_PROFILING_ENABLED=true` in your environment, OR enable it using `Datadog.configure`.
+
+    For Rails applications, you can set this in `config/initializers/datadog.rb`:
+
+    ```ruby
+    Datadog.configure do |c|
+      c.profiling.enabled = true
+    end
+    ```
+
+3. Start your application with the preloader:
+
+    ```sh
+    bundle exec ddtracerb exec rails s
+    ```
+
+    Manual alternative: If starting the application via `ddtracerb exec` is not an option (for instance, when using the
+    Phusion Passenger web server), you can alternatively start the profiler by adding the following to your application
+    entry point (such as `config.ru` for a web application):
+
+    ```ruby
+    require 'ddtrace/profiling/preload'
+    ```

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2490,16 +2490,10 @@ However, additional instrumentation provided by Datadog can be activated alongsi
 
 **Compatibility**
 
-Basic profiling requires:
-
-- MRI Ruby 2.0+
-- `google-protobuf` gem installed
-
-In addition, CPU time measurements require:
+Profiling requires:
 
 - MRI Ruby 2.1+
-- Linux OS with `pthread` support
-- `ffi` gem installed
+- `google-protobuf` gem installed
 
 **Setup**
 
@@ -2507,8 +2501,7 @@ In addition, CPU time measurements require:
 
     ```ruby
     gem 'ddtrace'
-    gem 'google-protobuf'
-    gem 'ffi'
+    gem 'google-protobuf', '~> 3.0'
     ```
 
 2. Enable profiling flag:

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -547,7 +547,7 @@ Datadog.configure do |c|
   # Symbol matching your database connection in config/database.yml
   # Only available if you are using Rails with ActiveRecord.
   c.use :active_record, describes: :secondary_database, service_name: 'secondary-db'
-  
+
   # Block configuration pattern.
   c.use :active_record, describes: :secondary_database do |second_db|
     second_db.service_name = 'secondary-db'
@@ -585,7 +585,7 @@ Datadog.configure do |c|
 
   # Matches any `mysql2` connection.
   c.use :active_record, describes: { adapter: 'mysql2'}, service_name: 'mysql-db'
-  
+
   # Matches any `mysql2` connection to the `reports` database.
   #
   # In case of multiple matching `describe` configurations, the latest one applies.
@@ -1566,7 +1566,7 @@ Datadog.configure do |c|
   # For network connections, only these fields are considered during matching:
   # scheme, host, port, db
   # Other fields are ignored.
-  
+
   # Network connection string
   c.use :redis, describes: 'redis://127.0.0.1:6379/0', service_name: 'redis-connection-string'
   c.use :redis, describes: { url: 'redis://127.0.0.1:6379/1' }, service_name: 'redis-connection-url'
@@ -1868,7 +1868,7 @@ Datadog.configure do |c|
 
   # Breaks down very large traces into smaller batches
   c.tracer.partial_flush.enabled = false
-  
+
   # You can specify your own tracer
   c.tracer.instance = Datadog::Tracer.new
 
@@ -1955,7 +1955,7 @@ We recommend setting the environment variable `DD_TRACE_SAMPLE_RATE=1.0` in all 
 App Analytics, previously configured with the `analytics_enabled` setting, is deprecated in favor of Tracing without Limits™. Documentation for this [deprecated configuration is still available](https://docs.datadoghq.com/tracing/legacy_app_analytics/).
 
 #### Application-side sampling
- 
+
 While the trace agent can sample traces to reduce bandwidth usage, application-side sampling reduces the performance overhead.
 
 This will **reduce visibility and is not recommended**. See [DD_TRACE_SAMPLE_RATE](#environment-variables) for the recommended sampling approach.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2488,47 +2488,9 @@ However, additional instrumentation provided by Datadog can be activated alongsi
 
 `ddtrace` can produce profiles that measure method-level application resource usage within production environments. These profiles can give insight into resources spent in Ruby code outside of existing trace instrumentation.
 
-**Compatibility**
-
-Profiling requires:
-
-- MRI Ruby 2.1+
-- `google-protobuf` gem installed
-
 **Setup**
 
-1. Add gems to your `Gemfile` and `bundle install`:
-
-    ```ruby
-    gem 'ddtrace'
-    gem 'google-protobuf', '~> 3.0'
-    ```
-
-2. Enable profiling flag:
-
-    Set `DD_PROFILING_ENABLED=true` in your environment, OR enable it using `Datadog.configure`.
-
-    For Rails applications, you can set this in `config/initializers/datadog.rb`:
-
-    ```ruby
-    Datadog.configure do |c|
-      c.profiling.enabled = true
-    end
-    ```
-
-3. Start your application with the preloader:
-
-    ```sh
-    bundle exec ddtracerb exec rails s
-    ```
-
-    Manual alternative: If starting the application via `ddtracerb exec` is not an option (for instance, when using the
-    Phusion Passenger web server), you can alternatively start the profiler by adding the following to your application
-    entry point (such as `config.ru` for a web application):
-
-    ```ruby
-    require 'ddtrace/profiling/preload'
-    ```
+To get started with profiling, follow the [Profiler Getting Started Guide](https://docs.datadoghq.com/tracing/profiler/getting_started/?code-lang=ruby).
 
 #### Profiling Resque jobs
 


### PR DESCRIPTION
Add profiler user documentation: an intro, a link to the getting started docs, as well as the workaround needed for resque.