### PR TITLE
Sorbet: Correctly handle nil backtraces when logging

### DIFF
--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -339,49 +339,49 @@ module Datadog
             committer_date: Time.at(fields[5].to_i).utc.to_datetime.iso8601
           }
         rescue => e
-          Datadog.logger.debug("Unable to read git commit users: #{e.message} at #{e.backtrace.first}")
+          Datadog.logger.debug("Unable to read git commit users: #{e.message} at #{Array(e.backtrace).first}")
           nil
         end
 
         def git_repository_url
           exec_git_command('git ls-remote --get-url')
         rescue => e
-          Datadog.logger.debug("Unable to read git repository url: #{e.message} at #{e.backtrace.first}")
+          Datadog.logger.debug("Unable to read git repository url: #{e.message} at #{Array(e.backtrace).first}")
           nil
         end
 
         def git_commit_message
           exec_git_command('git show -s --format=%s')
         rescue => e
-          Datadog.logger.debug("Unable to read git commit message: #{e.message} at #{e.backtrace.first}")
+          Datadog.logger.debug("Unable to read git commit message: #{e.message} at #{Array(e.backtrace).first}")
           nil
         end
 
         def git_branch
           exec_git_command('git rev-parse --abbrev-ref HEAD')
         rescue => e
-          Datadog.logger.debug("Unable to read git branch: #{e.message} at #{e.backtrace.first}")
+          Datadog.logger.debug("Unable to read git branch: #{e.message} at #{Array(e.backtrace).first}")
           nil
         end
 
         def git_commit_sha
           exec_git_command('git rev-parse HEAD')
         rescue => e
-          Datadog.logger.debug("Unable to read git commit SHA: #{e.message} at #{e.backtrace.first}")
+          Datadog.logger.debug("Unable to read git commit SHA: #{e.message} at #{Array(e.backtrace).first}")
           nil
         end
 
         def git_tag
           exec_git_command('git tag --points-at HEAD')
         rescue => e
-          Datadog.logger.debug("Unable to read git tag: #{e.message} at #{e.backtrace.first}")
+          Datadog.logger.debug("Unable to read git tag: #{e.message} at #{Array(e.backtrace).first}")
           nil
         end
 
         def git_base_directory
           exec_git_command('git rev-parse --show-toplevel')
         rescue => e
-          Datadog.logger.debug("Unable to read git base directory: #{e.message} at #{e.backtrace.first}")
+          Datadog.logger.debug("Unable to read git base directory: #{e.message} at #{Array(e.backtrace).first}")
           nil
         end
 

--- a/lib/datadog/core/environment/cgroup.rb
+++ b/lib/datadog/core/environment/cgroup.rb
@@ -31,7 +31,7 @@ module Datadog
                 end
               end
             rescue StandardError => e
-              Datadog.logger.error("Error while parsing cgroup. Cause: #{e.message} Location: #{e.backtrace.first}")
+              Datadog.logger.error("Error while parsing cgroup. Cause: #{e.message} Location: #{Array(e.backtrace).first}")
             end
           end
         end

--- a/lib/datadog/core/environment/container.rb
+++ b/lib/datadog/core/environment/container.rb
@@ -77,7 +77,7 @@ module Datadog
               end
             rescue StandardError => e
               Datadog.logger.error(
-                "Error while parsing container info. Cause: #{e.message} Location: #{e.backtrace.first}"
+                "Error while parsing container info. Cause: #{e.message} Location: #{Array(e.backtrace).first}"
               )
             end
           end

--- a/lib/ddtrace/buffer.rb
+++ b/lib/ddtrace/buffer.rb
@@ -259,7 +259,7 @@ module Datadog
 
       @buffer_spans += trace.length
     rescue StandardError => e
