### PR TITLE
Fix cgroup descriptor parsing when path has less than 2 parts

### DIFF
--- a/lib/ddtrace/runtime/container.rb
+++ b/lib/ddtrace/runtime/container.rb
@@ -49,6 +49,8 @@ module Datadog
               container_id, task_uid = nil
 
               case parts.length
+              when 0..1
+                next
               when 2
                 container_id = parts[-1][CONTAINER_REGEX] || parts[-1][FARGATE_14_CONTAINER_REGEX]
               else


### PR DESCRIPTION
From [this issue](https://github.com/DataDog/dd-trace-rb/issues/1475).  Easy fix, but TBH I don't have a great way to test this other than copying code to a repl, and it appears there are no unit tests around it?