### PR TITLE
Ensure special tags are always strings

### DIFF
--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -119,8 +119,8 @@ module Datadog
 
         def build_tracer_tags(settings)
           settings.tags.dup.tap do |tags|
-            tags['env'] = settings.env unless settings.env.nil?
-            tags['version'] = settings.version unless settings.version.nil?
+            tags[Ext::Environment::TAG_ENV] = settings.env unless settings.env.nil?
+            tags[Ext::Environment::TAG_VERSION] = settings.version unless settings.version.nil?
           end
         end
 

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -116,7 +116,7 @@ module Datadog
       @metrics.delete(key)
 
       # DEV: This is necessary because the agent looks at `meta[key]`, not `metrics[key]`.
-      value = value.to_s if ENSURE_AGENT_TAGS.key?(key)
+      value = value.to_s if ENSURE_AGENT_TAGS[key]
 
       # NOTE: Adding numeric tags as metrics is stop-gap support
       #       for numeric typed tags. Eventually they will become

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -2,7 +2,10 @@
 
 require 'time'
 require 'ddtrace/utils'
+require 'ddtrace/ext/distributed'
 require 'ddtrace/ext/errors'
+require 'ddtrace/ext/http'
+require 'ddtrace/ext/net'
 require 'ddtrace/ext/priority'
 require 'ddtrace/environment'
 require 'ddtrace/analytics'
@@ -37,6 +40,17 @@ module Datadog
 
     # This limit is for numeric tags because uint64 could end up rounded.
     NUMERIC_TAG_SIZE_RANGE = (-1 << 53..1 << 53).freeze
+
+    # Some associated values should always be sent as Tags, never as Metrics, regardless
+    # if their value is numeric or not.
+    # The Datadog agent will look for these values only as Tags, not Metrics.
+    # @see https://github.com/DataDog/datadog-agent/blob/2ae2cdd315bcda53166dd8fa0dedcfc448087b9d/pkg/trace/stats/aggregation.go#L13-L17
+    ENSURE_AGENT_TAGS = {
+      Ext::DistributedTracing::ORIGIN_KEY => true,
+      Ext::Environment::TAG_VERSION => true,
+      Ext::HTTP::STATUS_CODE => true,
+      Ext::NET::TAG_HOSTNAME => true
+    }.freeze
 
     attr_accessor :name, :service, :resource, :span_type,
                   :span_id, :trace_id, :parent_id,
@@ -101,11 +115,8 @@ module Datadog
       # Keys must be unique between tags and metrics
       @metrics.delete(key)
 
-      # Ensure `http.status_code` is always a string so it is added to
-      #   @meta instead of @metrics
-      # DEV: This is necessary because the agent looks to `meta['http.status_code']` for
-      #   tagging necessary metrics
-      value = value.to_s if key == Ext::HTTP::STATUS_CODE
+      # DEV: This is necessary because the agent looks at `meta[key]`, not `metrics[key]`.
+      value = value.to_s if ENSURE_AGENT_TAGS.key?(key)
 
       # NOTE: Adding numeric tags as metrics is stop-gap support
       #       for numeric typed tags. Eventually they will become

--- a/spec/ddtrace/span_spec.rb
+++ b/spec/ddtrace/span_spec.rb
@@ -425,9 +425,30 @@ RSpec.describe Datadog::Span do
       end
     end
 
+    context 'given _dd.hostname' do
+      let(:key) { '_dd.hostname' }
+      let(:value) { 1 }
+
+      it_behaves_like 'meta tag'
+    end
+
+    context 'given _dd.origin' do
+      let(:key) { '_dd.origin' }
+      let(:value) { 2 }
+
+      it_behaves_like 'meta tag'
+    end
+
     context 'given http.status_code' do
       let(:key) { 'http.status_code' }
       let(:value) { 200 }
+
+      it_behaves_like 'meta tag'
+    end
+
+    context 'given version' do
+      let(:key) { 'version' }
+      let(:value) { 3 }
 
       it_behaves_like 'meta tag'
     end


### PR DESCRIPTION
Some Span tags have special handling in the Datadog Agent. [Here's the list of these tags](https://github.com/DataDog/datadog-agent/blob/2ae2cdd315bcda53166dd8fa0dedcfc448087b9d/pkg/trace/stats/aggregation.go#L13-L17).
These tags have to always be reported as string Tags, not numerical Metrics.

One example of issues caused by setting these values as numerical is this:
```
span.set_tag('version', 123)
```
In this case, `version` will not correctly set the span version, thus not correctly updating the Datadog backend version value.

This PR adds a check and ensures that these values are always string tags.