### PR TITLE
Dont set peer.service tag on grpc.server spans

### DIFF
--- a/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
@@ -50,9 +50,6 @@ module Datadog
               span.set_tag(header, value)
             end
 
-            # Tag as an external peer service
-            span.set_tag(Datadog::Ext::Integration::TAG_PEER_SERVICE, span.service)
-
             # Set analytics sample rate
             Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
 

--- a/spec/ddtrace/contrib/grpc/datadog_interceptor/server_spec.rb
+++ b/spec/ddtrace/contrib/grpc/datadog_interceptor/server_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'tracing on the server connection' do
       let(:analytics_sample_rate_var) { Datadog::Contrib::GRPC::Ext::ENV_ANALYTICS_SAMPLE_RATE }
     end
 
-    it_behaves_like 'a peer service span'
+    it_behaves_like 'a non-peer service span'
 
     it_behaves_like 'measured span for integration', true
   end

--- a/spec/ddtrace/contrib/grpc/interception_context_spec.rb
+++ b/spec/ddtrace/contrib/grpc/interception_context_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe GRPC::InterceptionContext do
           let(:analytics_sample_rate_var) { Datadog::Contrib::GRPC::Ext::ENV_ANALYTICS_SAMPLE_RATE }
         end
 
-        it_behaves_like 'a peer service span'
+        it_behaves_like 'a non-peer service span'
       end
 
       context 'request response call type' do

--- a/spec/ddtrace/contrib/integration_examples.rb
+++ b/spec/ddtrace/contrib/integration_examples.rb
@@ -9,3 +9,13 @@ RSpec.shared_examples 'a peer service span' do
     expect(span.get_tag('peer.service')).to eq(peer_service)
   end
 end
+
+RSpec.shared_examples 'a non-peer service span' do
+  before { subject }
+
+  let(:peer_service) { span.service }
+
+  it 'does not contain a peer service tag' do
+    expect(span.get_tag('peer.service')).to be nil
+  end
+end


### PR DESCRIPTION
### Summary

Generally speaking (_though open to interpretation and not specific to a datadog tracing specification_), a `peer.service` tag ought to only be applied to services which represent an operation that's accessing a _remote_ service. So, generally the _callee_ spans (`http.client`, `grpc.client`, `aws.client`, `elasticsearch.client` etc etc). Currently we have also labeled `grpc.server` with a `peer.service` tag, which goes against convention and causes (_later in our tracing pipeline_) the `language:ruby` tag to not be applied to `grpc.server` spans. This `language` tag drives behavior in the UI. When absent, it will cause our UI to _hide_ runtime metrics for this service (_since they'd be representative of the underlying host/container and not particularly relevant to the service in question, since that service's operations' execution time is supposed to be mostly spent in the remote service_).

This PR updates the `grpc.server` instrumentation to _not_ include the `peer.service` tag, which will have the downstream effect of allowing "runtime metrics" to be displayed in the UI for this service.

### Notes

- Also added a lil smol test helper which we may want to use more widely in the future should a tighter specification/set of semantic convetions emerge
- [community reference regarding use of `peer.service` tag](https://github.com/open-telemetry/opentelemetry-specification/blob/52cc12879e8c2d372c5200c00d4574fa73996369/specification/trace/semantic_conventions/span-general.md#general-remote-service-attributes)