### PR TITLE
Use Array#to_h instead of Hash[array]

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -175,10 +175,6 @@ Performance/Sum: # (new in 1.8)
   Enabled: true
 
 # Requires Ruby 2.1
-Style/HashConversion:
-  Enabled: false
-
-# Requires Ruby 2.1
 Lint/SendWithMixinArgument:
   Enabled: false
 

--- a/lib/ddtrace/configuration/base.rb
+++ b/lib/ddtrace/configuration/base.rb
@@ -53,10 +53,7 @@ module Datadog
           ordering = self.class.options.dependency_order
           sorted_opts = opts.sort_by do |name, _value|
             ordering.index(name) || (ordering.length + 1)
-          end
-
-          # Ruby 2.0 doesn't support Array#to_h
-          sorted_opts = Hash[*sorted_opts.flatten]
+          end.to_h
 
           # Apply options in sort order
           sorted_opts.each do |name, value|

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -225,7 +225,7 @@ module Datadog
 
         o.setter do |new_value, old_value|
           # Coerce keys to strings
-          string_tags = Hash[new_value.collect { |k, v| [k.to_s, v] }]
+          string_tags = new_value.collect { |k, v| [k.to_s, v] }.to_h
 
           # Cross-populate tag values with other settings
           self.env = string_tags[Ext::Environment::TAG_ENV] if env.nil? && string_tags.key?(Ext::Environment::TAG_ENV)

--- a/lib/ddtrace/contrib/aws/patcher.rb
+++ b/lib/ddtrace/contrib/aws/patcher.rb
@@ -23,7 +23,7 @@ module Datadog
 
           # Special handling for S3 URL Presigning.
           # @see {Datadog::Contrib::Aws::S3Presigner}
-          ::Aws::S3::Presigner.send(:prepend, S3Presigner)
+          ::Aws::S3::Presigner.prepend S3Presigner
         end
 
         def add_plugin(*targets)

--- a/lib/ddtrace/diagnostics/environment_logger.rb
+++ b/lib/ddtrace/diagnostics/environment_logger.rb
@@ -259,7 +259,7 @@ module Datadog
 
       # Capture all active integration settings into "integrationName_settingName: value" entries.
       def instrumented_integrations_settings
-        Hash[instrumented_integrations.flat_map do |name, integration|
+        instrumented_integrations.flat_map do |name, integration|
           integration.configuration.to_h.flat_map do |setting, value|
             next [] if setting == :tracer # Skip internal Ruby objects
 
@@ -267,7 +267,7 @@ module Datadog
             # handlers possibly causing errors.
             [[:"integration_#{name}_#{setting}", value.to_s]]
           end
-        end]
+        end.to_h
       end
 
       # Outputs "k1:v1,k2:v2,..."

--- a/lib/ddtrace/runtime/metrics.rb
+++ b/lib/ddtrace/runtime/metrics.rb
@@ -58,11 +58,9 @@ module Datadog
       end
 
       def gc_metrics
-        Hash[
-          GC.stat.flat_map do |k, v|
-            nested_gc_metric(Ext::Runtime::Metrics::METRIC_GC_PREFIX, k, v)
-          end
-        ]
+        GC.stat.flat_map do |k, v|
+          nested_gc_metric(Ext::Runtime::Metrics::METRIC_GC_PREFIX, k, v)
+        end.to_h
       end
 
       def try_flush

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -162,7 +162,7 @@ module Datadog
     #
     #   tracer.set_tags('env' => 'prod', 'component' => 'core')
     def set_tags(tags)
-      string_tags = Hash[tags.collect { |k, v| [k.to_s, v] }]
+      string_tags = tags.collect { |k, v| [k.to_s, v] }.to_h
       @tags = @tags.merge(string_tags)
     end
 


### PR DESCRIPTION
This PR uses [`Array#to_h`](https://ruby-doc.org/core-2.1.0/Array.html#method-i-to_h), instead of `Hash[array]`, as this method is available since Ruby 2.1.

`Array#to_h` has cleaner syntax, is much faster with empty arrays, and is slightly faster with populated arrays:

```ruby
require 'benchmark/ips'

arr = []
a16 = 16.times.map{|i|[i.to_s.to_sym, 'test']}

Benchmark.ips do |x|
  x.config(time: 2, warmup: 0.1) if x.respond_to? :config

  x.report('empty array: Hash[A]') { Hash[arr] }
  x.report('empty array: A.to_h ') { arr.to_h }
  x.report('16 elements: Hash[A]') { Hash[a16] }
  x.report('16 elements: A.to_h ') { a16.to_h }

  x.compare!
end

# empty array: A.to_h : 13333116.0 i/s
# empty array: Hash[A]:  8432958.2 i/s - 1.58x  (± 0.00) slower
# 16 elements: A.to_h :   770205.8 i/s - 17.31x  (± 0.00) slower
# 16 elements: Hash[A]:   697552.1 i/s - 19.11x  (± 0.00) slower

```

### Ruby 2.0 deprecation checklist

- [x] Remove 2.0 from CI
- [x] Remove 2.0-specific code paths
- [ ] Update to 2.1+ standards: https://github.com/ruby/ruby/blob/v2_1_0/NEWS
  - [x] Module#include and Module#prepend are now public methods.
  - [x] Exception#cause _(no changes)_
  - [x] **Array#to_h converts an array of key-value pairs into a Hash.**
  - [ ] Kernel#singleton_method
  - [ ] Process.clock_gettime
  - [x] **Enumerable#to_h converts a list of key-value pairs into a Hash.**
  - [ ] Now the default values of keyword arguments can be omitted. Those “required keyword arguments” need giving explicitly at the call time.
- [ ] Update documentation
