### PR TITLE
[PROF-3692] Expand CI integration tests, and test using profiler

### DIFF
--- a/integration/apps/rack/Dockerfile-ci
+++ b/integration/apps/rack/Dockerfile-ci
@@ -9,6 +9,6 @@ COPY . /vendor/dd-trace-rb
 ENV DD_DEMO_ENV_GEM_LOCAL_DDTRACE /vendor/dd-trace-rb
 
 # Build the ddtrace profiling native extension
-RUN cd /vendor/dd-trace-rb && bundle install && bundle exec rake compile
+RUN unset BUNDLE_GEMFILE && cd /vendor/dd-trace-rb && bundle install && bundle exec rake compile
 
 RUN bundle install

--- a/integration/apps/rack/Dockerfile-ci
+++ b/integration/apps/rack/Dockerfile-ci
@@ -9,6 +9,6 @@ COPY . /vendor/dd-trace-rb
 ENV DD_DEMO_ENV_GEM_LOCAL_DDTRACE /vendor/dd-trace-rb
 
 # Build the ddtrace profiling native extension
-RUN unset BUNDLE_GEMFILE && cd /vendor/dd-trace-rb && bundle install && bundle exec rake compile
+RUN export BUNDLE_GEMFILE=/vendor/dd-trace-rb/Gemfile && cd /vendor/dd-trace-rb && bundle install && bundle exec rake compile
 
 RUN bundle install

--- a/integration/apps/rack/Dockerfile-ci
+++ b/integration/apps/rack/Dockerfile-ci
@@ -8,4 +8,8 @@ COPY . /vendor/dd-trace-rb
 # Install dependencies
 # Setup specific version of ddtrace, if specified.
 ENV DD_DEMO_ENV_GEM_LOCAL_DDTRACE /vendor/dd-trace-rb
+
+# Build the ddtrace profiling native extension
+RUN cd /vendor/dd-trace-rb && bundle install && bundle exec rake compile
+
 RUN bundle install

--- a/integration/apps/rack/Dockerfile-ci
+++ b/integration/apps/rack/Dockerfile-ci
@@ -6,7 +6,6 @@ FROM ${BASE_IMAGE}
 COPY . /vendor/dd-trace-rb
 
 # Install dependencies
-# Setup specific version of ddtrace, if specified.
 ENV DD_DEMO_ENV_GEM_LOCAL_DDTRACE /vendor/dd-trace-rb
 
 # Build the ddtrace profiling native extension

--- a/integration/apps/rack/app/acme.rb
+++ b/integration/apps/rack/app/acme.rb
@@ -62,7 +62,7 @@ module Acme
       end
 
       def default(request)
-        ['200', { 'Content-Type' => 'text/plain' }, ['Basic: Default']]
+        ['200', { 'Content-Type' => 'text/plain' }, ["Basic: Default", "\nWebserver process: #{$PROGRAM_NAME}"]]
       end
 
       private

--- a/integration/apps/rack/bin/run
+++ b/integration/apps/rack/bin/run
@@ -3,24 +3,16 @@
 # Start application process
 puts "\n== Starting application process =="
 
-profiling = ''
-env_vars = ''
-
-if Datadog::DemoEnv.feature?('profiling')
-  profiling = 'ddtracerb exec'
-  env_vars = 'DD_PROFILING_ENABLED=true'
-end
-
 process = (ARGV[0] || Datadog::DemoEnv.process)
 command = case process
           when 'puma'
-            "#{env_vars} bundle exec #{profiling} puma -C /app/config/puma.rb /app/config.ru"
+            "bundle exec ddtracerb exec puma -C /app/config/puma.rb /app/config.ru"
           when 'unicorn'
-            "#{env_vars} bundle exec #{profiling} unicorn -c /app/config/unicorn.rb /app/config.ru"
+            "bundle exec ddtracerb exec unicorn -c /app/config/unicorn.rb /app/config.ru"
           when 'webrick'
-            "#{env_vars} bundle exec #{profiling} rackup -s webrick -o 0.0.0.0 -p 80 /app/config.ru"
+            "bundle exec ddtracerb exec rackup -s webrick -o 0.0.0.0 -p 80 /app/config.ru"
           when 'irb'
-            "#{env_vars} bundle exec #{profiling} irb"
+            "bundle exec ddtracerb exec irb"
           when nil, ''
             abort("\n== ERROR: Must specify a application process! ==")
           else

