### PR TITLE
Avoid shipping development cruft files in gem releases

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -28,7 +28,14 @@ Gem::Specification.new do |spec|
     raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files =
+    `git ls-files -z`
+    .split("\x0")
+    .reject { |f| f.match(%r{^(test|spec|features|[.]circleci|[.]github|[.]dd-ci|benchmarks|gemfiles|integration|tasks)/}) }
+    .reject do |f|
+      ['.dockerignore', '.env', '.gitattributes', '.gitlab-ci.yml', '.rspec', '.rubocop.yml',
+       '.rubocop_todo.yml', '.simplecov', 'Appraisals', 'Gemfile', 'Rakefile', 'docker-compose.yml'].include?(f)
+    end
   spec.executables   = ['ddtracerb']
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
The `spec.files` setting controls which files get shipped when the gem gets packaged/installed.

We still use the default setup of everything in git, other than spec/test/features folders. The problem is, that this means that
we're shipping the `integration/`, `gemfiles/`, `.circleci/` and a bunch of extra development stuff.

(Full list at: <https://gist.github.com/ivoanjo/0e3aa44ae9e3ca7a14194d8318f52b62>)

I've pared this list down to include only things useful. After this change, we include the following files in a release (with current master):

```
.gitignore
.yardopts
CHANGELOG.md
CONTRIBUTING.md
LICENSE
LICENSE-3rdparty.csv
LICENSE.Apache
LICENSE.BSD3
NOTICE
README.md
bin/ddtracerb
ddtrace.gemspec
docs/DevelopmentGuide.md
docs/GettingStarted.md
docs/ProfilingDevelopment.md
lib/*
```

This means that gem releases will be smaller and have less irrelevant things.