### PR TITLE
[PROF-3692] Add sidekiq and resque to rack integration test app

### DIFF
--- a/integration/apps/rack/Gemfile
+++ b/integration/apps/rack/Gemfile
@@ -6,6 +6,8 @@ source 'https://rubygems.org' do
   gem 'rack'
   gem 'redis'
   gem 'sidekiq'
+  gem 'resque'
+  gem 'rake'
 
   gem 'dogstatsd-ruby'
   gem 'google-protobuf'

--- a/integration/apps/rack/Gemfile
+++ b/integration/apps/rack/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org' do
   gem 'puma'
   gem 'unicorn'
   gem 'rack'
+  gem 'redis'
+  gem 'sidekiq'
 
   gem 'dogstatsd-ruby'
   gem 'google-protobuf'
@@ -17,4 +19,5 @@ source 'https://rubygems.org' do
   # gem 'ruby-prof'
 
   gem 'rspec'
+  gem 'rspec-wait'
 end

--- a/integration/apps/rack/Gemfile
+++ b/integration/apps/rack/Gemfile
@@ -3,22 +3,18 @@ require 'datadog/demo_env'
 source 'https://rubygems.org' do
   gem 'puma'
   gem 'unicorn'
-
-  gem 'dogstatsd-ruby'
   gem 'rack'
 
-  gem 'ffi'
+  gem 'dogstatsd-ruby'
   gem 'google-protobuf'
-
   # Choose correct specs for 'ddtrace' demo environment
   gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
 
   # Development
-  gem 'byebug'
+  gem 'pry-byebug'
   # gem 'pry-stack_explorer', platform: :ruby
   # gem 'rbtrace'
   # gem 'ruby-prof'
 
-  # Testing/CI
   gem 'rspec'
 end

--- a/integration/apps/rack/Rakefile
+++ b/integration/apps/rack/Rakefile
@@ -1,0 +1,4 @@
+require 'resque'
+require 'resque/tasks'
+
+require_relative './app/resque_background_job'

--- a/integration/apps/rack/app/acme.rb
+++ b/integration/apps/rack/app/acme.rb
@@ -94,7 +94,7 @@ module Acme
 
     class BackgroundJobs
       def read_sidekiq(request)
-        ['200', { 'Content-Type' => 'text/plain' }, [SidekiqBackgroundJob.read(request.params.fetch('key')).inspect, "\n"]]
+        ['200', { 'Content-Type' => 'application/json' }, [SidekiqBackgroundJob.read(request.params.fetch('key')), "\n"]]
       end
 
       def write_sidekiq(request)

--- a/integration/apps/rack/app/acme.rb
+++ b/integration/apps/rack/app/acme.rb
@@ -13,14 +13,14 @@ module Acme
         '/health' => { controller: controllers[:health], action: :check },
         '/health/profiling' => { controller: controllers[:health], action: :profiling_check },
         '/basic/fibonacci' => { controller: controllers[:basic], action: :fibonacci },
-        '/basic/default' => { controller: controllers[:basic], action: :default }
+        '/basic/default' => { controller: controllers[:basic], action: :default },
       )
     end
 
     def controllers
       {
         basic: Controllers::Basic.new,
-        health: Controllers::Health.new
+        health: Controllers::Health.new,
       }
     end
   end

--- a/integration/apps/rack/app/resque_background_job.rb
+++ b/integration/apps/rack/app/resque_background_job.rb
@@ -1,0 +1,35 @@
+require 'redis'
+require 'resque'
+require 'json'
+
+Resque.redis = ENV.fetch('REDIS_URL')
+
+# To exercise resque, this class allows us to write some key and value to redis asynchronously (in a background job)
+# and to read it synchronously (so we can return its value easily in a web request).
+# This way we can simulate the full cycle of submitting something to resque, having it be executed, and its result be
+# observable.
+class ResqueBackgroundJob
+  REDIS = Redis.new(url: ENV.fetch('REDIS_URL'))
+
+  @queue = :resque_testing
+
+  def self.read(key)
+    REDIS.get("resque-background-job-key-#{key}")
+  end
+
+  def self.async_write(key, value)
+    Resque.enqueue(self, key, value)
+  end
+
+  def self.perform(key, value)
+    puts "ResqueBackgroundJob#perform(#{key}, #{value})"
+
+    REDIS.set("resque-background-job-key-#{key}", JSON.pretty_generate(
+      key: key,
+      value: value,
+      resque_process: $PROGRAM_NAME,
+      profiler_available: !!Datadog.profiler,
+      profiler_threads: Thread.list.map(&:name).filter { |it| it && it.include?('Profiling') }
+    ))
+  end
+end

