### PR TITLE
Fix container parsing for k8s cgroup

### DIFF
--- a/lib/ddtrace/runtime/container.rb
+++ b/lib/ddtrace/runtime/container.rb
@@ -58,8 +58,11 @@ module Datadog
                 container_id = parts[-1][CONTAINER_REGEX, :container] \
                                || parts[-1][FARGATE_14_CONTAINER_REGEX, :container]
               else
-                container_id = parts[-1][CONTAINER_REGEX, :container]
-                task_uid = parts[-2][POD_REGEX, :pod]
+                if (container_id = parts[-1][CONTAINER_REGEX, :container])
+                  task_uid = parts[-2][POD_REGEX, :pod]
+                else
+                  container_id = parts[-1][FARGATE_14_CONTAINER_REGEX, :container]
+                end
               end
 
               # If container ID wasn't found, ignore.

--- a/spec/ddtrace/runtime/cgroup_spec.rb
+++ b/spec/ddtrace/runtime/cgroup_spec.rb
@@ -122,6 +122,16 @@ RSpec.describe Datadog::Runtime::Cgroup do
           is_expected.to include(be_a_kind_of(described_class::Descriptor))
         end
       end
+
+      context 'in a Fargate 1.4+ (2-part) environment' do
+        include_context 'Fargate 1.4+ (2-part) environment'
+
+        it do
+          is_expected.to be_a_kind_of(Array)
+          is_expected.to have(11).items
+          is_expected.to include(be_a_kind_of(described_class::Descriptor))
+        end
+      end
     end
   end
 
@@ -274,6 +284,21 @@ RSpec.describe Datadog::Runtime::Cgroup do
             id: '1',
             groups: 'name=systemd',
             path: '/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890',
+            controllers: ['name=systemd']
+          )
+        end
+      end
+
+      context 'in Fargate format 1.4+ (2-part)' do
+        let(:line) { '1:name=systemd:/ecs/34dc0b5e626f2c5c4c5170e34b10e765/34dc0b5e626f2c5c4c5170e34b10e765-1234567890' }
+
+        it { is_expected.to be_a_kind_of(described_class::Descriptor) }
+
+        it do
+          is_expected.to have_attributes(
+            id: '1',
+            groups: 'name=systemd',
+            path: '/ecs/34dc0b5e626f2c5c4c5170e34b10e765/34dc0b5e626f2c5c4c5170e34b10e765-1234567890',
             controllers: ['name=systemd']
           )
         end

--- a/spec/ddtrace/runtime/cgroup_spec.rb
+++ b/spec/ddtrace/runtime/cgroup_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe Datadog::Runtime::Cgroup do
         end
       end
 
+      context 'in a non-containerized environment with VTE' do
+        include_context 'non-containerized environment with VTE'
+
+        it do
+          is_expected.to be_a_kind_of(Array)
+          is_expected.to have(13).items
+          is_expected.to include(be_a_kind_of(described_class::Descriptor))
+        end
+      end
+
       context 'in a Docker environment' do
         include_context 'Docker environment'
 

--- a/spec/ddtrace/runtime/cgroup_spec.rb
+++ b/spec/ddtrace/runtime/cgroup_spec.rb
@@ -73,6 +73,16 @@ RSpec.describe Datadog::Runtime::Cgroup do
         end
       end
 
+      context 'in a Kubernetes burstable environment' do
+        include_context 'Kubernetes burstable environment'
+
+        it do
+          is_expected.to be_a_kind_of(Array)
+          is_expected.to have(11).items
+          is_expected.to include(be_a_kind_of(described_class::Descriptor))
+        end
+      end
+
       context 'in an ECS environment' do
         include_context 'ECS environment'
 

--- a/spec/ddtrace/runtime/container_spec.rb
+++ b/spec/ddtrace/runtime/container_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Datadog::Runtime::Container do
       include_context 'non-containerized environment'
 
       it_behaves_like 'container descriptor' do
-        let(:platform) { nil }
         let(:container_id) { nil }
         let(:task_uid) { nil }
       end
@@ -39,8 +38,15 @@ RSpec.describe Datadog::Runtime::Container do
       include_context 'Docker environment'
 
       it_behaves_like 'container descriptor' do
-        let(:platform) { 'docker' }
         let(:task_uid) { nil }
+      end
+    end
+
+    context 'when in a Kubernetes burstable environment' do
+      include_context 'Kubernetes burstable environment'
+
+      it_behaves_like 'container descriptor' do
+        let(:task_uid) { pod_id }
       end
     end
 
