### PR TITLE
Grpc: add metadata exclusion option

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1054,6 +1054,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | --- | ----------- | ------- |
 | `service_name` | Service name used for `grpc` instrumentation | `'grpc'` |
 | `error_handler` | Custom error handler invoked when a request is an error. A `Proc` that accepts `span` and `error` parameters. Sets error on the span by default. | `proc { |span, error| span.set_error(error) unless span.nil? }` |
+| `metadata` | Hash of grpc client or server metadata fields to exclude as span tags on the `grpc.client` and `grpc.server` spans, respectively. Accepts `client` and `server` keys set to a Hash with an `exclude` key set to Array values e.g. `['authorization']`. | `{ client: { exclude: [] }, server: { exclude: [] } }` |
 
 **Configuring clients to use different settings**
 

--- a/lib/ddtrace/contrib/grpc/configuration/settings.rb
+++ b/lib/ddtrace/contrib/grpc/configuration/settings.rb
@@ -8,6 +8,17 @@ module Datadog
       module Configuration
         # Custom settings for the gRPC integration
         class Settings < Contrib::Configuration::Settings
+          # Users may pass sensitive Info via metadata such as 'authorization' that they wish to exclude
+          # https://github.com/grpc/grpc-go/blob/1c598a11a4e503e1cfd500999c040e72072dc16b/credentials/oauth/oauth.go#L50
+          DEFAULT_METADATA = {
+            server: {
+              exclude: []
+            },
+            client: {
+              exclude: []
+            }
+          }.freeze
+
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }
             o.lazy
@@ -25,6 +36,7 @@ module Datadog
 
           option :service_name, default: Ext::SERVICE_NAME
           option :error_handler, default: Datadog::Tracer::DEFAULT_ON_ERROR
+          option :metadata, default: DEFAULT_METADATA
         end
       end
     end

--- a/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
@@ -62,7 +62,10 @@ module Datadog
           def reserved_headers
             [Datadog::Ext::DistributedTracing::GRPC_METADATA_TRACE_ID,
              Datadog::Ext::DistributedTracing::GRPC_METADATA_PARENT_ID,
-             Datadog::Ext::DistributedTracing::GRPC_METADATA_SAMPLING_PRIORITY]
+             Datadog::Ext::DistributedTracing::GRPC_METADATA_SAMPLING_PRIORITY,
+             Ext::TAG_AUTH].concat(
+               (configuration[:metadata][:server] && configuration[:metadata][:server][:exclude]) || []
+             )
           end
 
           def format_resource(proto_method)
@@ -72,6 +75,10 @@ module Datadog
                         .split('::')
                         .<<(proto_method.name)
                         .join('.')
+          end
+
+          def configuration
+            Datadog.configuration[:grpc]
           end
         end
       end

--- a/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
+++ b/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb
@@ -62,8 +62,7 @@ module Datadog
           def reserved_headers
             [Datadog::Ext::DistributedTracing::GRPC_METADATA_TRACE_ID,
              Datadog::Ext::DistributedTracing::GRPC_METADATA_PARENT_ID,
-             Datadog::Ext::DistributedTracing::GRPC_METADATA_SAMPLING_PRIORITY,
-             Ext::TAG_AUTH].concat(
+             Datadog::Ext::DistributedTracing::GRPC_METADATA_SAMPLING_PRIORITY].concat(
                (configuration[:metadata][:server] && configuration[:metadata][:server][:exclude]) || []
              )
           end

--- a/lib/ddtrace/contrib/grpc/ext.rb
+++ b/lib/ddtrace/contrib/grpc/ext.rb
@@ -12,6 +12,7 @@ module Datadog
         ENV_ANALYTICS_SAMPLE_RATE_OLD = 'DD_GRPC_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'grpc'.freeze
         SPAN_CLIENT = 'grpc.client'.freeze
+        SPAN_SERVICE = 'grpc.service'.freeze
       end
     end
   end

--- a/lib/ddtrace/contrib/grpc/ext.rb
+++ b/lib/ddtrace/contrib/grpc/ext.rb
@@ -12,7 +12,6 @@ module Datadog
         ENV_ANALYTICS_SAMPLE_RATE_OLD = 'DD_GRPC_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'grpc'.freeze
         SPAN_CLIENT = 'grpc.client'.freeze
-        SPAN_SERVICE = 'grpc.service'.freeze
       end
     end
   end

--- a/spec/ddtrace/contrib/grpc/datadog_interceptor/server_spec.rb
+++ b/spec/ddtrace/contrib/grpc/datadog_interceptor/server_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'tracing on the server connection' do
   describe '#request_response' do
     let(:keywords) do
       { request: instance_double(Object),
-        call: instance_double('GRPC::ActiveCall', metadata: { some: 'datum' }),
+        call: instance_double('GRPC::ActiveCall', metadata: { some: 'datum', thing_to_filter: 'sensitive_info' }),
         method: instance_double(Method, owner: 'My::Server', name: 'endpoint') }
     end
 
@@ -87,6 +87,14 @@ RSpec.describe 'tracing on the server connection' do
           expect(span).to_not have_error
           expect(span.get_tag('custom.handler')).to eq('Got error test error, but ignored it')
         end
+      end
+    end
+
+    context 'with server-side metadata configuration' do
+      let(:configuration_options) { { service_name: 'rspec', metadata: { server: { exclude: ['thing_to_filter'] } } } }
+
+      it do
+        expect(span.get_tag('sensitive_info')).to be_nil
       end
     end
   end


### PR DESCRIPTION
It would appear some users have potentially sensitive information in their metadata that they would want to not set as a span tag. Although a "Processing Pipeline" can achieve this, it has a performance penalty associated with having to iterate over every span. Instead, we can introduce a `metadata` configuration to the `grpc` contrib integration, which allows users to exclude specific metadata fields for both the `client` and `server` spans.