### PR TITLE
Use public prepend, include, and extend methods

### DIFF
--- a/lib/ddtrace/configuration/base.rb
+++ b/lib/ddtrace/configuration/base.rb
@@ -6,12 +6,12 @@ module Datadog
     # Basic configuration behavior
     module Base
       def self.included(base)
-        base.send(:extend, Datadog::Environment::Helpers)
-        base.send(:include, Datadog::Environment::Helpers)
-        base.send(:include, Options)
+        base.extend(Datadog::Environment::Helpers)
+        base.include(Datadog::Environment::Helpers)
+        base.include(Options)
 
-        base.send(:extend, ClassMethods)
-        base.send(:include, InstanceMethods)
+        base.extend(ClassMethods)
+        base.include(InstanceMethods)
       end
 
       # Class methods for configuration

--- a/lib/ddtrace/configuration/options.rb
+++ b/lib/ddtrace/configuration/options.rb
@@ -7,8 +7,8 @@ module Datadog
     # Behavior for a configuration object that has options
     module Options
       def self.included(base)
-        base.send(:extend, ClassMethods)
-        base.send(:include, InstanceMethods)
+        base.extend(ClassMethods)
+        base.include(InstanceMethods)
       end
 
       # Class behavior for a configuration object with options

--- a/lib/ddtrace/contrib/action_cable/event.rb
+++ b/lib/ddtrace/contrib/action_cable/event.rb
@@ -8,8 +8,8 @@ module Datadog
       # Defines basic behaviors for an event.
       module Event
         def self.included(base)
-          base.send(:include, ActiveSupport::Notifications::Event)
-          base.send(:extend, ClassMethods)
+          base.include(ActiveSupport::Notifications::Event)
+          base.extend(ClassMethods)
         end
 
         # Class methods for events.
@@ -34,8 +34,8 @@ module Datadog
       # but to start a fresh tracing context.
       module RootContextEvent
         def self.included(base)
-          base.send(:include, ActiveSupport::Notifications::Event)
-          base.send(:extend, ClassMethods)
+          base.include(ActiveSupport::Notifications::Event)
+          base.extend(ClassMethods)
         end
 
         # Class methods for events.

--- a/lib/ddtrace/contrib/action_pack/action_controller/patcher.rb
+++ b/lib/ddtrace/contrib/action_pack/action_controller/patcher.rb
@@ -16,7 +16,7 @@ module Datadog
           end
 
           def patch
-            ::ActionController::Metal.send(:prepend, ActionController::Instrumentation::Metal)
+            ::ActionController::Metal.prepend(ActionController::Instrumentation::Metal)
           end
         end
       end

--- a/lib/ddtrace/contrib/action_view/event.rb
+++ b/lib/ddtrace/contrib/action_view/event.rb
@@ -6,8 +6,8 @@ module Datadog
       # Defines basic behavior for an ActionView event.
       module Event
         def self.included(base)
-          base.send(:include, ActiveSupport::Notifications::Event)
-          base.send(:extend, ClassMethods)
+          base.include(ActiveSupport::Notifications::Event)
+          base.extend(ClassMethods)
         end
 
         # Class methods for ActionView events.

--- a/lib/ddtrace/contrib/action_view/patcher.rb
+++ b/lib/ddtrace/contrib/action_view/patcher.rb
@@ -31,12 +31,12 @@ module Datadog
             #  Rendering events are not nested in this version, creating
             #  render_partial spans outside of the parent render_template span.
             #  We fall back to manual patching instead.
-            ::ActionView::TemplateRenderer.send(:prepend, Instrumentation::TemplateRenderer::RailsLessThan4)
-            ::ActionView::PartialRenderer.send(:prepend, Instrumentation::PartialRenderer::RailsLessThan4)
+            ::ActionView::TemplateRenderer.prepend(Instrumentation::TemplateRenderer::RailsLessThan4)
+            ::ActionView::PartialRenderer.prepend(Instrumentation::PartialRenderer::RailsLessThan4)
           elsif defined?(::ActionView::Rendering) && defined?(::ActionView::Partials::PartialRenderer)
             # NOTE: Rails < 3.1 compatibility: different classes are used
-            ::ActionView::Rendering.send(:prepend, Instrumentation::TemplateRenderer::Rails30)
-            ::ActionView::Partials::PartialRenderer.send(:prepend, Instrumentation::PartialRenderer::RailsLessThan4)
+            ::ActionView::Rendering.prepend(Instrumentation::TemplateRenderer::Rails30)
+            ::ActionView::Partials::PartialRenderer.prepend(Instrumentation::PartialRenderer::RailsLessThan4)
           else
             Datadog.logger.debug('Expected Template/Partial classes not found; template rendering disabled')
           end

--- a/lib/ddtrace/contrib/active_model_serializers/event.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/event.rb
@@ -9,8 +9,8 @@ module Datadog
       # Defines basic behaviors for an ActiveModelSerializers event.
       module Event
         def self.included(base)
-          base.send(:include, ActiveSupport::Notifications::Event)
-          base.send(:extend, ClassMethods)
+          base.include(ActiveSupport::Notifications::Event)
+          base.extend(ClassMethods)
         end
 
         # Class methods for ActiveModelSerializers events.

--- a/lib/ddtrace/contrib/active_record/event.rb
+++ b/lib/ddtrace/contrib/active_record/event.rb
@@ -6,8 +6,8 @@ module Datadog
       # Defines basic behaviors for an ActiveRecord event.
       module Event
         def self.included(base)
