### PR TITLE
Fix dependency cache resolution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,12 @@ check_exact_bundle_cache_hit: &check_exact_bundle_cache_hit
 save_bundle_checksum: &save_bundle_checksum
   run:
     name: Save current bundle checksum alongside cached gems
-    command: cp .circleci/bundle_checksum /usr/local/bundle/bundle_checksum
+    command: |
+      if [ "$CI_BUNDLE_CACHE_HIT" != 1 ]; then
+        # Recompute gemfiles/*.lock checksum, as it might have changed.
+        cat Gemfile Appraisals gemfiles/*.gemfile.lock | md5sum > .circleci/bundle_checksum
+      fi
+      cp .circleci/bundle_checksum /usr/local/bundle/bundle_checksum
 step_bundle_install: &step_bundle_install
   run:
     name: Install gem dependencies


### PR DESCRIPTION
Follow up to #1579

This PR addresses the scenario where we do not find a matching cache for dependencies, thus have to perform `appraisal install`.

In that case, we'll possibly modify the contents of `gemfiles/*.lock`.

As we always save a cache version of the dependencies for future use, that cache should match the newly changed `gemfiles/*.lock`, as to not deceive future cache restorations on the content of the cached dependencies.
