### PR TITLE
Fix some thread-leaking tests

### DIFF
--- a/spec/ddtrace/context_provider_spec.rb
+++ b/spec/ddtrace/context_provider_spec.rb
@@ -137,6 +137,7 @@ RSpec.describe Datadog::ThreadLocalContext do
       subject(:local) { thread_local_context.local(thread) }
 
       let(:thread) { Thread.new {} }
+      after { thread.join }
 
       it 'retrieves the context for the provided thread' do
         is_expected.to be_a_kind_of(Datadog::Context)

--- a/spec/ddtrace/diagnostics/health_spec.rb
+++ b/spec/ddtrace/diagnostics/health_spec.rb
@@ -4,6 +4,7 @@ require 'ddtrace/diagnostics/health'
 
 RSpec.describe Datadog::Diagnostics::Health::Metrics do
   subject(:health_metrics) { described_class.new }
+  after { health_metrics.close }
 
   shared_examples_for 'a health metric' do |type, name, stat|
     subject(:health_metric) { health_metrics.send(name, *args, &block) }

--- a/spec/ddtrace/runtime/metrics_spec.rb
+++ b/spec/ddtrace/runtime/metrics_spec.rb
@@ -4,6 +4,7 @@ require 'ddtrace/runtime/metrics'
 
 RSpec.describe Datadog::Runtime::Metrics do
   subject(:runtime_metrics) { described_class.new(options) }
+  after { runtime_metrics.close }
 
   let(:options) { {} }
 


### PR DESCRIPTION
While trying to debug leaking threads associated with `dogstatsd-ruby`, I noticed that some of our tests are leaking threads, which makes it hard to use our test suite to help us debug the issue.

This PR addresses leaky threads associated with `spec:main` tests.

A run of `spec:main` won't be 100% clean yet, as the dreaded ` ./spec/ddtrace/workers/*` tests are still leaking, but they are pretty hard to clean, so have to be addressed separately.