### PR TITLE
Nested error reporting not walking clause chain

### DIFF
--- a/lib/ddtrace/error.rb
+++ b/lib/ddtrace/error.rb
@@ -38,7 +38,8 @@ module Datadog
         causes = {}
         causes[ex] = true
 
-        while (cause = ex.cause) && !causes.key?(cause)
+        cause = ex
+        while (cause = cause.cause) && !causes.key?(cause)
           backtrace_for(cause, backtrace)
           causes[cause] = true
         end

--- a/spec/ddtrace/error_spec.rb
+++ b/spec/ddtrace/error_spec.rb
@@ -47,8 +47,14 @@ RSpec.describe Datadog::Error do
               raise 'root cause'
             end
 
-            def wrapper
+            def middle
               root
+            rescue
+              raise 'middle cause'
+            end
+
+            def wrapper
+              middle
             rescue
               raise 'wrapper layer'
             end
@@ -65,7 +71,7 @@ RSpec.describe Datadog::Error do
           begin
             clazz.new.call
           rescue => e
-            e
+            puts e
           end
         end
 
@@ -73,22 +79,24 @@ RSpec.describe Datadog::Error do
           expect(error.type).to eq('RuntimeError')
           expect(error.message).to eq('wrapper layer')
 
-          wrapper_error_message = /error_spec.rb:\d+:in.*wrapper': wrapper layer \(RuntimeError\)/
-          caller_stack = /from.*error_spec.rb:\d+:in `call'/
-          root_error_message = /error_spec.rb:\d+:in.*root': root cause \(RuntimeError\)/
-          wrapper_stack = /from.*error_spec.rb:\d+:in `wrapper'/
+          # Outer-most error first, inner-most last
+          wrapper_error_message = /in.*wrapper': wrapper layer \(RuntimeError\)/
+          wrapper_stack = /from.*in `wrapper'/
+          middle_error_message = /in.*middle': middle cause \(RuntimeError\)/
+          middle_stack = /from.*in `middle'/
+          root_error_message = /in.*root': root cause \(RuntimeError\)/
 
           expect(error.backtrace)
             .to match(/
                        #{wrapper_error_message}.*
-                       #{caller_stack}.*
-                       #{root_error_message}.*
                        #{wrapper_stack}.*
-                       #{caller_stack}.*
+                       #{middle_error_message}.*
+                       #{middle_stack}.*
+                       #{root_error_message}.*
                        /mx)
 
           # Expect 2 "first-class" exception lines: 'root cause' and 'wrapper layer'.
-          expect(error.backtrace.each_line.reject { |l| l.start_with?("\tfrom") }).to have(2).items
+          expect(error.backtrace.each_line.reject { |l| l.start_with?("\tfrom") }).to have(3).items
         end
 
         context 'that is reused' do

--- a/spec/ddtrace/error_spec.rb
+++ b/spec/ddtrace/error_spec.rb
@@ -81,18 +81,20 @@ RSpec.describe Datadog::Error do
 
           # Outer-most error first, inner-most last
           wrapper_error_message = /in.*wrapper': wrapper layer \(RuntimeError\)/
-          wrapper_stack = /from.*in `wrapper'/
+          wrapper_caller = /from.*in `call'/
           middle_error_message = /in.*middle': middle cause \(RuntimeError\)/
-          middle_stack = /from.*in `middle'/
-          root_error_message = /in.*root': root cause \(RuntimeError\)/
+          middle_caller = /from.*in `wrapper'/
+          root_error_message = /in `root': root cause \(RuntimeError\)/
+          root_caller = /from.*in `middle'/
 
           expect(error.backtrace)
             .to match(/
                        #{wrapper_error_message}.*
-                       #{wrapper_stack}.*
+                       #{wrapper_caller}.*
                        #{middle_error_message}.*
-                       #{middle_stack}.*
+                       #{middle_caller}.*
                        #{root_error_message}.*
+                       #{root_caller}.*
                        /mx)
 
           # Expect 2 "first-class" exception lines: 'root cause' and 'wrapper layer'.


### PR DESCRIPTION
The implementation of nested error reporting in #1472 had a bug in which it did not correctly visit the full `#cause` error chain in the reported exception, only the first cause was reported.

This PR correctly navigate the whole cause chain and reports such information.