### PR TITLE
Convert mysql2 integration to Datadog::Instrumentation API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,8 @@ end
 # @see https://github.com/DataDog/dogstatsd-ruby/issues/182
 gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
 gem 'opentracing', '>= 0.4.1'
+# TODO: Promote this to ddtrace.gemspec. (Or contrib package? Only used by contrib.)
+gem 'datadog-instrumentation', git: 'https://github.com/DataDog/datadog-instrumentation-ruby', branch: 'master'
 
 # Profiler optional dependencies
 # NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424 and the big comment in

--- a/gemfiles/ruby_2.7.3_contrib.gemfile
+++ b/gemfiles/ruby_2.7.3_contrib.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_contrib.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -1300,9 +1307,6 @@ GEM
     mime-types-data (3.2021.0704)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     mongo (2.14.0)
       bson (>= 4.8.2, < 5.0.0)
     mono_logger (1.1.1)
@@ -1524,6 +1528,7 @@ DEPENDENCIES
   concurrent-ruby
   cucumber
   dalli
+  datadog-instrumentation!
   ddtrace!
   delayed_job
   delayed_job_active_record
@@ -1541,9 +1546,6 @@ DEPENDENCIES
   lograge (~> 0.11)
   makara
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   mongo (>= 2.8.0, != 2.15.0)
   mysql2 (< 1)
   opentracing (>= 0.4.1)

--- a/gemfiles/ruby_2.7.3_contrib_old.gemfile
+++ b/gemfiles/ruby_2.7.3_contrib_old.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_contrib_old.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -49,10 +56,6 @@ GEM
     hashdiff (1.0.1)
     memory_profiler (0.9.14)
     method_source (1.0.0)
-    minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     multipart-post (2.1.1)
     opentracing (0.5.0)
@@ -147,14 +150,12 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   faraday (= 0.17)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)

--- a/gemfiles/ruby_2.7.3_core_old.gemfile
+++ b/gemfiles/ruby_2.7.3_core_old.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", "~> 4"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_core_old.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -47,10 +54,6 @@ GEM
     hashdiff (1.0.1)
     memory_profiler (0.9.14)
     method_source (1.0.0)
-    minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     opentracing (0.5.0)
     os (1.1.1)
@@ -144,13 +147,11 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (~> 4)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)

--- a/gemfiles/ruby_2.7.3_cucumber3.gemfile
+++ b/gemfiles/ruby_2.7.3_cucumber3.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber3.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -65,10 +72,6 @@ GEM
     hashdiff (1.0.1)
     memory_profiler (0.9.14)
     method_source (1.0.0)
-    minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     multi_json (1.15.0)
     multi_test (0.1.2)
@@ -165,13 +168,11 @@ DEPENDENCIES
   climate_control (~> 0.2.0)
   concurrent-ruby
   cucumber (>= 3.0.0, < 4.0.0)
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)

--- a/gemfiles/ruby_2.7.3_cucumber4.gemfile
+++ b/gemfiles/ruby_2.7.3_cucumber4.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber4.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -88,9 +95,6 @@ GEM
     method_source (1.0.0)
     middleware (0.1.0)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     multi_test (0.1.2)
     opentracing (0.5.0)
@@ -197,13 +201,11 @@ DEPENDENCIES
   climate_control (~> 0.2.0)
   concurrent-ruby
   cucumber (>= 4.0.0, < 5.0.0)
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)

--- a/gemfiles/ruby_2.7.3_cucumber5.gemfile
+++ b/gemfiles/ruby_2.7.3_cucumber5.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber5.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -88,9 +95,6 @@ GEM
     method_source (1.0.0)
     middleware (0.1.0)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     multi_test (0.1.2)
     opentracing (0.5.0)
@@ -197,13 +201,11 @@ DEPENDENCIES
   climate_control (~> 0.2.0)
   concurrent-ruby
   cucumber (>= 5.0.0, < 6.0.0)
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)

--- a/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile
+++ b/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -109,9 +116,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     mysql2 (0.5.3)
     nio4r (2.5.7)
