### PR TITLE
Fix broken circleci edge job integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -745,43 +745,43 @@ workflows:
       # Integration
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.1
-          integration_apps: 'ruby rack rspec'
+          integration_apps: 'rack'
           ruby_version: '2.1'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.2
-          integration_apps: 'ruby rack rspec'
+          integration_apps: 'rack'
           ruby_version: '2.2'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.3
-          integration_apps: 'ruby rack rails-five rspec'
+          integration_apps: 'rack rails-five'
           ruby_version: '2.3'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.4
-          integration_apps: 'ruby rack rails-five rspec'
+          integration_apps: 'rack rails-five'
           ruby_version: '2.4'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.5
-          integration_apps: 'ruby rack rails-five rspec'
+          integration_apps: 'rack rails-five'
           ruby_version: '2.5'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.6
-          integration_apps: 'ruby rack rails-five rspec'
+          integration_apps: 'rack rails-five'
           ruby_version: '2.6'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.7
-          integration_apps: 'ruby rack rails-five rspec'
+          integration_apps: 'rack rails-five'
           ruby_version: '2.7'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-3.0
-          # TODO: Get Rack & Rails apps working with Ruby 3.0
-          integration_apps: 'ruby'
+          # Note: Ruby 3 is not supported by Rails 5, hence we skip it
+          integration_apps: 'rack'
           ruby_version: '3.0'
           <<: *filters_all_branches_and_tags
       # MRI


### PR DESCRIPTION
These had been broken since #1612, due to the change in 4175abdb68 where I added an explicit failure when the ruby and rspec tests tried to run in CI (since they don't actually test anything).

At that time, I changed the regular CI job configuration, but missed that the "edge" one had a copy-pasted configuration that also needed adjustment.