### PR TITLE
[PROF-3118] Refactor reading agent settings into separate class

### DIFF
--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -27,7 +27,6 @@ module Datadog
 
       def call
         {
-          adapter: :http,
           ssl: ssl?,
           hostname: hostname,
           port: port,

--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -14,6 +14,29 @@ module Datadog
     # Whenever there is a conflict (different configurations are provided in different orders), it MUST warn the users
     # about it and pick a value based on the following priority: code > environment variable > defaults.
     class AgentSettingsResolver
+      class AgentSettings < \
+          Struct.new(
+            :ssl,
+            :hostname,
+            :port,
+            :timeout_seconds,
+            :transport_configuration_proc,
+            :deprecated_for_removal_transport_configuration_options
+          )
+        def initialize(
+          # Hacky required kw args, we can get rid of this when we drop Ruby 2.0
+          ssl: raise(ArgumentError, 'missing keyword :ssl'),
+          hostname: raise(ArgumentError, 'missing keyword :hostname'),
+          port: raise(ArgumentError, 'missing keyword :port'),
+          timeout_seconds: raise(ArgumentError, 'missing keyword :timeout_seconds'),
+          transport_configuration_proc: raise(ArgumentError, 'missing keyword :transport_configuration_proc'),
+          deprecated_for_removal_transport_configuration_options: raise(ArgumentError, 'missing keyword :deprecated_for_removal_transport_configuration_options')
+        )
+          super(ssl, hostname, port, timeout_seconds, transport_configuration_proc, deprecated_for_removal_transport_configuration_options)
+          freeze
+        end
+      end
+
       def self.call(settings, logger: Datadog.logger)
         new(settings, logger: logger).send(:call)
       end
@@ -192,28 +215,6 @@ module Datadog
       end
       private_constant :DetectedConfiguration
 
-      class AgentSettings < \
-          Struct.new(
-            :ssl,
-            :hostname,
-            :port,
-            :timeout_seconds,
-            :transport_configuration_proc,
-            :deprecated_for_removal_transport_configuration_options
-          )
-        def initialize(
-          # Hacky required kw args, we can get rid of this when we drop Ruby 2.0
-          ssl: raise(ArgumentError, 'missing keyword :ssl'),
-          hostname: raise(ArgumentError, 'missing keyword :hostname'),
-          port: raise(ArgumentError, 'missing keyword :port'),
-          timeout_seconds: raise(ArgumentError, 'missing keyword :timeout_seconds'),
-          transport_configuration_proc: raise(ArgumentError, 'missing keyword :transport_configuration_proc'),
-          deprecated_for_removal_transport_configuration_options: raise(ArgumentError, 'missing keyword :deprecated_for_removal_transport_configuration_options')
-        )
-          super(ssl, hostname, port, timeout_seconds, transport_configuration_proc, deprecated_for_removal_transport_configuration_options)
-          freeze
-        end
-      end
     end
   end
 end

--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -147,23 +147,22 @@ module Datadog
       def parsed_url
         return @parsed_url if defined?(@parsed_url)
 
-        result = nil
+        @parsed_url =
+          if unparsed_url_from_env
+            parsed = URI.parse(unparsed_url_from_env)
 
-        if unparsed_url_from_env
-          result = URI.parse(unparsed_url_from_env)
+            if %w[http https].include?(parsed.scheme)
+              parsed
+            else
+              log_warning(
+                "Invalid URI scheme '#{parsed.scheme}' for #{Datadog::Ext::Transport::HTTP::ENV_DEFAULT_URL} " \
+                "environment variable ('#{unparsed_url_from_env}'). " \
+                "Ignoring the contents of #{Datadog::Ext::Transport::HTTP::ENV_DEFAULT_URL}."
+              )
 
-          unless %w[http https].include?(result.scheme)
-            log_warning(
-              "Invalid URI scheme '#{result.scheme}' for #{Datadog::Ext::Transport::HTTP::ENV_DEFAULT_URL} " \
-              "environment variable ('#{unparsed_url_from_env}'). " \
-              "Ignoring the contents of #{Datadog::Ext::Transport::HTTP::ENV_DEFAULT_URL}."
-            )
-
-            result = nil
+              nil
+            end
           end
-        end
-
-        @parsed_url = result
       end
 
       # NOTE: This should only be used AFTER parsing, via `#parsed_url`. The only other use-case where this can be used

--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -64,6 +64,11 @@ module Datadog
           hostname: hostname,
           port: port,
           timeout_seconds: timeout_seconds,
+          # NOTE: When provided, the deprecated_for_removal_transport_configuration_proc can override all
+          # values above (ssl, hostname, port, timeout), or even make them irrelevant (by using an unix socket or
+          # enabling test mode instead).
+          # That is the main reason why it is deprecated -- it's an opaque function that may set a bunch of settings
+          # that we know nothing of until we actually call it.
           deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc,
           deprecated_for_removal_transport_configuration_options: deprecated_for_removal_transport_configuration_options
         )

--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -208,7 +208,11 @@ module Datadog
       end
 
       DetectedConfiguration = Struct.new(:friendly_name, :value) do
-        def initialize(friendly_name:, value:)
+        def initialize(
+          # Hacky required kw args, we can get rid of this when we drop Ruby 2.0
+          friendly_name: raise(ArgumentError, 'missing keyword :friendly_name'),
+          value: raise(ArgumentError, 'missing keyword :value')
+        )
           super(friendly_name, value)
           freeze
         end

--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -4,6 +4,11 @@ module Datadog
   module Configuration
     # This class unifies all the different ways that users can configure how we talk to the agent.
     #
+    # It has quite a lot of complexity, but this complexity just reflects the actual complexity we have around our
+    # configuration today. E.g., this is just all of the complexity regarding agent settings gathered together in a
+    # single place. As we deprecate more and more of the different ways that these things can be configured,
+    # this class will reflect that simplification as well.
+    #
     # Whenever there is a conflict (different configurations are provided in different orders), it MUST warn the users
     # about it and pick a value based on the following priority: code > environment variable > defaults.
     class AgentSettingsResolver

--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -109,7 +109,7 @@ module Datadog
         if options.is_a?(Hash) && !options.empty?
           logger.warn(
             "Configuring the tracer via a settings.tracer.transport_options hash is deprecated for removal in a future " \
-            "ddtrace version."
+            "ddtrace version (settings.tracer.transport_options contained '#{options.inspect}')."
           )
 
           options

--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -21,7 +21,7 @@ module Datadog
             :hostname,
             :port,
             :timeout_seconds,
-            :transport_configuration_proc,
+            :deprecated_for_removal_transport_configuration_proc,
             :deprecated_for_removal_transport_configuration_options
           )
         def initialize(
@@ -30,10 +30,10 @@ module Datadog
           hostname: raise(ArgumentError, 'missing keyword :hostname'),
           port: raise(ArgumentError, 'missing keyword :port'),
           timeout_seconds: raise(ArgumentError, 'missing keyword :timeout_seconds'),
-          transport_configuration_proc: raise(ArgumentError, 'missing keyword :transport_configuration_proc'),
+          deprecated_for_removal_transport_configuration_proc: raise(ArgumentError, 'missing keyword :deprecated_for_removal_transport_configuration_proc'),
           deprecated_for_removal_transport_configuration_options: raise(ArgumentError, 'missing keyword :deprecated_for_removal_transport_configuration_options')
         )
-          super(ssl, hostname, port, timeout_seconds, transport_configuration_proc, deprecated_for_removal_transport_configuration_options)
+          super(ssl, hostname, port, timeout_seconds, deprecated_for_removal_transport_configuration_proc, deprecated_for_removal_transport_configuration_options)
           freeze
         end
       end
@@ -59,7 +59,7 @@ module Datadog
           hostname: hostname,
           port: port,
           timeout_seconds: timeout_seconds,
-          transport_configuration_proc: transport_configuration_proc,
+          deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc,
           deprecated_for_removal_transport_configuration_options: deprecated_for_removal_transport_configuration_options
         )
       end
@@ -125,7 +125,7 @@ module Datadog
         Datadog::Ext::Transport::HTTP::DEFAULT_TIMEOUT_SECONDS
       end
 
-      def transport_configuration_proc
+      def deprecated_for_removal_transport_configuration_proc
         settings.tracer.transport_options if settings.tracer.transport_options.is_a?(Proc)
       end
 