@@ -48,7 +54,6 @@ RSpec.describe Datadog::Runtime::Container do
       include_context 'Kubernetes environment'
 
       it_behaves_like 'container descriptor' do
-        let(:platform) { 'kubepods' }
         let(:task_uid) { pod_id }
       end
     end
@@ -57,7 +62,6 @@ RSpec.describe Datadog::Runtime::Container do
       include_context 'ECS environment'
 
       it_behaves_like 'container descriptor' do
-        let(:platform) { 'ecs' }
         let(:task_uid) { task_arn }
       end
     end
@@ -66,7 +70,6 @@ RSpec.describe Datadog::Runtime::Container do
       include_context 'Fargate 1.3- environment'
 
       it_behaves_like 'container descriptor' do
-        let(:platform) { 'ecs' }
         let(:task_uid) { task_arn }
       end
     end
@@ -75,7 +78,6 @@ RSpec.describe Datadog::Runtime::Container do
       include_context 'Fargate 1.4+ environment'
 
       it_behaves_like 'container descriptor' do
-        let(:platform) { 'ecs' }
         let(:task_uid) { nil }
       end
     end

--- a/spec/ddtrace/runtime/container_spec.rb
+++ b/spec/ddtrace/runtime/container_spec.rb
@@ -87,6 +87,16 @@ RSpec.describe Datadog::Runtime::Container do
       include_context 'Fargate 1.4+ environment'
 
       it_behaves_like 'container descriptor' do
+        let(:container_id) { container_id_with_random }
+        let(:task_uid) { nil }
+      end
+    end
+
+    context 'when in a Fargate 1.4+ (2-part) environment' do
+      include_context 'Fargate 1.4+ (2-part) environment'
+
+      it_behaves_like 'container descriptor' do
+        let(:container_id) { container_id_with_random }
         let(:task_uid) { nil }
       end
     end

--- a/spec/ddtrace/runtime/container_spec.rb
+++ b/spec/ddtrace/runtime/container_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe Datadog::Runtime::Container do
       end
     end
 
+    context 'when in a non-containerized environment with VTE' do
+      include_context 'non-containerized environment with VTE'
+
+      it_behaves_like 'container descriptor' do
+        let(:container_id) { terminal_id }
+        let(:task_uid) { nil }
+      end
+    end
+
     context 'when in a Docker environment' do
       include_context 'Docker environment'
 

--- a/spec/support/container_helpers.rb
+++ b/spec/support/container_helpers.rb
@@ -30,6 +30,7 @@ module ContainerHelpers
     include_context 'cgroup file'
 
     let(:platform) { nil }
+
     before do
       cgroup_file.puts '12:hugetlb:/'
       cgroup_file.puts '11:devices:/user.slice'
@@ -44,6 +45,30 @@ module ContainerHelpers
       cgroup_file.puts '2:net_cls,net_prio:/'
       cgroup_file.puts '1:name=systemd:/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service'
       cgroup_file.puts '0::/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service'
+      cgroup_file.rewind
+    end
+  end
+
+  shared_context 'non-containerized environment with VTE' do
+    include_context 'cgroup file'
+
+    let(:platform) { 'user' }
+    let(:terminal_id) { '6fec48c4-1f82-4313-a1c2-29e205a96958' }
+
+    before do
+      cgroup_file.puts '12:hugetlb:/'
+      cgroup_file.puts "11:devices:/#{platform}.slice"
+      cgroup_file.puts "10:pids:/#{platform}.slice/user-1000.slice/user@1000.service"
+      cgroup_file.puts "9:memory:/#{platform}.slice"
+      cgroup_file.puts '8:cpuset:/'
+      cgroup_file.puts '7:rdma:/'
+      cgroup_file.puts '6:freezer:/'
+      cgroup_file.puts '5:perf_event:/'
+      cgroup_file.puts "4:cpu,cpuacct:/#{platform}.slice"
+      cgroup_file.puts "3:blkio:/#{platform}.slice"
+      cgroup_file.puts '2:net_cls,net_prio:/'
+      cgroup_file.puts "1:name=systemd:/#{platform}.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service"
+      cgroup_file.puts "0::/#{platform}.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-#{terminal_id}.scope"
       cgroup_file.rewind
     end
   end

