### PR TITLE
Add RSpec integration app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -532,37 +532,37 @@ workflows:
       # Integration
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.1
-          integration_apps: 'ruby rack'
+          integration_apps: 'ruby rack rspec'
           ruby_version: '2.1'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.2
-          integration_apps: 'ruby rack'
+          integration_apps: 'ruby rack rspec'
           ruby_version: '2.2'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.3
-          integration_apps: 'ruby rack rails-five'
+          integration_apps: 'ruby rack rails-five rspec'
           ruby_version: '2.3'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.4
-          integration_apps: 'ruby rack rails-five'
+          integration_apps: 'ruby rack rails-five rspec'
           ruby_version: '2.4'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.5
-          integration_apps: 'ruby rack rails-five'
+          integration_apps: 'ruby rack rails-five rspec'
           ruby_version: '2.5'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.6
-          integration_apps: 'ruby rack rails-five'
+          integration_apps: 'ruby rack rails-five rspec'
           ruby_version: '2.6'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.7
-          integration_apps: 'ruby rack rails-five'
+          integration_apps: 'ruby rack rails-five rspec'
           ruby_version: '2.7'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
@@ -724,37 +724,37 @@ workflows:
       # Integration
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.1
-          integration_apps: 'ruby rack'
+          integration_apps: 'ruby rack rspec'
           ruby_version: '2.1'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.2
-          integration_apps: 'ruby rack'
+          integration_apps: 'ruby rack rspec'
           ruby_version: '2.2'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.3
-          integration_apps: 'ruby rack rails-five'
+          integration_apps: 'ruby rack rails-five rspec'
           ruby_version: '2.3'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.4
-          integration_apps: 'ruby rack rails-five'
+          integration_apps: 'ruby rack rails-five rspec'
           ruby_version: '2.4'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.5
-          integration_apps: 'ruby rack rails-five'
+          integration_apps: 'ruby rack rails-five rspec'
           ruby_version: '2.5'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.6
-          integration_apps: 'ruby rack rails-five'
+          integration_apps: 'ruby rack rails-five rspec'
           ruby_version: '2.6'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.7
-          integration_apps: 'ruby rack rails-five'
+          integration_apps: 'ruby rack rails-five rspec'
           ruby_version: '2.7'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:

--- a/integration/apps/rack/README.md
+++ b/integration/apps/rack/README.md
@@ -44,7 +44,7 @@ Within the container, run `bin/run <process>` where `<process>` is one of the fo
 
 ##### Features
 
-Set `DD_DEMO_ENV_PROCESS` to a comma-delimited list of any of the following values to activate the feature:
+Set `DD_DEMO_ENV_FEATURES` to a comma-delimited list of any of the following values to activate the feature:
 
  - `tracing`: Tracing instrumentation
  - `profiling`: Profiling (NOTE: Must also set `DD_PROFILING_ENABLED` to match.)
@@ -53,7 +53,7 @@ Set `DD_DEMO_ENV_PROCESS` to a comma-delimited list of any of the following valu
  - `runtime_metrics`: Enable runtime metrics
  - `pprof_to_file`: Dump profiling pprof to file instead of agent.
 
-e.g. `DD_DEMO_ENV_PROCESS=tracing,profiling`
+e.g. `DD_DEMO_ENV_FEATURES=tracing,profiling`
 
 ##### Routes
 

--- a/integration/apps/rails-five/README.md
+++ b/integration/apps/rails-five/README.md
@@ -45,7 +45,7 @@ Within the container, run `bin/dd-demo <process>` where `<process>` is one of th
 
 ##### Features
 
-Set `DD_DEMO_ENV_PROCESS` to a comma-delimited list of any of the following values to activate the feature:
+Set `DD_DEMO_ENV_FEATURES` to a comma-delimited list of any of the following values to activate the feature:
 
  - `tracing`: Tracing instrumentation
  - `profiling`: Profiling (NOTE: Must also set `DD_PROFILING_ENABLED` to match.)
