### PR TITLE
Explicitly start profiler on ddtrace/auto_instrument

### DIFF
--- a/lib/ddtrace/auto_instrument.rb
+++ b/lib/ddtrace/auto_instrument.rb
@@ -1,3 +1,4 @@
 require 'ddtrace'
 
 Datadog.add_auto_instrument
+Datadog.profiler.start if Datadog.profiler

--- a/spec/ddtrace/auto_instrument_spec.rb
+++ b/spec/ddtrace/auto_instrument_spec.rb
@@ -111,6 +111,8 @@ RSpec.describe 'Profiler startup' do
   end
 
   it 'starts the profiler' do
+    skip 'Profiler not supported on JRuby' if PlatformHelpers.jruby?
+
     profiler = instance_double(Datadog::Profiler)
 
     expect(Datadog).to receive(:profiler).and_return(profiler).at_least(:once)

--- a/spec/ddtrace/auto_instrument_spec.rb
+++ b/spec/ddtrace/auto_instrument_spec.rb
@@ -102,3 +102,28 @@ RSpec.describe 'Auto Instrumentation of non Rails' do
     end
   end
 end
+
+RSpec.describe 'Profiler startup' do
+  subject(:auto_instrument) { load 'ddtrace/auto_instrument.rb' }
+
+  before do
+    allow(Datadog).to receive(:add_auto_instrument)
+  end
+
+  it 'starts the profiler' do
+    profiler = instance_double(Datadog::Profiler)
+
+    expect(Datadog).to receive(:profiler).and_return(profiler).at_least(:once)
+    expect(profiler).to receive(:start)
+
+    auto_instrument
+  end
+
+  context 'when the profiler is not available' do
+    it 'does not raise any error' do
+      expect(Datadog).to receive(:profiler).and_return(nil)
+
+      auto_instrument
+    end
+  end
+end


### PR DESCRIPTION
For users that enable profiling via environment variable (`DD_PROFILING_ENABLED=true`), doing `require 'ddtrace/auto_instrument'` means that the profiler is also started as a side effect, even if they forget to use `ddtracerb exec` or `require 'ddtrace/profiling/preload'`.

This is a nice property!

Right now it semi-happens by chance, but I want to make it an actual feature, so I'm adding a bit more code and tests to make this happen explicitly so that we don't regress.