-          base.send(:include, ActiveSupport::Notifications::Event)
-          base.send(:extend, ClassMethods)
+          base.include(ActiveSupport::Notifications::Event)
+          base.extend(ClassMethods)
         end
 
         # Class methods for ActiveRecord events.

--- a/lib/ddtrace/contrib/active_support/cache/patcher.rb
+++ b/lib/ddtrace/contrib/active_support/cache/patcher.rb
@@ -30,37 +30,37 @@ module Datadog
           end
 
           def patch_cache_store_read
-            cache_store_class(:read).send(:prepend, Cache::Instrumentation::Read)
+            cache_store_class(:read).prepend(Cache::Instrumentation::Read)
           end
 
           def patch_cache_store_read_multi
-            cache_store_class(:read_multi).send(:prepend, Cache::Instrumentation::ReadMulti)
+            cache_store_class(:read_multi).prepend(Cache::Instrumentation::ReadMulti)
           end
 
           def patch_cache_store_fetch
-            cache_store_class(:fetch).send(:prepend, Cache::Instrumentation::Fetch)
+            cache_store_class(:fetch).prepend(Cache::Instrumentation::Fetch)
           end
 
           def patch_cache_store_fetch_multi
             klass = cache_store_class(:fetch_multi)
             return unless klass.public_method_defined?(:fetch_multi)
 
-            klass.send(:prepend, Cache::Instrumentation::FetchMulti)
+            klass.prepend(Cache::Instrumentation::FetchMulti)
           end
 
           def patch_cache_store_write
-            cache_store_class(:write).send(:prepend, Cache::Instrumentation::Write)
+            cache_store_class(:write).prepend(Cache::Instrumentation::Write)
           end
 
           def patch_cache_store_write_multi
             klass = cache_store_class(:write_multi)
             return unless klass.public_method_defined?(:write_multi)
 
-            klass.send(:prepend, Cache::Instrumentation::WriteMulti)
+            klass.prepend(Cache::Instrumentation::WriteMulti)
           end
 
           def patch_cache_store_delete
-            cache_store_class(:delete).send(:prepend, Cache::Instrumentation::Delete)
+            cache_store_class(:delete).prepend(Cache::Instrumentation::Delete)
           end
         end
       end

--- a/lib/ddtrace/contrib/active_support/notifications/event.rb
+++ b/lib/ddtrace/contrib/active_support/notifications/event.rb
@@ -10,8 +10,8 @@ module Datadog
         # invoke Event.subscribe! to more easily subscribe to an event.
         module Event
           def self.included(base)
-            base.send(:include, Subscriber)
-            base.send(:extend, ClassMethods)
+            base.include(Subscriber)
+            base.extend(ClassMethods)
             base.send(:on_subscribe) { base.subscribe }
           end
 

--- a/lib/ddtrace/contrib/active_support/notifications/subscriber.rb
+++ b/lib/ddtrace/contrib/active_support/notifications/subscriber.rb
@@ -9,7 +9,7 @@ module Datadog
         # Creates subscriptions that are wrapped with tracing.
         module Subscriber
           def self.included(base)
-            base.send(:extend, ClassMethods)
+            base.extend(ClassMethods)
           end
 
           # Class methods that are implemented in the inheriting class.

--- a/lib/ddtrace/contrib/auto_instrument.rb
+++ b/lib/ddtrace/contrib/auto_instrument.rb
@@ -6,7 +6,7 @@ module Datadog
     # AutoInstrumentation enables all integration
     module AutoInstrument
       def self.extended(base)
-        base.send(:extend, Patch)
+        base.extend(Patch)
       end
 
       # Patch adds method for invoking auto_instrumentation

--- a/lib/ddtrace/contrib/concurrent_ruby/patcher.rb
+++ b/lib/ddtrace/contrib/concurrent_ruby/patcher.rb
@@ -20,7 +20,7 @@ module Datadog
 
         # Propagate tracing context in Concurrent::Future
         def patch_future
-          ::Concurrent::Future.send(:include, FuturePatch)
+          ::Concurrent::Future.include(FuturePatch)
         end
       end
     end

--- a/lib/ddtrace/contrib/configurable.rb
+++ b/lib/ddtrace/contrib/configurable.rb
@@ -10,7 +10,7 @@ module Datadog
     # fallback.
     module Configurable
       def self.included(base)
-        base.send(:include, InstanceMethods)
+        base.include(InstanceMethods)
       end
 
       # Configurable instance behavior for integrations

--- a/lib/ddtrace/contrib/cucumber/instrumentation.rb
+++ b/lib/ddtrace/contrib/cucumber/instrumentation.rb
@@ -6,7 +6,7 @@ module Datadog
       # Instrumentation for Cucumber
       module Instrumentation
         def self.included(base)
-          base.send(:prepend, InstanceMethods)
+          base.prepend(InstanceMethods)
         end
 
         # Instance methods for configuration

--- a/lib/ddtrace/contrib/cucumber/patcher.rb
+++ b/lib/ddtrace/contrib/cucumber/patcher.rb
@@ -15,7 +15,7 @@ module Datadog
         end
 
         def patch
-          ::Cucumber::Runtime.send(:include, Instrumentation)
+          ::Cucumber::Runtime.include(Instrumentation)
         end
       end
     end

