### PR TITLE
Add error_handler option to GRPC tracer configuration

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1028,6 +1028,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | Key | Description | Default |
 | --- | ----------- | ------- |
 | `service_name` | Service name used for `grpc` instrumentation | `'grpc'` |
+| `error_handler` | Custom error handler invoked when a request is an error. A `Proc` that accepts `span` and `error` parameters. Sets error on the span by default. | `proc { |span, error| span.set_error(error) unless span.nil? }` |
 
 **Configuring clients to use different settings**
 

--- a/lib/ddtrace/contrib/grpc/configuration/settings.rb
+++ b/lib/ddtrace/contrib/grpc/configuration/settings.rb
@@ -23,6 +23,7 @@ module Datadog
           end
 
           option :service_name, default: Ext::SERVICE_NAME
+          option :error_handler, default: Datadog::Tracer::DEFAULT_ON_ERROR
         end
       end
     end

--- a/lib/ddtrace/contrib/grpc/datadog_interceptor.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor.rb
@@ -64,6 +64,10 @@ module Datadog
           def analytics_sample_rate
             datadog_configuration[:analytics_sample_rate]
           end
+
+          def error_handler
+            datadog_configuration[:error_handler]
+          end
         end
 
         require_relative 'datadog_interceptor/client'

--- a/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
@@ -18,7 +18,7 @@ module Datadog
               span_type: Datadog::Ext::HTTP::TYPE_INBOUND,
               service: service_name,
               resource: format_resource(keywords[:method]),
-              on_error: error_handler,
+              on_error: error_handler
             }
             metadata = keywords[:call].metadata
 

--- a/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
@@ -17,7 +17,8 @@ module Datadog
             options = {
               span_type: Datadog::Ext::HTTP::TYPE_INBOUND,
               service: service_name,
-              resource: format_resource(keywords[:method])
+              resource: format_resource(keywords[:method]),
+              on_error: error_handler,
             }
             metadata = keywords[:call].metadata
 

--- a/spec/ddtrace/contrib/grpc/datadog_interceptor/server_spec.rb
+++ b/spec/ddtrace/contrib/grpc/datadog_interceptor/server_spec.rb
@@ -95,4 +95,15 @@ RSpec.describe 'tracing on the server connection' do
 
     it_behaves_like 'span data contents'
   end
+
+  describe '#error_handler' do
+    let(:error_handler) { proc { |span, error| span.set_error(error) if error.is_a?(StandardError) } }
+    let(:configuration_options) { { service_name: 'rspec', on_error: error_handler } }
+
+    before do
+      subject.request_response(**keywords) { raise 'error' }
+    end
+
+    it { expect(span).to have_error }
+  end
 end


### PR DESCRIPTION
## Description

Exposes an `error_handler` option to the GRPC tracer configuration. It uses similar approach to the `error_handler`s for Sidekiq and Faraday.

The motivation behind this is that currently `GRPC::NotFound` errors are being reported as server-side errors, even though (in the semantics of our application) this error is acceptable. Having these errors appear in APM just adds noise and diminishes any other _real_ errors that might appear. 

Here's how that ☝️  looks like in Datadog's UI:

![Screen Shot 2021-07-09 at 11 10 45](https://user-images.githubusercontent.com/854173/125054325-5e868800-e0a6-11eb-9166-6c2ae56168d0.png)

By having the `error_handler` exposed as an option, we can set it to:

```ruby
c.use :grpc, service_name: 'grpc-service', error_handler: proc { |span, error|
  span.set_error(error) unless span.nil? || error.is_a?(GRPC::NotFound)
}
```

This ☝️ will allow us to ignore the `GPRC::NotFound` error from appearing in APM, while correctly marking any other errors.

N.B. I tried to follow the [contributing guidelines](https://github.com/DataDog/dd-trace-rb/blob/edb8b89debe0e3635d8c6c0e81182efc54413ba2/CONTRIBUTING.md#have-a-patch) as close as possible, but please feel free to let me know if any other changes are needed. 🙏  Thank you in advance! 