### PR TITLE
Fix kwargs passing on Ruby 3.0 for sucker_punch

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -7,7 +7,7 @@ require 'ddtrace/version'
 Gem::Specification.new do |spec|
   spec.name                  = 'ddtrace'
   spec.version               = Datadog::VERSION::STRING
-  spec.required_ruby_version = ">= #{Datadog::VERSION::MINIMUM_RUBY_VERSION}"
+  spec.required_ruby_version = [">= #{Datadog::VERSION::MINIMUM_RUBY_VERSION}", "< #{Datadog::VERSION::MAXIMUM_RUBY_VERSION}"]
   spec.required_rubygems_version = '>= 2.0.0'
   spec.authors               = ['Datadog, Inc.']
   spec.email                 = ['dev@datadoghq.com']

--- a/lib/ddtrace/contrib/sucker_punch/instrumentation.rb
+++ b/lib/ddtrace/contrib/sucker_punch/instrumentation.rb
@@ -10,11 +10,11 @@ module Datadog
         module_function
 
         # rubocop:disable Metrics/MethodLength
+        # rubocop:disable Metrics/AbcSize
         def patch!
           # rubocop:disable Metrics/BlockLength
           ::SuckerPunch::Job::ClassMethods.class_eval do
-            alias_method :__run_perform_without_datadog, :__run_perform
-            def __run_perform(*args)
+            def __run_perform_datadog_around
               pin = Datadog::Pin.get_from(::SuckerPunch)
               pin.tracer.provider.context = Datadog::Context.new
 
@@ -29,26 +29,60 @@ module Datadog
                 # Measure service stats
                 Contrib::Analytics.set_measured(span)
 
-                __run_perform_without_datadog(*args)
+                yield
               end
-            rescue => e
-              ::SuckerPunch.__exception_handler.call(e, self, args)
+            end
+            private :__run_perform_datadog_around
+
+            alias_method :__run_perform_without_datadog, :__run_perform
+            if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0')
+              def __run_perform(*args)
+                __run_perform_datadog_around do
+                  __run_perform_without_datadog(*args)
+                end
+              rescue => e
+                ::SuckerPunch.__exception_handler.call(e, self, args)
+              end
+              ruby2_keywords :__run_perform if respond_to?(:ruby2_keywords, true)
+            else
+              def __run_perform(*args, **kwargs)
+                __run_perform_datadog_around do
+                  __run_perform_without_datadog(*args, **kwargs)
+                end
+              rescue => e
+                ::SuckerPunch.__exception_handler.call(e, self, args)
+              end
             end
 
-            alias_method :__perform_async, :perform_async
-            def perform_async(*args)
+            def perform_async_datadog_around
               __with_instrumentation(Ext::SPAN_PERFORM_ASYNC) do |span|
                 span.resource = "ENQUEUE #{self}"
 
                 # Measure service stats
                 Contrib::Analytics.set_measured(span)
 
-                __perform_async(*args)
+                yield
+              end
+            end
+            private :perform_async_datadog_around
+
+            alias_method :__perform_async, :perform_async
+            if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0')
+              def perform_async(*args)
+                perform_async_datadog_around do
+                  __perform_async(*args)
+                end
+              end
+              ruby2_keywords :perform_async if respond_to?(:ruby2_keywords, true)
+            else
+              def perform_async(*args, **kwargs)
+                perform_async_datadog_around do
+                  __perform_async(*args, **kwargs)
+                end
               end
             end
 
-            alias_method :__perform_in, :perform_in
-            def perform_in(interval, *args)
+            def perform_in_datadog_around(interval)
               __with_instrumentation(Ext::SPAN_PERFORM_IN) do |span|
                 span.resource = "ENQUEUE #{self}"
                 span.set_tag(Ext::TAG_PERFORM_IN, interval)
@@ -56,7 +90,24 @@ module Datadog
                 # Measure service stats
                 Contrib::Analytics.set_measured(span)
 
-                __perform_in(interval, *args)
+                yield
+              end
+            end
+            private :perform_in_datadog_around
+
+            alias_method :__perform_in, :perform_in
+            if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0')
+              def perform_in(interval, *args)
+                perform_in_datadog_around(interval) do
+                  __perform_in(interval, *args)
+                end
+              end
+              ruby2_keywords :perform_in if respond_to?(:ruby2_keywords, true)
+            else
+              def perform_in(interval, *args, **kwargs)
+                perform_in_datadog_around(interval) do
+                  __perform_in(interval, *args, **kwargs)
+                end
               end
             end
 

