### PR TITLE
Add support for annotating profiler stacks with the resource of the active web trace, if any

### DIFF
--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -116,7 +116,7 @@ module Datadog
 
           trace_identifiers_helper = Datadog::Profiling::TraceIdentifiers::Helper.new(
             tracer: tracer,
-            extract_trace_resource: settings.profiling.advanced.extract_trace_resource,
+            extract_trace_resource: settings.profiling.advanced.extract_trace_resource
           )
 
           recorder = build_profiler_recorder(settings)

--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -170,7 +170,7 @@ module Datadog
         def build_profiler_recorder(settings)
           event_classes = [Datadog::Profiling::Events::StackSample]
 
-          Datadog::Profiling::Recorder.new(event_classes, settings.profiling.max_events)
+          Datadog::Profiling::Recorder.new(event_classes, settings.profiling.advanced.max_events)
         end
 
         def build_profiler_collectors(settings, recorder, trace_identifiers_helper)
@@ -178,7 +178,7 @@ module Datadog
             Datadog::Profiling::Collectors::Stack.new(
               recorder,
               trace_identifiers_helper: trace_identifiers_helper,
-              max_frames: settings.profiling.max_frames
+              max_frames: settings.profiling.advanced.max_frames
               # TODO: Provide proc that identifies Datadog worker threads?
               # ignore_thread: settings.profiling.ignore_profiler
             )

--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -114,7 +114,10 @@ module Datadog
 
           # NOTE: Please update the Initialization section of ProfilingDevelopment.md with any changes to this method
 
-          trace_identifiers_helper = Datadog::Profiling::TraceIdentifiers::Helper.new(tracer: tracer)
+          trace_identifiers_helper = Datadog::Profiling::TraceIdentifiers::Helper.new(
+            tracer: tracer,
+            extract_trace_resource: settings.profiling.advanced.extract_trace_resource,
+          )
 
           recorder = build_profiler_recorder(settings)
           collectors = build_profiler_collectors(settings, recorder, trace_identifiers_helper)

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -159,13 +159,19 @@ module Datadog
           end
         end
 
-        option :max_events, default: 32768
+        settings :advanced do
+          option :max_events, default: 32768
 
-        # Controls the maximum number of frames for each thread sampled. Can be tuned to avoid omitted frames in the
-        # produced profiles. Increasing this may increase the overhead of profiling.
-        option :max_frames do |o|
-          o.default { env_to_int(Ext::Profiling::ENV_MAX_FRAMES, 400) }
-          o.lazy
+          # Controls the maximum number of frames for each thread sampled. Can be tuned to avoid omitted frames in the
+          # produced profiles. Increasing this may increase the overhead of profiling.
+          option :max_frames do |o|
+            o.default { env_to_int(Ext::Profiling::ENV_MAX_FRAMES, 400) }
+            o.lazy
+          end
+
+          # When using profiling together with tracing, this controls if trace resources (usually the endpoint names)
+          # are gathered and reported together with profiles.
+          option :extract_trace_resource, default: true
         end
 
         settings :upload do

--- a/lib/ddtrace/ext/profiling.rb
+++ b/lib/ddtrace/ext/profiling.rb
@@ -10,6 +10,7 @@ module Datadog
         LABEL_KEY_SPAN_ID = 'span id'.freeze
         LABEL_KEY_THREAD_ID = 'thread id'.freeze
         LABEL_KEY_TRACE_ID = 'trace id'.freeze
+        LABEL_KEY_TRACE_ENDPOINT = 'trace endpoint'.freeze
         SAMPLE_VALUE_NO_VALUE = 0
         VALUE_TYPE_CPU = 'cpu-time'.freeze
         VALUE_TYPE_WALL = 'wall-time'.freeze

--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -125,8 +125,7 @@ module Datadog
           locations = convert_backtrace_locations(locations)
 
           thread_id = thread.respond_to?(:pthread_thread_id) ? thread.pthread_thread_id : thread.object_id
-          trace_id, span_id = trace_identifiers_helper.trace_identifiers_for(thread)
-          trace_resource_container = nil # WIP
+          trace_id, span_id, trace_resource_container = trace_identifiers_helper.trace_identifiers_for(thread)
           cpu_time = get_cpu_time_interval!(thread)
 
           Events::StackSample.new(

--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -126,6 +126,7 @@ module Datadog
 
           thread_id = thread.respond_to?(:pthread_thread_id) ? thread.pthread_thread_id : thread.object_id
           trace_id, span_id = trace_identifiers_helper.trace_identifiers_for(thread)
+          trace_resource_container = nil # WIP
           cpu_time = get_cpu_time_interval!(thread)
 
           Events::StackSample.new(
@@ -135,6 +136,7 @@ module Datadog
             thread_id,
             trace_id,
             span_id,
+            trace_resource_container,
             cpu_time,
             wall_time_interval_ns
           )

--- a/lib/ddtrace/profiling/events/stack.rb
+++ b/lib/ddtrace/profiling/events/stack.rb
@@ -6,12 +6,13 @@ module Datadog
       # Describes a stack profiling event
       class Stack < Event
         attr_reader \
-          :frames,
           :hash,
-          :span_id,
-          :thread_id,
+          :frames,
           :total_frame_count,
-          :trace_id
+          :thread_id,
+          :trace_id,
+          :span_id,
+          :trace_resource_container
 
         def initialize(
           timestamp,
@@ -19,7 +20,8 @@ module Datadog
           total_frame_count,
           thread_id,
           trace_id,
-          span_id
+          span_id,
+          trace_resource_container
         )
           super(timestamp)
 
@@ -28,11 +30,14 @@ module Datadog
           @thread_id = thread_id
           @trace_id = trace_id
           @span_id = span_id
+          @trace_resource_container = trace_resource_container
 
           @hash = [
             thread_id,
             trace_id,
             span_id,
+            # trace_resource_container is deliberately not included -- events that share the same (trace_id, span_id)
+            # pair should also have the same trace_resource_container
             frames.collect(&:hash),
             total_frame_count
           ].hash
@@ -52,6 +57,7 @@ module Datadog
           thread_id,
           trace_id,
           span_id,
+          trace_resource_container,
           cpu_time_interval_ns,
           wall_time_interval_ns
         )
