### PR TITLE
Print logs on integration app run failure

### DIFF
--- a/integration/apps/rack/script/ci
+++ b/integration/apps/rack/script/ci
@@ -44,7 +44,8 @@ echo ""
 APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES build
 
 # Run the test suite
-APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES run integration-tester
+APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES run integration-tester || \
+  APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES logs # Print container logs on `run` failure
 
 # Cleanup
 APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES down -t 0 --remove-orphans

--- a/integration/apps/rails-five/script/ci
+++ b/integration/apps/rails-five/script/ci
@@ -44,7 +44,8 @@ echo ""
 APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES build
 
 # Run the test suite
-APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES run integration-tester
+APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES run integration-tester || \
+  APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES logs # Print container logs on `run` failure
 
 # Cleanup
 APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES down -t 0 --remove-orphans

--- a/integration/apps/ruby/script/ci
+++ b/integration/apps/ruby/script/ci
@@ -44,7 +44,8 @@ echo ""
 APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES build
 
 # Run the test suite
-APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES run integration-tester
+APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES run integration-tester || \
+  APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES logs # Print container logs on `run` failure
 
 # Cleanup
 APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES down -t 0 --remove-orphans


### PR DESCRIPTION
Currently, when you manage to make a change that passes all unit tests, but fails only on our `integration/apps` tests, it's hard to know what the failure is as the error logs are not reported in CI.

This PR prints out the container logs for the `integration-tester` container when execution fails.