@@ -253,14 +257,12 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   mysql2 (< 1)
   opentracing (>= 0.4.1)
   os (~> 1.1)

--- a/gemfiles/ruby_2.7.3_rails5_postgres.gemfile
+++ b/gemfiles/ruby_2.7.3_rails5_postgres.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -109,9 +116,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     nio4r (2.5.7)
     nokogiri (1.11.7)
@@ -253,14 +257,12 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pg (< 1.0)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
@@ -40,7 +38,6 @@ gem "sorbet", ">= 0.5.6513", "< 0.6"
 gem "spoom", "~> 1.1"
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
-gem "redis-rails"
 gem "redis"
 gem "sprockets", "< 4"
 gem "lograge", "~> 0.11"

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -109,9 +116,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     nio4r (2.5.7)
     nokogiri (1.11.7)
@@ -167,22 +171,6 @@ GEM
       rake
     redcarpet (3.5.1)
     redis (4.3.1)
-    redis-actionpack (5.2.0)
-      actionpack (>= 5, < 7)
-      redis-rack (>= 2.1.0, < 3)
-      redis-store (>= 1.1.0, < 2)
-    redis-activesupport (5.2.1)
-      activesupport (>= 3, < 7)
-      redis-store (>= 1.3, < 2)
-    redis-rack (2.1.3)
-      rack (>= 2.0.8, < 3)
-      redis-store (>= 1.2, < 2)
-    redis-rails (5.0.2)
-      redis-actionpack (>= 5.0, < 6)
-      redis-activesupport (>= 5.0, < 6)
-      redis-store (>= 1.2, < 2)
-    redis-store (1.9.0)
-      redis (>= 4, < 5)
     regexp_parser (2.1.1)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -270,14 +258,12 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pg (< 1.0)
@@ -290,7 +276,6 @@ DEPENDENCIES
   rake-compiler (~> 1.1, >= 1.1.1)
   redcarpet (~> 3.4)
   redis
-  redis-rails
   rspec (~> 3.10)
   rspec-collection_matchers (~> 1.1)
   rspec_junit_formatter (>= 0.4.1)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
@@ -40,9 +38,9 @@ gem "sorbet", ">= 0.5.6513", "< 0.6"
 gem "spoom", "~> 1.1"
 gem "rails", "~> 5.2.1"
 gem "pg", "< 1.0", platform: :ruby
-gem "redis-rails"
 gem "redis"
 gem "sprockets", "< 4"
 gem "lograge", "~> 0.11"
+gem "redis-rails"
 
 gemspec path: "../"

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -109,9 +116,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     nio4r (2.5.7)
     nokogiri (1.11.7)
@@ -270,14 +274,12 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pg (< 1.0)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -110,9 +117,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     nio4r (2.5.7)
     nokogiri (1.11.7)
@@ -260,14 +264,12 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pg (< 1.0)

--- a/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -104,9 +111,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     nio4r (2.5.7)
     nokogiri (1.11.7)
@@ -252,13 +256,11 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pg (< 1.0)

--- a/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile
+++ b/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -126,9 +133,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     mysql2 (0.5.3)
     nio4r (2.5.7)
@@ -272,14 +276,12 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   mysql2 (~> 0.5)
   opentracing (>= 0.4.1)
   os (~> 1.1)

--- a/gemfiles/ruby_2.7.3_rails61_postgres.gemfile
+++ b/gemfiles/ruby_2.7.3_rails61_postgres.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -126,9 +133,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     nio4r (2.5.7)
     nokogiri (1.11.7)
@@ -272,14 +276,12 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pg (>= 1.1)

--- a/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -126,9 +133,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     nio4r (2.5.7)
     nokogiri (1.11.7)
@@ -273,14 +277,12 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pg (>= 1.1)

--- a/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -127,9 +134,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     nio4r (2.5.7)
     nokogiri (1.11.7)
@@ -278,14 +282,12 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pg (>= 1.1)

--- a/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -121,9 +128,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     nio4r (2.5.7)
     nokogiri (1.11.7)
@@ -271,13 +275,11 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pg (>= 1.1)