@@ -54,7 +54,7 @@ Set `DD_DEMO_ENV_PROCESS` to a comma-delimited list of any of the following valu
  - `runtime_metrics`: Enable runtime metrics
  - `pprof_to_file`: Dump profiling pprof to file instead of agent.
 
-e.g. `DD_DEMO_ENV_PROCESS=tracing,profiling`
+e.g. `DD_DEMO_ENV_FEATURES=tracing,profiling`
 
 ##### Routes
 

--- a/integration/apps/rspec/.dockerignore
+++ b/integration/apps/rspec/.dockerignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/integration/apps/rspec/.envrc.sample
+++ b/integration/apps/rspec/.envrc.sample
@@ -1,0 +1,1 @@
+export DD_API_KEY=<Your Datadog API key here>

--- a/integration/apps/rspec/.gitignore
+++ b/integration/apps/rspec/.gitignore
@@ -1,0 +1,2 @@
+.envrc
+.byebug_history

--- a/integration/apps/rspec/.rspec
+++ b/integration/apps/rspec/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/integration/apps/rspec/Dockerfile
+++ b/integration/apps/rspec/Dockerfile
@@ -1,0 +1,25 @@
+# Select base image
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+# Setup directory
+RUN mkdir /app
+WORKDIR /app
+
+# Setup specific version of ddtrace, if specified.
+ARG ddtrace_git
+ENV DD_DEMO_ENV_GEM_GIT_DDTRACE ${ddtrace_git}
+
+ARG ddtrace_ref
+ENV DD_DEMO_ENV_GEM_REF_DDTRACE ${ddtrace_ref}
+
+# Install dependencies
+COPY Gemfile /app/Gemfile
+RUN bundle install
+
+# Add files
+COPY . /app
+
+# Set entrypoint
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["bin/setup && bin/run"]

--- a/integration/apps/rspec/Dockerfile-ci
+++ b/integration/apps/rspec/Dockerfile-ci
@@ -1,0 +1,11 @@
+# Select base image
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+# Add gem
+COPY . /vendor/dd-trace-rb
+
+# Install dependencies
+# Setup specific version of ddtrace, if specified.
+ENV DD_DEMO_ENV_GEM_LOCAL_DDTRACE /vendor/dd-trace-rb
+RUN bundle install

--- a/integration/apps/rspec/Gemfile
+++ b/integration/apps/rspec/Gemfile
@@ -1,0 +1,14 @@
+require 'datadog/demo_env'
+
+source 'https://rubygems.org' do
+  gem 'ffi'
+  gem 'google-protobuf'
+
+  # Choose correct specs for 'ddtrace' demo environment
+  gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
+
+  gem 'byebug'
+
+  # Testing/CI
+  gem 'rspec'
+end