--- a/lib/ddtrace/contrib/dalli/instrumentation.rb
+++ b/lib/ddtrace/contrib/dalli/instrumentation.rb
@@ -10,7 +10,7 @@ module Datadog
       # Instruments every interaction with the memcached server
       module Instrumentation
         def self.included(base)
-          base.send(:prepend, InstanceMethods)
+          base.prepend(InstanceMethods)
         end
 
         # InstanceMethods - implementing instrumentation

--- a/lib/ddtrace/contrib/dalli/patcher.rb
+++ b/lib/ddtrace/contrib/dalli/patcher.rb
@@ -17,7 +17,7 @@ module Datadog
         end
 
         def patch
-          ::Dalli::Server.send(:include, Instrumentation)
+          ::Dalli::Server.include(Instrumentation)
         end
       end
     end

--- a/lib/ddtrace/contrib/ethon/easy_patch.rb
+++ b/lib/ddtrace/contrib/ethon/easy_patch.rb
@@ -11,7 +11,7 @@ module Datadog
       # Ethon EasyPatch
       module EasyPatch
         def self.included(base)
-          base.send(:prepend, InstanceMethods)
+          base.prepend(InstanceMethods)
         end
 
         # InstanceMethods - implementing instrumentation

--- a/lib/ddtrace/contrib/ethon/multi_patch.rb
+++ b/lib/ddtrace/contrib/ethon/multi_patch.rb
@@ -11,7 +11,7 @@ module Datadog
       module MultiPatch
         def self.included(base)
           # No need to prepend here since add method is included into Multi class
-          base.send(:include, InstanceMethods)
+          base.include(InstanceMethods)
         end
 
         # InstanceMethods - implementing instrumentation

--- a/lib/ddtrace/contrib/ethon/patcher.rb
+++ b/lib/ddtrace/contrib/ethon/patcher.rb
@@ -16,8 +16,8 @@ module Datadog
           require 'ddtrace/contrib/ethon/easy_patch'
           require 'ddtrace/contrib/ethon/multi_patch'
 
-          ::Ethon::Easy.send(:include, EasyPatch)
-          ::Ethon::Multi.send(:include, MultiPatch)
+          ::Ethon::Easy.include(EasyPatch)
+          ::Ethon::Multi.include(MultiPatch)
         end
       end
     end

--- a/lib/ddtrace/contrib/extensions.rb
+++ b/lib/ddtrace/contrib/extensions.rb
@@ -7,9 +7,9 @@ module Datadog
     # Adds registry, configuration access for integrations.
     module Extensions
       def self.extended(base)
-        Datadog.send(:extend, Helpers)
-        Datadog.send(:extend, Configuration)
-        Datadog::Configuration::Settings.send(:include, Configuration::Settings)
+        Datadog.extend(Helpers)
+        Datadog.extend(Configuration)
+        Datadog::Configuration::Settings.include(Configuration::Settings)
       end
 
       # Helper methods for Datadog module.

--- a/lib/ddtrace/contrib/faraday/patcher.rb
+++ b/lib/ddtrace/contrib/faraday/patcher.rb
@@ -34,7 +34,7 @@ module Datadog
             ::Faraday.default_connection.use(:ddtrace)
 
             # Patch new connection instances (e.g. +Faraday.new+)
-            ::Faraday::Connection.send(:prepend, Connection)
+            ::Faraday::Connection.prepend(Connection)
           else
             # Patch the default connection (e.g. +Faraday.get+)
             #
@@ -44,7 +44,7 @@ module Datadog
             ::Faraday.default_connection.builder.insert(idx, Middleware)
 
             # Patch new connection instances (e.g. +Faraday.new+)
-            ::Faraday::RackBuilder.send(:prepend, RackBuilder)
+            ::Faraday::RackBuilder.prepend(RackBuilder)
           end
         end
       end

--- a/lib/ddtrace/contrib/grape/instrumentation.rb
+++ b/lib/ddtrace/contrib/grape/instrumentation.rb
@@ -4,8 +4,8 @@ module Datadog
       # Instrumentation for Grape::Endpoint
       module Instrumentation
         def self.included(base)
-          base.singleton_class.send(:prepend, ClassMethods)
-          base.send(:prepend, InstanceMethods)
+          base.singleton_class.prepend(ClassMethods)
+          base.prepend(InstanceMethods)
         end
 
         # ClassMethods - implementing instrumentation

--- a/lib/ddtrace/contrib/grape/patcher.rb
+++ b/lib/ddtrace/contrib/grape/patcher.rb
@@ -20,7 +20,7 @@ module Datadog
 
         def patch
           # Patch endpoints
-          ::Grape::Endpoint.send(:include, Instrumentation)
+          ::Grape::Endpoint.include(Instrumentation)
 
           # Subscribe to ActiveSupport events
           Datadog::Contrib::Grape::Endpoint.subscribe

--- a/lib/ddtrace/contrib/grpc/patcher.rb
+++ b/lib/ddtrace/contrib/grpc/patcher.rb
@@ -24,7 +24,7 @@ module Datadog
 
         def prepend_interceptor
           ::GRPC::InterceptionContext
-            .send(:prepend, Datadog::Contrib::GRPC::InterceptWithDatadog)
+            .prepend(Datadog::Contrib::GRPC::InterceptWithDatadog)
         end
       end
     end

--- a/lib/ddtrace/contrib/http/instrumentation.rb
+++ b/lib/ddtrace/contrib/http/instrumentation.rb
@@ -14,7 +14,7 @@ module Datadog
       # Instrumentation for Net::HTTP
       module Instrumentation
         def self.included(base)
