### PR TITLE
Sorbet: Include Kernel module to disambiguate from usage in BasicObject 

### DIFF
--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -10,7 +10,7 @@ module Datadog
       # Defines constants for CI tags
       # rubocop:disable Metrics/ModuleLength:
       module Environment
-        include Kernel
+        include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
 
         TAG_JOB_NAME = 'ci.job.name'
         TAG_JOB_URL = 'ci.job.url'

--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -10,6 +10,8 @@ module Datadog
       # Defines constants for CI tags
       # rubocop:disable Metrics/ModuleLength:
       module Environment
+        include Kernel
+
         TAG_JOB_NAME = 'ci.job.name'
         TAG_JOB_URL = 'ci.job.url'
         TAG_PIPELINE_ID = 'ci.pipeline.id'

--- a/lib/datadog/core/environment/cgroup.rb
+++ b/lib/datadog/core/environment/cgroup.rb
@@ -8,7 +8,7 @@ module Datadog
       # about the current Linux container identity.
       # @see https://man7.org/linux/man-pages/man7/cgroups.7.html
       module Cgroup
-        include Kernel
+        include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
 
         LINE_REGEX = /^(\d+):([^:]*):(.+)$/.freeze
 

--- a/lib/datadog/core/environment/cgroup.rb
+++ b/lib/datadog/core/environment/cgroup.rb
@@ -8,6 +8,8 @@ module Datadog
       # about the current Linux container identity.
       # @see https://man7.org/linux/man-pages/man7/cgroups.7.html
       module Cgroup