--- a/integration/apps/rspec/README.md
+++ b/integration/apps/rspec/README.md
@@ -1,0 +1,70 @@
+# RSpec: Demo application for Datadog APM
+
+A generic RSpec test suite with some common use scenarios.
+
+For generating Datadog APM traces and profiles.
+
+## Installation
+
+Install [direnv](https://github.com/direnv/direnv) for applying local settings.
+
+1. `cp .envrc.sample .envrc` and add your Datadog API key.
+2. `direnv allow` to load the env var.
+4. `docker-compose run --rm app bin/setup`
+
+## Running the application
+
+### To monitor performance of Docker containers with Datadog
+
+```sh
+docker run --rm --name dd-agent  -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e API_KEY=$DD_API_KEY datadog/docker-dd-agent:latest
+```
+
+### Starting the application
+
+Run `docker-compose up` to auto-start the application.
+
+Alternatively, you can run it manually with:
+
+```sh
+docker-compose run --rm app bin/run <process>
+```
+
+The `<process>` argument is optional, and will default to `DD_DEMO_ENV_PROCESS` if not provided. See [Processes](#processes) for more details.
+
+##### Processes
+
+Within the container, run `bin/run <process>` where `<process>` is one of the following values:
+
+ - `rspec`: RSpec test suite.
+ - `irb`: IRB session
+
+ Alternatively, set `DD_DEMO_ENV_PROCESS` to run a particular process by default when `bin/run` is run.
+
+##### Features
+
+Set `DD_DEMO_ENV_FEATURES` to a comma-delimited list of any of the following values to activate the feature:
+
+ - `tracing`: Tracing instrumentation
+ - `profiling`: Profiling (NOTE: Must also set `DD_PROFILING_ENABLED` to match.)
+ - `debug`: Enable diagnostic debug mode
+ - `analytics`: Enable trace analytics
+ - `runtime_metrics`: Enable runtime metrics
+ - `pprof_to_file`: Dump profiling pprof to file instead of agent.
+
+e.g. `DD_DEMO_ENV_FEATURES=tracing,profiling`
+
+### Running integration tests
+
+You can run integration tests using the following and substituting for the Ruby major and minor version (e.g. `2.7`)
+
+```sh
+./script/build-images -v <RUBY_VERSION>
+./script/ci -v <RUBY_VERSION>
+```
+
+Or inside a running container:
+
+```sh
+./bin/test
+```

--- a/integration/apps/rspec/agent.yaml
+++ b/integration/apps/rspec/agent.yaml
@@ -1,0 +1,3 @@
+use_dogstatsd: true
+dogstatsd_port: 8125
+dogstatsd_non_local_traffic: true

--- a/integration/apps/rspec/app/datadog.rb
+++ b/integration/apps/rspec/app/datadog.rb
@@ -1,0 +1,13 @@
+require 'datadog/demo_env'
+require 'ddtrace'
+
+Datadog.configure do |c|
+  c.diagnostics.debug = true if Datadog::DemoEnv.feature?('debug')
+  c.analytics_enabled = true if Datadog::DemoEnv.feature?('analytics')
+  c.runtime_metrics.enabled = true if Datadog::DemoEnv.feature?('runtime_metrics')
+
+  if Datadog::DemoEnv.feature?('pprof_to_file')
+    # Reconfigure transport to write pprof to file
+    c.profiling.exporter.transport = Datadog::DemoEnv.profiler_file_transport
+  end
+end

--- a/integration/apps/rspec/app/fibonacci.rb
+++ b/integration/apps/rspec/app/fibonacci.rb
@@ -1,0 +1,30 @@
+require_relative 'datadog'
+
+def fib(n)
+  n <= 1 ? n : fib(n-1) + fib(n-2)
+end
+
+def trace(*options, &block)
+  raise ArgumentError('Must provide trace block') unless block_given?
+
+  if Datadog::DemoEnv.feature?('tracing')
+    Datadog.tracer.trace(*options, &block)
+  else
+    yield
+  end
+end
+
+def generate_fib
+  loop do
+    n = rand(25..35)
+
+    trace('compute.fibonacci') do |span|
+      result = fib(n)
+      span.set_metric('operation.fibonacci.n', n)
+      span.set_metric('operation.fibonacci.result', result)
+      yield(span) if block_given?
+    end
+
+    sleep(0.1)
+  end
+end

--- a/integration/apps/rspec/bin/run
+++ b/integration/apps/rspec/bin/run
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+# Start application process
+puts "\n== Starting application process =="
+
+profiling = Datadog::DemoEnv.feature?('profiling') ? 'DD_PROFILING_ENABLED=true ddtracerb exec ' : ''
+process = (ARGV[0] || Datadog::DemoEnv.process)
+command = case process
+          when 'rspec'
+            'bundle exec rspec'
+          when 'irb'
+            "bundle exec #{profiling}irb"
+          when nil, ''
+            abort("\n== ERROR: Must specify a application process! ==")
+          else
+            abort("\n== ERROR: Unknown application process '#{process}' ==")
+          end
+
+puts "Run: #{command}"
+Kernel.exec(command)

--- a/integration/apps/rspec/bin/setup
+++ b/integration/apps/rspec/bin/setup
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+require 'fileutils'
+include FileUtils
+
+# path to your application root.
+APP_ROOT = File.expand_path('..', __dir__)
+
+def system!(*args)
+  puts "Run: #{args.join(' ')}"
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+chdir APP_ROOT do
+  puts "\n== Installing dependencies =="
+  system! 'gem install bundler --conservative'
+  system('bundle check') || system!('bundle install')
+end

--- a/integration/apps/rspec/bin/test
+++ b/integration/apps/rspec/bin/test
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+require 'fileutils'
+include FileUtils
+
+# path to your application root.
+APP_ROOT = File.expand_path('..', __dir__)
+
+def system!(*args)
+  puts "Run: #{args.join(' ')}"
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+chdir APP_ROOT do
+  puts "\n== Performing setup =="
+  system!('./bin/setup')
+
+  puts "\n== Run test suite =="
+  # DEV: There are no RSpec tests right now.
+  #      Re-enable this when we have something worth testing.
+  # system!('rspec')
+end

--- a/integration/apps/rspec/docker-compose.ci.yml
+++ b/integration/apps/rspec/docker-compose.ci.yml
@@ -1,0 +1,51 @@
+version: '3.4'
+services:
+  app:
+    # Build at dd-trace-rb level to copy in current code
+    # and use it as the `ddtrace` gem.
+    build:
+      context: ../../..
+      dockerfile: integration/apps/rspec/Dockerfile-ci
+      args:
+        BASE_IMAGE: ${APP_IMAGE}
+    depends_on:
+      - ddagent
+    environment:
+      - BUNDLE_GEMFILE=/app/Gemfile
+      - DD_AGENT_HOST=ddagent
+      - DD_METRIC_AGENT_PORT=8125
+      - DD_TRACE_AGENT_PORT=8126
+      - DD_HEALTH_METRICS_ENABLED=true
+      - DD_SERVICE=acme-rspec
+      - DD_PROFILING_ENABLED=true
+      # Use these to choose what is run
+      - DD_DEMO_ENV_PROCESS=rspec
+      - DD_DEMO_ENV_FEATURES=tracing
+    stdin_open: true
+    tty: true
+  ddagent:
+    image: datadog/dd-apm-demo:agent
+    environment:
+      - DD_APM_ENABLED=true
+      - DD_PROCESS_AGENT_ENABLED=false
+      - DD_BIND_HOST=0.0.0.0
+      - DD_API_KEY=invalid_api_key
+      - LOG_LEVEL=DEBUG
+      - DD_LOGS_STDOUT=yes
+      - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
+    expose:
+      - "8125/udp"
+      - "8126"
+  # Build at dd-trace-rb level to copy in current code
+  # and use it as the `ddtrace` gem.
+  integration-tester:
+    build:
+      context: ../../..
+      dockerfile: integration/apps/rspec/Dockerfile-ci
+      args:
+        BASE_IMAGE: ${APP_IMAGE}
+    command: bin/test
+    # volumes:
+    #   - .:/app
+    #   - ../../images/include:/vendor/dd-demo
+    #   - ../../..:/vendor/dd-trace-rb

--- a/integration/apps/rspec/docker-compose.yml
+++ b/integration/apps/rspec/docker-compose.yml
@@ -1,0 +1,63 @@
+version: '3.4'
+services:
+  app:
+    build:
+      context: .
+      args:
+        BASE_IMAGE: datadog/dd-apm-demo:rb-3.0
+    depends_on:
+      - ddagent
+    environment:
+      - BUNDLE_GEMFILE=/app/Gemfile
+      - DD_AGENT_HOST=ddagent
+      - DD_METRIC_AGENT_PORT=8125
+      - DD_TRACE_AGENT_PORT=8126
+      - DD_HEALTH_METRICS_ENABLED=true
+      - DD_SERVICE=acme-rspec
+      - DD_PROFILING_ENABLED=true
+      # Use these to choose what is run
+      - DD_DEMO_ENV_PROCESS=rspec
+      - DD_DEMO_ENV_FEATURES=tracing
+      # Use this for a local version of ddtrace
+      - DD_DEMO_ENV_GEM_LOCAL_DDTRACE=/vendor/dd-trace-rb
+      # Use these for a specific revision of ddtrace
+      # - DD_DEMO_ENV_GEM_GIT_DDTRACE=https://github.com/DataDog/dd-trace-rb.git
+      # - DD_DEMO_ENV_GEM_REF_DDTRACE=f233336994315bfa04dac581387a8152bab8b85a
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/app
+      - ./data/app:/data/app
+      - bundle:/usr/local/bundle
+      - ../../images/include:/vendor/dd-demo
+      - ../../..:/vendor/dd-trace-rb
+  ddagent:
+    image: datadog/dd-apm-demo:agent
+    environment:
+      - DD_APM_ENABLED=true
+      - DD_PROCESS_AGENT_ENABLED=false
+      - DD_BIND_HOST=0.0.0.0
+      - DD_API_KEY
+      - LOG_LEVEL=DEBUG
+      - DD_LOGS_STDOUT=yes
+      - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
+    expose:
+      - "8125/udp"
+      - "8126"
+    volumes:
+      - ../../images/agent/agent.yaml:/etc/datadog-agent/datadog.yaml
+      # For monitoring performance of containers (e.g. CPU, Memory, etc...)
+      # - type: bind
+      #   source: ../../images/agent/agent.yaml
+      #   target: /etc/datadog-agent/datadog.yaml
+      # - type: bind
+      #   source: /var/run/docker.sock
+      #   target: /var/run/docker.sock:ro
+      # - type: bind
+      #   source: /proc/
+      #   target: /host/proc/:ro
+      # - type: bind
+      #   source: /sys/fs/cgroup/
+      #   target: /host/sys/fs/cgroup:ro
+volumes:
+  bundle:

--- a/integration/apps/rspec/script/build-images
+++ b/integration/apps/rspec/script/build-images
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+APP_DIR=${APP_SCRIPT_DIR%/script}
+cd $APP_DIR
+
+while getopts ":v:" opt; do
+  case $opt in
+    v)
+      APP_RUBY_VERSION=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "== Building Ruby app images... =="
+if [ -v APP_RUBY_VERSION ]; then
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-$APP_RUBY_VERSION -t datadog/dd-apm-demo:rb-$APP_RUBY_VERSION-rspec .
+else
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.0 -t datadog/dd-apm-demo:rb-2.0-rspec .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.1 -t datadog/dd-apm-demo:rb-2.1-rspec .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.2 -t datadog/dd-apm-demo:rb-2.2-rspec .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.3 -t datadog/dd-apm-demo:rb-2.3-rspec .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.4 -t datadog/dd-apm-demo:rb-2.4-rspec .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.5 -t datadog/dd-apm-demo:rb-2.5-rspec .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.6 -t datadog/dd-apm-demo:rb-2.6-rspec .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.7 -t datadog/dd-apm-demo:rb-2.7-rspec .
+  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-3.0 -t datadog/dd-apm-demo:rb-3.0-rspec .
+fi
+echo "== Done building Ruby app images. =="

--- a/integration/apps/rspec/script/build-images
+++ b/integration/apps/rspec/script/build-images
@@ -25,7 +25,6 @@ echo "== Building Ruby app images... =="
 if [ -v APP_RUBY_VERSION ]; then
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-$APP_RUBY_VERSION -t datadog/dd-apm-demo:rb-$APP_RUBY_VERSION-rspec .
 else
-  docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.0 -t datadog/dd-apm-demo:rb-2.0-rspec .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.1 -t datadog/dd-apm-demo:rb-2.1-rspec .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.2 -t datadog/dd-apm-demo:rb-2.2-rspec .
   docker build --build-arg BASE_IMAGE=datadog/dd-apm-demo:rb-2.3 -t datadog/dd-apm-demo:rb-2.3-rspec .

--- a/integration/apps/rspec/script/ci
+++ b/integration/apps/rspec/script/ci
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+APP_DIR=${APP_SCRIPT_DIR%/script}
+cd $APP_DIR
+
+# Parse options
+while getopts "v:" opt; do
+  case $opt in
+    v)
+      APP_RUBY_VERSION=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Validate options
+if [ -z ${APP_RUBY_VERSION+x} ]; then
+  echo "You must specify a Ruby version with -v. (e.g. 2.7)" >&2
+  exit 1
+fi
+
+# Set configuration
+APP_BASE_IMAGE=${APP_BASE_IMAGE:-datadog/dd-apm-demo:rb-$APP_RUBY_VERSION}
+APP_IMAGE=${APP_IMAGE:-$APP_BASE_IMAGE-rspec}
+APP_COMPOSE_FILES="-f docker-compose.ci.yml"
+
+echo "== Running integration tests... =="
+echo " - App: rspec"
+echo " - Ruby version: $APP_RUBY_VERSION"
+echo " - Base image: $APP_BASE_IMAGE"
+echo " - App image: $APP_IMAGE"
+echo ""
+
+# Pull/build any missing images
+APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES build
+
+# Run the test suite
+# NOTE: Normally we run "integration-tester" but in this case, the app is the test suite.
+#       Just run the app instead.
+#       It's expected to produce test failures and raise an exit code. Ignore this.
+APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES run app || true
+
+# Cleanup
+APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES down -t 0 --remove-orphans

