### PR TITLE
[PROF-2720] Remove automatic agentless support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,11 +78,11 @@ test_containers:
     image: memcached:1.5-alpine
   - &memcached_port 11211
   - &container_agent
-    image: datadog/docker-dd-agent
+    image: datadog/agent
     environment:
       - DD_APM_ENABLED=true
       - DD_BIND_HOST=0.0.0.0
-      - DD_API_KEY=invalid_key_but_this_is_fine
+      - DD_API_KEY=00000000000000000000000000000000
   - &agent_port 8126
 
 check_exact_bundle_cache_hit: &check_exact_bundle_cache_hit

--- a/lib/datadog/core/environment/variable_helpers.rb
+++ b/lib/datadog/core/environment/variable_helpers.rb
@@ -4,6 +4,8 @@ module Datadog
     module Environment
       # Defines helper methods for environment
       module VariableHelpers
+        extend self
+
         def env_to_bool(var, default = nil)
           var = decode_array(var)
           var && ENV.key?(var) ? ENV[var].to_s.strip.downcase == 'true' : default

--- a/lib/ddtrace/ext/profiling.rb
+++ b/lib/ddtrace/ext/profiling.rb
@@ -4,6 +4,7 @@ module Datadog
       ENV_ENABLED = 'DD_PROFILING_ENABLED'.freeze
       ENV_UPLOAD_TIMEOUT = 'DD_PROFILING_UPLOAD_TIMEOUT'.freeze
       ENV_MAX_FRAMES = 'DD_PROFILING_MAX_FRAMES'.freeze
+      ENV_AGENTLESS = 'DD_PROFILING_AGENTLESS'.freeze
 
       module Pprof
         LABEL_KEY_SPAN_ID = 'span id'.freeze

--- a/lib/ddtrace/profiling/transport/http.rb
+++ b/lib/ddtrace/profiling/transport/http.rb
@@ -23,8 +23,7 @@ module Datadog
         end
 
         # Builds a new Transport::HTTP::Client with default settings
-        # Pass a block to override any settings.
-        def default(profiling_upload_timeout_seconds:, agent_settings: nil, site: nil, api_key: nil)
+        def default(profiling_upload_timeout_seconds:, agent_settings:, site: nil, api_key: nil)
           new do |transport|
             transport.headers default_headers
 
@@ -37,13 +36,6 @@ module Datadog
                 api_key: api_key
               )
             else