@@ -61,7 +67,8 @@ module Datadog
             total_frame_count,
             thread_id,
             trace_id,
-            span_id
+            span_id,
+            trace_resource_container
           )
 
           @cpu_time_interval_ns = cpu_time_interval_ns

--- a/lib/ddtrace/profiling/pprof/stack_sample.rb
+++ b/lib/ddtrace/profiling/pprof/stack_sample.rb
@@ -79,19 +79,29 @@ module Datadog
             )
           ]
 
-          unless stack_sample.trace_id.nil? || stack_sample.trace_id.zero?
+          trace_id = stack_sample.trace_id || 0
+          span_id = stack_sample.span_id || 0
+
+          if trace_id != 0 && span_id != 0
             @processed_with_trace_ids += 1
+
             labels << Perftools::Profiles::Label.new(
               key: builder.string_table.fetch(Datadog::Ext::Profiling::Pprof::LABEL_KEY_TRACE_ID),
-              str: builder.string_table.fetch(stack_sample.trace_id.to_s)
+              str: builder.string_table.fetch(trace_id.to_s)
             )
-          end
 
-          unless stack_sample.span_id.nil? || stack_sample.span_id.zero?
             labels << Perftools::Profiles::Label.new(
               key: builder.string_table.fetch(Datadog::Ext::Profiling::Pprof::LABEL_KEY_SPAN_ID),
-              str: builder.string_table.fetch(stack_sample.span_id.to_s)
+              str: builder.string_table.fetch(span_id.to_s)
             )
+
+            trace_resource_container = stack_sample.trace_resource_container
+            if trace_resource_container
+              labels << Perftools::Profiles::Label.new(
+                key: builder.string_table.fetch(Datadog::Ext::Profiling::Pprof::LABEL_KEY_TRACE_ENDPOINT),
+                str: builder.string_table.fetch(trace_resource_container.latest)
+              )
+            end
           end
 
           labels

--- a/lib/ddtrace/profiling/pprof/stack_sample.rb
+++ b/lib/ddtrace/profiling/pprof/stack_sample.rb
@@ -95,11 +95,11 @@ module Datadog
               str: builder.string_table.fetch(span_id.to_s)
             )
 
-            trace_resource_container = stack_sample.trace_resource_container
-            if trace_resource_container
+            trace_resource = stack_sample.trace_resource_container && stack_sample.trace_resource_container.latest
+            if trace_resource && !trace_resource.empty?
               labels << Perftools::Profiles::Label.new(
                 key: builder.string_table.fetch(Datadog::Ext::Profiling::Pprof::LABEL_KEY_TRACE_ENDPOINT),
-                str: builder.string_table.fetch(trace_resource_container.latest)
+                str: builder.string_table.fetch(trace_resource)
               )
             end
           end

--- a/lib/ddtrace/profiling/trace_identifiers/ddtrace.rb
+++ b/lib/ddtrace/profiling/trace_identifiers/ddtrace.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ddtrace/ext/http'
+
 module Datadog
   module Profiling
     module TraceIdentifiers
@@ -7,17 +9,30 @@ module Datadog
       # given thread, if there is an active trace for that thread in Datadog.tracer.
       class Ddtrace
         def initialize(tracer: nil)
-          @tracer = (tracer if tracer.respond_to?(:active_correlation))
+          @tracer = (tracer if tracer.respond_to?(:call_context))
         end
 
         def trace_identifiers_for(thread)
           return unless @tracer
 
-          correlation = @tracer.active_correlation(thread)
-          trace_id = correlation.trace_id
-          span_id = correlation.span_id
+          context = @tracer.call_context(thread)
+          return unless context
 
-          [trace_id, span_id] if trace_id && trace_id != 0 && span_id && span_id != 0
+          trace_id = context.trace_id || 0
+          span_id = context.span_id || 0
+
+          [trace_id, span_id, maybe_extract_resource(context.current_root_span)] if trace_id != 0 && span_id != 0
+        end
+
+        private
+
+        # NOTE: Currently we're only interested in HTTP service endpoints. Over time, this list may be expanded.
+        # Resources MUST NOT include personal identifiable information (PII); this should not be the case with
+        # ddtrace integrations, but worth mentioning just in case :)
+        def maybe_extract_resource(root_span)
+          return unless root_span
+
+          root_span.resource_container if root_span.span_type == Datadog::Ext::HTTP::TYPE_INBOUND
         end
       end
     end

--- a/lib/ddtrace/profiling/trace_identifiers/helper.rb
+++ b/lib/ddtrace/profiling/trace_identifiers/helper.rb
@@ -20,6 +20,8 @@ module Datadog
           @supported_apis = supported_apis
         end
 
+        # Expected output of the #trace_identifiers_for
+        # duck type is [trace_id, span_id, (optional trace_resource_container)]
         def trace_identifiers_for(thread)
           @supported_apis.each do |api|
             trace_identifiers = api.trace_identifiers_for(thread)

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -52,12 +52,17 @@ module Datadog
       Ext::NET::TAG_HOSTNAME => true
     }.freeze
 
-    attr_accessor :name, :service, :resource, :span_type,
+    # Simple indirection used to contain the latest resource name for a span.
+    # The profiler keeps a reference to these objects while sampling so it can extract the latest resource after the
+    # fact, as some integrations only set the correct name at the end of the span.
+    ResourceContainer = Struct.new(:latest)
+
+    attr_accessor :name, :service, :span_type,
                   :span_id, :trace_id, :parent_id,
                   :status, :sampled,
                   :tracer, :context
 
