### PR TITLE
[PROF-3425] Bootstrap profiling native extension

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.h]
+indent_style = space
+indent_size = 2
+
+[*.c]
+indent_style = space
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ Gemfile.lock
 
 # bundle config
 gemfiles/.bundle
+
+# Native extension binaries
+lib/*.bundle
+lib/*.so

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
   TargetRubyVersion: 2.5 # Lowest version supported as of Rubocop 0.13.0
   Include:
     - 'lib/**/*.rb'
+    - 'ext/**/*.rb'
     - 'test/**/*.rb'
     - 'spec/**/*.rb'
     - 'Gemfile'

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ else
   gem 'pry-debugger-jruby'
 end
 gem 'rake', '>= 10.5', '< 13.0.4' # Locking rake until https://github.com/thoughtbot/appraisal/pull/184 is released
+gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
 gem 'rspec', '~> 3.10'
 gem 'rspec-collection_matchers', '~> 1.1'

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'bundler/gem_tasks'
 require 'ddtrace/version'
 require 'rubocop/rake_task' if Gem.loaded_specs.key? 'rubocop'
 require 'rspec/core/rake_task'
+require 'rake/extensiontask'
 require 'rake/testtask'
 require 'appraisal'
 require 'yard'
@@ -21,6 +22,7 @@ namespace :spec do
                         ' spec/**/auto_instrument_spec.rb'
     t.rspec_opts = args.to_a.join(' ')
   end
+  Rake::Task[:main].enhance([:compile]) if RUBY_PLATFORM != 'java' # Compile native extensions before running the main task
 
   RSpec::Core::RakeTask.new(:benchmark) do |t, args|
     t.pattern = 'spec/ddtrace/benchmark/**/*_spec.rb'
@@ -977,6 +979,10 @@ namespace :changelog do
 
     PimpMyChangelog::CLI.run!
   end
+end
+
+Rake::ExtensionTask.new("ddtrace_profiling_native_extension.#{RUBY_VERSION}_#{RUBY_PLATFORM}") do |ext|
+  ext.ext_dir = 'ext/ddtrace_profiling_native_extension'
 end
 
 task default: 'spec:main'

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -41,4 +41,6 @@ Gem::Specification.new do |spec|
 
   # Used by the profiler
   spec.add_dependency 'ffi', '~> 1.0'
+
+  spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb']
 end

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -1,0 +1,14 @@
+require 'mkmf'
+
+# We don't support JRuby for profiling, and JRuby doesn't support native extensions, so let's just skip this entire
+# thing so that JRuby users of dd-trace-rb aren't impacted.
+if RUBY_ENGINE == 'jruby'
+  File.write('Makefile', dummy_makefile($srcdir).join) # rubocop:disable Style/GlobalVars
+  return
+end
+
+# Tag the native extension library with the Ruby version and Ruby platform.
+# This makes it easier for development (avoids "oops I forgot to rebuild when I switched my Ruby") and ensures that
+# the wrong library is never loaded.
+# When requiring, we need to use the exact same string, including the version and the platform.
+create_makefile "ddtrace_profiling_native_extension.#{RUBY_VERSION}_#{RUBY_PLATFORM}"

--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -1,0 +1,17 @@
+#include <ruby.h>
+#include <stdio.h>
+
+static VALUE native_working_p(VALUE self);
+
+void Init_ddtrace_profiling_native_extension(void) {
+  VALUE datadog_module = rb_define_module("Datadog");
+  VALUE profiling_module = rb_define_module_under(datadog_module, "Profiling");
+  VALUE native_extension_module = rb_define_module_under(profiling_module, "NativeExtension");
+
+  rb_define_singleton_method(native_extension_module, "native_working?", native_working_p, 0);
+  rb_funcall(native_extension_module, rb_intern("private_class_method"), 1, ID2SYM(rb_intern("native_working?")));
+}
+
+static VALUE native_working_p(VALUE self) {
+  return Qtrue;
+}

--- a/lib/ddtrace/profiling/native_extension.rb
+++ b/lib/ddtrace/profiling/native_extension.rb
@@ -1,0 +1,17 @@
+module Datadog
+  module Profiling
+    # This module contains classes and methods which are implemented using native code in the
+    # ext/ddtrace_profiling_native_extension folder
+    module NativeExtension
+      private_class_method def self.working?
+        native_working?
+      end
+
+      unless singleton_class.private_method_defined?(:native_working?)
+        private_class_method def self.native_working?
+          false
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/auto_instrument_spec.rb
+++ b/spec/ddtrace/auto_instrument_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'Profiler startup' do
   it 'starts the profiler' do
     skip 'Profiler not supported on JRuby' if PlatformHelpers.jruby?
 
-    profiler = instance_double(Datadog::Profiler)
+    profiler = instance_double('Datadog::Profiler')
 
     expect(Datadog).to receive(:profiler).and_return(profiler).at_least(:once)
     expect(profiler).to receive(:start)

