### PR TITLE
Remove conditional checks for Process.clock_gettime

### DIFF
--- a/lib/ddtrace/profiling/ext/cthread.rb
+++ b/lib/ddtrace/profiling/ext/cthread.rb
@@ -91,9 +91,7 @@ module Datadog
         ruby2_keywords :initialize if respond_to?(:ruby2_keywords, true)
 
         def cpu_time(unit = :float_second)
-          return unless clock_id && ::Process.respond_to?(:clock_gettime)
-
-          ::Process.clock_gettime(clock_id, unit)
+          ::Process.clock_gettime(clock_id, unit) if clock_id
         end
 
         def cpu_time_instrumentation_installed?

--- a/spec/ddtrace/profiling/ext/cthread_spec.rb
+++ b/spec/ddtrace/profiling/ext/cthread_spec.rb
@@ -177,18 +177,16 @@ if Datadog::Profiling::Ext::CPU.supported?
 
           before { allow(thread).to receive(:clock_id).and_return(clock_id) }
 
-          if Process.respond_to?(:clock_gettime)
-            let(:cpu_time_measurement) { double('cpu time measurement') }
+          let(:cpu_time_measurement) { double('cpu time measurement') }
 
-            context 'when not given a unit' do
-              it 'gets time in CPU seconds' do
-                expect(Process)
-                  .to receive(:clock_gettime)
-                  .with(clock_id, :float_second)
-                  .and_return(cpu_time_measurement)
+          context 'when not given a unit' do
+            it 'gets time in CPU seconds' do
+              expect(Process)
+                .to receive(:clock_gettime)
+                .with(clock_id, :float_second)
+                .and_return(cpu_time_measurement)
 
-                is_expected.to be cpu_time_measurement
-              end
+              is_expected.to be cpu_time_measurement
             end
 
             context 'given a unit' do
@@ -204,10 +202,6 @@ if Datadog::Profiling::Ext::CPU.supported?
 
                 is_expected.to be cpu_time_measurement
               end
-            end
-          else
-            context 'but #clock_gettime is not' do
-              it { is_expected.to be nil }
             end
           end
         end

--- a/spec/ddtrace/profiling/ext/cthread_spec.rb
+++ b/spec/ddtrace/profiling/ext/cthread_spec.rb
@@ -174,10 +174,9 @@ if Datadog::Profiling::Ext::CPU.supported?
 
         context 'is available' do
           let(:clock_id) { double('clock ID') }
+          let(:cpu_time_measurement) { double('cpu time measurement') }
 
           before { allow(thread).to receive(:clock_id).and_return(clock_id) }
-
-          let(:cpu_time_measurement) { double('cpu time measurement') }
 
           context 'when not given a unit' do
             it 'gets time in CPU seconds' do


### PR DESCRIPTION
[Process.clock_gettime](https://ruby-doc.org/core-2.1.0/Process.html#method-c-clock_gettime) is now available for all supported versions of Ruby.
This PR removes conditional checks for its presence.

### Ruby 2.0 deprecation checklist

- [x] Remove 2.0 from CI
- [x] Remove 2.0-specific code paths
- [ ] Update to 2.1+ standards: https://github.com/ruby/ruby/blob/v2_1_0/NEWS
  - [x] Module#include and Module#prepend are now public methods.
  - [x] Exception#cause _(no changes)_
  - [x] Array#to_h converts an array of key-value pairs into a Hash.
  - [x] Kernel#singleton_method _(no changes)_
  - [x] **Process.clock_gettime**
  - [ ] Enumerable#to_h converts a list of key-value pairs into a Hash.
  - [ ] Now the default values of keyword arguments can be omitted. Those “required keyword arguments” need giving explicitly at the call time.
- [ ] Update documentation
