### PR TITLE
Add warning for incompatible dogstastd-ruby version

### DIFF
--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -3,8 +3,9 @@ require 'ddtrace/ext/metrics'
 require 'set'
 require 'logger'
 require 'ddtrace/environment'
-require 'ddtrace/utils/time'
 require 'ddtrace/runtime/identity'
+require 'ddtrace/utils/only_once'
+require 'ddtrace/utils/time'
 
 module Datadog
   # Acts as client for sending metrics (via Statsd)
@@ -48,6 +49,8 @@ module Datadog
 
     def default_statsd_client
       require 'datadog/statsd'
+
+      incompatible_statsd_warning
 
       # Create a StatsD client that points to the agent.
       Datadog::Statsd.new(default_hostname, default_port)
@@ -232,5 +235,21 @@ module Datadog
     include Options
     extend Options
     extend Helpers
+
+    private
+
+    INCOMPATIBLE_STATSD_ONLY_ONCE = Datadog::Utils::OnlyOnce.new
+    private_constant :INCOMPATIBLE_STATSD_ONLY_ONCE
+
+    def incompatible_statsd_warning
+      return if Gem.loaded_specs['dogstatsd-ruby'].version < Gem::Version.new('5.0')
+
+      INCOMPATIBLE_STATSD_ONLY_ONCE.run do
+        Datadog.logger.warn(
+          'This version of `ddtrace` is incompatible with `dogstastd-ruby` version >= 5.0 and can ' \
+          'cause unbounded memory usage. Please use `dogstastd-ruby` version < 5.0 instead.'
+        )
+      end
+    end
   end
 end

--- a/spec/ddtrace/metrics_spec.rb
+++ b/spec/ddtrace/metrics_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Datadog::Metrics do
   include_context 'metrics'
 
   subject(:metrics) { described_class.new(options) }
+  after { metrics.close }
 
   let(:options) { { statsd: statsd } }
 
@@ -719,6 +720,34 @@ RSpec.describe Datadog::Metrics do
 
       it 'does not call nonexistent method #close' do
         close
+      end
+    end
+  end
+
+  describe '#incompatible_statsd_warning' do
+    let(:options) { {} }
+
+    before { described_class.const_get('INCOMPATIBLE_STATSD_ONLY_ONCE').send(:reset_ran_once_state_for_tests) }
+    after { described_class.const_get('INCOMPATIBLE_STATSD_ONLY_ONCE').send(:reset_ran_once_state_for_tests) }
+
+    context 'with an incompatible dogstastd-ruby version' do
+      before { skip unless Gem.loaded_specs['dogstatsd-ruby'].version >= Gem::Version.new('5.0') }
+
+      it 'emits deprecation warning once' do
+        expect(Datadog.logger).to receive(:warn)
+          .with(/This version of `ddtrace` is incompatible with `dogstastd-ruby`/).once
+
+        metrics
+      end
+    end
+
+    context 'with a compatible dogstastd-ruby version' do
+      before { skip unless Gem.loaded_specs['dogstatsd-ruby'].version < Gem::Version.new('5.0') }
+
+      it 'emits no warnings' do
+        expect(Datadog.logger).to_not receive(:warn)
+
+        metrics
       end
     end
   end


### PR DESCRIPTION
This PR adds a one-time warning when `ddtrace` tries to instantiate `Datadog::Statsd` with a version that can cause unbounded memory usage by leaking threads #1491.

We've already updated our documentation instructing new users to not install `dogstastd-ruby` >= 5.0: #1533. Versions < 5.0 are confirmed safe.

There's only one place in `ddtrace` where `Datadog::Statsd` instances are created, so the warning was placed at that point.