### PR TITLE
[PROF-3118] Wire up profiler to use `AgentSettings` object for configuration

### DIFF
--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -125,21 +125,17 @@ module Datadog
         end
 
         def build_profiler_exporters(settings)
-          if settings.profiling.exporter.instances.is_a?(Array)
-            settings.profiling.exporter.instances
-          else
-            transport = if settings.profiling.exporter.transport
-                          settings.profiling.exporter.transport
-                        else
-                          transport_options = settings.profiling.exporter.transport_options.dup
-                          transport_options[:site] ||= settings.site if settings.site
-                          transport_options[:api_key] ||= settings.api_key if settings.api_key
-                          transport_options[:timeout] ||= settings.profiling.upload.timeout
-                          Datadog::Profiling::Transport::HTTP.default(transport_options)
-                        end
+          transport = if settings.profiling.exporter.transport
+                        settings.profiling.exporter.transport
+                      else
+                        transport_options = settings.profiling.exporter.transport_options.dup
+                        transport_options[:site] ||= settings.site if settings.site
+                        transport_options[:api_key] ||= settings.api_key if settings.api_key
+                        transport_options[:timeout] ||= settings.profiling.upload.timeout
+                        Datadog::Profiling::Transport::HTTP.default(transport_options)
+                      end
 
-            [Datadog::Profiling::Exporter.new(transport)]
-          end
+          [Datadog::Profiling::Exporter.new(transport)]
         end
 
         def build_profiler_scheduler(settings, recorder, exporters)

--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -10,7 +10,6 @@ module Datadog
   module Configuration
     # Global components for the trace library.
     # rubocop:disable Layout/LineLength
-    # rubocop:disable Metrics/ClassLength
     class Components
       class << self
         def build_health_metrics(settings)

--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -130,8 +130,8 @@ module Datadog
                         transport_options = settings.profiling.exporter.transport_options.dup
                         transport_options[:site] ||= settings.site if settings.site
                         transport_options[:api_key] ||= settings.api_key if settings.api_key
-                        transport_options[:timeout] ||= settings.profiling.upload.timeout
-                        Datadog::Profiling::Transport::HTTP.default(transport_options)
+                        transport_options[:profiling_upload_timeout_seconds] ||= settings.profiling.upload.timeout_seconds
+                        Datadog::Profiling::Transport::HTTP.default(**transport_options)
                       end
 
           [Datadog::Profiling::Exporter.new(transport)]

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -130,7 +130,7 @@ module Datadog
         end
 
         settings :upload do
-          option :timeout do |o|
+          option :timeout_seconds do |o|
             o.setter { |value| value.nil? ? 30.0 : value.to_f }
             o.default { env_to_float(Ext::Profiling::ENV_UPLOAD_TIMEOUT, 30.0) }
             o.lazy

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -116,7 +116,6 @@ module Datadog
         end
 
         settings :exporter do
-          option :instances
           option :transport
           option :transport_options, default: ->(_o) { {} }, lazy: true
         end

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -117,7 +117,20 @@ module Datadog
 
         settings :exporter do
           option :transport
-          option :transport_options, default: ->(_o) { {} }, lazy: true
+          option :transport_options do |o|
+            o.setter do
+              # NOTE: As of April 2021 there may be a few profiler private beta customers with this setting, but since I'm
+              # marking this as deprecated before public beta, we can remove this for 1.0 without concern.
+              Datadog.logger.warn(
+                'Configuring the profiler c.profiling.exporter.transport_options is no longer needed, as the profiler ' \
+                'will reuse your existing global or tracer configuration. ' \
+                'This setting is deprecated for removal in a future ddtrace version (1.0 or profiling GA, whichever comes first).'
+              )
+              nil
+            end
+            o.default { nil }
+            o.lazy
+          end
         end
 
         option :max_events, default: 32768

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -124,7 +124,8 @@ module Datadog
               Datadog.logger.warn(
                 'Configuring the profiler c.profiling.exporter.transport_options is no longer needed, as the profiler ' \
                 'will reuse your existing global or tracer configuration. ' \
-                'This setting is deprecated for removal in a future ddtrace version (1.0 or profiling GA, whichever comes first).'
+                'This setting is deprecated for removal in a future ddtrace version ' \
+                '(1.0 or profiling GA, whichever comes first).'
               )
               nil
             end

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -14,9 +14,6 @@ module Datadog
     class Settings
       include Base
 
