### PR TITLE
Clarify in warning that wall time profiles are still available when CPU time is not

### DIFF
--- a/lib/ddtrace/profiling/tasks/setup.rb
+++ b/lib/ddtrace/profiling/tasks/setup.rb
@@ -41,7 +41,8 @@ module Datadog
             Ext::CPU.apply!
           elsif Datadog.configuration.profiling.enabled
             # Log warning if profiling was supposed to be activated.
-            log "[DDTRACE] CPU profiling skipped because native CPU time is not supported: #{Ext::CPU.unsupported_reason}."
+            log '[DDTRACE] CPU time profiling skipped because native CPU time is not supported: ' \
+              "#{Ext::CPU.unsupported_reason}. Profiles containing Wall time will still be reported."
           end
         rescue StandardError, ScriptError => e
           log "[DDTRACE] CPU profiling unavailable. Cause: #{e.message} Location: #{e.backtrace.first}"

--- a/spec/ddtrace/profiling/tasks/setup_spec.rb
+++ b/spec/ddtrace/profiling/tasks/setup_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
         it 'skips CPU extensions with warning' do
           expect(Datadog::Profiling::Ext::CPU).to_not receive(:apply!)
           expect($stdout).to receive(:puts) do |message|
-            expect(message).to include('CPU profiling skipped')
+            expect(message).to include('CPU time profiling skipped')
           end
 
           activate_cpu_extensions


### PR DESCRIPTION
It seems like saying:

> [DDTRACE] CPU profiling skipped because native CPU time is not supported: Feature requires Linux; macOS is not supported.

is generating a bit of confusion on what users should expect. This PR changes it to:

> [DDTRACE] CPU time profiling skipped because native CPU time is not supported: Feature requires Linux; macOS is not supported. Profiles containing Wall time will still be reported.

to hopefully clarify to users that they're on the right path and they'll still get profiles.