### PR TITLE
Sorbet: Fix incorrect use of logger in error handling code

### DIFF
--- a/lib/ddtrace/contrib/httpclient/patcher.rb
+++ b/lib/ddtrace/contrib/httpclient/patcher.rb
@@ -28,7 +28,7 @@ module Datadog
             begin
               ::HTTPClient.include(Instrumentation)
             rescue StandardError => e
-              Datadog::Logger.error("Unable to apply httpclient integration: #{e}")
+              Datadog.logger.error("Unable to apply httpclient integration: #{e}")
             end
           end
         end

--- a/lib/ddtrace/contrib/httprb/patcher.rb
+++ b/lib/ddtrace/contrib/httprb/patcher.rb
@@ -28,7 +28,7 @@ module Datadog
             begin
               ::HTTP::Client.include(Instrumentation)
             rescue StandardError => e
-              Datadog::Logger.error("Unable to apply httprb integration: #{e}")
+              Datadog.logger.error("Unable to apply httprb integration: #{e}")
             end
           end
         end


### PR DESCRIPTION
I'm experimenting with adding the [sorbet](https://sorbet.org/) type checker to dd-trace-rb. Since my "adding sorbet" branch is getting quite large and will be hard to review, I've decided to break it into smaller PRs.

This PR fixes an issue caught by sorbet -- there's no "module functions" on the `Datadog::Logger` class, and thus these two methods would fail when trying to log that a failure happened. (I've checked that there are no other such instances in the codebase).

Nice going, sorbet 👌 