### PR TITLE
Avoid immediately reporting profile after start (alternative to #1462)

### DIFF
--- a/lib/ddtrace/profiling/scheduler.rb
+++ b/lib/ddtrace/profiling/scheduler.rb
@@ -5,13 +5,13 @@ require 'ddtrace/workers/polling'
 
 module Datadog
   module Profiling
-    # Periodically (every DEFAULT_INTERVAL seconds) takes data from the `Recorder` and pushes them to all configured
+    # Periodically (every DEFAULT_INTERVAL_SECONDS) takes data from the `Recorder` and pushes them to all configured
     # `Exporter`s. Runs on its own background thread.
     class Scheduler < Worker
       include Workers::Polling
 
-      DEFAULT_INTERVAL = 60
-      MIN_INTERVAL = 0
+      DEFAULT_INTERVAL_SECONDS = 60
+      MIN_INTERVAL_SECONDS = 0
 
       attr_reader \
         :exporters,
@@ -26,7 +26,7 @@ module Datadog
         self.fork_policy = options[:fork_policy] || Workers::Async::Thread::FORK_POLICY_RESTART
 
         # Workers::IntervalLoop settings
-        self.loop_base_interval = options[:interval] || DEFAULT_INTERVAL
+        self.loop_base_interval = options[:interval] || DEFAULT_INTERVAL_SECONDS
 
         # Workers::Polling settings
         self.enabled = options.key?(:enabled) ? options[:enabled] == true : true
@@ -60,7 +60,7 @@ module Datadog
 
         # Update wait time to try to wake consistently on time.
         # Don't drop below the minimum interval.
-        self.loop_wait_time = [loop_base_interval - run_time, MIN_INTERVAL].max
+        self.loop_wait_time = [loop_base_interval - run_time, MIN_INTERVAL_SECONDS].max
       end
 
       def flush_events

--- a/lib/ddtrace/profiling/scheduler.rb
+++ b/lib/ddtrace/profiling/scheduler.rb
@@ -17,19 +17,24 @@ module Datadog
         :exporters,
         :recorder
 
-      def initialize(recorder, exporters, options = {})
+      def initialize(
+        recorder,
+        exporters,
+        fork_policy: Workers::Async::Thread::FORK_POLICY_RESTART, # Restart in forks by default
+        interval: DEFAULT_INTERVAL_SECONDS,
+        enabled: true
+      )
         @recorder = recorder
         @exporters = [exporters].flatten
 
         # Workers::Async::Thread settings
-        # Restart in forks by default
-        self.fork_policy = options[:fork_policy] || Workers::Async::Thread::FORK_POLICY_RESTART
+        self.fork_policy = fork_policy
 
         # Workers::IntervalLoop settings
-        self.loop_base_interval = options[:interval] || DEFAULT_INTERVAL_SECONDS
+        self.loop_base_interval = interval
 
         # Workers::Polling settings
-        self.enabled = options.key?(:enabled) ? options[:enabled] == true : true
+        self.enabled = enabled
       end
 
       def start

--- a/lib/ddtrace/profiling/scheduler.rb
+++ b/lib/ddtrace/profiling/scheduler.rb
@@ -20,12 +20,15 @@ module Datadog
       def initialize(
         recorder,
         exporters,
+        # Should we flush immediately on the next call to flush_events, or loop/sleep at least once before doing it?
+        skip_next_flush: true,
         fork_policy: Workers::Async::Thread::FORK_POLICY_RESTART, # Restart in forks by default
         interval: DEFAULT_INTERVAL_SECONDS,
         enabled: true
       )
         @recorder = recorder
         @exporters = [exporters].flatten
+        @skip_next_flush = skip_next_flush
 
         # Workers::Async::Thread settings
         self.fork_policy = fork_policy
@@ -54,6 +57,9 @@ module Datadog
         # Objects from parent process will copy-on-write,
         # and we don't want to send events for the wrong process.
         recorder.flush
+
+        # Force loop/sleep before next report
+        @skip_next_flush = true
       end
 
       private
@@ -69,6 +75,14 @@ module Datadog
       end
 
       def flush_events
+        # When a scheduler gets created (or reset), we don't want it to immediately try to flush; we want it to wait for
+        # the loop wait time first. This avoids an issue where the scheduler reported a mostly-empty profile if the
+        # application just started but this thread took a bit longer so there's already samples in the recorder.
+        if skip_next_flush?
+          @skip_next_flush = false
+          return
+        end
+
         # Get events from recorder
         flush = recorder.flush
 
@@ -86,6 +100,10 @@ module Datadog
         end
 
         flush
+      end
+
+      def skip_next_flush?
+        @skip_next_flush
       end
     end
   end

--- a/lib/ddtrace/profiling/scheduler.rb
+++ b/lib/ddtrace/profiling/scheduler.rb
@@ -71,8 +71,9 @@ module Datadog
             begin
               exporter.export(flush)
             rescue StandardError => e
-              error_details = "Cause: #{e} Location: #{e.backtrace.first}"
-              Datadog.logger.error("Unable to export #{flush.event_count} profiling events. #{error_details}")
+              Datadog.logger.error(
+                "Unable to export #{flush.event_count} profiling events. Cause: #{e} Location: #{e.backtrace.first}"
+              )
             end
           end
         end

--- a/lib/ddtrace/profiling/scheduler.rb
+++ b/lib/ddtrace/profiling/scheduler.rb
@@ -51,6 +51,8 @@ module Datadog
         recorder.flush
       end
 
+      private
+
       def flush_and_wait
         run_time = Datadog::Utils::Time.measure do
           flush_events

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'profiling integration test' do
     it 'produces a profile' do
       expect(out).to receive(:puts)
       collector.collect_events
-      scheduler.flush_events
+      scheduler.send(:flush_events)
     end
   end
 
@@ -106,7 +106,7 @@ RSpec.describe 'profiling integration test' do
 
             expect(out).to receive(:puts)
             collector.collect_events
-            scheduler.flush_events
+            scheduler.send(:flush_events)
           end
         end
       end

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe 'profiling integration test' do
       Datadog::Profiling::Scheduler.new(
         recorder,
         exporter,
+        skip_next_flush: false,
         enabled: true
       )
     end

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe 'profiling integration test' do
       Datadog::Profiling::Scheduler.new(
         recorder,
         exporter,
-        skip_next_flush: false,
         enabled: true
       )
     end

--- a/spec/ddtrace/profiling/scheduler_spec.rb
+++ b/spec/ddtrace/profiling/scheduler_spec.rb
@@ -5,7 +5,7 @@ require 'ddtrace/profiling/recorder'
 require 'ddtrace/profiling/scheduler'
 
 RSpec.describe Datadog::Profiling::Scheduler do
-  subject(:scheduler) { described_class.new(recorder, exporters, options) }
+  subject(:scheduler) { described_class.new(recorder, exporters, **options) }
 
   let(:recorder) { instance_double(Datadog::Profiling::Recorder) }
   let(:exporters) { [instance_double(Datadog::Profiling::Exporter)] }
@@ -126,7 +126,7 @@ RSpec.describe Datadog::Profiling::Scheduler do
     end
 
     context 'when the flush takes longer than an interval' do
-      let(:options) { { interval: 0.01 } }
+      let(:options) { {**super(), interval: 0.01 } }
 
       # Assert that the interval isn't set below the min interval
       it "floors the wait interval to #{described_class::MIN_INTERVAL_SECONDS}" do

--- a/spec/ddtrace/profiling/scheduler_spec.rb
+++ b/spec/ddtrace/profiling/scheduler_spec.rb
@@ -143,31 +143,31 @@ RSpec.describe Datadog::Profiling::Scheduler do
 
     let(:flush) { instance_double(Datadog::Profiling::Flush, event_count: event_count) }
 
-    before do
-      expect(recorder).to receive(:flush).and_return(flush)
-      exporters.each { |exporter| allow(exporter).to receive(:export) }
-    end
 
     context 'when no events are available' do
       let(:event_count) { 0 }
 
-      it 'does not export' do
-        is_expected.to be flush
+      before { expect(recorder).to receive(:flush).and_return(flush) }
 
+      it 'does not export' do
         exporters.each do |exporter|
-          expect(exporter).to_not have_received(:export)
+          expect(exporter).to_not receive(:export)
         end
+
+        is_expected.to be flush
       end
     end
 
     context 'when events are available' do
       let(:event_count) { 4 }
 
+      before { expect(recorder).to receive(:flush).and_return(flush) }
+
       context 'and all the exporters succeed' do
         it 'returns the flush' do
-          is_expected.to be flush
+          expect(exporters).to all(receive(:export).with(flush))
 
-          expect(exporters).to all(have_received(:export).with(flush))
+          is_expected.to be flush
         end
       end
 

--- a/spec/ddtrace/profiling/scheduler_spec.rb
+++ b/spec/ddtrace/profiling/scheduler_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Datadog::Profiling::Scheduler do
         enabled?: true,
         exporters: exporters,
         fork_policy: Datadog::Workers::Async::Thread::FORK_POLICY_RESTART,
-        loop_base_interval: described_class::DEFAULT_INTERVAL,
+        loop_base_interval: described_class::DEFAULT_INTERVAL_SECONDS,
         recorder: recorder
       )
     end
