### PR TITLE
[PROF-3314] Do not report profiles with little data (duration < 1s)

### DIFF
--- a/lib/ddtrace/profiling/recorder.rb
+++ b/lib/ddtrace/profiling/recorder.rb
@@ -8,9 +8,9 @@ module Datadog
     class Recorder
       attr_reader :max_size
 
-      def initialize(event_classes, max_size)
+      def initialize(event_classes, max_size, last_flush_time: Time.now.utc)
         @buffers = {}
-        @last_flush_time = Time.now.utc
+        @last_flush_time = last_flush_time
         @max_size = max_size
 
         # Add a buffer for each class

--- a/lib/ddtrace/profiling/scheduler.rb
+++ b/lib/ddtrace/profiling/scheduler.rb
@@ -15,9 +15,9 @@ module Datadog
       MINIMUM_INTERVAL_SECONDS = 0
 
       # Profiles with duration less than this will not be reported
-      MINIMUM_FLUSH_CONTENT_SECONDS = 1
+      PROFILE_DURATION_THRESHOLD_SECONDS = 1
 
-      private_constant :DEFAULT_INTERVAL_SECONDS, :MINIMUM_INTERVAL_SECONDS, :MINIMUM_FLUSH_CONTENT_SECONDS
+      private_constant :DEFAULT_INTERVAL_SECONDS, :MINIMUM_INTERVAL_SECONDS, :PROFILE_DURATION_THRESHOLD_SECONDS
 
       attr_reader \
         :exporters,
@@ -102,7 +102,7 @@ module Datadog
         # Get events from recorder
         flush = recorder.flush
 
-        if duration_too_short?(flush)
+        if duration_below_threshold?(flush)
           Datadog.logger.debug do
             "Skipped exporting profiling events as profile duration is below minimum (#{flush.event_count} events skipped)"
           end
@@ -126,8 +126,8 @@ module Datadog
         flush
       end
 
-      def duration_too_short?(flush)
-        (flush.finish - flush.start) < MINIMUM_FLUSH_CONTENT_SECONDS
+      def duration_below_threshold?(flush)
+        (flush.finish - flush.start) < PROFILE_DURATION_THRESHOLD_SECONDS
       end
     end
   end

--- a/lib/ddtrace/profiling/scheduler.rb
+++ b/lib/ddtrace/profiling/scheduler.rb
@@ -12,7 +12,9 @@ module Datadog
       include Workers::Polling
 
       DEFAULT_INTERVAL_SECONDS = 60
-      MIN_INTERVAL_SECONDS = 0
+      MINIMUM_INTERVAL_SECONDS = 0
+
+      private_constant :DEFAULT_INTERVAL_SECONDS, :MINIMUM_INTERVAL_SECONDS
 
       attr_reader \
         :exporters,
@@ -90,7 +92,7 @@ module Datadog
 
         # Update wait time to try to wake consistently on time.
         # Don't drop below the minimum interval.
-        self.loop_wait_time = [loop_base_interval - run_time, MIN_INTERVAL_SECONDS].max
+        self.loop_wait_time = [loop_base_interval - run_time, MINIMUM_INTERVAL_SECONDS].max
       end
 
       def flush_events

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -88,7 +88,8 @@ RSpec.describe 'profiling integration test' do
     let(:recorder) do
       Datadog::Profiling::Recorder.new(
         [Datadog::Profiling::Events::StackSample],
-        100000
+        100000,
+        last_flush_time: Time.now.utc - 5
       )
     end
     let(:collector) do

--- a/spec/ddtrace/profiling/scheduler_spec.rb
+++ b/spec/ddtrace/profiling/scheduler_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Datadog::Profiling::Scheduler do
         enabled?: true,
         exporters: exporters,
         fork_policy: Datadog::Workers::Async::Thread::FORK_POLICY_RESTART,
-        loop_base_interval: described_class::DEFAULT_INTERVAL_SECONDS,
+        loop_base_interval: described_class.const_get(:DEFAULT_INTERVAL_SECONDS),
         recorder: recorder
       )
     end
@@ -119,7 +119,7 @@ RSpec.describe Datadog::Profiling::Scheduler do
 
     it 'changes its wait interval after flushing' do
       expect(scheduler).to receive(:loop_wait_time=) do |value|
-        expected_interval = described_class::DEFAULT_INTERVAL_SECONDS - flush_time
+        expected_interval = described_class.const_get(:DEFAULT_INTERVAL_SECONDS) - flush_time
         expect(value).to be <= expected_interval
       end
 
@@ -130,9 +130,9 @@ RSpec.describe Datadog::Profiling::Scheduler do
       let(:options) { { **super(), interval: 0.01 } }
 
       # Assert that the interval isn't set below the min interval
-      it "floors the wait interval to #{described_class::MIN_INTERVAL_SECONDS}" do
+      it "floors the wait interval to #{described_class.const_get(:MINIMUM_INTERVAL_SECONDS)}" do
         expect(scheduler).to receive(:loop_wait_time=)
-          .with(described_class::MIN_INTERVAL_SECONDS)
+          .with(described_class.const_get(:MINIMUM_INTERVAL_SECONDS))
 
         flush_and_wait
       end


### PR DESCRIPTION
Due to the way that ddtrace configuration works, if profiling is started using DD_PROFILING_ENABLED=true but the app is then reconfigured using Datadog.configure , the profiler tries to report an almost empty profile (with < 1s of data usually).

This can be even worse if the Datadog.configure call was also setting up the configuration for reporting to the agent, because this empty profile report will be using the environment defaults and thus result in an error if they are incorrect.

Since these profiles are of little value, let's just skip reporting them.