--- a/lib/ddtrace/contrib/sucker_punch/instrumentation.rb
+++ b/lib/ddtrace/contrib/sucker_punch/instrumentation.rb
@@ -14,7 +14,8 @@ module Datadog
         def patch!
           # rubocop:disable Metrics/BlockLength
           ::SuckerPunch::Job::ClassMethods.class_eval do
-            def __run_perform_datadog_around
+            alias_method :__run_perform_without_datadog, :__run_perform
+            def __run_perform(*args)
               pin = Datadog::Pin.get_from(::SuckerPunch)
               pin.tracer.provider.context = Datadog::Context.new
 
@@ -29,60 +30,28 @@ module Datadog
                 # Measure service stats
                 Contrib::Analytics.set_measured(span)
 
-                yield
+                __run_perform_without_datadog(*args)
               end
+            rescue => e
+              ::SuckerPunch.__exception_handler.call(e, self, args)
             end
-            private :__run_perform_datadog_around
+            ruby2_keywords :__run_perform if respond_to?(:ruby2_keywords, true)
 
-            alias_method :__run_perform_without_datadog, :__run_perform
-            if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0')
-              def __run_perform(*args)
-                __run_perform_datadog_around do
-                  __run_perform_without_datadog(*args)
-                end
-              rescue => e
-                ::SuckerPunch.__exception_handler.call(e, self, args)
-              end
-              ruby2_keywords :__run_perform if respond_to?(:ruby2_keywords, true)
-            else
-              def __run_perform(*args, **kwargs)
-                __run_perform_datadog_around do
-                  __run_perform_without_datadog(*args, **kwargs)
-                end
-              rescue => e
-                ::SuckerPunch.__exception_handler.call(e, self, args)
-              end
-            end
-
-            def perform_async_datadog_around
+            alias_method :__perform_async, :perform_async
+            def perform_async(*args)
               __with_instrumentation(Ext::SPAN_PERFORM_ASYNC) do |span|
                 span.resource = "ENQUEUE #{self}"
 
                 # Measure service stats
                 Contrib::Analytics.set_measured(span)
 
-                yield
+                __perform_async(*args)
               end
             end
-            private :perform_async_datadog_around
+            ruby2_keywords :perform_async if respond_to?(:ruby2_keywords, true)
 
-            alias_method :__perform_async, :perform_async
-            if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0')
-              def perform_async(*args)
-                perform_async_datadog_around do
-                  __perform_async(*args)
-                end
-              end
-              ruby2_keywords :perform_async if respond_to?(:ruby2_keywords, true)
-            else
-              def perform_async(*args, **kwargs)
-                perform_async_datadog_around do
-                  __perform_async(*args, **kwargs)
-                end
-              end
-            end
-
-            def perform_in_datadog_around(interval)
+            alias_method :__perform_in, :perform_in
+            def perform_in(interval, *args)
               __with_instrumentation(Ext::SPAN_PERFORM_IN) do |span|
                 span.resource = "ENQUEUE #{self}"
                 span.set_tag(Ext::TAG_PERFORM_IN, interval)
@@ -90,26 +59,10 @@ module Datadog
                 # Measure service stats
                 Contrib::Analytics.set_measured(span)
 
-                yield
+                __perform_in(interval, *args)
               end
             end
-            private :perform_in_datadog_around
-
-            alias_method :__perform_in, :perform_in
-            if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0')
-              def perform_in(interval, *args)
-                perform_in_datadog_around(interval) do
-                  __perform_in(interval, *args)
-                end
-              end
-              ruby2_keywords :perform_in if respond_to?(:ruby2_keywords, true)
-            else
-              def perform_in(interval, *args, **kwargs)
-                perform_in_datadog_around(interval) do
-                  __perform_in(interval, *args, **kwargs)
-                end
-              end
-            end
+            ruby2_keywords :perform_in if respond_to?(:ruby2_keywords, true)
 
             private
 

--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -10,5 +10,17 @@ module Datadog
     # Support for Ruby < 2.1 is currently deprecated in the tracer.
     # Support will be dropped in the near future.
     MINIMUM_RUBY_VERSION = '2.0.0'.freeze