--- a/spec/ddtrace/profiling/native_extension_spec.rb
+++ b/spec/ddtrace/profiling/native_extension_spec.rb
@@ -1,0 +1,20 @@
+require 'ddtrace/profiling/native_extension'
+
+RSpec.describe Datadog::Profiling::NativeExtension do
+  before do
+    skip('Profiling not supported on JRuby') if PlatformHelpers.jruby?
+
+    begin
+      require "ddtrace_profiling_native_extension.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
+    rescue LoadError
+      raise 'Profiling native extension does not seem to be compiled. ' \
+        'Try running `bundle exec rake compile` before running this test.'
+    end
+  end
+
+  describe '.working?' do
+    subject(:working?) { described_class.send(:working?) }
+
+    it { is_expected.to be true }
+  end
+end


### PR DESCRIPTION
My current plan is to use the profiling native extension to:

* Enable use of libddprof, a (native) shared library which allows datadog profilers to share common code.

  One of the main advantages of this library is that it will include its own profile encoding implementation, which will enable us to drop profiler's dependency on the `google-protobuf` gem.
  
  Right now, we need to tell customers to manually it when onboarding, see <https://docs.datadoghq.com/tracing/profiler/enabling/?code-lang=ruby>, which is annoying.

* Call Ruby VM APIs that are otherwise unavailable or costly when called from Ruby code.

But in this commit, I decided to scale it way, way, way back to just the basics: add an empty native extension, and the
scaffolding to load and test it.

Thus, I hope that by releasing the next version of dd-trace-rb with the empty native extension we can to validate the approach, or otherwise root out corner cases that we may have missed.

Furthermore, I'll point out that if our plans of a "big gem" go forward, having this kind of non-trivial addition on the gem is supposed to be the norm, not the exception ;)

---

EVEN SO, because this is a non-trivial change, here's my notes on possible concerns, in Q&A form:

**Q1**: Will requiring customers to compile a native extension during `gem install ddtrace` cause issues?

**A1**: No, because of our dependencies. dd-trace-rb currently has two dependencies: `ffi` and `msgpack`. Both of those gems rely on native components, and neither of them (as of this writing) ships pre-compiled extensions (*except on Windows), as can be seen on rubygems.org:

* <https://rubygems.org/gems/ffi/versions>
* <https://rubygems.org/gems/msgpack/versions>

This fortunate state of affairs means that customers already need to have a working setup for building native extensions, and so our addition of a native extension does not make it any harder for them to onboard.

**Q2**: Will this cause problems for Windows users?
**A2**: The `ffi` and `msgpack` gem ship precompiled binaries for Windows, so the reasoning from A1 doesn't apply to these users.

For Windows, it's possible that customers that previously were getting by without needing an environment to build Ruby native extensions will no longer be able to install dd-trace-rb.
But:

* `gem install rails` on Windows pulls at least one native extension that needs to be compiled, so if you can't build dd-trace-rb, you can't install `rails` either
* Recent versions of `msgpack` (since 1.4.2, from 2021-02-01) don't provide binaries either. This means that, out of the box, even before this change, `gem install ddtrace` fails on Windows if you don't have a build environment, because rubygems tries to download the latest version of `msgpack`. (Rather than picking an older version that ships a precompiled build.)

So my assertion is, I don't believe we'll have any customers that A) run on Windows and B) don't have a setup for building native extensions.

BUT, if this assertion turns out to be wrong, we have the option of doing the same thing that `ffi` and `msgpack` do: ship prebuilt versions of `ddtrace` for Windows users.

**Q3**: Should we provide precompiled versions of the gem right now instead?
**A3**: Precompiled versions of the gem introduce complexity into our release process (now we have several artifacts, that may need to be generated on multiple machines); it also may pose compatibility issues, given our Ruby 2.1 to 3.0 support Matrix.

So, given the fortunate state we're in (see A1), I think we should avoid them as much as possible.

**Q4**: Why write the extension in C and not Rust?
**A4**: The Ruby VM APIs and headers are written in C. They cannot be directly used from Rust (e.g. a few things are actually implemented as preprocessor macros), and thus, to write an extension using Rust, we'd need to rely on community-built bindings that translate the Ruby VM headers into Rust.

I've investigated the state of these bindings, and the only two that are still maintained are:

* https://crates.io/crates/rosy
* https://crates.io/crates/rutie

Unfortunately, there don't seem to be a lot of gems using them and support for older Rubies, 32-bit OSs and Windows seems spotty. So... not in a great state at the moment for our usage.

The second issue is that using Rust pushes us into needing to provide binary builds through rubygems.org -- we definitely can't assume that customers will have a working Rust compiler around.

We plan on implementing libddprof (the profiling shared library) using Rust, but because it doesn't need to talk to Ruby VM APIs (we'll wrap them with some C code in this profiling native extension), we don't need to worry about bindings, and also we get a bit more flexibility on binary builds, since we don't need to link to the Ruby VM from Rust code.

**Q5**: Can you use dd-trace-rb without the native extension?
**A5**: Yes...ish. The extension must get built during `gem install`, but we handle any issues that may happen while loading it.
So, if you're working on the gem, or the extension gets built but doesn't load properly, there should be no impact to the rest of the library; only the profiler will refuse to work.

**Q6**: Will this impact JRuby users?
**A6**: No. We'll skip trying to compile and load the native extension on JRuby. (Profiling is anyway not supported on JRuby).