-    attr_reader :parent, :start_time, :end_time
+    attr_reader :parent, :start_time, :end_time, :resource_container
 
     attr_writer :duration
 
@@ -75,7 +80,7 @@ module Datadog
 
       @name = name
       @service = options.fetch(:service, nil)
-      @resource = options.fetch(:resource, name)
+      @resource_container = ResourceContainer.new(options.fetch(:resource, name))
       @span_type = options.fetch(:span_type, nil)
 
       @span_id = Datadog::Utils.next_id
@@ -283,7 +288,7 @@ module Datadog
         trace_id: @trace_id,
         name: @name,
         service: @service,
-        resource: @resource,
+        resource: resource,
         type: @span_type,
         meta: @meta,
         metrics: @metrics,
@@ -337,7 +342,7 @@ module Datadog
       packer.write('service')
       packer.write(@service)
       packer.write('resource')
-      packer.write(@resource)
+      packer.write(resource)
       packer.write('type')
       packer.write(@span_type)
       packer.write('meta')
@@ -369,7 +374,7 @@ module Datadog
         q.text "Trace ID: #{@trace_id}\n"
         q.text "Type: #{@span_type}\n"
         q.text "Service: #{@service}\n"
-        q.text "Resource: #{@resource}\n"
+        q.text "Resource: #{resource}\n"
         q.text "Error: #{@status}\n"
         q.text "Start: #{start_time}\n"
         q.text "End: #{end_time}\n"
@@ -406,6 +411,14 @@ module Datadog
       else
         @duration_end - @duration_start
       end
+    end
+
+    def resource
+      @resource_container.latest
+    end
+
+    def resource=(resource)
+      @resource_container.latest = resource
     end
 
     private

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -84,14 +84,13 @@ module Datadog
 
       @default_service = options[:default_service]
       @enabled = options.fetch(:enabled, true)
-      @provider = options.fetch(:context_provider, Datadog::DefaultContextProvider.new)
+      @provider = options[:context_provider] || Datadog::DefaultContextProvider.new
       @sampler = options.fetch(:sampler, Datadog::AllSampler.new)
       @tags = options.fetch(:tags, {})
       @writer = options.fetch(:writer) { Datadog::Writer.new }
 
       # Instance variables
       @mutex = Mutex.new
-      @provider ||= Datadog::DefaultContextProvider.new # @provider should never be nil
 
       # Enable priority sampling by default
       activate_priority_sampling!(@sampler)

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -789,6 +789,19 @@ RSpec.describe Datadog::Configuration::Components do
 
             build_profiler
           end
+
+          [true, false].each do |value|
+            context "when extract_trace_resource is #{value}" do
+              before { settings.profiling.advanced.extract_trace_resource = value }
+
+              it "initializes the TraceIdentifiers::Helper with extract_trace_resource: #{value}" do
+                expect(Datadog::Profiling::TraceIdentifiers::Helper)
+                  .to receive(:new).with(tracer: tracer, extract_trace_resource: value)
+
+                build_profiler
+              end
+            end
+          end
         end
 
         context 'and :transport' do

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -709,7 +709,7 @@ RSpec.describe Datadog::Configuration::Components do
             enabled?: true,
             started?: false,
             ignore_thread: nil,
-            max_frames: settings.profiling.max_frames,
+            max_frames: settings.profiling.advanced.max_frames,
             max_time_usage_pct: 2.0
           )
         end
@@ -732,7 +732,7 @@ RSpec.describe Datadog::Configuration::Components do
         subject(:recorder) { profiler.scheduler.recorder }
 
         it do
-          is_expected.to have_attributes(max_size: settings.profiling.max_events)
+          is_expected.to have_attributes(max_size: settings.profiling.advanced.max_events)
         end
       end
 

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -539,51 +539,70 @@ RSpec.describe Datadog::Configuration::Settings do
       end
     end
 
-    describe '#max_events' do
-      subject(:max_events) { settings.profiling.max_events }
+    describe '#advanced' do
+      describe '#max_events' do
+        subject(:max_events) { settings.profiling.advanced.max_events }
 
-      it { is_expected.to eq(32768) }
-    end
-
-    describe '#max_events=' do
-      it 'updates the #max_events setting' do
-        expect { settings.profiling.max_events = 1234 }
-          .to change { settings.profiling.max_events }
-          .from(32768)
-          .to(1234)
+        it { is_expected.to eq(32768) }
       end
-    end
 
-    describe '#max_frames' do
-      subject(:max_frames) { settings.profiling.max_frames }
+      describe '#max_events=' do
+        it 'updates the #max_events setting' do
+          expect { settings.profiling.advanced.max_events = 1234 }
+            .to change { settings.profiling.advanced.max_events }
+            .from(32768)
+            .to(1234)
+        end
+      end
 
-      context "when #{Datadog::Ext::Profiling::ENV_MAX_FRAMES}" do
-        around do |example|
-          ClimateControl.modify(Datadog::Ext::Profiling::ENV_MAX_FRAMES => environment) do
-            example.run
+      describe '#max_frames' do
+        subject(:max_frames) { settings.profiling.advanced.max_frames }
+
+        context "when #{Datadog::Ext::Profiling::ENV_MAX_FRAMES}" do
+          around do |example|
+            ClimateControl.modify(Datadog::Ext::Profiling::ENV_MAX_FRAMES => environment) do
+              example.run
+            end
+          end
+
+          context 'is not defined' do
+            let(:environment) { nil }
+
+            it { is_expected.to eq(400) }
+          end
+
+          context 'is defined' do
+            let(:environment) { '123' }
+
+            it { is_expected.to eq(123) }
           end
         end
