### PR TITLE
Avoid creating thread when metrics are disabled

### DIFF
--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -14,8 +14,8 @@ module Datadog
     attr_reader :statsd
 
     def initialize(options = {})
-      @statsd = options.fetch(:statsd) { default_statsd_client if supported? }
       @enabled = options.fetch(:enabled, true)
+      @statsd = options.fetch(:statsd) { default_statsd_client if enabled? && supported? }
     end
 
     def supported?

--- a/lib/ddtrace/workers/runtime_metrics.rb
+++ b/lib/ddtrace/workers/runtime_metrics.rb
@@ -20,7 +20,9 @@ module Datadog
         :metrics
 
       def initialize(options = {})
-        @metrics = options.fetch(:metrics) { Runtime::Metrics.new }
+        self.enabled = options.fetch(:enabled, false)
+
+        @metrics = options.fetch(:metrics) { Runtime::Metrics.new if enabled? }
 
         # Workers::Async::Thread settings
         self.fork_policy = options.fetch(:fork_policy, Workers::Async::Thread::FORK_POLICY_STOP)
@@ -29,16 +31,20 @@ module Datadog
         self.loop_base_interval = options.fetch(:interval, DEFAULT_FLUSH_INTERVAL)
         self.loop_back_off_ratio = options[:back_off_ratio] if options.key?(:back_off_ratio)
         self.loop_back_off_max = options.fetch(:back_off_max, DEFAULT_BACK_OFF_MAX)
-
-        self.enabled = options.fetch(:enabled, false)
       end
 
       def perform
+        return unless enabled?
+
         metrics.flush
         true
       end
 
+      # Forwarded to @metrics.
+      # @see {Datadog::Runtime::Metrics}
       def associate_with_span(*args)
+        return unless enabled?
+
         # Start the worker
         metrics.associate_with_span(*args).tap { perform }
       end
@@ -52,13 +58,20 @@ module Datadog
       def stop(*args, close_metrics: true)
         self.enabled = false
         result = super(*args)
-        @metrics.close if close_metrics
+        @metrics.close if @metrics && close_metrics
         result
       end
 
-      def_delegators \
-        :metrics,
-        :register_service
+      # Forwarded to @metrics.
+      # @see {Datadog::Runtime::Metrics}
+      # TODO: This method has now value as a public API
+      # and should be removed from this worker.
+      # It is internally used by `#associate_with_span`.
+      def register_service(*args)
+        return unless enabled?
+
+        metrics.register_service(*args)
+      end
     end
   end
 end

--- a/spec/ddtrace/metrics_spec.rb
+++ b/spec/ddtrace/metrics_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe Datadog::Metrics do
 
   describe '#enabled?' do
     subject(:enabled) { metrics.enabled? }
+    let(:options) { {} }
 
     context 'by default' do
       it { is_expected.to be true }
@@ -96,6 +97,7 @@ RSpec.describe Datadog::Metrics do
       let(:options) { super().merge(enabled: false) }
 
       it { is_expected.to be false }
+      it { expect(metrics.statsd).to be_nil }
     end
   end
 
@@ -725,7 +727,7 @@ RSpec.describe Datadog::Metrics do
   end
 
   describe '#incompatible_statsd_warning' do
-    let(:options) { {} }
+    let(:options) { { enabled: true } }
 
     before { described_class.const_get('INCOMPATIBLE_STATSD_ONLY_ONCE').send(:reset_ran_once_state_for_tests) }
     after { described_class.const_get('INCOMPATIBLE_STATSD_ONLY_ONCE').send(:reset_ran_once_state_for_tests) }


### PR DESCRIPTION
> Should alleviate #1491

This PR skips the creation of expensive resources (threads) when metrics (Runtime Metrics and Health Metrics) are not enabled.

Currently, we always create StatsD instances (which create threads) for both Runtime and Health metrics regardless of their "enablement" status.
For Runtime Metrics, we create an additional thread (in `Datadog::RuntimeMetrics::Worker`) for a background collection of metrics.