### PR TITLE
Explicitly build default sampler

### DIFF
--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -57,7 +57,14 @@ module Datadog
             default_service: settings.service,
             enabled: settings.tracer.enabled,
             partial_flush: settings.tracer.partial_flush.enabled,
-            tags: build_tracer_tags(settings)
+            tags: build_tracer_tags(settings),
+            sampler: PrioritySampler.new(
+              base_sampler: AllSampler.new,
+              post_sampler: Sampling::RuleSampler.new(
+                rate_limit: settings.sampling.rate_limit,
+                default_sample_rate: settings.sampling.default_rate
+              )
+            )
           )
 
           # TODO: We reconfigure the tracer here because it has way too many

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -335,7 +335,12 @@ RSpec.describe Datadog::Configuration::Components do
             default_service: settings.service,
             enabled: settings.tracer.enabled,
             partial_flush: settings.tracer.partial_flush.enabled,
-            tags: settings.tags
+            tags: settings.tags,
+            sampler: lambda do |sampler|
+              expect(sampler.pre_sampler).to be_a(Datadog::AllSampler)
+              expect(sampler.priority_sampler.rate_limiter.rate).to eq(settings.sampling.rate_limit)
+              expect(sampler.priority_sampler.default_sampler).to be_a(Datadog::RateByServiceSampler)
+            end
           }
         end
         let(:options) { {} }


### PR DESCRIPTION
Coming from https://github.com/DataDog/dd-trace-rb/pull/1527, this PR builds the default sampler instance during tracer construction, instead of letting it build itself internally.

This is done because `trace.rb` calls https://github.com/DataDog/dd-trace-rb/blob/461a627641755f4338e1e7dbb93d366d4534d968/lib/ddtrace/tracer.rb#L432 which in turn invokes https://github.com/DataDog/dd-trace-rb/blob/461a627641755f4338e1e7dbb93d366d4534d968/lib/ddtrace/sampling/rule_sampler.rb#L30-L33 that tries to access the global `Datadog.configuration` object to find the sampling rates.

The issue is that this happens at `Datadog.configure` time, when the tracer is in the process of being initialized. This code only works today because we were careful when ordering invocation calls to `Datadog.configuration`.

This PR replaces that with directly accessing the readily available instance of the configuration (in the `settings` variable) and reading the defaults safely from there.

It's important to not access partially built references at initialization time as the tracer initialization process will be revamped in https://github.com/DataDog/dd-trace-rb/pull/1527, and more strictness will be required from our internals components when it comes to their inter-dependency.