### PR TITLE
Remove unhelpful default test

### DIFF
--- a/test/default_test.rb
+++ b/test/default_test.rb
@@ -1,8 +1,0 @@
-require 'helper'
-require 'ddtrace'
-
-class TracerTest < Minitest::Test
-  def test_default_tracer
-    assert Datadog.tracer.instance_of?(Datadog::Tracer)
-  end
-end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,7 +3,9 @@ require 'minitest/autorun'
 require 'webmock/minitest'
 require 'pry'
 
-require 'ddtrace'
+require 'ddtrace/encoding'
+require 'ddtrace/tracer'
+require 'ddtrace/span'
 
 begin
   # Ignore interpreter warnings from external libraries

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,9 +3,7 @@ require 'minitest/autorun'
 require 'webmock/minitest'
 require 'pry'
 
-require 'ddtrace/encoding'
-require 'ddtrace/tracer'
-require 'ddtrace/span'
+require 'ddtrace'
 
 begin
   # Ignore interpreter warnings from external libraries

--- a/test/rate_by_service_sampler_test.rb
+++ b/test/rate_by_service_sampler_test.rb
@@ -1,5 +1,5 @@
 require 'minitest'
-require 'ddtrace/sampler'
+require 'ddtrace'
 
 module Datadog
   class RateByServiceSamplerTest < Minitest::Test


### PR DESCRIPTION
This PR removes a minitest test that perform strict type checking on `Datadog.tracer`.

This tests is uncecessary, as we've since introduce more rich testing around the tracer's public API at `ddtrace_integration_spec.rb`: https://github.com/DataDog/dd-trace-rb/blob/aeecf5e95cc1ad0a45ecaf8f2ff18e84b73fe35b/spec/ddtrace_integration_spec.rb#L92-L157

This also help us clean up one more minitest test.