--- a/spec/support/container_helpers.rb
+++ b/spec/support/container_helpers.rb
@@ -10,9 +10,13 @@ module ContainerHelpers
     let(:cgroup_file) { StringIO.new }
 
     before do
+      allow(File).to receive(:exist?).and_call_original
+
       expect(File).to receive(:exist?)
         .with('/proc/self/cgroup')
         .and_return(true)
+
+      allow(File).to receive(:foreach).and_call_original
 
       allow(File).to receive(:foreach)
         .with('/proc/self/cgroup') do |&block|
@@ -21,9 +25,11 @@ module ContainerHelpers
     end
   end
 
+  # rubocop:disable Layout/LineLength
   shared_context 'non-containerized environment' do
     include_context 'cgroup file'
 
+    let(:platform) { nil }
     before do
       cgroup_file.puts '12:hugetlb:/'
       cgroup_file.puts '11:devices:/user.slice'
@@ -45,22 +51,23 @@ module ContainerHelpers
   shared_context 'Docker environment' do
     include_context 'cgroup file'
 
+    let(:platform) { 'docker' }
     let(:container_id) { '3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860' }
 
     before do
-      cgroup_file.puts "13:name=systemd:/docker/#{container_id}"
-      cgroup_file.puts "12:pids:/docker/#{container_id}"
-      cgroup_file.puts "11:hugetlb:/docker/#{container_id}"
-      cgroup_file.puts "10:net_prio:/docker/#{container_id}"
-      cgroup_file.puts "9:perf_event:/docker/#{container_id}"
-      cgroup_file.puts "8:net_cls:/docker/#{container_id}"
-      cgroup_file.puts "7:freezer:/docker/#{container_id}"
-      cgroup_file.puts "6:devices:/docker/#{container_id}"
-      cgroup_file.puts "5:memory:/docker/#{container_id}"
-      cgroup_file.puts "4:blkio:/docker/#{container_id}"
-      cgroup_file.puts "3:cpuacct:/docker/#{container_id}"
-      cgroup_file.puts "2:cpu:/docker/#{container_id}"
-      cgroup_file.puts "1:cpuset:/docker/#{container_id}"
+      cgroup_file.puts "13:name=systemd:/#{platform}/#{container_id}"
+      cgroup_file.puts "12:pids:/#{platform}/#{container_id}"
+      cgroup_file.puts "11:hugetlb:/#{platform}/#{container_id}"
+      cgroup_file.puts "10:net_prio:/#{platform}/#{container_id}"
+      cgroup_file.puts "9:perf_event:/#{platform}/#{container_id}"
+      cgroup_file.puts "8:net_cls:/#{platform}/#{container_id}"
+      cgroup_file.puts "7:freezer:/#{platform}/#{container_id}"
+      cgroup_file.puts "6:devices:/#{platform}/#{container_id}"
+      cgroup_file.puts "5:memory:/#{platform}/#{container_id}"
+      cgroup_file.puts "4:blkio:/#{platform}/#{container_id}"
+      cgroup_file.puts "3:cpuacct:/#{platform}/#{container_id}"
+      cgroup_file.puts "2:cpu:/#{platform}/#{container_id}"
+      cgroup_file.puts "1:cpuset:/#{platform}/#{container_id}"
       cgroup_file.rewind
     end
   end
@@ -68,21 +75,45 @@ module ContainerHelpers
   shared_context 'Kubernetes environment' do
     include_context 'cgroup file'
 
+    let(:platform) { 'kubepods' }
     let(:container_id) { '3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1' }
     let(:pod_id) { 'pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a' }
 
     before do
