### PR TITLE
Do not use configured dogstatsd instance when it's an incompatible version

### DIFF
--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -19,7 +19,7 @@ module Datadog
           options = { enabled: settings.enabled }
           options[:statsd] = settings.statsd unless settings.statsd.nil?
 
-          Datadog::Diagnostics::Health::Metrics.new(options)
+          Datadog::Diagnostics::Health::Metrics.new(**options)
         end
 
         def build_logger(settings)
@@ -34,7 +34,7 @@ module Datadog
           options[:statsd] = settings.runtime_metrics.statsd unless settings.runtime_metrics.statsd.nil?
           options[:services] = [settings.service] unless settings.service.nil?
 
-          Datadog::Runtime::Metrics.new(options)
+          Datadog::Runtime::Metrics.new(**options)
         end
 
         def build_runtime_metrics_worker(settings)

--- a/lib/ddtrace/runtime/metrics.rb
+++ b/lib/ddtrace/runtime/metrics.rb
@@ -11,7 +11,7 @@ module Datadog
   module Runtime
     # For generating runtime metrics
     class Metrics < Datadog::Metrics
-      def initialize(options = {})
+      def initialize(**options)
         super
 
         # Initialize service list

--- a/spec/ddtrace/metrics_spec.rb
+++ b/spec/ddtrace/metrics_spec.rb
@@ -9,7 +9,7 @@ require 'datadog/statsd'
 RSpec.describe Datadog::Metrics do
   include_context 'metrics'
 
-  subject(:metrics) { described_class.new(options) }
+  subject(:metrics) { described_class.new(**options) }
   after { metrics.close }
 
   let(:options) { { statsd: statsd } }

--- a/spec/ddtrace/metrics_spec.rb
+++ b/spec/ddtrace/metrics_spec.rb
@@ -23,6 +23,70 @@ RSpec.describe Datadog::Metrics do
     end
   end
 
+  describe '#initialize' do
+    before do
+      # NOTE: allow_any_instace_of is needed as when we run this no metrics instance has been created yet (and we
+      # don't want it to be created as the nested contexts still need to change the arguments to the call to new)
+      allow_any_instance_of(described_class).to receive(:supported?).and_return(statsd_supported)
+    end
+
+    context 'when a supported version of statsd is installed' do
+      let(:statsd_supported) { true }
+
+      context 'when no statsd instance is provided' do
+        let(:options) { {} }
+
+        after do
+          metrics.close
+        end
+
+        it 'creates a new instance' do
+          expect(metrics.statsd).to_not be nil
+        end
+      end
+
+      context 'when a statsd instance is provided' do
+        let(:statsd) { double('Statsd') }
+        let(:options) { { statsd: statsd } }
+
+        it 'uses the provided instance' do
+          expect(metrics.statsd).to be statsd
+        end
+      end
+    end
+
+    context 'when no statsd is either not installed, or an unsupported version is installed' do
+      let(:statsd_supported) { false }
+
+      context 'when no statsd instance is provided' do
+        let(:options) { {} }
+
+        it 'does not create a new instance' do
+          expect(metrics.statsd).to be nil
+        end
+      end
+
+      context 'when a statsd instance is provided' do
+        let(:options) { { statsd: statsd } }
+
+        before do
+          described_class.const_get('IGNORED_STATSD_ONLY_ONCE').send(:reset_ran_once_state_for_tests)
+          allow(Datadog.logger).to receive(:warn)
+        end
+
+        it 'does not use the provided instance' do
+          expect(metrics.statsd).to be nil
+        end
+
+        it 'logs a warning' do
+          expect(Datadog.logger).to receive(:warn).with(/Ignoring .* statsd instance/)
+
+          metrics
+        end
+      end
+    end
+  end
+
   describe '#supported?' do
     subject(:supported?) { metrics.supported? }
 
@@ -728,7 +792,6 @@ RSpec.describe Datadog::Metrics do
     let(:options) { {} }
 
     before { described_class.const_get('INCOMPATIBLE_STATSD_ONLY_ONCE').send(:reset_ran_once_state_for_tests) }
-    after { described_class.const_get('INCOMPATIBLE_STATSD_ONLY_ONCE').send(:reset_ran_once_state_for_tests) }
 
     context 'with an incompatible dogstastd-ruby version' do
       before { skip unless Gem.loaded_specs['dogstatsd-ruby'].version >= Gem::Version.new('5.0') }

--- a/spec/ddtrace/runtime/metrics_spec.rb
+++ b/spec/ddtrace/runtime/metrics_spec.rb
@@ -3,7 +3,7 @@ require 'ddtrace'
 require 'ddtrace/runtime/metrics'
 
 RSpec.describe Datadog::Runtime::Metrics do
-  subject(:runtime_metrics) { described_class.new(options) }
+  subject(:runtime_metrics) { described_class.new(**options) }
 
   let(:options) { {} }
 


### PR DESCRIPTION
A customer reported the following `NoMethodError`:
```
components.rb:245:in `each': private method `close' called for  #<Datadog::Statsd:0x00007fa757896bc8> (NoMethodError)
```

Turns out that the customer had an incompatible dogstatsd-ruby version, but since they had their instance manually configured, rather than created by the `Metrics` class, our version check was being bypassed. This led the incompatible dogstatsd-ruby version to be used, and one of the incompatibilites is the fact that `#close` was private on that old version.

A minimal test case for this issue is:

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'dogstatsd-ruby', '< 3'
  gem 'ddtrace', '= 0.50.0'
end

require 'ddtrace'
require 'datadog/statsd'

Datadog.configure do |c|
  c.runtime_metrics.statsd = Datadog::Statsd.new
end

Datadog.shutdown!
```

To fix this issue, I've changed the `#initialize` method to always call `#supported?` before either accepting a pre-existing `statsd` instance, or trying to create one.

To avoid silently breaking customer-expected behavior, I've also added a warning; hopefully customers with the wrong configuration will see the warning and know that they need to upgrade `dogstatsd-ruby`.

NOTE: We should really look into adding a hard dependency from ddtrace to dogstatsd-ruby so that we could do away with our home-grown incompatible version checking code.