### PR TITLE
Action: Add test for unstable Ruby VMs

### DIFF
--- a/.github/workflows/test-head.yaml
+++ b/.github/workflows/test-head.yaml
@@ -1,4 +1,4 @@
-name: Test with unstable Ruby VMs
+name: Test with Ruby unstable
 on: [push]
 jobs:
   test:
@@ -7,6 +7,7 @@ jobs:
       matrix:
         ruby: [head, jruby-head, truffleruby-head]
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@77ca66ce2792fb05b8b204a203328e12593a64f3 # v1.72.1

--- a/.github/workflows/test-head.yaml
+++ b/.github/workflows/test-head.yaml
@@ -1,26 +1,34 @@
-name: Test with Ruby unstable
-on: [push]
+name: Test unstable
+on: [push, pull_request]
 jobs:
-  test:
+  test-head:
     strategy:
       fail-fast: false
       matrix:
         ruby: [head, jruby-head, truffleruby-head]
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@77ca66ce2792fb05b8b204a203328e12593a64f3 # v1.72.1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        continue-on-error: true
       - run: bundle exec rake test:main
+        continue-on-error: true
       - run: bundle exec rake spec:main
+        continue-on-error: true
       - run: bundle exec rake spec:contrib
+        continue-on-error: true
       - run: bundle exec rake spec:opentracer
+        continue-on-error: true
       # A few contrib jobs that `ddtrace` already includes their gem in the global Gemfile.
       # We technically don't need appraisal to run them, thus are easy candidates for early testing.
       - run: bundle exec rake spec:rake
+        continue-on-error: true
       - run: bundle exec rake spec:rspec
+        continue-on-error: true
       - run: bundle exec rake spec:concurrent_ruby
+        continue-on-error: true
       - run: bundle exec rake spec:http
+        continue-on-error: true

--- a/.github/workflows/test-head.yaml
+++ b/.github/workflows/test-head.yaml
@@ -1,5 +1,5 @@
 name: Test unstable
-on: [push, pull_request]
+on: [push]
 jobs:
   test-head:
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,3 +17,9 @@ jobs:
       - run: bundle exec rake spec:main
       - run: bundle exec rake spec:contrib
       - run: bundle exec rake spec:opentracer
+      # A few contrib jobs that `ddtrace` already includes their gem in the global Gemfile.
+      # We technically don't need appraisal to run them, thus are easy candidates for early testing.
+      - run: bundle exec rake spec:rake
+      - run: bundle exec rake spec:rspec
+      - run: bundle exec rake spec:concurrent_ruby
+      - run: bundle exec rake spec:http

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,19 @@
+name: Test with unstable Ruby VMs
+on: [push]
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [head, jruby-head, truffleruby-head]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@77ca66ce2792fb05b8b204a203328e12593a64f3 # v1.72.1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - run: bundle exec rake test:main
+      - run: bundle exec rake spec:main
+      - run: bundle exec rake spec:contrib
+      - run: bundle exec rake spec:opentracer

--- a/spec/ddtrace/span_spec.rb
+++ b/spec/ddtrace/span_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe Datadog::Span do
     let(:duration_wall_time) { 0.0001 }
 
     context 'without start or end time provided' do
-      let(:static_time) { Time.new('2010-09-16 00:03:15 +0200') }
+      let(:static_time) { Time.utc(2010, 9, 15, 22, 3, 15) }
 
       before do
         # We set the same time no matter what.


### PR DESCRIPTION
This PR runs the latest, still unstable, version of CRuby, JRuby, and TruffleRuby against our existing test suite.

I used GitHub Actions instead of CircleCI because there's not easy way to get bleeding edge Ruby images in CircleCI, while the [GitHub Action `ruby/setup-ruby`](https://github.com/ruby/setup-ruby) has great support for it out of the box.

Luckily, they all the tests I could run pretty much pass, except for JRuby `ruby/setup-ruby` action being non-functional at this moment (not related to `ddtrace`). I've opened an issue description with the problem.

There was only a single fix required for Ruby 3.1 support as of today.

I did not attempt to run tests that depended on external services (MySQL, Redis, MongoDB, etc.), and stuck to the ones that only depend on Ruby code.

I'll leave this PR in draft until the JRuby issue gets traction.