### PR TITLE
Fix:Additional Faraday 1.4+ cgroup parsing formats

### DIFF
--- a/lib/datadog/core/environment/container.rb
+++ b/lib/datadog/core/environment/container.rb
@@ -11,7 +11,7 @@ module Datadog
         PLATFORM_REGEX = /(?<platform>.*?)(?:.slice)?$/.freeze
         POD_REGEX = /(?<pod>(pod)?#{UUID_PATTERN})(?:.slice)?$/.freeze
         CONTAINER_REGEX = /(?<container>#{UUID_PATTERN}|#{CONTAINER_PATTERN})(?:.scope)?$/.freeze
-        FARGATE_14_CONTAINER_REGEX = /(?<container>[0-9a-f]{32}-[0-9]{10})/.freeze
+        FARGATE_14_CONTAINER_REGEX = /(?<container>[0-9a-f]{32}-[0-9]{1,10})/.freeze
 
         Descriptor = Struct.new(
           :platform,
@@ -59,7 +59,7 @@ module Datadog
                                 || parts[-1][FARGATE_14_CONTAINER_REGEX, :container]
                 else
                   if (container_id = parts[-1][CONTAINER_REGEX, :container])
-                    task_uid = parts[-2][POD_REGEX, :pod]
+                    task_uid = parts[-2][POD_REGEX, :pod] || parts[1][POD_REGEX, :pod]
                   else
                     container_id = parts[-1][FARGATE_14_CONTAINER_REGEX, :container]
                   end

--- a/spec/datadog/core/environment/cgroup_spec.rb
+++ b/spec/datadog/core/environment/cgroup_spec.rb
@@ -43,114 +43,70 @@ RSpec.describe Datadog::Core::Environment::Cgroup do
         end
       end
 
+      shared_examples 'parsing cgroup file into an array of descriptors' do
+        it 'returns an array of descriptors' do
+          is_expected.to be_an(Array)
+          is_expected.to all(be_a(described_class::Descriptor))
+        end
+
+        it 'parses each line into an element' do
+          is_expected.to have(lines).items
+        end
+      end
+
       context 'in a non-containerized environment' do
         include_context 'non-containerized environment'
-
-        it do
-          is_expected.to be_a_kind_of(Array)
-          is_expected.to have(13).items
-          is_expected.to include(be_a_kind_of(described_class::Descriptor))
-        end
+        include_examples 'parsing cgroup file into an array of descriptors'
       end
 
       context 'in a non-containerized environment with VTE' do
         include_context 'non-containerized environment with VTE'
-
-        it do
-          is_expected.to be_a_kind_of(Array)
-          is_expected.to have(13).items
-          is_expected.to include(be_a_kind_of(described_class::Descriptor))
-        end
+        include_examples 'parsing cgroup file into an array of descriptors'
       end
 
       context 'in a Docker environment' do
         include_context 'Docker environment'
-
-        it do
-          is_expected.to be_a_kind_of(Array)
-          is_expected.to have(13).items
-          is_expected.to include(be_a_kind_of(described_class::Descriptor))
-        end
+        include_examples 'parsing cgroup file into an array of descriptors'
       end
 
       context 'in a Kubernetes environment' do
         include_context 'Kubernetes environment'
-
-        it do
-          is_expected.to be_a_kind_of(Array)
-          is_expected.to have(11).items
-          is_expected.to include(be_a_kind_of(described_class::Descriptor))
-        end
+        include_examples 'parsing cgroup file into an array of descriptors'
       end
 
       context 'in a Kubernetes burstable environment' do
         include_context 'Kubernetes burstable environment'
-
-        it do
-          is_expected.to be_a_kind_of(Array)
-          is_expected.to have(11).items
-          is_expected.to include(be_a_kind_of(described_class::Descriptor))
-        end
+        include_examples 'parsing cgroup file into an array of descriptors'
       end
 
       context 'in an ECS environment' do
         include_context 'ECS environment'
-
-        it do
-          is_expected.to be_a_kind_of(Array)
-          is_expected.to have(9).items
-          is_expected.to include(be_a_kind_of(described_class::Descriptor))
-        end
+        include_examples 'parsing cgroup file into an array of descriptors'
       end
 
       context 'in a Fargate 1.3- environment' do
         include_context 'Fargate 1.3- environment'
-
-        it do
-          is_expected.to be_a_kind_of(Array)
-          is_expected.to have(11).items
-          is_expected.to include(be_a_kind_of(described_class::Descriptor))
-        end
+        include_examples 'parsing cgroup file into an array of descriptors'
       end
 
       context 'in a Fargate 1.4+ environment' do
         include_context 'Fargate 1.4+ environment'
-
-        it do
-          is_expected.to be_a_kind_of(Array)
-          is_expected.to have(11).items
-          is_expected.to include(be_a_kind_of(described_class::Descriptor))
-        end
+        include_examples 'parsing cgroup file into an array of descriptors'
       end
 
       context 'in a Fargate 1.4+ (2-part) environment' do
         include_context 'Fargate 1.4+ (2-part) environment'
-
-        it do
-          is_expected.to be_a_kind_of(Array)
-          is_expected.to have(11).items
-          is_expected.to include(be_a_kind_of(described_class::Descriptor))
-        end
+        include_examples 'parsing cgroup file into an array of descriptors'
       end
 
       context 'in a Fargate 1.4+ (2-part short random) environment' do
         include_context 'Fargate 1.4+ (2-part short random) environment'
-
-        it do
-          is_expected.to be_a_kind_of(Array)
-          is_expected.to have(11).items
-          is_expected.to include(be_a_kind_of(described_class::Descriptor))
-        end
+        include_examples 'parsing cgroup file into an array of descriptors'
       end
 
       context 'in a Fargate 1.4+ with ECS+docker environment' do
         include_context 'Fargate 1.4+ with ECS+docker environment'
-
-        it do
-          is_expected.to be_a_kind_of(Array)
-          is_expected.to have(10).items
-          is_expected.to include(be_a_kind_of(described_class::Descriptor))
-        end
+        include_examples 'parsing cgroup file into an array of descriptors'
       end
     end
   end

--- a/spec/datadog/core/environment/cgroup_spec.rb
+++ b/spec/datadog/core/environment/cgroup_spec.rb
@@ -132,6 +132,26 @@ RSpec.describe Datadog::Core::Environment::Cgroup do
           is_expected.to include(be_a_kind_of(described_class::Descriptor))
         end
       end
+
+      context 'in a Fargate 1.4+ (2-part short random) environment' do
+        include_context 'Fargate 1.4+ (2-part short random) environment'
+
+        it do
+          is_expected.to be_a_kind_of(Array)
+          is_expected.to have(11).items
+          is_expected.to include(be_a_kind_of(described_class::Descriptor))
+        end
+      end
+
+      context 'in a Fargate 1.4+ with ECS+docker environment' do
+        include_context 'Fargate 1.4+ with ECS+docker environment'
+
+        it do
+          is_expected.to be_a_kind_of(Array)
+          is_expected.to have(10).items
+          is_expected.to include(be_a_kind_of(described_class::Descriptor))
+        end
+      end
     end
   end
 

--- a/spec/datadog/core/environment/container_spec.rb
+++ b/spec/datadog/core/environment/container_spec.rb
@@ -100,5 +100,23 @@ RSpec.describe Datadog::Core::Environment::Container do
         let(:task_uid) { nil }
       end
     end
+
+    context 'when in a Fargate 1.4+ (2-part short random) environment' do
+      include_context 'Fargate 1.4+ (2-part short random) environment'
+
+      it_behaves_like 'container descriptor' do
+        let(:container_id) { container_id_with_random }
+        let(:task_uid) { nil }
+      end
+    end
+
+    context 'when in a Fargate 1.4+ with ECS+docker environment' do
+      include_context 'Fargate 1.4+ with ECS+docker environment'
+
+      it_behaves_like 'container descriptor' do
+        let(:container_id) { child_container_id }
+        let(:task_uid) { task_arn }
+      end
+    end
   end
 end

--- a/spec/support/container_helpers.rb
+++ b/spec/support/container_helpers.rb
@@ -237,6 +237,7 @@ module ContainerHelpers
     include_context 'cgroup file'
 
     let(:platform) { 'ecs' }
+    # Container random ID is normally 10 characters, but we've seen cases with fewer characters in the wild.
     let(:container_id_with_random) { "#{container_id_without_random}-609015642" }
     let(:container_id_without_random) { 'cef584f232933b25e0c6933d7e86cb34' }
 

--- a/spec/support/container_helpers.rb
+++ b/spec/support/container_helpers.rb
@@ -30,6 +30,7 @@ module ContainerHelpers
     include_context 'cgroup file'
 
     let(:platform) { nil }
+    let(:lines) { 13 }
 
     before do
       cgroup_file.puts '12:hugetlb:/'
@@ -54,6 +55,7 @@ module ContainerHelpers
 
     let(:platform) { 'user' }
     let(:terminal_id) { '6fec48c4-1f82-4313-a1c2-29e205a96958' }
+    let(:lines) { 13 }
 
     before do
       cgroup_file.puts '12:hugetlb:/'
@@ -78,6 +80,7 @@ module ContainerHelpers
 
     let(:platform) { 'docker' }
     let(:container_id) { '3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860' }
+    let(:lines) { 13 }
 
     before do
       cgroup_file.puts "13:name=systemd:/#{platform}/#{container_id}"
@@ -103,6 +106,7 @@ module ContainerHelpers
     let(:platform) { 'kubepods' }
     let(:container_id) { '3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1' }
     let(:pod_id) { 'pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a' }
+    let(:lines) { 11 }
 
     before do
       cgroup_file.puts "11:perf_event:/#{platform}/besteffort/#{pod_id}/#{container_id}"
@@ -126,6 +130,7 @@ module ContainerHelpers
     let(:platform) { 'kubepods' }
     let(:container_id) { '7b8952daecf4c0e44bbcefe1b5c5ebc7b4839d4eefeccefe694709d3809b6199' }
     let(:pod_id) { 'pod2d3da189_6407_48e3_9ab6_78188d75e609' }
+    let(:lines) { 11 }
 
     before do
       cgroup_file.puts "11:perf_event:/#{platform}.slice/kubepods-burstable.slice/kubepods-burstable-#{pod_id}.slice/docker-#{container_id}.scope"
@@ -149,6 +154,7 @@ module ContainerHelpers
     let(:platform) { 'ecs' }
     let(:container_id) { '38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce' }
     let(:task_arn) { '5a0d5ceddf6c44c1928d367a815d890f' }
+    let(:lines) { 9 }
 
     before do
       cgroup_file.puts "9:perf_event:/#{platform}/haissam-ecs-classic/#{task_arn}/#{container_id}"
@@ -170,6 +176,7 @@ module ContainerHelpers
     let(:platform) { 'ecs' }
     let(:container_id) { '432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da' }
     let(:task_arn) { '55091c13-b8cf-4801-b527-f4601742204d' }
+    let(:lines) { 11 }
 
     before do
       cgroup_file.puts "11:hugetlb:/#{platform}/#{task_arn}/#{container_id}"
@@ -193,6 +200,7 @@ module ContainerHelpers
     let(:platform) { 'ecs' }
     let(:container_id_with_random) { "#{container_id_without_random}-1234567890" }
     let(:container_id_without_random) { '34dc0b5e626f2c5c4c5170e34b10e765' }
+    let(:lines) { 11 }
 
     before do
       cgroup_file.puts "11:hugetlb:/#{platform}/#{container_id_with_random}"
@@ -216,6 +224,7 @@ module ContainerHelpers
     let(:platform) { 'ecs' }
     let(:container_id_with_random) { "#{container_id_without_random}-1234567890" }
     let(:container_id_without_random) { '34dc0b5e626f2c5c4c5170e34b10e765' }
+    let(:lines) { 11 }
 
     before do
       cgroup_file.puts "11:hugetlb:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
@@ -240,6 +249,7 @@ module ContainerHelpers
     # Container random ID is normally 10 characters, but we've seen cases with fewer characters in the wild.
     let(:container_id_with_random) { "#{container_id_without_random}-609015642" }
     let(:container_id_without_random) { 'cef584f232933b25e0c6933d7e86cb34' }
+    let(:lines) { 11 }
 
     before do
       cgroup_file.puts "11:hugetlb:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
@@ -264,6 +274,7 @@ module ContainerHelpers
     let(:task_arn) { 'c101a02b-a99d-4016-b52d-449e313a8087' }
     let(:host_container_id) { '746a2eb2aa309b64c604f5f798c2df761a92ba9e80ad1948edc5f1c63e2e125e' }
     let(:child_container_id) { '3fb61c869147b933a1c459a87eb11429f640e1600e4c9c7f38a9fe39ecbc5d2a' }
+    let(:lines) { 10 }
 
     before do
       cgroup_file.puts "10:pids:/#{platform}/#{task_arn}/#{host_container_id}/docker/#{child_container_id}"

--- a/spec/support/container_helpers.rb
+++ b/spec/support/container_helpers.rb
@@ -232,4 +232,50 @@ module ContainerHelpers
       cgroup_file.rewind
     end
   end
+
+  shared_context 'Fargate 1.4+ (2-part short random) environment' do
+    include_context 'cgroup file'
+
+    let(:platform) { 'ecs' }
+    let(:container_id_with_random) { "#{container_id_without_random}-609015642" }
+    let(:container_id_without_random) { 'cef584f232933b25e0c6933d7e86cb34' }
+
+    before do
+      cgroup_file.puts "11:hugetlb:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "10:pids:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "9:cpuset:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "8:net_cls,net_prio:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "7:cpu,cpuacct:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "6:perf_event:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "5:freezer:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "4:devices:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "3:blkio:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "2:memory:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.puts "1:name=systemd:/#{platform}/#{container_id_without_random}/#{container_id_with_random}"
+      cgroup_file.rewind
+    end
+  end
+
+  shared_context 'Fargate 1.4+ with ECS+docker environment' do
+    include_context 'cgroup file'
+
+    let(:platform) { 'ecs' }
+    let(:task_arn) { 'c101a02b-a99d-4016-b52d-449e313a8087' }
+    let(:host_container_id) { '746a2eb2aa309b64c604f5f798c2df761a92ba9e80ad1948edc5f1c63e2e125e' }
+    let(:child_container_id) { '3fb61c869147b933a1c459a87eb11429f640e1600e4c9c7f38a9fe39ecbc5d2a' }
+
+    before do
+      cgroup_file.puts "10:pids:/#{platform}/#{task_arn}/#{host_container_id}/docker/#{child_container_id}"
+      cgroup_file.puts "9:perf_event:/#{platform}/#{task_arn}/#{host_container_id}/docker/#{child_container_id}"
+      cgroup_file.puts "8:memory:/#{platform}/#{task_arn}/#{host_container_id}/docker/#{child_container_id}"
+      cgroup_file.puts "7:hugetlb:/#{platform}/#{task_arn}/#{host_container_id}/docker/#{child_container_id}"
+      cgroup_file.puts "6:freezer:/#{platform}/#{task_arn}/#{host_container_id}/docker/#{child_container_id}"
+      cgroup_file.puts "5:devices:/#{platform}/#{task_arn}/#{host_container_id}/docker/#{child_container_id}"
+      cgroup_file.puts "4:cpuset:/#{platform}/#{task_arn}/#{host_container_id}/docker/#{child_container_id}"
+      cgroup_file.puts "3:cpuacct:/#{platform}/#{task_arn}/#{host_container_id}/docker/#{child_container_id}"
+      cgroup_file.puts "2:cpu:/#{platform}/#{task_arn}/#{host_container_id}/docker/#{child_container_id}"
+      cgroup_file.puts "1:blkio:/#{platform}/#{task_arn}/#{host_container_id}/docker/#{child_container_id}"
+      cgroup_file.rewind
+    end
+  end
 end


### PR DESCRIPTION
This PR supports two more Faraday 1.4 cgroup formats:
1. Shorter random component to Container ID suffix: e.g. `609015642` part in `cef584f232933b25e0c6933d7e86cb34-609015642`. This was previously expected to always have 1 digits, but we found production cases with 9. This PR performs a broader match, matching numbers from 1 to 10 digits.
1. Support nested docker ECS+docker deployment: This case contains 2 container ids, but the later one represents the currently running container, while the earlier one represents the host. We take the later one to correlate container metrics.