--- a/integration/apps/rspec/spec/fibonacci_spec.rb
+++ b/integration/apps/rspec/spec/fibonacci_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../app/fibonacci'
+
+# Test some library functions
+RSpec.describe '#fib' do
+  subject(:call_fib) { fib(n) }
+  let(:n) { rand(25..35) }
+
+  it { is_expected.to be_a_kind_of(Integer) }
+
+  context 'given a smaller and larger number' do
+    let(:smaller_fib) { fib(n) }
+    let(:larger_fib) { fib(n+1) }
+
+    it { expect(larger_fib).to be > smaller_fib }
+  end
+end

--- a/integration/apps/rspec/spec/rspec_spec.rb
+++ b/integration/apps/rspec/spec/rspec_spec.rb
@@ -1,0 +1,58 @@
+# Test some RSpec behavior
+# NOTE: This file is expected to always produce some test errors!
+#       So that we can 
+RSpec.describe 'RSpec behavior' do
+  shared_examples_for 'correct behavior' do
+    it 'passes' do
+      expect(1).to be < 2
+    end
+  end
+  
+  shared_examples_for 'incorrect behavior' do
+    it 'fails' do
+      expect(2).to be < 1
+    end
+  end
+
+  it 'passes correct assertions' do
+    expect(1).to be < 2
+  end
+
+  it 'fails incorrect assertions' do
+    expect(2).to be < 1
+  end
+
+  it_behaves_like 'correct behavior'
+  it_behaves_like 'incorrect behavior'
+
+  context 'context' do
+    it_behaves_like 'correct behavior'
+    it_behaves_like 'incorrect behavior'
+  end
+
+  context 'in a' do
+    context 'deeply' do
+      context 'nested' do
+        context 'context' do
+          it 'passes correct assertions' do
+            expect(1).to be < 2
+          end
+
+          it 'fails incorrect assertions' do
+            expect(2).to be < 1
+          end
+        end
+      end
+    end
+  end
+
+  context 'when calling traced code' do
+    it 'wraps the RSpec instrumentation around the traced code' do
+      Datadog.tracer.trace('code_under_test') do |span|
+        time_to_run = rand
+        sleep(rand)
+        span.set_tag('run_time', time_to_run)
+      end
+    end
+  end
+end

