### PR TITLE
Fix anchor in README.md

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2115,7 +2115,7 @@ For more details on how to activate distributed tracing for integrations, see th
 
 - [Excon](#excon)
 - [Faraday](#faraday)
-- [Rest Client](#restclient)
+- [Rest Client](#rest-client)
 - [Net/HTTP](#nethttp)
 - [Rack](#rack)
 - [Rails](#rails)


### PR DESCRIPTION
While looking for guidelines on `RestClient`'s integration, found that one of the references on it has a broken anchor and this is only a fix on it.

Regards,
Kex