### PR TITLE
Fix:Double initialization when auto instrumenting non-Rails applications

### DIFF
--- a/lib/ddtrace/contrib/auto_instrument.rb
+++ b/lib/ddtrace/contrib/auto_instrument.rb
@@ -19,7 +19,6 @@ module Datadog
           else
             AutoInstrument.patch_all
           end
-          AutoInstrument.patch_all
         end
       end
 

--- a/spec/ddtrace/contrib/rails/support/rails3.rb
+++ b/spec/ddtrace/contrib/rails/support/rails3.rb
@@ -60,14 +60,14 @@ RSpec.shared_context 'Rails 3 base application' do
     klass.send(:define_method, :test_initialize!) do
       # we want to disable explicit instrumentation
       # when testing auto patching
-      if ENV['TEST_AUTO_INSTRUMENT'] != true
+      if ENV['TEST_AUTO_INSTRUMENT'] == 'true'
+        require 'ddtrace/auto_instrument'
+      else
         # Enables the auto-instrumentation for the testing application
         Datadog.configure do |c|
           c.use :rails
           c.use :redis if Gem.loaded_specs['redis'] && defined?(::Redis)
         end
-      else
-        require 'ddtrace/auto_instrument'
       end
 
       before_test_init.call

--- a/spec/ddtrace/contrib/rails/support/rails4.rb
+++ b/spec/ddtrace/contrib/rails/support/rails4.rb
@@ -57,14 +57,14 @@ RSpec.shared_context 'Rails 4 base application' do
     klass.send(:define_method, :test_initialize!) do
       # we want to disable explicit instrumentation
       # when testing auto patching
-      if ENV['TEST_AUTO_INSTRUMENT'] != true
+      if ENV['TEST_AUTO_INSTRUMENT'] == 'true'
+        require 'ddtrace/auto_instrument'
+      else
         # Enables the auto-instrumentation for the testing application
         Datadog.configure do |c|
           c.use :rails
           c.use :redis if Gem.loaded_specs['redis'] && defined?(::Redis)
         end
-      else
-        require 'ddtrace/auto_instrument'
       end
 
       Rails.application.config.active_job.queue_adapter = :sidekiq

--- a/spec/ddtrace/contrib/rails/support/rails5.rb
+++ b/spec/ddtrace/contrib/rails/support/rails5.rb
@@ -55,14 +55,14 @@ RSpec.shared_context 'Rails 5 base application' do
     klass.send(:define_method, :test_initialize!) do
       # we want to disable explicit instrumentation
       # when testing auto patching
-      if ENV['TEST_AUTO_INSTRUMENT'] != true
+      if ENV['TEST_AUTO_INSTRUMENT'] == 'true'
+        require 'ddtrace/auto_instrument'
+      else
         # Enables the auto-instrumentation for the testing application
         Datadog.configure do |c|
           c.use :rails
           c.use :redis if Gem.loaded_specs['redis'] && defined?(::Redis)
         end
-      else
-        require 'ddtrace/auto_instrument'
       end
 
       Rails.application.config.active_job.queue_adapter = :sidekiq

--- a/spec/ddtrace/contrib/rails/support/rails6.rb
+++ b/spec/ddtrace/contrib/rails/support/rails6.rb
@@ -59,14 +59,14 @@ RSpec.shared_context 'Rails 6 base application' do
     klass.send(:define_method, :test_initialize!) do
       # we want to disable explicit instrumentation
       # when testing auto patching
-      if ENV['TEST_AUTO_INSTRUMENT'] != true
+      if ENV['TEST_AUTO_INSTRUMENT'] == 'true'
+        require 'ddtrace/auto_instrument'
+      else
         # Enables the auto-instrumentation for the testing application
         Datadog.configure do |c|
           c.use :rails
           c.use :redis if Gem.loaded_specs['redis'] && defined?(::Redis)
         end
-      else
-        require 'ddtrace/auto_instrument'
       end
 
       Rails.application.config.active_job.queue_adapter = :sidekiq if ENV['USE_SIDEKIQ']


### PR DESCRIPTION
We were invoking `AutoInstrument.patch_all` twice for users of 'ddtrace/auto_instrument' that are not running a Rails application.

This PR removes the unnecessary double call. Invoking `AutoInstrument.patch_all` multiple times has no ill effect, but creates unnecessary overhead.

Also, a few of the tests were not running with the expected setup, as we were comparing an environment variable against a boolean value `ENV['TEST_AUTO_INSTRUMENT'] != true`, while the returned value was always a string. This PR addresses that comparison.