--- a/integration/apps/rspec/spec/spec_helper.rb
+++ b/integration/apps/rspec/spec/spec_helper.rb
@@ -1,0 +1,24 @@
+require 'ddtrace'
+
+# Enable CI tracing
+Datadog.configure do |c|
+  c.ci_mode.enabled = true
+  c.use :rspec
+end
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.filter_run_when_matching :focus
+  config.disable_monkey_patching!
+  config.profile_examples = 10
+  config.order = :random
+  Kernel.srand config.seed
+end

--- a/integration/apps/rspec/spec/spec_helper.rb
+++ b/integration/apps/rspec/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'ddtrace'
+require 'datadog/ci'
 
 # Enable CI tracing
 Datadog.configure do |c|

--- a/integration/apps/ruby/README.md
+++ b/integration/apps/ruby/README.md
@@ -43,7 +43,7 @@ Within the container, run `bin/run <process>` where `<process>` is one of the fo
 
 ##### Features
 
-Set `DD_DEMO_ENV_PROCESS` to a comma-delimited list of any of the following values to activate the feature:
+Set `DD_DEMO_ENV_FEATURES` to a comma-delimited list of any of the following values to activate the feature:
 
  - `tracing`: Tracing instrumentation
  - `profiling`: Profiling (NOTE: Must also set `DD_PROFILING_ENABLED` to match.)