+      end
 
-        context 'is not defined' do
-          let(:environment) { nil }
-
-          it { is_expected.to eq(400) }
-        end
-
-        context 'is defined' do
-          let(:environment) { '123' }
-
-          it { is_expected.to eq(123) }
+      describe '#max_frames=' do
+        it 'updates the #max_frames setting' do
+          expect { settings.profiling.advanced.max_frames = 456 }
+            .to change { settings.profiling.advanced.max_frames }
+            .from(400)
+            .to(456)
         end
       end
-    end
 
-    describe '#max_frames=' do
-      it 'updates the #max_frames setting' do
-        expect { settings.profiling.max_frames = 456 }
-          .to change { settings.profiling.max_frames }
-          .from(400)
-          .to(456)
+      describe '#extract_trace_resource' do
+        subject(:extract_trace_resource) { settings.profiling.advanced.extract_trace_resource }
+
+        it 'defaults to true' do
+          is_expected.to be true
+        end
+      end
+
+      describe '#extract_trace_resource=' do
+        it 'updates the #extract_trace_resource setting' do
+          expect { settings.profiling.advanced.extract_trace_resource = false }
+            .to change { settings.profiling.advanced.extract_trace_resource }
+            .from(true)
+            .to(false)
+        end
       end
     end
 

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -299,8 +299,23 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
         it 'builds an event including the trace id and span id' do
           is_expected.to have_attributes(
             trace_id: trace_id,
-            span_id: span_id
+            span_id: span_id,
+            trace_resource_container: nil
           )
+        end
+
+        context 'and a trace_resource_container is provided' do
+          let(:trace_identifiers) { [trace_id, span_id, trace_resource_container] }
+
+          let(:trace_resource_container) { instance_double(Datadog::Span::ResourceContainer) }
+
+          it 'builds an event including the trace id, span id, and trace_resource_container' do
+            is_expected.to have_attributes(
+              trace_id: trace_id,
+              span_id: span_id,
+              trace_resource_container: trace_resource_container
+            )
+          end
         end
       end
 

--- a/spec/ddtrace/profiling/events/stack_spec.rb
+++ b/spec/ddtrace/profiling/events/stack_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Datadog::Profiling::Events do
           total_frame_count,
           thread_id,
           trace_id,
-          span_id
+          span_id,
+          trace_resource_container
         )
       end
 
@@ -22,6 +23,7 @@ RSpec.describe Datadog::Profiling::Events do
       let(:thread_id) { double('thread_id') }
       let(:trace_id) { double('trace_id') }
       let(:span_id) { double('span_id') }
+      let(:trace_resource_container) { double('trace_resource_container') }
 
       it do
         is_expected.to have_attributes(
@@ -30,7 +32,8 @@ RSpec.describe Datadog::Profiling::Events do
           total_frame_count: total_frame_count,
           thread_id: thread_id,
           trace_id: trace_id,
-          span_id: span_id
+          span_id: span_id,
+          trace_resource_container: trace_resource_container
         )
       end
     end
@@ -46,6 +49,7 @@ RSpec.describe Datadog::Profiling::Events do
           thread_id,
           trace_id,
           span_id,
+          trace_resource_container,
           cpu_time_interval_ns,
           wall_time_interval_ns
         )
@@ -57,6 +61,7 @@ RSpec.describe Datadog::Profiling::Events do
       let(:thread_id) { double('thread_id') }
       let(:trace_id) { double('trace_id') }
       let(:span_id) { double('span_id') }
+      let(:trace_resource_container) { double('trace_resource_container') }
       let(:cpu_time_interval_ns) { double('cpu_time_interval_ns') }
       let(:wall_time_interval_ns) { double('wall_time_interval_ns') }
 
@@ -68,6 +73,7 @@ RSpec.describe Datadog::Profiling::Events do
           thread_id: thread_id,
           trace_id: trace_id,
           span_id: span_id,
+          trace_resource_container: trace_resource_container,
           cpu_time_interval_ns: cpu_time_interval_ns,
           wall_time_interval_ns: wall_time_interval_ns
         )

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe 'profiling integration test' do
 
     let(:stack_samples) do
       [
-        build_stack_sample(stack_one, 100, trace_id, span_id, 100),
-        build_stack_sample(stack_two, 100, trace_id, span_id, 200),
-        build_stack_sample(stack_one, 101, trace_id, span_id, 400),
-        build_stack_sample(stack_two, 101, trace_id, span_id, 800),
-        build_stack_sample(stack_two, 101, trace_id, span_id, 1600)
+        build_stack_sample(locations: stack_one, thread_id: 100, trace_id: trace_id, span_id: span_id, cpu_time_ns: 100),
+        build_stack_sample(locations: stack_two, thread_id: 100, trace_id: trace_id, span_id: span_id, cpu_time_ns: 200),
+        build_stack_sample(locations: stack_one, thread_id: 101, trace_id: trace_id, span_id: span_id, cpu_time_ns: 400),
+        build_stack_sample(locations: stack_two, thread_id: 101, trace_id: trace_id, span_id: span_id, cpu_time_ns: 800),
+        build_stack_sample(locations: stack_two, thread_id: 101, trace_id: trace_id, span_id: span_id, cpu_time_ns: 1600)
       ]
     end
 

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -31,14 +31,50 @@ RSpec.describe 'profiling integration test' do
 
     let(:trace_id) { 0 }
     let(:span_id) { 0 }