--- a/integration/apps/rack/bin/run
+++ b/integration/apps/rack/bin/run
@@ -8,7 +8,7 @@ command = case process
           when 'puma'
             "bundle exec ddtracerb exec puma -C /app/config/puma.rb /app/config.ru"
           when 'unicorn'
-            "bundle exec ddtracerb exec unicorn -c /app/config/unicorn.rb /app/config.ru"
+            "bundle exec ddtracerb exec unicorn --port 80 -c /app/config/unicorn.rb /app/config.ru"
           when 'webrick'
             "bundle exec ddtracerb exec rackup -s webrick -o 0.0.0.0 -p 80 /app/config.ru"
           when 'irb'

--- a/integration/apps/rack/docker-compose.ci.yml
+++ b/integration/apps/rack/docker-compose.ci.yml
@@ -20,7 +20,7 @@ services:
       - DD_PROFILING_ENABLED=true
       # Use these to choose what is run
       - DD_DEMO_ENV_PROCESS=puma
-      - DD_DEMO_ENV_FEATURES=tracing
+      - DD_DEMO_ENV_FEATURES=tracing,profiling
     expose:
       - "80"
     stdin_open: true

--- a/integration/apps/rack/docker-compose.ci.yml
+++ b/integration/apps/rack/docker-compose.ci.yml
@@ -19,7 +19,7 @@ services:
       - DD_SERVICE=acme-rack
       - DD_PROFILING_ENABLED=true
       # Use these to choose what is run
-      - DD_DEMO_ENV_PROCESS=puma
+      - DD_DEMO_ENV_PROCESS # needs to be specified, see README for available options
       - DD_DEMO_ENV_FEATURES=tracing,profiling
     expose:
       - "80"

--- a/integration/apps/rack/docker-compose.yml
+++ b/integration/apps/rack/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - DD_PROFILING_ENABLED=true
       # Use these to choose what is run
       - DD_DEMO_ENV_PROCESS=puma
-      - DD_DEMO_ENV_FEATURES=tracing
+      - DD_DEMO_ENV_FEATURES=tracing,profiling
       # Use this for a local version of ddtrace
       - DD_DEMO_ENV_GEM_LOCAL_DDTRACE=/vendor/dd-trace-rb
       # Use these for a specific revision of ddtrace

--- a/integration/apps/rack/script/ci
+++ b/integration/apps/rack/script/ci
@@ -43,9 +43,16 @@ echo ""
 # Pull/build any missing images
 APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES build
 
-# Run the test suite
-APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES run integration-tester || \
-  APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES logs # Print container logs on `run` failure
+# Run the test suite with the different web servers
+for DD_DEMO_ENV_PROCESS in puma unicorn webrick
+do
+  echo -e "\n== Running with $DD_DEMO_ENV_PROCESS ================================================\n"
 
-# Cleanup
-APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES down -t 0 --remove-orphans
+  export DD_DEMO_ENV_PROCESS
+
+  APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES run integration-tester || \
+    APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES logs # Print container logs on `run` failure
+
+  # Cleanup
+  APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES down -t 0 --remove-orphans
+done

--- a/integration/apps/rack/spec/integration/basic_spec.rb
+++ b/integration/apps/rack/spec/integration/basic_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe 'Basic scenarios' do
 
   context 'default' do
     subject { get('basic/default') }
-    it { is_expected.to be_a_kind_of(Net::HTTPOK) }
+    it do
+      is_expected.to be_a_kind_of(Net::HTTPOK)
+      puts "    #{subject.body.each_line.to_a.last}" # Print last line of request (webserver info) for sanity checking
+    end
   end
 
   context 'profiling health' do

--- a/integration/apps/rack/spec/integration/basic_spec.rb
+++ b/integration/apps/rack/spec/integration/basic_spec.rb
@@ -7,4 +7,9 @@ RSpec.describe 'Basic scenarios' do
     subject { get('basic/default') }
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }
   end
+
+  context 'profiling health' do
+    subject { get('health/profiling') }
+    it { is_expected.to be_a_kind_of(Net::HTTPOK), "Got #{subject.inspect} with body: '#{subject.body}'" }
+  end
 end

--- a/integration/apps/rails-five/Dockerfile-ci
+++ b/integration/apps/rails-five/Dockerfile-ci
@@ -9,6 +9,6 @@ COPY . /vendor/dd-trace-rb
 ENV DD_DEMO_ENV_GEM_LOCAL_DDTRACE /vendor/dd-trace-rb
 
 # Build the ddtrace profiling native extension