-          base.send(:prepend, InstanceMethods)
+          base.prepend(InstanceMethods)
         end
 
         # Span hook invoked after request is completed.

--- a/lib/ddtrace/contrib/http/patcher.rb
+++ b/lib/ddtrace/contrib/http/patcher.rb
@@ -18,7 +18,7 @@ module Datadog
 
         # patch applies our patch if needed
         def patch
-          ::Net::HTTP.send(:include, Instrumentation)
+          ::Net::HTTP.include(Instrumentation)
         end
       end
     end

--- a/lib/ddtrace/contrib/httpclient/instrumentation.rb
+++ b/lib/ddtrace/contrib/httpclient/instrumentation.rb
@@ -12,7 +12,7 @@ module Datadog
       # Instrumentation for Httpclient
       module Instrumentation
         def self.included(base)
-          base.send(:prepend, InstanceMethods)
+          base.prepend(InstanceMethods)
         end
 
         # Instance methods for configuration

--- a/lib/ddtrace/contrib/httpclient/patcher.rb
+++ b/lib/ddtrace/contrib/httpclient/patcher.rb
@@ -26,7 +26,7 @@ module Datadog
         def patch
           PATCH_ONLY_ONCE.run do
             begin
-              ::HTTPClient.send(:include, Instrumentation)
+              ::HTTPClient.include(Instrumentation)
             rescue StandardError => e
               Datadog::Logger.error("Unable to apply httpclient integration: #{e}")
             end

--- a/lib/ddtrace/contrib/httprb/instrumentation.rb
+++ b/lib/ddtrace/contrib/httprb/instrumentation.rb
@@ -12,7 +12,7 @@ module Datadog
       # Instrumentation for Httprb
       module Instrumentation
         def self.included(base)
-          base.send(:prepend, InstanceMethods)
+          base.prepend(InstanceMethods)
         end
 
         # Instance methods for configuration

--- a/lib/ddtrace/contrib/httprb/patcher.rb
+++ b/lib/ddtrace/contrib/httprb/patcher.rb
@@ -26,7 +26,7 @@ module Datadog
         def patch
           PATCH_ONLY_ONCE.run do
             begin
-              ::HTTP::Client.send(:include, Instrumentation)
+              ::HTTP::Client.include(Instrumentation)
             rescue StandardError => e
               Datadog::Logger.error("Unable to apply httprb integration: #{e}")
             end

--- a/lib/ddtrace/contrib/integration.rb
+++ b/lib/ddtrace/contrib/integration.rb
@@ -7,9 +7,9 @@ module Datadog
     # Base provides features that are shared across all integrations
     module Integration
       def self.included(base)
-        base.send(:include, Configurable)
-        base.send(:include, Patchable)
-        base.send(:include, Registerable)
+        base.include(Configurable)
+        base.include(Patchable)
+        base.include(Registerable)
       end
     end
   end

--- a/lib/ddtrace/contrib/kafka/event.rb
+++ b/lib/ddtrace/contrib/kafka/event.rb
@@ -8,8 +8,8 @@ module Datadog
       # Defines basic behaviors for an ActiveSupport event.
       module Event
         def self.included(base)
-          base.send(:include, ActiveSupport::Notifications::Event)
-          base.send(:extend, ClassMethods)
+          base.include(ActiveSupport::Notifications::Event)
+          base.extend(ClassMethods)
         end
 
         # Class methods for Kafka events.

--- a/lib/ddtrace/contrib/mongodb/instrumentation.rb
+++ b/lib/ddtrace/contrib/mongodb/instrumentation.rb
@@ -13,7 +13,7 @@ module Datadog
         # Instrumentation for Mongo::Client
         module Client
           def self.included(base)
-            base.send(:include, InstanceMethods)
+            base.include(InstanceMethods)
           end
 
           # Instance methods for Mongo::Client
@@ -44,7 +44,7 @@ module Datadog
         # Instrumentation for Mongo::Address
         module Address
           def self.included(base)
-            base.send(:include, InstanceMethods)
+            base.include(InstanceMethods)
           end
 
           # Instance methods for Mongo::Address

--- a/lib/ddtrace/contrib/mongodb/patcher.rb
+++ b/lib/ddtrace/contrib/mongodb/patcher.rb
@@ -16,8 +16,8 @@ module Datadog
         end
 
         def patch
-          ::Mongo::Address.send(:include, Instrumentation::Address)
-          ::Mongo::Client.send(:include, Instrumentation::Client)
+          ::Mongo::Address.include(Instrumentation::Address)
+          ::Mongo::Client.include(Instrumentation::Client)
           add_mongo_monitoring
         end
 

--- a/lib/ddtrace/contrib/mysql2/instrumentation.rb
+++ b/lib/ddtrace/contrib/mysql2/instrumentation.rb
@@ -11,7 +11,7 @@ module Datadog
       # Mysql2::Client patch module
       module Instrumentation
         def self.included(base)
-          base.send(:prepend, InstanceMethods)
+          base.prepend(InstanceMethods)
         end
 
         # Mysql2::Client patch instance methods

--- a/lib/ddtrace/contrib/mysql2/patcher.rb
+++ b/lib/ddtrace/contrib/mysql2/patcher.rb
@@ -19,7 +19,7 @@ module Datadog
         end
 
         def patch_mysql2_client
