### PR TITLE
Extract default/fallback service name from tracer

### DIFF
--- a/lib/datadog/ci/contrib/cucumber/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/cucumber/configuration/settings.rb
@@ -14,7 +14,7 @@ module Datadog
             end
 
             option :service_name do |o|
-              o.default { Datadog.configuration.service || Ext::SERVICE_NAME }
+              o.default { Datadog.configuration.service_without_fallback || Ext::SERVICE_NAME }
               o.lazy
             end
 

--- a/lib/datadog/ci/contrib/rspec/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/rspec/configuration/settings.rb
@@ -14,7 +14,7 @@ module Datadog
             end
 
             option :service_name do |o|
-              o.default { Datadog.configuration.service || Ext::SERVICE_NAME }
+              o.default { Datadog.configuration.service_without_fallback || Ext::SERVICE_NAME }
               o.lazy
             end
 

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -228,6 +228,14 @@ module Datadog
         # NOTE: service also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
         o.default { ENV.fetch(Ext::Environment::ENV_SERVICE, Ext::Runtime::FALLBACK_SERVICE_NAME) }
         o.lazy
+
+        # There's a few cases where we don't want to use the fallback service name, so this helper allows us to get a
+        # nil instead so that one can do
+        # nice_service_name = Datadog.configure.service_without_fallback || nice_service_name_default
+        o.helper(:service_without_fallback) do
+          service_name = service
+          service_name unless service_name.equal?(Ext::Runtime::FALLBACK_SERVICE_NAME)
+        end
       end
 
       option :site do |o|
@@ -264,7 +272,7 @@ module Datadog
             self.version = string_tags[Ext::Environment::TAG_VERSION]
           end
 
-          if service.equal?(Ext::Runtime::FALLBACK_SERVICE_NAME) && string_tags.key?(Ext::Environment::TAG_SERVICE)
+          if service_without_fallback.nil? && string_tags.key?(Ext::Environment::TAG_SERVICE)
             self.service = string_tags[Ext::Environment::TAG_SERVICE]
           end
 

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -226,7 +226,7 @@ module Datadog
 
       option :service do |o|
         # NOTE: service also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
-        o.default { ENV.fetch(Ext::Environment::ENV_SERVICE, nil) }
+        o.default { ENV.fetch(Ext::Environment::ENV_SERVICE, Ext::Runtime::FALLBACK_SERVICE_NAME) }
         o.lazy
       end
 
@@ -264,7 +264,7 @@ module Datadog
             self.version = string_tags[Ext::Environment::TAG_VERSION]
           end
 
-          if service.nil? && string_tags.key?(Ext::Environment::TAG_SERVICE)
+          if service.equal?(Ext::Runtime::FALLBACK_SERVICE_NAME) && string_tags.key?(Ext::Environment::TAG_SERVICE)
             self.service = string_tags[Ext::Environment::TAG_SERVICE]
           end
 

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -53,7 +53,7 @@ module Datadog
           # We set defaults here instead of in the patcher because we need to wait
           # for the Rails application to be fully initialized.
           datadog_config[:rails].tap do |config|
-            config[:service_name] ||= (Datadog.configuration.service || Utils.app_name)
+            config[:service_name] ||= (Datadog.configure.service_without_fallback || Utils.app_name)
             config[:database_service] ||= "#{config[:service_name]}-#{Contrib::ActiveRecord::Utils.adapter_name}"
             config[:controller_service] ||= config[:service_name]
             config[:cache_service] ||= "#{config[:service_name]}-cache"

--- a/lib/ddtrace/ext/runtime.rb
+++ b/lib/ddtrace/ext/runtime.rb
@@ -15,6 +15,13 @@ module Datadog
       TAG_ID = 'runtime-id'.freeze
       TAG_LANG = 'language'.freeze
 
+      FALLBACK_SERVICE_NAME =
+        begin
+          File.basename($PROGRAM_NAME, '.*')
+        rescue StandardError
+          'ruby'
+        end.freeze
+
       # Metrics
       module Metrics
         ENV_ENABLED = 'DD_RUNTIME_METRICS_ENABLED'.freeze

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -149,15 +149,7 @@ module Datadog
     # for non-root spans which have a parent. However, root spans without
     # a service would be invalid and rejected.
     def default_service
-      return @default_service if instance_variable_defined?(:@default_service) && @default_service
-
-      begin
-        @default_service = File.basename($PROGRAM_NAME, '.*')
-      rescue StandardError => e
-        Datadog.logger.error("unable to guess default service: #{e}")
-        @default_service = 'ruby'.freeze
-      end
-      @default_service
+      @default_service ||= Datadog::Ext::Runtime::FALLBACK_SERVICE_NAME
     end
 
     # Set the given key / value tag pair at the tracer level. These tags will be

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Datadog::Configuration::Components do
     context 'given settings' do
       shared_examples_for 'new runtime metrics' do
         let(:runtime_metrics) { instance_double(Datadog::Runtime::Metrics) }
