### PR TITLE
Fix NoMethodError in sinatra integration when Tracer middleware is missing

### DIFF
--- a/lib/ddtrace/contrib/sinatra/env.rb
+++ b/lib/ddtrace/contrib/sinatra/env.rb
@@ -10,7 +10,8 @@ module Datadog
         module_function
 
         def datadog_span(env, app)
-          env[Ext::RACK_ENV_REQUEST_SPAN][app]
+          request_span = env[Ext::RACK_ENV_REQUEST_SPAN]
+          request_span && request_span[app]
         end
 
         def set_datadog_span(env, app, span)


### PR DESCRIPTION
This fixes a regression introduced in version 0.52.0 by #1628.

When a Sinatra modular application being traced is missing the `Datadog::Contrib::Sinatra::Tracer` middleware (as documented in <https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#sinatra>), no Sinatra request span is ever created (only a route span).

Because we didn't properly account for this in `#datadog_span`, the following `NoMethodError` was triggered:

```
NoMethodError: undefined method `[]' for nil:NilClass
  dd-trace-rb/lib/ddtrace/contrib/sinatra/env.rb:13:in `datadog_span'
  dd-trace-rb/lib/ddtrace/contrib/sinatra/tracer.rb:122:in `block in route_eval'
  dd-trace-rb/lib/ddtrace/tracer.rb:283:in `trace'
  dd-trace-rb/lib/ddtrace/contrib/sinatra/tracer.rb:105:in `route_eval'
  ruby-2.7.4/gems/sinatra-2.1.0/lib/sinatra/base.rb:1013:in `block (2 levels) in route!'
```

I suspect this is the same issue as was reported in #1643.

Because this configuration is actually not desirable -- spans reported will be missing crucial request information, as discussed in #1643 -- I've also added a warning to hopefully steer users in the right direction.