### PR TITLE
[PROF-3320] Include tags in profiles

### DIFF
--- a/lib/ddtrace/profiling/flush.rb
+++ b/lib/ddtrace/profiling/flush.rb
@@ -18,7 +18,8 @@ module Datadog
       :runtime_engine,
       :runtime_platform,
       :runtime_version,
-      :profiler_version
+      :profiler_version,
+      :tags
     ) do
       def initialize(*args)
         super
@@ -32,6 +33,7 @@ module Datadog
         self.runtime_platform = runtime_platform || Datadog::Runtime::Identity.lang_platform
         self.runtime_version = runtime_version || Datadog::Runtime::Identity.lang_version
         self.profiler_version = profiler_version || Datadog::Runtime::Identity.tracer_version
+        self.tags = tags || Datadog.configuration.tags
       end
     end
 

--- a/lib/ddtrace/profiling/transport/http/api/endpoint.rb
+++ b/lib/ddtrace/profiling/transport/http/api/endpoint.rb
@@ -17,7 +17,7 @@ module Datadog
             attr_reader \
               :encoder
 
-            def initialize(path, encoder, options = {})
+            def initialize(path, encoder)
               super(:post, path)
               @encoder = encoder
             end

--- a/spec/ddtrace/profiling/flush_spec.rb
+++ b/spec/ddtrace/profiling/flush_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Datadog::Profiling::Flush do
           runtime_engine: Datadog::Runtime::Identity.lang_engine,
           runtime_platform: Datadog::Runtime::Identity.lang_platform,
           runtime_version: Datadog::Runtime::Identity.lang_version,
-          profiler_version: Datadog::Runtime::Identity.tracer_version
+          profiler_version: Datadog::Runtime::Identity.tracer_version,
+          tags: Datadog.configuration.tags
         )
       end
     end
@@ -39,7 +40,8 @@ RSpec.describe Datadog::Profiling::Flush do
           runtime_engine,
           runtime_platform,
           runtime_version,
-          profiler_version
+          profiler_version,
+          tags
         )
       end
 
@@ -57,6 +59,7 @@ RSpec.describe Datadog::Profiling::Flush do
       let(:runtime_platform) { double('runtime_platform') }
       let(:runtime_version) { double('runtime_version') }
       let(:profiler_version) { double('profiler_version') }
+      let(:tags) { double('tags') }
 
       it do
         is_expected.to have_attributes(
@@ -73,7 +76,8 @@ RSpec.describe Datadog::Profiling::Flush do
           runtime_engine: runtime_engine,
           runtime_platform: runtime_platform,
           runtime_version: runtime_version,
-          profiler_version: profiler_version
+          profiler_version: profiler_version,
+          tags: tags
         )
       end
     end

--- a/spec/ddtrace/profiling/transport/http/adapters/net_integration_spec.rb
+++ b/spec/ddtrace/profiling/transport/http/adapters/net_integration_spec.rb
@@ -68,6 +68,12 @@ RSpec.describe 'Adapters::Net profiling integration tests' do
     shared_examples_for 'profile HTTP request' do
       subject(:request) { messages.first }
 
+      let(:tags) { { 'test_tag' => 'test_value' } }
+
+      before do
+        allow(Datadog.configuration).to receive(:tags).and_return(tags)
+      end
+
       # rubocop:disable Layout/LineLength
       it 'sends profiles successfully' do
         client.send_profiling_flush(flush)
@@ -103,7 +109,6 @@ RSpec.describe 'Adapters::Net profiling integration tests' do
         )
 
         tags = body["#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAGS}[]"].list
-        expect(tags).to be_a_kind_of(Array)
         expect(tags).to include(
           /#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_RUNTIME}:#{Datadog::Ext::Runtime::LANG}/o,
           /#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_RUNTIME_ID}:#{uuid_regex.source}/,
@@ -112,7 +117,8 @@ RSpec.describe 'Adapters::Net profiling integration tests' do
           /#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_RUNTIME_VERSION}:#{Datadog::Ext::Runtime::LANG_VERSION}/o,
           /#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_PID}:#{Process.pid}/o,
           /#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_PROFILER_VERSION}:#{Datadog::Ext::Runtime::TRACER_VERSION}/o,
-          /#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_LANGUAGE}:#{Datadog::Ext::Runtime::LANG}/o
+          /#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_LANGUAGE}:#{Datadog::Ext::Runtime::LANG}/o,
+          'test_tag:test_value'
         )
 
         if Datadog::Runtime::Container.container_id