-      cgroup_file.puts "11:perf_event:/kubepods/besteffort/#{pod_id}/#{container_id}"
-      cgroup_file.puts "10:pids:/kubepods/besteffort/#{pod_id}/#{container_id}"
-      cgroup_file.puts "9:memory:/kubepods/besteffort/#{pod_id}/#{container_id}"
-      cgroup_file.puts "8:cpu,cpuacct:/kubepods/besteffort/#{pod_id}/#{container_id}"
-      cgroup_file.puts "7:blkio:/kubepods/besteffort/#{pod_id}/#{container_id}"
-      cgroup_file.puts "6:cpuset:/kubepods/besteffort/#{pod_id}/#{container_id}"
-      cgroup_file.puts "5:devices:/kubepods/besteffort/#{pod_id}/#{container_id}"
-      cgroup_file.puts "4:freezer:/kubepods/besteffort/#{pod_id}/#{container_id}"
-      cgroup_file.puts "3:net_cls,net_prio:/kubepods/besteffort/#{pod_id}/#{container_id}"
-      cgroup_file.puts "2:hugetlb:/kubepods/besteffort/#{pod_id}/#{container_id}"
-      cgroup_file.puts "1:name=systemd:/kubepods/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "11:perf_event:/#{platform}/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "10:pids:/#{platform}/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "9:memory:/#{platform}/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "8:cpu,cpuacct:/#{platform}/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "7:blkio:/#{platform}/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "6:cpuset:/#{platform}/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "5:devices:/#{platform}/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "4:freezer:/#{platform}/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "3:net_cls,net_prio:/#{platform}/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "2:hugetlb:/#{platform}/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.puts "1:name=systemd:/#{platform}/besteffort/#{pod_id}/#{container_id}"
+      cgroup_file.rewind
+    end
+  end
+
+  shared_context 'Kubernetes burstable environment' do
+    include_context 'cgroup file'
+
+    let(:platform) { 'kubepods' }
+    let(:container_id) { '7b8952daecf4c0e44bbcefe1b5c5ebc7b4839d4eefeccefe694709d3809b6199' }
+    let(:pod_id) { 'pod2d3da189_6407_48e3_9ab6_78188d75e609' }
+
+    before do
+      cgroup_file.puts "11:perf_event:/#{platform}.slice/kubepods-burstable.slice/kubepods-burstable-#{pod_id}.slice/docker-#{container_id}.scope"
+      cgroup_file.puts "10:pids:/#{platform}.slice/kubepods-burstable.slice/kubepods-burstable-#{pod_id}.slice/docker-#{container_id}.scope"
+      cgroup_file.puts "9:memory:/#{platform}.slice/kubepods-burstable.slice/kubepods-burstable-#{pod_id}.slice/docker-#{container_id}.scope"
+      cgroup_file.puts "8:cpu,cpuacct:/#{platform}.slice/kubepods-burstable.slice/kubepods-burstable-#{pod_id}.slice/docker-#{container_id}.scope"
+      cgroup_file.puts "7:blkio:/#{platform}.slice/kubepods-burstable.slice/kubepods-burstable-#{pod_id}.slice/docker-#{container_id}.scope"
+      cgroup_file.puts "6:cpuset:/#{platform}.slice/kubepods-burstable.slice/kubepods-burstable-#{pod_id}.slice/docker-#{container_id}.scope"
+      cgroup_file.puts "5:devices:/#{platform}.slice/kubepods-burstable.slice/kubepods-burstable-#{pod_id}.slice/docker-#{container_id}.scope"
+      cgroup_file.puts "4:freezer:/#{platform}.slice/kubepods-burstable.slice/kubepods-burstable-#{pod_id}.slice/docker-#{container_id}.scope"
+      cgroup_file.puts "3:net_cls,net_prio:/#{platform}.slice/kubepods-burstable.slice/kubepods-burstable-#{pod_id}.slice/docker-#{container_id}.scope"
+      cgroup_file.puts "2:hugetlb:/#{platform}.slice/kubepods-burstable.slice/kubepods-burstable-#{pod_id}.slice/docker-#{container_id}.scope"
+      cgroup_file.puts "1:name=systemd:/#{platform}.slice/kubepods-burstable.slice/kubepods-burstable-#{pod_id}.slice/docker-#{container_id}.scope"
       cgroup_file.rewind
     end
   end
@@ -90,19 +121,20 @@ module ContainerHelpers
   shared_context 'ECS environment' do
     include_context 'cgroup file'
 
+    let(:platform) { 'ecs' }
     let(:container_id) { '38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce' }
     let(:task_arn) { '5a0d5ceddf6c44c1928d367a815d890f' }
 
     before do
-      cgroup_file.puts "9:perf_event:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
-      cgroup_file.puts "8:memory:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
-      cgroup_file.puts "7:hugetlb:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
-      cgroup_file.puts "6:freezer:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
-      cgroup_file.puts "5:devices:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
-      cgroup_file.puts "4:cpuset:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
-      cgroup_file.puts "3:cpuacct:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
-      cgroup_file.puts "2:cpu:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
-      cgroup_file.puts "1:blkio:/ecs/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "9:perf_event:/#{platform}/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "8:memory:/#{platform}/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "7:hugetlb:/#{platform}/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "6:freezer:/#{platform}/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "5:devices:/#{platform}/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "4:cpuset:/#{platform}/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "3:cpuacct:/#{platform}/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "2:cpu:/#{platform}/haissam-ecs-classic/#{task_arn}/#{container_id}"
+      cgroup_file.puts "1:blkio:/#{platform}/haissam-ecs-classic/#{task_arn}/#{container_id}"
       cgroup_file.rewind
     end
   end