+    let(:trace_resource_container) { nil }
 
     let(:stack_samples) do
       [
-        build_stack_sample(locations: stack_one, thread_id: 100, trace_id: trace_id, span_id: span_id, cpu_time_ns: 100),
-        build_stack_sample(locations: stack_two, thread_id: 100, trace_id: trace_id, span_id: span_id, cpu_time_ns: 200),
-        build_stack_sample(locations: stack_one, thread_id: 101, trace_id: trace_id, span_id: span_id, cpu_time_ns: 400),
-        build_stack_sample(locations: stack_two, thread_id: 101, trace_id: trace_id, span_id: span_id, cpu_time_ns: 800),
-        build_stack_sample(locations: stack_two, thread_id: 101, trace_id: trace_id, span_id: span_id, cpu_time_ns: 1600)
+        build_stack_sample(
+          locations: stack_one,
+          thread_id: 100,
+          trace_id: trace_id,
+          span_id: span_id,
+          trace_resource_container: trace_resource_container,
+          cpu_time_ns: 100
+        ),
+        build_stack_sample(
+          locations: stack_two,
+          thread_id: 100,
+          trace_id: trace_id,
+          span_id: span_id,
+          trace_resource_container: trace_resource_container,
+          cpu_time_ns: 200
+        ),
+        build_stack_sample(
+          locations: stack_one,
+          thread_id: 101,
+          trace_id: trace_id,
+          span_id: span_id,
+          trace_resource_container: trace_resource_container,
+          cpu_time_ns: 400
+        ),
+        build_stack_sample(
+          locations: stack_two,
+          thread_id: 101,
+          trace_id: trace_id,
+          span_id: span_id,
+          trace_resource_container: trace_resource_container,
+          cpu_time_ns: 800
+        ),
+        build_stack_sample(
+          locations: stack_two,
+          thread_id: 101,
+          trace_id: trace_id,
+          span_id: span_id,
+          trace_resource_container: trace_resource_container,
+          cpu_time_ns: 1600
+        )
       ]
     end
 
@@ -272,6 +308,7 @@ RSpec.describe 'profiling integration test' do
         context 'when trace and span IDs are available' do
           let(:trace_id) { rand(1e9) }
           let(:span_id) { rand(1e9) }
+          let(:trace_resource_container) { Datadog::Span::ResourceContainer.new('example trace resource') }
 
           it 'is well formed with trace and span ID labels' do
             expect(sample.last.to_h).to eq(
@@ -289,13 +326,19 @@ RSpec.describe 'profiling integration test' do
                 },
                 {
                   key: string_id_for(Datadog::Ext::Profiling::Pprof::LABEL_KEY_TRACE_ID),
-                  str: string_id_for(stack_samples.last.trace_id.to_s),
+                  str: string_id_for(trace_id.to_s),
                   num: 0,
                   num_unit: 0
                 },
                 {
                   key: string_id_for(Datadog::Ext::Profiling::Pprof::LABEL_KEY_SPAN_ID),
-                  str: string_id_for(stack_samples.last.span_id.to_s),
+                  str: string_id_for(span_id.to_s),
+                  num: 0,
+                  num_unit: 0
+                },
+                {
+                  key: string_id_for(Datadog::Ext::Profiling::Pprof::LABEL_KEY_TRACE_ENDPOINT),
+                  str: string_id_for('example trace resource'),
                   num: 0,
                   num_unit: 0
                 }

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -93,7 +93,8 @@ RSpec.describe 'profiling integration test' do
     let(:collector) do
       Datadog::Profiling::Collectors::Stack.new(
         recorder,
-        trace_identifiers_helper: Datadog::Profiling::TraceIdentifiers::Helper.new(tracer: tracer),
+        trace_identifiers_helper:
+          Datadog::Profiling::TraceIdentifiers::Helper.new(tracer: tracer, extract_trace_resource: true),
         max_frames: 400
       )
     end

--- a/spec/ddtrace/profiling/pprof/stack_sample_spec.rb
+++ b/spec/ddtrace/profiling/pprof/stack_sample_spec.rb
@@ -438,7 +438,7 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
           it_behaves_like 'contains trace ID label'
           it_behaves_like 'contains span ID label'
 
-          context 'when trace resource is non-null' do
+          context 'when trace resource is non-empty' do
             let(:trace_resource_container) { Datadog::Span::ResourceContainer.new('example trace resource') }
 
             it do
@@ -450,6 +450,19 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
             it_behaves_like 'contains trace ID label'
             it_behaves_like 'contains span ID label'
             it_behaves_like('contains trace endpoint label', trace_endpoint: 'example trace resource')
+          end
+
+          context 'when trace resource is empty' do
+            let(:trace_resource_container) { Datadog::Span::ResourceContainer.new('') }
+
+            it do
+              is_expected.to be_kind_of(Array)
+              is_expected.to have(3).items
+            end
+
+            it_behaves_like 'contains thread ID label'
+            it_behaves_like 'contains trace ID label'
+            it_behaves_like 'contains span ID label'
           end
         end
 

--- a/spec/ddtrace/profiling/pprof/stack_sample_spec.rb
+++ b/spec/ddtrace/profiling/pprof/stack_sample_spec.rb
@@ -91,11 +91,12 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
       let(:thread_id) { 1 }
       let(:trace_id) { 2 }
       let(:span_id) { 3 }
+      let(:trace_resource_container) { double('trace_resource_container') } # rubocop:disable RSpec/VerifiedDoubles
       let(:stack) { Thread.current.backtrace_locations }
 
       context 'with identical threads, stacks, trace and span IDs' do
-        let(:first) { build_stack_sample(stack, thread_id, trace_id, span_id) }
-        let(:second) { build_stack_sample(stack, thread_id, trace_id, span_id) }
+        let(:first) { build_stack_sample(locations: stack, thread_id: thread_id, trace_id: trace_id, span_id: span_id) }
+        let(:second) { build_stack_sample(locations: stack, thread_id: thread_id, trace_id: trace_id, span_id: span_id) }
 
         before { expect(first.frames).to eq(second.frames) }
 