-      #
-      # Configuration options
-      #
       settings :analytics do
         option :enabled do |o|
           o.default { env_to_bool(Ext::Analytics::ENV_TRACE_ANALYTICS_ENABLED, nil) }

--- a/lib/ddtrace/profiling/transport/http.rb
+++ b/lib/ddtrace/profiling/transport/http.rb
@@ -25,7 +25,7 @@ module Datadog
 
         # Builds a new Transport::HTTP::Client with default settings
         # Pass a block to override any settings.
-        def default(profiling_upload_timeout_seconds:, agent_settings: nil, site: nil, api_key: nil, **options)
+        def default(profiling_upload_timeout_seconds:, agent_settings: nil, site: nil, api_key: nil)
           new do |transport|
             transport.headers default_headers
 
@@ -50,12 +50,6 @@ module Datadog
                 profiling_upload_timeout_seconds: profiling_upload_timeout_seconds,
                 agent_settings: agent_settings
               )
-            end
-
-            # TODO: Change this to use the deprecated_for_removal_transport_configuration_proc
-            if !options.empty? && options[:on_build].is_a?(Proc)
-              # Execute on_build callback
-              options[:on_build].call(transport)
             end
           end
         end
@@ -90,6 +84,10 @@ module Datadog
             ssl: agent_settings.ssl
           )
           transport.api(API::V1, apis[API::V1], default: true)
+
+          if agent_settings.deprecated_for_removal_transport_configuration_proc
+            agent_settings.deprecated_for_removal_transport_configuration_proc.call(transport)
+          end
         end
 
         private_class_method def configure_for_agentless(transport, profiling_upload_timeout_seconds:, site:, api_key:)

--- a/lib/ddtrace/profiling/transport/http.rb
+++ b/lib/ddtrace/profiling/transport/http.rb
@@ -72,7 +72,7 @@ module Datadog
           ENV.fetch(Datadog::Ext::Transport::HTTP::ENV_DEFAULT_PORT, Datadog::Ext::Transport::HTTP::DEFAULT_PORT).to_i
         end
 
-        def configure_for_agent(transport, options = {})
+        private_class_method def configure_for_agent(transport, options = {})
           apis = API.agent_defaults
 
           hostname = options[:hostname] || default_hostname
@@ -86,7 +86,7 @@ module Datadog
           transport.api API::V1, apis[API::V1], default: true
         end
 
-        def configure_for_agentless(transport, options = {})
+        private_class_method def configure_for_agentless(transport, options = {})
           apis = API.api_defaults
 
           site_uri = URI(format(Datadog::Ext::Profiling::Transport::HTTP::URI_TEMPLATE_DD_API, options[:site]))
@@ -106,10 +106,6 @@ module Datadog
         Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::Net, :net_http)
         Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::Test, :test)
         Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::UnixSocket, :unix)
-
-        private \
-          :configure_for_agent,
-          :configure_for_agentless
       end
     end
   end

--- a/lib/ddtrace/profiling/transport/http.rb
+++ b/lib/ddtrace/profiling/transport/http.rb
@@ -38,9 +38,6 @@ module Datadog
 
             # Additional options
             unless options.empty?
-              # Change default API
-              transport.default_api = options[:api_version] if options.key?(:api_version)
-
               # Add headers
               transport.headers options[:headers] if options.key?(:headers)
 

--- a/lib/ddtrace/profiling/transport/http.rb
+++ b/lib/ddtrace/profiling/transport/http.rb
@@ -13,7 +13,6 @@ require 'ddtrace/transport/http/adapters/unix_socket'
 module Datadog
   module Profiling
     module Transport
-      # TODO: Consolidate with Datadog::Transport::HTTP
       # Namespace for HTTP transport components
       module HTTP
         module_function

--- a/lib/ddtrace/profiling/transport/http.rb
+++ b/lib/ddtrace/profiling/transport/http.rb
@@ -78,12 +78,13 @@ module Datadog
             agent_settings.hostname,
             agent_settings.port,
             # We explictly use profiling_upload_timeout_seconds instead of agent_settings.timeout because profile
-            # uploads are bigger and thus have different defaults/specific knobs.
+            # uploads are bigger and thus we employ a separate configuration.
             timeout: profiling_upload_timeout_seconds,
             ssl: agent_settings.ssl
           )
           transport.api(API::V1, apis[API::V1], default: true)
 
+          # NOTE: This proc, when it exists, usually overrides the transport specified above
           if agent_settings.deprecated_for_removal_transport_configuration_proc
             agent_settings.deprecated_for_removal_transport_configuration_proc.call(transport)
           end

