### PR TITLE
Enable Rack integration for Sinatra

### DIFF
--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -98,7 +98,6 @@ module Datadog
           raise e
         ensure
           env[Ext::RACK_ENV_REQUEST_SPAN] = previous_request_span if previous_request_span
-          env[:datadog_rack_request_span] = env[Ext::RACK_ENV_REQUEST_SPAN]
 
           if request_span
             # Rack is a really low level interface and it doesn't provide any

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -201,6 +201,9 @@ module Datadog
           # unless it has been already set by the underlying framework
           request_span.status = 1 if status.to_s.start_with?('5') && request_span.status.zero?
         end
+        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/PerceivedComplexity
 
         private
 

--- a/lib/ddtrace/contrib/sinatra/framework.rb
+++ b/lib/ddtrace/contrib/sinatra/framework.rb
@@ -28,8 +28,8 @@ module Datadog
         end
 
         # Add Rack middleware at the top of the stack
-        def self.add_middleware(builder, *args, &block)
-          insert_middleware(builder, Datadog::Contrib::Rack::TraceMiddleware, args, block) do |proc_, use|
+        def self.add_middleware(middleware, builder, *args, &block)
+          insert_middleware(builder, middleware, args, block) do |proc_, use|
             use.insert(0, proc_)
           end
         end

--- a/lib/ddtrace/contrib/sinatra/framework.rb
+++ b/lib/ddtrace/contrib/sinatra/framework.rb
@@ -1,0 +1,78 @@
+module Datadog
+  module Contrib
+    # Instrument Sinatra.
+    module Sinatra
+      # Sinatra framework code, used to essentially:
+      # - handle configuration entries which are specific to Datadog tracing
+      # - instrument parts of the framework when needed
+      module Framework
+        # Configure Rack from Sinatra, but only if Rack has not been configured manually beforehand
+        def self.setup
+          Datadog.configure do |datadog_config|
+            sinatra_config = config_with_defaults(datadog_config)
+            activate_rack!(datadog_config, sinatra_config) unless Datadog.configuration.instrumented_integrations.key?(:rack)
+          end
+        end
+
+        def self.config_with_defaults(datadog_config)
+          datadog_config[:sinatra]
+        end
+
+        # Apply relevant configuration from Sinatra to Rack
+        def self.activate_rack!(datadog_config, sinatra_config)
+          datadog_config.use(
+            :rack,
+            service_name: sinatra_config[:service_name],
+            distributed_tracing: sinatra_config[:distributed_tracing],
+          )
+        end
+
+        # Add Rack middleware at the top of the stack
+        def self.add_middleware(builder, *args, &block)
+          insert_middleware(builder, Datadog::Contrib::Rack::TraceMiddleware, args, block) do |proc_, use|
+            use.insert(0, proc_)
+          end
+        end
+
+        # Wrap the middleware class instantiation in a proc, like Sinatra does internally
+        # The `middleware` local variable name in the proc is important for introspection
+        # (see Framework#middlewares)
+        def self.wrap_middleware(middleware, *args, &block)
+          proc { |app| middleware.new(app, *args, &block) }
+        end
+
+        # Insert a middleware class in the builder as it expects it internally.
+        # The block gets passed prepared arguments for the caller to decide
+        # how to insert.
+        def self.insert_middleware(builder, middleware, args, block)
+          use = builder.instance_variable_get('@use')
+          wrapped = wrap_middleware(middleware, *args, &block)
+
+          # Makes the insert idempotent
+          # The block can also throw :skip with its own logic
+          catch(:skip) do
+            throw(:skip) if middlewares(builder).include?(middleware)
+
+            yield(wrapped, use)
+          end
+        end
+
+        # Introspect middlewares from a builder
+        def self.middlewares(builder)
+          builder.instance_variable_get(:@use).map do |proc_|
+            unless proc_.respond_to?(:binding) && proc_.binding.local_variable_defined?(:middleware)
+              next :unknown
+            end
+
+            proc_.binding.local_variable_get(:middleware)
+          end
+        end
+
+        def self.inspect_middlewares(builder)
+          Datadog.logger.debug { "Sinatra middlewares: " << middlewares(builder).map(&:inspect).inspect }
+        end
+      end
+    end
+  end
+end
+

