### PR TITLE
Hide generated gemfiles from GitHub diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+gemfiles/**/* linguist-generated=true


### PR DESCRIPTION
This PR hides Gemfiles that automatically generated in the `gemfiles/` direcotry from showing in GitHub diffs.

This follows this GitHub documentation on how to accomplish this: https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/customizing-how-changed-files-appear-on-github