### PR TITLE
[PROF-3321] Fix CPU-time accounting when fibers are used

### DIFF
--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -156,11 +156,11 @@ module Datadog
           # *before* the thread had time to finish the initialization
           return unless current_cpu_time_ns
 
-          last_cpu_time_ns = (thread[THREAD_LAST_CPU_TIME_KEY] || current_cpu_time_ns)
+          last_cpu_time_ns = (thread.thread_variable_get(THREAD_LAST_CPU_TIME_KEY) || current_cpu_time_ns)
           interval = current_cpu_time_ns - last_cpu_time_ns
 
           # Update CPU time for thread
-          thread[THREAD_LAST_CPU_TIME_KEY] = current_cpu_time_ns
+          thread.thread_variable_set(THREAD_LAST_CPU_TIME_KEY, current_cpu_time_ns)
 
           # Return interval
           interval
@@ -248,7 +248,7 @@ module Datadog
         # By resetting the last cpu time seen, we start with a clean slate every time we start the stack collector.
         def reset_cpu_time_tracking
           thread_api.list.each do |thread|
-            thread[THREAD_LAST_CPU_TIME_KEY] = nil
+            thread.thread_variable_set(THREAD_LAST_CPU_TIME_KEY, nil)
           end
         end
       end

--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -237,7 +237,7 @@ module Datadog
         end
 
         # If the profiler is started for a while, stopped and then restarted OR whenever the process forks, we need to
-        # clean up the per-thread cpu time counters we keep, so that the first sample after starting doesn't end up with:
+        # clean up any leftover per-thread cpu time counters, so that the first sample after starting doesn't end up with:
         #
         # a) negative time: At least on my test docker container, and on the reliability environment, after the process
         #    forks, the clock reference changes and (old cpu time - new cpu time) can be < 0
@@ -248,7 +248,7 @@ module Datadog
         # By resetting the last cpu time seen, we start with a clean slate every time we start the stack collector.
         def reset_cpu_time_tracking
           thread_api.list.each do |thread|
-            thread[THREAD_LAST_CPU_TIME_KEY] = nil if thread[THREAD_LAST_CPU_TIME_KEY]
+            thread[THREAD_LAST_CPU_TIME_KEY] = nil
           end
         end
       end

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -71,28 +71,10 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
         expect(thread_api).to receive(:list).and_return([thread])
       end
 
-      context 'when there is existing cpu time tracking state in threads' do
-        before do
-          expect(thread).to receive(:[]).with(described_class::THREAD_LAST_CPU_TIME_KEY).and_return(12345)
-        end
+      it 'cleans up any leftover cpu tracking state in existing threads' do
+        expect(thread).to receive(:[]=).with(described_class::THREAD_LAST_CPU_TIME_KEY, nil)
 
-        it 'resets the existing state back to nil' do
-          expect(thread).to receive(:[]=).with(described_class::THREAD_LAST_CPU_TIME_KEY, nil)
-
-          start
-        end
-      end
-
-      context 'when there is no cpu time tracking state in threads' do
-        before do
-          allow(thread).to receive(:[]).and_return(nil)
-        end
-
-        it 'does nothing' do
-          expect(thread).to_not receive(:[]=)
-
-          start
-        end
+        start
       end
     end
   end

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       end
 
       it 'cleans up any leftover cpu tracking state in existing threads' do
-        expect(thread).to receive(:[]=).with(described_class::THREAD_LAST_CPU_TIME_KEY, nil)
+        expect(thread).to receive(:thread_variable_set).with(described_class::THREAD_LAST_CPU_TIME_KEY, nil)
 
         start
       end
@@ -347,12 +347,12 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
             .and_return(current_cpu_time)
 
           allow(thread)
-            .to receive(:[])
+            .to receive(:thread_variable_get)
             .with(described_class::THREAD_LAST_CPU_TIME_KEY)
             .and_return(last_cpu_time)
 
           expect(thread)
-            .to receive(:[]=)
+            .to receive(:thread_variable_set)
             .with(described_class::THREAD_LAST_CPU_TIME_KEY, current_cpu_time)
         end
 
@@ -499,14 +499,14 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
             .and_return(current_cpu_time)
 
           expect(thread)
-            .to receive(:[]=)
+            .to receive(:thread_variable_set)
             .with(described_class::THREAD_LAST_CPU_TIME_KEY, current_cpu_time)
         end
 
         context 'and the thread CPU time has not been retrieved before' do
           before do
             allow(thread)
-              .to receive(:[])
+              .to receive(:thread_variable_get)
               .with(described_class::THREAD_LAST_CPU_TIME_KEY)
               .and_return(nil)
           end
@@ -523,7 +523,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
 
           before do
             allow(thread)
-              .to receive(:[])
+              .to receive(:thread_variable_get)
               .with(described_class::THREAD_LAST_CPU_TIME_KEY)
               .and_return(last_cpu_time)
           end


### PR DESCRIPTION
The Ruby `Thread` API has a really sharp edge around `Thread#[]` and `Thread#[]=`: these methods are "not thread-local but fiber-local". 
The documentation even goes as far as calling this "a confusion", see <https://rubyapi.org/3.0/o/thread#method-i-5B-5D>.

Our CPU-time tracking was suffering from this confusion. Because it was using `Thread#[]`/`Thread#[]=`, if a thread switched between fibers, our CPU-time tracking started miscounting time.

E.g., consider the following test application:

```ruby
def fake_cpu_time(n)
  Thread.pass
  sleep 0.01
  Thread.pass
  puts "Fiber #{n} yielding..."
  Fiber.yield :frozen
  puts "Fiber #{n} resumed..."
  Thread.pass
  sleep 0.005
  Thread.pass
  sleep 0.005
  Thread.pass
end

def start_fibers
  fibers = (0..1000).map do |n|
    Fiber.new do
      fake_cpu_time(n)
    end
  end
  run_fibers(fibers)
  fibers
end

def actually_do_cpu_work
  puts "Starting cpu work"
  start = Time.now
  nil while Time.now < (start + 28)
  puts "Finished cpu work..."
end

def run_fibers(the_fibers)
  the_fibers.each(&:resume)
end

the_fibers = start_fibers
actually_do_cpu_work
run_fibers(the_fibers)
```

The following happens in this example:

1. It starts 1000 fibers, using `Thread.pass`+`sleep` to try to give the profiler a chance to run and sample them.
2. Because `Thread#[]=` is fiber-local, every fiber that is sampled gets its own copy of `THREAD_LAST_CPU_TIME_KEY`
3. Then the example switches back to the original fiber, and does some CPU-heavy work for around 28 seconds
4. The example app then runs through every fiber again, using `Thread.pass`+`sleep` to give the profiler a chance to sample every fiber.
5. While sampling, the profiler will observe that the current cpu time for on every fiber has advanced 28 seconds from the last value stored in the `THREAD_LAST_CPU_TIME_KEY`
6. Profiler will report that the same thread will have spent hours of CPU time in a 1-minute period. (In my experiment, it reported close to 2 hours, 40 minutes).

The fix here is simple: switch to using the `Thread#thread_variable_get` and `Thread#thread_variable_set` APIs, which give us the intended behavior: even across multiple fibers, we just keep a single value for the same thread, and thus we get the
expected ~28s of cpu-time in the test application.