### PR TITLE
Tweak debug message about missing instrumentation

### DIFF
--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -224,6 +224,7 @@ module Datadog
             #    In this case, the fix is to make sure ddtrace gets loaded before any other parts of the application.
             #
             # b) The thread was started using the Ruby native APIs (e.g. from a C extension such as ffi).
+            #    Known cases right now that trigger this are the ethon/typhoeus gems.
             #    We currently have no solution for this case; these threads will always be missing our CPU instrumentation.
             #
             # c) The thread was started with `Thread.start`/`Thread.fork` and hasn't yet enabled the instrumentation.
@@ -232,7 +233,9 @@ module Datadog
             #    it to run and our instrumentation to be applied.
             #
             if thread_api.current.respond_to?(:cpu_time) && thread_api.current.cpu_time
-              Datadog.logger.debug("Detected thread ('#{thread}') with missing CPU profiling instrumentation.")
+              Datadog.logger.debug(
+                "Thread ('#{thread}') is missing profiling instrumentation; other threads should be unaffected"
+              )
             end
           end
         end

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -427,7 +427,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
         it { is_expected.to be nil }
 
         it 'logs a warning' do
-          expect(Datadog.logger).to receive(:debug).with(/missing CPU profiling instrumentation/)
+          expect(Datadog.logger).to receive(:debug).with(/missing profiling instrumentation/)
 
           get_cpu_time_interval!
         end


### PR DESCRIPTION
A customer was a bit misled by seeing this message in their logs (e.g. it led them to believe CPU time profiling was not working).

This debug message is still useful for our own debugging so I've left it, but I've reworded it to clarify that seeing this message is mostly harmless.