### PR TITLE
Add cause to error stack trace

### DIFF
--- a/lib/ddtrace/error.rb
+++ b/lib/ddtrace/error.rb
@@ -1,26 +1,108 @@
+# frozen_string_literal: true
+
+require 'set'
+
 # Datadog global namespace
 module Datadog
   # Error is a value-object responsible for sanitizing/encapsulating error data
   class Error
     attr_reader :type, :message, :backtrace
 
-    def self.build_from(value)
-      case value
-      when Error then value
-      when Array then new(*value)
-      when Exception then new(value.class, value.message, value.backtrace)
-      when ContainsMessage then new(value.class, value.message)
-      else BlankError
+    class << self
+      def build_from(value)
+        case value
+        when Error then value
+        when Array then new(*value)
+        when Exception then from_exception(value.class, value.message, full_backtrace(value))
+        when ContainsMessage then new(value.class, value.message)
+        else BlankError
+        end
+      end
+
+      private
+
+      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1.0')
+        # Ruby 2.0 exceptions don't have `cause`.
+        # Only current exception stack trace is reported.
+        # This is the same behavior as before.
+        def full_backtrace(ex)
+          ex.backtrace.join("\n")
+        end
+      elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.6.0')
+        # Backports Ruby >= 2.6 output to older versions.
+        # This exposes the 'cause' chain in the stack trace,
+        # allowing for complete visibility of the error stack.
+        def full_backtrace(ex)
+          backtrace = []
+          backtrace_for(ex, backtrace)
+
+          # Avoid circular causes
+          causes = Set.new
+          causes.add(ex)
+
+          while (cause = ex.cause) && !causes.include?(cause)
+            backtrace_for(cause, backtrace)
+            causes.add(cause)
+          end
+
+          backtrace.join("\n")
+        end
+
+        # Outputs the following format for exceptions:
+        #
+        # ```
+        # error_spec.rb:55:in `wrapper': wrapper layer (RuntimeError)
+        # 	from error_spec.rb:40:in `wrapper'
+        # 	from error_spec.rb:61:in `caller'
+        #   ...
+        # ```
+        def backtrace_for(ex, backtrace)
+          trace = ex.backtrace
+          return unless trace
+
+          error_line, *caller_lines = trace
+
+          if error_line
+            # Add Exception information to error line
+            error_line = "#{error_line}: #{ex.message} (#{ex.class})"
+            backtrace << error_line
+          end
+
+          if caller_lines
+            # Ident stack trace for caller lines, to separate
+            # them from the main error lines.
+            caller_lines = caller_lines.map do |line|
+              "	from #{line}"
+            end
+
+            backtrace.concat(caller_lines)
+          end
+        end
+      else # Ruby >= 2.6.0
+        # Full stack trace, with each cause reported with its
+        # respective stack trace.
+        def full_backtrace(ex)
+          ex.full_message(highlight: false, order: :top)
+        end
       end
     end
 
     def initialize(type = nil, message = nil, backtrace = nil)
       backtrace = Array(backtrace).join("\n")
 
-      # DEV: We should measure if `Utils.utf8_encode` is still needed in practice.
       @type = Utils.utf8_encode(type)
       @message = Utils.utf8_encode(message)
       @backtrace = Utils.utf8_encode(backtrace)
+    end
+
+    # Optimized version for Exception objects.
+    #
+    # Exceptions return UTF-8 strings for their class name
+    # and backtrace, or return an ASCII strings that is byte
+    # equivalent to its UTF-8 counterpart:
+    # `str.encode('ASCII').bytes == str.encode('UTF-8').bytes`
+    def self.from_exception(clazz, message, backtrace)
+      new(clazz, Utils.utf8_encode(message), backtrace)
     end
 
     BlankError = Error.new

--- a/lib/ddtrace/error.rb
+++ b/lib/ddtrace/error.rb
@@ -27,7 +27,7 @@ module Datadog
         # This is the same behavior as before.
         def full_backtrace(ex)
           backtrace = ex.backtrace
-          ex.backtrace.join("\n")
+          backtrace.join("\n") if backtrace
         end
       elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.6.0')
         # Backports Ruby >= 2.6 output to older versions.