@@ -110,21 +142,22 @@ module ContainerHelpers
   shared_context 'Fargate 1.3- environment' do
     include_context 'cgroup file'
 
+    let(:platform) { 'ecs' }
     let(:container_id) { '432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da' }
     let(:task_arn) { '55091c13-b8cf-4801-b527-f4601742204d' }
 
     before do
-      cgroup_file.puts "11:hugetlb:/ecs/#{task_arn}/#{container_id}"
-      cgroup_file.puts "10:pids:/ecs/#{task_arn}/#{container_id}"
-      cgroup_file.puts "9:cpuset:/ecs/#{task_arn}/#{container_id}"
-      cgroup_file.puts "8:net_cls,net_prio:/ecs/#{task_arn}/#{container_id}"
-      cgroup_file.puts "7:cpu,cpuacct:/ecs/#{task_arn}/#{container_id}"
-      cgroup_file.puts "6:perf_event:/ecs/#{task_arn}/#{container_id}"
-      cgroup_file.puts "5:freezer:/ecs/#{task_arn}/#{container_id}"
-      cgroup_file.puts "4:devices:/ecs/#{task_arn}/#{container_id}"
-      cgroup_file.puts "3:blkio:/ecs/#{task_arn}/#{container_id}"
-      cgroup_file.puts "2:memory:/ecs/#{task_arn}/#{container_id}"
-      cgroup_file.puts "1:name=systemd:/ecs/#{task_arn}/#{container_id}"
+      cgroup_file.puts "11:hugetlb:/#{platform}/#{task_arn}/#{container_id}"
+      cgroup_file.puts "10:pids:/#{platform}/#{task_arn}/#{container_id}"
+      cgroup_file.puts "9:cpuset:/#{platform}/#{task_arn}/#{container_id}"
+      cgroup_file.puts "8:net_cls,net_prio:/#{platform}/#{task_arn}/#{container_id}"
+      cgroup_file.puts "7:cpu,cpuacct:/#{platform}/#{task_arn}/#{container_id}"
+      cgroup_file.puts "6:perf_event:/#{platform}/#{task_arn}/#{container_id}"
+      cgroup_file.puts "5:freezer:/#{platform}/#{task_arn}/#{container_id}"
+      cgroup_file.puts "4:devices:/#{platform}/#{task_arn}/#{container_id}"
+      cgroup_file.puts "3:blkio:/#{platform}/#{task_arn}/#{container_id}"
+      cgroup_file.puts "2:memory:/#{platform}/#{task_arn}/#{container_id}"
+      cgroup_file.puts "1:name=systemd:/#{platform}/#{task_arn}/#{container_id}"
       cgroup_file.rewind
     end
   end
@@ -132,20 +165,21 @@ module ContainerHelpers
   shared_context 'Fargate 1.4+ environment' do
     include_context 'cgroup file'
 
+    let(:platform) { 'ecs' }
     let(:container_id) { '34dc0b5e626f2c5c4c5170e34b10e765-1234567890' }
 
     before do
-      cgroup_file.puts "11:hugetlb:/ecs/#{container_id}"
-      cgroup_file.puts "10:pids:/ecs/#{container_id}"
-      cgroup_file.puts "9:cpuset:/ecs/#{container_id}"
-      cgroup_file.puts "8:net_cls,net_prio:/ecs/#{container_id}"
-      cgroup_file.puts "7:cpu,cpuacct:/ecs/#{container_id}"
-      cgroup_file.puts "6:perf_event:/ecs/#{container_id}"
-      cgroup_file.puts "5:freezer:/ecs/#{container_id}"
-      cgroup_file.puts "4:devices:/ecs/#{container_id}"
-      cgroup_file.puts "3:blkio:/ecs/#{container_id}"
-      cgroup_file.puts "2:memory:/ecs/#{container_id}"
-      cgroup_file.puts "1:name=systemd:/ecs/#{container_id}"
+      cgroup_file.puts "11:hugetlb:/#{platform}/#{container_id}"
+      cgroup_file.puts "10:pids:/#{platform}/#{container_id}"
+      cgroup_file.puts "9:cpuset:/#{platform}/#{container_id}"
+      cgroup_file.puts "8:net_cls,net_prio:/#{platform}/#{container_id}"
+      cgroup_file.puts "7:cpu,cpuacct:/#{platform}/#{container_id}"
+      cgroup_file.puts "6:perf_event:/#{platform}/#{container_id}"
+      cgroup_file.puts "5:freezer:/#{platform}/#{container_id}"
+      cgroup_file.puts "4:devices:/#{platform}/#{container_id}"
+      cgroup_file.puts "3:blkio:/#{platform}/#{container_id}"
+      cgroup_file.puts "2:memory:/#{platform}/#{container_id}"
+      cgroup_file.puts "1:name=systemd:/#{platform}/#{container_id}"
       cgroup_file.rewind
     end
   end

