### PR TITLE
Workaround truffleruby-head CI testing performance issue by disabling code coverage

### DIFF
--- a/.github/workflows/test-head.yaml
+++ b/.github/workflows/test-head.yaml
@@ -7,6 +7,9 @@ jobs:
       matrix:
         ruby: [head, jruby-head, truffleruby-head]
     runs-on: ubuntu-latest
+    env:
+      SKIP_SIMPLECOV: 1
+      JRUBY_OPTS: --dev
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@77ca66ce2792fb05b8b204a203328e12593a64f3 # v1.72.1


### PR DESCRIPTION
Recently, our truffleruby-head CI tests have been taking a long while to run. I've tracked it down to a performance  regression related to code coverage, and reported it upstream as <https://github.com/oracle/truffleruby/issues/2407>.

Since in our "truffleruby-head" tests we don't care about code coverage (we use CircleCI for that), I've also gone ahead and disabled coverage calculation for all of the "Test unstable" github action.

While I was in the "make this github action faster" neighborhood, I've also added `JRUBY_OPTS=--dev` that makes JRuby go faster in test environments (avoids trying to optimize code that's not going to be executed for long). It's otherwise completely unrelated.

https://github.com/DataDog/dd-trace-rb/runs/3143318972?check_suite_focus=true shows show the GitHub action is back to working fine.

Note: CircleCI is broken for master due to unrelated issues (some issue with caching leading it not to get the correct rubocop version).