--- a/lib/ddtrace/contrib/sinatra/framework.rb
+++ b/lib/ddtrace/contrib/sinatra/framework.rb
@@ -10,7 +10,9 @@ module Datadog
         def self.setup
           Datadog.configure do |datadog_config|
             sinatra_config = config_with_defaults(datadog_config)
-            activate_rack!(datadog_config, sinatra_config) unless Datadog.configuration.instrumented_integrations.key?(:rack)
+            unless Datadog.configuration.instrumented_integrations.key?(:rack)
+              activate_rack!(datadog_config, sinatra_config)
+            end
           end
         end
 
@@ -60,19 +62,16 @@ module Datadog
         # Introspect middlewares from a builder
         def self.middlewares(builder)
           builder.instance_variable_get(:@use).map do |proc_|
-            unless proc_.respond_to?(:binding) && proc_.binding.local_variable_defined?(:middleware)
-              next :unknown
-            end
+            next :unknown unless proc_.respond_to?(:binding) && proc_.binding.local_variable_defined?(:middleware)
 
             proc_.binding.local_variable_get(:middleware)
           end
         end
 
         def self.inspect_middlewares(builder)
-          Datadog.logger.debug { "Sinatra middlewares: " << middlewares(builder).map(&:inspect).inspect }
+          Datadog.logger.debug { 'Sinatra middlewares: ' << middlewares(builder).map(&:inspect).inspect }
         end
       end
     end
   end
 end
-

--- a/lib/ddtrace/contrib/sinatra/framework.rb
+++ b/lib/ddtrace/contrib/sinatra/framework.rb
@@ -8,11 +8,11 @@ module Datadog
       module Framework
         # Configure Rack from Sinatra, but only if Rack has not been configured manually beforehand
         def self.setup
+          return if Datadog.configuration.instrumented_integrations.key?(:rack)
+
           Datadog.configure do |datadog_config|
             sinatra_config = config_with_defaults(datadog_config)
-            unless Datadog.configuration.instrumented_integrations.key?(:rack)
-              activate_rack!(datadog_config, sinatra_config)
-            end
+            activate_rack!(datadog_config, sinatra_config)
           end
         end
 

--- a/lib/ddtrace/contrib/sinatra/framework.rb
+++ b/lib/ddtrace/contrib/sinatra/framework.rb
@@ -8,9 +8,9 @@ module Datadog
       module Framework
         # Configure Rack from Sinatra, but only if Rack has not been configured manually beforehand
         def self.setup
-          return if Datadog.configuration.instrumented_integrations.key?(:rack)
+          return if Datadog::Tracing.configuration.instrumented_integrations.key?(:rack)
 
-          Datadog.configure do |datadog_config|
+          Datadog::Tracing.configure do |datadog_config|
             sinatra_config = config_with_defaults(datadog_config)
             activate_rack!(datadog_config, sinatra_config)
           end
@@ -22,7 +22,7 @@ module Datadog
 
         # Apply relevant configuration from Sinatra to Rack
         def self.activate_rack!(datadog_config, sinatra_config)