-        let(:default_options) { { enabled: settings.runtime_metrics.enabled } }
+        let(:default_options) { { enabled: settings.runtime_metrics.enabled, services: [settings.service] } }
         let(:options) { {} }
 
         before do

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -888,6 +888,32 @@ RSpec.describe Datadog::Configuration::Settings do
     end
   end
 
+  describe '#service_without_fallback' do
+    subject(:service_without_fallback) { settings.service_without_fallback }
+
+    context 'when no service name is configured' do
+      around do |example|
+        ClimateControl.modify(Datadog::Ext::Environment::ENV_SERVICE => nil) do
+          example.run
+        end
+      end
+
+      it { is_expected.to be nil }
+    end
+
+    context 'when a service name is configured' do
+      around do |example|
+        ClimateControl.modify(Datadog::Ext::Environment::ENV_SERVICE => 'test_service_name') do
+          example.run
+        end
+      end
+
+      it 'returns the service name' do
+        is_expected.to eq 'test_service_name'
+      end
+    end
+  end
+
   describe '#site' do
     subject(:site) { settings.site }
 

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -833,19 +833,19 @@ RSpec.describe Datadog::Configuration::Settings do
 
     context "when #{Datadog::Ext::Environment::ENV_SERVICE}" do
       around do |example|
-        ClimateControl.modify(Datadog::Ext::Environment::ENV_SERVICE => service) do
+        ClimateControl.modify(Datadog::Ext::Environment::ENV_SERVICE => env_service) do
           example.run
         end
       end
 
       context 'is not defined' do
-        let(:service) { nil }
+        let(:env_service) { nil }
 
-        it { is_expected.to be nil }
+        it { is_expected.to include 'rspec' }
       end
 
       context 'is defined' do
-        let(:service) { 'service-value' }
+        let(:env_service) { 'service-value' }
 
         it { is_expected.to eq(service) }
       end

--- a/spec/ddtrace/diagnostics/environment_logger_spec.rb
+++ b/spec/ddtrace/diagnostics/environment_logger_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Datadog::Diagnostics::EnvironmentLogger do
           'priority_sampling_enabled' => false,
           'runtime_metrics_enabled' => false,
           'version' => Datadog::VERSION::STRING,
-          'vm' => be_a(String)
+          'vm' => be_a(String),
+          'service' => be_a(String)
         )
       end
     end
@@ -144,7 +145,7 @@ RSpec.describe Datadog::Diagnostics::EnvironmentLogger do
           runtime_metrics_enabled: false,
           sample_rate: nil,
           sampling_rules: nil,
-          service: nil,
+          service: be_a(String),
           tags: nil,
           version: Datadog::VERSION::STRING,
           vm: be_a(String)

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -4,8 +4,9 @@ require 'ddtrace'
 
 RSpec.describe Datadog::Tracer do
   let(:writer) { FauxWriter.new }
+  let(:tracer_options) { {} }
 
-  subject(:tracer) { described_class.new(writer: writer) }
+  subject(:tracer) { described_class.new(writer: writer, **tracer_options) }
 
   after { tracer.shutdown! }
 
@@ -39,11 +40,8 @@ RSpec.describe Datadog::Tracer do
   end
 
   describe '::new' do
-    subject(:tracer) { described_class.new(options) }
-    let(:options) { { writer: writer } }
-
     context 'given :context_flush' do
-      let(:options) { super().merge(context_flush: context_flush) }
+      let(:tracer_options) { super().merge(context_flush: context_flush) }
       let(:context_flush) { instance_double(Datadog::ContextFlush::Finished) }
       it { is_expected.to have_attributes(context_flush: context_flush) }
     end
@@ -622,6 +620,23 @@ RSpec.describe Datadog::Tracer do
   describe '#trace_completed' do
     subject(:trace_completed) { tracer.trace_completed }
     it { is_expected.to be_a_kind_of(described_class::TraceCompleted) }
+  end
+
+  describe '#default_service' do
+    subject(:default_service) { tracer.default_service }
+
+    context 'when tracer is initialized with a default_service' do
+      let(:tracer_options) { { **super(), default_service: default_service_value } }
+      let(:default_service_value) { 'test_default_service' }
+
+      it { is_expected.to be default_service_value }
+    end
+
+    context 'when no default_service is provided' do
+      it 'sets the default_service based on the current ruby process name' do
+        is_expected.to include 'rspec'
+      end
+    end
   end
 end
 


### PR DESCRIPTION
When no service name is provided (no `DD_SERVICE`, `DD_TAGS=service:...` or they equivalents via code), the tracer falls back to using the Ruby process name.

This default was embedded within the tracer class, which meant that profiler did not use it, resulting in mismatched service names in tracing/profiling: tracing would use the Ruby process name, and profiler would get "unnamed service".

To fix this, I've extracted this fallback service name into a constant set when ddtrace gets loaded, and added it as a default for the service.

Note that the existing priority for deciding the service name is still respected: `c.service` > `DD_SERVICE` > `c.tags` > `DD_TAGS` > fallback name.