### PR TITLE
Fix test typo

### DIFF
--- a/spec/ddtrace_integration_spec.rb
+++ b/spec/ddtrace_integration_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'ddtrace integration' do
           .to(
             eq(before_open_file_descriptors.size),
             lambda {
-              "Open fds before (#{after_open_file_descriptors.size}): #{before_open_file_descriptors}\n" \
+              "Open fds before (#{before_open_file_descriptors.size}): #{before_open_file_descriptors}\n" \
               "Open fds after (#{after_open_file_descriptors.size}):  #{after_open_file_descriptors}"
             }
           )


### PR DESCRIPTION
I noticed one of my tests didn't seem to have failed ([expected 11, got 11](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/3615/workflows/8b5bfc13-08c4-484b-a669-b7c5416bc62b/jobs/141636/parallel-runs/2)), but it turns out that the custom message was using the wrong count.

This PR addresses that.