### PR TITLE
Unlock rake version after appraisal release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ if RUBY_PLATFORM != 'java'
 else
   gem 'pry-debugger-jruby'
 end
-gem 'rake', '>= 10.5', '< 13.0.4' # Locking rake until https://github.com/thoughtbot/appraisal/pull/184 is released
+gem 'rake', '>= 10.5'
 gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
 gem 'rspec', '~> 3.10'


### PR DESCRIPTION
With the release of https://github.com/thoughtbot/appraisal/releases/tag/v2.4.1, the missing require issue has been fixed: https://github.com/thoughtbot/appraisal/pull/184.

We can now safely unlock `rake` upgrades, as `appraisal` was previously depending on a require statement from `rake`, which it doesn't anymore in `2.4.1`