--- a/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile
+++ b/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -122,9 +129,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     mysql2 (0.5.3)
     nio4r (2.5.7)
@@ -269,14 +273,12 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   mysql2 (< 1)
   opentracing (>= 0.4.1)
   os (~> 1.1)

--- a/gemfiles/ruby_2.7.3_rails6_postgres.gemfile
+++ b/gemfiles/ruby_2.7.3_rails6_postgres.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -122,9 +129,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     nio4r (2.5.7)
     nokogiri (1.11.7)
@@ -269,14 +273,12 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pg (< 1.0)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
@@ -40,7 +38,6 @@ gem "sorbet", ">= 0.5.6513", "< 0.6"
 gem "spoom", "~> 1.1"
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
-gem "redis-rails"
 gem "redis"
 gem "sprockets", "< 4"
 gem "lograge", "~> 0.11"

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -122,9 +129,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     nio4r (2.5.7)
     nokogiri (1.11.7)
@@ -182,22 +186,6 @@ GEM
       rake
     redcarpet (3.5.1)
     redis (4.3.1)
-    redis-actionpack (5.2.0)
-      actionpack (>= 5, < 7)
-      redis-rack (>= 2.1.0, < 3)
-      redis-store (>= 1.1.0, < 2)
-    redis-activesupport (5.2.1)
-      activesupport (>= 3, < 7)
-      redis-store (>= 1.3, < 2)
-    redis-rack (2.1.3)
-      rack (>= 2.0.8, < 3)
-      redis-store (>= 1.2, < 2)
-    redis-rails (5.0.2)
-      redis-actionpack (>= 5.0, < 6)
-      redis-activesupport (>= 5.0, < 6)
-      redis-store (>= 1.2, < 2)
-    redis-store (1.9.0)
-      redis (>= 4, < 5)
     regexp_parser (2.1.1)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -286,14 +274,12 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pg (< 1.0)
@@ -306,7 +292,6 @@ DEPENDENCIES
   rake-compiler (~> 1.1, >= 1.1.1)
   redcarpet (~> 3.4)
   redis
-  redis-rails
   rspec (~> 3.10)
   rspec-collection_matchers (~> 1.1)
   rspec_junit_formatter (>= 0.4.1)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]
@@ -40,9 +38,9 @@ gem "sorbet", ">= 0.5.6513", "< 0.6"
 gem "spoom", "~> 1.1"
 gem "rails", "~> 6.0.0"
 gem "pg", "< 1.0", platform: :ruby
-gem "redis-rails"
 gem "redis"
 gem "sprockets", "< 4"
 gem "lograge", "~> 0.11"
+gem "redis-rails"
 
 gemspec path: "../"

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -122,9 +129,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     nio4r (2.5.7)
     nokogiri (1.11.7)
@@ -286,14 +290,12 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pg (< 1.0)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -123,9 +130,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     nio4r (2.5.7)
     nokogiri (1.11.7)
@@ -276,14 +280,12 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   lograge (~> 0.11)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pg (< 1.0)

--- a/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile
+++ b/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -117,9 +124,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     msgpack (1.4.2)
     nio4r (2.5.7)
     nokogiri (1.11.7)
@@ -268,13 +272,11 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pg (< 1.0)

--- a/gemfiles/ruby_2.7.3_resque2_redis3.gemfile
+++ b/gemfiles/ruby_2.7.3_resque2_redis3.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_resque2_redis3.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -47,10 +54,6 @@ GEM
     hashdiff (1.0.1)
     memory_profiler (0.9.14)
     method_source (1.0.0)
-    minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     mono_logger (1.1.1)
     msgpack (1.4.2)
     multi_json (1.15.0)
@@ -169,13 +172,11 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)

--- a/gemfiles/ruby_2.7.3_resque2_redis4.gemfile
+++ b/gemfiles/ruby_2.7.3_resque2_redis4.gemfile
@@ -10,9 +10,6 @@ gem "builder"
 gem "climate_control", "~> 0.2.0"
 gem "concurrent-ruby"
 gem "memory_profiler", "~> 0.9"
