### PR TITLE
More profiler pprof encoding performance improvements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -174,14 +174,6 @@ Performance/StringInclude: # (new in 1.7)
 Performance/Sum: # (new in 1.8)
   Enabled: true
 
-# Requires Ruby 2.1
-Style/HashConversion:
-  Enabled: false
-
-# Requires Ruby 2.1
-Lint/SendWithMixinArgument:
-  Enabled: false
-
 # Requires Ruby 2.2
 Style/HashSyntax:
   Enabled: false

--- a/benchmarks/profiler_submission.rb
+++ b/benchmarks/profiler_submission.rb
@@ -60,13 +60,16 @@ class ProfilerSubmission
         run_once
       end
 
-      x.save! 'profiler-submission-results.ipsbench'
+      x.save! 'profiler-submission-results.json'
       x.compare!
     end
   end
 
   def run_forever
-    run_once while true
+    while true
+      run_once
+      print '.'
+    end
   end
 
   def run_once

--- a/lib/ddtrace/profiling/pprof/builder.rb
+++ b/lib/ddtrace/profiling/pprof/builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ddtrace/profiling/flush'
 require 'ddtrace/profiling/pprof/message_set'
 require 'ddtrace/profiling/pprof/string_table'
@@ -7,9 +9,9 @@ module Datadog
     module Pprof
       # Accumulates profile data and produces a Perftools::Profiles::Profile
       class Builder
-        DEFAULT_ENCODING = 'UTF-8'.freeze
-        DESC_FRAME_OMITTED = 'frame omitted'.freeze
-        DESC_FRAMES_OMITTED = 'frames omitted'.freeze
+        DEFAULT_ENCODING = 'UTF-8'
+        DESC_FRAME_OMITTED = 'frame omitted'
+        DESC_FRAMES_OMITTED = 'frames omitted'
 
         attr_reader \
           :functions,
@@ -70,7 +72,7 @@ module Datadog
           # Add placeholder stack frame if frames were truncated
           if omitted > 0
             desc = omitted == 1 ? DESC_FRAME_OMITTED : DESC_FRAMES_OMITTED
-            locations << @locations[Profiling::BacktraceLocation.new(''.freeze, 0, "#{omitted} #{desc}")]
+            locations << @locations[Profiling::BacktraceLocation.new('', 0, "#{omitted} #{desc}")]
           end
 
           locations

--- a/lib/ddtrace/profiling/pprof/stack_sample.rb
+++ b/lib/ddtrace/profiling/pprof/stack_sample.rb
@@ -46,7 +46,7 @@ module Datadog
           )
 
           Perftools::Profiles::Sample.new(
-            location_id: locations.collect(&:id),
+            location_id: locations.collect { |location| location['id'.freeze] },
             value: values,
             label: build_sample_labels(stack_sample)
           )

--- a/lib/ddtrace/utils/object_set.rb
+++ b/lib/ddtrace/utils/object_set.rb
@@ -16,12 +16,10 @@ module Datadog
       # If they match an existing message, it will return the
       # matching object. If it doesn't match, it will yield to
       # the block with the next ID & args given.
-      def fetch(*args, &block)
+      def fetch(*args)
+        # TODO: Array hashing is **really** expensive, we probably want to get rid of it in the future
         key = @key_block ? @key_block.call(*args) : args.hash
-        # TODO: Ruby 2.0 doesn't like yielding here... switch when 2.0 is dropped.
-        # rubocop:disable Performance/RedundantBlockCall
-        @items[key] ||= block.call(@sequence.next, *args)
-        # rubocop:enable Performance/RedundantBlockCall
+        @items[key] ||= yield(@sequence.next, *args)
       end
 
       def length

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -168,14 +168,7 @@ RSpec.describe 'profiling integration test' do
 
     include_context 'StackSample events' do
       def stack_frame_to_location_id(backtrace_location)
-        template.builder.locations.fetch(
-          # Filename
-          backtrace_location.path,
-          # Line number
-          backtrace_location.lineno,
-          # Function name
-          backtrace_location.base_label
-        ) { raise 'Unknown stack frame!' }.id
+        template.builder.locations.fetch(backtrace_location) { raise 'Unknown stack frame!' }.id
       end
 
       def stack_frame_to_function_id(backtrace_location)

