### PR TITLE
Improve debug logging for worker termination during shutdown

### DIFF
--- a/lib/ddtrace/profiling/scheduler.rb
+++ b/lib/ddtrace/profiling/scheduler.rb
@@ -42,7 +42,18 @@ module Datadog
       end
 
       def perform
-        flush_and_wait
+        # A profiling flush may be called while the VM is shutting down, to report the last profile. When we do so,
+        # we impose a strict timeout. This means this last profile may or may not be sent, depending on if the flush can
+        # successfully finish in the strict timeout.
+        # This can be somewhat confusing (why did it not get reported?), so let's at least log what happened.
+        interrupted = true
+
+        begin
+          flush_and_wait
+          interrupted = false
+        ensure
+          Datadog.logger.debug('#flush was interrupted or failed before it could complete') if interrupted
+        end
       end
 
       def loop_back_off?

--- a/lib/ddtrace/workers/async.rb
+++ b/lib/ddtrace/workers/async.rb
@@ -39,6 +39,7 @@ module Datadog
           return false unless running?
 
           @run_async = false
+          Datadog.logger.debug("Forcibly terminating worker thread for: #{self}")
           worker.terminate
           true
         end

--- a/lib/ddtrace/workers/async.rb
+++ b/lib/ddtrace/workers/async.rb
@@ -39,7 +39,7 @@ module Datadog
           return false unless running?
 
           @run_async = false
-          Datadog.logger.debug("Forcibly terminating worker thread for: #{self}")
+          Datadog.logger.debug { "Forcibly terminating worker thread for: #{self}" }
           worker.terminate
           true
         end

--- a/lib/ddtrace/workers/polling.rb
+++ b/lib/ddtrace/workers/polling.rb
@@ -26,8 +26,12 @@ module Datadog
           stop_loop
           graceful = join(timeout)
 
-          # If timeout and force stop...
-          !graceful && force_stop ? terminate : graceful
+          if !graceful && force_stop
+            Datadog.logger.debug "Timeout while waiting for worker to finish gracefully, forcing termination for: #{self}"
+            terminate
+          else
+            graceful
+          end
         else
           false
         end

--- a/lib/ddtrace/workers/polling.rb
+++ b/lib/ddtrace/workers/polling.rb
@@ -27,7 +27,9 @@ module Datadog
           graceful = join(timeout)
 
           if !graceful && force_stop
-            Datadog.logger.debug "Timeout while waiting for worker to finish gracefully, forcing termination for: #{self}"
+            Datadog.logger.debug do
+              "Timeout while waiting for worker to finish gracefully, forcing termination for: #{self}"
+            end
             terminate
           else
             graceful


### PR DESCRIPTION
When a Ruby process is about to finish, ddtrace has an `at_exit` hook to shut down any ongoing work.

In the case of the profiler, if it was working, the profiler will try to report the current profiling data as part of that shut down.

We need to be very careful with these kinds of "extra work items during shutdown" as we don't want to make it appear that
applications "hang". Thus, we enforce a strict timeout of 1 second -- see `SHUTDOWN_TIMEOUT` in `Datadog::Workers::Polling`.

But this whole mecanism was quite confusing, as even with `DD_TRACE_ENABLED` customers would see either:

```
DEBUG -- ddtrace: [ddtrace] (/Users/ivo.anjo/datadog/third-dd-trace-rb/lib/ddtrace/profiling/profiler.rb:19:in `shutdown!') Shutting down profiler
DEBUG -- ddtrace: [ddtrace] (/Users/ivo.anjo/datadog/third-dd-trace-rb/lib/ddtrace/profiling/transport/http/client.rb:17:in `block in send_profiling_flush') Successfully reported profiling data
(process finishes)
```

OR

```
DEBUG -- ddtrace: [ddtrace] (/Users/ivo.anjo/datadog/third-dd-trace-rb/lib/ddtrace/profiling/profiler.rb:19:in `shutdown!') Shutting down profiler
(process finishes)
```

In the latter case, it was not clear at all (even for me) why the "Successfully reported profiling data" message was missing,
even if in my experience the data did show up in the UX.

To clarify this confusion, I've added a few debug logs that tell the whole story of a shutdown that took too long:

```
DEBUG -- ddtrace: [ddtrace] (/Users/ivo.anjo/datadog/third-dd-trace-rb/lib/ddtrace/profiling/profiler.rb:19:in `shutdown!') Shutting down profiler
DEBUG -- ddtrace: [ddtrace] (/Users/ivo.anjo/datadog/third-dd-trace-rb/lib/ddtrace/workers/polling.rb:30:in `stop') Timeout while waiting for worker to finish gracefully, forcing termination for: #<Datadog::Profiling::Scheduler:0x00007ff336166468>
DEBUG -- ddtrace: [ddtrace] (/Users/ivo.anjo/datadog/third-dd-trace-rb/lib/ddtrace/workers/async.rb:42:in `terminate') Forcibly terminating worker thread for: #<Datadog::Profiling::Scheduler:0x00007ff336166468>
DEBUG -- ddtrace: [ddtrace] (/Users/ivo.anjo/datadog/third-dd-trace-rb/lib/ddtrace/profiling/scheduler.rb:55:in `ensure in perform') #flush was interrupted or failed before it could complete
```

Both cases can be easily simulated by changing `scheduler.stop(true)` call in `Datadog::Profiler`: the optional second argument is a timeout, so passing in `0.1` will usually trigger the timeout, and `5` will usually mean enough time for all reporting to finish.

In the future, we may want to allow this timeout to be configurable but I'm somewhat unsure how often users will hit this (I hit it more often because I do weird things in my tests) so for now I'll just add the debug logs.