### PR TITLE
Add spec to validate that benchmarks don't break + fix profiler spec flakiness

### DIFF
--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -684,7 +684,7 @@ RSpec.describe Datadog::Configuration::Components do
 
     context 'given settings' do
       before do
-        skip 'Profiling is not supported.' unless Datadog::Profiling.supported?
+        skip 'Profiling is not supported on JRuby.' if PlatformHelpers.jruby?
       end
 
       shared_examples_for 'disabled profiler' do

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe Datadog::Configuration do
 
       context 'when the profiler' do
         context 'is not changed' do
-          before { skip 'Profiling is not supported.' unless Datadog::Profiling.supported? }
+          before { skip 'Profiling is not supported on JRuby.' if PlatformHelpers.jruby? }
 
           context 'and profiling is enabled' do
             before do

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -13,7 +13,7 @@ require 'ddtrace/profiling/encoding/profile'
 
 RSpec.describe 'profiling integration test' do
   before do
-    skip 'Profiling is not supported.' unless Datadog::Profiling.supported?
+    skip 'Profiling is not supported on JRuby.' if PlatformHelpers.jruby?
   end
 
   let(:tracer) { instance_double(Datadog::Tracer) }

--- a/spec/ddtrace/profiling/pprof/builder_spec.rb
+++ b/spec/ddtrace/profiling/pprof/builder_spec.rb
@@ -7,7 +7,7 @@ require 'ddtrace/profiling/pprof/builder'
 
 RSpec.describe Datadog::Profiling::Pprof::Builder do
   before do
-    skip 'Profiling is not supported.' unless Datadog::Profiling.supported?
+    skip 'Profiling is not supported on JRuby.' if PlatformHelpers.jruby?
   end
 
   subject(:builder) { described_class.new }

--- a/spec/ddtrace/profiling/pprof/stack_sample_spec.rb
+++ b/spec/ddtrace/profiling/pprof/stack_sample_spec.rb
@@ -8,7 +8,7 @@ require 'ddtrace/profiling/pprof/stack_sample'
 
 RSpec.describe Datadog::Profiling::Pprof::StackSample do
   before do
-    skip 'Profiling is not supported.' unless Datadog::Profiling.supported?
+    skip 'Profiling is not supported on JRuby.' if PlatformHelpers.jruby?
   end
 
   subject(:converter) { described_class.new(builder, sample_type_mappings) }

--- a/spec/ddtrace/profiling/pprof/template_spec.rb
+++ b/spec/ddtrace/profiling/pprof/template_spec.rb
@@ -6,7 +6,7 @@ require 'ddtrace/profiling/pprof/template'
 
 RSpec.describe Datadog::Profiling::Pprof::Template do
   before do
-    skip 'Profiling is not supported.' unless Datadog::Profiling.supported?
+    skip 'Profiling is not supported on JRuby.' if PlatformHelpers.jruby?
   end
 
   subject(:template) { described_class.new(mappings) }

--- a/spec/ddtrace/profiling/transport/http/adapters/net_integration_spec.rb
+++ b/spec/ddtrace/profiling/transport/http/adapters/net_integration_spec.rb
@@ -14,7 +14,7 @@ require 'ddtrace/transport/http/adapters/net'
 RSpec.describe 'Adapters::Net profiling integration tests' do
   before do
     skip 'TEST_DATADOG_INTEGRATION is not defined' unless ENV['TEST_DATADOG_INTEGRATION']
-    skip 'Profiling is not supported.' unless Datadog::Profiling.supported?
+    skip 'Profiling is not supported on JRuby.' if PlatformHelpers.jruby?
   end
 
   let(:settings) { Datadog::Configuration::Settings.new }

--- a/spec/ddtrace/profiling/validate_benchmarks_spec.rb
+++ b/spec/ddtrace/profiling/validate_benchmarks_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe 'Profiling benchmarks', if: (RUBY_VERSION >= '2.4.0' && PlatformHelpers.supports_fork?) do
+  around do |example|
+    ClimateControl.modify('VALIDATE_BENCHMARK' => 'true') do
+      example.run
+    end
+  end
+
+  describe 'profiler_submission' do
+    it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_submission.rb' } }
+  end
+
+  describe 'profiler_sample_loop' do
+    it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_sample_loop.rb' } }
+  end
+end

--- a/spec/ddtrace/profiling_spec.rb
+++ b/spec/ddtrace/profiling_spec.rb
@@ -115,6 +115,9 @@ RSpec.describe Datadog::Profiling do
   describe '::protobuf_loaded_successfully?' do
     subject(:protobuf_loaded_successfully?) { described_class.send(:protobuf_loaded_successfully?) }
 
+    # NOTE: Be careful not to leave leftover state here, as marking protobuf as failed makes Profiling.supported?
+    # return false and may impact other tests.
+
     before do
       # Remove any previous state
       if described_class.instance_variable_defined?(:@protobuf_loaded)
@@ -122,6 +125,11 @@ RSpec.describe Datadog::Profiling do
       end
 
       allow(Kernel).to receive(:warn)
+    end
+
+    after do
+      # Remove leftover state
+      described_class.remove_instance_variable(:@protobuf_loaded)
     end
 
     context 'when there is an issue requiring protobuf' do


### PR DESCRIPTION
While working on #1648 I discovered that one of the profiler benchmarks (profiler_submission.rb) was actually broken, and had been for some time.

To avoid these "surprises", I've added a small spec to load and run the benchmarks, so that if they start failing, we'll know about it.

To avoid impacting the speediness of our test suite, the benchmarks are run with a minimal time/warmup -- the objective is not to measure anything at all, but just to confirm that they do run.

P.s.: This PR was opened on top of #1648; once that branch is merged, this one will switch to target master as well.

P.s.2: Initially when I pushed this branch I got some flakiness in CI, and dividing deep on those failures also made me uncover that one of our specs caused flakiness that made the profiler spec suite not run with some seeds!

Because we had a bunch of `skip 'Profiling is not supported.' unless Datadog::Profiling.supported?` we actually did not trigger an error as expected; because this new spec I added did not have this skip, it finally uncovered the issue. I've fixed both the source of flakiness as well as changed those skips to assume that profiling is working as it should. See individual commit messages for more details.