--- a/lib/ddtrace/profiling/transport/http.rb
+++ b/lib/ddtrace/profiling/transport/http.rb
@@ -47,9 +47,6 @@ module Datadog
               # Execute on_build callback
               options[:on_build].call(transport) if options[:on_build].is_a?(Proc)
             end
-
-            # Call block to apply any customization, if provided.
-            yield(transport) if block_given?
           end
         end
 

--- a/lib/ddtrace/profiling/transport/http.rb
+++ b/lib/ddtrace/profiling/transport/http.rb
@@ -73,7 +73,7 @@ module Datadog
           end
         end
 
-        def default_adapter
+        private_class_method def default_adapter
           :net_http
         end
 

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -703,44 +703,6 @@ RSpec.describe Datadog::Configuration::Components do
           end
         end
 
-        # TODO: :ignore_profiler is not implemented.
-        #       when it is, it shouldn't behave like a default collector.
-        #       It should define a proc that excludes Datadog profiler.
-        # context 'and :cpu.ignore_profiler' do
-        #   context 'true' do
-        #     before do
-        #       allow(settings.profiling.cpu)
-        #         .to receive(:ignore_profiler)
-        #         .and_return(true)
-        #     end
-        #
-        #     it_behaves_like 'profiler with default collectors'
-        #     it_behaves_like 'profiler with default scheduler'
-        #     it_behaves_like 'profiler with default recorder'
-        #     it_behaves_like 'profiler with default exporters'
-        #   end
-        # end
-
-        context 'and :exporter.instances' do
-          context 'with custom exporters' do
-            let(:instances) { Array.new(2) { double('collector') } }
-
-            before do
-              allow(settings.profiling.exporter)
-                .to receive(:instances)
-                .and_return(instances)
-            end
-
-            it_behaves_like 'profiler with default collectors'
-            it_behaves_like 'profiler with default scheduler'
-            it_behaves_like 'profiler with default recorder'
-
-            it 'uses the custom exporters instead' do
-              expect(profiler.scheduler.exporters).to eq(instances)
-            end
-          end
-        end
-
         context 'and :site + :api_key' do
           context 'are set' do
             let(:site) { 'test.datadoghq.com' }

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Datadog::Configuration::Components do
     if Datadog::Profiling.supported?
       allow(Datadog::Profiling::Tasks::Setup).to receive(:new).and_return(profiler_setup_task)
     end
+    allow(Datadog::Statsd).to receive(:new) { instance_double(Datadog::Statsd) }
   end
 
   describe '::new' do

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Datadog::Configuration::Components do
         .and_return(tracer)
 
       expect(described_class).to receive(:build_profiler)
-        .with(settings)
+        .with(settings, instance_of(Datadog::Configuration::AgentSettingsResolver::AgentSettings))
         .and_return(profiler)
 
       expect(described_class).to receive(:build_runtime_metrics_worker)
@@ -583,9 +583,10 @@ RSpec.describe Datadog::Configuration::Components do
   end
 
   describe '::build_profiler' do
-    subject(:build_profiler) { described_class.build_profiler(settings) }
-
+    let(:agent_settings) { Datadog::Configuration::AgentSettingsResolver.call(settings, logger: nil) }
     let(:profiler) { build_profiler }
+
+    subject(:build_profiler) { described_class.build_profiler(settings, agent_settings) }
 
     context 'when profiling is not supported' do
       before { allow(Datadog::Profiling).to receive(:supported?).and_return(false) }
@@ -665,9 +666,9 @@ RSpec.describe Datadog::Configuration::Components do
             spec: Datadog::Profiling::Transport::HTTP::API.agent_defaults[default_api]
           )
           expect(http_exporter.transport.api.adapter).to have_attributes(
-            hostname: Datadog::Profiling::Transport::HTTP.default_hostname,
-            port: Datadog::Profiling::Transport::HTTP.default_port,
-            ssl: false,
+            hostname: agent_settings.hostname,
+            port: agent_settings.port,
+            ssl: agent_settings.ssl,
             timeout: settings.profiling.upload.timeout_seconds
           )
         end
