### PR TITLE
Upgrade CI docker server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,7 @@ orbs:
           - checkout
           - setup_remote_docker:
               docker_layer_caching: true
+              version: 20.10.6
           - run:
               name: Build integration base images
               command: ./integration/script/build-images -v <<parameters.ruby_version>>


### PR DESCRIPTION
The version of docker we are using in CircleCI today to build our integration test apps (17.09.0-ce) is rather old (from 2017).

In light of [mysterious recent CI failures](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/4055/workflows/53c4c6b2-f8f6-4898-aeec-48f38bd80ba3/jobs/155861) related to the inner workings of docker, I'm upgrading the docker server version in CI.

I found a somewhat relevant issue in docker upstream that might or might not be related to this issue: https://github.com/moby/moby/issues/40993. I think it might not be the exact same case, but it doesn't hurt to bring in over 3 years of bug fixes.