### PR TITLE
Minor: Make default rake target do something useful

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -979,4 +979,4 @@ namespace :changelog do
   end
 end
 
-task default: :test
+task default: 'spec:main'


### PR DESCRIPTION
Having `bundle exec rake` do something useful (usually running the test suite) is a common convention on Ruby codebases.

Since we switched to RSpec, the default target was not doing anything. I've changed it to run the main test suite.