### PR TITLE
Profiler sampling loop performance improvements

### DIFF
--- a/benchmarks/profiler_sample_loop.rb
+++ b/benchmarks/profiler_sample_loop.rb
@@ -1,0 +1,69 @@
+require 'benchmark/ips'
+require 'ddtrace'
+require 'pry'
+
+# This benchmark measures the performance of the main stack sampling loop of the profiler
+
+class ProfilerSampleLoopBenchmark
+  def create_profiler
+    Datadog.configure do |c|
+      # c.diagnostics.debug = true
+      c.profiling.enabled = true
+      c.tracer.transport_options = proc { |t| t.adapter :test }
+    end
+
+    # Stop background threads
+    Datadog.profiler.shutdown!
+
+    # Call collection directly
+    @stack_collector = Datadog.profiler.collectors.first
+    @recorder = @stack_collector.recorder
+  end
+
+  def thread_with_very_deep_stack(depth: 500)
+    deep_stack = proc do |n|
+      if n > 0
+        deep_stack.call(n - 1)
+      else
+        sleep
+      end
+    end
+
+    Thread.new { deep_stack.call(depth) }.tap { |t| t.name = "Deep stack #{depth}" }
+  end
+
+  def run_benchmark
+    Benchmark.ips do |x|
+      x.config(time: 10, warmup: 2)
+
+      x.report("stack collector #{ENV['CONFIG']}") do
+        @stack_collector.collect_and_wait
+      end
+
+      x.save! 'profiler-sample-loop-results'
+      x.compare!
+    end
+
+    @recorder.flush
+  end
+
+  def run_forever
+    while true
+      1000.times { @stack_collector.collect_and_wait }
+      @recorder.flush
+      print '.'
+    end
+  end
+end
+
+puts "Current pid is #{Process.pid}"
+
+ProfilerSampleLoopBenchmark.new.instance_exec do
+  create_profiler
+  4.times { thread_with_very_deep_stack }
+  if ARGV.include?('--forever')
+    run_forever
+  else
+    run_benchmark
+  end
+end

--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -11,6 +11,7 @@ module Datadog
       # Collects stack trace samples from Ruby threads for both CPU-time (if available) and wall-clock.
       # Runs on its own background thread.
       #
+      # rubocop:disable Metrics/ClassLength
       class Stack < Worker
         include Workers::Polling
 
@@ -51,6 +52,9 @@ module Datadog
           self.enabled = enabled
 
           @warn_about_missing_cpu_time_instrumentation_only_once = Datadog::Utils::OnlyOnce.new
+
+          # Cache this proc, since it's pretty expensive to keep recreating it
+          @build_backtrace_location = method(:build_backtrace_location).to_proc
         end
 
         def start
@@ -190,7 +194,7 @@ module Datadog
               # Filename
               location.path,
               # Build function
-              &method(:build_backtrace_location)
+              &@build_backtrace_location
             )
           end
         end
@@ -247,6 +251,7 @@ module Datadog
           end
         end
       end
+      # rubocop:enable Metrics/ClassLength
     end
   end
 end

--- a/lib/ddtrace/profiling/recorder.rb
+++ b/lib/ddtrace/profiling/recorder.rb
@@ -16,6 +16,9 @@ module Datadog
         event_classes.each do |event_class|
           @buffers[event_class] = Profiling::Buffer.new(max_size)
         end
+
+        # Event classes can only be added ahead of time
+        @buffers.freeze
       end
 
       def [](event_class)


### PR DESCRIPTION
I spent a bit of time checking for low-hanging fruit in the main sampling loop, using the simple benchmark attached.

As a result of these improvements, in my machine (Ruby 2.7.3/macOS 10.15.7/i7-1068NG7) I get a 1.68x speedup on samples/s:

```
stack collector before
                        233.553  (± 6.0%) i/s -      2.346k in  10.084525s
stack collector after
                        392.156  (± 6.4%) i/s -      3.939k in  10.092307s
```

Of course, during the normal work of the profiler, we don't sample "as fast as possible", but lowering the amount of work we do to take every sample goes towards minimizing the impact we have on the profiled application.