@@ -105,8 +106,10 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
       context 'with identical threads and stacks but different' do
         context 'trace IDs' do
           let(:other_trace_id) { 3 }
-          let(:first) { build_stack_sample(stack, thread_id, trace_id, span_id) }
-          let(:second) { build_stack_sample(stack, thread_id, other_trace_id, span_id) }
+          let(:first) { build_stack_sample(locations: stack, thread_id: thread_id, trace_id: trace_id, span_id: span_id) }
+          let(:second) do
+            build_stack_sample(locations: stack, thread_id: thread_id, trace_id: other_trace_id, span_id: span_id)
+          end
 
           before { expect(first.frames).to eq(second.frames) }
 
@@ -115,8 +118,10 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
 
         context 'span IDs' do
           let(:other_span_id) { 4 }
-          let(:first) { build_stack_sample(stack, thread_id, trace_id, span_id) }
-          let(:second) { build_stack_sample(stack, thread_id, trace_id, other_span_id) }
+          let(:first) { build_stack_sample(locations: stack, thread_id: thread_id, trace_id: trace_id, span_id: span_id) }
+          let(:second) do
+            build_stack_sample(locations: stack, thread_id: thread_id, trace_id: trace_id, span_id: other_span_id)
+          end
 
           before { expect(first.frames).to eq(second.frames) }
 
@@ -126,8 +131,8 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
 
       context 'with identical threads and different' do
         context 'stacks' do
-          let(:first) { build_stack_sample(nil, thread_id, trace_id, span_id) }
-          let(:second) { build_stack_sample(nil, thread_id, trace_id, span_id) }
+          let(:first) { build_stack_sample(locations: nil, thread_id: thread_id, trace_id: trace_id, span_id: span_id) }
+          let(:second) { build_stack_sample(locations: nil, thread_id: thread_id, trace_id: trace_id, span_id: span_id) }
 
           before { expect(first.frames).to_not eq(second.frames) }
 
@@ -143,6 +148,7 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
               thread_id,
               trace_id,
               span_id,
+              trace_resource_container,
               rand(1e9),
               rand(1e9)
             )
@@ -156,6 +162,7 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
               thread_id,
               trace_id,
               span_id,
+              trace_resource_container,
               rand(1e9),
               rand(1e9)
             )
@@ -168,8 +175,8 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
       end
 
       context 'with identical stacks and different thread IDs' do
-        let(:first) { build_stack_sample(stack, 1) }
-        let(:second) { build_stack_sample(stack, 2) }
+        let(:first) { build_stack_sample(locations: stack, thread_id: 1) }
+        let(:second) { build_stack_sample(locations: stack, thread_id: 2) }
 
         before do
           expect(first.frames).to eq(second.frames)
@@ -190,6 +197,7 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
       let(:thread_id) { 1 }
       let(:trace_id) { 2 }
       let(:span_id) { 3 }
+      let(:trace_resource_container) { double('trace_resource_container') } # rubocop:disable RSpec/VerifiedDoubles
       let(:stack) { Thread.current.backtrace_locations }
 
       shared_examples_for 'independent stack samples' do
@@ -214,8 +222,8 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
       end
 
       context 'with identical threads, stacks, trace and span IDs' do
-        let(:first) { build_stack_sample(stack, thread_id, trace_id, span_id) }
-        let(:second) { build_stack_sample(stack, thread_id, trace_id, span_id) }
+        let(:first) { build_stack_sample(locations: stack, thread_id: thread_id, trace_id: trace_id, span_id: span_id) }
+        let(:second) { build_stack_sample(locations: stack, thread_id: thread_id, trace_id: trace_id, span_id: span_id) }
 
         before { expect(first.frames).to eq(second.frames) }
 
@@ -236,8 +244,8 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
 
       context 'with identical threads and different' do
         context 'stacks' do
-          let(:first) { build_stack_sample(nil, thread_id, trace_id, span_id) }
-          let(:second) { build_stack_sample(nil, thread_id, trace_id, span_id) }
+          let(:first) { build_stack_sample(locations: nil, thread_id: thread_id, trace_id: trace_id, span_id: span_id) }
+          let(:second) { build_stack_sample(locations: nil, thread_id: thread_id, trace_id: trace_id, span_id: span_id) }
 
           before { expect(first.frames).to_not eq(second.frames) }
 
@@ -253,6 +261,7 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
               thread_id,
               trace_id,
               span_id,
+              trace_resource_container,
               rand(1e9),
               rand(1e9)
             )
@@ -266,6 +275,7 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
               thread_id,
               trace_id,
               span_id,
+              trace_resource_container,
               rand(1e9),
               rand(1e9)
             )
@@ -278,8 +288,8 @@ RSpec.describe Datadog::Profiling::Pprof::StackSample do
       end
 
       context 'with identical stacks and different thread IDs' do
-        let(:first) { build_stack_sample(stack, 1) }
-        let(:second) { build_stack_sample(stack, 2) }
+        let(:first) { build_stack_sample(locations: stack, thread_id: 1) }
+        let(:second) { build_stack_sample(locations: stack, thread_id: 2) }
 
         before do
           expect(first.frames).to eq(second.frames)

--- a/spec/ddtrace/profiling/spec_helper.rb
+++ b/spec/ddtrace/profiling/spec_helper.rb
@@ -97,7 +97,7 @@ module ProfileHelpers
       thread_id || rand(1e9),
       trace_id || rand(1e9),
       span_id || rand(1e9),
-      trace_resource_container || double('trace_resource_container'), # rubocop:disable RSpec/VerifiedDoubles
+      trace_resource_container || Datadog::Span::ResourceContainer.new("resource#{rand(1e9)}"),
       cpu_time_ns || rand(1e9),
       wall_time_ns || rand(1e9)
     )