-          ::Mysql2::Client.send(:include, Instrumentation)
+          ::Mysql2::Client.include(Instrumentation)
         end
       end
     end

--- a/lib/ddtrace/contrib/patchable.rb
+++ b/lib/ddtrace/contrib/patchable.rb
@@ -3,8 +3,8 @@ module Datadog
     # Base provides features that are shared across all integrations
     module Patchable
       def self.included(base)
-        base.send(:extend, ClassMethods)
-        base.send(:include, InstanceMethods)
+        base.extend(ClassMethods)
+        base.include(InstanceMethods)
       end
 
       # Class methods for integrations

--- a/lib/ddtrace/contrib/patcher.rb
+++ b/lib/ddtrace/contrib/patcher.rb
@@ -5,8 +5,8 @@ module Datadog
     # Common behavior for patcher modules
     module Patcher
       def self.included(base)
-        base.singleton_class.send(:prepend, CommonMethods)
-        base.send(:prepend, CommonMethods) if base.instance_of?(Class)
+        base.singleton_class.prepend(CommonMethods)
+        base.prepend(CommonMethods) if base.instance_of?(Class)
       end
 
       # Prepended instance methods for all patchers

--- a/lib/ddtrace/contrib/presto/instrumentation.rb
+++ b/lib/ddtrace/contrib/presto/instrumentation.rb
@@ -11,7 +11,7 @@ module Datadog
         # Instrumentation for Presto::Client::Client
         module Client
           def self.included(base)
-            base.send(:prepend, InstanceMethods)
+            base.prepend(InstanceMethods)
           end
 
           # Instance methods for Presto::Client

--- a/lib/ddtrace/contrib/presto/patcher.rb
+++ b/lib/ddtrace/contrib/presto/patcher.rb
@@ -21,7 +21,7 @@ module Datadog
         def patch
           PATCH_ONLY_ONCE.run do
             begin
-              ::Presto::Client::Client.send(:include, Instrumentation::Client)
+              ::Presto::Client::Client.include(Instrumentation::Client)
             rescue StandardError => e
               Datadog.logger.error("Unable to apply Presto integration: #{e}")
             end

--- a/lib/ddtrace/contrib/racecar/event.rb
+++ b/lib/ddtrace/contrib/racecar/event.rb
@@ -9,8 +9,8 @@ module Datadog
       # Defines basic behaviors for an ActiveRecord event.
       module Event
         def self.included(base)
-          base.send(:include, ActiveSupport::Notifications::Event)
-          base.send(:extend, ClassMethods)
+          base.include(ActiveSupport::Notifications::Event)
+          base.extend(ClassMethods)
         end
 
         # Class methods for Racecar events.

--- a/lib/ddtrace/contrib/rake/instrumentation.rb
+++ b/lib/ddtrace/contrib/rake/instrumentation.rb
@@ -7,7 +7,7 @@ module Datadog
       # Instrumentation for Rake tasks
       module Instrumentation
         def self.included(base)
-          base.send(:prepend, InstanceMethods)
+          base.prepend(InstanceMethods)
         end
 
         # Instance methods for Rake instrumentation

--- a/lib/ddtrace/contrib/rake/patcher.rb
+++ b/lib/ddtrace/contrib/rake/patcher.rb
@@ -18,7 +18,7 @@ module Datadog
 
         def patch
           # Add instrumentation patch to Rake task
-          ::Rake::Task.send(:include, Instrumentation)
+          ::Rake::Task.include(Instrumentation)
         end
 
         def get_option(option)

--- a/lib/ddtrace/contrib/registerable.rb
+++ b/lib/ddtrace/contrib/registerable.rb
@@ -5,8 +5,8 @@ module Datadog
     # Defines registerable behavior for integrations
     module Registerable
       def self.included(base)
-        base.send(:extend, ClassMethods)
-        base.send(:include, InstanceMethods)
+        base.extend(ClassMethods)
+        base.include(InstanceMethods)
       end
 
       # Class methods for registerable behavior

--- a/lib/ddtrace/contrib/resque/patcher.rb
+++ b/lib/ddtrace/contrib/resque/patcher.rb
@@ -18,7 +18,7 @@ module Datadog
         def patch
           require_relative 'resque_job'
 
-          ::Resque::Job.send(:prepend, Resque::Job)
+          ::Resque::Job.prepend(Resque::Job)
 
           workers = Datadog.configuration[:resque][:workers] || []
           workers.each { |worker| worker.extend(ResqueJob) }

--- a/lib/ddtrace/contrib/rest_client/patcher.rb
+++ b/lib/ddtrace/contrib/rest_client/patcher.rb
@@ -15,7 +15,7 @@ module Datadog
           require 'ddtrace/ext/app_types'
           require 'ddtrace/contrib/rest_client/request_patch'
 
-          ::RestClient::Request.send(:include, RequestPatch)
+          ::RestClient::Request.include(RequestPatch)
         end
       end
     end

--- a/lib/ddtrace/contrib/rest_client/request_patch.rb
+++ b/lib/ddtrace/contrib/rest_client/request_patch.rb
@@ -10,7 +10,7 @@ module Datadog
       # RestClient RequestPatch
       module RequestPatch
         def self.included(base)
-          base.send(:prepend, InstanceMethods)
+          base.prepend(InstanceMethods)
         end
 
         # InstanceMethods - implementing instrumentation