@@ -52,7 +52,7 @@ Set `DD_DEMO_ENV_PROCESS` to a comma-delimited list of any of the following valu
  - `runtime_metrics`: Enable runtime metrics
  - `pprof_to_file`: Dump profiling pprof to file instead of agent.
 
-e.g. `DD_DEMO_ENV_PROCESS=tracing,profiling`
+e.g. `DD_DEMO_ENV_FEATURES=tracing,profiling`
 
 ### Running integration tests
 

--- a/lib/datadog/ci/contrib/rspec/patcher.rb
+++ b/lib/datadog/ci/contrib/rspec/patcher.rb
@@ -1,5 +1,4 @@
 require 'ddtrace/contrib/patcher'
-require 'datadog/ci/contrib/rspec/integration'
 require 'datadog/ci/contrib/rspec/example'
 
 module Datadog

--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -80,6 +80,3 @@ require 'ddtrace/contrib/sidekiq/integration'
 require 'ddtrace/contrib/sinatra/integration'
 require 'ddtrace/contrib/sneakers/integration'
 require 'ddtrace/contrib/sucker_punch/integration'
-
-# Load extensions from CI namespace
-require 'datadog/ci'

--- a/spec/datadog/ci/configuration/components_spec.rb
+++ b/spec/datadog/ci/configuration/components_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'datadog/ci/spec_helper'
 require 'datadog/ci/configuration/components'
 
 RSpec.describe Datadog::CI::Configuration::Components do

