### PR TITLE
Fix CGroup parsing for non-containerized environment.

### DIFF
--- a/lib/ddtrace/runtime/container.rb
+++ b/lib/ddtrace/runtime/container.rb
@@ -49,10 +49,11 @@ module Datadog
               container_id, task_uid = nil
 
               case parts.length
+              when 0..1
+                next
               when 2
                 container_id = parts[-1][CONTAINER_REGEX] || parts[-1][FARGATE_14_CONTAINER_REGEX]
               else
-                platform = parts[0]
                 container_id = parts[-1][CONTAINER_REGEX]
                 task_uid = parts[-2][POD_REGEX]
               end

--- a/spec/ddtrace/runtime/container_spec.rb
+++ b/spec/ddtrace/runtime/container_spec.rb
@@ -12,83 +12,71 @@ RSpec.describe Datadog::Runtime::Container do
       described_class.instance_variable_set(:@descriptor, nil)
     end
 
-    context 'when not in a containerized environment' do
-      include_context 'non-containerized environment'
+    shared_examples_for 'container descriptor' do
+      before { expect(Datadog.logger).to_not receive(:error) }
 
       it do
         is_expected.to be_a_kind_of(described_class::Descriptor)
         is_expected.to have_attributes(
-          platform: nil,
-          container_id: nil,
-          task_uid: nil
+          platform: platform,
+          container_id: container_id,
+          task_uid: task_uid
         )
+      end
+    end
+
+    context 'when in a non-containerized environment' do
+      include_context 'non-containerized environment'
+
+      it_behaves_like 'container descriptor' do
+        let(:platform) { nil }
+        let(:container_id) { nil }
+        let(:task_uid) { nil }
       end
     end
 
     context 'when in a Docker environment' do
       include_context 'Docker environment'
 
-      it do
-        is_expected.to be_a_kind_of(described_class::Descriptor)
-        is_expected.to have_attributes(
-          platform: 'docker',
-          container_id: container_id,
-          task_uid: nil
-        )
+      it_behaves_like 'container descriptor' do
+        let(:platform) { 'docker' }
+        let(:task_uid) { nil }
       end
     end
 
     context 'when in a Kubernetes environment' do
       include_context 'Kubernetes environment'
 
-      it do
-        is_expected.to be_a_kind_of(described_class::Descriptor)
-        is_expected.to have_attributes(
-          platform: 'kubepods',
-          container_id: container_id,
-          task_uid: pod_id
-        )
+      it_behaves_like 'container descriptor' do
+        let(:platform) { 'kubepods' }
+        let(:task_uid) { pod_id }
       end
     end
 
     context 'when in a ECS environment' do
       include_context 'ECS environment'
 
-      it do
-        is_expected.to be_a_kind_of(described_class::Descriptor)
-        is_expected.to have_attributes(
-          platform: 'ecs',
-          container_id: container_id,
-          task_uid: task_arn
-        )
+      it_behaves_like 'container descriptor' do
+        let(:platform) { 'ecs' }
+        let(:task_uid) { task_arn }
       end
     end
 
     context 'when in a Fargate 1.3- environment' do
       include_context 'Fargate 1.3- environment'
 
-      it do
-        is_expected.to be_a_kind_of(described_class::Descriptor)
-        is_expected.to have_attributes(
-          platform: 'ecs',
-          container_id: container_id,
-          task_uid: task_arn
-        )
+      it_behaves_like 'container descriptor' do
+        let(:platform) { 'ecs' }
+        let(:task_uid) { task_arn }
       end
     end
 
     context 'when in a Fargate 1.4+ environment' do
       include_context 'Fargate 1.4+ environment'
 
-      it do
-        # allow(File).to receive(:exist?)
-
-        is_expected.to be_a_kind_of(described_class::Descriptor)
-        is_expected.to have_attributes(
-          platform: 'ecs',
-          container_id: container_id,
-          task_uid: nil
-        )
+      it_behaves_like 'container descriptor' do
+        let(:platform) { 'ecs' }
+        let(:task_uid) { nil }
       end
     end
   end


### PR DESCRIPTION
Fixes #1475 

Our container parsing code was raising an error when encountering cgroup paths that weren't in containerized environments; although the defensive measure in place was working as intended, this pull request prevents that error and makes CI assert no such error is raised.