### PR TITLE
[PROF-3430] Get rid of puts logging during profiler initialization

### DIFF
--- a/lib/ddtrace/profiling.rb
+++ b/lib/ddtrace/profiling.rb
@@ -66,6 +66,8 @@ module Datadog
         require 'google/protobuf'
         @protobuf_loaded = true
       rescue LoadError => e
+        # NOTE: We use Kernel#warn here because this code gets run BEFORE Datadog.logger is actually set up.
+        # In the future it'd be nice to shuffle the logger startup to happen first to avoid this special case.
         Kernel.warn(
           "[DDTRACE] Error while loading google-protobuf gem. Cause: '#{e.message}' Location: '#{e.backtrace.first}'. " \
           'This can happen when google-protobuf is missing its native components. ' \

--- a/lib/ddtrace/profiling/tasks/setup.rb
+++ b/lib/ddtrace/profiling/tasks/setup.rb
@@ -18,7 +18,7 @@ module Datadog
               activate_cpu_extensions
               setup_at_fork_hooks
             rescue StandardError, ScriptError => e
-              log "[DDTRACE] Main extensions unavailable. Cause: #{e.message} Location: #{e.backtrace.first}"
+              Datadog.logger.warn { "Profiler extensions unavailable. Cause: #{e.message} Location: #{e.backtrace.first}" }
             end
           end
         end
@@ -29,23 +29,27 @@ module Datadog
           if Ext::Forking.supported?
             Ext::Forking.apply!
           elsif Datadog.configuration.profiling.enabled
-            # Log warning if profiling was supposed to be activated.
-            log '[DDTRACE] Forking extensions skipped; forking not supported.'
+            Datadog.logger.debug('Profiler forking extensions skipped; forking not supported.')
           end
         rescue StandardError, ScriptError => e
-          log "[DDTRACE] Forking extensions unavailable. Cause: #{e.message} Location: #{e.backtrace.first}"
+          Datadog.logger.warn do
+            "Profiler forking extensions unavailable. Cause: #{e.message} Location: #{e.backtrace.first}"
+          end
         end
 
         def activate_cpu_extensions
           if Ext::CPU.supported?
             Ext::CPU.apply!
           elsif Datadog.configuration.profiling.enabled
-            # Log warning if profiling was supposed to be activated.
-            log '[DDTRACE] CPU time profiling skipped because native CPU time is not supported: ' \
+            Datadog.logger.info do
+              'CPU time profiling skipped because native CPU time is not supported: ' \
               "#{Ext::CPU.unsupported_reason}. Profiles containing Wall time will still be reported."
+            end
           end
         rescue StandardError, ScriptError => e
-          log "[DDTRACE] CPU profiling unavailable. Cause: #{e.message} Location: #{e.backtrace.first}"
+          Datadog.logger.warn do
+            "Profiler CPU profiling extensions unavailable. Cause: #{e.message} Location: #{e.backtrace.first}"
+          end
         end
 
         def setup_at_fork_hooks
@@ -62,15 +66,10 @@ module Datadog
                 # Restart profiler, if enabled
                 Datadog.profiler.start if Datadog.profiler
               rescue StandardError => e
-                log "[DDTRACE] Error during post-fork hooks. Cause: #{e.message} Location: #{e.backtrace.first}"
+                Datadog.logger.warn { "Error during post-fork hooks. Cause: #{e.message} Location: #{e.backtrace.first}" }
               end
             end
           end
-        end
-
-        def log(message)
-          # Print to STDOUT for now because logging may not be setup yet...
-          puts message
         end
       end
     end

--- a/spec/ddtrace/profiling/tasks/setup_spec.rb
+++ b/spec/ddtrace/profiling/tasks/setup_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
       context 'and succeeds' do
         it 'applies forking extensions' do
           expect(Datadog::Profiling::Ext::Forking).to receive(:apply!)
-          expect($stdout).to_not receive(:puts)
+          expect(Datadog.logger).to_not receive(:warn)
           activate_forking_extensions
         end
       end
@@ -60,9 +60,9 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
             .and_raise(StandardError)
         end
 
-        it 'displays a warning to $stdout' do
-          expect($stdout).to receive(:puts) do |message|
-            expect(message).to include('Forking extensions unavailable')
+        it 'logs a warning' do
+          expect(Datadog.logger).to receive(:warn) do |&message|
+            expect(message.call).to include('forking extensions unavailable')
           end
 
           activate_forking_extensions
@@ -86,8 +86,8 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
 
         it 'skips forking extensions with warning' do
           expect(Datadog::Profiling::Ext::Forking).to_not receive(:apply!)
-          expect($stdout).to receive(:puts) do |message|
-            expect(message).to include('Forking extensions skipped')
+          expect(Datadog.logger).to receive(:debug) do |message|
+            expect(message).to include('forking extensions skipped')
           end
 
           activate_forking_extensions
@@ -103,7 +103,7 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
 
         it 'skips forking extensions without warning' do
           expect(Datadog::Profiling::Ext::Forking).to_not receive(:apply!)
-          expect($stdout).to_not receive(:puts)
+          expect(Datadog.logger).to_not receive(:debug)
           activate_forking_extensions
         end
       end
@@ -123,7 +123,7 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
       context 'and succeeds' do
         it 'applies CPU extensions' do
           expect(Datadog::Profiling::Ext::CPU).to receive(:apply!)
-          expect($stdout).to_not receive(:puts)
+          expect(Datadog.logger).to_not receive(:warn)
           activate_cpu_extensions
         end
       end
@@ -135,9 +135,9 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
             .and_raise(StandardError)
         end
 
-        it 'displays a warning to $stdout' do
-          expect($stdout).to receive(:puts) do |message|
-            expect(message).to include('CPU profiling unavailable')
+        it 'logs a warning' do
+          expect(Datadog.logger).to receive(:warn) do |&message|
+            expect(message.call).to include('CPU profiling extensions unavailable')
           end
 
           activate_cpu_extensions
@@ -159,10 +159,10 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
             .and_return(true)
         end
 
-        it 'skips CPU extensions with warning' do
+        it 'skips CPU extensions with an info message' do
           expect(Datadog::Profiling::Ext::CPU).to_not receive(:apply!)
-          expect($stdout).to receive(:puts) do |message|
-            expect(message).to include('CPU time profiling skipped')
+          expect(Datadog.logger).to receive(:info) do |&message|
+            expect(message.call).to include('CPU time profiling skipped')
           end
 
           activate_cpu_extensions
@@ -178,7 +178,7 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
 
         it 'skips CPU extensions without warning' do
           expect(Datadog::Profiling::Ext::CPU).to_not receive(:apply!)
-          expect($stdout).to_not receive(:puts)
+          expect(Datadog.logger).to_not receive(:warn)
           activate_cpu_extensions
         end
       end
@@ -224,7 +224,7 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
       context 'when there is an issue starting the profiler' do
         before do
           expect(Datadog).to receive(:profiler).and_raise('Dummy exception')
-          allow($stdout).to receive(:puts) # Silence logging during tests
+          allow(Datadog.logger).to receive(:warn) # Silence logging during tests
         end
 
         it 'does not raise any error' do
@@ -232,8 +232,8 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
         end
 
         it 'logs an exception' do
-          expect($stdout).to receive(:puts) do |message|
-            expect(message).to include('Dummy exception')
+          expect(Datadog.logger).to receive(:warn) do |&message|
+            expect(message.call).to include('Dummy exception')
           end
 
           at_fork_hook.call
@@ -253,7 +253,7 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
           without_partial_double_verification do
             expect(Thread.current).to receive(:update_native_ids).and_raise('Dummy exception')
           end
-          allow($stdout).to receive(:puts) # Silence logging during tests
+          allow(Datadog.logger).to receive(:warn) # Silence logging during tests
         end
 
         it 'does not raise any error' do
@@ -261,8 +261,8 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
         end
 
         it 'logs an exception' do
-          expect($stdout).to receive(:puts) do |message|
-            expect(message).to include('Dummy exception')
+          expect(Datadog.logger).to receive(:warn) do |&message|
+            expect(message.call).to include('Dummy exception')
           end
 
           at_fork_hook.call


### PR DESCRIPTION
Before #1391, the `Datadog::Profiling::Tasks::Setup` task was run before the gem logger was initialized/available, and thus the class was made to use `puts` for its logging needs.

But since the refactor in #1391, this is no longer the case -- this task is now called by `Datadog::Configuration::Components#build_profiler` and thus we can safely make use of the logger and get rid of any custom logging specific to this class.