### PR TITLE
Sorbet: Set of misc clean ups to enable successful sorbet typechecking

### DIFF
--- a/benchmarks/profiler_sample_loop.rb
+++ b/benchmarks/profiler_sample_loop.rb
@@ -1,3 +1,5 @@
+return unless __FILE__ == $PROGRAM_NAME
+
 require 'benchmark/ips'
 require 'ddtrace'
 require 'pry'

--- a/benchmarks/profiler_submission.rb
+++ b/benchmarks/profiler_submission.rb
@@ -1,3 +1,5 @@
+return unless __FILE__ == $PROGRAM_NAME
+
 require 'benchmark/ips'
 require 'ddtrace'
 require 'pry'

--- a/lib/ddtrace/profiling.rb
+++ b/lib/ddtrace/profiling.rb
@@ -4,19 +4,17 @@ require 'ddtrace/utils/only_once'
 module Datadog
   # Contains profiler for generating stack profiles, etc.
   module Profiling # rubocop:disable Metrics/ModuleLength
-    module_function
-
     GOOGLE_PROTOBUF_MINIMUM_VERSION = Gem::Version.new('3.0')
     private_constant :GOOGLE_PROTOBUF_MINIMUM_VERSION
 
     SKIPPED_NATIVE_EXTENSION_ONLY_ONCE = Datadog::Utils::OnlyOnce.new
     private_constant :SKIPPED_NATIVE_EXTENSION_ONLY_ONCE
 
-    def supported?
+    def self.supported?
       unsupported_reason.nil?
     end
 
-    def unsupported_reason
+    def self.unsupported_reason
       # NOTE: Only the first matching reason is returned, so try to keep a nice order on reasons -- e.g. tell users
       # first that they can't use this on JRuby before telling them that they are missing protobuf
 
@@ -27,12 +25,11 @@ module Datadog
         protobuf_failed_to_load?
     end
 
-    def self.ruby_engine_unsupported?
+    private_class_method def self.ruby_engine_unsupported?
       'JRuby is not supported' if RUBY_ENGINE == 'jruby'
     end
-    private_class_method :ruby_engine_unsupported?
 
-    def self.protobuf_gem_unavailable?
+    private_class_method def self.protobuf_gem_unavailable?
       # NOTE: On environments where protobuf is already loaded, we skip the check. This allows us to support environments
       # where no Gem.loaded_version is NOT available but customers are able to load protobuf; see for instance
       # https://github.com/teamcapybara/capybara/commit/caf3bcd7664f4f2691d0ca9ef3be9a2a954fecfb
@@ -40,9 +37,8 @@ module Datadog
         "Missing google-protobuf dependency; please add `gem 'google-protobuf', '~> 3.0'` to your Gemfile or gems.rb file"
       end
     end
-    private_class_method :protobuf_gem_unavailable?
 
-    def self.protobuf_version_unsupported?
+    private_class_method def self.protobuf_version_unsupported?
       # See above for why we skip the check when protobuf is already loaded; note that when protobuf was already loaded
       # we skip the version check to avoid the call to Gem.loaded_specs. Unfortunately, protobuf does not seem to
       # expose the gem version constant elsewhere, so in that setup we are not able to check the version.
@@ -51,14 +47,12 @@ module Datadog
         "adding `gem 'google-protobuf', '~> 3.0'` to your Gemfile or gems.rb file"
       end
     end
-    private_class_method :protobuf_version_unsupported?
 
-    def self.protobuf_failed_to_load?
+    private_class_method def self.protobuf_failed_to_load?
       unless protobuf_loaded_successfully?
         'There was an error loading the google-protobuf library; see previous warning message for details'
       end
     end
-    private_class_method :protobuf_failed_to_load?
 
     # The `google-protobuf` gem depends on a native component, and its creators helpfully tried to provide precompiled
     # versions of this extension on rubygems.org.
@@ -69,7 +63,7 @@ module Datadog
     #
     # Thus, the gem can still be installed, but can be in a broken state. To avoid breaking customer applications, we
     # use this helper to load it and gracefully handle failures.
-    def self.protobuf_loaded_successfully?
+    private_class_method def self.protobuf_loaded_successfully?
       return @protobuf_loaded if defined?(@protobuf_loaded)
 
       begin