-          datadog_config.use(
+          datadog_config.instrument(
             :rack,
             service_name: sinatra_config[:service_name],
             distributed_tracing: sinatra_config[:distributed_tracing],

--- a/lib/ddtrace/contrib/sinatra/framework.rb
+++ b/lib/ddtrace/contrib/sinatra/framework.rb
@@ -8,8 +8,6 @@ module Datadog
       module Framework
         # Configure Rack from Sinatra, but only if Rack has not been configured manually beforehand
         def self.setup
-          return if Datadog::Tracing.configuration.instrumented_integrations.key?(:rack)
-
           Datadog::Tracing.configure do |datadog_config|
             sinatra_config = config_with_defaults(datadog_config)
             activate_rack!(datadog_config, sinatra_config)

--- a/lib/ddtrace/contrib/sinatra/patcher.rb
+++ b/lib/ddtrace/contrib/sinatra/patcher.rb
@@ -1,9 +1,32 @@
 # typed: true
 require 'ddtrace/contrib/patcher'
+require 'ddtrace/contrib/sinatra/framework'
+require 'ddtrace/contrib/rack/middlewares'
 
 module Datadog
   module Contrib
     module Sinatra
+      # Set tracer configuration at a late enough time
+      module TracerSetupPatch
+        def setup_middleware(*args, &block)
+          super.tap do
+            Datadog::Contrib::Sinatra::Framework.setup
+          end
+        end
+      end
+
+      # Hook into builder before the middleware list gets frozen
+      module DefaultMiddlewarePatch
+        def setup_middleware(*args, &block)
+          builder = args.first
+
+          super.tap do
+            Datadog::Contrib::Sinatra::Framework.add_middleware(builder)
+            Datadog::Contrib::Sinatra::Framework.inspect_middlewares(builder)
+          end
+        end
+      end
+
       # Patcher enables patching of 'sinatra' module.
       module Patcher
         include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
@@ -18,11 +41,22 @@ module Datadog
         def patch
           require 'ddtrace/contrib/sinatra/tracer'
           register_tracer
+
+          patch_default_middlewares
+          setup_tracer
         end
 
         def register_tracer
           ::Sinatra.send(:register, Datadog::Contrib::Sinatra::Tracer)
           ::Sinatra::Base.prepend(Sinatra::Tracer::Base)
+        end
+
+        def setup_tracer
+          ::Sinatra::Base.singleton_class.prepend(TracerSetupPatch)
+        end
+
+        def patch_default_middlewares
+          ::Sinatra::Base.singleton_class.prepend(DefaultMiddlewarePatch)
         end
       end
     end

--- a/lib/ddtrace/contrib/sinatra/patcher.rb
+++ b/lib/ddtrace/contrib/sinatra/patcher.rb
@@ -28,7 +28,7 @@ module Datadog
 
           super.tap do
             ONLY_ONCE_PER_APP[self].run do
-              Datadog::Contrib::Sinatra::Framework.add_middleware(builder)
+              Datadog::Contrib::Sinatra::Framework.add_middleware(Datadog::Contrib::Rack::TraceMiddleware, builder)
               Datadog::Contrib::Sinatra::Framework.inspect_middlewares(builder)
             end
           end

--- a/lib/ddtrace/contrib/sinatra/patcher.rb
+++ b/lib/ddtrace/contrib/sinatra/patcher.rb
@@ -8,21 +8,29 @@ module Datadog
     module Sinatra
       # Set tracer configuration at a late enough time
       module TracerSetupPatch
+        ONLY_ONCE_PER_APP = Hash.new { |h, key| h[key] = Datadog::Utils::OnlyOnce.new }
+
         def setup_middleware(*args, &block)
           super.tap do
-            Datadog::Contrib::Sinatra::Framework.setup
+            ONLY_ONCE_PER_APP[self].run do
+              Datadog::Contrib::Sinatra::Framework.setup
+            end
           end
         end
       end
 
       # Hook into builder before the middleware list gets frozen
       module DefaultMiddlewarePatch
+        ONLY_ONCE_PER_APP = Hash.new { |h, key| h[key] = Datadog::Utils::OnlyOnce.new }
+
         def setup_middleware(*args, &block)
           builder = args.first
 
           super.tap do
-            Datadog::Contrib::Sinatra::Framework.add_middleware(builder)
-            Datadog::Contrib::Sinatra::Framework.inspect_middlewares(builder)
+            ONLY_ONCE_PER_APP[self].run do
+              Datadog::Contrib::Sinatra::Framework.add_middleware(builder)
+              Datadog::Contrib::Sinatra::Framework.inspect_middlewares(builder)
+            end
           end
         end
       end

--- a/lib/ddtrace/contrib/sinatra/patcher.rb
+++ b/lib/ddtrace/contrib/sinatra/patcher.rb
@@ -8,7 +8,7 @@ module Datadog
     module Sinatra
       # Set tracer configuration at a late enough time
       module TracerSetupPatch
-        ONLY_ONCE_PER_APP = Hash.new { |h, key| h[key] = Datadog::Utils::OnlyOnce.new }
+        ONLY_ONCE_PER_APP = Hash.new { |h, key| h[key] = Datadog::Core::Utils::OnlyOnce.new }
 
         def setup_middleware(*args, &block)
           super.tap do
@@ -21,7 +21,7 @@ module Datadog
 
       # Hook into builder before the middleware list gets frozen
       module DefaultMiddlewarePatch
-        ONLY_ONCE_PER_APP = Hash.new { |h, key| h[key] = Datadog::Utils::OnlyOnce.new }
+        ONLY_ONCE_PER_APP = Hash.new { |h, key| h[key] = Datadog::Core::Utils::OnlyOnce.new }
 
         def setup_middleware(*args, &block)
           builder = args.first

--- a/lib/ddtrace/contrib/sinatra/tracer_middleware.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer_middleware.rb
@@ -55,6 +55,16 @@ module Datadog
               # resource; if no resource was set, let's use a fallback
               span.resource = env['REQUEST_METHOD'] if span.resource.nil?
 
+              rack_request_span = env[Datadog::Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
+              if rack_request_span
+                unless rack_request_span.resource
+                  # This propagates the Sinatra resource to the Rack span,
+                  # since the latter is unaware of what the resource might be
+                  # and would fallback to a generic resource name when unset
+                  rack_request_span.resource = span.resource
+                end
+              end
+
               if response
                 if (status = response[0])
                   sinatra_response = ::Sinatra::Response.new([], status) # Build object to use status code helpers

--- a/lib/ddtrace/contrib/sinatra/tracer_middleware.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer_middleware.rb
@@ -16,6 +16,8 @@ module Datadog
 
         # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/MethodLength
+        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/PerceivedComplexity
         def call(env)
           # Set the trace context (e.g. distributed tracing)
           if configuration[:distributed_tracing] && Datadog::Tracing.active_trace.nil?
@@ -85,6 +87,10 @@ module Datadog
             end
           end
         end
+        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/MethodLength
+        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/PerceivedComplexity
 
         private
 

--- a/lib/ddtrace/contrib/sinatra/tracer_middleware.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer_middleware.rb
@@ -56,14 +56,11 @@ module Datadog
               span.resource = env['REQUEST_METHOD'] if span.resource.nil?
 
               rack_request_span = env[Datadog::Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
-              if rack_request_span
-                unless rack_request_span.resource
-                  # This propagates the Sinatra resource to the Rack span,
-                  # since the latter is unaware of what the resource might be
-                  # and would fallback to a generic resource name when unset
-                  rack_request_span.resource = span.resource
-                end
-              end
+
+              # This propagates the Sinatra resource to the Rack span,
+              # since the latter is unaware of what the resource might be
+              # and would fallback to a generic resource name when unset
+              rack_request_span.resource ||= span.resource if rack_request_span
 
               if response
                 if (status = response[0])

--- a/spec/ddtrace/contrib/sinatra/multi_app_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/multi_app_spec.rb
@@ -69,8 +69,15 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
 
         it do
           is_expected.to be_ok
-          expect(spans).to have(2).items
+          expect(spans).to have(3).items
           spans.each do |span|
+            if span.name == Datadog::Contrib::Rack::Ext::SPAN_REQUEST
+              expect(span.resource).to eq('GET /endpoint')
+              expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/endpoint')
+
+              next
+            end
+
             expect(span.resource).to eq('GET /endpoint')
             expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_ROUTE_PATH)).to eq('/endpoint')
             expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_SCRIPT_NAME)).to eq('/one')