--- a/spec/ddtrace/profiling/spec_helper.rb
+++ b/spec/ddtrace/profiling/spec_helper.rb
@@ -44,11 +44,21 @@ module ProfileHelpers
     stack_two = Array(Thread.current.backtrace_locations).first(3)
 
     stack_samples = [
-      build_stack_sample(stack_one, 100, 0, 0, 100, 100),
-      build_stack_sample(stack_two, 100, 0, 0, 200, 200),
-      build_stack_sample(stack_one, 101, 0, 0, 400, 400),
-      build_stack_sample(stack_two, 101, 0, 0, 800, 800),
-      build_stack_sample(stack_two, 101, 0, 0, 1600, 1600)
+      build_stack_sample(
+        locations: stack_one, thread_id: 100, trace_id: 0, span_id: 0, cpu_time_ns: 100, wall_time_ns: 100
+      ),
+      build_stack_sample(
+        locations: stack_two, thread_id: 100, trace_id: 0, span_id: 0, cpu_time_ns: 200, wall_time_ns: 200
+      ),
+      build_stack_sample(
+        locations: stack_one, thread_id: 101, trace_id: 0, span_id: 0, cpu_time_ns: 400, wall_time_ns: 400
+      ),
+      build_stack_sample(
+        locations: stack_two, thread_id: 101, trace_id: 0, span_id: 0, cpu_time_ns: 800, wall_time_ns: 800
+      ),
+      build_stack_sample(
+        locations: stack_two, thread_id: 101, trace_id: 0, span_id: 0, cpu_time_ns: 1600, wall_time_ns: 1600
+      )
     ]
 
     start = Time.now.utc
@@ -68,12 +78,13 @@ module ProfileHelpers
   end
 
   def build_stack_sample(
-    locations = nil,
-    thread_id = nil,
-    trace_id = nil,
-    span_id = nil,
-    cpu_time_ns = nil,
-    wall_time_ns = nil
+    locations: nil,
+    thread_id: nil,
+    trace_id: nil,
+    span_id: nil,
+    trace_resource_container: nil,
+    cpu_time_ns: nil,
+    wall_time_ns: nil
   )
     locations ||= Thread.current.backtrace_locations
 
@@ -86,6 +97,7 @@ module ProfileHelpers
       thread_id || rand(1e9),
       trace_id || rand(1e9),
       span_id || rand(1e9),
+      trace_resource_container || double('trace_resource_container'), # rubocop:disable RSpec/VerifiedDoubles
       cpu_time_ns || rand(1e9),
       wall_time_ns || rand(1e9)
     )

--- a/spec/ddtrace/profiling/trace_identifiers/ddtrace_spec.rb
+++ b/spec/ddtrace/profiling/trace_identifiers/ddtrace_spec.rb
@@ -1,7 +1,8 @@
 require 'ddtrace/profiling/trace_identifiers/ddtrace'
 
-require 'ddtrace/correlation'
 require 'ddtrace/tracer'
+require 'ddtrace/context'
+require 'ddtrace/span'
 
 RSpec.describe Datadog::Profiling::TraceIdentifiers::Ddtrace do
   let(:thread) { instance_double(Thread) }
@@ -15,31 +16,73 @@ RSpec.describe Datadog::Profiling::TraceIdentifiers::Ddtrace do
     context 'when there is an active datadog trace for the thread' do
       let(:trace_id) { rand(1e12) }
       let(:span_id) { rand(1e12) }
-
-      before do
-        expect(tracer)
-          .to receive(:active_correlation)
-          .with(thread)
-          .and_return(Datadog::Correlation::Identifier.new(trace_id, span_id))
+      let(:context) do
+        instance_double(Datadog::Context, trace_id: trace_id, span_id: span_id, current_root_span: root_span)
       end
 
-      it 'returns the identifiers' do
-        trace_identifiers_for
+      before do
+        expect(tracer).to receive(:call_context).with(thread).and_return(context)
+      end
 
-        expect(trace_identifiers_for).to eq [trace_id, span_id]
+      context 'when root span is not available' do
+        let(:root_span) { nil }
+
+        it 'returns the identifiers and no trace resource' do
+          trace_identifiers_for
+
+          expect(trace_identifiers_for).to eq [trace_id, span_id, nil]
+        end
+      end
+
+      context 'when root span is available' do
+        let(:root_span) { instance_double(Datadog::Span, span_type: root_span_type) }
+
+        context "when root span type is 'web'" do
+          let(:root_span_type) { 'web' }
+          let(:resource_container) { Datadog::Span::ResourceContainer.new('example trace resource') }
+
+          before do
+            allow(root_span).to receive(:resource_container).and_return(resource_container)
+          end
+
+          it 'returns the identifiers and it returns the trace resource' do
+            trace_identifiers_for
+
+            expect(trace_identifiers_for).to eq [trace_id, span_id, resource_container]
+          end
+        end
+
+        context "when root span type is not 'web'" do
+          let(:root_span_type) { 'not web' }
+
+          it 'returns the identifiers and no trace resource' do
+            trace_identifiers_for
+
+            expect(trace_identifiers_for).to eq [trace_id, span_id, nil]
+          end
+        end
       end
     end
 
     context 'when there is no active datadog trace for the thread' do
-      before do
-        expect(tracer)
-          .to receive(:active_correlation)
-          .with(thread)
-          .and_return(Datadog::Correlation::Identifier.new)
+      context 'and an empty context is returned' do
+        before do
+          expect(tracer).to receive(:call_context).and_return(Datadog::Context.new)
+        end
+
+        it do
+          expect(trace_identifiers_for).to be nil
+        end
       end
 