@@ -79,7 +73,8 @@ module Datadog
         # NOTE: We use Kernel#warn here because this code gets run BEFORE Datadog.logger is actually set up.
         # In the future it'd be nice to shuffle the logger startup to happen first to avoid this special case.
         Kernel.warn(
-          "[DDTRACE] Error while loading google-protobuf gem. Cause: '#{e.message}' Location: '#{e.backtrace.first}'. " \
+          '[DDTRACE] Error while loading google-protobuf gem. ' \
+          "Cause: '#{e.message}' Location: '#{Array(e.backtrace).first}'. " \
           'This can happen when google-protobuf is missing its native components. ' \
           'To fix this, try removing and reinstalling the gem, forcing it to recompile the components: ' \
           '`gem uninstall google-protobuf -a; BUNDLE_FORCE_RUBY_PLATFORM=true bundle install`. ' \
@@ -89,7 +84,6 @@ module Datadog
         @protobuf_loaded = false
       end
     end
-    private_class_method :protobuf_loaded_successfully?
 
     private_class_method def self.native_library_failed_to_load?
       success, exception = try_loading_native_library
@@ -130,7 +124,7 @@ module Datadog
       end
     end
 
-    def self.load_profiling
+    private_class_method def self.load_profiling
       return false unless supported?
 
       require 'ddtrace/profiling/ext/cpu'
@@ -150,7 +144,6 @@ module Datadog
 
       true
     end
-    private_class_method :load_profiling
 
     load_profiling if supported?
   end

--- a/lib/ddtrace/profiling/ext/cpu.rb
+++ b/lib/ddtrace/profiling/ext/cpu.rb
@@ -58,8 +58,7 @@ module Datadog
           # Here we check if the behavior is enabled
           inherit_context_configuration = ENV['LOGGING_INHERIT_CONTEXT']
 
-          inherit_context_configuration.nil? ||
-          (inherit_context_configuration && !%w[false no 0].include?(inherit_context_configuration.downcase))
+          inherit_context_configuration.nil? || !%w[false no 0].include?(inherit_context_configuration.downcase)
         end
       end
     end

--- a/lib/ddtrace/profiling/pprof/message_set.rb
+++ b/lib/ddtrace/profiling/pprof/message_set.rb
@@ -5,7 +5,9 @@ module Datadog
     module Pprof
       # Acts as a unique dictionary of protobuf messages
       class MessageSet < Utils::ObjectSet
-        alias_method :messages, :objects
+        def messages
+          objects
+        end
       end
     end
   end

--- a/lib/ddtrace/profiling/pprof/payload.rb
+++ b/lib/ddtrace/profiling/pprof/payload.rb
@@ -4,7 +4,7 @@ module Datadog
       # Pprof output data.
       # Includes encoded data and list of types.
       Payload = Struct.new(:data, :types) do
-        def initialize(*args)
+        def initialize(data, types)
           super
           self.types = types || []
         end

--- a/lib/ddtrace/profiling/transport/http.rb
+++ b/lib/ddtrace/profiling/transport/http.rb
@@ -110,9 +110,9 @@ module Datadog
         end
 
         # Add adapters to registry
-        Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::Net, :net_http)
-        Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::Test, :test)
-        Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::UnixSocket, :unix)
+        Datadog::Transport::HTTP::Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::Net, :net_http)
+        Datadog::Transport::HTTP::Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::Test, :test)
+        Datadog::Transport::HTTP::Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::UnixSocket, :unix)
       end
     end
   end

--- a/lib/ddtrace/profiling/transport/http.rb
+++ b/lib/ddtrace/profiling/transport/http.rb
@@ -16,15 +16,13 @@ module Datadog
     module Transport
       # Namespace for HTTP transport components
       module HTTP
-        module_function
-
         # Builds a new Transport::HTTP::Client
-        def new(&block)
+        def self.new(&block)
           Builder.new(&block).to_transport
         end
 
         # Builds a new Transport::HTTP::Client with default settings
