### PR TITLE
CI:Add Gemfile.lock to avoid mismatch cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,8 +105,8 @@ save_bundle_checksum: &save_bundle_checksum
     name: Save current bundle checksum alongside cached gems
     command: |
       if [ "$CI_BUNDLE_CACHE_HIT" != 1 ]; then
-        # Recompute gemfiles/*.lock checksum, as it might have changed.
-        cat Gemfile Appraisals gemfiles/*.gemfile.lock | md5sum > .circleci/bundle_checksum
+        # Recompute gemfiles/*.lock checksum, as those files might have changed
+        cat Gemfile Gemfile.lock Appraisals gemfiles/*.gemfile.lock | md5sum > .circleci/bundle_checksum
       fi
       cp .circleci/bundle_checksum /usr/local/bundle/bundle_checksum
 step_bundle_install: &step_bundle_install
@@ -144,7 +144,7 @@ step_compute_bundle_checksum: &step_compute_bundle_checksum
     # updating the gemset lock files produces extremely large commits.
     command: |
       bundle lock # Create Gemfile.lock
-      cat Gemfile Appraisals gemfiles/*.gemfile.lock | md5sum > .circleci/bundle_checksum
+      cat Gemfile Gemfile.lock Appraisals gemfiles/*.gemfile.lock | md5sum > .circleci/bundle_checksum
 step_run_all_tests: &step_run_all_tests
   run:
     name: Run tests


### PR DESCRIPTION
The `Gemfile.lock` was missing from the cache key causing [errors like this in CI](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/3946/workflows/769ae5e9-3eff-4120-ad0f-68b2ffd84b60/jobs/152200):
```
Could not find rubocop-1.18.4 in any of the sources
Run `bundle install` to install missing gems.
```

The contents of `Gemfile.lock` weren't used for cache key in the past because they weren't available before `bundle install`, which defeats the purpose of restoring the cache to avoid installing all gems.

We've more recently started using `bundle lock` to only generate the lock file, but not install all gems. This allows us to now have a lock file before fetching all remote gems.