### PR TITLE
Clean up singleton class eval statements

### DIFF
--- a/lib/ddtrace/contrib/active_support/cache/redis.rb
+++ b/lib/ddtrace/contrib/active_support/cache/redis.rb
@@ -35,11 +35,7 @@ module Datadog
           end
 
           # Decorate Cache patcher with Redis support
-          Cache::Patcher.instance_eval do
-            class << self
-              prepend Redis::Patcher
-            end
-          end
+          Cache::Patcher.singleton_class.prepend(Redis::Patcher)
         end
       end
     end

--- a/lib/ddtrace/contrib/qless/patcher.rb
+++ b/lib/ddtrace/contrib/qless/patcher.rb
@@ -19,11 +19,9 @@ module Datadog
           require_relative 'tracer_cleaner'
 
           # Instrument all Qless Workers
-          ::Qless::Workers::BaseWorker.class_eval do
-            # These are executed in inverse order of listing here
-            include QlessJob
-            include TracerCleaner
-          end
+          # These are executed in inverse order of listing here
+          ::Qless::Workers::BaseWorker.include(QlessJob)
+          ::Qless::Workers::BaseWorker.include(TracerCleaner)
         end
 
         def get_option(option)

--- a/lib/ddtrace/contrib/sucker_punch/exception_handler.rb
+++ b/lib/ddtrace/contrib/sucker_punch/exception_handler.rb
@@ -10,13 +10,11 @@ module Datadog
         module_function
 
         def patch!
-          ::SuckerPunch.class_eval do
-            class << self
-              alias_method :__exception_handler, :exception_handler
+          ::SuckerPunch.singleton_class.instance_eval do
+            alias_method :__exception_handler, :exception_handler
 
-              def exception_handler
-                ::Datadog::Contrib::SuckerPunch::ExceptionHandler::METHOD
-              end
+            def exception_handler
+              ::Datadog::Contrib::SuckerPunch::ExceptionHandler::METHOD
             end
           end
         end

--- a/lib/ddtrace/contrib/sucker_punch/exception_handler.rb
+++ b/lib/ddtrace/contrib/sucker_punch/exception_handler.rb
@@ -10,7 +10,7 @@ module Datadog
         module_function
 
         def patch!
-          ::SuckerPunch.singleton_class.instance_eval do
+          ::SuckerPunch.singleton_class.class_eval do
             alias_method :__exception_handler, :exception_handler
 
             def exception_handler

--- a/lib/ddtrace/opentracer.rb
+++ b/lib/ddtrace/opentracer.rb
@@ -17,14 +17,5 @@ require 'ddtrace/opentracer/binary_propagator'
 require 'ddtrace/opentracer/rack_propagator'
 require 'ddtrace/opentracer/global_tracer'
 
-module Datadog
-  # Namespace for ddtrace OpenTracing implementation
-  module OpenTracer
-    # Modify the OpenTracing module functions
-    ::OpenTracing.module_eval do
-      class << self
-        prepend Datadog::OpenTracer::GlobalTracer
-      end
-    end
-  end
-end
+# Modify the OpenTracing module functions
+::OpenTracing.singleton_class.prepend(Datadog::OpenTracer::GlobalTracer)

--- a/lib/ddtrace/profiling/ext/forking.rb
+++ b/lib/ddtrace/profiling/ext/forking.rb
@@ -24,13 +24,13 @@ module Datadog
           #       It could also have collisions with other libraries that patch.
           #       Opt to modify the inheritance of each relevant target instead.
           modules.each do |mod|
-            if mod.class <= Module
-              mod.singleton_class.class_eval do
-                prepend Kernel
-              end
-            else
-              mod.class.prepend(Kernel)
-            end
+            clazz = if mod.class <= Module
+                      mod.singleton_class
+                    else
+                      mod.class
+                    end
+
+            clazz.prepend(Kernel)
           end
         end
 

--- a/spec/ddtrace/contrib/rails/support/rails3.rb
+++ b/spec/ddtrace/contrib/rails/support/rails3.rb
@@ -13,15 +13,13 @@ require 'ddtrace/contrib/rails/support/models'
 
 # Patch Rails::Application so it doesn't raise an exception
 # when we reinitialize applications.
-Rails::Application.class_eval do
-  class << self
-    def inherited(base)
-      # raise "You cannot have more than one Rails::Application" if Rails.application
-      super
-      Rails.application = base.instance
-      Rails.application.add_lib_to_load_path!
-      ActiveSupport.run_load_hooks(:before_configuration, base.instance)
-    end
+Rails::Application.singleton_class.instance_eval do
+  def inherited(base)
+    # raise "You cannot have more than one Rails::Application" if Rails.application
+    super
+    Rails.application = base.instance
+    Rails.application.add_lib_to_load_path!
+    ActiveSupport.run_load_hooks(:before_configuration, base.instance)
   end
 end
 

--- a/spec/ddtrace/contrib/rails/support/rails3.rb
+++ b/spec/ddtrace/contrib/rails/support/rails3.rb
@@ -13,7 +13,7 @@ require 'ddtrace/contrib/rails/support/models'
 
 # Patch Rails::Application so it doesn't raise an exception
 # when we reinitialize applications.
-Rails::Application.singleton_class.instance_eval do
+Rails::Application.singleton_class.class_eval do
   def inherited(base)
     # raise "You cannot have more than one Rails::Application" if Rails.application
     super

--- a/spec/ddtrace/profiling/ext/forking_spec.rb
+++ b/spec/ddtrace/profiling/ext/forking_spec.rb
@@ -62,9 +62,11 @@ RSpec.describe Datadog::Profiling::Ext::Forking do
 
         expect(::Process.ancestors).to include(described_class::Kernel)
         expect(::Kernel.ancestors).to include(described_class::Kernel)
+        expect(toplevel_receiver.class.ancestors).to include(described_class::Kernel)
 
         expect(::Process.method(:fork).source_location.first).to match(%r{.*ddtrace/profiling/ext/forking.rb})
         expect(::Kernel.method(:fork).source_location.first).to match(%r{.*ddtrace/profiling/ext/forking.rb})
+        expect(toplevel_receiver.method(:fork).source_location.first).to match(%r{.*ddtrace/profiling/ext/forking.rb})
       end
     end
 

--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -61,7 +61,5 @@ module SynchronizationHelpers
     30
   end
 
-  class << self
-    include SynchronizationHelpers
-  end
+  singleton_class.include SynchronizationHelpers
 end


### PR DESCRIPTION
Quite a few of our `class_eval` and `class_eval + class << self` statements were due to not having access the previously private #prepend or #include methods.

This PR cleans up such usages.

Not all occurrences across the code base were converted, as some performed other operations (e.g. defining methods inside the `class << self` block). This PR touches the ones that are safe to do so, with minimal refactor.

### Ruby 2.0 deprecation checklist

- [x] Remove 2.0 from CI
- [x] Remove 2.0-specific code paths
- [ ] Update to 2.1+ standards: https://github.com/ruby/ruby/blob/v2_1_0/NEWS
  - [x] Module#include and Module#prepend are now public methods.
  - [x] Exception#cause _(no changes)_
  - [x] Array#to_h converts an array of key-value pairs into a Hash.
  - [x] Kernel#singleton_method _(no changes)_
  - [x] Process.clock_gettime
  - [x] Enumerable#to_h converts a list of key-value pairs into a Hash.
  - [x] **instance_eval/class_eval for accessing #include/#prepend**
  - [ ] Now the default values of keyword arguments can be omitted. Those “required keyword arguments” need giving explicitly at the call time.
- [ ] Update documentation