-        def default(
+        def self.default(
           profiling_upload_timeout_seconds:,
           agent_settings:,
           site: nil,
@@ -52,7 +50,7 @@ module Datadog
           end
         end
 
-        def default_headers
+        def self.default_headers
           {
             Datadog::Ext::Transport::HTTP::HEADER_META_LANG => Core::Environment::Ext::LANG,
             Datadog::Ext::Transport::HTTP::HEADER_META_LANG_VERSION => Core::Environment::Ext::LANG_VERSION,
@@ -65,11 +63,11 @@ module Datadog
           end
         end
 
-        private_class_method def default_adapter
+        private_class_method def self.default_adapter
           :net_http
         end
 
-        private_class_method def configure_for_agent(transport, profiling_upload_timeout_seconds:, agent_settings:)
+        private_class_method def self.configure_for_agent(transport, profiling_upload_timeout_seconds:, agent_settings:)
           apis = API.agent_defaults
 
           transport.adapter(
@@ -89,7 +87,7 @@ module Datadog
           end
         end
 
-        private_class_method def configure_for_agentless(transport, profiling_upload_timeout_seconds:, site:, api_key:)
+        private_class_method def self.configure_for_agentless(transport, profiling_upload_timeout_seconds:, site:, api_key:)
           apis = API.api_defaults
 
           site_uri = URI(format(Datadog::Ext::Profiling::Transport::HTTP::URI_TEMPLATE_DD_API, site))
@@ -107,7 +105,7 @@ module Datadog
           transport.headers(Datadog::Ext::Transport::HTTP::HEADER_DD_API_KEY => api_key)
         end
 
-        private_class_method def agentless_allowed?
+        private_class_method def self.agentless_allowed?
           Datadog::Core::Environment::VariableHelpers.env_to_bool(Datadog::Ext::Profiling::ENV_AGENTLESS, false)
         end
 

--- a/lib/ddtrace/tasks/exec.rb
+++ b/lib/ddtrace/tasks/exec.rb
@@ -22,11 +22,9 @@ module Datadog
       private
 
       def set_rubyopt!
-        if ENV.key?('RUBYOPT')
-          ENV['RUBYOPT'] += " #{rubyopts.join(' ')}"
-        else
-          ENV['RUBYOPT'] = rubyopts.join(' ')
-        end
+        existing_rubyopt = ENV['RUBYOPT']
+
+        ENV['RUBYOPT'] = existing_rubyopt ? "#{existing_rubyopt} #{rubyopts.join(' ')}" : rubyopts.join(' ')
       end
 
       # If there's an error here, rather than throwing a cryptic stack trace, let's instead have clearer messages, and

--- a/lib/ddtrace/transport/traces.rb
+++ b/lib/ddtrace/transport/traces.rb
@@ -7,7 +7,7 @@ module Datadog
     module Traces
       # Data transfer object for encoded traces
       class EncodedParcel
-        include Transport::Parcel
+        include Datadog::Transport::Parcel
 
         attr_reader :trace_count
 
@@ -22,7 +22,7 @@ module Datadog
       end
 
       # Traces request
-      class Request < Transport::Request
+      class Request < Datadog::Transport::Request
       end
 
       # Traces response

--- a/spec/ddtrace/benchmark/gem_loading_spec.rb
+++ b/spec/ddtrace/benchmark/gem_loading_spec.rb
@@ -6,7 +6,7 @@ unless PlatformHelpers.jruby?
 end
 
 RSpec.describe 'Gem loading' do
-  def subject
+  def run_ruby
     `ruby -e #{Shellwords.escape(load_path + program + flush_output)}`
   end
 
@@ -31,7 +31,7 @@ RSpec.describe 'Gem loading' do
   end
 
   let(:iterations) { 30 }
-  let(:benchmark) { iterations.times.reduce(0) { |acc, _| acc + subject.to_f } }
+  let(:benchmark) { iterations.times.reduce(0) { |acc, _| acc + run_ruby.to_f } }
   let(:report_average) { benchmark / iterations }
 
   context 'timing' do
@@ -57,7 +57,7 @@ RSpec.describe 'Gem loading' do
       RUBY
     end
 
-    def subject
+    def run_ruby
       output = super()
 
       before, after = output.split
@@ -92,7 +92,7 @@ RSpec.describe 'Gem loading' do
     it 'memory report' do
       skip("'benchmark/memory' not supported") if PlatformHelpers.jruby?
 
-      puts subject
+      puts run_ruby
     end
   end
 end

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe 'profiling integration test' do
     # we want the method names on the resulting stacks to be stack_one or
     # stack_two, not block in ... when showing up in the stack traces
     def stack_one
-      @stack_one ||= Thread.current.backtrace_locations[1..3]
+      @stack_one ||= Array(Thread.current.backtrace_locations)[1..3]
     end
 
     def stack_two
-      @stack_two ||= Thread.current.backtrace_locations[1..3]
+      @stack_two ||= Array(Thread.current.backtrace_locations)[1..3]
     end
 
     let(:trace_id) { 0 }

--- a/spec/ddtrace/profiling/spec_helper.rb
+++ b/spec/ddtrace/profiling/spec_helper.rb
@@ -1,6 +1,8 @@
 require 'ddtrace/profiling'
 
 module ProfilingFeatureHelpers
+  include Kernel
+
   # Stubs Ruby classes before applying profiling patches.
   # This allows original, pristine classes to be restored after the test.
   RSpec.shared_context 'with profiling extensions' do
@@ -35,9 +37,11 @@ module ProfilingFeatureHelpers
 end
 
 module ProfileHelpers
+  include Kernel
+
   def get_test_profiling_flush
-    stack_one = Thread.current.backtrace_locations.first(3)
-    stack_two = Thread.current.backtrace_locations.first(3)
+    stack_one = Array(Thread.current.backtrace_locations).first(3)
+    stack_two = Array(Thread.current.backtrace_locations).first(3)
 
     stack_samples = [
       build_stack_sample(stack_one, 100, 0, 0, 100, 100),


### PR DESCRIPTION
I'm experimenting with adding the [sorbet](https://sorbet.org/) type checker to dd-trace-rb. Since my "adding sorbet" branch is getting quite large and will be hard to review, I've decided to break it into smaller PRs.

This PR contains a bunch of small code changes that semantically are expected to be equivalent, but that make it easy for sorbet to typecheck the affected files.

While I'm not the biggest fan of "just do whatevs to make the tool happy", I think most of these changes are quite reasonable and do make the code easier to understand for humans as well, so I think they're an overall win.

I suggest reviewing this PR commit-by-commit, as I've added context to every message.