-gem "minitest", "= 5.10.1"
-gem "minitest-around", "0.5.0"
-gem "minitest-stub_any_instance", "1.0.2"
 gem "os", "~> 1.1"
 gem "pimpmychangelog", ">= 0.1.2"
 gem "pry"
@@ -33,6 +30,7 @@ gem "yard", "~> 0.9"
 gem "rubocop", "~> 1.10", require: false
 gem "rubocop-performance", "~> 1.9", require: false
 gem "rubocop-rspec", "~> 2.2", require: false
+gem "datadog-instrumentation", git: "https://github.com/DataDog/datadog-instrumentation-ruby", branch: "master"
 gem "dogstatsd-ruby", ">= 3.3.0", "!= 5.0.0", "!= 5.0.1", "!= 5.1.0"
 gem "opentracing", ">= 0.4.1"
 gem "google-protobuf", ["~> 3.0", "!= 3.7.0", "!= 3.7.1"]

--- a/gemfiles/ruby_2.7.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_resque2_redis4.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -47,10 +54,6 @@ GEM
     hashdiff (1.0.1)
     memory_profiler (0.9.14)
     method_source (1.0.0)
-    minitest (5.10.1)
-    minitest-around (0.5.0)
-      minitest (~> 5.0)
-    minitest-stub_any_instance (1.0.2)
     mono_logger (1.1.1)
     msgpack (1.4.2)
     multi_json (1.15.0)
@@ -169,13 +172,11 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
   memory_profiler (~> 0.9)
-  minitest (= 5.10.1)
-  minitest-around (= 0.5.0)
-  minitest-stub_any_instance (= 1.0.2)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)

--- a/lib/ddtrace/contrib/mysql2/instrumentation.rb
+++ b/lib/ddtrace/contrib/mysql2/instrumentation.rb
@@ -9,15 +9,20 @@ require 'ddtrace/contrib/mysql2/ext'
 module Datadog
   module Contrib
     module Mysql2
-      # Mysql2::Client patch module
       module Instrumentation
-        def self.included(base)
-          base.prepend(InstanceMethods)
-        end
+        # Mysql2::Client tracing
+        module Client
+          module_function
 
-        # Mysql2::Client patch instance methods
-        module InstanceMethods
-          def query(sql, options = {})
+          def query(env)
+            # Retrieve pin. Skip tracing if unavailable.
+            client = get_client(env)
+            datadog_pin = get_datadog_pin(client)
+            return yield(env) unless client && datadog_pin
+
+            sql, _options = env[:args]
+            query_options = client.query_options
+
             datadog_pin.tracer.trace(Ext::SPAN_QUERY) do |span|
               span.resource = sql
               span.service = datadog_pin.service
@@ -27,36 +32,43 @@ module Datadog
               span.set_tag(Datadog::Ext::Integration::TAG_PEER_SERVICE, span.service)
 
               # Set analytics sample rate
-              Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
+              if Datadog.configuration[:mysql2][:analytics_enabled]
+                Contrib::Analytics.set_sample_rate(span, Datadog.configuration[:mysql2][:analytics_sample_rate])
+              end
 
               span.set_tag(Ext::TAG_DB_NAME, query_options[:database])
               span.set_tag(Datadog::Ext::NET::TARGET_HOST, query_options[:host])
               span.set_tag(Datadog::Ext::NET::TARGET_PORT, query_options[:port])
-              super(sql, options)
+
+              # Invoke original method
+              yield(env)
             end
           end
 
-          def datadog_pin
-            @datadog_pin ||= Datadog::Pin.new(
-              Datadog.configuration[:mysql2][:service_name],
-              app: Ext::APP,
-              app_type: Datadog::Ext::AppTypes::DB,
-              tracer: -> { Datadog.configuration[:mysql2][:tracer] }
-            )
+          def get_client(env)
+            return unless env[:self].instance_of?(::Mysql2::Client)
+
+            env[:self]
           end
 
-          private
+          def get_datadog_pin(client)
+            # Only get a pin from a Mysql2::Client
+            return unless client
 
