### PR TITLE
[PROF-3285] User-friendly handling of slow submissions on shutdown

### DIFF
--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -37,7 +37,13 @@ module Datadog
   # Add shutdown hook:
   # Ensures the tracer has an opportunity to flush traces
   # and cleanup before terminating the process.
-  at_exit { Datadog.shutdown! }
+  at_exit do
+    if Interrupt === $! # rubocop:disable Style/SpecialGlobalVars is process terminating due to a ctrl+c or similar?
+      Datadog.send(:handle_interrupt_shutdown!)
+    else
+      Datadog.shutdown!
+    end
+  end
 end
 
 require 'ddtrace/contrib/action_cable/integration'


### PR DESCRIPTION
dd-trace-rb installs a VM `at_exit` handler that allows it to shut down all of its background tasks cleanly, including attempting to submit and remaining traces and profiles.

This finishing of background tasks is already protected by timeouts (to make sure we don't just hang if talking to the agent is slow), but can still take a few seconds.

When a user presses ctrl+c, they usually expect their process to finish in a timely manner, and may assume the process hung if it doesn't finish immediately. To clarify what's going on (and tell users that they **can** press ctrl+c again to force an exit), I've added a nice message that is printed whenever shut down takes longer than 200ms.

Whenever shutdown is fast enough, no message is printed, to avoid extra noise.