--- a/lib/ddtrace/error.rb
+++ b/lib/ddtrace/error.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
-
 # Datadog global namespace
 module Datadog
   # Error is a value-object responsible for sanitizing/encapsulating error data
@@ -46,7 +44,7 @@ module Datadog
           backtrace_for(ex, backtrace)
 
           # Avoid circular causes
-          causes = Hash.new
+          causes = {}
           causes[ex] = true
 
           while (cause = ex.cause) && !causes.key?(cause)

--- a/spec/ddtrace/error_spec.rb
+++ b/spec/ddtrace/error_spec.rb
@@ -33,12 +33,121 @@ RSpec.describe Datadog::Error do
     subject(:error) { described_class.build_from(value) }
 
     context 'with an exception' do
-      let(:value) { ZeroDivisionError.new('divided by 0') }
-
+      let(:value) { begin 1 / 0; rescue => e; e; end }
       it do
         expect(error.type).to eq('ZeroDivisionError')
         expect(error.message).to eq('divided by 0')
-        expect(error.backtrace).to be_empty
+        expect(error.backtrace).to include('error_spec.rb')
+      end
+
+      context 'with a cause' do
+        let(:clazz) do
+          Class.new do
+            def root
+              raise 'root cause'
+            end
+
+            def wrapper
+              root
+            rescue
+              raise 'wrapper layer'
+            end
+
+            def call
+              wrapper
+            rescue => e
+              e
+            end
+          end
+        end
+
+        let(:value) do
+          begin
+            clazz.new.call
+          rescue => e
+            e
+          end
+        end
+
+        it 'reports nested errors' do
+          expect(error.type).to eq('RuntimeError')
+          expect(error.message).to eq('wrapper layer')
+
+          if RUBY_VERSION >= '2.1.0'
+            wrapper_error_message = /error_spec.rb:\d+:in.*wrapper': wrapper layer \(RuntimeError\)/
+            caller_stack = /from.*error_spec.rb:\d+:in `call'/
+            root_error_message = /error_spec.rb:\d+:in.*root': root cause \(RuntimeError\)/
+            wrapper_stack = /from.*error_spec.rb:\d+:in `wrapper'/
+
+            expect(error.backtrace)
+              .to match(/
+                         #{wrapper_error_message}.*
+                         #{caller_stack}.*
+                         #{root_error_message}.*
+                         #{wrapper_stack}.*
+                         #{caller_stack}.*
+                         /mx)
+
+            # Expect 2 "first-class" exception lines: 'root cause' and 'wrapper layer'.
+            expect(error.backtrace.each_line.reject { |l| l.start_with?("\tfrom") }).to have(2).items
+          end
+        end
+
+        context 'that is reused' do
+          before { skip("This version of Ruby doesn't support setting exception cause") if RUBY_VERSION < '2.2.0' }
+
+          let(:value) do
+            begin
+              begin
+                raise 'first error'
+              rescue => e
+                raise 'second error' rescue ex2 = $ERROR_INFO
+                raise e, cause: ex2 # raises ArgumentError('circular causes') on Ruby >= 2.6
+              end
+            rescue => e
+              e
+            end
+          end
+
+          it 'reports errors only once', if: RUBY_VERSION < '2.6.0' do
+            expect(error.type).to eq('RuntimeError')
+            expect(error.message).to eq('first error')
+
+            expect(error.backtrace).to match(/first error \(RuntimeError\).*second error \(RuntimeError\)/m)
+
+            # Expect 2 "first-class" exception lines: 'first error' and 'second error'.
+            expect(error.backtrace.each_line.reject { |l| l.start_with?("\tfrom") }).to have(2).items
+          end
+
+          it 'reports errors only once', if: RUBY_VERSION >= '2.6.0' do
+            expect(error.type).to eq('ArgumentError')
+            expect(error.message).to eq('circular causes')
+
+            expect(error.backtrace).to match(/circular causes \(ArgumentError\).*first error \(RuntimeError\)/m)
+
+            # Expect 2 "first-class" exception lines: 'circular causes' and 'first error'.
+            # Ruby doesn't report 'second error' as it was never successfully set as the cause of 'first error'.
+            expect(error.backtrace.each_line.reject { |l| l.start_with?("\tfrom") }).to have(2).items
+          end
+        end
+
+        context 'benchmark' do
+          before { skip('Benchmark results not currently captured in CI') if ENV.key?('CI') }
+
+          it do
+            require 'benchmark/ips'
+
+            Benchmark.ips do |x|
+              x.config(time: 8, warmup: 2)
+
+              x.report 'build_from' do
+                described_class.build_from(value)
+              end
+
+              x.compare!
+            end
+          end
+        end
       end
     end
 