@@ -118,7 +118,7 @@ RSpec.describe Datadog::Profiling::Scheduler do
 
     it 'changes its wait interval after flushing' do
       expect(scheduler).to receive(:loop_wait_time=) do |value|
-        expected_interval = described_class::DEFAULT_INTERVAL - flush_time
+        expected_interval = described_class::DEFAULT_INTERVAL_SECONDS - flush_time
         expect(value).to be <= expected_interval
       end
 
@@ -129,9 +129,9 @@ RSpec.describe Datadog::Profiling::Scheduler do
       let(:options) { { interval: 0.01 } }
 
       # Assert that the interval isn't set below the min interval
-      it "floors the wait interval to #{described_class::MIN_INTERVAL}" do
+      it "floors the wait interval to #{described_class::MIN_INTERVAL_SECONDS}" do
         expect(scheduler).to receive(:loop_wait_time=)
-          .with(described_class::MIN_INTERVAL)
+          .with(described_class::MIN_INTERVAL_SECONDS)
 
         flush_and_wait
       end

--- a/spec/ddtrace/profiling/scheduler_spec.rb
+++ b/spec/ddtrace/profiling/scheduler_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Datadog::Profiling::Scheduler do
   end
 
   describe '#flush_and_wait' do
-    subject(:flush_and_wait) { scheduler.flush_and_wait }
+    subject(:flush_and_wait) { scheduler.send(:flush_and_wait) }
 
     let(:flush_time) { 0.05 }
 
