### PR TITLE
Instrument Action Cable subscribe/unsubscribe hooks

### DIFF
--- a/lib/ddtrace/contrib/action_cable/instrumentation.rb
+++ b/lib/ddtrace/contrib/action_cable/instrumentation.rb
@@ -26,6 +26,52 @@ module Datadog
             end
           end
         end
+
+        # Instrumentation for when a Channel is subscribed to/unsubscribed from.
+        module ActionCableChannel
+          def self.included(base)
+            base.class_eval do
+              set_callback(
+                :subscribe,
+                :around,
+                ->(channel, block) { Tracer.trace(channel, :subscribe, &block) },
+                prepend: true
+              )
+
+              set_callback(
+                :unsubscribe,
+                :around,
+                ->(channel, block) { Tracer.trace(channel, :unsubscribe, &block) },
+                prepend: true
+              )
+            end
+          end
+
+          # Instrumentation for Channel hooks.
+          class Tracer
+            def self.trace(channel, hook)
+              configuration = Datadog.configuration[:action_cable]
+
+              Datadog.tracer.trace("action_cable.#{hook}") do |span|
+                span.service = configuration[:service_name]
+                span.resource = "#{channel.class}##{hook}"
+                span.span_type = Datadog::Ext::AppTypes::WEB
+
+                # Set analytics sample rate
+                if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
+                  Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])
+                end
+
+                # Measure service stats
+                Contrib::Analytics.set_measured(span)
+
+                span.set_tag(Ext::TAG_CHANNEL_CLASS, channel.class.to_s)
+
+                yield
+              end
+            end
+          end
+        end
       end
     end
   end

--- a/lib/ddtrace/contrib/action_cable/patcher.rb
+++ b/lib/ddtrace/contrib/action_cable/patcher.rb
@@ -21,6 +21,7 @@ module Datadog
         def patch
           Events.subscribe!
           ::ActionCable::Connection::Base.prepend(Instrumentation::ActionCableConnection)
+          ::ActionCable::Channel::Base.include(Instrumentation::ActionCableChannel)
         end
       end
     end

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -3,6 +3,7 @@
 
 # typed: strong
 module ::ActionCable::Connection::Base; end
+module ::ActionCable::Channel::Base; end
 module ::ActionDispatch::ExceptionWrapper; end
 module ::ActionDispatch::Response; end
 module ::ActionView::PartialRenderer; end

--- a/spec/ddtrace/contrib/action_cable/patcher_spec.rb
+++ b/spec/ddtrace/contrib/action_cable/patcher_spec.rb
@@ -3,10 +3,8 @@ require 'ddtrace/contrib/support/spec_helper'
 require 'spec/ddtrace/contrib/rails/support/deprecation'
 
 require 'ddtrace'
+require 'ddtrace/contrib/rails/rails_helper'
 require 'ddtrace/contrib/analytics_examples'
-
-require 'rails'
-require 'active_support/core_ext/hash/indifferent_access'
 
 begin
   require 'action_cable'
@@ -20,7 +18,7 @@ RSpec.describe 'ActionCable patcher' do
   let(:configuration_options) { {} }
   let(:span) do
     expect(spans).to have(1).item
-    spans.find { |s| s.service == 'action_cable' }
+    spans.first
   end
 
   before do
@@ -80,12 +78,54 @@ RSpec.describe 'ActionCable patcher' do
   context 'with channel' do
     let(:channel_class) do
       stub_const('ChatChannel', Class.new(ActionCable::Channel::Base) do
+        def subscribed; end
+
+        def unsubscribed; end
+
         def foo(_data); end
       end)
     end
 
     let(:channel_instance) { channel_class.new(connection, '{id: 1}', id: 1) }
     let(:connection) { double('connection', logger: Logger.new($stdout), transmit: nil, identifiers: []) }
+
+    context 'on subscribe' do
+      include_context 'Rails test application'
+
+      subject(:subscribe) { channel_instance.subscribe_to_channel }
+
+      before { app }
+
+      it 'traces the subscribe hook' do
+        subscribe
+
+        expect(span.service).to end_with('-action_cable')
+        expect(span.name).to eq('action_cable.subscribe')
+        expect(span.span_type).to eq('web')
+        expect(span.resource).to eq('ChatChannel#subscribe')
+        expect(span.get_tag('action_cable.channel_class')).to eq('ChatChannel')
+        expect(span).to_not have_error
+      end
+    end
+
+    context 'on unsubscribe' do
+      include_context 'Rails test application'
+
+      subject(:unsubscribe) { channel_instance.unsubscribe_from_channel }
+
+      before { app }
+
+      it 'traces the unsubscribe hook' do
+        unsubscribe
+
+        expect(span.service).to end_with('-action_cable')
+        expect(span.name).to eq('action_cable.unsubscribe')
+        expect(span.span_type).to eq('web')
+        expect(span.resource).to eq('ChatChannel#unsubscribe')
+        expect(span.get_tag('action_cable.channel_class')).to eq('ChatChannel')
+        expect(span).to_not have_error
+      end
+    end
 
     context 'on perform action' do
       subject(:perform) { channel_instance.perform_action(data) }


### PR DESCRIPTION
Action Cable's channel hooks allow users to perform various tasks, including checking if the channel can actually be subscribed to, and establishing streams based on different parameters (i.e. stream updates from a particular `Post` based on `params[:id]`).

These hooks can result in Active Record calls (and thus database queries), which can cause "orphaned" spans to exist outside of a particular APM service, without a single top-level span that they roll up to. Active Record span in particular end up behaving slightly differently, due to the way Active Record's tracing attempts to use the same service as the span's `parent` (if it exists).

Now, we create an outer span that these lower-level spans roll up to, allowing for much clearer understanding when monitoring Action Cable.