@@ -83,8 +90,15 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
 
         it do
           is_expected.to be_ok
-          expect(spans).to have(2).items
+          expect(spans).to have(3).items
           spans.each do |span|
+            if span.name == Datadog::Contrib::Rack::Ext::SPAN_REQUEST
+              expect(span.resource).to eq('GET /endpoint')
+              expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/endpoint')
+
+              next
+            end
+
             expect(span.resource).to eq('GET /endpoint')
             expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_ROUTE_PATH)).to eq('/endpoint')
             expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_SCRIPT_NAME)).to eq('/two')
@@ -101,8 +115,15 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
 
         it do
           is_expected.to be_ok
-          expect(spans).to have(2).items
+          expect(spans).to have(3).items
           spans.each do |span|
+            if span.name == Datadog::Contrib::Rack::Ext::SPAN_REQUEST
+              expect(span.resource).to eq('GET /one/endpoint')
+              expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/endpoint')
+
+              next
+            end
+
             expect(span.resource).to eq('GET /one/endpoint')
             expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_ROUTE_PATH)).to eq('/one/endpoint')
             expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_SCRIPT_NAME)).to eq('/one')
@@ -115,8 +136,15 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
 
         it do
           is_expected.to be_ok
-          expect(spans).to have(2).items
+          expect(spans).to have(3).items
           spans.each do |span|
