### PR TITLE
[PROF-3514] Skip CPU time instrumentation if logging gem is detected

### DIFF
--- a/lib/ddtrace/profiling/ext/cpu.rb
+++ b/lib/ddtrace/profiling/ext/cpu.rb
@@ -43,8 +43,23 @@ module Datadog
           elsif Gem::Specification.find_all_by_name('rollbar', ROLLBAR_INCOMPATIBLE_VERSIONS).any?
             'You have an incompatible rollbar gem version installed; ensure that you have rollbar >= 3.1.2 by ' \
             "adding `gem 'rollbar', '>= 3.1.2'` to your Gemfile or gems.rb file. " \
-            'See https://github.com/rollbar/rollbar-gem/pull/1018 for details.'
+            'See https://github.com/rollbar/rollbar-gem/pull/1018 for details'
+          elsif Gem::Specification.find_all_by_name('logging').any? && logging_inherit_context_enabled?
+            'The `logging` gem is installed and its thread inherit context feature is enabled. ' \
+            "Please add LOGGING_INHERIT_CONTEXT=false to your application's environment variables to disable the " \
+            'conflicting `logging` gem feature. ' \
+            'See https://github.com/TwP/logging/pull/230 for details'
           end
+        end
+
+        private_class_method def self.logging_inherit_context_enabled?
+          # The logging gem provides a mechanism to disable the conflicting behavior, see
+          # https://github.com/TwP/logging/blob/ae9872d093833b2a5a34cbe1faa4e895a81f6845/lib/logging/diagnostic_context.rb#L418
+          # Here we check if the behavior is enabled
+          inherit_context_configuration = ENV['LOGGING_INHERIT_CONTEXT']
+
+          inherit_context_configuration.nil? ||
+          (inherit_context_configuration && !%w[false no 0].include?(inherit_context_configuration.downcase))
         end
       end
     end


### PR DESCRIPTION
...instead, customers will get a log message as follows:

```
    INFO -- ddtrace: [ddtrace] (/app/lib/ddtrace/profiling/tasks/setup.rb
    :44:in `activate_cpu_extensions') CPU time profiling skipped because
    native CPU time is not supported: The `logging` gem is installed and
    its thread inherit context feature is enabled. Please add
    LOGGING_INHERIT_CONTEXT=false to your application's environment
    variables to disable the conflicting `logging` gem feature. See
    https://github.com/TwP/logging/pull/230 for details. Profiles
    containing Wall time will still be reported.
```

This is a repeat of #1362 -- the logging gem also monkey patches `Thread` initialization using `alias_method`, which is incompatible with our instrumentation that uses `preload`.

For details, see https://github.com/TwP/logging/pull/230 where we submitted a fix to the upstream gem.

Right now the only way to avoid this issue and still enable proflier is to either remove the logging gem or to disable the feature using the `LOGGING_INHERIT_CONTEXT` environment variable.

If/when the gem creators accept our proposed change and release it, we'll need to revise this to take that into consideration, as we do for rollbar.

NOTE: I'm not entirely happy with the complexity that is accumulating for the tests, but I've decided to not refactor it yet. If we need to add more gems, we should definitely refactor the tests. My hope is that soon we can get rid of our `Thread` monkey patches, and thus get rid of all of this instead.