--- a/spec/ddtrace/span_spec.rb
+++ b/spec/ddtrace/span_spec.rb
@@ -663,7 +663,9 @@ RSpec.describe Datadog::Span do
       expect(span).to have_error
       expect(span).to have_error_message('oops')
       expect(span).to have_error_type('RuntimeError')
-      expect(span).to have_error_stack(backtrace.join($RS))
+      backtrace.each do |method|
+        expect(span).to have_error_stack(include(method))
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #1265 

This PR changes the format of Ruby exceptions reported in `ddtrace` spans to match the latest default language format.

`ddtrace` will now include all exception causes and format the output to exactly match the Ruby native format, introduced in Ruby 2.6.

```ruby
def root
  raise 'root cause'
end

def wrapper
  root
rescue
  raise 'wrapper layer'
end

wrapper

# /tmp/test.rb:8:in `rescue in wrapper': wrapper layer (RuntimeError)
# 	from /tmp/test.rb:5:in `wrapper'
# 	from /tmp/test.rb:11:in `<main>'
# /tmp/test.rb:2:in `root': root cause (RuntimeError)
# 	from /tmp/test.rb:6:in `wrapper'
# 	from /tmp/test.rb:11:in `<main>'
```

The stack trace order was reversed between Ruby 2.5 and 2.7, but `ddtrace` will follow the current Ruby 3.0 format, using natural ordering on all Ruby versions supported.

For recent Ruby versions (>= 2.6), the output is retrieved from a single VM call (`Exception#full_message`), thus incurring a much lower cost compared to the backported versions for Ruby < 2.6.

Ruby 2.0 does not support `Exception#cause`, thus this change does not affect the output for that version.

### Benchmarks

A benchmark is committed as part of this PR (RSpec test named `Datadog::Error.build_from with an exception with a cause benchmark`) and here are the results for different versions of Ruby, each taking a different code path in this PR:

| Ruby version | Top-level error only (before) | Full error stack (after) | Implementation |
| --- | --- | --- | --- |
| 2.0 | ~~39.933k i/s~~ | ~~39.933k i/s*~~ | Incomplete: only top-level error |
| 2.5 | ~~92.231k i/s~~ | ~~0.33k i/s~~ | Our implementation to generate a full error stack report |
| 2.6 | ~~95.634k i/s~~ | ~~8.034k i/s~~ | VM method call to retrieve a full error stack report |

_New amended numbers, after performance improvement work:_

| Ruby version | Top-level error only (before) | Full error stack (after) | Implementation |
| --- | --- | --- | --- |
| 2.0 | 61.005k i/s | 51.075k i/s* | Incomplete: only top-level error |
| 2.5 | 93.955k i/s | 22.729k i/s | Our implementation to generate a full error stack report |
| 2.6 | 97.763k i/s | 21.709k i/s | Our implementation to generate a full error stack report |
| 2.6 | 97.763k i/s | 10.360k i/s | `Exception#full_message` |

Ruby 2.0 stays relatively unchanged from before: it performs the same work in both implementations.

~~Ruby 2.6 to 3.0 (and beyond) invokes `Exception#full_message`, which generates the full stack trace natively. This method is roughly 11 times slower than before, but provides all the information required for stack trace analysis.~~ _Ruby 2.6 to 3.0 have moved to our Ruby-based implementation, due to better performance, explained below._

Ruby 2.1 to 2.5 uses a Ruby-based implementation to generate the same output as `Exception#full_message`. This allows for a consistent format between all versions of Ruby (except 2.0), at the expense of performance. This method is roughly 4-4.5 times slower than before.

Given this method should only happen on exceptional code paths, having a richer output would be preferable to a more performance, but less informative dataset.