--- a/lib/ddtrace/contrib/rspec/example.rb
+++ b/lib/ddtrace/contrib/rspec/example.rb
@@ -4,7 +4,7 @@ module Datadog
       # Instrument RSpec::Core::Example
       module Example
         def self.included(base)
-          base.send(:prepend, InstanceMethods)
+          base.prepend(InstanceMethods)
         end
 
         # Instance methods for configuration

--- a/lib/ddtrace/contrib/rspec/patcher.rb
+++ b/lib/ddtrace/contrib/rspec/patcher.rb
@@ -15,7 +15,7 @@ module Datadog
         end
 
         def patch
-          ::RSpec::Core::Example.send(:include, Example)
+          ::RSpec::Core::Example.include(Example)
         end
       end
     end

--- a/lib/ddtrace/contrib/sequel/database.rb
+++ b/lib/ddtrace/contrib/sequel/database.rb
@@ -10,7 +10,7 @@ module Datadog
       # Adds instrumentation to Sequel::Database
       module Database
         def self.included(base)
-          base.send(:prepend, InstanceMethods)
+          base.prepend(InstanceMethods)
         end
 
         # Instance methods for instrumenting Sequel::Database

--- a/lib/ddtrace/contrib/sequel/dataset.rb
+++ b/lib/ddtrace/contrib/sequel/dataset.rb
@@ -10,7 +10,7 @@ module Datadog
       # Adds instrumentation to Sequel::Dataset
       module Dataset
         def self.included(base)
-          base.send(:prepend, InstanceMethods)
+          base.prepend(InstanceMethods)
         end
 
         # Instance methods for instrumenting Sequel::Dataset

--- a/lib/ddtrace/contrib/sequel/patcher.rb
+++ b/lib/ddtrace/contrib/sequel/patcher.rb
@@ -21,11 +21,11 @@ module Datadog
         end
 
         def patch_sequel_database
-          ::Sequel::Database.send(:include, Database)
+          ::Sequel::Database.include(Database)
         end
 
         def patch_sequel_dataset
-          ::Sequel::Dataset.send(:include, Dataset)
+          ::Sequel::Dataset.include(Dataset)
         end
       end
     end

--- a/lib/ddtrace/contrib/sinatra/patcher.rb
+++ b/lib/ddtrace/contrib/sinatra/patcher.rb
@@ -20,7 +20,7 @@ module Datadog
 
         def register_tracer
           ::Sinatra.send(:register, Datadog::Contrib::Sinatra::Tracer)
-          ::Sinatra::Base.send(:prepend, Sinatra::Tracer::Base)
+          ::Sinatra::Base.prepend(Sinatra::Tracer::Base)
         end
       end
     end

--- a/lib/ddtrace/opentelemetry/extensions.rb
+++ b/lib/ddtrace/opentelemetry/extensions.rb
@@ -6,7 +6,7 @@ module Datadog
     # Defines extensions to ddtrace for OpenTelemetry support
     module Extensions
       def self.extended(base)
-        Datadog::Span.send(:prepend, OpenTelemetry::Span)
+        Datadog::Span.prepend(OpenTelemetry::Span)
       end
     end
   end

--- a/lib/ddtrace/patcher.rb
+++ b/lib/ddtrace/patcher.rb
@@ -16,8 +16,8 @@ module Datadog
         )
       end
 
-      base.send(:extend, CommonMethods)
-      base.send(:include, CommonMethods)
+      base.extend(CommonMethods)
+      base.include(CommonMethods)
     end
 
     # Defines some common methods for patching, that can be used

--- a/lib/ddtrace/profiling/ext/cpu.rb
+++ b/lib/ddtrace/profiling/ext/cpu.rb
@@ -24,8 +24,8 @@ module Datadog
           # Applying CThread to Thread will ensure any new threads
           # will provide a thread/clock ID for CPU timing.
           require 'ddtrace/profiling/ext/cthread'
-          ::Thread.send(:prepend, Profiling::Ext::CThread)
-          ::Thread.singleton_class.send(:prepend, Datadog::Profiling::Ext::WrapThreadStartFork)
+          ::Thread.prepend(Profiling::Ext::CThread)
+          ::Thread.singleton_class.prepend(Datadog::Profiling::Ext::WrapThreadStartFork)
         end
 
         def self.unsupported_reason

--- a/lib/ddtrace/profiling/ext/forking.rb
+++ b/lib/ddtrace/profiling/ext/forking.rb
@@ -29,7 +29,7 @@ module Datadog
                 prepend Kernel
               end
             else
-              mod.class.send(:prepend, Kernel)
+              mod.class.prepend(Kernel)
             end
           end
         end

--- a/lib/ddtrace/transport/http/statistics.rb
+++ b/lib/ddtrace/transport/http/statistics.rb
@@ -6,8 +6,8 @@ module Datadog
       # Tracks statistics for HTTP transports
       module Statistics
         def self.included(base)
-          base.send(:include, Datadog::Transport::Statistics)
-          base.send(:include, InstanceMethods)
+          base.include(Datadog::Transport::Statistics)
+          base.include(InstanceMethods)
         end
 
         # Instance methods for HTTP statistics

--- a/lib/ddtrace/transport/http/traces.rb
+++ b/lib/ddtrace/transport/http/traces.rb
@@ -133,9 +133,9 @@ module Datadog
         end
 
         # Add traces behavior to transport components