--- a/spec/ddtrace/profiling/pprof/builder_spec.rb
+++ b/spec/ddtrace/profiling/pprof/builder_spec.rb
@@ -21,19 +21,6 @@ RSpec.describe Datadog::Profiling::Pprof::Builder do
     builder.string_table.fetch(string)
   end
 
-  describe '#initialize' do
-    it do
-      is_expected.to have_attributes(
-        functions: kind_of(Datadog::Profiling::Pprof::MessageSet),
-        locations: kind_of(Datadog::Profiling::Pprof::MessageSet),
-        mappings: kind_of(Datadog::Profiling::Pprof::MessageSet),
-        sample_types: kind_of(Datadog::Profiling::Pprof::MessageSet),
-        samples: [],
-        string_table: kind_of(Datadog::Profiling::Pprof::StringTable)
-      )
-    end
-  end
-
   describe '#encode_profile' do
     subject(:build_profile) { builder.encode_profile(profile) }
 
@@ -66,7 +53,7 @@ RSpec.describe Datadog::Profiling::Pprof::Builder do
           sample_type: builder.sample_types.messages,
           sample: builder.samples,
           mapping: builder.mappings.messages,
-          location: builder.locations.messages,
+          location: builder.locations.values,
           function: builder.functions.messages,
           string_table: builder.string_table.strings
         )
@@ -98,27 +85,13 @@ RSpec.describe Datadog::Profiling::Pprof::Builder do
     let(:backtrace_locations) { Thread.current.backtrace_locations.first(3) }
     let(:length) { backtrace_locations.length }
 
-    let(:expected_locations) do
-      backtrace_locations.each_with_object({}) do |loc, map|
-        key = [loc.path, loc.lineno, loc.base_label]
-        # Use double instead of instance_double because protobuf doesn't define verifiable methods
-        map[key] = double('Perftools::Profiles::Location')
-      end
-    end
-
-    before do
-      expect(builder.locations).to receive(:fetch).at_least(backtrace_locations.length).times do |*args, &block|
-        expect(expected_locations).to include(args)
-        expect(block.source_location).to eq(builder.method(:build_location).source_location)
-        expected_locations[args]
-      end
-    end
-
     context 'given backtrace locations matching length' do
-      it do
-        is_expected.to be_a_kind_of(Array)
-        is_expected.to have(backtrace_locations.length).items
-        is_expected.to include(*expected_locations.values)
+      it { is_expected.to be_a_kind_of(Array) }
+      it { is_expected.to have(backtrace_locations.length).items }
+
+      it 'converts the BacktraceLocations to matching Perftools::Profiles::Location objects' do
+        # Lines are the simplest to compare, since they aren't converted to ids
+        expect(build_locations.map { |location| location.to_h[:line].first[:line] }).to eq backtrace_locations.map(&:lineno)
       end
     end
 
@@ -128,56 +101,47 @@ RSpec.describe Datadog::Profiling::Pprof::Builder do
       let(:omitted_location) { double('Perftools::Profiles::Location') }
 
       before do
-        expected_locations[['', 0, "#{omitted} #{described_class::DESC_FRAMES_OMITTED}"]] = omitted_location
+        omitted_backtrace_location =
+          Datadog::Profiling::BacktraceLocation.new('', 0, "#{omitted} #{described_class::DESC_FRAMES_OMITTED}")
+
+        builder.locations[omitted_backtrace_location] = omitted_location
       end
 
-      it do
-        is_expected.to be_a_kind_of(Array)
-        is_expected.to have(backtrace_locations.length + 1).items
-        is_expected.to include(*expected_locations.values)
-        expect(build_locations.last).to be(omitted_location)
+      it { is_expected.to have(backtrace_locations.length + 1).items }
+
+      it 'converts the BacktraceLocations to matching Perftools::Profiles::Location objects' do
+        expect(build_locations[0..-2].map { |location| location.to_h[:line].first[:line] })
+          .to eq backtrace_locations.map(&:lineno)
+      end
+
+      it 'adds a placeholder frame as the last element to indicate the omitted frames' do
+        expect(build_locations.last).to be omitted_location
       end
     end
   end
 
   describe '#build_location' do