-RUN cd /vendor/dd-trace-rb && bundle install && bundle exec rake compile
+RUN unset BUNDLE_GEMFILE && cd /vendor/dd-trace-rb && bundle install && bundle exec rake compile
 
 RUN bundle install

--- a/integration/apps/rails-five/Dockerfile-ci
+++ b/integration/apps/rails-five/Dockerfile-ci
@@ -9,6 +9,6 @@ COPY . /vendor/dd-trace-rb
 ENV DD_DEMO_ENV_GEM_LOCAL_DDTRACE /vendor/dd-trace-rb
 
 # Build the ddtrace profiling native extension
-RUN unset BUNDLE_GEMFILE && cd /vendor/dd-trace-rb && bundle install && bundle exec rake compile
+RUN export BUNDLE_GEMFILE=/vendor/dd-trace-rb/Gemfile && cd /vendor/dd-trace-rb && bundle install && bundle exec rake compile
 
 RUN bundle install

--- a/integration/apps/rails-five/Dockerfile-ci
+++ b/integration/apps/rails-five/Dockerfile-ci
@@ -6,6 +6,9 @@ FROM ${BASE_IMAGE}
 COPY . /vendor/dd-trace-rb
 
 # Install dependencies
-# Setup specific version of ddtrace, if specified.
 ENV DD_DEMO_ENV_GEM_LOCAL_DDTRACE /vendor/dd-trace-rb
+
+# Build the ddtrace profiling native extension
+RUN cd /vendor/dd-trace-rb && bundle install && bundle exec rake compile
+
 RUN bundle install

