### PR TITLE
Add gitlab trigger for system tests project

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,9 +2,12 @@ stages:
   - deploy
 
 variables:
-  DOWNSTREAM_BRANCH:
+  DOWNSTREAM_REL_BRANCH:
     value: "master"
     description: "Run a specific datadog-reliability-env branch downstream"
+  DOWNSTREAM_SYS_TEST_BRANCH:
+    value: "master"
+    description: "Run a specific system test branch downstream"
   FORCE_TRIGGER:
     value: "false"
     description: "Set to true to override rules in the reliability-env pipeline (e.g. override 'only deploy master')"
@@ -17,7 +20,7 @@ deploy_to_reliability_env:
   when: on_success
   trigger:
     project: DataDog/datadog-reliability-env
-    branch: $DOWNSTREAM_BRANCH
+    branch: $DOWNSTREAM_REL_BRANCH
   variables:
     UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
     UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
@@ -25,3 +28,15 @@ deploy_to_reliability_env:
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
     FORCE_TRIGGER: $FORCE_TRIGGER
 
+deploy_to_system_test:
+  stage: deploy
+  when: on_success
+  trigger:
+    project: DataDog/system-tests
+    branch: $DOWNSTREAM_SYS_TEST_BRANCH
+  variables:
+    UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
+    UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
+    UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID
+    UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
+    UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA


### PR DESCRIPTION
This PR adds a gitlab trigger for the [system tests project](https://github.com/DataDog/system-tests). The system tests project aims to verify the behaviors of all of the tracers externally.