### PR TITLE
Bump TruffleRuby docker images to latest version, and a few more test suite fixes

### DIFF
--- a/.circleci/images/primary/Dockerfile-truffleruby-21.1.0
+++ b/.circleci/images/primary/Dockerfile-truffleruby-21.1.0
@@ -1,4 +1,4 @@
-FROM flavorjones/truffleruby:21.0.0-buster
+FROM flavorjones/truffleruby:21.1.0-buster
 
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -300,8 +300,8 @@ services:
       - .:/app
       - bundle-jruby-9.2-latest:/usr/local/bundle
   # TruffleRuby
-  tracer-truffleruby-21.0.0:
-    image: ivoanjo/docker-library:ddtrace_rb_truffleruby_21_0_0
+  tracer-truffleruby-21.1.0:
+    image: ivoanjo/docker-library:ddtrace_rb_truffleruby_21_1_0
     command: /bin/bash
     depends_on:
       - ddagent
@@ -329,7 +329,7 @@ services:
     tty: true
     volumes:
       - .:/app
-      - bundle-truffleruby-21.0.0:/usr/local/bundle
+      - bundle-truffleruby-21.1.0:/usr/local/bundle
   ddagent:
     image: datadog/agent
     environment:
@@ -411,4 +411,4 @@ volumes:
   bundle-3.0:
   bundle-jruby-9.2.0.0:
   bundle-jruby-9.2-latest:
-  bundle-truffleruby-21.0.0:
+  bundle-truffleruby-21.1.0:

--- a/spec/ddtrace/error_spec.rb
+++ b/spec/ddtrace/error_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Datadog::Error do
             end
           end
 
-          it 'reports errors only once', if: RUBY_VERSION < '2.6.0' do
+          it 'reports errors only once', if: (RUBY_VERSION < '2.6.0' || PlatformHelpers.truffleruby?) do
             expect(error.type).to eq('RuntimeError')
             expect(error.message).to eq('first error')
 
@@ -117,7 +117,7 @@ RSpec.describe Datadog::Error do
             expect(error.backtrace.each_line.reject { |l| l.start_with?("\tfrom") }).to have(2).items
           end
 
-          it 'reports errors only once', if: RUBY_VERSION >= '2.6.0' do
+          it 'reports errors only once', if: (RUBY_VERSION >= '2.6.0' && !PlatformHelpers.truffleruby?) do
             expect(error.type).to eq('ArgumentError')
             expect(error.message).to eq('circular causes')
 

--- a/spec/ddtrace/profiling/ext/cthread_spec.rb
+++ b/spec/ddtrace/profiling/ext/cthread_spec.rb
@@ -6,6 +6,10 @@ if Datadog::Profiling::Ext::CPU.supported?
   require 'ddtrace/profiling/ext/cthread'
 
   RSpec.describe Datadog::Profiling::Ext::CThread do
+    before do
+      skip "CThread specs cannot run on TruffleRuby because they rely on fork()" if PlatformHelpers.truffleruby?
+    end
+
     subject(:thread) do
       thread_class.new(&block).tap do
         # Give thread a chance to start,

--- a/spec/ddtrace/profiling/ext/cthread_spec.rb
+++ b/spec/ddtrace/profiling/ext/cthread_spec.rb
@@ -7,7 +7,7 @@ if Datadog::Profiling::Ext::CPU.supported?
 
   RSpec.describe Datadog::Profiling::Ext::CThread do
     before do
-      skip "CThread specs cannot run on TruffleRuby because they rely on fork()" if PlatformHelpers.truffleruby?
+      skip 'CThread specs cannot run on TruffleRuby because they rely on fork()' if PlatformHelpers.truffleruby?
     end
 
     subject(:thread) do

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'profiling integration test' do
         include_context 'end-to-end profiler'
 
         before do
-          skip "This test cannot run on TruffleRuby because it relies on fork()" if PlatformHelpers.truffleruby?
+          skip 'This test cannot run on TruffleRuby because it relies on fork()' if PlatformHelpers.truffleruby?
         end
 
         it 'produces a profile' do

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -97,8 +97,11 @@ RSpec.describe 'profiling integration test' do
 
     if Datadog::Profiling::Ext::CPU.supported?
       context 'with CPU profiling' do
-        # include_context 'with profiling extensions'
         include_context 'end-to-end profiler'
+
+        before do
+          skip "This test cannot run on TruffleRuby because it relies on fork()" if PlatformHelpers.truffleruby?
+        end
 
         it 'produces a profile' do
           with_profiling_extensions_in_fork do


### PR DESCRIPTION
I took a look at the current state of adding TruffleRuby to our test suite.

I found out two new issues (https://github.com/oracle/truffleruby/issues/2356 and https://github.com/oracle/truffleruby/issues/2359) and updated the list on #1383 of things that prevent our test suite from passing on TruffleRuby.

Again I keep being amazed how most of it passes, without excluding large parts of it like we do for JRuby.