### PR TITLE
Pin `dogstatsd-ruby` to v4 while we adapt the compatibility with the dogstatsd-ruby companion thread.

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2411,7 +2411,7 @@ The tracer and its integrations can produce some additional metrics that can pro
 To configure your application for metrics collection:
 
 1. [Configure your Datadog agent for StatsD](https://docs.datadoghq.com/developers/dogstatsd/#setup)
-2. Add `gem 'dogstatsd-ruby'` to your Gemfile
+2. Add `gem 'dogstatsd-ruby', '~> 4.0'` to your Gemfile
 
 #### For application runtime
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2411,7 +2411,7 @@ The tracer and its integrations can produce some additional metrics that can pro
 To configure your application for metrics collection:
 
 1. [Configure your Datadog agent for StatsD](https://docs.datadoghq.com/developers/dogstatsd/#setup)
-2. Add `gem 'dogstatsd-ruby', '~> 4.0'` to your Gemfile
+2. Add `gem 'dogstatsd-ruby', '~> 4.0'` to your Gemfile (note that it is pinned to v4.x [until this issue is solved](https://github.com/DataDog/dd-trace-rb/issues/1491))
 
 #### For application runtime
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2411,7 +2411,7 @@ The tracer and its integrations can produce some additional metrics that can pro
 To configure your application for metrics collection:
 
 1. [Configure your Datadog agent for StatsD](https://docs.datadoghq.com/developers/dogstatsd/#setup)
-2. Add `gem 'dogstatsd-ruby', '~> 4.0'` to your Gemfile (note that it is pinned to v4.x [until this issue is solved](https://github.com/DataDog/dd-trace-rb/issues/1491))
+2. Add `gem 'dogstatsd-ruby', '~> 4.0'` to your Gemfile (note that it is advised to pin v4.x [until this issue is solved](https://github.com/DataDog/dd-trace-rb/issues/1491))
 
 #### For application runtime
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2411,7 +2411,7 @@ The tracer and its integrations can produce some additional metrics that can pro
 To configure your application for metrics collection:
 
 1. [Configure your Datadog agent for StatsD](https://docs.datadoghq.com/developers/dogstatsd/#setup)
-2. Add `gem 'dogstatsd-ruby', '~> 4.0'` to your Gemfile (note that it is advised to pin v4.x [until this issue is solved](https://github.com/DataDog/dd-trace-rb/issues/1491))
+2. Add `gem 'dogstatsd-ruby', '~> 4.0'` to your Gemfile (note that it is advised to pin v4.x [until this issue is solved](https://github.com/DataDog/dogstatsd-ruby/issues/182))
 
 #### For application runtime
 


### PR DESCRIPTION
Let's advise to pin to `dogstatsd-ruby` to v4.x until https://github.com/DataDog/dogstatsd-ruby/issues/182 is fixed.