### PR TITLE
Increase JRuby 9.2.0.0 memory limit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ test_containers:
         description: Use latest version of dependencies during testing
         type: boolean
         default: false
+    resource_class: <<parameters.resource_class_to_use>>
   - &container_base_environment
     BUNDLE_GEMFILE: /app/Gemfile
     JRUBY_OPTS: --dev # Faster JVM startup: https://github.com/jruby/jruby/wiki/Improving-startup-time#use-the---dev-flag
@@ -483,6 +484,7 @@ job_configuration:
     <<: *filters_all_branches_and_tags
     ruby_version: 'jruby-9.2.0.0'
     image: ivoanjo/docker-library:ddtrace_rb_jruby_9_2_0_0
+    resource_class_to_use: medium+
   - &config-jruby-9_2-latest # More recent release of 9.2
     <<: *filters_all_branches_and_tags
     ruby_version: 'jruby-9.2-latest'
@@ -492,7 +494,7 @@ job_configuration:
     <<: *filters_all_branches_and_tags
     ruby_version: 'truffleruby-21.0.0'
     image: ivoanjo/docker-library:ddtrace_rb_truffleruby_21_0_0
-    resource_class_to_use: large
+    resource_class_to_use: medium+
 
 workflows:
   version: 2


### PR DESCRIPTION
Recent runs of the `test-jruby-9.2.0.0` CI job have been failing across all branches: https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/3811/workflows/1a5694f2-1172-4daf-ae2a-09071c9480aa/jobs/147775

These jobs are `Killed` by CircleCI itself. The jobs are not taking too long, and are being killed before the 3 minute mark, so it's not a timeout.

I suspect that it is running our of memory, thus getting killed.

This PR increases the resource class from medium (4GiB) to medium+ (6GiB): https://circleci.com/docs/2.0/executor-types/#available-docker-resource-classes

medium+ is a newly introduced resource class, so I also changed the still unused truffleruby CI config to medium+ (down from large), as it will likely fit in such resource class as well.