--- a/integration/apps/rack/app/sidekiq_background_job.rb
+++ b/integration/apps/rack/app/sidekiq_background_job.rb
@@ -1,0 +1,26 @@
+require 'redis'
+require 'sidekiq'
+
+# To exercise sidekiq, this class allows us to write some key and value to redis asynchronously (in a background job)
+# and to read it synchronously (so we can return its value easily in a web request).
+# This way we can simulate the full cycle of submitting something to sidekiq, having it be executed, and its result be
+# observable.
+class SidekiqBackgroundJob
+  include Sidekiq::Worker
+
+  REDIS = Redis.new(url: ENV.fetch('REDIS_URL'))
+
+  def self.read(key)
+    REDIS.get("sidekiq-background-job-key-#{key}")
+  end
+
+  def self.async_write(key, value)
+    perform_async(key, value)
+  end
+
+  def perform(key, value)
+    puts "SidekiqBackgroundJob#perform(#{key}, #{value})"
+
+    REDIS.set("sidekiq-background-job-key-#{key}", value)
+  end
+end

--- a/integration/apps/rack/bin/resque
+++ b/integration/apps/rack/bin/resque
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+puts "\n== Starting resque process =="
+
+command = "QUEUE=resque_testing bundle exec ddtracerb exec rake resque:work"
+
+puts "Run: #{command}"
+Kernel.exec(command)

--- a/integration/apps/rack/bin/run
+++ b/integration/apps/rack/bin/run
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-# Start application process
 puts "\n== Starting application process =="
 
 process = (ARGV[0] || Datadog::DemoEnv.process)

--- a/integration/apps/rack/bin/sidekiq
+++ b/integration/apps/rack/bin/sidekiq
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+puts "\n== Starting sidekiq process =="
+
+command = "bundle exec ddtracerb exec sidekiq -r ./app/sidekiq_background_job.rb"
+
+puts "Run: #{command}"
+Kernel.exec(command)

--- a/integration/apps/rack/docker-compose.ci.yml
+++ b/integration/apps/rack/docker-compose.ci.yml
@@ -27,6 +27,30 @@ services:
       - "80"
     stdin_open: true
     tty: true
+  resque:
+    build:
+      context: ../../..
+      dockerfile: integration/apps/rack/Dockerfile-ci
+      args:
+        BASE_IMAGE: ${APP_IMAGE}
+    depends_on:
+      - ddagent
+      - redis
+    environment:
+      - BUNDLE_GEMFILE=/app/Gemfile
+      - REDIS_URL=redis://redis:6379
+      - DD_AGENT_HOST=ddagent
+      - DD_METRIC_AGENT_PORT=8125
+      - DD_TRACE_AGENT_PORT=8126
+      - DD_HEALTH_METRICS_ENABLED=true
+      - DD_SERVICE=acme-rack-resque
+      - DD_PROFILING_ENABLED=true
+      # Use these to choose what is run
+      - DD_DEMO_ENV_FEATURES=tracing,profiling
+    command:
+      bin/resque
+    stdin_open: true
+    tty: true
   sidekiq:
     build:
       context: ../../..
@@ -75,6 +99,7 @@ services:
     command: bin/test
     depends_on:
       - app
+      - resque
       - sidekiq
     environment:
       - TEST_HOSTNAME=app

--- a/integration/apps/rack/docker-compose.ci.yml
+++ b/integration/apps/rack/docker-compose.ci.yml
@@ -10,8 +10,10 @@ services:
         BASE_IMAGE: ${APP_IMAGE}
     depends_on:
       - ddagent
+      - redis
     environment:
       - BUNDLE_GEMFILE=/app/Gemfile
+      - REDIS_URL=redis://redis:6379
       - DD_AGENT_HOST=ddagent
       - DD_METRIC_AGENT_PORT=8125
       - DD_TRACE_AGENT_PORT=8126
@@ -23,6 +25,30 @@ services:
       - DD_DEMO_ENV_FEATURES=tracing,profiling
     expose:
       - "80"
+    stdin_open: true
+    tty: true
+  sidekiq:
+    build:
+      context: ../../..
+      dockerfile: integration/apps/rack/Dockerfile-ci
+      args:
+        BASE_IMAGE: ${APP_IMAGE}
+    depends_on:
+      - ddagent
+      - redis
+    environment:
+      - BUNDLE_GEMFILE=/app/Gemfile
+      - REDIS_URL=redis://redis:6379
+      - DD_AGENT_HOST=ddagent
+      - DD_METRIC_AGENT_PORT=8125
+      - DD_TRACE_AGENT_PORT=8126
+      - DD_HEALTH_METRICS_ENABLED=true
+      - DD_SERVICE=acme-rack-sidekiq
+      - DD_PROFILING_ENABLED=true
+      # Use these to choose what is run
+      - DD_DEMO_ENV_FEATURES=tracing,profiling
+    command:
+      bin/sidekiq
     stdin_open: true
     tty: true
   ddagent:
