### PR TITLE
Fixed an issue where backtrace handling of exception classes that return nil message fails.

### DIFF
--- a/lib/ddtrace/error.rb
+++ b/lib/ddtrace/error.rb
@@ -71,7 +71,7 @@ module Datadog
             # Add Exception information to error line
             backtrace << trace[0]
             backtrace << ': '
-            backtrace << ex.message
+            backtrace << ex.message.to_s
             backtrace << ' ('
             backtrace << ex.class.to_s
             backtrace << ')'

--- a/spec/ddtrace/error_spec.rb
+++ b/spec/ddtrace/error_spec.rb
@@ -131,6 +131,28 @@ RSpec.describe Datadog::Error do
           end
         end
 
+        context 'with nil message' do
+          let(:cause) do
+            Class.new(StandardError) do
+              def message; end
+            end
+          end
+          let(:value) { begin; raise cause; rescue => e; e; end }
+          before do
+            stub_const('NilMessageError', cause)
+          end
+
+          it 'is expected to message is empty' do
+            expect(error.type).to eq('NilMessageError')
+            expect(error.message).to eq('')
+            expect(error.backtrace).to include('error_spec.rb')
+          end
+
+          it 'is expected to include class name in backtrace', if: RUBY_VERSION >= '2.1.0' do
+            expect(error.backtrace).to include(':  (NilMessageError)') # :[space][nil][space](NilMessageError)
+          end
+        end
+
         context 'benchmark' do
           before { skip('Benchmark results not currently captured in CI') if ENV.key?('CI') }
 


### PR DESCRIPTION
Raise a new TypeError when handling an exception class that returns an nil message.
Changed to always treat exception message as String.

The actual case is as follows.
```
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'ddtrace', '0.49.0', require: 'ddtrace'
  gem 'thrift', require: 'thrift'
end


class SomethingException < Thrift::Exception
  include Thrift::Struct
  FIELDS = {}
  def struct_fields; FIELDS; end
  Thrift::Struct.generate_accessors self
end

begin
  Datadog.tracer.trace('SomethingException') do
    raise SomethingException
  end
rescue SomethingException => e
  p 'nice catch!', e.message
end
```
