### PR TITLE
Remove check for uncommitted gemset changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,11 @@ check_exact_bundle_cache_hit: &check_exact_bundle_cache_hit
     # To accomplish such check, we save `bundle_checksum` alongside the cached
     # gems. After gems are restored, we compare the restored `bundle_checksum`'s
     # content with the current commit's `bundle_checksum`.
+    #
+    # Because we are using a "soft" approach to our gemset lock files, we allow
+    # for partial matches to lock files until a new release goes out.
+    # This means that we might install slightly out of date gems, instead of the
+    # very latest versions from RubyGems until the next gemset update commit.
     command: |
       ! cmp -s .circleci/bundle_checksum /usr/local/bundle/bundle_checksum
       echo "export CI_BUNDLE_CACHE_HIT=$?" >> $BASH_ENV
@@ -125,27 +130,15 @@ step_appraisal_update: &step_appraisal_update
     name: Update Appraisal gems
     command: | # Remove all generated gemfiles and lockfiles, resolve, and install dependencies again
       bundle exec appraisal update
-ensure_lockfile_committed: &ensure_lockfile_committed
-  run:
-    name: Ensure Gem lock files are commited
-    command: |
-      CHANGED_FILES=$(git status gemfiles/ --porcelain)
-      if [[ $CHANGED_FILES ]]
-      then
-        >&2 echo "Gem lock files were modified or new lock files were created during"
-        >&2 echo "'bundle install' and 'bundle appraisal install' installation in CI."
-        >&2 echo "You need to check in those changes in your branch."
-        >&2 echo "Affected files:"
-        >&2 echo $CHANGED_FILES
-        >&2 GIT_PAGER=cat git diff HEAD
-        exit 1
-      fi
 step_compute_bundle_checksum: &step_compute_bundle_checksum
   run:
     name: Compute bundle checksum
+    # This checksum leaves some leeway for changes to Gemfile.lock, as
+    # we have a "soft" approach to committing gemset changes until release, given
+    # updating the gemset lock files produces extremely large commits.
     command: |
       bundle lock # Create Gemfile.lock
-      cat Gemfile.lock gemfiles/*.gemfile.lock | md5sum > .circleci/bundle_checksum
+      cat Gemfile Appraisals gemfiles/*.gemfile.lock | md5sum > .circleci/bundle_checksum
 step_run_all_tests: &step_run_all_tests
   run:
     name: Run tests
@@ -202,7 +195,6 @@ orbs:
                   equal: [ << parameters.edge >>, true ]
               steps:
                 - *step_appraisal_install # Run on a stable set of gems we integrate with
-                - *ensure_lockfile_committed
           - *save_bundle_checksum
           - save_cache:
               key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-<<parameters.ruby_version>>-{{ .Environment.CIRCLE_SHA1 }}'


### PR DESCRIPTION
This PR brings us to a point in between the old days approach (everything dependency is always dynamically resolved in CI to their latest version) to the new days approach (everything is locked by gem lock files checked into the repository).

This new approach allows for changes to Gemfile and Appraisals without respective changes to the committed gem lock files.

This allows for smaller commits that contain dependency changes at the cost of non-deterministic version resolution until the next update to the committed gem lock files. This non-determinism only applies to any changed gems.

This PR ensures that we removed the enforced CI check that prevents dependency changes without lock file changes. Also, it adapts the dependency caching strategy to account for the fact that Appraisals can be modified without changes to `gemfiles/*.lock` files.