--- a/spec/ddtrace/profiling/transport/http/api/endpoint_spec.rb
+++ b/spec/ddtrace/profiling/transport/http/api/endpoint_spec.rb
@@ -83,7 +83,25 @@ RSpec.describe Datadog::Profiling::Transport::HTTP::API::Endpoint do
       it_behaves_like 'profile request'
     end
 
-    context 'when additional env tags are available' do
+    context 'when additional tags are provided' do
+      it_behaves_like 'profile request' do
+        let(:tags) { { 'test_tag_key' => 'test_tag_value', 'another_tag_key' => :another_tag_value } }
+
+        before do
+          flush.tags = tags
+        end
+
+        it 'reports the additional tags as part of the tags field' do
+          call
+
+          expect(env.form).to include(Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAGS => array_including(
+            'test_tag_key:test_tag_value', 'another_tag_key:another_tag_value'
+          ))
+        end
+      end
+    end
+
+    context 'when service/env/version are available' do
       let(:service) { 'test-service' }
       let(:env_name) { 'test-env' }
       let(:version) { '1.2.3' }
@@ -95,7 +113,7 @@ RSpec.describe Datadog::Profiling::Transport::HTTP::API::Endpoint do
           flush.version = version
         end
 
-        it 'includes env tags' do
+        it 'includes service/env/version as tags' do
           call
           expect(env.form).to include(
             Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAGS => array_including(
@@ -104,6 +122,44 @@ RSpec.describe Datadog::Profiling::Transport::HTTP::API::Endpoint do
               "#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_VERSION}:#{flush.version}"
             )
           )
+        end
+
+        context 'when service/env/version were configured via tags' do
+          # NOTE: In normal operation, flush.tags SHOULD never be different from flush.service/env/version because we set
+          # the service/env/version in the settings object from the tags if they are available (see settings.rb).
+          # But simulating them being different here makes it easier to test that no duplicates are added -- that
+          # effectively the tag versions are ignored and we only include the top-level flush versions.
+          let(:tags) { { 'service' => 'service_tag', 'env' => 'env_tag', 'version' => 'version_tag', 'some_other_tag' => 'some_other_value' } }
+
+          before do
+            flush.tags = tags
+          end
+
+          it 'includes the flush.service / flush.env / flush.version values for these tags' do
+            call
+
+            expect(env.form).to include(
+              Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAGS => array_including(
+                "#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_SERVICE}:#{flush.service}",
+                "#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_ENV}:#{flush.env}",
+                "#{Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAG_VERSION}:#{flush.version}"
+              )
+            )
+          end
+
+          it 'does not include the values for these tags from the flush.tags hash' do
+            call
+
+            expect(env.form.fetch(Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAGS))
+              .to_not include('service:service_tag', 'env:env_tag', 'version:version_tag')
+          end
+
+          it 'includes other defined tags' do
+            call
+
+            expect(env.form.fetch(Datadog::Ext::Profiling::Transport::HTTP::FORM_FIELD_TAGS))
+              .to include('some_other_tag:some_other_value')
+          end
         end
       end
     end

--- a/spec/ddtrace/profiling/transport/http/api/endpoint_spec.rb
+++ b/spec/ddtrace/profiling/transport/http/api/endpoint_spec.rb
@@ -10,11 +10,10 @@ require 'ddtrace/transport/http/env'
 
 # rubocop:disable Layout/LineLength
 RSpec.describe Datadog::Profiling::Transport::HTTP::API::Endpoint do
-  subject(:endpoint) { described_class.new(path, encoder, options) }
+  subject(:endpoint) { described_class.new(path, encoder) }
 
   let(:path) { double('path') }
   let(:encoder) { class_double(Datadog::Profiling::Encoding::Profile::Protobuf) }
-  let(:options) { {} }
 
   describe '#initialize' do
     it do


### PR DESCRIPTION
Tags configured via `Datadog.configure { |c| c.tags = { ... } }` or via `DD_TAGS` are now included in reported profiles.

This brings the Ruby profiler into feature parity with our other profilers (such as dd-trace-py).