-        HTTP::Client.send(:include, Traces::Client)
-        HTTP::API::Spec.send(:include, Traces::API::Spec)
-        HTTP::API::Instance.send(:include, Traces::API::Instance)
+        HTTP::Client.include(Traces::Client)
+        HTTP::API::Spec.include(Traces::API::Spec)
+        HTTP::API::Instance.include(Traces::API::Instance)
       end
     end
   end

--- a/lib/ddtrace/transport/io/traces.rb
+++ b/lib/ddtrace/transport/io/traces.rb
@@ -90,7 +90,7 @@ module Datadog
         end
 
         # Add traces behavior to transport components
-        IO::Client.send(:include, Traces::Client)
+        IO::Client.include(Traces::Client)
       end
     end
   end

--- a/lib/ddtrace/utils/forking.rb
+++ b/lib/ddtrace/utils/forking.rb
@@ -3,7 +3,7 @@ module Datadog
     # Helper methods for managing forking behavior
     module Forking
       def self.included(base)
-        base.send(:prepend, ClassExtensions) if base.is_a?(Class)
+        base.prepend(ClassExtensions) if base.is_a?(Class)
       end
 
       def self.extended(base)

--- a/lib/ddtrace/workers/async.rb
+++ b/lib/ddtrace/workers/async.rb
@@ -12,7 +12,7 @@ module Datadog
         SHUTDOWN_TIMEOUT = 1
 
         def self.included(base)
-          base.send(:prepend, PrependedMethods)
+          base.prepend(PrependedMethods)
         end
 
         # Methods that must be prepended

--- a/lib/ddtrace/workers/loop.rb
+++ b/lib/ddtrace/workers/loop.rb
@@ -8,7 +8,7 @@ module Datadog
       BASE_INTERVAL = 1
 
       def self.included(base)
-        base.send(:prepend, PrependedMethods)
+        base.prepend(PrependedMethods)
       end
 
       # Methods that must be prepended

--- a/lib/ddtrace/workers/polling.rb
+++ b/lib/ddtrace/workers/polling.rb
@@ -8,9 +8,9 @@ module Datadog
       SHUTDOWN_TIMEOUT = 1
 
       def self.included(base)
-        base.send(:include, Workers::IntervalLoop)
-        base.send(:include, Workers::Async::Thread)
-        base.send(:prepend, PrependedMethods)
+        base.include(Workers::IntervalLoop)
+        base.include(Workers::Async::Thread)
+        base.prepend(PrependedMethods)
       end
 
       # Methods that must be prepended

--- a/lib/ddtrace/workers/queue.rb
+++ b/lib/ddtrace/workers/queue.rb
@@ -4,7 +4,7 @@ module Datadog
     # to which items can be queued then dequeued.
     module Queue
       def self.included(base)
-        base.send(:prepend, PrependedMethods)
+        base.prepend(PrependedMethods)
       end
 
       # Methods that must be prepended

--- a/spec/ddtrace/configuration/base_spec.rb
+++ b/spec/ddtrace/configuration/base_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Datadog::Configuration::Base do
   describe 'implemented' do
     subject(:base_class) do
       Class.new.tap do |klass|
-        klass.send(:include, described_class)
+        klass.include(described_class)
       end
     end
 

--- a/spec/ddtrace/configuration/options_spec.rb
+++ b/spec/ddtrace/configuration/options_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Datadog::Configuration::Options do
   describe 'implemented' do
     subject(:options_class) do
       Class.new.tap do |klass|
-        klass.send(:include, described_class)
+        klass.include(described_class)
       end
     end
 
@@ -21,7 +21,7 @@ RSpec.describe Datadog::Configuration::Options do
         context 'on class inheriting from a class implementing Options' do
           let(:parent_class) do
             Class.new.tap do |klass|
-              klass.send(:include, described_class)
+              klass.include(described_class)
             end
           end
           let(:options_class) { Class.new(parent_class) }

--- a/spec/ddtrace/contrib/active_support/notifications/event_spec.rb
+++ b/spec/ddtrace/contrib/active_support/notifications/event_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Event do
       test_span_name = span_name
 
       Class.new.tap do |klass|
-        klass.send(:include, described_class)
+        klass.include(described_class)
         klass.send(:define_singleton_method, :event_name) { test_event_name }
         klass.send(:define_singleton_method, :span_name) { test_span_name }
         klass.send(:define_singleton_method, :process, &process_block)

--- a/spec/ddtrace/contrib/active_support/notifications/subscriber_spec.rb
+++ b/spec/ddtrace/contrib/active_support/notifications/subscriber_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscriber do
   describe 'implemented' do
     subject(:test_class) do
       Class.new.tap do |klass|
-        klass.send(:include, described_class)
+        klass.include(described_class)
       end
     end
 

--- a/spec/ddtrace/contrib/configurable_spec.rb
+++ b/spec/ddtrace/contrib/configurable_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Datadog::Contrib::Configurable do
   describe 'implemented' do
     subject(:configurable_class) do
       Class.new.tap do |klass|
-        klass.send(:include, described_class)
+        klass.include(described_class)
       end
     end
 

--- a/spec/ddtrace/contrib/integration_spec.rb
+++ b/spec/ddtrace/contrib/integration_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Datadog::Contrib::Integration do
   describe 'implemented' do
     subject(:integration_class) do
       Class.new.tap do |klass|
-        klass.send(:include, described_class)
+        klass.include(described_class)
       end
     end
 

