### PR TITLE
Debug log statistics during profile encoding + Tweak "started thread" debug logs

### DIFF
--- a/lib/ddtrace/profiling/encoding/profile.rb
+++ b/lib/ddtrace/profiling/encoding/profile.rb
@@ -1,4 +1,5 @@
 require 'set'
+require 'time'
 
 require 'ddtrace/profiling/flush'
 require 'ddtrace/profiling/pprof/template'
@@ -20,6 +21,11 @@ module Datadog
 
             # Add all events to the pprof
             flush.event_groups.each { |event_group| template.add_events!(event_group.event_class, event_group.events) }
+
+            Datadog.logger.debug do
+              "Encoding profile covering #{flush.start.iso8601} to #{flush.finish.iso8601}, " \
+              "events: #{flush.event_count} (#{template.debug_statistics})"
+            end
 
             # Build the profile and encode it
             template.to_pprof

--- a/lib/ddtrace/profiling/pprof/converter.rb
+++ b/lib/ddtrace/profiling/pprof/converter.rb
@@ -62,6 +62,10 @@ module Datadog
           Array.new(@sample_type_mappings.length, Datadog::Ext::Profiling::Pprof::SAMPLE_VALUE_NO_VALUE)
         end
 
+        def debug_statistics
+          # Empty; can be used by subclasses to report a string containing debug statistics to be logged
+        end
+
         # Represents a grouped event
         # 'sample' is an example event object from the group.
         # 'values' is the the summation of the group's sample values

--- a/lib/ddtrace/profiling/pprof/template.rb
+++ b/lib/ddtrace/profiling/pprof/template.rb
@@ -75,6 +75,10 @@ module Datadog
           converters[event_class].add_events!(events)
         end
 
+        def debug_statistics
+          converters.values.map(&:debug_statistics).join(', ')
+        end
+
         def to_pprof
           profile = builder.build_profile
           data = builder.encode_profile(profile)

--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -69,7 +69,7 @@ module Datadog
           return if @run
 
           @run = true
-          Datadog.logger.debug("Starting thread in the process: #{Process.pid}")
+          Datadog.logger.debug { "Starting thread for: #{self}" }
           @worker = Thread.new { perform }
           @worker.name = self.class.name unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
 

--- a/lib/ddtrace/workers/async.rb
+++ b/lib/ddtrace/workers/async.rb
@@ -127,7 +127,7 @@ module Datadog
           @run_async = true
           @pid = Process.pid
           @error = nil
-          Datadog.logger.debug("Starting thread in the process: #{Process.pid} for: #{self}")
+          Datadog.logger.debug { "Starting thread for: #{self}" }
 
           @worker = ::Thread.new do
             begin

--- a/spec/ddtrace/profiling/encoding/profile_spec.rb
+++ b/spec/ddtrace/profiling/encoding/profile_spec.rb
@@ -35,5 +35,29 @@ RSpec.describe Datadog::Profiling::Encoding::Profile::Protobuf do
     end
 
     it { is_expected.to be payload }
+
+    context 'debug logging' do
+      let(:flush) do
+        instance_double(
+          Datadog::Profiling::Flush,
+          event_groups: event_groups,
+          start: Time.new(2020).utc,
+          finish: Time.new(2021).utc,
+          event_count: 42
+        )
+      end
+
+      let(:template) { instance_double(Datadog::Profiling::Pprof::Template, debug_statistics: 'template_debug_statistics') }
+
+      it 'debug logs profile information' do
+        expect(Datadog.logger).to receive(:debug) do |&message|
+          expect(message.call).to include '2020-01-01T00:00:00Z'
+          expect(message.call).to include '2021-01-01T00:00:00Z'
+          expect(message.call).to include 'template_debug_statistics'
+        end
+
+        encode
+      end
+    end
   end
 end

--- a/spec/ddtrace/profiling/pprof/converter_spec.rb
+++ b/spec/ddtrace/profiling/pprof/converter_spec.rb
@@ -123,4 +123,12 @@ RSpec.describe Datadog::Profiling::Pprof::Converter do
     # and expects all values to be "no value"
     it { is_expected.to eq(default_sample_values) }
   end
+
+  describe '#debug_statistics' do
+    subject(:debug_statistics) { converter.debug_statistics }
+
+    it 'provides no debug statistics by default, as this is a hook for subclasses to use' do
+      is_expected.to be nil
+    end
+  end
 end

--- a/spec/ddtrace/profiling/pprof/stack_sample_spec.rb
+++ b/spec/ddtrace/profiling/pprof/stack_sample_spec.rb
@@ -440,4 +440,13 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
       end
     end
   end
+
+  describe '#debug_statistics' do
+    subject(:debug_statistics) { converter.debug_statistics }
+
+    # NOTE: I don't think it's worth testing this beyond "it doesn't break when it's called"
+    it 'returns a string with counters related to the conversion work' do
+      is_expected.to be_a(String)
+    end
+  end
 end

--- a/spec/ddtrace/profiling/pprof/template_spec.rb
+++ b/spec/ddtrace/profiling/pprof/template_spec.rb
@@ -149,4 +149,27 @@ RSpec.describe Datadog::Profiling::Pprof::Template do
       )
     end
   end
+
+  describe '#debug_statistics' do
+    subject(:debug_statistics) { template.debug_statistics }
+
+    let(:mappings) do
+      {
+        dummy_mapping_one: class_double(
+          Datadog::Profiling::Pprof::Converter,
+          sample_value_types: { dummy_mapping_one: ['dummy_mapping_one'] },
+          new: instance_double(Datadog::Profiling::Pprof::Converter, debug_statistics: 'dummy_mapping_one_stats')
+        ),
+        dummy_mapping_two: class_double(
+          Datadog::Profiling::Pprof::Converter,
+          sample_value_types: { dummy_mapping_two: ['dummy_mapping_two'] },
+          new: instance_double(Datadog::Profiling::Pprof::Converter, debug_statistics: 'dummy_mapping_two_stats')
+        )
+      }
+    end
+
+    it 'returns a string containing the available debug statistics from each converter' do
+      is_expected.to eq 'dummy_mapping_one_stats, dummy_mapping_two_stats'
+    end
+  end
 end


### PR DESCRIPTION
I was trying to diagnose some issues in the connection between traces and profiles and did these two improvements to our current debug logging; see individual commit messages for more details.