### PR TITLE
Add experimental toggle to disable the profiling native extension

### DIFF
--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -1,11 +1,24 @@
-require 'mkmf'
+def skip_building_extension?
+  # We don't support JRuby for profiling, and JRuby doesn't support native extensions, so let's just skip this entire
+  # thing so that JRuby users of dd-trace-rb aren't impacted.
+  on_jruby = RUBY_ENGINE == 'jruby'
 
-# We don't support JRuby for profiling, and JRuby doesn't support native extensions, so let's just skip this entire
-# thing so that JRuby users of dd-trace-rb aren't impacted.
-if RUBY_ENGINE == 'jruby'
-  File.write('Makefile', dummy_makefile($srcdir).join) # rubocop:disable Style/GlobalVars
+  # Experimental toggle to disable building the extension.
+  # Disabling the extension will lead to the profiler not working in future releases.
+  # If you needed to use this, please tell us why on <https://github.com/DataDog/dd-trace-rb/issues/new>.
+  disabled_via_env = ENV['DD_PROFILING_NO_EXTENSION'].to_s.downcase == 'true'
+
+  on_jruby || disabled_via_env
+end
+
+if skip_building_extension?
+  File.write('Makefile', 'all install clean: # dummy makefile that does nothing')
   return
 end
+
+# NOTE: we MUST NOT require 'mkmf' before we check the #skip_building_extension? because the require triggers checks
+# that may fail on an environment not properly setup for building Ruby extensions.
+require 'mkmf'
 
 # Tag the native extension library with the Ruby version and Ruby platform.
 # This makes it easier for development (avoids "oops I forgot to rebuild when I switched my Ruby") and ensures that


### PR DESCRIPTION
In #1584 I identified that users of dd-trace-rb on Linux/macOS needed to have a working build environment to compile msgpack and ffi, and so installing our gem would be no different.

I've since identified a possible corner case: in the reliability environment, we use the GitLab omnibus distribution
(<https://docs.gitlab.com/omnibus/>), which already ships pre-compiled versions of msgpack and ffi, but does not include a compiler nor the Ruby headers required for compiling extensions.

Thus, up until now it was trivial to add dd-trace-rb (and profiling) to these images, but the addition of the native extension complicates things a lot.

Since the native extension is still in the "we're evaluating and learning about the downsides/sharp edges of having it" phase, I decided to add a `DD_PROFILING_NO_EXTENSION` environment variable, that for now can be used to disable building and usage of the extension.

Because the extension is currently empty, doing this is is harmless, but in the future, the use of `DD_PROFILING_NO_EXTENSION` will lead to the profiler being disabled as well, once the profiler code starts requiring the native extension to be available. For that reason, I documented this toggle as experimental, and added a warning whenever the app is loaded with it.

For users reading this (if any!): if you needed to use this option, please tell us why on
<https://github.com/DataDog/dd-trace-rb/issues/new> as we want to accommodate your use cases.