### PR TITLE
Allow to set sampling interval for profiling

### DIFF
--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -139,7 +139,8 @@ module Datadog
           [
             Datadog::Profiling::Collectors::Stack.new(
               recorder,
-              max_frames: settings.profiling.max_frames
+              max_frames: settings.profiling.max_frames,
+              interval: settings.profiling.sampling_interval,
               # TODO: Provide proc that identifies Datadog worker threads?
               # ignore_thread: settings.profiling.ignore_profiler
             )

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -141,6 +141,12 @@ module Datadog
           o.lazy
         end
 
+        # Controls the interval at which the stack trace is sampled
+        option :sampling_interval do |o|
+          o.default { env_to_float(Ext::Profiling::ENV_SAMPLING_INTERVAL, 0.01) }
+          o.lazy
+        end
+
         settings :upload do
           option :timeout_seconds do |o|
             o.setter { |value| value.nil? ? 30.0 : value.to_f }


### PR DESCRIPTION
This PR is not complete yet (no specs etc), but I wanted to create a draft for a discussion. I wanted to play with sampling interval (which currently is set to 10ms), but at the moment the only way to do that is to change the hardcoded value. This PR adds it as an option in configurator. If that looks good I'll gladly prepare the PR to be merged.