### PR TITLE
Set Sinatra resource setting at beginning of request and delay setting fallback resource

### DIFF
--- a/lib/ddtrace/contrib/sinatra/tracer_middleware.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer_middleware.rb
@@ -28,7 +28,9 @@ module Datadog
             Ext::SPAN_REQUEST,
             service: configuration[:service_name],
             span_type: Datadog::Ext::HTTP::TYPE_INBOUND,
-            resource: env['REQUEST_METHOD']
+            # this is kept nil until we set a correct one (either in the route or with a fallback in the ensure below)
+            # the nil signals that there's no good one yet and is also seen by profiler, when sampling the resource
+            resource: nil,
           ) do |span|
             begin
               Sinatra::Env.set_datadog_span(env, @app_instance, span)
@@ -45,6 +47,10 @@ module Datadog
               span.set_tag(Ext::TAG_SCRIPT_NAME, request.script_name) if request.script_name && !request.script_name.empty?
 
               span.set_tag(Ext::TAG_APP_NAME, @app_instance.settings.name)
+
+              # If this app handled the request, then Contrib::Sinatra::Tracer OR Contrib::Sinatra::Base set the
+              # resource; if no resource was set, let's use a fallback
+              span.resource = env['REQUEST_METHOD'] if span.resource.nil?
 
               # TODO: This backfills the non-matching Sinatra app with a "#{method} #{path}"
               # TODO: resource name. This shouldn't be the case, as that app has never handled

--- a/spec/ddtrace/contrib/sinatra/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/tracer_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe 'Sinatra instrumentation' do
   let(:url) { '/' }
   let(:http_method) { 'GET' }
   let(:resource) { "#{http_method} #{url}" }
+  let(:observed) { {} }
   let(:sinatra_routes) do
+    observed = self.observed
     lambda do
       get '/' do
         headers['X-Request-ID'] = 'test id'
@@ -61,6 +63,15 @@ RSpec.describe 'Sinatra instrumentation' do
 
       get '/erb_literal' do
         erb '<%= msg %>', locals: { msg: 'hello' }
+      end
+
+      get '/span_resource' do
+        active_span = Datadog.tracer.active_span
+        observed[:active_span] = { name: active_span.name, resource: active_span.resource }
+        root_span = Datadog.tracer.active_root_span
+        observed[:root_span] = { name: root_span.name, resource: root_span.resource }
+
+        'ok'
       end
     end
   end
@@ -345,6 +356,22 @@ RSpec.describe 'Sinatra instrumentation' do
             expect(span.parent).to be(rack_span)
 
             expect(rack_span.resource).to eq('GET 404')
+          end
+        end
+
+        describe 'span resource' do
+          subject(:response) { get '/span_resource' }
+
+          before do
+            is_expected.to be_ok
+          end
+
+          it 'sets the route span resource before calling the route' do
+            expect(observed[:active_span]).to eq(name: 'sinatra.route', resource: 'GET /span_resource')
+          end
+
+          it 'sets the request span resource before calling the route' do
+            expect(observed[:root_span]).to eq(name: 'sinatra.request', resource: 'GET /span_resource')
           end
         end
       end


### PR DESCRIPTION
As of #1623, the profiler records the `resource` of the root span, on top of the span id and trace id during sampling.

Also, as discusssed in the description of #1623 (in the "Getting the correct `resource`" section) integrations where the
`resource` is only set at the end pose an extra challenge, as the request may not be finished in time for the `resource` to be included in the profiler payload.

This means that the profiler may miss the `resource` for some of the requests, depending on timing of when the sampling happens and when the request finishes.

(Note that in this case, the trace id and span id will still be propagated, so the samples will always be able to be tied back to the trace that originated them; it's just the `resource` that will not be included in the profiler data).

To avoid this issue for many of our customers, let's set the Sinatra `resource` setting at the beginning of the request, thus avoiding the issue altogether for Sinatra.

Note: I did not touch the existing code to set the resource at the end, which had a quite scary TODO (lines 47-64) and seemed like something I shouldn't touch.

Note 2: This is similar to what we did in #1626 for the Rails integration. 

Finally, I also tweaked `TracerMiddleware` to only set the fallback resource (the request method) at the end of the request (if needed at all), instead keeping a `nil` until the `resource` gets resolved. This way, the profiler can tell that no resource is
yet available, and thus will not gather/display the fallback resource.