@@ -139,7 +139,7 @@ RSpec.describe Datadog::Profiling::Scheduler do
   end
 
   describe '#flush_events' do
-    subject(:flush_events) { scheduler.flush_events }
+    subject(:flush_events) { scheduler.send(:flush_events) }
 
     let(:flush) { instance_double(Datadog::Profiling::Flush, event_count: event_count) }
 


### PR DESCRIPTION
Note: _This PR is an alternative to #1462. I think both approaches are reasonable and solve the issue, although having done this one, I think I like it a bit more than the other. On the other hand, the other only modifies the one specific profiling class where we need this behavior, whereas this one modifies a core class to add a behavior that effectively has a single customer right now. Hence, I opened a separate PR so that it's easy to compare both approaches and pick one._

When a scheduler starts, it immediately tries to report a profile, which is incorrect, because there's nothing to profile yet.

In most cases, we avoided this incorrect report because we checked if the recorder had anything to report, and skipped it whenever the recorder was empty.

BUT, ever so often, and because both the scheduler and the collectors are executed in background threads and started at the same time, the collectors may have already left something in the recorder, leading the scheduler to report an almost-empty profile, which is really confusing when looking at individual profiles (e.g. outside the aggregation page).

To fix this, I've added a new callback to `IntervalLoop` -- `loop_wait_before_first_iteration?`  that allows its users to control if when `perform` gets called the task runs immediately or if it waits before actually starting the executions.