@@ -769,50 +770,6 @@ RSpec.describe Datadog::Configuration::Components do
 
               expect(http_exporter).to have_attributes(
                 transport: transport
-              )
-            end
-          end
-        end
-
-        context 'and :transport_options' do
-          context 'are provided' do
-            # Must be a kind of Datadog::Profiling::Transport::Client
-            let(:transport_options) do
-              {
-                profiling_upload_timeout_seconds: 10.0
-              }
-            end
-
-            before do
-              allow(settings.profiling.exporter)
-                .to receive(:transport_options)
-                .and_return(transport_options)
-            end
-
-            it_behaves_like 'profiler with default collectors'
-            it_behaves_like 'profiler with default scheduler'
-            it_behaves_like 'profiler with default recorder'
-
-            it 'uses the transport options' do
-              expect(profiler.scheduler.exporters).to have(1).item
-              expect(profiler.scheduler.exporters).to include(kind_of(Datadog::Profiling::Exporter))
-              http_exporter = profiler.scheduler.exporters.first
-
-              expect(http_exporter).to have_attributes(
-                transport: kind_of(Datadog::Profiling::Transport::HTTP::Client)
-              )
-
-              # Should be configured for agent transport
-              default_api = Datadog::Profiling::Transport::HTTP::API::V1
-              expect(http_exporter.transport.api).to have_attributes(
-                adapter: kind_of(Datadog::Transport::HTTP::Adapters::Net),
-                spec: Datadog::Profiling::Transport::HTTP::API.agent_defaults[default_api]
-              )
-              expect(http_exporter.transport.api.adapter).to have_attributes(
-                hostname: Datadog::Profiling::Transport::HTTP.default_hostname,
-                port: Datadog::Profiling::Transport::HTTP.default_port,
-                ssl: false,
-                timeout: transport_options.fetch(:profiling_upload_timeout_seconds)
               )
             end
           end

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -668,7 +668,7 @@ RSpec.describe Datadog::Configuration::Components do
             hostname: Datadog::Profiling::Transport::HTTP.default_hostname,
             port: Datadog::Profiling::Transport::HTTP.default_port,
             ssl: false,
-            timeout: settings.profiling.upload.timeout
+            timeout: settings.profiling.upload.timeout_seconds
           )
         end
       end
@@ -741,7 +741,7 @@ RSpec.describe Datadog::Configuration::Components do
                 hostname: "intake.profile.#{site}",
                 port: 443,
                 ssl: true,
-                timeout: settings.profiling.upload.timeout
+                timeout: settings.profiling.upload.timeout_seconds
               )
             end
           end
@@ -779,7 +779,7 @@ RSpec.describe Datadog::Configuration::Components do
             # Must be a kind of Datadog::Profiling::Transport::Client
             let(:transport_options) do
               {
-                timeout: 10.0
+                profiling_upload_timeout_seconds: 10.0
               }
             end
 
@@ -812,7 +812,7 @@ RSpec.describe Datadog::Configuration::Components do
                 hostname: Datadog::Profiling::Transport::HTTP.default_hostname,
                 port: Datadog::Profiling::Transport::HTTP.default_port,
                 ssl: false,
-                timeout: transport_options[:timeout]
+                timeout: transport_options.fetch(:profiling_upload_timeout_seconds)
               )
             end
           end

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -555,8 +555,8 @@ RSpec.describe Datadog::Configuration::Settings do
     end
 
     describe '#upload' do
-      describe '#timeout' do
-        subject(:timeout) { settings.profiling.upload.timeout }
+      describe '#timeout_seconds' do
+        subject(:timeout_seconds) { settings.profiling.upload.timeout_seconds }
 
         context "when #{Datadog::Ext::Profiling::ENV_UPLOAD_TIMEOUT}" do
           around do |example|
@@ -579,18 +579,18 @@ RSpec.describe Datadog::Configuration::Settings do
         end
       end
 
-      describe '#timeout=' do
-        it 'updates the #timeout setting' do
-          expect { settings.profiling.upload.timeout = 10 }
-            .to change { settings.profiling.upload.timeout }
+      describe '#timeout_seconds=' do
+        it 'updates the #timeout_seconds setting' do
+          expect { settings.profiling.upload.timeout_seconds = 10 }
+            .to change { settings.profiling.upload.timeout_seconds }
             .from(30.0)
             .to(10.0)
         end
 
         context 'given nil' do
           it 'uses the default setting' do
-            expect { settings.profiling.upload.timeout = nil }
-              .to_not change { settings.profiling.upload.timeout }
+            expect { settings.profiling.upload.timeout_seconds = nil }
+              .to_not change { settings.profiling.upload.timeout_seconds }
               .from(30.0)
           end
         end

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -491,17 +491,24 @@ RSpec.describe Datadog::Configuration::Settings do
       describe '#transport_options' do
         subject(:transport_options) { settings.profiling.exporter.transport_options }
 
