### PR TITLE
Fix tracer ignoring value for service tag (service name) in DD_TAGS

### DIFF
--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -229,7 +229,10 @@ module Datadog
           string_tags = new_value.collect { |k, v| [k.to_s, v] }.to_h
 
           # Cross-populate tag values with other settings
-          self.env = string_tags[Ext::Environment::TAG_ENV] if env.nil? && string_tags.key?(Ext::Environment::TAG_ENV)
+
+          if env.nil? && string_tags.key?(Ext::Environment::TAG_ENV)
+            self.env = string_tags[Ext::Environment::TAG_ENV]
+          end
 
           if version.nil? && string_tags.key?(Ext::Environment::TAG_VERSION)
             self.version = string_tags[Ext::Environment::TAG_VERSION]

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -5,7 +5,9 @@ require 'ddtrace'
 require 'ddtrace/configuration/settings'
 
 RSpec.describe Datadog::Configuration::Settings do
-  subject(:settings) { described_class.new }
+  subject(:settings) { described_class.new(options) }
+
+  let(:options) { {} }
 
   describe '#analytics' do
     describe '#enabled' do
@@ -896,39 +898,17 @@ RSpec.describe Datadog::Configuration::Settings do
         it { is_expected.to include('a' => '1', 'b' => '2') }
 
         context 'with an invalid tag' do
-          context do
-            let(:env_tags) { '' }
+          ['', 'a', ':', ',', 'a:'].each do |invalid_tag|
+            context "when tag is #{invalid_tag.inspect}" do
+              let(:env_tags) { invalid_tag }
 
-            it { is_expected.to eq({}) }
-          end
-
-          context do
-            let(:env_tags) { 'a' }
-
-            it { is_expected.to eq({}) }
-          end
-
-          context do
-            let(:env_tags) { ':' }
-
-            it { is_expected.to eq({}) }
-          end
-
-          context do
-            let(:env_tags) { ',' }
-
-            it { is_expected.to eq({}) }
-          end
-
-          context do
-            let(:env_tags) { 'a:' }
-
-            it { is_expected.to eq({}) }
+              it { is_expected.to eq({}) }
+            end
           end
         end
 
         context 'and when #env' do
-          before { allow(settings).to receive(:env).and_return(env) }
+          let(:options) { {**super(), env: env} }
 
           context 'is set' do
             let(:env) { 'env-value' }
@@ -944,7 +924,7 @@ RSpec.describe Datadog::Configuration::Settings do
         end
 
         context 'and when #version' do
-          before { allow(settings).to receive(:version).and_return(version) }
+          let(:options) { { **super(), version: version } }
 
           context 'is set' do
             let(:version) { 'version-value' }
@@ -973,11 +953,11 @@ RSpec.describe Datadog::Configuration::Settings do
       end
 
       context 'conflicts with #env' do
+        let(:options) { { **super(), env: env_value } }
+
         let(:env_tags) { "env:#{tag_env_value}" }
         let(:tag_env_value) { 'tag-env-value' }
         let(:env_value) { 'env-value' }
-
-        before { allow(settings).to receive(:env).and_return(env_value) }
 
         it { is_expected.to include('env' => env_value) }
       end
@@ -995,11 +975,11 @@ RSpec.describe Datadog::Configuration::Settings do
       end
 
       context 'conflicts with #version' do
+        let(:options) { { **super(), version: version_value } }
+
         let(:env_tags) { "env:#{tag_version_value}" }
         let(:tag_version_value) { 'tag-version-value' }
         let(:version_value) { 'version-value' }
-
-        before { allow(settings).to receive(:version).and_return(version_value) }
 
         it { is_expected.to include('version' => version_value) }
       end

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -371,6 +371,30 @@ RSpec.describe Datadog::Configuration::Settings do
         it { is_expected.to eq(environment) }
       end
     end
+
+    context 'when an env tag is defined in DD_TAGS' do
+      around do |example|
+        ClimateControl.modify(Datadog::Ext::Environment::ENV_TAGS => 'env:env-from-tag') do
+          example.run
+        end
+      end
+
+      it 'uses the env from DD_TAGS' do
+        is_expected.to eq('env-from-tag')
+      end
+
+      context 'and defined via DD_ENV' do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::Environment::ENV_ENVIRONMENT => 'env-from-dd-env') do
+            example.run
+          end
+        end
+
+        it 'uses the env from DD_ENV' do
+          is_expected.to eq('env-from-dd-env')
+        end
+      end
+    end
   end
 
   describe '#env=' do
@@ -826,6 +850,30 @@ RSpec.describe Datadog::Configuration::Settings do
         it { is_expected.to eq(service) }
       end
     end
