### PR TITLE
Require pry plugins in `.pryrc`

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,4 @@
+# Modern pry versions don't auto-require plugins, so let's try to load whatever we can
+%w[pry-byebug pry-stack_explorer pry-nav pry-debugger-jruby].each do |extension|
+  begin; require extension; rescue LoadError; nil end
+end

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
     .reject { |f| f.match(%r{^(test|spec|features|[.]circleci|[.]github|[.]dd-ci|benchmarks|gemfiles|integration|tasks|sorbet)/}) }
     .reject do |f|
       ['.dockerignore', '.env', '.gitattributes', '.gitlab-ci.yml', '.rspec', '.rubocop.yml',
-       '.rubocop_todo.yml', '.simplecov', 'Appraisals', 'Gemfile', 'Rakefile', 'docker-compose.yml'].include?(f)
+       '.rubocop_todo.yml', '.simplecov', 'Appraisals', 'Gemfile', 'Rakefile', 'docker-compose.yml', '.pryrc'].include?(f)
     end
   spec.executables   = ['ddtracerb']
   spec.require_paths = ['lib']


### PR DESCRIPTION
Pry 0.14.0 dropped support for auto-loading plugins (<https://github.com/pry/pry/blob/master/CHANGELOG.md#breaking-changes>) which is really annoying.

Thus, I've decided to add a project-level `.pryrc` that loads all plugins when using pry in dd-trace-rb.