@@ -49,6 +75,7 @@ services:
     command: bin/test
     depends_on:
       - app
+      - sidekiq
     environment:
       - TEST_HOSTNAME=app
       - TEST_PORT=80
@@ -60,3 +87,7 @@ services:
     #   - .:/app
     #   - ../../images/include:/vendor/dd-demo
     #   - ../../..:/vendor/dd-trace-rb
+  redis:
+    image: redis:6.2-buster
+    expose:
+      - "6379"

--- a/integration/apps/rack/docker-compose.yml
+++ b/integration/apps/rack/docker-compose.yml
@@ -7,8 +7,10 @@ services:
         BASE_IMAGE: datadog/dd-apm-demo:rb-2.7
     depends_on:
       - ddagent
+      - redis
     environment:
       - BUNDLE_GEMFILE=/app/Gemfile
+      - REDIS_URL=redis://redis:6379
       - DD_AGENT_HOST=ddagent
       - DD_METRIC_AGENT_PORT=8125
       - DD_TRACE_AGENT_PORT=8126
@@ -74,5 +76,9 @@ services:
       - HEALTH_CHECK_MAX_ATTEMPTS=30
     volumes:
       - ../../images/wrk/scripts:/scripts
+  redis:
+    image: redis:6.2-buster
+    expose:
+      - "6379"
 volumes:
   bundle:

--- a/integration/apps/rack/spec/integration/basic_spec.rb
+++ b/integration/apps/rack/spec/integration/basic_spec.rb
@@ -37,8 +37,16 @@ RSpec.describe 'Basic scenarios' do
       post('background_jobs/write_sidekiq', key: key, value: 'it works!')
     end
 
-    it 'runs a simple task successfully' do
-      wait_for { get("background_jobs/read_sidekiq?key=#{key}").body }.to include('it works!')
+    it 'runs a test task, with profiling enabled' do
+      body = nil
+      wait_for { body = get("background_jobs/read_sidekiq?key=#{key}").body.to_s }.to include('it works!')
+
+      expect(JSON.parse(body, symbolize_names: true)).to include(
+        key: key,
+        sidekiq_process: match(/sidekiq/),
+        profiler_available: true,
+        profiler_threads: contain_exactly('Datadog::Profiling::Collectors::Stack', 'Datadog::Profiling::Scheduler')
+      )
     end
   end
 end

--- a/integration/apps/rack/spec/integration/basic_spec.rb
+++ b/integration/apps/rack/spec/integration/basic_spec.rb
@@ -30,6 +30,26 @@ RSpec.describe 'Basic scenarios' do
     end
   end
 
+  context 'resque usage' do
+    let(:key) { SecureRandom.uuid }
+
+    before do
+      post('background_jobs/write_resque', key: key, value: 'it works!')
+    end
+
+    it 'runs a test task, with profiling enabled' do
+      body = nil
+      wait_for { body = get("background_jobs/read_resque?key=#{key}").body.to_s }.to include('it works!')
+
+      expect(JSON.parse(body, symbolize_names: true)).to include(
+        key: key,
+        resque_process: match(/resque/),
+        profiler_available: true,
+        profiler_threads: contain_exactly('Datadog::Profiling::Collectors::Stack', 'Datadog::Profiling::Scheduler')
+      )
+    end
+  end
+
   context 'sidekiq usage' do
     let(:key) { SecureRandom.uuid }
 

--- a/integration/apps/rack/spec/integration/basic_spec.rb
+++ b/integration/apps/rack/spec/integration/basic_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+require 'rspec/wait'
+require 'securerandom'
 
 RSpec.describe 'Basic scenarios' do
   include_context 'integration test'
@@ -14,5 +16,17 @@ RSpec.describe 'Basic scenarios' do
   context 'profiling health' do
     subject { get('health/profiling') }
     it { is_expected.to be_a_kind_of(Net::HTTPOK), "Got #{subject.inspect} with body: '#{subject.body}'" }
+  end
+
+  context 'sidekiq usage' do
+    let(:key) { SecureRandom.uuid }
+
+    before do
+      post('background_jobs/write_sidekiq', key: key, value: 'it works!')
+    end
+
+    it 'runs a simple task successfully' do
+      wait_for { get("background_jobs/read_sidekiq?key=#{key}").body }.to include('it works!')
+    end
   end
 end

--- a/integration/apps/rack/spec/integration/basic_spec.rb
+++ b/integration/apps/rack/spec/integration/basic_spec.rb
@@ -1,21 +1,33 @@
 require 'spec_helper'
 require 'rspec/wait'
 require 'securerandom'