--- a/integration/apps/rails-five/README.md
+++ b/integration/apps/rails-five/README.md
@@ -11,7 +11,7 @@ Install [direnv](https://github.com/direnv/direnv) for applying local settings.
 1. `cp .envrc.sample .envrc` and add your Datadog API key.
 2. `direnv allow` to load the env var.
 3. `cp docker-compose.yml.sample docker-compose.yml` and configure if necessary.
-4. `docker-compose run --rm api bin/setup`
+4. `docker-compose run --rm app bin/setup`
 
 ## Running the application
 
@@ -28,7 +28,7 @@ Run `docker-compose up` to auto-start the webserver. It should bind to `localhos
 Alternatively, you can run it manually with:
 
 ```sh
-docker-compose run --rm -p 80:80 api bin/dd-demo <process>
+docker-compose run --rm -p 80:80 app "bin/run <process>"
 ```
 
 The `<process>` argument is optional, and will default to `DD_DEMO_ENV_PROCESS` if not provided. See [Processes](#processes) for more details.

--- a/integration/apps/rails-five/app/controllers/health_controller.rb
+++ b/integration/apps/rails-five/app/controllers/health_controller.rb
@@ -6,4 +6,14 @@ class HealthController < ApplicationController
   def check
     head :no_content
   end
+
+  def profiling_check
+    return render(body: "Profiler not running\n", status: 503) unless Datadog.profiler
+
+    ["Datadog::Profiling::Collectors::Stack", "Datadog::Profiling::Scheduler"].each do |name|
+      return render(body: "Profiler thread missing: #{name}\n", status: 503) unless Thread.list.map(&:name).include?(name)
+    end
+
+    render body: "Profiling check OK\n"
+  end
 end

--- a/integration/apps/rails-five/bin/run
+++ b/integration/apps/rails-five/bin/run
@@ -1,23 +1,22 @@
 #!/usr/bin/env ruby
 
-# Start demo process
-puts "\n== Starting demo process =="
+# Start application process
+puts "\n== Starting application process =="
 
-profiling = Datadog::DemoEnv.feature?('profiling') ? 'DD_PROFILING_ENABLED=true ddtracerb exec ' : ''
 process = (ARGV[0] || Datadog::DemoEnv.process)
 command = case process
           when 'puma'
-            "bundle exec #{profiling}puma -C /app/config/puma.rb"
+            "bundle exec ddtracerb exec puma -C /app/config/puma.rb"
           when 'unicorn'
-            "bundle exec #{profiling}unicorn -c /app/config/unicorn.rb"
+            "bundle exec ddtracerb exec unicorn -c /app/config/unicorn.rb"
           when 'console'
-            "bundle exec #{profiling}rails c"
+            "bundle exec ddtracerb exec rails c"
           when 'irb'
-            "bundle exec #{profiling}irb"
+            "bundle exec ddtracerb exec irb"
           when nil, ''
-            abort("\n== ERROR: Must specify a demo process! ==")
+            abort("\n== ERROR: Must specify a application process! ==")
           else
-            abort("\n== ERROR: Unknown demo process '#{process}' ==")
+            abort("\n== ERROR: Unknown application process '#{process}' ==")
           end
 
 puts "Run: #{command}"

--- a/integration/apps/rails-five/config/routes.rb
+++ b/integration/apps/rails-five/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   get '/', to: 'basic#default'
   get 'health', to: 'health#check'
+  get 'health/profiling', to: 'health#profiling_check'
 
   # Basic test scenarios
   get 'basic/default', to: 'basic#default'

--- a/integration/apps/rails-five/docker-compose.ci.yml
+++ b/integration/apps/rails-five/docker-compose.ci.yml
@@ -22,7 +22,9 @@ services:
       - DD_TRACE_AGENT_PORT=8126
       - DD_HEALTH_METRICS_ENABLED=true
       - DD_SERVICE=acme-rails-five
+      - DD_PROFILING_ENABLED=true
       - RAILS_ENV=production
+      - RAILS_LOG_TO_STDOUT=true
       - REDIS_URL=redis://redis:6379
       - SECRET_KEY_BASE=5ced2602472cdf650e2cfa5be40c7d0dffd4e1da1483e21fa9c776e338b363c8bf75144bc6e6c5177a0d7a208a899552f98b3f82d4ea74cf5f9b9d3accbb1537
       # Use these to choose what is run

--- a/integration/apps/rails-five/docker-compose.ci.yml
+++ b/integration/apps/rails-five/docker-compose.ci.yml
@@ -29,7 +29,7 @@ services:
       - SECRET_KEY_BASE=5ced2602472cdf650e2cfa5be40c7d0dffd4e1da1483e21fa9c776e338b363c8bf75144bc6e6c5177a0d7a208a899552f98b3f82d4ea74cf5f9b9d3accbb1537
       # Use these to choose what is run
       - DD_DEMO_ENV_PROCESS=puma
-      - DD_DEMO_ENV_FEATURES=tracing
+      - DD_DEMO_ENV_FEATURES=tracing,profiling
     expose:
       - "80"
     stdin_open: true

--- a/integration/apps/rails-five/docker-compose.yml
+++ b/integration/apps/rails-five/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - SECRET_KEY_BASE=5ced2602472cdf650e2cfa5be40c7d0dffd4e1da1483e21fa9c776e338b363c8bf75144bc6e6c5177a0d7a208a899552f98b3f82d4ea74cf5f9b9d3accbb1537
       # Use these to choose what is run
       - DD_DEMO_ENV_PROCESS=puma
-      - DD_DEMO_ENV_FEATURES=tracing
+      - DD_DEMO_ENV_FEATURES=tracing,profiling
       # Use this for a local version of ddtrace
       - DD_DEMO_ENV_GEM_LOCAL_DDTRACE=/vendor/dd-trace-rb
       # Use these for a specific revision of ddtrace

--- a/integration/apps/rails-five/docker-compose.yml
+++ b/integration/apps/rails-five/docker-compose.yml
@@ -19,7 +19,9 @@ services:
       - DD_TRACE_AGENT_PORT=8126
       - DD_HEALTH_METRICS_ENABLED=true
       - DD_SERVICE=acme-rails-five
+      - DD_PROFILING_ENABLED=true
       - RAILS_ENV=production
+      - RAILS_LOG_TO_STDOUT=true
       - REDIS_URL=redis://redis:6379
       - SECRET_KEY_BASE=5ced2602472cdf650e2cfa5be40c7d0dffd4e1da1483e21fa9c776e338b363c8bf75144bc6e6c5177a0d7a208a899552f98b3f82d4ea74cf5f9b9d3accbb1537
       # Use these to choose what is run

--- a/integration/apps/rails-five/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-five/spec/integration/basic_spec.rb
@@ -7,4 +7,9 @@ RSpec.describe 'Basic scenarios' do
     subject { get('basic/default') }
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }
   end
+
+  context 'profiling health' do
+    subject { get('health/profiling') }
+    it { is_expected.to be_a_kind_of(Net::HTTPOK), "Got #{subject.inspect} with body: '#{subject.body}'" }
+  end
 end


### PR DESCRIPTION
This PR enables and validates that profiler is working for the `rack` and `rails-five` test apps.

It additionally tweaks the `rack` test app to run tests with multiple webservers (puma, unicorn, webrick).