### PR TITLE
Ignore appraisal empty artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ Gemfile.lock
 
 # bundle config
 gemfiles/.bundle
+# Appraisal artifact file, always empty
+gemfiles/_.gemfile.lock


### PR DESCRIPTION
Some of our builds create a strange emtpy file, `gemfiles/_.gemfile.lock`: https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/3317/workflows/cb87c676-8e05-4c41-a67c-24b779e08d0a/jobs/131458:
```
Gem lock files were modified or new lock files were created during
'bundle install' and 'bundle appraisal install' installation in CI.
You need to check in those changes in your branch.
Affected files:
?? gemfiles/_.gemfile.lock
```

I have not been able to reproduce the CI steps that create this file, and removing it from CI cache prevent it from be recreated for a while.

This file has always been empty, and I see no references in `ddtrace` or Appraisal source code that could create a `_` gemfile, specially one with no content.

Because we check for changes to `gemfiles` during CI, to prevent us from pushing changes to `Appraisal` without committing the respective Gemfile and lock file, this mysterious empty file trips the CI cleanliness check.

This PR ignores that file for git purposes.