+require 'json'
 
 RSpec.describe 'Basic scenarios' do
   include_context 'integration test'
 
   context 'default' do
     subject { get('basic/default') }
-    it do
-      is_expected.to be_a_kind_of(Net::HTTPOK)
-      puts "    #{subject.body.each_line.to_a.last}" # Print last line of request (webserver info) for sanity checking
-    end
+    it { is_expected.to be_a_kind_of(Net::HTTPOK) }
   end
 
-  context 'profiling health' do
-    subject { get('health/profiling') }
-    it { is_expected.to be_a_kind_of(Net::HTTPOK), "Got #{subject.inspect} with body: '#{subject.body}'" }
+  context 'component checks' do
+    subject { get('health/detailed') }
+
+    let(:json_result) { JSON.parse(subject.body, symbolize_names: true) }
+
+    it { is_expected.to be_a_kind_of(Net::HTTPOK) }
+
+    it 'should be profiling' do
+      expect(json_result).to include(
+        profiler_available: true,
+        profiler_threads: contain_exactly('Datadog::Profiling::Collectors::Stack', 'Datadog::Profiling::Scheduler')
+      )
+    end
+
+    it 'webserver sanity checking' do
+      puts "      Webserver: #{json_result.fetch(:webserver_process)}"
+    end
   end
 
   context 'sidekiq usage' do

--- a/integration/apps/rack/spec/support/integration_helper.rb
+++ b/integration/apps/rack/spec/support/integration_helper.rb
@@ -18,5 +18,10 @@ module IntegrationHelper
       uri = URI("http://#{hostname}:#{port}/#{path}")
       Net::HTTP.get_response(uri)
     end
+
+    def post(path, arguments)
+      uri = URI("http://#{hostname}:#{port}/#{path}")
+      Net::HTTP.post_form(uri, arguments)
+    end
   end
 end

--- a/integration/apps/rails-five/app/controllers/health_controller.rb
+++ b/integration/apps/rails-five/app/controllers/health_controller.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 class HealthController < ApplicationController
   #
   # Check if web application is responsive
@@ -7,13 +9,11 @@ class HealthController < ApplicationController
     head :no_content
   end
 
-  def profiling_check
-    return render(body: "Profiler not running\n", status: 503) unless Datadog.profiler
-
-    ["Datadog::Profiling::Collectors::Stack", "Datadog::Profiling::Scheduler"].each do |name|
-      return render(body: "Profiler thread missing: #{name}\n", status: 503) unless Thread.list.map(&:name).include?(name)
-    end
-
-    render body: "Profiling check OK\n"
+  def detailed_check
+    render json: {
+      webserver_process: $PROGRAM_NAME,
+      profiler_available: !!Datadog.profiler,
+      profiler_threads: Thread.list.map(&:name).filter { |it| it && it.include?('Profiling') }
+    }
   end
 end

--- a/integration/apps/rails-five/config/routes.rb
+++ b/integration/apps/rails-five/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   get '/', to: 'basic#default'
   get 'health', to: 'health#check'
-  get 'health/profiling', to: 'health#profiling_check'
+  get 'health/detailed', to: 'health#detailed_check'
 
   # Basic test scenarios
   get 'basic/default', to: 'basic#default'

--- a/integration/apps/rails-five/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-five/spec/integration/basic_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'json'
 
 RSpec.describe 'Basic scenarios' do
   include_context 'integration test'
@@ -8,8 +9,22 @@ RSpec.describe 'Basic scenarios' do
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }
   end
 
-  context 'profiling health' do
-    subject { get('health/profiling') }
-    it { is_expected.to be_a_kind_of(Net::HTTPOK), "Got #{subject.inspect} with body: '#{subject.body}'" }
+  context 'component checks' do
+    subject { get('health/detailed') }
+
+    let(:json_result) { JSON.parse(subject.body, symbolize_names: true) }
+
+    it { is_expected.to be_a_kind_of(Net::HTTPOK) }
+
+    it 'should be profiling' do
+      expect(json_result).to include(
+        profiler_available: true,
+        profiler_threads: contain_exactly('Datadog::Profiling::Collectors::Stack', 'Datadog::Profiling::Scheduler')
+      )
+    end
+
+    it 'webserver sanity checking' do
+      puts "      Webserver: #{json_result.fetch(:webserver_process)}"
+    end
   end
 end


### PR DESCRIPTION
I've extended the rack integration test app with a few more endpoints that allow some value to be round tripped asynchronously through a sidekiq/resque worker.

This is used to validate that tracing and profiling-enabled sidekiq/resque workers are working correctly.

As I was going through this work, I realized the same JSON-object pattern could be used in the regular health endpoints, so I've replaced the profiler-specific endpoints with generic endpoints that return a JSON object with a lot of information that can then be asserted in the integration tester.