### PR TITLE
Fix flaky test in cthread_spec.rb

### DIFF
--- a/spec/ddtrace/profiling/ext/cthread_spec.rb
+++ b/spec/ddtrace/profiling/ext/cthread_spec.rb
@@ -278,7 +278,7 @@ if Datadog::Profiling::Ext::CPU.supported?
 
           with_profiling_extensions_in_fork(
             fork_expectations: proc do |status, stderr|
-              expect(Signal.signame(status.termsig)).to eq 'ABRT'
+              expect(Signal.signame(status.termsig)).to eq('SEGV').or eq('ABRT')
               expect(stderr).to include('[BUG] Segmentation fault')
             end
           ) do


### PR DESCRIPTION
It seems that sometimes the signal can also be SEGV, not just ABRT, see
<https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/3305/workflows/79cd1d5d-75a2-410e-b91a-1634ed39c6f5/jobs/131082>.

So let's extend this test to avoid flakiness.