+
+    # Ruby 3.2 is not supported: Ruby 3.x support as implemented using *args
+    # needs ruby2_keywords to continue working, yet the scheduled removal of
+    # ruby2_keywords when Ruby 2.6 is EOL'd (i.e on Ruby 3.2 release) would
+    # leave the code with no option, other than to move to *args, **kwargs.
+    #
+    # See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
+    #
+    # This constraint can only be removed when the dependency on ruby2_keywords is
+    # dropped. An allowance is nonetheless made to test prerelease versions.
+    # The version constraint may be bumped if the removal is postponed.
+    MAXIMUM_RUBY_VERSION = '3.2'.freeze
   end
 end

--- a/spec/ddtrace/contrib/sucker_punch/patcher_spec.rb
+++ b/spec/ddtrace/contrib/sucker_punch/patcher_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe 'sucker_punch instrumentation' do
     SuckerPunch::Queue.all.each(&:shutdown)
     SuckerPunch::Queue.clear
 
+    next unless expect_thread?
+
     # Unfortunately, SuckerPunch queues (which are concurrent-ruby
     # ThreadPoolExecutor instances) don't have an interface that
     # waits until threads have completely terminated.
@@ -35,6 +37,8 @@ RSpec.describe 'sucker_punch instrumentation' do
     example.run
     Datadog.registry[:sucker_punch].reset_configuration!
   end
+
+  let(:expect_thread?) { true }
 
   let(:worker_class) do
     Class.new do
@@ -138,6 +142,63 @@ RSpec.describe 'sucker_punch instrumentation' do
       expect(enqueue_span.resource).to eq("ENQUEUE #{worker_class}")
       expect(enqueue_span.get_tag('sucker_punch.queue')).to eq(worker_class.to_s)
       expect(enqueue_span.get_tag('sucker_punch.perform_in')).to eq(0)
+    end
+  end
+
+  context 'keyword arguments' do
+    # We do not want mocks or stubs here, as these would define their own
+    # wrapper or replacement methods interfering with the argument passing
+    # test, therefore we record behaviour data on a side-effect of an object.
+    let(:recorded) { [] }
+
+    let(:worker_class) do
+      clazz = Class.new do
+        include SuckerPunch::Job
+
+        def perform(*args, required: nil)
+          raise ArgumentError if required.nil? # Ruby 2.0 doesn't support `required:`
+
+          self.class.instance_variable_get(:@recorded) << [args, required]
+        end
+      end
+
+      clazz.instance_variable_set(:@recorded, recorded)
+
+      clazz
+    end
+
+    context 'internal call to job' do
+      subject(:dummy_worker) { worker_class.__run_perform(1, required: 2) }
+      let(:expect_thread?) { false }
+
+      it 'passes kwargs correctly through instrumentation' do
+        dummy_worker
+        try_wait_until { recorded.any? }
+
+        expect(recorded.first).to eq([[1], 2])
+      end
+    end
+
+    context 'async job' do
+      subject(:dummy_worker) { worker_class.perform_async(1, required: 2) }
+
+      it 'passes kwargs correctly through instrumentation' do
+        dummy_worker
+        try_wait_until { recorded.any? }
+
+        expect(recorded.first).to eq([[1], 2])
+      end
+    end
+
+    context 'delayed job' do
+      subject(:dummy_worker) { worker_class.perform_in(0, 1, required: 2) }
+
+      it 'passes kwargs correctly through instrumentation' do
+        dummy_worker
+        try_wait_until { recorded.any? }
+
+        expect(recorded.first).to eq([[1], 2])
+      end
     end
   end
 end


### PR DESCRIPTION
The kwargs separation change for Ruby 3.0 is tricky: there are different behaviours on 2.6, 2.7, and 3.0. While `ruby2_keywords` attempts to smooth that out, it is due to disappear on 3.2, therefore relying on it produces surefire broken code when 3.2 is released and 2.6 EOL'd.

`ruby2_keywords` also suffers from subtle brokenness by virtue of leveraging an internal stateful flag attached to the hash. This is generally OK for very local uses but gets troublesome with complex delegations and even more for instrumentors. Case in point, attempting to use `ruby2_keywords` here works for `perform_in` and `perform_async`, but does not solve the issue in the `__run_perform` direct call case.

Thus the only future-proof and reliable syntax on Ruby >= 3 is to capture the arguments with `*args, **kwargs` and forward them the same way, without `ruby2_keywords`.

Conversely, the only working syntax on Ruby < 3 is capturing both with `*args` and forwarding them the same way, using `ruby2_keywords` on 2.7 to restore the previous behaviour.

Therefore dynamic function definition per version is sadly necessary because of the syntactic difference in argument passing and forwarding.

Fixes #1372 