+            if span.name == Datadog::Contrib::Rack::Ext::SPAN_REQUEST
+              expect(span.resource).to eq('GET /two/endpoint')
+              expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/endpoint')
+
+              next
+            end
+
             expect(span.resource).to eq('GET /two/endpoint')
             expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_ROUTE_PATH)).to eq('/two/endpoint')
             expect(span.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_SCRIPT_NAME)).to eq('/two')

--- a/spec/ddtrace/contrib/sinatra/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/tracer_spec.rb
@@ -614,6 +614,8 @@ RSpec.describe 'Sinatra instrumentation' do
     end
 
     context 'when modular app does not register the Datadog::Contrib::Sinatra::Tracer middleware' do
+      include_context 'tracer logging'
+
       let(:sinatra_app) do
         sinatra_routes = self.sinatra_routes
         stub_const('App', Class.new(Sinatra::Base) do
@@ -624,21 +626,18 @@ RSpec.describe 'Sinatra instrumentation' do
       subject(:response) { get url }
 
       before do
-        allow(Datadog.logger).to receive(:warn)
         Datadog::Contrib::Sinatra::Tracer::Base
           .const_get('MISSING_REQUEST_SPAN_ONLY_ONCE').send(:reset_ran_once_state_for_tests)
       end
 
       it { is_expected.to be_ok }
 
-      xit '[TODO:BROKEN:might not be possible anymore] logs a warning' do
-        expect(Datadog.logger).to receive(:warn) do |&message|
-          expect(message.call).to include 'Sinatra integration is misconfigured'
-        end
-
+      it 'logs a warning' do
         # NOTE: We actually need to check that the request finished ok, as sinatra may otherwise "swallow" an RSpec
         # exception and thus the test will appear to pass because the RSpec exception doesn't propagate out
         is_expected.to be_ok
+
+        expect(log_buffer.string).to match(/WARN.*Sinatra integration is misconfigured/)
       end
     end
   end

--- a/spec/ddtrace/contrib/sinatra/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/tracer_spec.rb
@@ -564,7 +564,7 @@ RSpec.describe 'Sinatra instrumentation' do
         let(:span) { top_span }
         let(:rack_span) { top_rack_span }
 
-        include_examples 'sinatra examples' #
+        include_examples 'sinatra examples'
         include_examples 'header tags'
         include_examples 'distributed tracing'
       end

--- a/spec/ddtrace/contrib/sinatra/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/tracer_spec.rb
@@ -638,7 +638,7 @@ RSpec.describe 'Sinatra instrumentation' do
 
       it { is_expected.to be_ok }
 
-      it 'logs a warning' do
+      xit '[TODO:BROKEN:might not be possible anymore] logs a warning' do
         expect(Datadog.logger).to receive(:warn) do |&message|
           expect(message.call).to include 'Sinatra integration is misconfigured'
         end

--- a/spec/ddtrace/contrib/sinatra/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/tracer_spec.rb
@@ -70,16 +70,32 @@ RSpec.describe 'Sinatra instrumentation' do
     end
   end
 
-  let(:span) { spans.reverse.find { |x| x.name == Datadog::Contrib::Sinatra::Ext::SPAN_REQUEST } }
-  let(:route_span) { spans.find { |x| x.name == Datadog::Contrib::Sinatra::Ext::SPAN_ROUTE } }
-
   let(:app) { sinatra_app }
 
-  let(:with_rack) { false }
+  let(:sorted_spans) do
+    chain = lambda do |start|
+      loop.with_object([start]) do |_, o|
+        # root reached (default)
+        break o if o.last.parent_id == 0
+
+        parent = spans.find { |span| span.span_id == o.last.parent_id }
+
+        # root reached (distributed tracing)
+        break o if parent.nil?
+
+        o << parent
+      end
+    end
+    sort = ->(list) { list.sort_by { |e| chain.call(e).count } }
+    sort.call(spans)
+  end
+
+  let(:span) { sorted_spans.reverse.find { |x| x.name == Datadog::Contrib::Sinatra::Ext::SPAN_REQUEST } }
+  let(:route_span) { sorted_spans.find { |x| x.name == Datadog::Contrib::Sinatra::Ext::SPAN_ROUTE } }
+  let(:rack_span) { sorted_spans.reverse.find { |x| x.name == Datadog::Contrib::Rack::Ext::SPAN_REQUEST } }
 
   before do
     Datadog::Tracing.configure do |c|
-      c.instrument :rack if with_rack
       c.instrument :sinatra, configuration_options
     end
   end
@@ -91,28 +107,12 @@ RSpec.describe 'Sinatra instrumentation' do
     Datadog::Tracing.registry[:sinatra].reset_configuration!
   end
 
-  shared_context 'with rack instrumentation' do
-    let(:with_rack) { true }
-    let(:rack_span) { spans.find { |x| x.parent_id == 0 && x.name == Datadog::Contrib::Rack::Ext::SPAN_REQUEST } }
-    let(:rack_middlewares) { [Datadog::Contrib::Rack::TraceMiddleware] }
-
-    let(:app) do
-      example = self
-      Rack::Builder.new do
-        example.rack_middlewares.each { |m| use m }
-        run example.sinatra_app
-      end.to_app
-    end
-  end
-
   shared_examples 'sinatra examples' do |opts = {}|
-    let(:nested_span_count) { defined?(mount_nested_app) && mount_nested_app ? 1 : 0 }
+    let(:nested_span_count) { defined?(mount_nested_app) && mount_nested_app ? 2 : 0 }
 
     context 'when configured' do
       context 'with default settings' do
         context 'and a simple request is made' do
-          include_context 'with rack instrumentation'
-
           subject(:response) { get url }
 
           # let(:top_span) { defined?(super) ? super() : rack_span }
@@ -128,7 +128,7 @@ RSpec.describe 'Sinatra instrumentation' do
               expect(trace.resource).to eq('GET /')
               expect(span).to be_request_span parent: rack_span, http_tags: true
               expect(route_span).to be_request_span parent: route_parent
-              expect(rack_span.resource).to eq('GET 200')
+              expect(rack_span.resource).to eq('GET /')
             end
           end
 
@@ -208,7 +208,7 @@ RSpec.describe 'Sinatra instrumentation' do
           let(:request_span) { spans.find { |s| route_span.parent_id == s.span_id } }
           let(:route_span) { spans.find { |s| template_parent_span.parent_id == s.span_id } }
           let(:template_parent_span) { spans.find { |s| template_child_span.parent_id == s.span_id } }
-          let(:template_child_span) { spans.find { |s| s.get_tag('sinatra.template_name') == 'layout' } }
+          let(:template_child_span) { sorted_spans.find { |s| s.get_tag('sinatra.template_name') == 'layout' } }
 
           before do
             expect(response).to be_ok
@@ -259,19 +259,20 @@ RSpec.describe 'Sinatra instrumentation' do
         context 'and a request to a literal template route is made' do
           subject(:response) { get '/erb_literal' }
 
-          let(:template_parent_span) { spans[0] }
-          let(:template_child_span) { spans[1] }
+          let(:rack_span) { sorted_spans[0] }
+          let(:template_parent_span) { sorted_spans[-2] }
+          let(:template_child_span) { sorted_spans[-1] }
 
           before do
             expect(response).to be_ok
-            expect(spans).to have(4 + nested_span_count).items
+            expect(spans).to have(5 + nested_span_count).items
           end
 
           describe 'the sinatra.request span' do
             it do
               expect(span.resource).to eq('GET /erb_literal')
               expect(span.get_tag(Datadog::Ext::HTTP::URL)).to eq('/erb_literal')
-              expect(span).to be_root_span
+              expect(span.parent_id).to eq(rack_span.span_id)
             end
 
             it_behaves_like 'measured span for integration', true
@@ -324,7 +325,7 @@ RSpec.describe 'Sinatra instrumentation' do
 
           it do
             is_expected.to be_server_error
-            expect(spans).to have(2 + nested_span_count).items
+            expect(spans).to have(3 + nested_span_count).items
             expect(span).to_not have_error_type
             expect(span).to_not have_error_message
             expect(span.status).to eq(1)
@@ -336,7 +337,7 @@ RSpec.describe 'Sinatra instrumentation' do
 
           it do
             is_expected.to be_server_error
-            expect(spans).to have(2 + nested_span_count).items
+            expect(spans).to have(3 + nested_span_count).items
             expect(span).to have_error_type('RuntimeError')
             expect(span).to have_error_message('test error')
             expect(span.status).to eq(1)
@@ -344,8 +345,6 @@ RSpec.describe 'Sinatra instrumentation' do
         end
 
         context 'and a request to a nonexistent route' do
-          include_context 'with rack instrumentation'
-
           subject(:response) { get '/not_a_route' }
 
           it do
@@ -353,7 +352,7 @@ RSpec.describe 'Sinatra instrumentation' do
             expect(trace).to_not be nil
             expect(spans).to have(2 + nested_span_count).items
 
-            expect(trace.resource).to eq('GET 404')
+            expect(trace.resource).to eq('GET /not_a_route')
 
             expect(span.service).to eq(tracer.default_service)
             expect(span.resource).to eq('GET /not_a_route')
@@ -369,7 +368,7 @@ RSpec.describe 'Sinatra instrumentation' do
             expect(span.get_tag(Datadog::Ext::Metadata::TAG_OPERATION))
               .to eq('request')
 
-            expect(rack_span.resource).to eq('GET 404')
+            expect(rack_span.resource).to eq('GET /not_a_route')
           end
         end
 
@@ -438,7 +437,7 @@ RSpec.describe 'Sinatra instrumentation' do
   end
 
   shared_examples 'distributed tracing' do
-    context 'default' do
+    context 'with default settings' do
       context 'and a simple request is made' do
         subject(:response) { get '/', query_string, headers }
 
@@ -457,16 +456,19 @@ RSpec.describe 'Sinatra instrumentation' do
 
           it do
             is_expected.to be_ok
-            expect(span.trace_id).to eq(1)
-            expect(span.parent_id).to eq(2)
             expect(trace.sampling_priority).to eq(2)
             expect(trace.origin).to eq('synthetics')
+            expect(span.trace_id).to eq(1)
+            expect(span.parent_id).to_not eq(2)
+            expect(span.parent_id).to eq(rack_span.span_id)
+            expect(rack_span.trace_id).to eq(1)
+            expect(rack_span.parent_id).to eq(2)
           end
         end
       end
     end
 
-    context 'disabled' do
+    context 'with distributed tracing disabled' do
       let(:configuration_options) { super().merge(distributed_tracing: false) }
 
       context 'and a simple request is made' do
@@ -475,7 +477,7 @@ RSpec.describe 'Sinatra instrumentation' do
         let(:query_string) { {} }
         let(:headers) { {} }
 
-        context 'without distributed tracing headers' do
+        context 'with distributed tracing headers' do
           let(:headers) do
             {
               'HTTP_X_DATADOG_TRACE_ID' => '1',
@@ -487,10 +489,14 @@ RSpec.describe 'Sinatra instrumentation' do
 
           it do
             is_expected.to be_ok
-            expect(span.trace_id).to_not eq(1)
-            expect(span.parent_id).to_not eq(2)
             expect(trace.sampling_priority).to_not eq(2)
             expect(trace.origin).to_not eq('synthetics')
+
+            expect(span.trace_id).to_not eq(1)
+            expect(span.parent_id).to_not eq(2)
+            expect(span.parent_id).to eq(rack_span.span_id)
+            expect(rack_span.trace_id).to_not eq(1)
+            expect(rack_span.parent_id).to_not eq(2)
           end
         end
       end
@@ -540,14 +546,25 @@ RSpec.describe 'Sinatra instrumentation' do
 
     context 'with nested app' do
       let(:mount_nested_app) { true }
-      let(:top_span) { spans.find { |x| x.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_APP_NAME) == top_app_name } }
-      let(:nested_span) { spans.find { |x| x.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_APP_NAME) == nested_app_name } }
+      let(:top_span) do
+        spans.find { |x| x.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_APP_NAME) == top_app_name }
+      end
+      let(:top_rack_span) do
+        spans.find { |x| x.name == Datadog::Contrib::Rack::Ext::SPAN_REQUEST && x.span_id == top_span.parent_id }
+      end
+      let(:nested_span) do
+        spans.find { |x| x.get_tag(Datadog::Contrib::Sinatra::Ext::TAG_APP_NAME) == nested_app_name }
+      end
+      let(:nested_rack_span) do
+        spans.find { |x| x.name == Datadog::Contrib::Rack::Ext::SPAN_REQUEST && x.span_id == nested_span.parent_id }
+      end
       let(:nested_app_name) { 'NestedApp' }
 
       context 'making request to top level app' do
         let(:span) { top_span }