+
+    context 'when a service tag is defined in DD_TAGS' do
+      around do |example|
+        ClimateControl.modify(Datadog::Ext::Environment::ENV_TAGS => 'service:service-name-from-tag') do
+          example.run
+        end
+      end
+
+      it 'uses the service name from DD_TAGS' do
+        is_expected.to eq('service-name-from-tag')
+      end
+
+      context 'and defined via DD_SERVICE' do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::Environment::ENV_SERVICE => 'service-name-from-dd-service') do
+            example.run
+          end
+        end
+
+        it 'uses the service name from DD_SERVICE' do
+          is_expected.to eq('service-name-from-dd-service')
+        end
+      end
+    end
   end
 
   describe '#service=' do
@@ -908,7 +956,7 @@ RSpec.describe Datadog::Configuration::Settings do
         end
 
         context 'and when #env' do
-          let(:options) { {**super(), env: env} }
+          let(:options) { { **super(), env: env } }
 
           context 'is set' do
             let(:env) { 'env-value' }
@@ -940,18 +988,6 @@ RSpec.describe Datadog::Configuration::Settings do
         end
       end
 
-      context 'defines :env with missing #env' do
-        let(:env_tags) { "env:#{tag_env_value}" }
-        let(:tag_env_value) { 'tag-env-value' }
-
-        it 'populates #env from the tag' do
-          expect { tags }
-            .to change { settings.env }
-            .from(nil)
-            .to(tag_env_value)
-        end
-      end
-
       context 'conflicts with #env' do
         let(:options) { { **super(), env: env_value } }
 
@@ -962,18 +998,6 @@ RSpec.describe Datadog::Configuration::Settings do
         it { is_expected.to include('env' => env_value) }
       end
 
-      context 'defines :service with missing #service' do
-        let(:env_tags) { "service:#{tag_service_value}" }
-        let(:tag_service_value) { 'tag-service-value' }
-
-        it 'populates #service from the tag' do
-          expect { tags }
-            .to change { settings.service }
-            .from(nil)
-            .to(tag_service_value)
-        end
-      end
-
       context 'conflicts with #version' do
         let(:options) { { **super(), version: version_value } }
 
@@ -982,18 +1006,6 @@ RSpec.describe Datadog::Configuration::Settings do
         let(:version_value) { 'version-value' }
 
         it { is_expected.to include('version' => version_value) }
-      end
-
-      context 'defines :version with missing #version' do
-        let(:env_tags) { "version:#{tag_version_value}" }
-        let(:tag_version_value) { 'tag-version-value' }
-
-        it 'populates #version from the tag' do
-          expect { tags }
-            .to change { settings.version }
-            .from(nil)
-            .to(tag_version_value)
-        end
       end
     end
   end
@@ -1527,6 +1539,30 @@ RSpec.describe Datadog::Configuration::Settings do
         let(:version) { 'version-value' }
 
         it { is_expected.to eq(version) }
+      end
+    end
+
+    context 'when a version tag is defined in DD_TAGS' do
+      around do |example|
+        ClimateControl.modify(Datadog::Ext::Environment::ENV_TAGS => 'version:version-from-tag') do
+          example.run
+        end
+      end
+
+      it 'uses the version from DD_TAGS' do
+        is_expected.to eq('version-from-tag')
+      end
+
+      context 'and defined via DD_VERSION' do
+        around do |example|
+          ClimateControl.modify(Datadog::Ext::Environment::ENV_VERSION => 'version-from-dd-version') do
+            example.run
+          end
+        end
+
+        it 'uses the version from DD_VERSION' do
+          is_expected.to eq('version-from-dd-version')
+        end
       end
     end
   end


### PR DESCRIPTION
As documented in <https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#environment-and-tags>:

> If `DD_ENV`, `DD_SERVICE` or `DD_VERSION` are NOT set, tags defined in `DD_TAGS` will be used to populate `env`/`service`/`version` respectively.

Unfortunately, the previous implementation was missing a weird corner case: the `service`/`env`/`version` in the settings object were only set as a side-effect of trying to access or write to the `tags` option.

This meant that in a situation where `service`/`env`/`version` were defined in `DD_TAGS` only AND those values were accessed BEFORE calling `tags`, the accessing code would not see the correct values (it would still see them as `nil`).

In particular, this happened during tracer initialization inside `Components#build_tracer`, and meant that rather than using the service name defined in `DD_TAGS`, the fallback default from `Tracer#default_service` would be used instead.

I'm not very happy with the fix (hence it's more of a workaround), see the huge comment I left on the code for more details on why I'm not happy and why it works.