-      it do
-        expect(trace_identifiers_for).to be nil
+      context 'and no context is returned' do
+        before do
+          expect(tracer).to receive(:call_context).and_return(nil)
+        end
+
+        it do
+          expect(trace_identifiers_for).to be nil
+        end
       end
     end
 
@@ -51,8 +94,8 @@ RSpec.describe Datadog::Profiling::TraceIdentifiers::Ddtrace do
       end
     end
 
-    context 'when tracer does not support #active_correlation' do
-      let(:tracer) { double('Tracer') } # rubocop:disable RSpec/VerifiedDoubles
+    context 'when tracer does not support #call_context' do
+      let(:tracer) { double('empty tracer') } # rubocop:disable RSpec/VerifiedDoubles
 
       it do
         expect(trace_identifiers_for).to be nil

--- a/spec/ddtrace/profiling/trace_identifiers/helper_spec.rb
+++ b/spec/ddtrace/profiling/trace_identifiers/helper_spec.rb
@@ -5,8 +5,11 @@ RSpec.describe Datadog::Profiling::TraceIdentifiers::Helper do
   let(:thread) { instance_double(Thread) }
   let(:api1) { instance_double(Datadog::Profiling::TraceIdentifiers::Ddtrace, 'api1') }
   let(:api2) { instance_double(Datadog::Profiling::TraceIdentifiers::Ddtrace, 'api2') }
+  let(:extract_trace_resource) { true }
 
-  subject(:trace_identifiers_helper) { described_class.new(tracer: nil, supported_apis: [api1, api2]) }
+  subject(:trace_identifiers_helper) do
+    described_class.new(tracer: nil, extract_trace_resource: extract_trace_resource, supported_apis: [api1, api2])
+  end
 
   describe '::DEFAULT_SUPPORTED_APIS' do
     it 'contains the Datadog trace identifiers' do
@@ -65,6 +68,14 @@ RSpec.describe Datadog::Profiling::TraceIdentifiers::Helper do
 
       it 'returns the trace resource container together with the trace identifiers' do
         expect(trace_identifiers_for).to eq [:api1_trace_id, :api1_span_id, :api1_trace_resource_container]
+      end
+
+      context 'and extract_trace_resource is set to false' do
+        let(:extract_trace_resource) { false }
+
+        it 'returns the trace identifiers but removes the trace resource container' do
+          expect(trace_identifiers_for).to eq [:api1_trace_id, :api1_span_id]
+        end
       end
     end
   end

--- a/spec/ddtrace/profiling/trace_identifiers/helper_spec.rb
+++ b/spec/ddtrace/profiling/trace_identifiers/helper_spec.rb
@@ -55,5 +55,17 @@ RSpec.describe Datadog::Profiling::TraceIdentifiers::Helper do
         expect(trace_identifiers_for).to be nil
       end
     end
+
+    context 'when the api provider returns a trace resource container together with the trace identifiers' do
+      before do
+        allow(api1)
+          .to receive(:trace_identifiers_for)
+          .and_return([:api1_trace_id, :api1_span_id, :api1_trace_resource_container])
+      end
+
+      it 'returns the trace resource container together with the trace identifiers' do
+        expect(trace_identifiers_for).to eq [:api1_trace_id, :api1_span_id, :api1_trace_resource_container]
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR extends the existing support for linking traces to profiles with one extra feature: the `resource` from root spans representing inbound web requests (aka "the endpoint") will be included as part of the profiling data.

This will enable the profiler to expose this as part of the profiling UX (which is still WIP/under discussion).

## Getting the correct `resource`

This feature would've been really easy to add ~~if it weren't for those meddling kids~~ if it weren't for the fact that quite a few integrations set the `resource` on the span at the end of the request, not at the beginning. This creates a problem: the profiler can (and probably will) observe the span before this, and would observe a missing or incorrect `resource` if it just recorded the current `resource` at the time of sampling.

To tackle this issue, I introduced a new `ResourceContainer` object in `Span` that serves only to keep a mutable reference to the latest `resource`. This way, and during sampling, the profiler records not the `resource` it sees but the `ResourceContainer` (which is always the same throughout the span's lifetime). Only when the profiling data is encoded does the profiler actually get the `resource` from inside the `ResourceContainer`. (This is the equivalent of the profiler holding on to a reference to the span, but without actually doing that)

While the above doesn't guarantee that the profiler will always observe the correct `resource` -- for instance we may observe a request that started just as the profiler was about to report the data, and is still ongoing -- I think this should be a "good enough" approximation to start. To improve on this, I plan to put aside some time to go through our most common tracing integrations and see if I can change any that set the `resource` at the end and move it to the beginning. Worst case, the correct data will be sent with the trace, so we can always chose to correct this information on the backend by querying the apm data.

## Personal Identifiable Information (PII) in the resource?

When I started this work, there was some doubts on wether the `resource` could contain some PII data. While discussing with @ericmustin  and @marcotc and inspired on https://github.com/DataDog/dd-trace-py/pull/2573 it became clear the `resource` would not include this information, especially not in traces with type `web`.

Of course, customers with really weird custom integrations can still "break" this, but that's the same with the rest of the profiling data -- you can always create a class, file name or method name with PII that will then be gathered by the profiler.

Nevertheless, I've added an option to disable the gathering of the `resource`, if needed (see below).

## Configuration

I've created a new `advanced` section in the `profiling` settings, and added a new `extract_trace_resource` option that can be used to control this feature (defaults to enabled).

I also moved two other obscure profiler settings -- `max_events` and `max_frames` inside this group. This move is technically backwards-incompatible, but these settings were never documented, and the profiler still being in beta, I think we should just rip of the band-aid now, rather than waiting for a later GA/1.0 to change them.

## Final note

This PR is on top #1620  to preemptively fix a merge conflict. Once that one is merged, GitHub will change the target branch of this PR to master.