-    subject(:build_location) { builder.build_location(id, filename, line_number) }
-
-    let(:id) { id_sequence.next }
-    let(:filename) { double('filename') }
-    let(:line_number) { rand_int }
-
-    # Use double instead of instance_double because protobuf doesn't define verifiable methods
-    let(:function) { double('Perftools::Profiles::Function', id: id_sequence.next) }
-
-    before do
-      expect(builder.functions).to receive(:fetch) do |*args, &block|
-        expect(args).to eq([filename, nil])
-        expect(block.source_location).to eq(builder.method(:build_function).source_location)
-        function
-      end
+    subject(:build_location) do
+      builder.build_location(location_id, Datadog::Profiling::BacktraceLocation.new(function_name, line_number, filename))
     end
 
-    context 'given no function name' do
-      it do
-        is_expected.to be_a_kind_of(Perftools::Profiles::Location)
-        is_expected.to have_attributes(
-          id: id,
-          line: array_including(kind_of(Perftools::Profiles::Line))
-        )
-        expect(build_location.line).to have(1).items
-      end
+    let(:location_id) { rand_int }
+    let(:line_number) { rand_int }
+    let(:function_name) { 'the_function_name' }
+    let(:filename) { 'the_file_name.rb' }
 
-      describe 'returns a Location with Line that' do
-        subject(:line) { build_location.line.first }
+    it 'creates a new Perftools::Profiles::Location object with the contents of the BacktraceLocation' do
+      function = double('Function', id: rand_int)
 
-        it do
-          is_expected.to have_attributes(
-            function_id: function.id,
-            line: line_number
-          )
-        end
-      end
+      expect(Perftools::Profiles::Function)
+        .to receive(:new).with(hash_including(filename: string_id_for(filename), name: string_id_for(function_name)))
+                         .and_return(function)
+
+      expect(build_location).to be_a_kind_of(Perftools::Profiles::Location)
+      expect(build_location.to_h).to match(hash_including(id: location_id,
+                                                          line: [{
+                                                            function_id: function.id, line: line_number
+                                                          }]))
     end
   end
 

--- a/spec/ddtrace/profiling/pprof/stack_sample_spec.rb
+++ b/spec/ddtrace/profiling/pprof/stack_sample_spec.rb
@@ -314,7 +314,7 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
 
         it 'each map to a Location on the profile' do
           locations.each do |id|
-            expect(builder.locations.messages[id - 1])
+            expect(builder.locations.values[id - 1])
               .to be_kind_of(Perftools::Profiles::Location)
           end
         end

--- a/spec/ddtrace/profiling/spec_helper.rb
+++ b/spec/ddtrace/profiling/spec_helper.rb
@@ -75,7 +75,9 @@ module ProfileHelpers
 
     Datadog::Profiling::Events::StackSample.new(
       nil,
-      locations,
+      locations.map do |location|
+        Datadog::Profiling::BacktraceLocation.new(location.base_label, location.lineno, location.path)
+      end,
       locations.length,
       thread_id || rand(1e9),
       trace_id || rand(1e9),


### PR DESCRIPTION
A second round of performance improvements to pprof encoding. Compared to dd-trace-rb 0.49.0, there's a 3.7x speedup, or 2.27x speedup when comparing with current master.

This takes care of the low-hanging fruit I could identify in pprof encoding.

```
exporter objectset-yield
                         10.028  (± 0.0%) i/s -    101.000  in  10.079207s

Comparison:
exporter objectset-yield:       10.0 i/s
exporter locations-avoid-method-missing:        9.9 i/s - 1.01x  (± 0.00) slower
exporter locations-hashmap:        9.2 i/s - 1.09x  (± 0.00) slower
exporter cached-build-location-v2 (current master):        4.4 i/s - 2.30x  (± 0.00) slower
exporter baseline (before any work):        2.7 i/s - 3.72x  (± 0.00) slower
```