### PR TITLE
Move Grape span resource setting to beginning of request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,3 @@ gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1'] if RUBY_PLATFORM != 'j
 # For type checking
 gem 'sorbet', '>= 0.5.6513', '< 0.6' if RUBY_VERSION >= '2.3.0'
 gem 'spoom', '~> 1.1' if RUBY_VERSION >= '2.4.0'
-
-gem 'grape'
-gem 'rack-test'

--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,6 @@ gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1'] if RUBY_PLATFORM != 'j
 # For type checking
 gem 'sorbet', '>= 0.5.6513', '< 0.6' if RUBY_VERSION >= '2.3.0'
 gem 'spoom', '~> 1.1' if RUBY_VERSION >= '2.4.0'
+
+gem 'grape'
+gem 'rack-test'

--- a/lib/ddtrace/contrib/grape/endpoint.rb
+++ b/lib/ddtrace/contrib/grape/endpoint.rb
@@ -34,16 +34,26 @@ module Datadog
             end
           end
 
-          def endpoint_start_process(*)
+          def endpoint_start_process(_name, _start, _finish, _id, payload)
             return if Thread.current[KEY_RUN]
             return unless enabled?
 
+            # collect endpoint details
+            endpoint = payload.fetch(:endpoint)
+            api_view = api_view(endpoint.options[:for])
+            request_method = endpoint.options.fetch(:method).first
+            path = endpoint_expand_path(endpoint)
+            resource = "#{api_view} #{request_method} #{path}"
+
             # Store the beginning of a trace
-            tracer.trace(
+            span = tracer.trace(
               Ext::SPAN_ENDPOINT_RUN,
               service: service_name,
-              span_type: Datadog::Ext::HTTP::TYPE_INBOUND
+              span_type: Datadog::Ext::HTTP::TYPE_INBOUND,
+              resource: resource,
             )
+
+            try_setting_rack_request_resource(payload, span.resource)
 
             Thread.current[KEY_RUN] = true
           rescue StandardError => e
@@ -62,20 +72,12 @@ module Datadog
 
             begin
               # collect endpoint details
-              api = payload[:endpoint].options[:for]
+              endpoint = payload.fetch(:endpoint)
+              api_view = api_view(endpoint.options[:for])
+              request_method = endpoint.options.fetch(:method).first
+              path = endpoint_expand_path(endpoint)
 
-              api_view = api_view(api)
-
-              request_method = payload[:endpoint].options[:method].first
-              path = endpoint_expand_path(payload[:endpoint])
-              resource = "#{api_view} #{request_method} #{path}"
-              span.resource = resource
-
-              # set the request span resource if it's a `rack.request` span
-              request_span = payload[:env][Datadog::Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
-              if !request_span.nil? && request_span.name == Datadog::Contrib::Rack::Ext::SPAN_REQUEST
-                request_span.resource = resource
-              end
+              try_setting_rack_request_resource(payload, span.resource)
 
               # Set analytics sample rate
               Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
@@ -229,6 +231,13 @@ module Datadog
 
           def datadog_configuration
             Datadog.configuration[:grape]
+          end
+
+          def try_setting_rack_request_resource(payload, resource)
+            request_span = payload[:env][Datadog::Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
+            if !request_span.nil? && request_span.name == Datadog::Contrib::Rack::Ext::SPAN_REQUEST
+              request_span.resource = resource
+            end
           end
         end
       end

--- a/lib/ddtrace/contrib/grape/instrumentation.rb
+++ b/lib/ddtrace/contrib/grape/instrumentation.rb
@@ -24,7 +24,7 @@ module Datadog
         # InstanceMethods - implementing instrumentation
         module InstanceMethods
           def run(*args)
-            ::ActiveSupport::Notifications.instrument('endpoint_run.grape.start_process')
+            ::ActiveSupport::Notifications.instrument('endpoint_run.grape.start_process', endpoint: self, env: env)
             super
           end
         end


### PR DESCRIPTION
As of #1623, the profiler records the `resource` of the root span, on top of the span id and trace id during sampling.

Also, as discusssed in the description of #1623 (in the "Getting the correct `resource`" section) integrations where the
`resource` is only set at the end pose an extra challenge, as the request may not be finished in time for the `resource` to be included in the profiler payload.

This means that the profiler may miss the `resource` for some of the requests, depending on timing of when the sampling happens and when the request finishes.

(Note that in this case, the trace id and span id will still be propagated, so the samples will always be able to be tied back to the trace that originated them; it's just the `resource` that will not be included in the profiler data).

To avoid this issue for many of our customers, let's move the Grape `resource` setting to the beginning of the request, thus avoiding the issue altogether for this integration.

(Note: This is similar to what we did for Rails in #1626 and Sinatra in #1628)