### PR TITLE
Fix:Aws instrumentation patch without S3

### DIFF
--- a/lib/ddtrace/contrib/aws/patcher.rb
+++ b/lib/ddtrace/contrib/aws/patcher.rb
@@ -23,7 +23,7 @@ module Datadog
 
           # Special handling for S3 URL Presigning.
           # @see {Datadog::Contrib::Aws::S3Presigner}
-          ::Aws::S3::Presigner.prepend S3Presigner
+          ::Aws::S3::Presigner.prepend(S3Presigner) if defined?(::Aws::S3::Presigner)
         end
 
         def add_plugin(*targets)

--- a/spec/ddtrace/contrib/aws/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/aws/instrumentation_spec.rb
@@ -10,9 +10,6 @@ require 'ddtrace/ext/http'
 RSpec.describe 'AWS instrumentation' do
   let(:configuration_options) { {} }
 
-  let(:client) { ::Aws::S3::Client.new(stub_responses: responses) }
-  let(:responses) { true }
-
   before do
     Datadog.configure do |c|
       c.use :aws, configuration_options
@@ -26,7 +23,47 @@ RSpec.describe 'AWS instrumentation' do
     Datadog.registry[:aws].reset_configuration!
   end
 
-  context 'when the client runs' do
+  context 'with a core AWS SDK client', if: RUBY_VERSION >= '2.2.0' do
+    before { hide_const('Aws::S3') }
+
+    let(:client) { ::Aws::STS::Client.new(stub_responses: responses) } # STS is part of aws-sdk-core
+
+    describe '#get_access_key_info' do
+      subject!(:get_access_key_info) { client.get_access_key_info(access_key_id: 'dummy') }
+      let(:responses) { { get_access_key_info: { account: 'test account' } } }
+
+      it_behaves_like 'analytics for integration' do
+        let(:analytics_enabled_var) { Datadog::Contrib::Aws::Ext::ENV_ANALYTICS_ENABLED }
+        let(:analytics_sample_rate_var) { Datadog::Contrib::Aws::Ext::ENV_ANALYTICS_SAMPLE_RATE }
+      end
+
+      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'a peer service span'
+
+      it 'generates a span' do
+        expect(span.name).to eq('aws.command')
+        expect(span.service).to eq('aws')
+        expect(span.span_type).to eq('http')
+        expect(span.resource).to eq('sts.get_access_key_info')
+
+        expect(span.get_tag('aws.agent')).to eq('aws-sdk-ruby')
+        expect(span.get_tag('aws.operation')).to eq('get_access_key_info')
+        expect(span.get_tag('aws.region')).to eq('us-stubbed-1')
+        expect(span.get_tag('path')).to eq('')
+        expect(span.get_tag('host')).to eq('sts.us-stubbed-1.amazonaws.com')
+        expect(span.get_tag('http.method')).to eq('POST')
+        expect(span.get_tag('http.status_code')).to eq('200')
+      end
+
+      it 'returns an unmodified response' do
+        expect(get_access_key_info.account).to eq('test account')
+      end
+    end
+  end
+
+  context 'with an S3 client' do
+    let(:client) { ::Aws::S3::Client.new(stub_responses: responses) }
+
     describe '#list_buckets' do
       subject!(:list_buckets) { client.list_buckets }
 
@@ -58,21 +95,30 @@ RSpec.describe 'AWS instrumentation' do
 
       it_behaves_like 'a peer service span'
 
-      it 'returns the correct response' do
+      it 'returns an unmodified response' do
         expect(list_buckets.buckets.map(&:name)).to eq(['bucket1'])
       end
     end
 
     describe 'S3::Presigner' do
+      let(:presigner) { ::Aws::S3::Presigner.new(client: client) }
+
       describe '#presigned_url' do
         subject!(:presign) { presigner.presigned_url(:get_object, bucket: 'bucket', key: 'key') }
 
-        let(:presigner) { Aws::S3::Presigner.new(client: client) }
+        # presigned_url returns a string instead of a Seahorse object, so it does not accept
+        # object stubbing like other S3 methods. We simply tell it to enable stubbing and it
+        # will return a stubbed URL without hitting the remote.
+        let(:responses) { { presigned_url: true } }
 
         it 'does not instrument presign as an HTTP request' do
           presign
 
           expect(spans).to be_empty
+        end
+
+        it 'returns an unmodified response' do
+          expect(presign).to start_with('https://bucket.s3.us-stubbed-1.amazonaws.com/key')
         end
       end
     end


### PR DESCRIPTION
Fixes #1589 

This PR modifies the AWS instrumentation to only augment the `Aws::S3` package if present.

This issue was introduced in #1494, when presign S3 requests became excluded from network instrumentation in https://github.com/DataDog/dd-trace-rb/releases/tag/v0.51.0.