--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -73,7 +73,7 @@ module Datadog
         pick_from(
           configurations_in_priority_order: [
             DetectedConfiguration.new(
-              friendly_name: "'settings.tracer.hostname'",
+              friendly_name: "'c.tracer.hostname'",
               value: settings.tracer.hostname
             ),
             DetectedConfiguration.new(
@@ -106,7 +106,7 @@ module Datadog
         pick_from(
           configurations_in_priority_order: [
             DetectedConfiguration.new(
-              friendly_name: '"settings.tracer.port"',
+              friendly_name: '"c.tracer.port"',
               value: settings.tracer.port
             ),
             DetectedConfiguration.new(
@@ -139,8 +139,8 @@ module Datadog
 
         if options.is_a?(Hash) && !options.empty?
           log_warning(
-            'Configuring the tracer via a settings.tracer.transport_options hash is deprecated for removal in a future ' \
-            "ddtrace version (settings.tracer.transport_options contained '#{options.inspect}')."
+            'Configuring the tracer via a c.tracer.transport_options hash is deprecated for removal in a future ' \
+            "ddtrace version (c.tracer.transport_options contained '#{options.inspect}')."
           )
 
           options

--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -31,7 +31,8 @@ module Datadog
           ssl: ssl?,
           hostname: hostname,
           port: port,
-          timeout_seconds: timeout_seconds
+          timeout_seconds: timeout_seconds,
+          transport_configuration_proc: transport_configuration_proc
         }.freeze
       end
 
@@ -96,6 +97,10 @@ module Datadog
 
       def timeout_seconds
         Datadog::Ext::Transport::HTTP::DEFAULT_TIMEOUT_SECONDS
+      end
+
+      def transport_configuration_proc
+        settings.tracer.transport_options if settings.tracer.transport_options.is_a?(Proc)
       end
 
       def parsed_url

--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -32,7 +32,8 @@ module Datadog
           hostname: hostname,
           port: port,
           timeout_seconds: timeout_seconds,
-          transport_configuration_proc: transport_configuration_proc
+          transport_configuration_proc: transport_configuration_proc,
+          deprecated_for_removal_transport_configuration_options: deprecated_for_removal_transport_configuration_options
         }.freeze
       end
 
@@ -101,6 +102,19 @@ module Datadog
 
       def transport_configuration_proc
         settings.tracer.transport_options if settings.tracer.transport_options.is_a?(Proc)
+      end
+
+      def deprecated_for_removal_transport_configuration_options
+        options = settings.tracer.transport_options
+
+        if options.is_a?(Hash) && !options.empty?
+          logger.warn(
+            "Configuring the tracer via a settings.tracer.transport_options hash is deprecated for removal in a future " \
+            "ddtrace version."
+          )
+
+          options
+        end
       end
 
       def parsed_url

--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -15,28 +15,30 @@ module Datadog
     # Whenever there is a conflict (different configurations are provided in different orders), it MUST warn the users
     # about it and pick a value based on the following priority: code > environment variable > defaults.
     class AgentSettingsResolver
-      class AgentSettings < \
-          Struct.new(
-            :ssl,
-            :hostname,
-            :port,
-            :timeout_seconds,
-            :deprecated_for_removal_transport_configuration_proc,
-            :deprecated_for_removal_transport_configuration_options
+      AgentSettings = \
+        Struct.new(
+          :ssl,
+          :hostname,
+          :port,
+          :timeout_seconds,
+          :deprecated_for_removal_transport_configuration_proc,
+          :deprecated_for_removal_transport_configuration_options
+        ) do
+          def initialize(
+            # Hacky required kw args, we can get rid of this when we drop Ruby 2.0
+            ssl: raise(ArgumentError, 'missing keyword :ssl'),
+            hostname: raise(ArgumentError, 'missing keyword :hostname'),
+            port: raise(ArgumentError, 'missing keyword :port'),
+            timeout_seconds: raise(ArgumentError, 'missing keyword :timeout_seconds'),
+            deprecated_for_removal_transport_configuration_proc: raise(ArgumentError,
+                                                                       'missing keyword :deprecated_for_removal_transport_configuration_proc'),
+            deprecated_for_removal_transport_configuration_options: raise(ArgumentError,
+                                                                          'missing keyword :deprecated_for_removal_transport_configuration_options')
           )
-        def initialize(
-          # Hacky required kw args, we can get rid of this when we drop Ruby 2.0
-          ssl: raise(ArgumentError, 'missing keyword :ssl'),
-          hostname: raise(ArgumentError, 'missing keyword :hostname'),
-          port: raise(ArgumentError, 'missing keyword :port'),
-          timeout_seconds: raise(ArgumentError, 'missing keyword :timeout_seconds'),
-          deprecated_for_removal_transport_configuration_proc: raise(ArgumentError, 'missing keyword :deprecated_for_removal_transport_configuration_proc'),
-          deprecated_for_removal_transport_configuration_options: raise(ArgumentError, 'missing keyword :deprecated_for_removal_transport_configuration_options')
-        )
-          super(ssl, hostname, port, timeout_seconds, deprecated_for_removal_transport_configuration_proc, deprecated_for_removal_transport_configuration_options)
-          freeze
+            super(ssl, hostname, port, timeout_seconds, deprecated_for_removal_transport_configuration_proc, deprecated_for_removal_transport_configuration_options)
+            freeze
+          end
         end
-      end
 
       def self.call(settings, logger: Datadog.logger)
         new(settings, logger: logger).send(:call)
@@ -93,7 +95,7 @@ module Datadog
             rescue ArgumentError
               log_warning(
                 "Invalid value for #{Datadog::Ext::Transport::HTTP::ENV_DEFAULT_PORT} environment variable ('#{port_from_env}'). " \
-                "Ignoring this configuration."
+                'Ignoring this configuration.'
               )
             end
           end
@@ -118,7 +120,7 @@ module Datadog
       end
 
       def ssl?
-        !parsed_url.nil? && parsed_url.scheme == "https"
+        !parsed_url.nil? && parsed_url.scheme == 'https'
       end
 
       def timeout_seconds
@@ -134,7 +136,7 @@ module Datadog
 
         if options.is_a?(Hash) && !options.empty?
           log_warning(
-            "Configuring the tracer via a settings.tracer.transport_options hash is deprecated for removal in a future " \
+            'Configuring the tracer via a settings.tracer.transport_options hash is deprecated for removal in a future ' \
             "ddtrace version (settings.tracer.transport_options contained '#{options.inspect}')."
           )
 
@@ -150,7 +152,7 @@ module Datadog
         if unparsed_url_from_env
           result = URI.parse(unparsed_url_from_env)
 
-          unless ["http", "https"].include?(result.scheme)
+          unless %w[http https].include?(result.scheme)
             log_warning(
               "Invalid URI scheme '#{result.scheme}' for #{Datadog::Ext::Transport::HTTP::ENV_DEFAULT_URL} " \
               "environment variable ('#{unparsed_url_from_env}'). " \
@@ -192,10 +194,10 @@ module Datadog
         return unless detected_configurations_in_priority_order.map(&:value).uniq.size > 1
 
         log_warning(
-          "Configuration mismatch: values differ between " +
-          detected_configurations_in_priority_order.map { |config|
+          'Configuration mismatch: values differ between ' +
+          detected_configurations_in_priority_order.map do |config|
             "#{config.friendly_name} ('#{config.value}')"
-          }.join(" and ") +
+          end.join(' and ') +
           ". Using '#{detected_configurations_in_priority_order.first.value}'."
         )
       end
@@ -204,7 +206,7 @@ module Datadog
         logger.warn(message) if logger
       end
 
-      class DetectedConfiguration < Struct.new(:friendly_name, :value)
+      DetectedConfiguration = Struct.new(:friendly_name, :value) do
         def initialize(friendly_name:, value:)
           super(friendly_name, value)
           freeze

--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -14,6 +14,8 @@ module Datadog
     #
     # Whenever there is a conflict (different configurations are provided in different orders), it MUST warn the users
     # about it and pick a value based on the following priority: code > environment variable > defaults.
+    #
+    # rubocop:disable Metrics/ClassLength
     class AgentSettingsResolver
       AgentSettings = \
         Struct.new(
@@ -30,12 +32,13 @@ module Datadog
             hostname: raise(ArgumentError, 'missing keyword :hostname'),
             port: raise(ArgumentError, 'missing keyword :port'),
             timeout_seconds: raise(ArgumentError, 'missing keyword :timeout_seconds'),
-            deprecated_for_removal_transport_configuration_proc: raise(ArgumentError,
-                                                                       'missing keyword :deprecated_for_removal_transport_configuration_proc'),
-            deprecated_for_removal_transport_configuration_options: raise(ArgumentError,
-                                                                          'missing keyword :deprecated_for_removal_transport_configuration_options')
+            deprecated_for_removal_transport_configuration_proc: \
+              raise(ArgumentError, 'missing keyword :deprecated_for_removal_transport_configuration_proc'),
+            deprecated_for_removal_transport_configuration_options: \
+              raise(ArgumentError, 'missing keyword :deprecated_for_removal_transport_configuration_options')
           )
-            super(ssl, hostname, port, timeout_seconds, deprecated_for_removal_transport_configuration_proc, deprecated_for_removal_transport_configuration_options)
+            super(ssl, hostname, port, timeout_seconds, deprecated_for_removal_transport_configuration_proc, \
+              deprecated_for_removal_transport_configuration_options)
             freeze
           end
         end
@@ -94,8 +97,8 @@ module Datadog
               Integer(port_from_env)
             rescue ArgumentError
               log_warning(
-                "Invalid value for #{Datadog::Ext::Transport::HTTP::ENV_DEFAULT_PORT} environment variable ('#{port_from_env}'). " \
-                'Ignoring this configuration.'
+                "Invalid value for #{Datadog::Ext::Transport::HTTP::ENV_DEFAULT_PORT} environment variable " \
+                "('#{port_from_env}'). Ignoring this configuration."
               )
             end
           end
@@ -193,10 +196,9 @@ module Datadog
         return unless detected_configurations_in_priority_order.map(&:value).uniq.size > 1
 
         log_warning(
-          'Configuration mismatch: values differ between ' +
-          detected_configurations_in_priority_order.map do |config|
-            "#{config.friendly_name} ('#{config.value}')"
-          end.join(' and ') +
+          'Configuration mismatch: values differ between ' \
+          "#{detected_configurations_in_priority_order
+            .map { |config| "#{config.friendly_name} ('#{config.value}')" }.join(' and ')}" \
           ". Using '#{detected_configurations_in_priority_order.first.value}'."
         )
       end
@@ -225,5 +227,6 @@ module Datadog
       # by users via `Datadog.configure`.
       ENVIRONMENT_AGENT_SETTINGS = call(Settings.new, logger: nil)
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -68,6 +68,10 @@ module Datadog
         pick_from(
           configurations_in_priority_order: [
             DetectedConfiguration.new(
+              friendly_name: '"settings.tracer.port"',
+              value: settings.tracer.port
+            ),
+            DetectedConfiguration.new(
               friendly_name: "#{Datadog::Ext::Transport::HTTP::ENV_DEFAULT_URL} environment variable",
               value: parsed_url && parsed_url.port
             ),

--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -26,7 +26,8 @@ module Datadog
           ssl: ssl?,
           hostname: hostname,
           port: port,
-        }
+          timeout_seconds: timeout_seconds
+        }.freeze
       end
 
       private
@@ -86,6 +87,10 @@ module Datadog
 
       def ssl?
         !parsed_url.nil? && parsed_url.scheme == "https"
+      end
+
+      def timeout_seconds
+        Datadog::Ext::Transport::HTTP::DEFAULT_TIMEOUT_SECONDS
       end
 
       def parsed_url

--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -1,0 +1,111 @@
+require 'uri'
+
+module Datadog
+  module Configuration
+    # This class unifies all the different ways that users can configure how we talk to the agent.
+    #
+    # Whenever there is a conflict (different configurations are provided in different orders), it MUST warn the users
+    # about it and pick a value based on the following priority: code > environment variable > defaults.
+    class AgentSettingsResolver
+      private
+
+      attr_reader \
+        :logger
+
+      public
+
+      def initialize(logger: Datadog.logger)
+        @logger = logger
+      end
+
+      def call
+        {
+          adapter: :http,
+          ssl: ssl?,
+          hostname: hostname,
+          port: port,
+        }
+      end
+
+      private
+
+      def hostname
+        hostname_from_env = ENV[Datadog::Ext::Transport::HTTP::ENV_DEFAULT_HOST]
+
+        if parsed_url
+          if hostname_from_env && hostname_from_env != parsed_url.hostname
+            logger.warn(
+              "Configuration mismatch: both the #{Datadog::Ext::Transport::HTTP::ENV_DEFAULT_URL} ('#{unparsed_url_from_env}') " \
+              "and the #{Datadog::Ext::Transport::HTTP::ENV_DEFAULT_HOST} ('#{hostname_from_env}') were specified, " \
+              "and their values differ. Using #{unparsed_url_from_env}."
+            )
+          end
+
+          parsed_url.hostname
+        else
+          hostname_from_env || Datadog::Ext::Transport::HTTP::DEFAULT_HOST
+        end
+      end
+
+      def port
+        port_from_env = ENV[Datadog::Ext::Transport::HTTP::ENV_DEFAULT_PORT]
+
+        if parsed_url
+          if port_from_env && port_from_env != parsed_url.port
+            logger.warn(
+              "Configuration mismatch: both the #{Datadog::Ext::Transport::HTTP::ENV_DEFAULT_URL} ('#{unparsed_url_from_env}') " \
+              "and the #{Datadog::Ext::Transport::HTTP::ENV_DEFAULT_PORT} ('#{port_from_env}') were specified, " \
+              "and their values differ. Using #{unparsed_url_from_env}."
+            )
+          end
+
+          return parsed_url.port
+        end
+
+        default_value = Datadog::Ext::Transport::HTTP::DEFAULT_PORT
+
+        if port_from_env
+          begin
+            return Integer(port_from_env)
+          rescue ArgumentError
+            logger.warn("Invalid value for #{Datadog::Ext::Transport::HTTP::ENV_DEFAULT_PORT} environment variable ('#{port_from_env}'). Falling back to default value #{default_value}.")
+          end
+        end
+
+        default_value
+      end
+
+      def ssl?
+        !parsed_url.nil? && parsed_url.scheme == "https"
+      end
+
+      def parsed_url
+        return @parsed_url if defined?(@parsed_url)
+
+        result = nil
+
+        if unparsed_url_from_env
+          result = URI.parse(unparsed_url_from_env)
+
+          unless ["http", "https"].include?(result.scheme)
+            logger.warn(
+              "Invalid URI scheme '#{result.scheme}' for #{Datadog::Ext::Transport::HTTP::ENV_DEFAULT_URL} " \
+              "environment variable ('#{unparsed_url_from_env}'). " \
+              "Ignoring the contents of #{Datadog::Ext::Transport::HTTP::ENV_DEFAULT_URL}."
+            )
+
+            result = nil
+          end
+        end
+
+        @parsed_url = result
+      end
+
+      # NOTE: This should only be used AFTER parsing, via `#parsed_url`. The only other use-case where this can be used
+      # directly without parsing, is when displaying in warning messages, to show users what it actually contains.
+      def unparsed_url_from_env
+        @unparsed_url_from_env ||= ENV[Datadog::Ext::Transport::HTTP::ENV_DEFAULT_URL]
+      end
+    end
+  end
+end

--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -1,6 +1,7 @@
 require 'uri'
 
 require 'ddtrace/ext/transport'
+require 'ddtrace/configuration/settings'
 
 module Datadog
   module Configuration
@@ -215,6 +216,13 @@ module Datadog
       end
       private_constant :DetectedConfiguration
 
+      # NOTE: Due to... legacy reasons... Some classes like having an `AgentSettings` instance to fall back to.
+      # Because we generate this instance with an empty instance of `Settings`, the resulting `AgentSettings` below
+      # represents only settings specified via environment variables + the usual defaults.
+      #
+      # YOU DO NOT WANT TO USE THE BELOW INSTANCE ON ANY NEWLY WRITTEN CODE, as it ignores any settings specified
+      # by users via `Datadog.configure`.
+      ENVIRONMENT_AGENT_SETTINGS = call(Settings.new, logger: nil)
     end
   end
 end

--- a/lib/ddtrace/ext/transport.rb
+++ b/lib/ddtrace/ext/transport.rb
@@ -4,6 +4,7 @@ module Datadog
       module HTTP
         DEFAULT_HOST = '127.0.0.1'.freeze
         DEFAULT_PORT = 8126
+        DEFAULT_TIMEOUT_SECONDS = 1
         ENV_DEFAULT_HOST = 'DD_AGENT_HOST'.freeze
         ENV_DEFAULT_PORT = 'DD_TRACE_AGENT_PORT'.freeze
         ENV_DEFAULT_URL = 'DD_TRACE_AGENT_URL'.freeze

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -391,9 +391,6 @@ module Datadog
 
     # TODO: Move this kind of configuration building out of the tracer.
     #       Tracer should not have this kind of knowledge of writer.
-    # rubocop:disable Metrics/PerceivedComplexity
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/MethodLength
     def configure_writer(options = {})
       sampler = options.fetch(:sampler, nil)
       priority_sampling = options.fetch(:priority_sampling, nil)

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -85,7 +85,7 @@ module Datadog
       @provider = options.fetch(:context_provider, Datadog::DefaultContextProvider.new)
       @sampler = options.fetch(:sampler, Datadog::AllSampler.new)
       @tags = options.fetch(:tags, {})
-      @writer = options.fetch(:writer, Datadog::Writer.new)
+      @writer = options.fetch(:writer) { Datadog::Writer.new }
 
       # Instance variables
       @mutex = Mutex.new
@@ -395,16 +395,13 @@ module Datadog
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/MethodLength
     def configure_writer(options = {})
-      hostname = options.fetch(:hostname, nil)
-      port = options.fetch(:port, nil)
       sampler = options.fetch(:sampler, nil)
       priority_sampling = options.fetch(:priority_sampling, nil)
       writer = options.fetch(:writer, nil)
-      transport_options = options.fetch(:transport_options, {}).dup
+      agent_settings = options.fetch(:agent_settings, nil)
 
       # Compile writer options
       writer_options = options.fetch(:writer_options, {}).dup
-      rebuild_writer = !writer_options.empty?
 
       # Re-build the sampler and writer if priority sampling is enabled,
       # but neither are configured. Verify the sampler isn't already a
@@ -417,35 +414,20 @@ module Datadog
         end
       elsif priority_sampling != false && !@sampler.is_a?(PrioritySampler)
         writer_options[:priority_sampler] = activate_priority_sampling!(@sampler)
-        rebuild_writer = true
       elsif priority_sampling == false
         deactivate_priority_sampling!(sampler)
-        rebuild_writer = true
       elsif @sampler.is_a?(PrioritySampler)
         # Make sure to add sampler to options if transport is rebuilt.
         writer_options[:priority_sampler] = @sampler
       end
 
-      # Apply options to transport
-      if transport_options.is_a?(Proc)
-        transport_options = { on_build: transport_options }
-        rebuild_writer = true
-      end
+      writer_options[:agent_settings] = agent_settings if agent_settings
 
-      if hostname || port
-        transport_options[:hostname] = hostname unless hostname.nil?
-        transport_options[:port] = port unless port.nil?
-        rebuild_writer = true
-      end
+      # Make sure old writer is shut down before throwing away.
+      # Don't want additional threads running...
+      @writer.stop unless writer.nil?
 
-      writer_options[:transport_options] = transport_options
-
-      if rebuild_writer || writer
-        # Make sure old writer is shut down before throwing away.
-        # Don't want additional threads running...
-        @writer.stop unless writer.nil?
-        @writer = writer || Writer.new(writer_options)
-      end
+      @writer = writer || Writer.new(writer_options)
     end
 
     def activate_priority_sampling!(base_sampler = nil)

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -39,7 +39,7 @@ module Datadog
           if agent_settings.deprecated_for_removal_transport_configuration_options
             # The deprecated_for_removal_transport_configuration_options take precedence over any options the caller
             # specifies
-            options = {**options, **agent_settings.deprecated_for_removal_transport_configuration_options}
+            options = { **options, **agent_settings.deprecated_for_removal_transport_configuration_options }
           end
 
           apis = API.defaults
@@ -54,7 +54,9 @@ module Datadog
             transport.headers options[:headers] if options.key?(:headers)
           end
 
-          agent_settings.deprecated_for_removal_transport_configuration_proc.call(transport) if agent_settings.deprecated_for_removal_transport_configuration_proc
+          if agent_settings.deprecated_for_removal_transport_configuration_proc
+            agent_settings.deprecated_for_removal_transport_configuration_proc.call(transport)
+          end
 
           # Call block to apply any customization, if provided
           yield(transport) if block_given?

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -80,6 +80,33 @@ module Datadog
         :net_http
       end
 
+      def default_hostname(logger: Datadog.logger)
+        logger.warn(
+          'Deprecated for removal: Using #default_hostname for configuration is deprecated and will ' \
+          'be removed on a future ddtrace release.'
+        )
+
+        Datadog::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS.hostname
+      end
+
+      def default_port(logger: Datadog.logger)
+        logger.warn(
+          'Deprecated for removal: Using #default_hostname for configuration is deprecated and will ' \
+          'be removed on a future ddtrace release.'
+        )
+
+        Datadog::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS.port
+      end
+
+      def default_url(logger: Datadog.logger)
+        logger.warn(
+          'Deprecated for removal: Using #default_url for configuration is deprecated and will ' \
+          'be removed on a future ddtrace release.'
+        )
+
+        nil
+      end
+
       # Add adapters to registry
       Builder::REGISTRY.set(Adapters::Net, :net_http)
       Builder::REGISTRY.set(Adapters::Test, :test)

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -39,7 +39,7 @@ module Datadog
           if agent_settings.deprecated_for_removal_transport_configuration_options
             # The deprecated_for_removal_transport_configuration_options take precedence over any options the caller
             # specifies
-            options = { **options, **agent_settings.deprecated_for_removal_transport_configuration_options }
+            options = options.merge(**agent_settings.deprecated_for_removal_transport_configuration_options)
           end
 
           apis = API.defaults

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -54,7 +54,7 @@ module Datadog
             transport.headers options[:headers] if options.key?(:headers)
           end
 
-          agent_settings.transport_configuration_proc.call(transport) if agent_settings.transport_configuration_proc
+          agent_settings.deprecated_for_removal_transport_configuration_proc.call(transport) if agent_settings.deprecated_for_removal_transport_configuration_proc
 
           # Call block to apply any customization, if provided
           yield(transport) if block_given?

--- a/lib/ddtrace/workers/trace_writer.rb
+++ b/lib/ddtrace/workers/trace_writer.rb
@@ -16,13 +16,10 @@ module Datadog
       def initialize(options = {})
         transport_options = options.fetch(:transport_options, {})
 
-        transport_options = { on_build: transport_options } if transport_options.is_a?(Proc)
-
-        transport_options[:hostname] = options[:hostname] if options.key?(:hostname)
-        transport_options[:port] = options[:port] if options.key?(:port)
+        transport_options[:agent_settings] = options[:agent_settings] if options.key?(:agent_settings)
 
         @transport = options.fetch(:transport) do
-          Transport::HTTP.default(transport_options)
+          Transport::HTTP.default(**transport_options)
         end
       end
 

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -3,6 +3,7 @@ require 'json'
 require 'ddtrace/ext/net'
 require 'ddtrace/runtime/socket'
 
+require 'ddtrace/configuration/agent_settings_resolver'
 require 'ddtrace/transport/http'
 require 'ddtrace/transport/io'
 require 'ddtrace/encoding'
@@ -26,6 +27,8 @@ module Datadog
       @flush_interval = options.fetch(:flush_interval, Workers::AsyncTransport::DEFAULT_FLUSH_INTERVAL)
       transport_options = options.fetch(:transport_options, {})
 
+      transport_options[:agent_settings] = options[:agent_settings] if options.key?(:agent_settings)
+
       # priority sampling
       if options[:priority_sampler]
         @priority_sampler = options[:priority_sampler]
@@ -34,7 +37,7 @@ module Datadog
 
       # transport and buffers
       @transport = options.fetch(:transport) do
-        Transport::HTTP.default(transport_options)
+        Transport::HTTP.default(**transport_options)
       end
 
       # handles the thread creation after an eventual fork

--- a/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
+++ b/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
 
   let(:default_settings) {
     {
-      adapter: :http,
       ssl: false,
       hostname: '127.0.0.1',
       port: 8126,
@@ -191,7 +190,6 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
     it 'contacts the agent using the http adapter, using the custom hostname and port' do
       expect(subject.call).to eq(
         **default_settings,
-        adapter: :http,
         ssl: false,
         hostname: 'custom-hostname',
         port: 1234

--- a/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
+++ b/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       adapter: :http,
       ssl: false,
       hostname: '127.0.0.1',
-      port: 8126
+      port: 8126,
+      timeout_seconds: 1
     }
   }
 
@@ -187,6 +188,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
 
     it 'contacts the agent using the http adapter, using the custom hostname and port' do
       expect(subject.call).to eq(
+        **default_settings,
         adapter: :http,
         ssl: false,
         hostname: 'custom-hostname',

--- a/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
+++ b/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       end
     end
 
-    context 'when a custom hostname is specified via code using tracer.hostname =' do
+    context 'when a custom hostname is specified via code using "tracer.hostname ="' do
       before do
         ddtrace_settings.tracer.hostname = 'custom-hostname'
       end
@@ -50,7 +50,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
         expect(subject.call).to eq(**default_settings, hostname: 'custom-hostname')
       end
 
-      context 'when a different hostname is also specified via the DD_AGENT_HOST environment variable' do
+      context 'and a different hostname is also specified via the DD_AGENT_HOST environment variable' do
         let(:environment) { {'DD_AGENT_HOST' => 'this-is-a-different-hostname'} }
 
         before do
@@ -68,7 +68,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
         end
       end
 
-      context 'when a different hostname is also specified via the DD_TRACE_AGENT_URL environment variable' do
+      context 'and a different hostname is also specified via the DD_TRACE_AGENT_URL environment variable' do
         let(:environment) { {'DD_TRACE_AGENT_URL' => 'http://this-is-a-different-hostname:8126'} }
 
         before do
@@ -126,7 +126,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       )
     end
 
-    context 'when a different hostname is also specified via the DD_AGENT_HOST environment variable' do
+    context 'and a different hostname is also specified via the DD_AGENT_HOST environment variable' do
       let(:environment) {
         {
           'DD_TRACE_AGENT_URL' => 'http://custom-hostname:1234',
@@ -149,7 +149,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       end
     end
 
-    context 'when a different port is also specified via the DD_TRACE_AGENT_PORT environment variable' do
+    context 'and a different port is also specified via the DD_TRACE_AGENT_PORT environment variable' do
       let(:environment) {
         {
           'DD_TRACE_AGENT_URL' => 'http://custom-hostname:1234',

--- a/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
+++ b/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
     }
   }
 
-  subject { described_class.new(ddtrace_settings, logger: logger) }
+  subject(:resolver) { described_class.call(ddtrace_settings, logger: logger) }
 
   context 'by default' do
     it 'contacts the agent using the http adapter, using hostname 127.0.0.1 and port 8126' do
-      expect(subject.call).to eq default_settings
+      expect(resolver).to have_attributes default_settings
     end
   end
 
@@ -39,7 +39,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       let(:environment) { {'DD_AGENT_HOST' => 'custom-hostname'} }
 
       it 'contacts the agent using the http adapter, using the custom hostname' do
-        expect(subject.call).to eq(**default_settings, hostname: 'custom-hostname')
+        expect(resolver).to have_attributes(**default_settings, hostname: 'custom-hostname')
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       end
 
       it 'contacts the agent using the http adapter, using the custom hostname' do
-        expect(subject.call).to eq(**default_settings, hostname: 'custom-hostname')
+        expect(resolver).to have_attributes(**default_settings, hostname: 'custom-hostname')
       end
 
       context 'and a different hostname is also specified via the DD_AGENT_HOST environment variable' do
@@ -60,13 +60,13 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
         end
 
         it 'prioritizes the hostname specified via code' do
-          expect(subject.call).to eq(**default_settings, hostname: 'custom-hostname')
+          expect(resolver).to have_attributes(**default_settings, hostname: 'custom-hostname')
         end
 
         it 'logs a warning' do
           expect(logger).to receive(:warn).with(/Configuration mismatch/)
 
-          subject.call
+          resolver
         end
       end
 
@@ -78,13 +78,13 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
         end
 
         it 'prioritizes the hostname specified via code' do
-          expect(subject.call).to eq(**default_settings, hostname: 'custom-hostname')
+          expect(resolver).to have_attributes(**default_settings, hostname: 'custom-hostname')
         end
 
         it 'logs a warning' do
           expect(logger).to receive(:warn).with(/Configuration mismatch/)
 
-          subject.call
+          resolver
         end
       end
     end
@@ -95,7 +95,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       end
 
       it 'contacts the agent using the http adapter, using the custom hostname' do
-        expect(subject.call).to eq(**default_settings, hostname: 'custom-hostname')
+        expect(resolver).to have_attributes(**default_settings, hostname: 'custom-hostname')
       end
     end
   end
@@ -105,7 +105,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       let(:environment) { {'DD_TRACE_AGENT_PORT' => '1234'} }
 
       it 'contacts the agent using the http adapter, using the custom port' do
-        expect(subject.call).to eq(**default_settings, port: 1234)
+        expect(resolver).to have_attributes(**default_settings, port: 1234)
       end
 
       context 'when the custom port is invalid' do
@@ -118,11 +118,11 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
         it 'logs a warning' do
           expect(logger).to receive(:warn).with(/Invalid value/)
 
-          subject.call
+          resolver
         end
 
         it 'falls back to the defaults' do
-          expect(subject.call).to eq default_settings
+          expect(resolver).to have_attributes default_settings
         end
       end
     end
@@ -133,7 +133,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       end
 
       it 'contacts the agent using the http adapter, using the custom port' do
-        expect(subject.call).to eq(**default_settings, port: 1234)
+        expect(resolver).to have_attributes(**default_settings, port: 1234)
       end
 
       context 'and a different port is also specified via the DD_TRACE_AGENT_PORT environment variable' do
@@ -144,13 +144,13 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
         end
 
         it 'prioritizes the port specified via code' do
-          expect(subject.call).to eq(**default_settings, port: 1234)
+          expect(resolver).to have_attributes(**default_settings, port: 1234)
         end
 
         it 'logs a warning' do
           expect(logger).to receive(:warn).with(/Configuration mismatch/)
 
-          subject.call
+          resolver
         end
       end
 
@@ -162,13 +162,13 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
         end
 
         it 'prioritizes the port specified via code' do
-          expect(subject.call).to eq(**default_settings, port: 1234)
+          expect(resolver).to have_attributes(**default_settings, port: 1234)
         end
 
         it 'logs a warning' do
           expect(logger).to receive(:warn).with(/Configuration mismatch/)
 
-          subject.call
+          resolver
         end
       end
     end
@@ -179,7 +179,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       end
 
       it 'contacts the agent using the http adapter, using the custom port' do
-        expect(subject.call).to eq(**default_settings, port: 1234)
+        expect(resolver).to have_attributes(**default_settings, port: 1234)
       end
     end
   end
@@ -188,7 +188,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
     let(:environment) { {'DD_TRACE_AGENT_URL' => 'http://custom-hostname:1234'} }
 
     it 'contacts the agent using the http adapter, using the custom hostname and port' do
-      expect(subject.call).to eq(
+      expect(resolver).to have_attributes(
         **default_settings,
         ssl: false,
         hostname: 'custom-hostname',
@@ -209,13 +209,13 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       end
 
       it 'it prioritizes the hostname specified via DD_TRACE_AGENT_URL' do
-        expect(subject.call).to include(hostname: 'custom-hostname')
+        expect(resolver).to have_attributes(hostname: 'custom-hostname')
       end
 
       it 'logs a warning' do
         expect(logger).to receive(:warn).with(/Configuration mismatch/)
 
-        subject.call
+        resolver
       end
     end
 
@@ -232,13 +232,13 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       end
 
       it 'prioritizes the port specified via DD_TRACE_AGENT_URL' do
-        expect(subject.call).to include(port: 1234)
+        expect(resolver).to have_attributes(port: 1234)
       end
 
       it 'logs a warning' do
         expect(logger).to receive(:warn).with(/Configuration mismatch/)
 
-        subject.call
+        resolver
       end
     end
 
@@ -246,7 +246,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       let(:environment) { {'DD_TRACE_AGENT_URL' => 'https://custom-hostname:1234'} }
 
       it 'contacts the agent using the http adapter, using ssl: true' do
-        expect(subject.call).to include(ssl: true)
+        expect(resolver).to have_attributes(ssl: true)
       end
     end
 
@@ -254,7 +254,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       let(:environment) { {'DD_TRACE_AGENT_URL' => 'steam://custom-hostname:1234'} }
 
       it 'falls back to the defaults' do
-        expect(subject.call).to eq default_settings
+        expect(resolver).to have_attributes default_settings
       end
 
       before do
@@ -264,7 +264,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       it 'logs a warning' do
         expect(logger).to receive(:warn).with(/Invalid URI scheme/)
 
-        subject.call
+        resolver
       end
     end
   end
@@ -277,7 +277,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
     end
 
     it 'includes the given proc in the resolved settings as the transport_configuration_proc entry' do
-      expect(subject.call).to eq(**default_settings, transport_configuration_proc: transport_configuration_proc)
+      expect(resolver).to have_attributes(**default_settings, transport_configuration_proc: transport_configuration_proc)
     end
   end
 
@@ -290,7 +290,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
     end
 
     it 'includes the given hash in the resolved settings as the deprecated_for_removal_transport_configuration_options entry' do
-      expect(subject.call).to eq(
+      expect(resolver).to have_attributes(
         **default_settings,
         deprecated_for_removal_transport_configuration_options: deprecated_for_removal_transport_configuration_options
       )
@@ -299,7 +299,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
     it 'logs a deprecation warning' do
       expect(logger).to receive(:warn).with(/deprecated for removal/)
 
-      subject.call
+      resolver
     end
   end
 end

--- a/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
+++ b/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       ssl: false,
       hostname: '127.0.0.1',
       port: 8126,
-      timeout_seconds: 1
+      timeout_seconds: 1,
+      transport_configuration_proc: nil
     }
   }
 
@@ -266,6 +267,18 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
 
         subject.call
       end
+    end
+  end
+
+  context 'when a proc is configured in tracer.transport_options' do
+    let(:transport_configuration_proc) { proc { } }
+
+    before do
+      ddtrace_settings.tracer.transport_options = transport_configuration_proc
+    end
+
+    it 'includes the given proc in the resolved settings as the transport_configuration_proc entry' do
+      expect(subject.call).to eq(**default_settings, transport_configuration_proc: transport_configuration_proc)
     end
   end
 end

--- a/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
+++ b/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
@@ -276,9 +276,11 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       ddtrace_settings.tracer.transport_options = deprecated_for_removal_transport_configuration_proc
     end
 
-    it 'includes the given proc in the resolved settings as the deprecated_for_removal_transport_configuration_proc entry' do
-      expect(resolver).to have_attributes(**default_settings,
-deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc)
+    it 'includes the given proc in the resolved settings as the deprecated_for_removal_transport_configuration_proc' do
+      expect(resolver).to have_attributes(
+        **default_settings,
+        deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc
+      )
     end
   end
 
@@ -290,7 +292,7 @@ deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_tran
       allow(logger).to receive(:warn)
     end
 
-    it 'includes the given hash in the resolved settings as the deprecated_for_removal_transport_configuration_options entry' do
+    it 'includes the given hash in the resolved settings as the deprecated_for_removal_transport_configuration_options' do
       expect(resolver).to have_attributes(
         **default_settings,
         deprecated_for_removal_transport_configuration_options: deprecated_for_removal_transport_configuration_options

--- a/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
+++ b/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
@@ -2,7 +2,7 @@ require 'ddtrace/configuration/agent_settings_resolver'
 require 'ddtrace/configuration/settings'
 
 RSpec.describe Datadog::Configuration::AgentSettingsResolver do
-  around { |example| ClimateControl.modify(**default_environment, **environment) { example.run } }
+  around { |example| ClimateControl.modify(default_environment.merge(environment)) { example.run } }
 
   let(:default_environment) do
     {

--- a/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
+++ b/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
@@ -1,0 +1,152 @@
+require 'ddtrace/configuration/agent_settings_resolver'
+require 'ddtrace/configuration/settings'
+
+RSpec.describe Datadog::Configuration::AgentSettingsResolver do
+  around { |example| ClimateControl.modify(**default_environment, **environment) { example.run } }
+
+  let(:default_environment) {
+    {
+      'DD_AGENT_HOST' => nil,
+      'DD_TRACE_AGENT_PORT' => nil,
+      'DD_TRACE_AGENT_URL' => nil,
+    }
+  }
+  let(:environment) { Hash.new }
+  let(:logger) { instance_double(Datadog::Logger) }
+
+  let(:default_settings) {
+    {
+      adapter: :http,
+      ssl: false,
+      hostname: '127.0.0.1',
+      port: 8126
+    }
+  }
+
+  subject { described_class.new(logger: logger) }
+
+  context 'by default' do
+    it 'contacts the agent using the http adapter, using hostname 127.0.0.1 and port 8126' do
+      expect(subject.call).to eq default_settings
+    end
+  end
+
+  context 'when a custom hostname is specified via environment variable' do
+    let(:environment) { {'DD_AGENT_HOST' => 'custom-hostname'} }
+
+    it 'contacts the agent using the http adapter, using the custom hostname' do
+      expect(subject.call).to eq(**default_settings, hostname: 'custom-hostname')
+    end
+  end
+
+  context 'when a custom port is specified via environment variable' do
+    let(:environment) { {'DD_TRACE_AGENT_PORT' => '1234'} }
+
+    it 'contacts the agent using the http adapter, using the custom port' do
+      expect(subject.call).to eq(**default_settings, port: 1234)
+    end
+
+    context 'when the custom port is invalid' do
+      let(:environment) { {'DD_TRACE_AGENT_PORT' => 'this-is-an-invalid-port'} }
+
+      before do
+        allow(logger).to receive(:warn)
+      end
+
+      it 'logs a warning' do
+        expect(logger).to receive(:warn).with(/Invalid value/)
+
+        subject.call
+      end
+
+      it 'falls back to the defaults' do
+        expect(subject.call).to eq default_settings
+      end
+    end
+  end
+
+  context 'when a custom url is specified via environment variable' do
+    let(:environment) { {'DD_TRACE_AGENT_URL' => 'http://custom-hostname:1234'} }
+
+    it 'contacts the agent using the http adapter, using the custom hostname and port' do
+      expect(subject.call).to eq(
+        adapter: :http,
+        ssl: false,
+        hostname: 'custom-hostname',
+        port: 1234
+      )
+    end
+
+    context 'when a custom hostname is also specified' do
+      let(:environment) {
+        {
+          'DD_TRACE_AGENT_URL' => 'http://custom-hostname:1234',
+          'DD_AGENT_HOST' => 'this-is-a-different-hostname',
+        }
+      }
+
+      before do
+        allow(logger).to receive(:warn)
+      end
+
+      it 'contacts the agent using the http adapter, using the hostname specified via DD_TRACE_AGENT_URL' do
+        expect(subject.call).to include(hostname: 'custom-hostname')
+      end
+
+      it 'logs a warning' do
+        expect(logger).to receive(:warn).with(/Configuration mismatch/)
+
+        subject.call
+      end
+    end
+
+    context 'when a custom port is also specified' do
+      let(:environment) {
+        {
+          'DD_TRACE_AGENT_URL' => 'http://custom-hostname:1234',
+          'DD_TRACE_AGENT_PORT' => '5678',
+        }
+      }
+
+      before do
+        allow(logger).to receive(:warn)
+      end
+
+      it 'contacts the agent using the http adapter, using the port specified via DD_TRACE_AGENT_URL' do
+        expect(subject.call).to include(port: 1234)
+      end
+
+      it 'logs a warning' do
+        expect(logger).to receive(:warn).with(/Configuration mismatch/)
+
+        subject.call
+      end
+    end
+
+    context 'when the uri scheme is https' do
+      let(:environment) { {'DD_TRACE_AGENT_URL' => 'https://custom-hostname:1234'} }
+
+      it 'contacts the agent using the http adapter, using ssl: true' do
+        expect(subject.call).to include(ssl: true)
+      end
+    end
+
+    context 'when the uri scheme is not http OR https' do
+      let(:environment) { {'DD_TRACE_AGENT_URL' => 'steam://custom-hostname:1234'} }
+
+      it 'falls back to the defaults' do
+        expect(subject.call).to eq default_settings
+      end
+
+      before do
+        allow(logger).to receive(:warn)
+      end
+
+      it 'logs a warning' do
+        expect(logger).to receive(:warn).with(/Invalid URI scheme/)
+
+        subject.call
+      end
+    end
+  end
+end

--- a/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
+++ b/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
@@ -4,18 +4,18 @@ require 'ddtrace/configuration/settings'
 RSpec.describe Datadog::Configuration::AgentSettingsResolver do
   around { |example| ClimateControl.modify(**default_environment, **environment) { example.run } }
 
-  let(:default_environment) {
+  let(:default_environment) do
     {
       'DD_AGENT_HOST' => nil,
       'DD_TRACE_AGENT_PORT' => nil,
-      'DD_TRACE_AGENT_URL' => nil,
+      'DD_TRACE_AGENT_URL' => nil
     }
-  }
-  let(:environment) { Hash.new }
+  end
+  let(:environment) { {} }
   let(:ddtrace_settings) { Datadog::Configuration::Settings.new }
   let(:logger) { instance_double(Datadog::Logger) }
 
-  let(:default_settings) {
+  let(:default_settings) do
     {
       ssl: false,
       hostname: '127.0.0.1',
@@ -24,7 +24,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       deprecated_for_removal_transport_configuration_proc: nil,
       deprecated_for_removal_transport_configuration_options: nil
     }
-  }
+  end
 
   subject(:resolver) { described_class.call(ddtrace_settings, logger: logger) }
 
@@ -36,7 +36,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
 
   describe 'http adapter hostname' do
     context 'when a custom hostname is specified via environment variable' do
-      let(:environment) { {'DD_AGENT_HOST' => 'custom-hostname'} }
+      let(:environment) { { 'DD_AGENT_HOST' => 'custom-hostname' } }
 
       it 'contacts the agent using the http adapter, using the custom hostname' do
         expect(resolver).to have_attributes(**default_settings, hostname: 'custom-hostname')
@@ -53,7 +53,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       end
 
       context 'and a different hostname is also specified via the DD_AGENT_HOST environment variable' do
-        let(:environment) { {'DD_AGENT_HOST' => 'this-is-a-different-hostname'} }
+        let(:environment) { { 'DD_AGENT_HOST' => 'this-is-a-different-hostname' } }
 
         before do
           allow(logger).to receive(:warn)
@@ -71,7 +71,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       end
 
       context 'and a different hostname is also specified via the DD_TRACE_AGENT_URL environment variable' do
-        let(:environment) { {'DD_TRACE_AGENT_URL' => 'http://this-is-a-different-hostname:8126'} }
+        let(:environment) { { 'DD_TRACE_AGENT_URL' => 'http://this-is-a-different-hostname:8126' } }
 
         before do
           allow(logger).to receive(:warn)
@@ -102,14 +102,14 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
 
   describe 'http adapter port' do
     context 'when a custom port is specified via environment variable' do
-      let(:environment) { {'DD_TRACE_AGENT_PORT' => '1234'} }
+      let(:environment) { { 'DD_TRACE_AGENT_PORT' => '1234' } }
 
       it 'contacts the agent using the http adapter, using the custom port' do
         expect(resolver).to have_attributes(**default_settings, port: 1234)
       end
 
       context 'when the custom port is invalid' do
-        let(:environment) { {'DD_TRACE_AGENT_PORT' => 'this-is-an-invalid-port'} }
+        let(:environment) { { 'DD_TRACE_AGENT_PORT' => 'this-is-an-invalid-port' } }
 
         before do
           allow(logger).to receive(:warn)
@@ -137,7 +137,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       end
 
       context 'and a different port is also specified via the DD_TRACE_AGENT_PORT environment variable' do
-        let(:environment) { {'DD_TRACE_AGENT_PORT' => '5678'} }
+        let(:environment) { { 'DD_TRACE_AGENT_PORT' => '5678' } }
 
         before do
           allow(logger).to receive(:warn)
@@ -155,7 +155,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       end
 
       context 'and a different port is also specified via the DD_TRACE_AGENT_URL environment variable' do
-        let(:environment) { {'DD_TRACE_AGENT_URL' => 'http://127.0.0.1:5678'} }
+        let(:environment) { { 'DD_TRACE_AGENT_URL' => 'http://127.0.0.1:5678' } }
 
         before do
           allow(logger).to receive(:warn)
@@ -185,7 +185,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
   end
 
   context 'when a custom url is specified via environment variable' do
-    let(:environment) { {'DD_TRACE_AGENT_URL' => 'http://custom-hostname:1234'} }
+    let(:environment) { { 'DD_TRACE_AGENT_URL' => 'http://custom-hostname:1234' } }
 
     it 'contacts the agent using the http adapter, using the custom hostname and port' do
       expect(resolver).to have_attributes(
@@ -197,18 +197,18 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
     end
 
     context 'and a different hostname is also specified via the DD_AGENT_HOST environment variable' do
-      let(:environment) {
+      let(:environment) do
         {
           'DD_TRACE_AGENT_URL' => 'http://custom-hostname:1234',
-          'DD_AGENT_HOST' => 'this-is-a-different-hostname',
+          'DD_AGENT_HOST' => 'this-is-a-different-hostname'
         }
-      }
+      end
 
       before do
         allow(logger).to receive(:warn)
       end
 
-      it 'it prioritizes the hostname specified via DD_TRACE_AGENT_URL' do
+      it 'prioritizes the hostname specified via DD_TRACE_AGENT_URL' do
         expect(resolver).to have_attributes(hostname: 'custom-hostname')
       end
 
@@ -220,12 +220,12 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
     end
 
     context 'and a different port is also specified via the DD_TRACE_AGENT_PORT environment variable' do
-      let(:environment) {
+      let(:environment) do
         {
           'DD_TRACE_AGENT_URL' => 'http://custom-hostname:1234',
-          'DD_TRACE_AGENT_PORT' => '5678',
+          'DD_TRACE_AGENT_PORT' => '5678'
         }
-      }
+      end
 
       before do
         allow(logger).to receive(:warn)
@@ -243,7 +243,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
     end
 
     context 'when the uri scheme is https' do
-      let(:environment) { {'DD_TRACE_AGENT_URL' => 'https://custom-hostname:1234'} }
+      let(:environment) { { 'DD_TRACE_AGENT_URL' => 'https://custom-hostname:1234' } }
 
       it 'contacts the agent using the http adapter, using ssl: true' do
         expect(resolver).to have_attributes(ssl: true)
@@ -251,14 +251,14 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
     end
 
     context 'when the uri scheme is not http OR https' do
-      let(:environment) { {'DD_TRACE_AGENT_URL' => 'steam://custom-hostname:1234'} }
-
-      it 'falls back to the defaults' do
-        expect(resolver).to have_attributes default_settings
-      end
+      let(:environment) { { 'DD_TRACE_AGENT_URL' => 'steam://custom-hostname:1234' } }
 
       before do
         allow(logger).to receive(:warn)
+      end
+
+      it 'falls back to the defaults' do
+        expect(resolver).to have_attributes default_settings
       end
 
       it 'logs a warning' do
@@ -270,19 +270,20 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
   end
 
   context 'when a proc is configured in tracer.transport_options' do
-    let(:deprecated_for_removal_transport_configuration_proc) { proc { } }
+    let(:deprecated_for_removal_transport_configuration_proc) { proc {} }
 
     before do
       ddtrace_settings.tracer.transport_options = deprecated_for_removal_transport_configuration_proc
     end
 
     it 'includes the given proc in the resolved settings as the deprecated_for_removal_transport_configuration_proc entry' do
-      expect(resolver).to have_attributes(**default_settings, deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc)
+      expect(resolver).to have_attributes(**default_settings,
+deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc)
     end
   end
 
   context 'when a non-empty hash is configured in tracer.transport_options' do
-    let(:deprecated_for_removal_transport_configuration_options) { {batman: :cool} }
+    let(:deprecated_for_removal_transport_configuration_options) { { batman: :cool } }
 
     before do
       ddtrace_settings.tracer.transport_options = deprecated_for_removal_transport_configuration_options
@@ -304,14 +305,14 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
   end
 
   describe '#log_warning' do
-    let(:message) { "this is a test warning" }
+    let(:message) { 'this is a test warning' }
 
-    subject(:log_warning) {
+    subject(:log_warning) do
       described_class.new(ddtrace_settings, logger: logger).send(:log_warning, message)
-    }
+    end
 
     it 'logs a warning used the configured logger' do
-      expect(logger).to receive(:warn).with("this is a test warning")
+      expect(logger).to receive(:warn).with('this is a test warning')
 
       log_warning
     end

--- a/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
+++ b/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
@@ -86,6 +86,16 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
         end
       end
     end
+
+    context 'when a custom hostname is specified via code using "tracer(hostname: ...)"' do
+      before do
+        ddtrace_settings.tracer(hostname: 'custom-hostname')
+      end
+
+      it 'contacts the agent using the http adapter, using the custom hostname' do
+        expect(subject.call).to eq(**default_settings, hostname: 'custom-hostname')
+      end
+    end
   end
 
   describe 'http adapter port' do
@@ -158,6 +168,16 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
 
           subject.call
         end
+      end
+    end
+
+    context 'when a custom port is specified via code using "tracer(port: ...)"' do
+      before do
+        ddtrace_settings.tracer(port: 1234)
+      end
+
+      it 'contacts the agent using the http adapter, using the custom port' do
+        expect(subject.call).to eq(**default_settings, port: 1234)
       end
     end
   end

--- a/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
+++ b/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
@@ -302,4 +302,26 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       resolver
     end
   end
+
+  describe '#log_warning' do
+    let(:message) { "this is a test warning" }
+
+    subject(:log_warning) {
+      described_class.new(ddtrace_settings, logger: logger).send(:log_warning, message)
+    }
+
+    it 'logs a warning used the configured logger' do
+      expect(logger).to receive(:warn).with("this is a test warning")
+
+      log_warning
+    end
+
+    context 'when logger is nil' do
+      let(:logger) { nil }
+
+      it 'does not log anything' do
+        log_warning
+      end
+    end
+  end
 end

--- a/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
+++ b/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
       hostname: '127.0.0.1',
       port: 8126,
       timeout_seconds: 1,
-      transport_configuration_proc: nil,
+      deprecated_for_removal_transport_configuration_proc: nil,
       deprecated_for_removal_transport_configuration_options: nil
     }
   }
@@ -270,14 +270,14 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
   end
 
   context 'when a proc is configured in tracer.transport_options' do
-    let(:transport_configuration_proc) { proc { } }
+    let(:deprecated_for_removal_transport_configuration_proc) { proc { } }
 
     before do
-      ddtrace_settings.tracer.transport_options = transport_configuration_proc
+      ddtrace_settings.tracer.transport_options = deprecated_for_removal_transport_configuration_proc
     end
 
-    it 'includes the given proc in the resolved settings as the transport_configuration_proc entry' do
-      expect(resolver).to have_attributes(**default_settings, transport_configuration_proc: transport_configuration_proc)
+    it 'includes the given proc in the resolved settings as the deprecated_for_removal_transport_configuration_proc entry' do
+      expect(resolver).to have_attributes(**default_settings, deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc)
     end
   end
 

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -497,17 +497,26 @@ RSpec.describe 'Tracer integration tests' do
     subject(:configure) do
       tracer.configure(
         priority_sampling: true,
-        hostname: hostname,
-        port: port,
-        transport_options: transport_options
+        agent_settings: agent_settings
       )
     end
 
     let(:tracer) { Datadog::Tracer.new }
     let(:hostname) { double('hostname') }
     let(:port) { double('port') }
+    let(:settings) { Datadog::Configuration::Settings.new }
+    let(:agent_settings) { Datadog::Configuration::AgentSettingsResolver.call(settings, logger: nil) }
+
+    before do
+      settings.tracer.hostname = hostname
+      settings.tracer.port = port
+    end
 
     context 'when :transport_options' do
+      before do
+        settings.tracer.transport_options = transport_options
+      end
+
       context 'is a Proc' do
         let(:transport_options) { proc { |t| on_build.call(t) } }
         let(:on_build) { double('on_build') }

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -39,16 +39,36 @@ RSpec.describe Datadog::Tracer do
   end
 
   describe '#configure' do
-    subject!(:configure) { tracer.configure(options) }
+    context 'by default' do
+      subject!(:configure) { tracer.configure(options) }
 
-    let(:options) { {} }
+      let(:options) { {} }
 
-    it { expect(tracer.context_flush).to be_a(Datadog::ContextFlush::Finished) }
+      it { expect(tracer.context_flush).to be_a(Datadog::ContextFlush::Finished) }
+    end
 
     context 'with partial flushing' do
+      subject!(:configure) { tracer.configure(options) }
+
       let(:options) { { partial_flush: true } }
 
       it { expect(tracer.context_flush).to be_a(Datadog::ContextFlush::Partial) }
+    end
+
+    context 'with agent_settings' do
+      subject(:configure) { tracer.configure(options) }
+
+      let(:agent_settings) { double('agent_settings') }
+      let(:options) { { agent_settings: agent_settings } }
+
+      it 'creates a new writer using the given agent_settings' do
+        # create writer first, to avoid colliding with the below expectation
+        writer
+
+        expect(Datadog::Writer).to receive(:new).with(hash_including(agent_settings: agent_settings))
+
+        configure
+      end
     end
   end
 

--- a/spec/ddtrace/transport/http_spec.rb
+++ b/spec/ddtrace/transport/http_spec.rb
@@ -45,9 +45,11 @@ RSpec.describe Datadog::Transport::HTTP do
       default.apis.each_value do |api|
         expect(api).to be_a_kind_of(Datadog::Transport::HTTP::API::Instance)
         expect(api.adapter).to be_a_kind_of(Datadog::Transport::HTTP::Adapters::Net)
-        expect(api.adapter.hostname).to eq(Datadog::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS.hostname)
+        expect(api.adapter.hostname).to \
+          eq(Datadog::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS.hostname)
         expect(api.adapter.port).to eq(Datadog::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS.port)
-        expect(api.adapter.timeout).to eq(Datadog::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS.timeout_seconds)
+        expect(api.adapter.timeout).to \
+          eq(Datadog::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS.timeout_seconds)
         expect(api.adapter.ssl).to be(Datadog::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS.ssl)
         expect(api.headers).to include(described_class.default_headers)
       end
@@ -147,7 +149,8 @@ RSpec.describe Datadog::Transport::HTTP do
         let(:deprecated_for_removal_transport_configuration_proc) { proc {} }
 
         it 'calls the deprecated_for_removal_transport_configuration_proc with a transport' do
-          expect(deprecated_for_removal_transport_configuration_proc).to receive(:call).with(an_instance_of(Datadog::Transport::HTTP::Builder))
+          expect(deprecated_for_removal_transport_configuration_proc).to \
+            receive(:call).with(an_instance_of(Datadog::Transport::HTTP::Builder))
 
           default
         end

--- a/spec/ddtrace/transport/http_spec.rb
+++ b/spec/ddtrace/transport/http_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Datadog::Transport::HTTP do
       let(:hostname) { nil }
       let(:port) { nil }
       let(:timeout_seconds) { nil }
-      let(:transport_configuration_proc) { nil }
+      let(:deprecated_for_removal_transport_configuration_proc) { nil }
       let(:deprecated_for_removal_transport_configuration_options) { nil }
 
       let(:agent_settings) {
@@ -72,7 +72,7 @@ RSpec.describe Datadog::Transport::HTTP do
           hostname: hostname,
           port: port,
           timeout_seconds: timeout_seconds,
-          transport_configuration_proc: transport_configuration_proc,
+          deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc,
           deprecated_for_removal_transport_configuration_options: deprecated_for_removal_transport_configuration_options
         )
       }
@@ -143,11 +143,11 @@ RSpec.describe Datadog::Transport::HTTP do
         end
       end
 
-      context 'that specifies a transport_configuration_proc' do
-        let(:transport_configuration_proc) { proc { } }
+      context 'that specifies a deprecated_for_removal_transport_configuration_proc' do
+        let(:deprecated_for_removal_transport_configuration_proc) { proc { } }
 
-        it 'calls the transport_configuration_proc with a transport' do
-          expect(transport_configuration_proc).to receive(:call).with(an_instance_of(Datadog::Transport::HTTP::Builder))
+        it 'calls the deprecated_for_removal_transport_configuration_proc with a transport' do
+          expect(deprecated_for_removal_transport_configuration_proc).to receive(:call).with(an_instance_of(Datadog::Transport::HTTP::Builder))
 
           default
         end

--- a/spec/ddtrace/transport/http_spec.rb
+++ b/spec/ddtrace/transport/http_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Datadog::Transport::HTTP do
       let(:deprecated_for_removal_transport_configuration_proc) { nil }
       let(:deprecated_for_removal_transport_configuration_options) { nil }
 
-      let(:agent_settings) {
+      let(:agent_settings) do
         instance_double(
           Datadog::Configuration::AgentSettingsResolver::AgentSettings,
           ssl: ssl,
@@ -75,7 +75,7 @@ RSpec.describe Datadog::Transport::HTTP do
           deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc,
           deprecated_for_removal_transport_configuration_options: deprecated_for_removal_transport_configuration_options
         )
-      }
+      end
 
       context 'that specifies host, port, timeout and ssl' do
         let(:hostname) { double('hostname') }
@@ -95,7 +95,7 @@ RSpec.describe Datadog::Transport::HTTP do
       end
 
       context 'that specifies an API version' do
-        let(:deprecated_for_removal_transport_configuration_options) { {api_version: api_version} }
+        let(:deprecated_for_removal_transport_configuration_options) { { api_version: api_version } }
 
         context 'that is defined' do
           let(:api_version) { Datadog::Transport::HTTP::API::V2 }
@@ -111,7 +111,7 @@ RSpec.describe Datadog::Transport::HTTP do
 
         context 'when the options also try to set the api_version' do
           let(:api_version) { Datadog::Transport::HTTP::API::V2 }
-          let(:options) { {api_version: Datadog::Transport::HTTP::API::V4} }
+          let(:options) { { api_version: Datadog::Transport::HTTP::API::V4 } }
 
           it 'prioritizes the version in the agent_settings' do
             expect(default.current_api_id).to eq(api_version)
@@ -120,7 +120,7 @@ RSpec.describe Datadog::Transport::HTTP do
       end
 
       context 'that specifies headers' do
-        let(:deprecated_for_removal_transport_configuration_options) { {headers: headers} }
+        let(:deprecated_for_removal_transport_configuration_options) { { headers: headers } }
 
         let(:headers) { { 'Test-Header' => 'foo' } }
 
@@ -132,7 +132,7 @@ RSpec.describe Datadog::Transport::HTTP do
         end
 
         context 'when the options also try to set the headers' do
-          let(:options) { {headers: { 'Some-Other-Test-Header' => 'foo' }} }
+          let(:options) { { headers: { 'Some-Other-Test-Header' => 'foo' } } }
 
           it 'prioritizes the headers in the agent_settings' do
             default.apis.each_value do |api|
@@ -144,7 +144,7 @@ RSpec.describe Datadog::Transport::HTTP do
       end
 
       context 'that specifies a deprecated_for_removal_transport_configuration_proc' do
-        let(:deprecated_for_removal_transport_configuration_proc) { proc { } }
+        let(:deprecated_for_removal_transport_configuration_proc) { proc {} }
 
         it 'calls the deprecated_for_removal_transport_configuration_proc with a transport' do
           expect(deprecated_for_removal_transport_configuration_proc).to receive(:call).with(an_instance_of(Datadog::Transport::HTTP::Builder))

--- a/spec/ddtrace/transport/http_spec.rb
+++ b/spec/ddtrace/transport/http_spec.rb
@@ -232,4 +232,64 @@ RSpec.describe Datadog::Transport::HTTP do
 
     it { is_expected.to be(:net_http) }
   end
+
+  describe '.default_hostname' do
+    subject(:default_hostname) { described_class.default_hostname(logger: logger) }
+
+    let(:logger) { instance_double(Datadog::Logger, warn: nil) }
+
+    before do
+      stub_const(
+        'Datadog::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS',
+        instance_double(Datadog::Configuration::AgentSettingsResolver::AgentSettings, hostname: 'example-hostname')
+      )
+    end
+
+    it 'returns the hostname from the ENVIRONMENT_AGENT_SETTINGS object' do
+      expect(default_hostname).to eq 'example-hostname'
+    end
+
+    it 'logs a deprecation warning' do
+      expect(logger).to receive(:warn).with(/Deprecated/)
+
+      default_hostname
+    end
+  end
+
+  describe '.default_port' do
+    subject(:default_port) { described_class.default_port(logger: logger) }
+
+    let(:logger) { instance_double(Datadog::Logger, warn: nil) }
+
+    before do
+      stub_const(
+        'Datadog::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS',
+        instance_double(Datadog::Configuration::AgentSettingsResolver::AgentSettings, port: 12345)
+      )
+    end
+
+    it 'returns the port from the ENVIRONMENT_AGENT_SETTINGS object' do
+      expect(default_port).to eq 12345
+    end
+
+    it 'logs a deprecation warning' do
+      expect(logger).to receive(:warn).with(/Deprecated/)
+
+      default_port
+    end
+  end
+
+  describe '.default_url' do
+    subject(:default_url) { described_class.default_url(logger: logger) }
+
+    let(:logger) { instance_double(Datadog::Logger, warn: nil) }
+
+    it { is_expected.to be nil }
+
+    it 'logs a deprecation warning' do
+      expect(logger).to receive(:warn).with(/Deprecated/)
+
+      default_url
+    end
+  end
 end

--- a/spec/ddtrace/workers/trace_writer_spec.rb
+++ b/spec/ddtrace/workers/trace_writer_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe Datadog::Workers::TraceWriter do
   let(:options) { {} }
 
   describe '#initialize' do
+    let(:transport) { instance_double(Datadog::Transport::HTTP::Client) }
+
     context 'given :transport' do
       let(:options) { { transport: transport } }
-      let(:transport) { instance_double(Datadog::Transport::HTTP::Client) }
 
       it { expect(writer.transport).to be transport }
     end
@@ -19,59 +20,40 @@ RSpec.describe Datadog::Workers::TraceWriter do
     context 'given :transport_options' do
       let(:options) { { transport_options: transport_options } }
 
-      context 'that is a Hash' do
-        let(:transport_options) { {} }
-        let(:transport) { instance_double(Datadog::Transport::HTTP::Client) }
-
-        before do
-          expect(Datadog::Transport::HTTP).to receive(:default)
-            .with(transport_options)
-            .and_return(transport)
-        end
-
-        it { expect(writer.transport).to be transport }
-      end
-
-      context 'that is a Proc' do
-        let(:transport_options) { proc {} }
-        let(:transport) { instance_double(Datadog::Transport::HTTP::Client) }
-
-        before do
-          expect(Datadog::Transport::HTTP).to receive(:default)
-            .with(on_build: kind_of(Proc))
-            .and_return(transport)
-        end
-
-        it { expect(writer.transport).to be transport }
-      end
-    end
-
-    context 'given :hostname' do
-      let(:options) { { hostname: hostname } }
-      let(:hostname) { double('hostname') }
-      let(:transport) { instance_double(Datadog::Transport::HTTP::Client) }
+      let(:transport_options) { {example_transport_option: true} }
 
       before do
         expect(Datadog::Transport::HTTP).to receive(:default)
-          .with(hostname: hostname)
+          .with(transport_options)
           .and_return(transport)
       end
 
       it { expect(writer.transport).to be transport }
     end
 
-    context 'given :port' do
-      let(:options) { { port: port } }
-      let(:port) { double('port') }
-      let(:transport) { instance_double(Datadog::Transport::HTTP::Client) }
+    context 'given :agent_settings' do
+      let(:options) { {agent_settings: agent_settings} }
+      let(:agent_settings) { double('AgentSettings') }
 
-      before do
-        expect(Datadog::Transport::HTTP).to receive(:default)
-          .with(port: port)
-          .and_return(transport)
+      it 'configures a transport with the agent_settings' do
+        expect(Datadog::Transport::HTTP).to receive(:default).with(agent_settings: agent_settings).and_return(transport)
+
+        expect(writer.transport).to be transport
       end
 
-      it { expect(writer.transport).to be transport }
+      context 'and also :transport_options' do
+        let(:options) { { **super(), transport_options: transport_options } }
+
+        let(:transport_options) { {example_transport_option: true} }
+
+        before do
+          expect(Datadog::Transport::HTTP).to receive(:default)
+            .with(agent_settings: agent_settings, example_transport_option: true)
+            .and_return(transport)
+        end
+
+        it { expect(writer.transport).to be transport }
+      end
     end
   end
 

--- a/spec/ddtrace/workers/trace_writer_spec.rb
+++ b/spec/ddtrace/workers/trace_writer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Datadog::Workers::TraceWriter do
     context 'given :transport_options' do
       let(:options) { { transport_options: transport_options } }
 
-      let(:transport_options) { {example_transport_option: true} }
+      let(:transport_options) { { example_transport_option: true } }
 
       before do
         expect(Datadog::Transport::HTTP).to receive(:default)
@@ -32,7 +32,7 @@ RSpec.describe Datadog::Workers::TraceWriter do
     end
 
     context 'given :agent_settings' do
-      let(:options) { {agent_settings: agent_settings} }
+      let(:options) { { agent_settings: agent_settings } }
       let(:agent_settings) { double('AgentSettings') }
 
       it 'configures a transport with the agent_settings' do
@@ -44,7 +44,7 @@ RSpec.describe Datadog::Workers::TraceWriter do
       context 'and also :transport_options' do
         let(:options) { { **super(), transport_options: transport_options } }
 
-        let(:transport_options) { {example_transport_option: true} }
+        let(:transport_options) { { example_transport_option: true } }
 
         before do
           expect(Datadog::Transport::HTTP).to receive(:default)

--- a/spec/ddtrace/writer_spec.rb
+++ b/spec/ddtrace/writer_spec.rb
@@ -43,6 +43,18 @@ RSpec.describe Datadog::Writer do
             end
           end
         end
+
+        context 'with agent_settings' do
+          let(:agent_settings) { double('AgentSettings') }
+
+          let(:options) { { agent_settings: agent_settings } }
+
+          it 'configures the transport using the agent_settings' do
+            expect(Datadog::Transport::HTTP).to receive(:default).with(agent_settings: agent_settings)
+
+            writer
+          end
+        end
       end
 
       describe '#send_spans' do


### PR DESCRIPTION
After getting reports from two customers that had tracing working, but no profiles, I discovered those customers were running into issues because they had the agent settings configured via code.

Currently, if you configure your agent via the `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` environment variables, these settings are shared by both the tracer as well as the profiler. So for such a customer, adding the profiler would be as easy as enabling it + adding any needed dependencies.

BUT, if you configure your agent using code, e.g.

```ruby
Datadog.configure { |c| c.tracer.hostname = 'some-hostname' }
```

then as the code hints at, this setting is ONLY for the tracer. In such a case, customers would need to also provide separate configuration for the profiler as well (currently something like `c.profiling.exporter.transport_options = {hostname: 'home-hostname'}`).

I want to avoid this confusion, and make it so that:
1. You only need to configure the agent once
2. If you have a correctly-configured tracer, you can just enable profiler and it will be correctly configured as well

This PR is the first step toward these goals:
* It reimplements the many ways in which the agent can be configured (different environment variables, via code, via a proc, etc etc) and puts all that logic in a single file, with heavy test coverage.
    * _This logic is quite complex, which reflects the complexity that was hidden in the codebase and spread out among many files. This class aims to replicate the existing behavior without yet changing anything, although it's obvious that this is ripe for further simplification._
* It then removes the very spread out among the codebase bits of code that were implementing this logic previously **FOR the tracer**, and makes sure that an instance of `AgentSettings` is carried around from component configuration to the actual adapter configuration.

Thus the result is that the tracer configuration is now done directly from the `AgentSettings` centralized object.

Because this is already quite a big change, this PR is only an enabler for the next steps; I ask that you consider that while reviewing, and especially consider if improvements (of which I think we all can see many) can be done in separate, incremental steps. Otherwise, I fear that we may end up with an even bigger change that will be scarier to apply.

My plans for the next steps (after this is merged are):
* Make profiler use `AgentSettings`. Right now only the tracer does it.
* Propose a toplevel `Datadog.configure { |c| c.agent_hostname = 'some-hostname' }` and deprecate (some?) tracer-level settings, to reflect that these are now shared.

Thanks for reading this far. Hopefully this change is reasonable :)

P.s.: I was slightly opinionated on `deprecated_for_removal_transport_configuration_options` and `deprecated_for_removal_transport_configuration_proc`. This is because I want to highlight that they are problematic and should be replaced by regular settings that then show up top-level in the `AgentSettings` object. Note that these two names are internal, and thus never show up for customers, but allow us to not forget that we need to improve these bits as well.