### PR TITLE
Move Rails span resource setting to beginning of request

### DIFF
--- a/lib/ddtrace/contrib/action_pack/action_controller/instrumentation.rb
+++ b/lib/ddtrace/contrib/action_pack/action_controller/instrumentation.rb
@@ -18,11 +18,18 @@ module Datadog
             tracer = Datadog.configuration[:action_pack][:tracer]
             service = Datadog.configuration[:action_pack][:controller_service]
             type = Datadog::Ext::HTTP::TYPE_INBOUND
-            span = tracer.trace(Ext::SPAN_ACTION_CONTROLLER, service: service, span_type: type)
+            span = tracer.trace(
+              Ext::SPAN_ACTION_CONTROLLER,
+              service: service,
+              span_type: type,
+              resource: "#{payload.fetch(:controller)}##{payload.fetch(:action)}",
+            )
 
             # attach the current span to the tracing context
             tracing_context = payload.fetch(:tracing_context)
             tracing_context[:dd_request_span] = span
+
+            try_setting_rack_request_resource(payload, span.resource)
           rescue StandardError => e
             Datadog.logger.error(e.message)
           end
@@ -30,19 +37,12 @@ module Datadog
           def finish_processing(payload)
             # retrieve the tracing context and the latest active span
             tracing_context = payload.fetch(:tracing_context)
-            env = payload.fetch(:env)
             span = tracing_context[:dd_request_span]
             return unless span && !span.finished?
 
             begin
-              # Set the resource name, if it's still the default name
-              span.resource = "#{payload.fetch(:controller)}##{payload.fetch(:action)}" if span.resource == span.name
-
-              # Set the resource name of the Rack request span unless this is an exception controller.
-              unless exception_controller?(payload)
-                rack_request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
-                rack_request_span.resource = span.resource if rack_request_span
-              end
+              # We repeat this in both start and at finish because the resource may have changed during the request
+              try_setting_rack_request_resource(payload, span.resource)
 
               # Set analytics sample rate
               Utils.set_analytics_sample_rate(span)
@@ -92,6 +92,14 @@ module Datadog
             end
           end
 
+          def try_setting_rack_request_resource(payload, resource)
+            # Set the resource name of the Rack request span unless this is an exception controller.
+            unless payload.fetch(:exception_controller?)
+              rack_request_span = payload.fetch(:env)[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
+              rack_request_span.resource = resource if rack_request_span
+            end
+          end
+
           # Instrumentation for ActionController::Metal
           module Metal
             def process_action(*args)
@@ -111,6 +119,8 @@ module Datadog
               }
 
               begin
+                payload[:exception_controller?] = Instrumentation.exception_controller?(payload)
+
                 # process and catch request exceptions
                 Instrumentation.start_processing(payload)
                 result = super(*args)

--- a/spec/ddtrace/contrib/action_pack/action_controller/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/action_pack/action_controller/instrumentation_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Datadog::Contrib::ActionPack::ActionController::Instrumentation d
             # which is typical if the controller is configured to handle exceptions.
             request_exception: action_dispatch_exception
           },
-          tracing_context: {}
+          tracing_context: {},
+          exception_controller?: false,
         }
       end
 


### PR DESCRIPTION
As of #1623, the profiler records the `resource` of the root span, on top of the span id and trace id during sampling.

Also, as discusssed in the description of #1623 (in the "Getting the correct `resource`" section) integrations where the
`resource` is only set at the end pose an extra challenge, as the request may not be finished in time for the `resource` to be included in the profiler payload.

This means that the profiler may miss the `resource` for some of the requests, depending on timing of when the sampling happens and when the request finishes.

(Note that in this case, the trace id and span id will still be propagated, so the samples will always be able to be tied back to the trace that originated them; it's just the `resource` that will not be included in the profiler data).

To avoid this issue for many of our customers, let's move the Rails `resource` setting to the beginning of the request, thus avoiding the issue altogether for the Rails (action_pack/action_controller) integration.