### PR TITLE
Fix test time zones

### DIFF
--- a/spec/ddtrace/opentracer/tracer_integration_spec.rb
+++ b/spec/ddtrace/opentracer/tracer_integration_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Datadog::OpenTracer::Tracer do
 
         context 'when given start_time' do
           let(:options) { { start_time: start_time } }
-          let(:start_time) { Time.new(2000, 1, 1) }
+          let(:start_time) { Time.utc(2000, 1, 1) }
 
           it { expect(datadog_span.start_time).to be(start_time) }
         end
@@ -191,7 +191,7 @@ RSpec.describe Datadog::OpenTracer::Tracer do
 
         context 'when given start_time' do
           let(:options) { { start_time: start_time } }
-          let(:start_time) { Time.new(2000, 1, 1) }
+          let(:start_time) { Time.utc(2000, 1, 1) }
 
           it { expect(datadog_span.start_time).to be(start_time) }
         end

--- a/spec/ddtrace/profiling/encoding/profile_spec.rb
+++ b/spec/ddtrace/profiling/encoding/profile_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe Datadog::Profiling::Encoding::Profile::Protobuf do
         instance_double(
           Datadog::Profiling::Flush,
           event_groups: event_groups,
-          start: Time.new(2020).utc,
-          finish: Time.new(2021).utc,
+          start: Time.utc(2020),
+          finish: Time.utc(2021),
           event_count: 42
         )
       end

--- a/spec/ddtrace/span_spec.rb
+++ b/spec/ddtrace/span_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe Datadog::Span do
 
       after { Datadog.configuration.reset! }
 
-      let(:time_now) { ::Time.new(2020, 1, 1) }
+      let(:time_now) { ::Time.utc(2020, 1, 1) }
 
       it 'sets the start time to the provider time' do
         span.start


### PR DESCRIPTION
Some of our tests do not reliably set a time zone for their time objects.

The only truly offending test today is:
```
  1) Datadog::Profiling::Encoding::Profile::Protobuf::encode debug logging debug logs profile information
     Failure/Error: expect(message.call).to include '2020-01-01T00:00:00Z'
       expected "Encoding profile covering 2020-01-01T08:00:00Z to 2021-01-01T08:00:00Z, events: 42 (template_debug_statistics)" to include "2020-01-01T00:00:00Z"
     # ./spec/ddtrace/profiling/encoding/profile_spec.rb:54:in `block (5 levels) in <top (required)>'
     # ./lib/ddtrace/profiling/encoding/profile.rb:25:in `encode'
     # ./spec/ddtrace/profiling/encoding/profile_spec.rb:8:in `block (3 levels) in <top (required)>'
     # ./spec/ddtrace/profiling/encoding/profile_spec.rb:59:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:202:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:95:in `block (2 levels) in <top (required)>'
```
This happens because my laptop's timezone is not UTC.

This PR fixes all cases where we were initializing a time object without a set time zone in our test suite.

There are no occurrences of this pattern in our production code.