--- a/spec/support/container_helpers.rb
+++ b/spec/support/container_helpers.rb
@@ -191,20 +191,44 @@ module ContainerHelpers
     include_context 'cgroup file'
 
     let(:platform) { 'ecs' }
-    let(:container_id) { '34dc0b5e626f2c5c4c5170e34b10e765-1234567890' }
+    let(:container_id_with_random) { "#{container_id_without_random}-1234567890" }
+    let(:container_id_without_random) { '34dc0b5e626f2c5c4c5170e34b10e765' }
 
     before do
-      cgroup_file.puts "11:hugetlb:/#{platform}/#{container_id}"
-      cgroup_file.puts "10:pids:/#{platform}/#{container_id}"
-      cgroup_file.puts "9:cpuset:/#{platform}/#{container_id}"
-      cgroup_file.puts "8:net_cls,net_prio:/#{platform}/#{container_id}"
-      cgroup_file.puts "7:cpu,cpuacct:/#{platform}/#{container_id}"
-      cgroup_file.puts "6:perf_event:/#{platform}/#{container_id}"
-      cgroup_file.puts "5:freezer:/#{platform}/#{container_id}"
-      cgroup_file.puts "4:devices:/#{platform}/#{container_id}"
-      cgroup_file.puts "3:blkio:/#{platform}/#{container_id}"
-      cgroup_file.puts "2:memory:/#{platform}/#{container_id}"
-      cgroup_file.puts "1:name=systemd:/#{platform}/#{container_id}"
+      cgroup_file.puts "11:hugetlb:/#{platform}/#{container_id_with_random}"
+      cgroup_file.puts "10:pids:/#{platform}/#{container_id_with_random}"
+      cgroup_file.puts "9:cpuset:/#{platform}/#{container_id_with_random}"
+      cgroup_file.puts "8:net_cls,net_prio:/#{platform}/#{container_id_with_random}"
+      cgroup_file.puts "7:cpu,cpuacct:/#{platform}/#{container_id_with_random}"
+      cgroup_file.puts "6:perf_event:/#{platform}/#{container_id_with_random}"
+      cgroup_file.puts "5:freezer:/#{platform}/#{container_id_with_random}"
+      cgroup_file.puts "4:devices:/#{platform}/#{container_id_with_random}"
+      cgroup_file.puts "3:blkio:/#{platform}/#{container_id_with_random}"
+      cgroup_file.puts "2:memory:/#{platform}/#{container_id_with_random}"
+      cgroup_file.puts "1:name=systemd:/#{platform}/#{container_id_with_random}"
+      cgroup_file.rewind
+    end
+  end
+
+  shared_context 'Fargate 1.4+ (2-part) environment' do
+    include_context 'cgroup file'
+
+    let(:platform) { 'ecs' }
+    let(:container_id_with_random) { "#{container_id_without_random}-1234567890" }
+    let(:container_id_without_random) { '34dc0b5e626f2c5c4c5170e34b10e765' }
+
+    before do
+      cgroup_file.puts "11:hugetlb:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "10:pids:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "9:cpuset:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "8:net_cls,net_prio:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "7:cpu,cpuacct:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "6:perf_event:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "5:freezer:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "4:devices:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "3:blkio:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "2:memory:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "1:name=systemd:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
       cgroup_file.rewind
     end
   end


### PR DESCRIPTION
Adds support for:

 - k8s burstable containers (drops `.slice` and `.scope` from IDs)
 - Gnome VTE cgroup
 - More defensive behavior against empty cgroup paths.

Also includes some minor refactoring for tests and a slightly more permissive expectation (so it doesn't break with `pry`.)