+        include Kernel
+
         LINE_REGEX = /^(\d+):([^:]*):(.+)$/.freeze
 
         Descriptor = Struct.new(

--- a/lib/datadog/core/environment/container.rb
+++ b/lib/datadog/core/environment/container.rb
@@ -5,7 +5,7 @@ module Datadog
     module Environment
       # For container environments
       module Container
-        include Kernel
+        include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
 
         UUID_PATTERN = '[0-9a-f]{8}[-_]?[0-9a-f]{4}[-_]?[0-9a-f]{4}[-_]?[0-9a-f]{4}[-_]?[0-9a-f]{12}'.freeze
         CONTAINER_PATTERN = '[0-9a-f]{64}'.freeze

--- a/lib/datadog/core/environment/container.rb
+++ b/lib/datadog/core/environment/container.rb
@@ -5,6 +5,8 @@ module Datadog
     module Environment
       # For container environments
       module Container
+        include Kernel
+
         UUID_PATTERN = '[0-9a-f]{8}[-_]?[0-9a-f]{4}[-_]?[0-9a-f]{4}[-_]?[0-9a-f]{4}[-_]?[0-9a-f]{12}'.freeze
         CONTAINER_PATTERN = '[0-9a-f]{64}'.freeze
 

--- a/lib/ddtrace/buffer.rb
+++ b/lib/ddtrace/buffer.rb
@@ -213,6 +213,8 @@ module Datadog
 
   # Health metrics for trace buffers.
   module MeasuredBuffer
+    include Kernel
+
     def initialize(*_)
       super
 

--- a/lib/ddtrace/buffer.rb
+++ b/lib/ddtrace/buffer.rb
@@ -213,7 +213,7 @@ module Datadog
 
   # Health metrics for trace buffers.
   module MeasuredBuffer
-    include Kernel
+    include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
 
     def initialize(*_)
       super

--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -6,7 +6,7 @@ require 'ddtrace/configuration/components'
 module Datadog
   # Configuration provides a unique access point for configurations
   module Configuration # rubocop:disable Metrics/ModuleLength
-    include Kernel
+    include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
     extend Forwardable
 
     # Used to ensure that @components initialization/reconfiguration is performed one-at-a-time, by a single thread.

--- a/lib/ddtrace/configuration.rb
+++ b/lib/ddtrace/configuration.rb
@@ -6,6 +6,7 @@ require 'ddtrace/configuration/components'
 module Datadog
   # Configuration provides a unique access point for configurations
   module Configuration # rubocop:disable Metrics/ModuleLength
+    include Kernel
     extend Forwardable
 
     # Used to ensure that @components initialization/reconfiguration is performed one-at-a-time, by a single thread.

--- a/lib/ddtrace/contrib/concurrent_ruby/patcher.rb
+++ b/lib/ddtrace/contrib/concurrent_ruby/patcher.rb
@@ -5,6 +5,7 @@ module Datadog
     module ConcurrentRuby
       # Patcher enables patching of 'Future' class.
       module Patcher
+        include Kernel
         include Contrib::Patcher
 
         module_function

--- a/lib/ddtrace/contrib/concurrent_ruby/patcher.rb
+++ b/lib/ddtrace/contrib/concurrent_ruby/patcher.rb
@@ -5,7 +5,7 @@ module Datadog
     module ConcurrentRuby
       # Patcher enables patching of 'Future' class.
       module Patcher
-        include Kernel
+        include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
         include Contrib::Patcher
 
         module_function

--- a/lib/ddtrace/contrib/elasticsearch/quantize.rb
+++ b/lib/ddtrace/contrib/elasticsearch/quantize.rb
@@ -3,6 +3,8 @@ module Datadog
     module Elasticsearch
       # Quantize contains ES-specific resource quantization tools.
       module Quantize
+        include Kernel
+
         PLACEHOLDER = '?'.freeze
         ID_PLACEHOLDER = '\1?'.freeze
         EXCLUDE_KEYS = [].freeze

--- a/lib/ddtrace/contrib/elasticsearch/quantize.rb
+++ b/lib/ddtrace/contrib/elasticsearch/quantize.rb
@@ -3,7 +3,7 @@ module Datadog
     module Elasticsearch
       # Quantize contains ES-specific resource quantization tools.
       module Quantize
-        include Kernel
+        include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
 
         PLACEHOLDER = '?'.freeze
         ID_PLACEHOLDER = '\1?'.freeze

--- a/lib/ddtrace/contrib/ethon/patcher.rb
+++ b/lib/ddtrace/contrib/ethon/patcher.rb
@@ -3,7 +3,7 @@ module Datadog
     module Ethon
       # Patcher enables patching of 'ethon' module.
       module Patcher
-        include Kernel
+        include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
         include Contrib::Patcher
 
         module_function

--- a/lib/ddtrace/contrib/ethon/patcher.rb
+++ b/lib/ddtrace/contrib/ethon/patcher.rb
@@ -3,6 +3,7 @@ module Datadog
     module Ethon
       # Patcher enables patching of 'ethon' module.
       module Patcher
+        include Kernel
         include Contrib::Patcher
 
         module_function

--- a/lib/ddtrace/contrib/grpc/patcher.rb
+++ b/lib/ddtrace/contrib/grpc/patcher.rb
@@ -6,6 +6,7 @@ module Datadog
     module GRPC
       # Patcher enables patching of 'grpc' module.
       module Patcher
+        include Kernel
         include Contrib::Patcher
 
         module_function

--- a/lib/ddtrace/contrib/grpc/patcher.rb
+++ b/lib/ddtrace/contrib/grpc/patcher.rb
@@ -6,7 +6,7 @@ module Datadog
     module GRPC
       # Patcher enables patching of 'grpc' module.
       module Patcher
-        include Kernel
+        include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
         include Contrib::Patcher
 
         module_function

--- a/lib/ddtrace/contrib/qless/patcher.rb
+++ b/lib/ddtrace/contrib/qless/patcher.rb
@@ -6,6 +6,7 @@ module Datadog
     module Qless
       # Patcher enables patching of 'qless' module.
       module Patcher
+        include Kernel
         include Contrib::Patcher
 
         module_function

--- a/lib/ddtrace/contrib/qless/patcher.rb
+++ b/lib/ddtrace/contrib/qless/patcher.rb
@@ -6,7 +6,7 @@ module Datadog
     module Qless
       # Patcher enables patching of 'qless' module.
       module Patcher
-        include Kernel
+        include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
         include Contrib::Patcher
 
         module_function

--- a/lib/ddtrace/contrib/rest_client/patcher.rb
+++ b/lib/ddtrace/contrib/rest_client/patcher.rb
@@ -3,7 +3,7 @@ module Datadog
     module RestClient
       # Patcher enables patching of 'rest_client' module.
       module Patcher
-        include Kernel
+        include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
         include Contrib::Patcher
 
         module_function

--- a/lib/ddtrace/contrib/rest_client/patcher.rb
+++ b/lib/ddtrace/contrib/rest_client/patcher.rb
@@ -3,6 +3,7 @@ module Datadog
     module RestClient
       # Patcher enables patching of 'rest_client' module.
       module Patcher
+        include Kernel
         include Contrib::Patcher
 
         module_function

--- a/lib/ddtrace/contrib/sinatra/patcher.rb
+++ b/lib/ddtrace/contrib/sinatra/patcher.rb
@@ -5,7 +5,7 @@ module Datadog
     module Sinatra
       # Patcher enables patching of 'sinatra' module.
       module Patcher
-        include Kernel
+        include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
         include Contrib::Patcher
 
         module_function

--- a/lib/ddtrace/contrib/sinatra/patcher.rb
+++ b/lib/ddtrace/contrib/sinatra/patcher.rb
@@ -5,6 +5,7 @@ module Datadog
     module Sinatra
       # Patcher enables patching of 'sinatra' module.
       module Patcher
+        include Kernel
         include Contrib::Patcher
 
         module_function

--- a/lib/ddtrace/contrib/sucker_punch/patcher.rb
+++ b/lib/ddtrace/contrib/sucker_punch/patcher.rb
@@ -7,7 +7,7 @@ module Datadog
     module SuckerPunch
       # Patcher enables patching of 'sucker_punch' module.
       module Patcher
-        include Kernel
+        include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
         include Contrib::Patcher
 
         module_function

--- a/lib/ddtrace/contrib/sucker_punch/patcher.rb
+++ b/lib/ddtrace/contrib/sucker_punch/patcher.rb
@@ -7,6 +7,7 @@ module Datadog
     module SuckerPunch
       # Patcher enables patching of 'sucker_punch' module.
       module Patcher
+        include Kernel
         include Contrib::Patcher
 
         module_function

--- a/lib/ddtrace/encoding.rb
+++ b/lib/ddtrace/encoding.rb
@@ -6,6 +6,8 @@ module Datadog
   module Encoding
     # Encoder interface that provides the logic to encode traces and service
     module Encoder
+      include Kernel
+
       def content_type
         raise NotImplementedError
       end

--- a/lib/ddtrace/encoding.rb
+++ b/lib/ddtrace/encoding.rb
@@ -6,7 +6,7 @@ module Datadog
   module Encoding
     # Encoder interface that provides the logic to encode traces and service
     module Encoder
-      include Kernel
+      include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
 
       def content_type
         raise NotImplementedError

--- a/lib/ddtrace/profiling/transport/client.rb
+++ b/lib/ddtrace/profiling/transport/client.rb
@@ -3,7 +3,7 @@ module Datadog
     module Transport
       # Generic interface for profiling transports
       module Client
-        include Kernel
+        include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
 
         def send_profiling_flush(flush)
           raise NotImplementedError

--- a/lib/ddtrace/profiling/transport/client.rb
+++ b/lib/ddtrace/profiling/transport/client.rb
@@ -3,6 +3,8 @@ module Datadog
     module Transport
       # Generic interface for profiling transports
       module Client
+        include Kernel
+
         def send_profiling_flush(flush)
           raise NotImplementedError
         end

--- a/lib/ddtrace/quantization/http.rb
+++ b/lib/ddtrace/quantization/http.rb
@@ -5,6 +5,8 @@ module Datadog
   module Quantization
     # Quantization for HTTP resources
     module HTTP
+      include Kernel
+
       PLACEHOLDER = '?'.freeze
 
       module_function

--- a/lib/ddtrace/quantization/http.rb
+++ b/lib/ddtrace/quantization/http.rb
@@ -5,7 +5,7 @@ module Datadog
   module Quantization
     # Quantization for HTTP resources
     module HTTP
-      include Kernel
+      include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
 
       PLACEHOLDER = '?'.freeze
 

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -16,7 +16,7 @@ module Datadog
   module Transport
     # Namespace for HTTP transport components
     module HTTP
-      include Kernel
+      include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
 
       module_function
 

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -16,6 +16,8 @@ module Datadog
   module Transport
     # Namespace for HTTP transport components
     module HTTP
+      include Kernel
+
       module_function
 
       # Builds a new Transport::HTTP::Client

--- a/lib/ddtrace/transport/io/traces.rb
+++ b/lib/ddtrace/transport/io/traces.rb
@@ -20,6 +20,8 @@ module Datadog
 
         # Extensions for HTTP client
         module Client
+          include Kernel
+
           def send_traces(traces)
             # Build a request
             req = Transport::Traces::Request.new(Parcel.new(traces))

--- a/lib/ddtrace/transport/io/traces.rb
+++ b/lib/ddtrace/transport/io/traces.rb
@@ -20,7 +20,7 @@ module Datadog
 
         # Extensions for HTTP client
         module Client
-          include Kernel
+          include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
 
           def send_traces(traces)
             # Build a request

--- a/lib/ddtrace/transport/parcel.rb
+++ b/lib/ddtrace/transport/parcel.rb
@@ -2,7 +2,7 @@ module Datadog
   module Transport
     # Data transfer object for generic data
     module Parcel
-      include Kernel
+      include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
 
       attr_reader \
         :data

--- a/lib/ddtrace/transport/parcel.rb
+++ b/lib/ddtrace/transport/parcel.rb
@@ -2,6 +2,8 @@ module Datadog
   module Transport
     # Data transfer object for generic data
     module Parcel
+      include Kernel
+
       attr_reader \
         :data
 

--- a/lib/ddtrace/utils/time.rb
+++ b/lib/ddtrace/utils/time.rb
@@ -2,6 +2,8 @@ module Datadog
   module Utils
     # Common database-related utility functions.
     module Time
+      include Kernel
+
       module_function
 
       # Current monotonic time.

--- a/lib/ddtrace/utils/time.rb
+++ b/lib/ddtrace/utils/time.rb
@@ -2,7 +2,7 @@ module Datadog
   module Utils
     # Common database-related utility functions.
     module Time
-      include Kernel
+      include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
 
       module_function
 


### PR DESCRIPTION
I'm experimenting with adding the [sorbet](https://sorbet.org/) type checker to dd-trace-rb. Since my "adding sorbet" branch is getting quite large and will be hard to review, I've decided to break it into smaller PRs.

As pointed out in <https://sorbet.org/docs/error-reference#7003> (case number 5), there's nothing stopping our `Module`s from being `include`d in Ruby `BasicObject` instances.

Thus, Sorbet points out that `Module`s can't assume that they can use methods in `Object` and `Kernel`, because they aren't present in `BasicObject`s.

Of course that's not how we're using them right now, but Sorbet complains anyway that this may be problematic.

I've thus fixed many such issues pointed out by Sorbet by adding `include Kernel` to our modules. I did not fix all of them, as other files I tried to modify were failing type checks for other reasons, so I decided to leave them alone for now.

(Note: This PR has a trivially-fixable conflict with #1601 due to the addition of `# rubocop:disable Metrics/ModuleLength` in `configuration.rb`. Sigh, I really dislike our current rubocop configuration.)