### PR TITLE
Remove circular dependencies.

### DIFF
--- a/lib/ddtrace/contrib/auto_instrument.rb
+++ b/lib/ddtrace/contrib/auto_instrument.rb
@@ -1,5 +1,4 @@
 # typed: false
-require 'ddtrace'
 
 module Datadog
   module Contrib

--- a/lib/ddtrace/contrib/rails/auto_instrument_railtie.rb
+++ b/lib/ddtrace/contrib/rails/auto_instrument_railtie.rb
@@ -1,5 +1,4 @@
 # typed: ignore
-require 'ddtrace'
 
 # Railtie to include AutoInstrumentation in rails loading
 class DatadogAutoInstrumentRailtie < Rails::Railtie

--- a/lib/ddtrace/contrib/registerable.rb
+++ b/lib/ddtrace/contrib/registerable.rb
@@ -1,5 +1,4 @@
 # typed: false
-require 'datadog/contrib'
 
 module Datadog
   module Contrib

--- a/lib/ddtrace/profiling/tasks/setup.rb
+++ b/lib/ddtrace/profiling/tasks/setup.rb
@@ -1,5 +1,4 @@
 # typed: false
-require 'ddtrace'
 require 'ddtrace/utils/only_once'
 require 'ddtrace/profiling'
 require 'ddtrace/profiling/ext/cpu'


### PR DESCRIPTION
Requiring ddtrace leads to requiring these files which in turn require ddtrace