-        it { is_expected.to eq({}) }
+        before do
+          allow(Datadog.logger).to receive(:warn)
+        end
+
+        it { is_expected.to be nil }
+
+        it 'logs a deprecation warning' do
+          expect(Datadog.logger).to receive(:warn).with(/deprecated for removal/)
+
+          transport_options
+        end
       end
 
       describe '#transport_options=' do
-        let(:transport_options) { { timeout: 10 } }
+        it 'logs a deprecation warning' do
+          expect(Datadog.logger).to receive(:warn).with(/deprecated for removal/)
 
-        it 'updates the #transport_options setting' do
-          expect { settings.profiling.exporter.transport_options = transport_options }
-            .to change { settings.profiling.exporter.transport_options }
-            .from({})
-            .to(transport_options)
+          settings.profiling.exporter.transport_options = :foo
         end
       end
     end

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -471,23 +471,6 @@ RSpec.describe Datadog::Configuration::Settings do
     end
 
     describe '#exporter' do
-      describe '#instances' do
-        subject(:instances) { settings.profiling.exporter.instances }
-
-        it { is_expected.to be nil }
-      end
-
-      describe '#instances=' do
-        let(:instances) { [double('exporter')] }
-
-        it 'updates the #instances setting' do
-          expect { settings.profiling.exporter.instances = instances }
-            .to change { settings.profiling.exporter.instances }
-            .from(nil)
-            .to(instances)
-        end
-      end
-
       describe '#transport' do
         subject(:transport) { settings.profiling.exporter.transport }
 

--- a/spec/ddtrace/profiling/transport/http_spec.rb
+++ b/spec/ddtrace/profiling/transport/http_spec.rb
@@ -105,10 +105,4 @@ RSpec.describe Datadog::Profiling::Transport::HTTP do
       end
     end
   end
-
-  describe '::default_adapter' do
-    subject(:default_adapter) { described_class.default_adapter }
-
-    it { is_expected.to be(:net_http) }
-  end
 end

--- a/spec/ddtrace/profiling/transport/http_spec.rb
+++ b/spec/ddtrace/profiling/transport/http_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Datadog::Profiling::Transport::HTTP do
           hostname: hostname,
           port: port,
           ssl: ssl,
-          deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc,
+          deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc
         )
       end
       let(:hostname) { double('hostname') }

--- a/spec/ddtrace/profiling/transport/http_spec.rb
+++ b/spec/ddtrace/profiling/transport/http_spec.rb
@@ -57,13 +57,18 @@ RSpec.describe Datadog::Profiling::Transport::HTTP do
 
       let(:agent_settings) do
         instance_double(
-          Datadog::Configuration::AgentSettingsResolver::AgentSettings, hostname: hostname, port: port, ssl: ssl
+          Datadog::Configuration::AgentSettingsResolver::AgentSettings,
+          hostname: hostname,
+          port: port,
+          ssl: ssl,
+          deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc,
         )
       end
       let(:hostname) { double('hostname') }
       let(:port) { double('port') }
       let(:profiling_upload_timeout_seconds) { double('timeout') }
       let(:ssl) { true }
+      let(:deprecated_for_removal_transport_configuration_proc) { nil }
 
       it 'returns a transport with provided options' do
         expect(default.api.adapter).to be_a_kind_of(Datadog::Transport::HTTP::Adapters::Net)
@@ -73,6 +78,17 @@ RSpec.describe Datadog::Profiling::Transport::HTTP do
         expect(default.api.adapter.ssl).to be true
         expect(default.api.headers).to include(described_class.default_headers)
         expect(default.api.headers).to_not include(Datadog::Ext::Transport::HTTP::HEADER_DD_API_KEY)
+      end
+
+      context 'when agent_settings has a deprecated_for_removal_transport_configuration_proc' do
+        let(:deprecated_for_removal_transport_configuration_proc) { proc {} }
+
+        it 'calls the deprecated_for_removal_transport_configuration_proc with the transport builder' do
+          expect(deprecated_for_removal_transport_configuration_proc).to \
+            receive(:call).with(an_instance_of(Datadog::Profiling::Transport::HTTP::Builder))
+
+          default
+        end
       end
     end
   end