--- a/spec/datadog/ci/configuration/settings_spec.rb
+++ b/spec/datadog/ci/configuration/settings_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'datadog/ci/spec_helper'
 require 'datadog/ci/configuration/settings'
 
 RSpec.describe Datadog::CI::Configuration::Settings do

--- a/spec/datadog/ci/context_flush_spec.rb
+++ b/spec/datadog/ci/context_flush_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'datadog/ci/spec_helper'
 
 require 'ddtrace/context'
 require 'ddtrace/span'

--- a/spec/datadog/ci/contrib/support/spec_helper.rb
+++ b/spec/datadog/ci/contrib/support/spec_helper.rb
@@ -1,1 +1,2 @@
+require 'datadog/ci/spec_helper'
 require 'datadog/ci/contrib/support/mode_helpers'

--- a/spec/datadog/ci/ext/environment_spec.rb
+++ b/spec/datadog/ci/ext/environment_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'datadog/ci/spec_helper'
 
 require 'json'
 require 'datadog/ci/ext/environment'

--- a/spec/datadog/ci/spec_helper.rb
+++ b/spec/datadog/ci/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'datadog/ci'
+require 'spec_helper'

--- a/spec/datadog/ci/test_spec.rb
+++ b/spec/datadog/ci/test_spec.rb
@@ -1,6 +1,5 @@
-require 'spec_helper'
+require 'datadog/ci/spec_helper'
 
-require 'ddtrace'
 require 'datadog/ci/test'
 
 RSpec.describe Datadog::CI::Test do


### PR DESCRIPTION
Given the tracer now supports CI tracing with #1504, this PR adds an RSpec integration app that will run in our own CI and produce CI test traces (if provided an API key.) This application can also be run locally as a sandbox to verify CI tracing behavior.

A special caveat for this application is that 1) the RSpec test suite *is* the app so it doesn't have an accompanying "tester" that verifies its behavior, and 2) the RSpec test suite is designed to produce test failures and an exit code on purpose, so as to produce a variety of tests, thus the CI process that runs it must ignore/tolerate these "failures".

There could be more done here if we want to make it more sophisticated, but this should be a good first step towards having some kind of environment in which to test CI tracing.