-              unless agent_settings
-                raise(
-                  ArgumentError,
-                  "Missing configuration for #{self}.default: All of `agent_settings`, `site` and `api_key` are nil"
-                )
-              end
-
               configure_for_agent(
                 transport,
                 profiling_upload_timeout_seconds: profiling_upload_timeout_seconds,

--- a/lib/ddtrace/profiling/transport/http.rb
+++ b/lib/ddtrace/profiling/transport/http.rb
@@ -2,6 +2,7 @@ require 'datadog/core/environment/ext'
 require 'ddtrace/ext/transport'
 
 require 'datadog/core/environment/container'
+require 'datadog/core/environment/variable_helpers'
 
 require 'ddtrace/profiling/transport/http/builder'
 require 'ddtrace/profiling/transport/http/api'
@@ -23,12 +24,18 @@ module Datadog
         end
 
         # Builds a new Transport::HTTP::Client with default settings
-        def default(profiling_upload_timeout_seconds:, agent_settings:, site: nil, api_key: nil)
+        def default(
+          profiling_upload_timeout_seconds:,
+          agent_settings:,
+          site: nil,
+          api_key: nil,
+          agentless_allowed: agentless_allowed?
+        )
           new do |transport|
             transport.headers default_headers
 
             # Configure adapter & API
-            if site && api_key
+            if site && api_key && agentless_allowed
               configure_for_agentless(
                 transport,
                 profiling_upload_timeout_seconds: profiling_upload_timeout_seconds,
@@ -98,6 +105,10 @@ module Datadog
           )
           transport.api(API::V1, apis[API::V1], default: true)
           transport.headers(Datadog::Ext::Transport::HTTP::HEADER_DD_API_KEY => api_key)
+        end
+
+        private_class_method def agentless_allowed?
+          Datadog::Core::Environment::VariableHelpers.env_to_bool(Datadog::Ext::Profiling::ENV_AGENTLESS, false)
         end
 
         # Add adapters to registry

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -785,50 +785,6 @@ RSpec.describe Datadog::Configuration::Components do
           end
         end
 
-        context 'and :site + :api_key' do
-          context 'are set' do
-            let(:site) { 'test.datadoghq.com' }
-            let(:api_key) { SecureRandom.uuid }
-
-            before do
-              allow(settings)
-                .to receive(:site)
-                .and_return(site)
-
-              allow(settings)
-                .to receive(:api_key)
-                .and_return(api_key)
-            end
-
-            it_behaves_like 'profiler with default collectors'
-            it_behaves_like 'profiler with default scheduler'
-            it_behaves_like 'profiler with default recorder'
-
-            it 'configures agentless transport' do
-              expect(profiler.scheduler.exporters).to have(1).item
-              expect(profiler.scheduler.exporters).to include(kind_of(Datadog::Profiling::Exporter))
-              http_exporter = profiler.scheduler.exporters.first
-
-              expect(http_exporter).to have_attributes(
-                transport: kind_of(Datadog::Profiling::Transport::HTTP::Client)
-              )
-
-              # Should be configured for agentless transport
-              default_api = Datadog::Profiling::Transport::HTTP::API::V1
-              expect(http_exporter.transport.api).to have_attributes(
-                adapter: kind_of(Datadog::Transport::HTTP::Adapters::Net),
-                spec: Datadog::Profiling::Transport::HTTP::API.api_defaults[default_api]
-              )
-              expect(http_exporter.transport.api.adapter).to have_attributes(
-                hostname: "intake.profile.#{site}",
-                port: 443,
-                ssl: true,
-                timeout: settings.profiling.upload.timeout_seconds
-              )
-            end
-          end
-        end
-
         context 'and :transport' do
           context 'is given' do
             # Must be a kind of Datadog::Profiling::Transport::Client

--- a/spec/ddtrace/profiling/transport/http/adapters/net_integration_spec.rb
+++ b/spec/ddtrace/profiling/transport/http/adapters/net_integration_spec.rb
@@ -162,9 +162,10 @@ RSpec.describe 'Adapters::Net profiling integration tests' do
       let(:client) do
         Datadog::Profiling::Transport::HTTP.default(
           profiling_upload_timeout_seconds: settings.profiling.upload.timeout_seconds,
-          agent_settings: double('agent_settings which should not be used'),
+          agent_settings: double('agent_settings which should not be used'), # rubocop:disable RSpec/VerifiedDoubles
           api_key: api_key,
-          site: hostname
+          site: hostname,
+          agentless_allowed: true
         )
       end
 

--- a/spec/ddtrace/profiling/transport/http/adapters/net_integration_spec.rb
+++ b/spec/ddtrace/profiling/transport/http/adapters/net_integration_spec.rb
@@ -162,6 +162,7 @@ RSpec.describe 'Adapters::Net profiling integration tests' do
       let(:client) do
         Datadog::Profiling::Transport::HTTP.default(
           profiling_upload_timeout_seconds: settings.profiling.upload.timeout_seconds,
+          agent_settings: double('agent_settings which should not be used'),
           api_key: api_key,
           site: hostname
         )

--- a/spec/ddtrace/profiling/transport/http/integration_spec.rb
+++ b/spec/ddtrace/profiling/transport/http/integration_spec.rb
@@ -5,18 +5,20 @@ require 'ddtrace'
 require 'ddtrace/profiling/transport/http'
 
 RSpec.describe 'Datadog::Profiling::Transport::HTTP integration tests' do
-  before do
-    skip 'Only runs in fully integrated environment.' unless ENV['TEST_DATADOG_INTEGRATION']
-    skip 'Valid API key must be set.' unless ENV['DD_API_KEY'] && !ENV['DD_API_KEY'].empty?
-  end
-
   describe 'HTTP#default' do
-    subject(:transport) { Datadog::Profiling::Transport::HTTP.default(options, &option_block) }
+    subject(:transport) do
+      Datadog::Profiling::Transport::HTTP.default(
+        profiling_upload_timeout_seconds: settings.profiling.upload.timeout_seconds,
+        **options
+      )
+    end
 
-    let(:options) { {} }
-    let(:option_block) { proc { |_client| } }
+    before do
+      # Make sure the transport is being built correctly, even if we then skip the tests
+      transport
+    end
 
-    it { is_expected.to be_a(Datadog::Profiling::Transport::HTTP::Client) }
+    let(:settings) { Datadog::Configuration::Settings.new }
 
     describe '#send_profiling_flush' do
       subject(:response) { transport.send_profiling_flush(flush) }
@@ -25,17 +27,31 @@ RSpec.describe 'Datadog::Profiling::Transport::HTTP integration tests' do
 
       shared_examples_for 'a successful profile flush' do
         it do
+          skip 'Only runs in fully integrated environment.' unless ENV['TEST_DATADOG_INTEGRATION']
+
           is_expected.to be_a(Datadog::Profiling::Transport::HTTP::Response)
           expect(response.code).to eq(200).or eq(403)
         end
       end
 
       context 'agent' do
+        let(:options) { { agent_settings: Datadog::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS } }
+
         it_behaves_like 'a successful profile flush'
       end
 
       context 'agentless' do
-        let(:options) { { site: 'datadoghq.com', api_key: ENV['DD_API_KEY'] } }
+        before do
+          skip 'Valid API key must be set.' unless ENV['DD_API_KEY'] && !ENV['DD_API_KEY'].empty?
+        end
+
+        let(:options) do
+          {
+            agent_settings: double('agent_settings which should not be used'),
+            site: 'datadoghq.com',
+            api_key: ENV['DD_API_KEY'] || 'Invalid API key',
+          }
+        end
 
         it_behaves_like 'a successful profile flush'
       end

--- a/spec/ddtrace/profiling/transport/http/integration_spec.rb
+++ b/spec/ddtrace/profiling/transport/http/integration_spec.rb
@@ -47,9 +47,10 @@ RSpec.describe 'Datadog::Profiling::Transport::HTTP integration tests' do
 
         let(:options) do
           {
-            agent_settings: double('agent_settings which should not be used'),
+            agent_settings: double('agent_settings which should not be used'), # rubocop:disable RSpec/VerifiedDoubles
             site: 'datadoghq.com',
             api_key: ENV['DD_API_KEY'] || 'Invalid API key',
+            agentless_allowed: true
           }
         end
 

--- a/spec/ddtrace/profiling/transport/http/integration_spec.rb
+++ b/spec/ddtrace/profiling/transport/http/integration_spec.rb
@@ -5,6 +5,10 @@ require 'ddtrace'
 require 'ddtrace/profiling/transport/http'
 
 RSpec.describe 'Datadog::Profiling::Transport::HTTP integration tests' do
+  before do
+    skip 'Profiler not supported on JRuby' if PlatformHelpers.jruby?
+  end
+
   describe 'HTTP#default' do
     subject(:transport) do
       Datadog::Profiling::Transport::HTTP.default(

--- a/spec/ddtrace/profiling/transport/http_spec.rb
+++ b/spec/ddtrace/profiling/transport/http_spec.rb
@@ -71,20 +71,61 @@ RSpec.describe Datadog::Profiling::Transport::HTTP do
     end
 
     context 'when called with a site and api' do
-      let(:options) { { agent_settings: nil, site: site, api_key: api_key } }
+      let(:options) do
+        { agent_settings: double('agent_settings which should not be used'), site: site, api_key: api_key }
+      end
 
       let(:site) { 'test.datadoghq.com' }
       let(:api_key) { SecureRandom.uuid }
 
-      it 'returns a transport configured for agentless' do
-        expected_host = URI(format(Datadog::Ext::Profiling::Transport::HTTP::URI_TEMPLATE_DD_API, site)).host
-        expect(default.api.adapter).to be_a_kind_of(Datadog::Transport::HTTP::Adapters::Net)
-        expect(default.api.adapter.hostname).to eq(expected_host)
-        expect(default.api.adapter.port).to eq(443)
-        expect(default.api.adapter.timeout).to be timeout_seconds
-        expect(default.api.adapter.ssl).to be true
-        expect(default.api.headers).to include(described_class.default_headers)
-        expect(default.api.headers).to include(Datadog::Ext::Transport::HTTP::HEADER_DD_API_KEY => api_key)
+      context 'when DD_PROFILING_AGENTLESS environment variable is set to "true"' do
+        around do |example|
+          ClimateControl.modify('DD_PROFILING_AGENTLESS' => 'true') do
+            example.run
+          end
+        end
+
+        it 'returns a transport configured for agentless' do
+          expected_host = URI(format(Datadog::Ext::Profiling::Transport::HTTP::URI_TEMPLATE_DD_API, site)).host
+          expect(default.api.adapter).to be_a_kind_of(Datadog::Transport::HTTP::Adapters::Net)
+          expect(default.api.adapter.hostname).to eq(expected_host)
+          expect(default.api.adapter.port).to eq(443)
+          expect(default.api.adapter.timeout).to be timeout_seconds
+          expect(default.api.adapter.ssl).to be true
+          expect(default.api.headers).to include(described_class.default_headers)
+          expect(default.api.headers).to include(Datadog::Ext::Transport::HTTP::HEADER_DD_API_KEY => api_key)
+        end
+      end
+
+      context 'when agentless_allowed is true' do
+        let(:options) { { **super(), agentless_allowed: true } }
+
+        it 'returns a transport configured for agentless' do
+          expected_host = URI(format(Datadog::Ext::Profiling::Transport::HTTP::URI_TEMPLATE_DD_API, site)).host
+          expect(default.api.adapter).to be_a_kind_of(Datadog::Transport::HTTP::Adapters::Net)
+          expect(default.api.adapter.hostname).to eq(expected_host)
+          expect(default.api.adapter.port).to eq(443)
+          expect(default.api.adapter.timeout).to be timeout_seconds
+          expect(default.api.adapter.ssl).to be true
+          expect(default.api.headers).to include(described_class.default_headers)
+          expect(default.api.headers).to include(Datadog::Ext::Transport::HTTP::HEADER_DD_API_KEY => api_key)
+        end
+      end
+
+      ['false', nil].each do |environment_value|
+        context "when DD_PROFILING_AGENTLESS environment variable is set to #{environment_value.inspect}" do
+          let(:options) { { **super(), agent_settings: agent_settings } }
+
+          around do |example|
+            ClimateControl.modify('DD_PROFILING_AGENTLESS' => environment_value) do
+              example.run
+            end
+          end
+
+          it 'returns a transport configured for agent mode' do
+            expect(default.api.adapter.hostname).to eq(hostname)
+          end
+        end
       end
     end
   end

--- a/spec/ddtrace/profiling/transport/http_spec.rb
+++ b/spec/ddtrace/profiling/transport/http_spec.rb
@@ -32,10 +32,46 @@ RSpec.describe Datadog::Profiling::Transport::HTTP do
     subject(:default) { described_class.default(profiling_upload_timeout_seconds: timeout_seconds, **options) }
 
     let(:timeout_seconds) { double('Timeout in seconds') }
-    let(:options) { {} }
+    let(:options) { { agent_settings: agent_settings } }
+
+    let(:agent_settings) do
+      instance_double(
+        Datadog::Configuration::AgentSettingsResolver::AgentSettings,
+        hostname: hostname,
+        port: port,
+        ssl: ssl,
+        deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc
+      )
+    end
+    let(:hostname) { double('hostname') }
+    let(:port) { double('port') }
+    let(:profiling_upload_timeout_seconds) { double('timeout') }
+    let(:ssl) { true }
+    let(:deprecated_for_removal_transport_configuration_proc) { nil }
+
+    it 'returns a transport with provided options configured for agent mode' do
+      expect(default.api.adapter).to be_a_kind_of(Datadog::Transport::HTTP::Adapters::Net)
+      expect(default.api.adapter.hostname).to eq(hostname)
+      expect(default.api.adapter.port).to eq(port)
+      expect(default.api.adapter.timeout).to be timeout_seconds
+      expect(default.api.adapter.ssl).to be true
+      expect(default.api.headers).to include(described_class.default_headers)
+      expect(default.api.headers).to_not include(Datadog::Ext::Transport::HTTP::HEADER_DD_API_KEY)
+    end
+
+    context 'when agent_settings has a deprecated_for_removal_transport_configuration_proc' do
+      let(:deprecated_for_removal_transport_configuration_proc) { proc {} }
+
+      it 'calls the deprecated_for_removal_transport_configuration_proc with the transport builder' do
+        expect(deprecated_for_removal_transport_configuration_proc).to \
+          receive(:call).with(an_instance_of(Datadog::Profiling::Transport::HTTP::Builder))
+
+        default
+      end
+    end
 
     context 'when called with a site and api' do
-      let(:options) { { site: site, api_key: api_key } }
+      let(:options) { { agent_settings: nil, site: site, api_key: api_key } }
 
       let(:site) { 'test.datadoghq.com' }
       let(:api_key) { SecureRandom.uuid }
@@ -49,46 +85,6 @@ RSpec.describe Datadog::Profiling::Transport::HTTP do
         expect(default.api.adapter.ssl).to be true
         expect(default.api.headers).to include(described_class.default_headers)
         expect(default.api.headers).to include(Datadog::Ext::Transport::HTTP::HEADER_DD_API_KEY => api_key)
-      end
-    end
-
-    context 'when called with agent_settings' do
-      let(:options) { { agent_settings: agent_settings } }
-
-      let(:agent_settings) do
-        instance_double(
-          Datadog::Configuration::AgentSettingsResolver::AgentSettings,
-          hostname: hostname,
-          port: port,
-          ssl: ssl,
-          deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc
-        )
-      end
-      let(:hostname) { double('hostname') }
-      let(:port) { double('port') }
-      let(:profiling_upload_timeout_seconds) { double('timeout') }
-      let(:ssl) { true }
-      let(:deprecated_for_removal_transport_configuration_proc) { nil }
-
-      it 'returns a transport with provided options' do
-        expect(default.api.adapter).to be_a_kind_of(Datadog::Transport::HTTP::Adapters::Net)
-        expect(default.api.adapter.hostname).to eq(hostname)
-        expect(default.api.adapter.port).to eq(port)
-        expect(default.api.adapter.timeout).to be timeout_seconds
-        expect(default.api.adapter.ssl).to be true
-        expect(default.api.headers).to include(described_class.default_headers)
-        expect(default.api.headers).to_not include(Datadog::Ext::Transport::HTTP::HEADER_DD_API_KEY)
-      end
-
-      context 'when agent_settings has a deprecated_for_removal_transport_configuration_proc' do
-        let(:deprecated_for_removal_transport_configuration_proc) { proc {} }
-
-        it 'calls the deprecated_for_removal_transport_configuration_proc with the transport builder' do
-          expect(deprecated_for_removal_transport_configuration_proc).to \
-            receive(:call).with(an_instance_of(Datadog::Profiling::Transport::HTTP::Builder))
-
-          default
-        end
       end
     end
   end


### PR DESCRIPTION
The profiler supports reporting profiling data directly to the datadog backend, without having to go through an agent. This setup is actively discouraged by the profiling team for users, but hey, it is really handy for testing and prototyping.

But we don't want users to accidentally enable this mode. Up until now, profiler would implicitly use this mode if users set a `DD_API_KEY` and a `DD_SITE` configuration. Now, this mode will only be enabled if a `DD_PROFILING_AGENTLESS` environment variable is set to `true`.