--- a/spec/ddtrace/profiling/transport/http_spec.rb
+++ b/spec/ddtrace/profiling/transport/http_spec.rb
@@ -119,14 +119,6 @@ RSpec.describe Datadog::Profiling::Transport::HTTP do
         end
       end
     end
-
-    context 'when given a block' do
-      it do
-        expect { |b| described_class.default(&b) }.to yield_with_args(
-          kind_of(Datadog::Profiling::Transport::HTTP::Builder)
-        )
-      end
-    end
   end
 
   describe '::default_headers' do

--- a/spec/ddtrace/profiling/transport/http_spec.rb
+++ b/spec/ddtrace/profiling/transport/http_spec.rb
@@ -99,16 +99,6 @@ RSpec.describe Datadog::Profiling::Transport::HTTP do
         end
       end
 
-      context 'that specify an API version' do
-        let(:options) { { api_version: api_version } }
-
-        context 'that is not defined' do
-          let(:api_version) { double('non-existent API') }
-
-          it { expect { default }.to raise_error(Datadog::Transport::HTTP::Builder::UnknownApiError) }
-        end
-      end
-
       context 'that specify headers' do
         let(:options) { { headers: headers } }
         let(:headers) { { 'Test-Header' => 'foo' } }

--- a/spec/ddtrace/profiling/transport/http_spec.rb
+++ b/spec/ddtrace/profiling/transport/http_spec.rb
@@ -29,7 +29,10 @@ RSpec.describe Datadog::Profiling::Transport::HTTP do
   end
 
   describe '::default' do
-    subject(:default) { described_class.default }
+    subject(:default) { described_class.default(profiling_upload_timeout_seconds: timeout_seconds, **options) }
+
+    let(:timeout_seconds) { nil }
+    let(:options) { {} }
 
     shared_examples_for 'default HTTP agent transport' do
       it 'returns default configuration' do
@@ -52,8 +55,6 @@ RSpec.describe Datadog::Profiling::Transport::HTTP do
     it_behaves_like 'default HTTP agent transport'
 
     context 'when given options' do
-      subject(:default) { described_class.default(options) }
-
       context 'that are empty' do
         let(:options) { {} }
 
@@ -75,12 +76,12 @@ RSpec.describe Datadog::Profiling::Transport::HTTP do
         end
       end
 
-      context 'that specify host, port, timeout or ssl' do
+      context 'that specify host, port, profiling_upload_timeout_seconds or ssl' do
         let(:options) do
           {
             hostname: hostname,
             port: port,
-            timeout: timeout,
+            profiling_upload_timeout_seconds: timeout,
             ssl: ssl
           }
         end

--- a/spec/ddtrace/transport/http_spec.rb
+++ b/spec/ddtrace/transport/http_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Datadog::Transport::HTTP do
       context 'that specifies a deprecated_for_removal_transport_configuration_proc' do
         let(:deprecated_for_removal_transport_configuration_proc) { proc {} }
 
-        it 'calls the deprecated_for_removal_transport_configuration_proc with a transport' do
+        it 'calls the deprecated_for_removal_transport_configuration_proc with the transport builder' do
           expect(deprecated_for_removal_transport_configuration_proc).to \
             receive(:call).with(an_instance_of(Datadog::Transport::HTTP::Builder))
 


### PR DESCRIPTION
Following the refactoring on #1478 that introduced the `AgentSettings` object and wired the tracer up to use it, we now also make the profiler use the same object.

This also means the deprecation of `c.profiling.exporter.transport_options` that some private beta customers had to use to be able to match their profiler and tracer configurations (whenever they were configuring them via code).

It also means that temporarily, and until global agent settings such as `Datadog.configure { |c| c.agent_hostname = ... }` are introduced, that the only way to configure the profiler via code is through the tracer configurations (e.g. `c.tracer.hostname` and friends). I claim that this is an acceptable trade-off for beta and we can clean it up separately (e.g. by adding these settings to the `AgentSettingsResolver`, or by moving to a configuration file.

With this change, the profiler should work out-of-the-box for any application that already has a working tracer configuration 🎉  -- customers only really need to enable profiling.

I've tested locally that all ways of configuring the profiler are correctly being picked up:
* Config via DD_AGENT_HOST / DD_AGENT_PORT
* Config via DD_TRACE_AGENT_URL
* Config via DD_SITE / DD_API_KEY
* Config via tracer.hostname
* Config net_http via transport_options proc
* Config unix socket via transport_options proc