### PR TITLE
Add loaded specs fallback

### DIFF
--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -18,8 +18,14 @@ module Datadog
     end
 
     def supported?
-      version = (defined?(Datadog::Statsd::VERSION) && Gem::Version.new(Datadog::Statsd::VERSION)) ||
-                (Gem.loaded_specs['dogstatsd-ruby'] && Gem.loaded_specs['dogstatsd-ruby'].version)
+      version = (
+          defined?(Datadog::Statsd::VERSION) &&
+          Datadog::Statsd::VERSION &&
+          Gem::Version.new(Datadog::Statsd::VERSION)
+        ) || (
+          Gem.loaded_specs['dogstatsd-ruby'] &&
+          Gem.loaded_specs['dogstatsd-ruby'].version
+        )
 
       !version.nil? && (version >= Gem::Version.new('3.3.0'))
     end

--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -18,8 +18,7 @@ module Datadog
     end
 
     def supported?
-      version = Gem.loaded_specs['dogstatsd-ruby'] \
-                  && Gem.loaded_specs['dogstatsd-ruby'].version
+      version = defined?(Datadog::Statsd::VERSION) && Gem::Version.new(Datadog::Statsd::VERSION)
 
       !version.nil? && (version >= Gem::Version.new('3.3.0'))
     end

--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -18,9 +18,8 @@ module Datadog
     end
 
     def supported?
-      version = (Gem.loaded_specs['dogstatsd-ruby'] \
-                  && Gem.loaded_specs['dogstatsd-ruby'].version) \
-                  || (defined?(Datadog::Statsd::VERSION) && Gem::Version.new(Datadog::Statsd::VERSION))
+      version = defined?(Datadog::Statsd::VERSION) && Gem::Version.new(Datadog::Statsd::VERSION) ||
+        Gem.loaded_specs['dogstatsd-ruby'] && Gem.loaded_specs['dogstatsd-ruby'].version
 
       !version.nil? && (version >= Gem::Version.new('3.3.0'))
     end

--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -18,7 +18,9 @@ module Datadog
     end
 
     def supported?
-      version = defined?(Datadog::Statsd::VERSION) && Gem::Version.new(Datadog::Statsd::VERSION)
+      version = (Gem.loaded_specs['dogstatsd-ruby'] \
+                  && Gem.loaded_specs['dogstatsd-ruby'].version) \
+                  || (defined?(Datadog::Statsd::VERSION) && Gem::Version.new(Datadog::Statsd::VERSION))
 
       !version.nil? && (version >= Gem::Version.new('3.3.0'))
     end

--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -18,8 +18,8 @@ module Datadog
     end
 
     def supported?
-      version = defined?(Datadog::Statsd::VERSION) && Gem::Version.new(Datadog::Statsd::VERSION) ||
-        Gem.loaded_specs['dogstatsd-ruby'] && Gem.loaded_specs['dogstatsd-ruby'].version
+      version = (defined?(Datadog::Statsd::VERSION) && Gem::Version.new(Datadog::Statsd::VERSION)) ||
+                (Gem.loaded_specs['dogstatsd-ruby'] && Gem.loaded_specs['dogstatsd-ruby'].version)
 
       !version.nil? && (version >= Gem::Version.new('3.3.0'))
     end

--- a/spec/ddtrace/metrics_spec.rb
+++ b/spec/ddtrace/metrics_spec.rb
@@ -27,15 +27,19 @@ RSpec.describe Datadog::Metrics do
 
     context 'when the dogstatsd gem' do
       before do
-        allow(Gem.loaded_specs).to receive(:[])
-          .with('dogstatsd-ruby')
-          .and_return(spec)
+        stub_const 'Datadog::Statsd::VERSION', spec
       end
 
       context 'is not loaded' do
         let(:spec) { nil }
 
         it { is_expected.to be false }
+
+        context 'is loaded outside of default Gem setup' do
+          let(:spec) { '3.3.0' }
+
+          it { is_expected.to be true }
+        end
       end
 
       context 'is loaded' do

--- a/spec/ddtrace/metrics_spec.rb
+++ b/spec/ddtrace/metrics_spec.rb
@@ -34,25 +34,17 @@ RSpec.describe Datadog::Metrics do
         let(:spec) { nil }
 
         it { is_expected.to be false }
-
-        context 'is loaded outside of default Gem setup' do
-          let(:spec) { '3.3.0' }
-
-          it { is_expected.to be true }
-        end
       end
 
       context 'is loaded' do
-        let(:spec) { instance_double(Gem::Specification, version: version) }
-
         context 'with version < 3.3.0' do
-          let(:version) { Gem::Version.new('3.2.9') }
+          let(:spec) { '3.2.9' }
 
           it { is_expected.to be false }
         end
 
         context 'with version 3.3.0' do
-          let(:version) { Gem::Version.new('3.3.0') }
+          let(:spec) { '3.3.0' }
 
           it { is_expected.to be true }
         end


### PR DESCRIPTION
this pr addresses https://github.com/DataDog/dd-trace-rb/issues/1505. Within the core tracer we should generally try to avoid `Gem.loaded_specs` if a known libraries version constant exists, as `loaded_specs` may not work depending on how the user is using Rubygems.

This work builds on top of https://github.com/DataDog/dd-trace-rb/pull/1506 and the next step here would be to add fallback code, where possible, for each contrib integration. Doing this repeatedly would be a chore so it's preferable to have a helper class for this that safely checks the version constant, maybe something like

```
module Datadog
  module Utils
    # Common gem-related utility functions.
    module Gem
      module_function

      # Safely falls back to checking if a gem has been loaded
      def loaded_specs_present?(gem_name = '', &block)
        begin
          Gem.loaded_specs[gem_name] || block.call

        # catch errors for an undefined or unsupported version constant
        rescue NameError, ArgumentError
        end
      end


      # Safely falls back to checking a gem's version constant if defined
      def loaded_specs_version(gem_name = '', &block)
        begin
          (Gem.loaded_specs[gem_name] && Gem.loaded_specs[gem_name].version) || Gem::Version.new(block.call)

        # catch errors for an undefined or unsupported version constant
        rescue NameError, ArgumentError
        end
      end
    end
  end
end
```

```
Datadog::Utils::Gem.loaded_specs_version('dogstatsd-ruby') { Datadog::Statsd::VERSION }
````