-          def datadog_configuration
-            Datadog.configuration[:mysql2]
-          end
-
-          def analytics_enabled?
-            datadog_configuration[:analytics_enabled]
-          end
-
-          def analytics_sample_rate
-            datadog_configuration[:analytics_sample_rate]
+            # Get existing pin or create a new one.
+            if client.instance_variable_defined?(:@datadog_pin)
+              client.instance_variable_get(:@datadog_pin)
+            else
+              client.instance_variable_set(
+                :@datadog_pin,
+                Datadog::Pin.new(
+                  Datadog.configuration[:mysql2][:service_name],
+                  app: Ext::APP,
+                  app_type: Datadog::Ext::AppTypes::DB,
+                  tracer: -> { Datadog.configuration[:mysql2][:tracer] }
+                )
+              )
+            end
           end
         end
       end

--- a/spec/ddtrace/contrib/mysql2/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/mysql2/instrumentation_spec.rb
@@ -1,0 +1,54 @@
+require 'ddtrace/contrib/support/spec_helper'
+
+require 'ddtrace/contrib/mysql2/instrumentation'
+
+RSpec.describe Datadog::Contrib::Mysql2::Instrumentation::Client do
+  let(:service_name) { 'my-sql' }
+  let(:configuration_options) { { service_name: service_name } }
+
+  let(:client) do
+    Mysql2::Client.new(
+      host: host,
+      port: port,
+      database: database,
+      username: username,
+      password: password
+    )
+  end
+
+  let(:host) { ENV.fetch('TEST_MYSQL_HOST') { '127.0.0.1' } }
+  let(:port) { ENV.fetch('TEST_MYSQL_PORT') { '3306' } }
+  let(:database) { ENV.fetch('TEST_MYSQL_DB') { 'mysql' } }
+  let(:username) { ENV.fetch('TEST_MYSQL_USER') { 'root' } }
+  let(:password) { ENV.fetch('TEST_MYSQL_PASSWORD') { 'root' } }
+
+  before do
+    Datadog.configure do |c|
+      c.use :mysql2, configuration_options
+    end
+  end
+
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:mysql2].reset_configuration!
+    example.run
+    Datadog.registry[:mysql2].reset_configuration!
+  end
+
+  describe '::get_datadog_pin' do
+    subject(:pin) { described_class.get_datadog_pin(client) }
+
+    context 'given nil' do
+      let(:client) { nil }
+      it { is_expected.to be nil }
+    end
+
+    context 'given a Mysql2::Client' do
+      it 'has the correct attributes' do
+        expect(pin.service).to eq(service_name)
+        expect(pin.app).to eq('mysql2')
+        expect(pin.app_type).to eq('db')
+      end
+    end
+  end
+end

--- a/spec/ddtrace/contrib/mysql2/patcher_spec.rb
+++ b/spec/ddtrace/contrib/mysql2/patcher_spec.rb
@@ -39,16 +39,6 @@ RSpec.describe 'Mysql2::Client patcher' do
     Datadog.registry[:mysql2].reset_configuration!
   end
 
-  context 'pin' do
-    subject(:pin) { client.datadog_pin }
-
-    it 'has the correct attributes' do
-      expect(pin.service).to eq(service_name)
-      expect(pin.app).to eq('mysql2')
-      expect(pin.app_type).to eq('db')
-    end
-  end
-
   describe 'tracing' do
     describe '#query' do
       context 'when the tracer is disabled' do


### PR DESCRIPTION
This pull request converts the Mysql2 integration over to the [`datadog-instrumentation` API](https://github.com/DataDog/datadog-instrumentation-ruby). The changes to this library are entirely internal and do not affect user implementation, or trace data.

***Work in progress prototype: DO NOT MERGE!***

This is intended to be a proof-of-concept in the development of the new instrumentation API. Some things we may want to take into consideration before merging this:

1. Is the instrumentation API sufficient for the needs of this integration? Does the API need to be altered in any way?
2. Should we add a layer within `ddtrace` that makes the implementation of the API a little more friendly/specific to tracing? (We may only understand the usage patterns better after we convert more integrations and observe the overlap.)
3. Does this PR need to be broken into smaller pieces? (Especially if we add more code related to the above point?)
4. Is there any significant performance impact?