### PR TITLE
Declare EOL for Ruby 2.0 support

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   if RUBY_VERSION >= '2.2.0'
     spec.add_dependency 'msgpack'
   else
-    # msgpack 1.4 fails for Ruby 2.0 and 2.1: https://github.com/msgpack/msgpack-ruby/issues/205
+    # msgpack 1.4 fails for Ruby 2.1: https://github.com/msgpack/msgpack-ruby/issues/205
     spec.add_dependency 'msgpack', '< 1.4'
   end
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -101,7 +101,7 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
 |       |                            | 2.3     | Full                                 | Latest              |
 |       |                            | 2.2     | Full                                 | Latest              |
 |       |                            | 2.1     | Full                                 | Latest              |
-|       |                            | 2.0     | Deprecated                           | < 0.50.0            |
+|       |                            | 2.0     | EOL since June X, 2021               | < 0.50.0            |
 |       |                            | 1.9.3   | EOL since August 6th, 2020           | < 0.27.0            |
 |       |                            | 1.9.1   | EOL since August 6th, 2020           | < 0.27.0            |
 | JRuby | https://www.jruby.org      | 9.2     | Full                                 | Latest              |
@@ -1678,8 +1678,6 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | Key | Description | Default |
 | --- | ----------- | ------- |
 | `service_name` | Service name for `sequel` instrumentation | Name of database adapter (e.g. `'mysql2'`) |
-
-Only Ruby 2.0+ is supported.
 
 **Configuring databases to use different settings**
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -101,7 +101,7 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
 |       |                            | 2.3     | Full                                 | Latest              |
 |       |                            | 2.2     | Full                                 | Latest              |
 |       |                            | 2.1     | Full                                 | Latest              |
-|       |                            | 2.0     | EOL since June X, 2021               | < 0.50.0            |
+|       |                            | 2.0     | EOL since June 7th, 2021             | < 0.50.0            |
 |       |                            | 1.9.3   | EOL since August 6th, 2020           | < 0.27.0            |
 |       |                            | 1.9.1   | EOL since August 6th, 2020           | < 0.27.0            |
 | JRuby | https://www.jruby.org      | 9.2     | Full                                 | Latest              |

--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -7,9 +7,7 @@ module Datadog
 
     STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.')
 
-    # Support for Ruby < 2.1 is currently deprecated in the tracer.
-    # Support will be dropped in the near future.
-    MINIMUM_RUBY_VERSION = '2.0.0'.freeze
+    MINIMUM_RUBY_VERSION = '2.1.0'.freeze
 
     # Ruby 3.2 is not supported: Ruby 3.x support as implemented using *args
     # needs ruby2_keywords to continue working, yet the scheduled removal of


### PR DESCRIPTION
This PR updates the minimum Ruby version in our gemspec, as well the official documentation with the remove of support for Ruby 2.0.

Ruby 2.1 is the new minimum Ruby version supported.