### PR TITLE
Workaround Ruby segfault when reading instance variable from Process::Waiter

### DIFF
--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -380,6 +380,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
         if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2')
           skip 'Test case only applies to Ruby 2.2+ (previous versions did not have the Process::Waiter class)'
         end
+        skip 'Test case only applies to MRI Ruby' if RUBY_ENGINE != 'ruby'
       end
 
       it 'can sample an instance of Process::Waiter without crashing' do

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -372,6 +372,19 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
         end
       end
     end
+
+    context 'Process::Waiter crash regression tests' do
+      # See cthread.rb for more details
+
+      it 'can sample an instance of Process::Waiter without crashing' do
+        with_profiling_extensions_in_fork do
+          Process.detach(fork {})
+          process_waiter_thread = Thread.list.find { |thread| thread.instance_of?(Process::Waiter) }
+
+          expect(collector.collect_thread_event(process_waiter_thread, 0)).to be_truthy
+        end
+      end
+    end
   end
 
   describe '#get_cpu_time_interval!' do

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -376,6 +376,12 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     context 'Process::Waiter crash regression tests' do
       # See cthread.rb for more details
 
+      before do
+        if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2')
+          skip 'Test case only applies to Ruby 2.2+ (previous versions did not have the Process::Waiter class)'
+        end
+      end
+
       it 'can sample an instance of Process::Waiter without crashing' do
         with_profiling_extensions_in_fork do
           Process.detach(fork {})

--- a/spec/ddtrace/profiling/ext/cthread_spec.rb
+++ b/spec/ddtrace/profiling/ext/cthread_spec.rb
@@ -89,10 +89,10 @@ if Datadog::Profiling::Ext::CPU.supported?
     describe '::new' do
       it 'has native thread IDs available' do
         is_expected.to have_attributes(
-          clock_id: kind_of(Integer),
           native_thread_id: kind_of(Integer),
           cpu_time: kind_of(Float)
         )
+        expect(thread.send(:clock_id)).to be_kind_of(Integer)
       end
 
       it 'correctly forwards all received arguments to the passed proc' do
@@ -131,7 +131,7 @@ if Datadog::Profiling::Ext::CPU.supported?
     end
 
     describe '#clock_id' do
-      subject(:clock_id) { thread.clock_id }
+      subject(:clock_id) { thread.send(:clock_id) }
 
       it { is_expected.to be_a_kind_of(Integer) }
 
@@ -142,12 +142,12 @@ if Datadog::Profiling::Ext::CPU.supported?
           it 'returns a new clock ID' do
             on_main_thread do
               # Get main thread clock ID
-              original_clock_id = thread_class.current.clock_id
+              original_clock_id = thread_class.current.send(:clock_id)
 
               expect_in_fork do
                 # Expect main thread clock ID to change (to match fork's main thread)
-                expect(thread_class.current.clock_id).to be_a_kind_of(Integer)
-                expect(thread_class.current.clock_id).to_not eq(original_clock_id)
+                expect(thread_class.current.send(:clock_id)).to be_a_kind_of(Integer)
+                expect(thread_class.current.send(:clock_id)).to_not eq(original_clock_id)
               end
             end
           end

--- a/spec/ddtrace/profiling/ext/cthread_spec.rb
+++ b/spec/ddtrace/profiling/ext/cthread_spec.rb
@@ -245,6 +245,12 @@ if Datadog::Profiling::Ext::CPU.supported?
     end
 
     context 'Process::Waiter crash regression tests' do
+      before do
+        if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2')
+          skip 'Test case only applies to Ruby 2.2+ (previous versions did not have the Process::Waiter class)'
+        end
+      end
+
       let(:process_waiter_thread) do
         Process.detach(fork {})
         Thread.list.find { |thread| thread.instance_of?(Process::Waiter) }

--- a/spec/ddtrace/profiling/spec_helper.rb
+++ b/spec/ddtrace/profiling/spec_helper.rb
@@ -23,9 +23,9 @@ module ProfilingFeatureHelpers
   # lingering side effects (since patching occurs within a fork.)
   # Useful for profiling tests involving the main Thread, which cannot
   # be unpatched after applying profiling extensions.
-  def with_profiling_extensions_in_fork
+  def with_profiling_extensions_in_fork(fork_expectations: nil)
     # Apply extensions in a fork so we don't modify the original Thread class
-    expect_in_fork do
+    expect_in_fork(fork_expectations: fork_expectations) do
       require 'ddtrace/profiling/tasks/setup'
       Datadog::Profiling::Tasks::Setup::ACTIVATE_EXTENSIONS_ONLY_ONCE.send(:reset_ran_once_state_for_tests)
       Datadog::Profiling::Tasks::Setup.new.run


### PR DESCRIPTION
In Ruby versions 2.3 to 2.6, there's a very special subclass of `Thread` called `Process::Waiter` that causes VM crashes whenever something tries to read its instance variables. This subclass of thread only shows up when the `Process.detach` API gets used.

In this case the "something that tries to read its instance variables" is our stack sampler, which was trying to read the `native_thread_id` from one such instance.

I've reported this issue upstream https://bugs.ruby-lang.org/issues/17807 .

To workaround this issue, I've added a check if the instance variable exists before reading it, and validated it works with all affected Ruby versions (as well as adding regression tests for it all).