-      Datadog.logger.debug("Failed to measure queue accept. Cause: #{e.message} Source: #{e.backtrace.first}")
+      Datadog.logger.debug("Failed to measure queue accept. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
     end
 
     def measure_drop(trace)
@@ -267,7 +267,7 @@ module Datadog
 
       @buffer_spans -= trace.length
     rescue StandardError => e
-      Datadog.logger.debug("Failed to measure queue drop. Cause: #{e.message} Source: #{e.backtrace.first}")
+      Datadog.logger.debug("Failed to measure queue drop. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
     end
 
     def measure_pop(traces)
@@ -290,7 +290,7 @@ module Datadog
       @buffer_dropped = 0
       @buffer_spans = 0
     rescue StandardError => e
-      Datadog.logger.debug("Failed to measure queue. Cause: #{e.message} Source: #{e.backtrace.first}")
+      Datadog.logger.debug("Failed to measure queue. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
     end
   end
 

--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -137,7 +137,7 @@ module Datadog
           logger_without_components.error(
             'Detected deadlock during ddtrace initialization. ' \
             'Please report this at https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug' \
-            "\n\tSource:\n\t#{e.backtrace.join("\n\t")}"
+            "\n\tSource:\n\t#{Array(e.backtrace).join("\n\t")}"
           )
           nil
         end

--- a/lib/ddtrace/contrib/active_record/configuration/resolver.rb
+++ b/lib/ddtrace/contrib/active_record/configuration/resolver.rb
@@ -66,7 +66,7 @@ module Datadog
           rescue => e
             Datadog.logger.error(
               "Failed to resolve ActiveRecord configuration key #{db_config.inspect}. " \
-              "Cause: #{e.message} Source: #{e.backtrace.first}"
+              "Cause: #{e.message} Source: #{Array(e.backtrace).first}"
             )
 
             nil
@@ -85,7 +85,7 @@ module Datadog
           rescue => e
             Datadog.logger.error(
               "Failed to resolve ActiveRecord configuration key #{matcher.inspect}. " \
-              "Cause: #{e.message} Source: #{e.backtrace.first}"
+              "Cause: #{e.message} Source: #{Array(e.backtrace).first}"
             )
           end
 

--- a/lib/ddtrace/contrib/active_record/utils.rb
+++ b/lib/ddtrace/contrib/active_record/utils.rb
@@ -73,7 +73,7 @@ module Datadog
             # in case.
             Datadog.logger.debug(
               "connection_id #{connection_id} does not represent a valid object. " \
-                      "Cause: #{e.message} Source: #{e.backtrace.first}"
+                      "Cause: #{e.message} Source: #{Array(e.backtrace).first}"
             )
           end
         else

--- a/lib/ddtrace/contrib/patcher.rb
+++ b/lib/ddtrace/contrib/patcher.rb
@@ -38,7 +38,7 @@ module Datadog
         # @param e [Exception]
         def on_patch_error(e)
           # Log the error
-          Datadog.logger.error("Failed to apply #{patch_name} patch. Cause: #{e} Location: #{e.backtrace.first}")
+          Datadog.logger.error("Failed to apply #{patch_name} patch. Cause: #{e} Location: #{Array(e.backtrace).first}")
 
           # Emit a metric
           tags = default_tags

--- a/lib/ddtrace/diagnostics/environment_logger.rb
+++ b/lib/ddtrace/diagnostics/environment_logger.rb
@@ -22,7 +22,7 @@ module Datadog
           log_environment!(data.to_json)
           log_error!('Agent Error'.freeze, data[:agent_error]) if data[:agent_error]
         rescue => e
-          Datadog.logger.warn("Failed to collect environment information: #{e} location: #{e.backtrace.first}")
+          Datadog.logger.warn("Failed to collect environment information: #{e} Location: #{Array(e.backtrace).first}")
         end
 
         private

--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -88,7 +88,7 @@ module Datadog
 
       statsd.count(stat, value, metric_options(options))
     rescue StandardError => e
-      Datadog.logger.error("Failed to send count stat. Cause: #{e.message} Source: #{e.backtrace.first}")
+      Datadog.logger.error("Failed to send count stat. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
     end
 
     def distribution(stat, value = nil, options = nil, &block)
@@ -99,7 +99,7 @@ module Datadog
 
       statsd.distribution(stat, value, metric_options(options))
     rescue StandardError => e
-      Datadog.logger.error("Failed to send distribution stat. Cause: #{e.message} Source: #{e.backtrace.first}")
+      Datadog.logger.error("Failed to send distribution stat. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
     end
 
     def increment(stat, options = nil)
@@ -109,7 +109,7 @@ module Datadog
 
       statsd.increment(stat, metric_options(options))
     rescue StandardError => e
-      Datadog.logger.error("Failed to send increment stat. Cause: #{e.message} Source: #{e.backtrace.first}")
+      Datadog.logger.error("Failed to send increment stat. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
     end
 
     def gauge(stat, value = nil, options = nil, &block)
@@ -120,7 +120,7 @@ module Datadog
 
       statsd.gauge(stat, value, metric_options(options))
     rescue StandardError => e
-      Datadog.logger.error("Failed to send gauge stat. Cause: #{e.message} Source: #{e.backtrace.first}")
+      Datadog.logger.error("Failed to send gauge stat. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
     end
 
     def time(stat, options = nil)
@@ -136,7 +136,7 @@ module Datadog
           distribution(stat, ((finished - start) * 1000), options)
         end
       rescue StandardError => e
-        Datadog.logger.error("Failed to send time stat. Cause: #{e.message} Source: #{e.backtrace.first}")
+        Datadog.logger.error("Failed to send time stat. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
       end
     end
 

--- a/lib/ddtrace/profiling/scheduler.rb
+++ b/lib/ddtrace/profiling/scheduler.rb
@@ -103,7 +103,7 @@ module Datadog
               exporter.export(flush)
             rescue StandardError => e
               Datadog.logger.error(
-                "Unable to export #{flush.event_count} profiling events. Cause: #{e} Location: #{e.backtrace.first}"
+                "Unable to export #{flush.event_count} profiling events. Cause: #{e} Location: #{Array(e.backtrace).first}"
               )
             end
           end

--- a/lib/ddtrace/profiling/tasks/setup.rb
+++ b/lib/ddtrace/profiling/tasks/setup.rb
@@ -18,7 +18,9 @@ module Datadog
               activate_cpu_extensions
               setup_at_fork_hooks
             rescue StandardError, ScriptError => e
-              Datadog.logger.warn { "Profiler extensions unavailable. Cause: #{e.message} Location: #{e.backtrace.first}" }
+              Datadog.logger.warn do
+                "Profiler extensions unavailable. Cause: #{e.message} Location: #{Array(e.backtrace).first}"
+              end
             end
           end
         end
@@ -33,7 +35,7 @@ module Datadog
           end
         rescue StandardError, ScriptError => e
           Datadog.logger.warn do
-            "Profiler forking extensions unavailable. Cause: #{e.message} Location: #{e.backtrace.first}"
+            "Profiler forking extensions unavailable. Cause: #{e.message} Location: #{Array(e.backtrace).first}"
           end
         end
 
@@ -48,7 +50,7 @@ module Datadog
           end
         rescue StandardError, ScriptError => e
           Datadog.logger.warn do
-            "Profiler CPU profiling extensions unavailable. Cause: #{e.message} Location: #{e.backtrace.first}"
+            "Profiler CPU profiling extensions unavailable. Cause: #{e.message} Location: #{Array(e.backtrace).first}"
           end
         end
 
@@ -66,7 +68,9 @@ module Datadog
                 # Restart profiler, if enabled
                 Datadog.profiler.start if Datadog.profiler
               rescue StandardError => e
-                Datadog.logger.warn { "Error during post-fork hooks. Cause: #{e.message} Location: #{e.backtrace.first}" }
+                Datadog.logger.warn do
+                  "Error during post-fork hooks. Cause: #{e.message} Location: #{Array(e.backtrace).first}"
+                end
               end
             end
           end

--- a/lib/ddtrace/propagation/http_propagator.rb
+++ b/lib/ddtrace/propagation/http_propagator.rb
@@ -31,7 +31,7 @@ module Datadog
         rescue => e
           Datadog.logger.error(
             'Error injecting propagated context into the environment. ' \
-            "Cause: #{e} Location: #{e.backtrace.first}"
+            "Cause: #{e} Location: #{Array(e.backtrace).first}"
           )
         end
       end
@@ -54,7 +54,7 @@ module Datadog
         rescue => e
           Datadog.logger.error(
             'Error extracting propagated context from the environment. ' \
-            "Cause: #{e} Location: #{e.backtrace.first}"
+            "Cause: #{e} Location: #{Array(e.backtrace).first}"
           )
         end
 

--- a/lib/ddtrace/sampling/rule.rb
+++ b/lib/ddtrace/sampling/rule.rb
@@ -28,7 +28,7 @@ module Datadog
       def match?(span)
         @matcher.match?(span)
       rescue => e
-        Datadog.logger.error("Matcher failed. Cause: #{e.message} Source: #{e.backtrace.first}")
+        Datadog.logger.error("Matcher failed. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
         nil
       end
 

--- a/lib/ddtrace/sampling/rule_sampler.rb
+++ b/lib/ddtrace/sampling/rule_sampler.rb
@@ -104,7 +104,7 @@ module Datadog
           set_limiter_metrics(span, rate_limiter.effective_rate)
         end
       rescue StandardError => e
-        Datadog.logger.error("Rule sampling failed. Cause: #{e.message} Source: #{e.backtrace.first}")
+        Datadog.logger.error("Rule sampling failed. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
         yield(span)
       end
 

--- a/lib/ddtrace/transport/http/client.rb
+++ b/lib/ddtrace/transport/http/client.rb
@@ -26,7 +26,8 @@ module Datadog
 
           response
         rescue StandardError => e
-          message = "Internal error during HTTP transport request. Cause: #{e.message} Location: #{e.backtrace.first}"
+          message =
+            "Internal error during HTTP transport request. Cause: #{e.message} Location: #{Array(e.backtrace).first}"
 
           # Log error
           if stats.consecutive_errors > 0

--- a/lib/ddtrace/transport/io/client.rb
+++ b/lib/ddtrace/transport/io/client.rb
@@ -38,7 +38,7 @@ module Datadog
           # Return response
           response
         rescue StandardError => e
-          message = "Internal error during IO transport request. Cause: #{e.message} Location: #{e.backtrace.first}"
+          message = "Internal error during IO transport request. Cause: #{e.message} Location: #{Array(e.backtrace).first}"
 
           # Log error
           if stats.consecutive_errors > 0

--- a/lib/ddtrace/workers.rb
+++ b/lib/ddtrace/workers.rb
@@ -58,7 +58,7 @@ module Datadog
           # TODO[manu]: findout the reason and reschedule the send if it's not
           # a fatal exception
           Datadog.logger.error(
-            "Error during traces flush: dropped #{traces.length} items. Cause: #{e} Location: #{e.backtrace.first}"
+            "Error during traces flush: dropped #{traces.length} items. Cause: #{e} Location: #{Array(e.backtrace).first}"
           )
         end
       end

--- a/lib/ddtrace/workers/async.rb
+++ b/lib/ddtrace/workers/async.rb
@@ -135,7 +135,7 @@ module Datadog
             # rubocop:disable Lint/RescueException
             rescue Exception => e
               @error = e
-              Datadog.logger.debug("Worker thread error. Cause #{e.message} Location: #{e.backtrace.first}")
+              Datadog.logger.debug("Worker thread error. Cause #{e.message} Location: #{Array(e.backtrace).first}")
               raise
             end
           end

--- a/lib/ddtrace/workers/trace_writer.rb
+++ b/lib/ddtrace/workers/trace_writer.rb
@@ -36,7 +36,7 @@ module Datadog
         flush_traces(traces)
       rescue StandardError => e
         Datadog.logger.error(
-          "Error while writing traces: dropped #{traces.length} items. Cause: #{e} Location: #{e.backtrace.first}"
+          "Error while writing traces: dropped #{traces.length} items. Cause: #{e} Location: #{Array(e.backtrace).first}"
         )
       end
 


### PR DESCRIPTION
I'm experimenting with adding the [sorbet](https://sorbet.org/) type checker to dd-trace-rb. Since my "adding sorbet" branch is getting quite large and will be hard to review, I've decided to break it into smaller PRs.

This PR fixes a "possible but probably not gonna happen" issue pointed by sorbet -- Ruby exceptions aren't guaranteed to have a backtrace, and thus `.first` is not guaranteed to always work.

(I wish I could've just used `e.backtrace&.first` but alas that feature is only 6 years old [2.3] so we can't use it yet 😭)