+        let(:rack_span) { top_rack_span }
 
-        include_examples 'sinatra examples'
+        include_examples 'sinatra examples' #
         include_examples 'header tags'
         include_examples 'distributed tracing'
       end
@@ -559,6 +576,7 @@ RSpec.describe 'Sinatra instrumentation' do
         context 'asserting the parent span' do
           let(:app_name) { top_app_name }
           let(:span) { top_span }
+          let(:rack_span) { top_rack_span }
 
           include_examples 'sinatra examples', matching_app: false
           include_examples 'header tags'
@@ -567,53 +585,28 @@ RSpec.describe 'Sinatra instrumentation' do
 
         context 'matching the nested span' do
           let(:span) { nested_span }
-
-          context 'without rack' do
-            it 'creates spans for intermediate Sinatra apps' do
-              is_expected.to be_ok
-              expect(trace).to_not be nil
-              expect(spans).to have(3).items
-
-              expect(trace.resource).to eq(resource)
-
-              expect(top_span).to be_request_span resource: 'GET', app_name: top_app_name, matching_app: false
-              expect(span).to be_request_span parent: top_span
-              expect(route_span).to be_route_span parent: span
-            end
-
-            context 'with route not found' do
-              let(:url) { '/not_a_route' }
-
-              # TODO: `resource` should not be high-cardinality for not found routes
-              # TODO: Using the HTTP method is one suggested alternative, as we
-              # TODO: don't yet have the HTTP response available to also retrieve the
-              # TODO: status code at middleware processing time.
-              # let(:resource) { 'GET' }
-
-              it do
-                is_expected.to be_not_found
-                expect(spans).to have(2).items
-
-                expect(top_span).to be_request_span app_name: top_app_name
-                expect(span).to be_request_span parent: top_span
-              end
-            end
-          end
+          let(:rack_span) { nested_rack_span }
 
           context 'with rack' do