--- a/spec/ddtrace/contrib/patchable_spec.rb
+++ b/spec/ddtrace/contrib/patchable_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Datadog::Contrib::Patchable do
   describe 'implemented' do
     subject(:patchable_class) do
       Class.new.tap do |klass|
-        klass.send(:include, described_class)
+        klass.include(described_class)
       end
     end
 

--- a/spec/ddtrace/contrib/registerable_spec.rb
+++ b/spec/ddtrace/contrib/registerable_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Datadog::Contrib::Registerable do
   describe 'implemented' do
     subject(:registerable_class) do
       Class.new.tap do |klass|
-        klass.send(:include, described_class)
+        klass.include(described_class)
       end
     end
 

--- a/spec/ddtrace/patcher_spec.rb
+++ b/spec/ddtrace/patcher_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Datadog::Patcher do
   describe 'implemented' do
     subject(:patcher_class) do
       Class.new.tap do |klass|
-        klass.send(:include, described_class)
+        klass.include(described_class)
       end
     end
 

--- a/spec/ddtrace/profiling/ext/cthread_spec.rb
+++ b/spec/ddtrace/profiling/ext/cthread_spec.rb
@@ -21,7 +21,7 @@ if Datadog::Profiling::Ext::CPU.supported?
       expect(::Thread.ancestors).to_not include(described_class)
 
       klass = ::Thread.dup
-      klass.send(:prepend, described_class)
+      klass.prepend(described_class)
       klass
     end
 
@@ -35,7 +35,7 @@ if Datadog::Profiling::Ext::CPU.supported?
       klass.send(:alias_method, :original_initialize, :initialize)
 
       # Add the module under test (Ext::CThread)
-      klass.send(:prepend, described_class)
+      klass.prepend(described_class)
 
       # Add a module that skips over the module under test's initialize changes
       skip_instrumentation = Module.new do
@@ -43,7 +43,7 @@ if Datadog::Profiling::Ext::CPU.supported?
           original_initialize(*args, &block) # directly call original initialize, skipping the one in Ext::CThread
         end
       end
-      klass.send(:prepend, skip_instrumentation)
+      klass.prepend(skip_instrumentation)
 
       klass
     end
@@ -64,7 +64,7 @@ if Datadog::Profiling::Ext::CPU.supported?
       def on_main_thread
         # Patch thread in a fork so we don't modify the original Thread class
         expect_in_fork do
-          thread_class.send(:prepend, described_class)
+          thread_class.prepend(described_class)
           yield
         end
 
@@ -82,7 +82,7 @@ if Datadog::Profiling::Ext::CPU.supported?
         # Skip verification because the thread will not have been patched with the method yet
         without_partial_double_verification do
           expect(thread).to receive(:update_native_ids)
-          thread_class.send(:prepend, described_class)
+          thread_class.prepend(described_class)
         end
       end
     end
@@ -302,8 +302,8 @@ if Datadog::Profiling::Ext::CPU.supported?
       expect(Thread.singleton_class.ancestors).to_not include(described_class)
 
       klass = ::Thread.dup
-      klass.send(:prepend, Datadog::Profiling::Ext::CThread)
-      klass.singleton_class.send(:prepend, described_class)
+      klass.prepend(Datadog::Profiling::Ext::CThread)
+      klass.singleton_class.prepend(described_class)
       klass
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -225,7 +225,7 @@ module DatadogThreadDebugger
   ruby2_keywords :initialize if respond_to?(:ruby2_keywords, true)
 end
 
-Thread.send(:prepend, DatadogThreadDebugger)
+Thread.prepend(DatadogThreadDebugger)
 
 # Helper matchers
 RSpec::Matchers.define_negated_matcher :not_be, :be

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -245,7 +245,7 @@ def remove_patch!(integration)
 end
 
 require 'ddtrace/contrib/patcher'
-Datadog::Contrib::Patcher::CommonMethods.send(:prepend, Module.new do
+Datadog::Contrib::Patcher::CommonMethods.prepend(Module.new do
   # Raise error during tests that fail to patch integration, instead of simply printing a warning message.
   def on_patch_error(e)
     raise e


### PR DESCRIPTION
This uses the public version of [Module#prepend](https://docs.ruby-lang.org/en/2.1.0/Module.html#method-i-prepend) and [Module#include](https://docs.ruby-lang.org/en/2.1.0/Module.html#method-i-include).

#prepend and #include were private in 2.0.

Also, this PR cleans up usages of [Object#extend](https://docs.ruby-lang.org/en/2.1.0/Object.html#method-i-extend) that used the `send(:extend)` syntax, instead of `#extend`. This method was public in Ruby 2.0, but we were likely conservative with its call syntax due to its apparent proximity to the non-public #prepend and #include.

### Ruby 2.0 deprecation checklist

- [x] Remove 2.0 from CI
- [x] Remove 2.0-specific code paths
- [ ] Update to 2.1+ standards: https://github.com/ruby/ruby/blob/v2_1_0/NEWS
  - [x] **Module#include and Module#prepend are now public methods.**
  - [ ] Exception#cause
  - [ ] Array#to_h converts an array of key-value pairs into a Hash.
  - [ ] Kernel#singleton_method
  - [ ] Process.clock_gettime
  - [ ] Enumerable#to_h converts a list of key-value pairs into a Hash.
  - [ ] Now the default values of keyword arguments can be omitted. Those “required keyword arguments” need giving explicitly at the call time.
- [ ] Update documentation
