### PR TITLE
Skip Gem.loaded_specs calls if protobuf is already loaded

### DIFF
--- a/lib/ddtrace/profiling.rb
+++ b/lib/ddtrace/profiling.rb
@@ -23,14 +23,20 @@ module Datadog
     private_class_method :ruby_engine_unsupported?
 
     def self.protobuf_gem_unavailable?
-      if Gem.loaded_specs['google-protobuf'].nil?
+      # NOTE: On environments where protobuf is already loaded, we skip the check. This allows us to support environments
+      # where no Gem.loaded_version is NOT available but customers are able to load protobuf; see for instance
+      # https://github.com/teamcapybara/capybara/commit/caf3bcd7664f4f2691d0ca9ef3be9a2a954fecfb
+      if !defined?(::Google::Protobuf) && Gem.loaded_specs['google-protobuf'].nil?
         "Missing google-protobuf dependency; please add `gem 'google-protobuf', '~> 3.0'` to your Gemfile or gems.rb file"
       end
     end
     private_class_method :protobuf_gem_unavailable?
 
     def self.protobuf_version_unsupported?
-      if Gem.loaded_specs['google-protobuf'].version < GOOGLE_PROTOBUF_MINIMUM_VERSION
+      # See above for why we skip the check when protobuf is already loaded; note that when protobuf was already loaded
+      # we skip the version check to avoid the call to Gem.loaded_specs. Unfortunately, protobuf does not seem to
+      # expose the gem version constant elsewhere, so in that setup we are not able to check the version.
+      if !defined?(::Google::Protobuf) && Gem.loaded_specs['google-protobuf'].version < GOOGLE_PROTOBUF_MINIMUM_VERSION
         'Your google-protobuf is too old; ensure that you have google-protobuf >= 3.0 by ' \
         "adding `gem 'google-protobuf', '~> 3.0'` to your Gemfile or gems.rb file"
       end

--- a/spec/ddtrace/profiling_spec.rb
+++ b/spec/ddtrace/profiling_spec.rb
@@ -36,10 +36,18 @@ RSpec.describe Datadog::Profiling do
         context 'is not available' do
           include_context 'loaded gems', :'google-protobuf' => nil
 
+          before do
+            hide_const('::Google::Protobuf')
+          end
+
           it { is_expected.to include 'Missing google-protobuf' }
         end
 
-        context 'is available' do
+        context 'is available but not yet loaded' do
+          before do
+            hide_const('::Google::Protobuf')
+          end
+
           context 'but is below the minimum version' do
             include_context 'loaded gems', :'google-protobuf' => Gem::Version.new('2.9')
 
@@ -61,6 +69,15 @@ RSpec.describe Datadog::Profiling do
               it { is_expected.to be nil }
             end
           end
+        end
+
+        context 'is already loaded' do
+          before do
+            stub_const('::Google::Protobuf', Module.new)
+            allow(described_class).to receive(:protobuf_loaded_successfully?).and_return(true)
+          end
+
+          it { is_expected.to be nil }
         end
       end
     end


### PR DESCRIPTION
On environments where protobuf is already loaded, we skip any interaction with `Gem.loaded_specs`. This allows us to support customers that don't load gems using rubygems but still have all the needed dependencies.

This is similar to
https://github.com/teamcapybara/capybara/commit/caf3bcd7664f4f2691d0ca9ef3be9a2a954fecfb

The change is quite small so I think it's worth it.