### PR TITLE
Add install gemset task

### DIFF
--- a/tasks/update_appraisal_gemfiles.rake
+++ b/tasks/update_appraisal_gemfiles.rake
@@ -11,17 +11,26 @@ TRACER_VERSIONS = %w[
   jruby-9.2-latest
 ].freeze
 
-desc 'Update gemfiles/* files based on Appraisals and Gemfile changes, ' \
+desc 'Installs gems based on Appraisals and Gemfile changes, ' \
+     'accepts list of tracer versions as task argument, defaults to all versions.'
+task :install_appraisal_gemfiles do |_task, args|
+  tracer_version_arg = args.to_a
+  versions = tracer_version_arg.empty? ? TRACER_VERSIONS : tracer_version_arg
+
+  versions.each do |version|
+    sh "docker-compose run --rm tracer-#{version} /bin/bash -c " \
+      "'rm -f Gemfile.lock && bundle install && bundle exec appraisal install'"
+  end
+end
+
+desc 'Update ALL gems based on Appraisals and Gemfile changes, ' \
      'accepts list of tracer versions as task argument, defaults to all versions.'
 task :update_appraisal_gemfiles do |_task, args|
   tracer_version_arg = args.to_a
   versions = tracer_version_arg.empty? ? TRACER_VERSIONS : tracer_version_arg
 
   versions.each do |version|
-    cmd = "docker-compose run --rm tracer-#{version} /bin/bash -c " \
+    sh "docker-compose run --rm tracer-#{version} /bin/bash -c " \
       "'rm -f Gemfile.lock && bundle install && bundle exec appraisal update'"
-
-    puts cmd
-    sh cmd
   end
 end


### PR DESCRIPTION
When updating `ddtrace`'s gemfiles, it's often useful to simple `install` a newly introduced dependency, instead of completely `update`ing the whole gemset.

`install` only applies the changes needed and is an order of magnitude faster than `update`.