-            include_context 'with rack instrumentation'
-
             it 'creates spans for intermediate Sinatra apps' do
               is_expected.to be_ok
               expect(trace).to_not be nil
-              expect(spans).to have(4).items
+              expect(spans).to have(5).items
 
               expect(trace.resource).to eq(resource)
 
-              expect(top_span).to be_request_span resource: 'GET', parent: rack_span, app_name: top_app_name
-              expect(span).to be_request_span parent: top_span
+              expect(top_span).to be_request_span resource: 'GET',
+                                                  app_name: top_app_name,
+                                                  matching_app: false,
+                                                  parent: top_rack_span
+              expect(top_rack_span).not_to be_nil
+              expect(top_rack_span).to be_root_span
+              expect(top_rack_span.resource).to eq('GET')
+              expect(span).to be_request_span parent: nested_rack_span
+              expect(nested_rack_span).not_to be_nil
+              expect(nested_rack_span.parent_id).to eq(top_span.span_id)
               expect(route_span).to be_route_span parent: span
-              expect(rack_span.resource).to eq('GET 200')
+              expect(nested_rack_span.resource).to eq(resource)
             end
           end
         end


### PR DESCRIPTION
This attemps to mimic what is currently done with Rails.

Sinatra provides only limited public facilities to manipulate the stack
(namely, appending with `use`), assumes his default middlewares are
always first, and has a peculiar way to wrap the middlewares to build
the app stack.

Sinatra also freezes the stack when the builder is run, so we have to
get access to the moment the builder is available but not yet run to
alter the list by patching `Sinatra::Base#setup_default_middlewares`.

The `Datadog::Contrib::Sinatra::Framework` class encapsulates these
internal implementation details behind a few methods to achieve the
desired manipulations.