### PR TITLE
Refactor reading of trace identifiers in profiler

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -86,6 +86,8 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
          - [For application runtime](#for-application-runtime)
      - [OpenTracing](#opentracing)
      - [Profiling](#profiling)
+         - [Troubleshooting](#troubleshooting)
+         - [Profiling Resque jobs](#profiling-resque-jobs)
  - [Known issues and suggested configurations](#known-issues-and-suggested-configurations)
     - [Payload too large](#payload-too-large)
     - [Stack level too deep](#stack-level-too-deep)
@@ -2490,6 +2492,10 @@ However, additional instrumentation provided by Datadog can be activated alongsi
 **Setup**
 
 To get started with profiling, follow the [Profiler Getting Started Guide](https://docs.datadoghq.com/tracing/profiler/getting_started/?code-lang=ruby).
+
+#### Troubleshooting
+
+If you run into issues with profiling, please check the [Profiler Troubleshooting Guide](https://docs.datadoghq.com/tracing/profiler/profiler_troubleshooting/?code-lang=ruby).
 
 #### Profiling Resque jobs
 

--- a/docs/ProfilingDevelopment.md
+++ b/docs/ProfilingDevelopment.md
@@ -42,22 +42,14 @@ flow:
 4. The `Setup` task activates our extensions
     * `Datadog::Profiling::Ext::Forking`
     * `Datadog::Profiling::Ext::CPU`
-5. Still inside `Datadog::Components`, the `build_profiler` method then creates and wires up the Profiler:
-    ```ruby
-          recorder = build_profiler_recorder(settings)
-          collectors = build_profiler_collectors(settings, recorder)
-          exporters = build_profiler_exporters(settings)
-          scheduler = build_profiler_scheduler(settings, recorder, exporters)
-
-          Datadog::Profiler.new(collectors, scheduler)
-    ```
+5. Still inside `Datadog::Components`, the `build_profiler` method then creates and wires up the Profiler as such:
     ```asciiflow
             +------------+
             |  Profiler  |
-            +-+--------+-+
-              |        |
-              v        v
-    +---------+--+  +--+--------+
+            +-+-------+--+
+              |       |
+              v       v
+    +---------+--+  +-+---------+
     | Collectors |  | Scheduler |
     +---------+--+  +-+-------+-+
               |       |       |

--- a/lib/ddtrace/profiling.rb
+++ b/lib/ddtrace/profiling.rb
@@ -126,6 +126,7 @@ module Datadog
       require 'ddtrace/profiling/transport/http'
       require 'ddtrace/profiling/profiler'
       require 'ddtrace/profiling/native_extension'
+      require 'ddtrace/profiling/trace_identifiers/helper'
       require 'ddtrace/profiling/pprof/pprof_pb'
 
       true

--- a/lib/ddtrace/profiling/trace_identifiers/ddtrace.rb
+++ b/lib/ddtrace/profiling/trace_identifiers/ddtrace.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Profiling
+    module TraceIdentifiers
+      # Used by Datadog::Profiling::TraceIdentifiers::Helper to get the trace identifiers (trace id and span id) for a
+      # given thread, if there is an active trace for that thread in Datadog.tracer.
+      class Ddtrace
+        def initialize(tracer: nil)
+          @tracer = tracer
+        end
+
+        def trace_identifiers_for(thread)
+          current_tracer = tracer
+          return unless current_tracer
+
+          correlation = current_tracer.active_correlation(thread)
+          trace_id = correlation.trace_id
+          span_id = correlation.span_id
+
+          [trace_id, span_id] if trace_id && trace_id != 0 && span_id && span_id != 0
+        end
+
+        private
+
+        def tracer
+          return @tracer if @tracer
+
+          # NOTE: Because the profiler may start working concurrently with tracer initialization,
+          # we need to be defensive here.
+          return unless Datadog.respond_to?(:tracer)
+
+          tracer = Datadog.tracer
+          return unless tracer.respond_to?(:active_correlation)
+
+          @tracer = tracer
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/profiling/trace_identifiers/ddtrace.rb
+++ b/lib/ddtrace/profiling/trace_identifiers/ddtrace.rb
@@ -7,33 +7,17 @@ module Datadog
       # given thread, if there is an active trace for that thread in Datadog.tracer.
       class Ddtrace
         def initialize(tracer: nil)
-          @tracer = tracer
+          @tracer = (tracer if tracer.respond_to?(:active_correlation))
         end
 
         def trace_identifiers_for(thread)
-          current_tracer = tracer
-          return unless current_tracer
+          return unless @tracer
 
-          correlation = current_tracer.active_correlation(thread)
+          correlation = @tracer.active_correlation(thread)
           trace_id = correlation.trace_id
           span_id = correlation.span_id
 
           [trace_id, span_id] if trace_id && trace_id != 0 && span_id && span_id != 0
-        end
-
-        private
-
-        def tracer
-          return @tracer if @tracer
-
-          # NOTE: Because the profiler may start working concurrently with tracer initialization,
-          # we need to be defensive here.
-          return unless Datadog.respond_to?(:tracer)
-
-          tracer = Datadog.tracer
-          return unless tracer.respond_to?(:active_correlation)
-
-          @tracer = tracer
         end
       end
     end

--- a/lib/ddtrace/profiling/trace_identifiers/helper.rb
+++ b/lib/ddtrace/profiling/trace_identifiers/helper.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'ddtrace/profiling/trace_identifiers/ddtrace'
+
+module Datadog
+  module Profiling
+    module TraceIdentifiers
+      # Helper used to retrieve the trace identifiers (trace id and span id) for a given thread,
+      # if there is an active trace for that thread for the supported tracing APIs.
+      #
+      # This data is used to connect profiles to the traces -- samples in a profile will be tagged with this data and
+      # the profile can be filtered down to look at only the samples for a given trace.
+      class Helper
+        DEFAULT_SUPPORTED_APIS = [
+          ::Datadog::Profiling::TraceIdentifiers::Ddtrace
+        ].freeze
+        private_constant :DEFAULT_SUPPORTED_APIS
+
+        def initialize(supported_apis: DEFAULT_SUPPORTED_APIS.map(&:new))
+          @supported_apis = supported_apis
+        end
+
+        def trace_identifiers_for(thread)
+          @supported_apis.each do |api|
+            trace_identifiers = api.trace_identifiers_for(thread)
+            return trace_identifiers unless trace_identifiers.nil?
+          end
+
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/profiling/trace_identifiers/helper.rb
+++ b/lib/ddtrace/profiling/trace_identifiers/helper.rb
@@ -16,7 +16,7 @@ module Datadog
         ].freeze
         private_constant :DEFAULT_SUPPORTED_APIS
 
-        def initialize(supported_apis: DEFAULT_SUPPORTED_APIS.map(&:new))
+        def initialize(tracer:, supported_apis: DEFAULT_SUPPORTED_APIS.map { |api| api.new(tracer: tracer) })
           @supported_apis = supported_apis
         end
 

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Datadog::Configuration::Components do
         .and_return(tracer)
 
       expect(described_class).to receive(:build_profiler)
-        .with(settings, instance_of(Datadog::Configuration::AgentSettingsResolver::AgentSettings))
+        .with(settings, instance_of(Datadog::Configuration::AgentSettingsResolver::AgentSettings), tracer)
         .and_return(profiler)
 
       expect(described_class).to receive(:build_runtime_metrics_worker)
@@ -666,8 +666,9 @@ RSpec.describe Datadog::Configuration::Components do
   describe '::build_profiler' do
     let(:agent_settings) { Datadog::Configuration::AgentSettingsResolver.call(settings, logger: nil) }
     let(:profiler) { build_profiler }
+    let(:tracer) { instance_double(Datadog::Tracer) }
 
-    subject(:build_profiler) { described_class.build_profiler(settings, agent_settings) }
+    subject(:build_profiler) { described_class.build_profiler(settings, agent_settings, tracer) }
 
     context 'when profiling is not supported' do
       before { allow(Datadog::Profiling).to receive(:supported?).and_return(false) }

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe 'profiling integration test' do
     skip 'Profiling is not supported.' unless Datadog::Profiling.supported?
   end
 
+  let(:tracer) { instance_double(Datadog::Tracer) }
+
   shared_context 'StackSample events' do
     # NOTE: Please do not convert stack_one or stack_two to let, because
     # we want the method names on the resulting stacks to be stack_one or
@@ -55,7 +57,7 @@ RSpec.describe 'profiling integration test' do
     let(:collector) do
       Datadog::Profiling::Collectors::Stack.new(
         recorder,
-        enabled: true,
+        trace_identifiers_helper: Datadog::Profiling::TraceIdentifiers::Helper.new(tracer: tracer),
         max_frames: 400
       )
     end
@@ -121,9 +123,10 @@ RSpec.describe 'profiling integration test' do
           @current_span = span
           example.run
         end
-
         Datadog.tracer.shutdown!
       end
+
+      let(:tracer) { Datadog.tracer }
 
       before do
         expect(recorder)

--- a/spec/ddtrace/profiling/trace_identifiers/ddtrace_spec.rb
+++ b/spec/ddtrace/profiling/trace_identifiers/ddtrace_spec.rb
@@ -46,22 +46,16 @@ RSpec.describe Datadog::Profiling::TraceIdentifiers::Ddtrace do
     context 'when no tracer instance is available' do
       let(:tracer) { nil }
 
-      context 'because the tracer is unavailable' do
-        let(:datadog) { Module.new { const_set('Utils', Datadog::Utils) } }
-
-        before { stub_const('Datadog', datadog, transfer_nested_constant: true) }
-
-        it do
-          expect(trace_identifiers_for).to be nil
-        end
+      it do
+        expect(trace_identifiers_for).to be nil
       end
+    end
 
-      context 'because correlations are unavailable' do
-        before { allow(Datadog).to receive(:tracer).and_return(instance_double(Datadog::Tracer)) }
+    context 'when tracer does not support #active_correlation' do
+      let(:tracer) { double('Tracer') } # rubocop:disable RSpec/VerifiedDoubles
 
-        it do
-          expect(trace_identifiers_for).to be nil
-        end
+      it do
+        expect(trace_identifiers_for).to be nil
       end
     end
   end

--- a/spec/ddtrace/profiling/trace_identifiers/ddtrace_spec.rb
+++ b/spec/ddtrace/profiling/trace_identifiers/ddtrace_spec.rb
@@ -1,0 +1,68 @@
+require 'ddtrace/profiling/trace_identifiers/ddtrace'
+
+require 'ddtrace/correlation'
+require 'ddtrace/tracer'
+
+RSpec.describe Datadog::Profiling::TraceIdentifiers::Ddtrace do
+  let(:thread) { instance_double(Thread) }
+  let(:tracer) { instance_double(Datadog::Tracer) }
+
+  subject(:datadog_trace_identifiers) { described_class.new(tracer: tracer) }
+
+  describe '#trace_identifiers_for' do
+    subject(:trace_identifiers_for) { datadog_trace_identifiers.trace_identifiers_for(thread) }
+
+    context 'when there is an active datadog trace for the thread' do
+      let(:trace_id) { rand(1e12) }
+      let(:span_id) { rand(1e12) }
+
+      before do
+        expect(tracer)
+          .to receive(:active_correlation)
+          .with(thread)
+          .and_return(Datadog::Correlation::Identifier.new(trace_id, span_id))
+      end
+
+      it 'returns the identifiers' do
+        trace_identifiers_for
+
+        expect(trace_identifiers_for).to eq [trace_id, span_id]
+      end
+    end
+
+    context 'when there is no active datadog trace for the thread' do
+      before do
+        expect(tracer)
+          .to receive(:active_correlation)
+          .with(thread)
+          .and_return(Datadog::Correlation::Identifier.new)
+      end
+
+      it do
+        expect(trace_identifiers_for).to be nil
+      end
+    end
+
+    context 'when no tracer instance is available' do
+      let(:tracer) { nil }
+
+      context 'because the tracer is unavailable' do
+        let(:datadog) { Module.new { const_set('Utils', Datadog::Utils) } }
+
+        before { stub_const('Datadog', datadog, transfer_nested_constant: true) }
+
+        it do
+          expect(trace_identifiers_for).to be nil
+        end
+      end
+
+      context 'because correlations are unavailable' do
+        before { allow(Datadog).to receive(:tracer).and_return(instance_double(Datadog::Tracer)) }
+
+        it do
+          expect(trace_identifiers_for).to be nil
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/profiling/trace_identifiers/helper_spec.rb
+++ b/spec/ddtrace/profiling/trace_identifiers/helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Datadog::Profiling::TraceIdentifiers::Helper do
   let(:api1) { instance_double(Datadog::Profiling::TraceIdentifiers::Ddtrace, 'api1') }
   let(:api2) { instance_double(Datadog::Profiling::TraceIdentifiers::Ddtrace, 'api2') }
 
-  subject(:trace_identifiers_helper) { described_class.new(supported_apis: [api1, api2]) }
+  subject(:trace_identifiers_helper) { described_class.new(tracer: nil, supported_apis: [api1, api2]) }
 
   describe '::DEFAULT_SUPPORTED_APIS' do
     it 'contains the Datadog trace identifiers' do

--- a/spec/ddtrace/profiling/trace_identifiers/helper_spec.rb
+++ b/spec/ddtrace/profiling/trace_identifiers/helper_spec.rb
@@ -1,0 +1,59 @@
+require 'ddtrace/profiling/trace_identifiers/helper'
+require 'ddtrace/profiling/trace_identifiers/ddtrace'
+
+RSpec.describe Datadog::Profiling::TraceIdentifiers::Helper do
+  let(:thread) { instance_double(Thread) }
+  let(:api1) { instance_double(Datadog::Profiling::TraceIdentifiers::Ddtrace, 'api1') }
+  let(:api2) { instance_double(Datadog::Profiling::TraceIdentifiers::Ddtrace, 'api2') }
+
+  subject(:trace_identifiers_helper) { described_class.new(supported_apis: [api1, api2]) }
+
+  describe '::DEFAULT_SUPPORTED_APIS' do
+    it 'contains the Datadog trace identifiers' do
+      expect(described_class.const_get(:DEFAULT_SUPPORTED_APIS))
+        .to eq([::Datadog::Profiling::TraceIdentifiers::Ddtrace])
+    end
+  end
+
+  describe '#trace_identifiers_for' do
+    subject(:trace_identifiers_for) { trace_identifiers_helper.trace_identifiers_for(thread) }
+
+    context 'when the first api provider returns trace identifiers' do
+      before do
+        allow(api1).to receive(:trace_identifiers_for).and_return([:api1_trace_id, :api1_span_id])
+      end
+
+      it 'returns the first api provider trace identifiers' do
+        expect(trace_identifiers_for).to eq [:api1_trace_id, :api1_span_id]
+      end
+
+      it 'does not attempt to read trace identifiers from the second api provider' do
+        expect(api2).to_not receive(:trace_identifiers_for)
+
+        trace_identifiers_for
+      end
+    end
+
+    context 'when the first api provider does not return trace identifiers, but the second one does' do
+      before do
+        allow(api1).to receive(:trace_identifiers_for).and_return(nil)
+        allow(api2).to receive(:trace_identifiers_for).and_return([:api2_trace_id, :api2_span_id])
+      end
+
+      it 'returns the second api provider trace identifiers' do
+        expect(trace_identifiers_for).to eq [:api2_trace_id, :api2_span_id]
+      end
+    end
+
+    context 'when no api providers return trace identifiers' do
+      before do
+        allow(api1).to receive(:trace_identifiers_for).and_return(nil)
+        allow(api2).to receive(:trace_identifiers_for).and_return(nil)
+      end
+
+      it do
+        expect(trace_identifiers_for).to be nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is an extraction of the work did for #1568, but without the addition of opentelemetry support for profiler.

We're still discussing with upstream how opentelemetry support will look (see https://github.com/open-telemetry/opentelemetry-ruby/pull/842), but I rather liked the refactoring that we did, so I'd like to merge it in, and later we can just add the missing bits from #1568.