### PR TITLE
Tracer#trace produces SpanOperation instead of Span

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -284,7 +284,7 @@ And `options` is an optional `Hash` that accepts the following parameters:
 | `service`     | `String` | The service name which this span belongs (e.g. `'my-web-service'`) | Tracer `default-service`, `$PROGRAM_NAME` or `'ruby'` |
 | `resource`    | `String` | Name of the resource or action being operated on. Traces with the same resource value will be grouped together for the purpose of metrics (but still independently viewable.) Usually domain specific, such as a URL, query, request, etc. (e.g. `'Article#submit'`, `http://example.com/articles/list`.) | `name` of Span. |
 | `span_type`   | `String` | The type of the span (such as `'http'`, `'db'`, etc.) | `nil` |
-| `child_of`    | `Datadog::Span` / `Datadog::Context` | Parent for this span. If not provided, will automatically become current active span. | `nil` |
+| `child_of`    | `Datadog::SpanOperation` / `Datadog::Context` | Parent for this span. If not provided, will automatically become current active span. | `nil` |
 | `start_time`  | `Time` | When the span actually starts. Useful when tracing events that have already happened. | `Time.now` |
 | `tags`        | `Hash` | Extra tags which should be added to the span. | `{}` |
 | `on_error`    | `Proc` | Handler invoked when a block is provided to trace, and it raises an error. Provided `span` and `error` as arguments. Sets error on the span by default. | `proc { |span, error| span.set_error(error) unless span.nil? }` |
@@ -329,7 +329,7 @@ def db_query(start, finish, query)
 end
 ```
 
-Calling `Datadog.tracer.trace` without a block will cause the function to return a `Datadog::Span` that is started, but not finished. You can then modify this span however you wish, then close it `finish`.
+Calling `Datadog.tracer.trace` without a block will cause the function to return a `Datadog::SpanOperation` that is started, but not finished. You can then modify this span however you wish, then close it `finish`.
 
 *You must not leave any unfinished spans.* If any spans are left open when the trace completes, the trace will be discarded. You can [activate debug mode](#tracer-settings) to check for warnings if you suspect this might be happening.
 

--- a/lib/ddtrace/context.rb
+++ b/lib/ddtrace/context.rb
@@ -88,17 +88,20 @@ module Datadog
       end
     end
 
-    # Add a span to the context trace list, keeping it as the last active span.
-    def add_span(span)
+    def add_span(operation)
       @mutex.synchronize do
+        # Make the span follow the current span, unless there isn't one.
+        operation.trace_id = @parent_trace_id unless @parent_trace_id.nil?
+        operation.parent_id = @parent_span_id unless @parent_span_id.nil?
+
         # If hitting the hard limit, just drop spans. This is really a rare case
         # as it means despite the soft limit, the hard limit is reached, so the trace
         # by default has 10000 spans, all of which belong to unfinished parts of a
         # larger trace. This is a catch-all to reduce global memory usage.
-        if @max_length > 0 && @trace.length >= @max_length
-          # Detach the span from any context, it's being dropped and ignored.
-          span.context = nil
-          Datadog.logger.debug("context full, ignoring span #{span.name}")
+        if full?
+          # Detach the span from the context; it's being dropped and ignored.
+          operation.context = nil
+          Datadog.logger.debug("context full, ignoring span #{operation.name}")
 
           # If overflow has already occurred, don't send this metric.
           # Prevents metrics spam if buffer repeatedly overflows for the same trace.
@@ -109,28 +112,40 @@ module Datadog
 
           return
         end
-        set_current_span(span)
-        @current_root_span = span if @trace.empty?
-        @trace << span
-        span.context = self
+
+        # Add the span to the context
+        operation.context = self
+        self.current_span = operation
+        @current_root_span = operation if @trace.empty?
+        @trace << operation
       end
     end
 
     # Mark a span as a finished, increasing the internal counter to prevent
     # cycles inside _trace list.
-    def close_span(span)
+    def close_span(operation)
       @mutex.synchronize do
         @finished_spans += 1
-        # Current span is only meaningful for linear tree-like traces,
-        # in other cases, this is just broken and one should rely
-        # on per-instrumentation code to retrieve handle parent/child relations.
-        set_current_span(span.parent)
-        return if span.tracer.nil?
 
-        if span.parent.nil? && !all_spans_finished?
+        # Find the new current span: it should be an ancestor that is not finished.
+        # This is because it's possible that a parent span will finish before a child.
+        # If this happens, we don't want to set the current span to a completed span.
+        parent = operation.parent
+        parent = parent.parent while !parent.nil? && parent.finished?
+
+        # Current span is only meaningful for linear tree-like traces.
+        # In other cases, this is just broken and one should rely
+        # on per-instrumentation code to handle parent/child relations.
+        self.current_span = parent
+
+        # If root span has been closed and spans are still unfinished...
+        # ...emit some warnings/metrics to bring attention to this.
+        # All spans should be closed when the root span closes.
+        # Otherwise traces can leak, or be associated incorrectly.
+        if parent.nil? && !all_spans_finished?
           if Datadog.configuration.diagnostics.debug
             opened_spans = @trace.length - @finished_spans
-            Datadog.logger.debug("root span #{span.name} closed but has #{opened_spans} unfinished spans:")
+            Datadog.logger.debug("root span #{operation.name} closed but has #{opened_spans} unfinished spans:")
           end
 
           @trace.reject(&:finished?).group_by(&:name).each do |unfinished_span_name, unfinished_spans|
@@ -193,8 +208,11 @@ module Datadog
         # Allow caller to modify trace before context is reset
         yield(trace) if block_given?
 
+        # Reset the context for re-use.
         reset
-        [trace, sampled]
+
+        # Return Span measurements and whether it was sampled.
+        [trace.collect(&:span), sampled]
       end
     end
 
@@ -203,25 +221,25 @@ module Datadog
     # @return [Array<Span>] deleted spans
     def delete_span_if
       @mutex.synchronize do
-        [].tap do |deleted_spans|
-          @trace.delete_if do |span|
-            finished = span.finished?
+        deleted_spans = []
+        return deleted_spans unless block_given?
 
-            next unless yield span
+        @trace.delete_if do |operation|
+          finished = operation.finished?
 
-            deleted_spans << span
+          # Check condition
+          next unless yield(operation)
 
-            # We need to detach the span from the context, else, some code
-            # finishing it afterwards would mess up with the number of
-            # finished_spans and possibly cause other side effects.
-            span.context = nil
-            # Acknowledge there's one span less to finish, if needed.
-            # It's very important to keep this balanced.
-            @finished_spans -= 1 if finished
+          deleted_spans << operation.span
 
-            true
-          end
+          # Acknowledge there's one span less to finish, if needed.
+          # It's very important to keep this balanced.
+          @finished_spans -= 1 if finished
+
+          true
         end
+
+        deleted_spans
       end
     end
 
@@ -283,7 +301,7 @@ module Datadog
       @overflow = false
     end
 
-    def set_current_span(span)
+    def current_span=(span)
       @current_span = span
       if span
         @parent_trace_id = span.trace_id
@@ -294,33 +312,16 @@ module Datadog
       end
     end
 
+    # Returns true if the context is full
+    # and cannot accept any more spans.
+    def full?
+      @max_length > 0 && @trace.length >= @max_length
+    end
+
     # Returns if the trace for the current Context is finished or not.
     # Low-level internal function, not thread-safe.
     def all_spans_finished?
       @finished_spans > 0 && @trace.length == @finished_spans
-    end
-
-    # Return the start time of the root span, or nil if there are no spans or this is undefined.
-    def start_time
-      @mutex.synchronize do
-        return nil if @trace.empty?
-
-        @trace[0].start_time
-      end
-    end
-
-    # Return the length of the current trace held by this context.
-    def length
-      @mutex.synchronize do
-        @trace.length
-      end
-    end
-
-    # Iterate on each span within the trace. This is thread safe.
-    def each_span(&block)
-      @mutex.synchronize do
-        @trace.each(&block)
-      end
     end
   end
 end

--- a/lib/ddtrace/forced_tracing.rb
+++ b/lib/ddtrace/forced_tracing.rb
@@ -19,8 +19,8 @@ module Datadog
       end
     end
 
-    # Extension for Datadog::Span
-    module Span
+    # Extension for Datadog::SpanOperation
+    module SpanOperation
       def set_tag(key, value)
         # Configure sampling priority if they give us a forced tracing tag
         # DEV: Do not set if the value they give us is explicitly "false"

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -10,7 +10,6 @@ require 'ddtrace/ext/http'
 require 'ddtrace/ext/net'
 require 'ddtrace/ext/priority'
 require 'ddtrace/analytics'
-require 'ddtrace/forced_tracing'
 require 'ddtrace/diagnostics/health'
 require 'ddtrace/utils/time'
 
@@ -24,7 +23,6 @@ module Datadog
   # rubocop:disable Metrics/ClassLength
   class Span
     prepend Analytics::Span
-    prepend ForcedTracing::Span
 
     # The max value for a \Span identifier.
     # Span and trace identifiers should be strictly positive and strictly inferior to this limit.
@@ -60,15 +58,14 @@ module Datadog
 
     attr_accessor :name, :service, :span_type,
                   :span_id, :trace_id, :parent_id,
-                  :status, :sampled,
-                  :tracer, :context
+                  :status, :sampled
 
     attr_reader :parent, :start_time, :end_time, :resource_container
 
     attr_writer :duration
 
-    # Create a new span linked to the given tracer. Call the \Tracer method <tt>start_span()</tt>
-    # and then <tt>finish()</tt> once the tracer operation is over.
+    # Create a new span manually. Call the <tt>start()</tt> method to start the time
+    # measurement and then <tt>stop()</tt> once the timing operation is over.
     #
     # * +service+: the service name for this span
     # * +resource+: the resource this span refers, or +name+ if it's missing.
@@ -76,10 +73,7 @@ module Datadog
     # * +span_type+: the type of the span (such as +http+, +db+ and so on)
     # * +parent_id+: the identifier of the parent span
     # * +trace_id+: the identifier of the root span for this trace
-    # * +context+: the context of the span
-    def initialize(tracer, name, options = {})
-      @tracer = tracer
-
+    def initialize(name, options = {})
       @name = name
       @service = options.fetch(:service, nil)
       @resource_container = ResourceContainer.new(options.fetch(:resource, name))
@@ -89,8 +83,6 @@ module Datadog
       @parent_id = options.fetch(:parent_id, 0)
       @trace_id = options.fetch(:trace_id, Datadog::Utils.next_id)
 
-      @context = options.fetch(:context, nil)
-
       @meta = {}
       @metrics = {}
       @status = 0
@@ -99,7 +91,7 @@ module Datadog
       @sampled = true
 
       @allocation_count_start = now_allocations
-      @allocation_count_finish = @allocation_count_start
+      @allocation_count_stop = @allocation_count_start
 
       # start_time and end_time track wall clock. In Ruby, wall clock
       # has less accuracy than monotonic clock, so if possible we look to only use wall clock
@@ -211,55 +203,37 @@ module Datadog
 
     # for backwards compatibility
     def end_time=(time)
-      time.tap { finish(time) }
+      time.tap { stop(time) }
     end
 
-    # Mark the span finished at the current time and submit it.
-    def finish(finish_time = nil)
-      # A span should not be finished twice. Note that this is not thread-safe,
-      # finish is called from multiple threads, a given span might be finished
+    # Mark the span stopped at the current time
+    def stop(stop_time = nil)
+      # A span should not be stopped twice. Note that this is not thread-safe,
+      # stop is called from multiple threads, a given span might be stopped
       # several times. Again, one should not do this, so this test is more a
       # fallback to avoid very bad things and protect you in most common cases.
-      return if finished?
+      return if stopped?
 
-      @allocation_count_finish = now_allocations
+      @allocation_count_stop = now_allocations
 
       now = Utils::Time.now.utc
 
       # Provide a default start_time if unset.
       # Using `now` here causes duration to be 0; this is expected
       # behavior when start_time is unknown.
-      start(finish_time || now) unless started?
+      start(stop_time || now) unless started?
 
-      @end_time = finish_time || now
-      @duration_end = finish_time.nil? ? duration_marker : nil
+      @end_time = stop_time || now
+      @duration_end = stop_time.nil? ? duration_marker : nil
 
-      # Finish does not really do anything if the span is not bound to a tracer and a context.
-      return self if @tracer.nil? || @context.nil?
-
-      # spans without a service would be dropped, so here we provide a default.
-      # This should really never happen with integrations in contrib, as a default
-      # service is always set. It's only for custom instrumentation.
-      @service ||= (@tracer && @tracer.default_service)
-
-      begin
-        @context.close_span(self)
-        @tracer.record(self)
-      rescue StandardError => e
-        Datadog.logger.debug("error recording finished trace: #{e}")
-        Datadog.health_metrics.error_span_finish(1, tags: ["error:#{e.class.name}"])
-      end
       self
     end
+    # DEPRECATED: Use #stop instead
+    alias finish stop
 
     # Return a string representation of the span.
     def to_s
       "Span(name:#{@name},sid:#{@span_id},tid:#{@trace_id},pid:#{@parent_id})"
-    end
-
-    # DEPRECATED: remove this function in the next release, replaced by ``parent=``
-    def set_parent(parent)
-      self.parent = parent
     end
 
     # Set this span's parent, inheriting any properties not explicitly set.
@@ -277,9 +251,11 @@ module Datadog
         @sampled = parent.sampled
       end
     end
+    # DEPRECATED: remove this function in the next release, replaced by ``parent=``
+    alias set_parent parent=
 
     def allocations
-      @allocation_count_finish - @allocation_count_start
+      @allocation_count_stop - @allocation_count_start
     end
 
     # Return the hash representation of the current span.
@@ -298,7 +274,7 @@ module Datadog
         error: @status
       }
 
-      if finished?
+      if stopped?
         h[:start] = start_time_nano
         h[:duration] = duration_nano
       end
@@ -318,7 +294,7 @@ module Datadog
       # As of 1.3.3, JRuby implementation doesn't pass an existing packer
       packer ||= MessagePack::Packer.new
 
-      if finished?
+      if stopped?
         packer.write_map_header(13) # Set header with how many elements in the map
 
         packer.write('start')
@@ -380,7 +356,7 @@ module Datadog
         q.text "Error: #{@status}\n"
         q.text "Start: #{start_time}\n"
         q.text "End: #{end_time}\n"
-        q.text "Duration: #{duration.to_f if finished?}\n"
+        q.text "Duration: #{duration.to_f if stopped?}\n"
         q.text "Allocations: #{allocations}\n"
         q.group(2, 'Tags: [', "]\n") do
           q.breakable
@@ -402,10 +378,12 @@ module Datadog
       !@start_time.nil?
     end
 
-    # Return whether the duration is finished or not.
-    def finished?
+    # Return whether the duration is stopped or not.
+    def stopped?
       !@end_time.nil?
     end
+    # DEPRECATED: Use #stopped? instead
+    alias finished? stopped?
 
     def duration
       if @duration_end.nil? || @duration_start.nil?

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -1,18 +1,20 @@
 # typed: true
+require 'forwardable'
 require 'logger'
 require 'pathname'
 
-require 'ddtrace/ext/environment'
-require 'ddtrace/span'
-require 'ddtrace/context'
-require 'ddtrace/logger'
-require 'ddtrace/writer'
 require 'datadog/core/environment/identity'
-require 'ddtrace/sampler'
-require 'ddtrace/sampling'
+require 'ddtrace/context'
 require 'ddtrace/correlation'
 require 'ddtrace/event'
+require 'ddtrace/ext/environment'
+require 'ddtrace/forced_tracing'
+require 'ddtrace/logger'
+require 'ddtrace/sampler'
+require 'ddtrace/sampling'
+require 'ddtrace/span'
 require 'ddtrace/utils/only_once'
+require 'ddtrace/writer'
 
 # \Datadog global namespace that includes all tracing functionality for Tracer and Span classes.
 module Datadog
@@ -164,17 +166,56 @@ module Datadog
 
     # Guess context and parent from child_of entry.
     def guess_context_and_parent(child_of)
-      # call_context should not be in this code path, as start_span
-      # should never try and pick an existing context, but only get
-      # it from the parameters passed to it (child_of)
-      return [Datadog::Context.new, nil] unless child_of
-
-      return [child_of, child_of.current_span] if child_of.is_a?(Context)
-
-      [child_of.context, child_of]
+      case child_of
+      when Context
+        [child_of, child_of.current_span]
+      when SpanOperation
+        [child_of.context, child_of]
+      when Span
+        [nil, child_of]
+      else
+        # Start of a trace
+        [Context.new, nil]
+      end
     end
 
-    # Return a span that will trace an operation called \name. This method allows
+    # Build a span that will trace an operation called \name. This method allows
+    # parenting passing \child_of as an option. If it's missing, the newly created span is a
+    # root span. Available options are:
+    #
+    # * +service+: the service name for this span
+    # * +resource+: the resource this span refers, or \name if it's missing
+    # * +span_type+: the type of the span (such as \http, \db and so on)
+    # * +child_of+: a \Span or a \Context instance representing the parent for this span.
+    # * +tags+: extra tags which should be added to the span.
+    def build_span(name, options = {})
+      # Resolve context, parent
+      context, parent = guess_context_and_parent(options[:child_of])
+
+      # Build span options
+      options[:tracer] = self
+      options[:context] = context
+      options[:child_of] = parent
+      options[:service] ||= (parent && parent.service) || default_service
+      options[:tags] =  if @tags.any? && options[:tags]
+                          # Combine default tags with provided tags,
+                          # preferring provided tags.
+                          @tags.merge(options[:tags])
+                        else
+                          # Use provided tags or default tags if none.
+                          options[:tags] || @tags.dup
+                        end
+
+      # Build a new span operation
+      span = Datadog::SpanOperation.new(name, options)
+
+      # If it's a root span...
+      @sampler.sample!(span) if parent.nil?
+
+      span
+    end
+
+    # Build and start a span that will trace an operation called \name. This method allows
     # parenting passing \child_of as an option. If it's missing, the newly created span is a
     # root span. Available options are:
     #
@@ -185,41 +226,19 @@ module Datadog
     # * +start_time+: when the span actually starts (defaults to \now)
     # * +tags+: extra tags which should be added to the span.
     def start_span(name, options = {})
-      start_time = options[:start_time]
-      tags = options.fetch(:tags, {})
-
-      span_options = options.select do |k, _v|
-        # Filter options, we want no side effects with unexpected args.
-        ALLOWED_SPAN_OPTIONS.include?(k)
-      end
-
-      ctx, parent = guess_context_and_parent(options[:child_of])
-      span_options[:context] = ctx unless ctx.nil?
-
-      span = Span.new(self, name, span_options)
-      if parent.nil?
-        # root span
-        @sampler.sample!(span)
-        span.set_tag(Datadog::Ext::Runtime::TAG_PID, Process.pid)
-        span.set_tag(Datadog::Ext::Runtime::TAG_ID, Datadog::Core::Environment::Identity.id)
-
-        if ctx && ctx.trace_id
-          span.trace_id = ctx.trace_id
-          span.parent_id = ctx.span_id unless ctx.span_id.nil?
-        end
-      else
-        # child span
-        span.parent = parent # sets service, trace_id, parent_id, sampled
-      end
-
-      span.set_tags(@tags) unless @tags.empty?
-      span.set_tags(tags) unless tags.empty?
-      span.start(start_time)
-
-      # this could at some point be optional (start_active_span vs start_manual_span)
-      ctx.add_span(span) unless ctx.nil?
-
+      span = build_span(name, options)
+      span.start(options[:start_time])
       span
+    end
+
+    def record_span(operation)
+      operation.service ||= default_service
+      record_context(operation.context) if operation.context
+      operation.span
+    end
+
+    def finish_span(operation, end_time = nil)
+      operation.finish(end_time)
     end
 
     # Return a +span+ that will trace an operation called +name+. You could trace your code
@@ -321,7 +340,7 @@ module Datadog
     # method will figure out what to do, submitting a +span+ for recording
     # is like trying to record its +context+.
     def record(context)
-      context = context.context if context.is_a?(Datadog::Span)
+      context = context.context if context.is_a?(Datadog::SpanOperation)
       return if context.nil?
 
       record_context(context)
@@ -445,5 +464,79 @@ module Datadog
       :guess_context_and_parent,
       :record_context,
       :write
+  end
+
+  # Represents the act of taking a span measurement.
+  # It gives a Span a context which can be used to
+  # manage and decorate the Span.
+  # When completed, it yields the Span.
+  class SpanOperation
+    extend Forwardable
+
+    INCLUDED_METHODS = [:==].to_set.freeze
+    EXCLUDED_METHODS = [:finish, :parent, :parent=].to_set.freeze
+
+    def initialize(span_name, options = {})
+      # Resolve service name
+      parent = options[:child_of]
+      options[:service] ||= parent.service unless parent.nil?
+
+      # Build span
+      @span = Span.new(
+        span_name,
+        options
+      )
+      @tracer = options[:tracer]
+      @context = options[:context]
+
+      # Add span to the context, if provided.
+      @context.add_span(self) if @context
+
+      if parent.nil?
+        # Root span: set default tags.
+        set_tag(Datadog::Ext::Runtime::TAG_PID, Process.pid)
+        set_tag(Datadog::Ext::Runtime::TAG_ID, Datadog::Core::Environment::Identity.id)
+      else
+        # Only set parent if explicitly provided.
+        # We don't want it to override context-derived
+        # IDs if it's a distributed trace w/o a parent span.
+        self.parent = parent
+      end
+
+      # Set tags if provided.
+      set_tags(options[:tags]) if options.key?(:tags)
+    end
+
+    attr_reader :parent
+    attr_accessor :span, :tracer, :context
+
+    # Set span parent
+    def parent=(parent)
+      @parent = parent
+      span.parent = parent && parent.span
+    end
+
+    def finish(end_time = nil)
+      return span if finished?
+
+      # Stop the span
+      span.stop(end_time)
+
+      begin
+        context.close_span(self) if context
+        tracer.record_span(self) if tracer
+      rescue StandardError => e
+        Datadog.logger.debug("error recording finished trace: #{e} Backtrace: #{e.backtrace.first(3)}")
+        Datadog.health_metrics.error_span_finish(1, tags: ["error:#{e.class.name}"])
+      end
+
+      span
+    end
+
+    # Forward instance methods except ones that would cause identity issues
+    def_delegators :span, *(Span.instance_methods(false).to_set - EXCLUDED_METHODS)
+
+    # Additional extensions
+    prepend ForcedTracing::SpanOperation
   end
 end

--- a/spec/datadog/ci/test_spec.rb
+++ b/spec/datadog/ci/test_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Datadog::CI::Test do
 
     context 'when given a block' do
       subject(:trace) { described_class.trace(tracer, span_name, options, &block) }
-      let(:span) { Datadog::Span.new(tracer, span_name) }
+      let(:span) { Datadog::SpanOperation.new(span_name, tracer: tracer) }
       let(:block) { proc { |s| block_spy.call(s) } }
       # rubocop:disable RSpec/VerifiedDoubles
       let(:block_result) { double('result') }
@@ -61,7 +61,7 @@ RSpec.describe Datadog::CI::Test do
 
     context 'when not given a block' do
       subject(:trace) { described_class.trace(tracer, span_name, options) }
-      let(:span) { Datadog::Span.new(tracer, span_name) }
+      let(:span) { Datadog::SpanOperation.new(span_name, tracer: tracer) }
 
       before do
         allow(tracer)
@@ -84,7 +84,7 @@ RSpec.describe Datadog::CI::Test do
 
   describe '::set_tags!' do
     subject(:set_tags!) { described_class.set_tags!(span, tags) }
-    let(:span) { Datadog::Span.new(tracer, span_name) }
+    let(:span) { Datadog::SpanOperation.new(span_name, tracer: tracer) }
     let(:tags) { {} }
 
     before do
@@ -238,7 +238,7 @@ RSpec.describe Datadog::CI::Test do
 
   describe '::passed!' do
     subject(:passed!) { described_class.passed!(span) }
-    let(:span) { instance_double(Datadog::Span) }
+    let(:span) { instance_double(Datadog::SpanOperation) }
 
     before do
       allow(span).to receive(:set_tag)
@@ -256,7 +256,7 @@ RSpec.describe Datadog::CI::Test do
   end
 
   describe '::failed!' do
-    let(:span) { instance_double(Datadog::Span) }
+    let(:span) { instance_double(Datadog::SpanOperation) }
 
     before do
       allow(span).to receive(:status=)
@@ -304,7 +304,7 @@ RSpec.describe Datadog::CI::Test do
   end
 
   describe '::skipped!' do
-    let(:span) { instance_double(Datadog::Span) }
+    let(:span) { instance_double(Datadog::SpanOperation) }
 
     before do
       allow(span).to receive(:set_tag)

--- a/spec/ddtrace/context_spec.rb
+++ b/spec/ddtrace/context_spec.rb
@@ -71,13 +71,7 @@ RSpec.describe Datadog::Context do
     let(:span) { new_span }
 
     def new_span
-      instance_double(
-        Datadog::Span,
-        name: double('name'),
-        trace_id: double('trace ID'),
-        span_id: double('span ID'),
-        sampled: double('sampled')
-      ).tap do |span|
+      Datadog::SpanOperation.new(double('name')).tap do |span|
         allow(span).to receive(:context=)
       end
     end
@@ -161,18 +155,7 @@ RSpec.describe Datadog::Context do
     let(:span) { new_span }
 
     def new_span(name = nil)
-      instance_double(
-        Datadog::Span,
-        name: name || double('name'),
-        trace_id: double('trace ID'),
-        span_id: double('span ID'),
-        parent: double('parent ID'),
-        sampled: double('sampled'),
-        tracer: instance_double(Datadog::Tracer),
-        finished?: false
-      ).tap do |span|
-        allow(span).to receive(:context=)
-      end
+      Datadog::SpanOperation.new(name || double('name'))
     end
 
     before { context.add_span(span) }
@@ -263,13 +246,13 @@ RSpec.describe Datadog::Context do
     end
 
     context 'with a trace' do
-      let(:span) { Datadog::Span.new(nil, 'dummy') }
-      let(:trace) { [span] }
+      let(:operation) { Datadog::SpanOperation.new('dummy') }
+      let(:trace) { [operation] }
       let(:sampled) { double('sampled flag') }
 
       before do
-        span.sampled = sampled
-        context.add_span(span)
+        operation.sampled = sampled
+        context.add_span(operation)
 
         allow(context).to receive(:annotate_for_flush!)
       end
@@ -285,10 +268,10 @@ RSpec.describe Datadog::Context do
 
       context 'finished' do
         before do
-          context.close_span(span)
+          context.close_span(operation)
         end
 
-        it { is_expected.to eq([trace, sampled]) }
+        it { is_expected.to eq([trace.collect(&:span), sampled]) }
 
         it 'configures root span' do
           subject
@@ -308,22 +291,24 @@ RSpec.describe Datadog::Context do
     it { is_expected.to be nil }
 
     context 'after a span is added' do
-      let(:span) { Datadog::Span.new(tracer, 'span.one', context: context) }
+      let(:span) { Datadog::SpanOperation.new('span.one', context: context) }
 
       before { context.add_span(span) }
 
       it { is_expected.to be span }
 
       context 'which is a child to another span' do
-        let(:parent_span) { Datadog::Span.new(tracer, 'span.parent') }
+        let(:parent_span) { Datadog::SpanOperation.new('span.parent', context: context) }
+
         let(:span) do
-          Datadog::Span.new(
-            tracer,
-            'span.child',
-            context: context
-          ).tap { |s| s.parent = parent_span }
+          Datadog::SpanOperation.new('span.child', context: context).tap do |op|
+            op.parent = parent_span
+          end
         end
 
+        # Do not set the root span to the parent(?)
+        # Presumably because the parent span wasn't added
+        # to the context itself, so it can't be the root.
         it { is_expected.to be span }
       end
 
@@ -334,10 +319,8 @@ RSpec.describe Datadog::Context do
       end
 
       context 'followed by a second span' do
-        let(:span_two) { Datadog::Span.new(tracer, 'span.two', context: context) }
-
+        let(:span_two) { Datadog::SpanOperation.new('span.two', context: context) }
         before { context.add_span(span_two) }
-
         it { is_expected.to be span }
       end
     end
@@ -367,34 +350,37 @@ RSpec.describe Datadog::Context do
   describe '#delete_span_if' do
     subject(:annotate_for_flush!) { context.delete_span_if(&block) }
 
-    let(:remaining_span) { Datadog::Span.new(tracer, 'remaining', context: context).tap(&:finish) }
-    let(:deleted_span) { Datadog::Span.new(tracer, 'deleted', context: context).tap(&:finish) }
-    let(:block) { proc { |s| s == deleted_span } }
+    context 'when the Context contains spans' do
+      let!(:remaining_span_op) do
+        Datadog::SpanOperation.new('span.remaining', context: context).tap(&:finish)
+      end
 
-    before do
-      context.add_span(remaining_span)
-      context.add_span(deleted_span)
-    end
+      let!(:deleted_span_op) do
+        Datadog::SpanOperation.new('deleted', context: context).tap(&:finish)
+      end
 
-    it 'returns deleted spans' do
-      is_expected.to contain_exactly(deleted_span)
-    end
+      let(:block) { proc { |s| s == deleted_span_op } }
 
-    it 'keeps spans not deleted' do
-      expect { subject }.to change { context.finished_span_count }.from(2).to(1)
+      it 'returns deleted spans' do
+        is_expected.to contain_exactly(deleted_span_op.span)
+      end
 
-      expect(context.get[0]).to contain_exactly(remaining_span)
-    end
+      it 'keeps spans not deleted' do
+        expect { subject }.to change { context.finished_span_count }.from(2).to(1)
 
-    it 'detaches context from delete span' do
-      expect { subject }.to change { deleted_span.context }.from(context).to(nil)
+        expect(context.get[0]).to contain_exactly(remaining_span_op.span)
+      end
+
+      it 'decrements the finished span count' do
+        expect { subject }.to change { context.finished_span_count }.from(2).to(1)
+      end
     end
   end
 
   describe '#annotate_for_flush!' do
     subject(:annotate_for_flush!) { context.annotate_for_flush!(root_span) }
 
-    let(:root_span) { Datadog::Span.new(nil, 'dummy') }
+    let(:root_span) { Datadog::SpanOperation.new('dummy') }
 
     let(:options) { { origin: origin, sampled: sampled, sampling_priority: sampling_priority } }
 
@@ -501,77 +487,9 @@ RSpec.describe Datadog::Context do
     end
   end
 
-  describe '#length' do
-    subject(:ctx) { context }
-
-    let(:span) { new_span }
-
-    def new_span(name = nil)
-      Datadog::Span.new(tracer, name)
-    end
-
-    context 'with many spans' do
-      it 'tracks the number of spans added to the trace' do
-        10.times do |i|
-          span_to_add = span
-          expect(ctx.send(:length)).to eq(i)
-          ctx.add_span(span_to_add)
-          expect(ctx.send(:length)).to eq(i + 1)
-          ctx.close_span(span_to_add)
-          expect(ctx.send(:length)).to eq(i + 1)
-        end
-
-        ctx.get
-        expect(ctx.send(:length)).to eq(0)
-      end
-    end
-  end
-
-  describe '#start_time' do
-    subject(:ctx) { tracer.call_context }
-
-    context 'with no active spans' do
-      it 'does not have a start time' do
-        expect(ctx.send(:start_time)).to be nil
-      end
-    end
-
-    context 'with a span in the trace' do
-      it 'tracks start time of the span when trace is active' do
-        expect(ctx.send(:start_time)).to be nil
-
-        tracer.trace('test.op') do |span|
-          expect(ctx.send(:start_time)).to eq(span.start_time)
-          expect(ctx.send(:start_time)).to_not be nil
-        end
-
-        expect(ctx.send(:start_time)).to be nil
-      end
-    end
-  end
-
-  describe '#each_span' do
-    subject(:ctx) { context }
-
-    def new_span(name = nil)
-      Datadog::Span.new(tracer, name)
-    end
-
-    context 'with a span in the trace' do
-      it 'iterates over all the spans available' do
-        test_name = 'op.test'
-        new_span(test_name)
-
-        ctx.send(:each_span) do |span|
-          expect(span.name).to eq(test_name)
-        end
-      end
-    end
-  end
-
   describe 'thread safe behavior' do
     def new_span(name = nil)
-      Datadog::Span.new(tracer, name)
+      Datadog::SpanOperation.new(name)
     end
 
     context 'with many threads' do

--- a/spec/ddtrace/contrib/active_support/notifications/subscription_spec.rb
+++ b/spec/ddtrace/contrib/active_support/notifications/subscription_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Datadog::Contrib::ActiveSupport::Notifications::Subscription do
         end
 
         it 'sets span in payload' do
-          expect { subject }.to change { payload[:datadog_span] }.to be_instance_of(Datadog::Span)
+          expect { subject }.to change { payload[:datadog_span] }.to be_instance_of(Datadog::SpanOperation)
         end
 
         it 'provides a mutable copy of options to Tracer#trace' do

--- a/spec/ddtrace/contrib/ethon/easy_patch_spec.rb
+++ b/spec/ddtrace/contrib/ethon/easy_patch_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Datadog::Contrib::Ethon::EasyPatch do
 
     it 'creates a span' do
       subject
-      expect(easy.instance_eval { @datadog_span }).to be_instance_of(Datadog::Span)
+      expect(easy.instance_eval { @datadog_span }).to be_instance_of(Datadog::SpanOperation)
     end
 
     context 'when split by domain' do
@@ -226,7 +226,7 @@ RSpec.describe Datadog::Contrib::Ethon::EasyPatch do
 
       it 'cleans up @datadog_span' do
         expect { subject }.to change { easy.instance_eval { @datadog_span } }
-          .from(an_instance_of(Datadog::Span)).to(nil)
+          .from(an_instance_of(Datadog::SpanOperation)).to(nil)
       end
     end
   end

--- a/spec/ddtrace/contrib/http/request_spec.rb
+++ b/spec/ddtrace/contrib/http/request_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'net/http requests' do
         context 'which defines each parameter' do
           let(:callback) do
             proc do |span, http, request, response|
-              expect(span).to be_a_kind_of(Datadog::Span)
+              expect(span).to be_a_kind_of(Datadog::SpanOperation)
               expect(http).to be_a_kind_of(Net::HTTP)
               expect(request).to be_a_kind_of(Net::HTTP::Get)
               expect(response).to be_a_kind_of(Net::HTTPNotFound)

--- a/spec/ddtrace/contrib/rack/middlewares_spec.rb
+++ b/spec/ddtrace/contrib/rack/middlewares_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Datadog::Contrib::Rack::TraceMiddleware do
 
         it do
           expect(env).to include(
-            datadog_rack_request_span: kind_of(Datadog::Span),
-            'datadog.rack_request_span' => kind_of(Datadog::Span)
+            datadog_rack_request_span: kind_of(Datadog::SpanOperation),
+            'datadog.rack_request_span' => kind_of(Datadog::SpanOperation)
           )
         end
       end

--- a/spec/ddtrace/contrib/resque/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/resque/instrumentation_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe 'Resque instrumentation' do
     context 'trace context' do
       before do
         expect(job_class).to receive(:perform) do
-          expect(tracer.active_span).to be_a_kind_of(Datadog::Span)
+          expect(tracer.active_span).to be_a_kind_of(Datadog::SpanOperation)
           expect(tracer.active_span.parent_id).to eq(0)
         end
 

--- a/spec/ddtrace/forced_tracing_spec.rb
+++ b/spec/ddtrace/forced_tracing_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Datadog::ForcedTracing do
   describe '.keep' do
     subject(:keep) { described_class.keep(span) }
 
-    let(:span) { instance_double(Datadog::Span, context: trace_context) }
+    let(:span) { instance_double(Datadog::SpanOperation, context: trace_context) }
     let(:trace_context) { instance_double(Datadog::Context) }
 
     context 'given span' do
@@ -43,7 +43,7 @@ RSpec.describe Datadog::ForcedTracing do
   describe '.drop' do
     subject(:drop) { described_class.drop(span) }
 
-    let(:span) { instance_double(Datadog::Span, context: trace_context) }
+    let(:span) { instance_double(Datadog::SpanOperation, context: trace_context) }
     let(:trace_context) { instance_double(Datadog::Context) }
 
     context 'given span' do
@@ -76,7 +76,7 @@ RSpec.describe Datadog::ForcedTracing do
   end
 end
 
-RSpec.describe Datadog::ForcedTracing::Span do
+RSpec.describe Datadog::ForcedTracing::SpanOperation do
   subject(:test_object) { test_class.new }
 
   describe '#set_tag' do
@@ -94,7 +94,7 @@ RSpec.describe Datadog::ForcedTracing::Span do
         s = span
 
         klass = Class.new do
-          prepend Datadog::ForcedTracing::Span
+          prepend Datadog::ForcedTracing::SpanOperation
         end
 
         klass.tap do

--- a/spec/ddtrace/opentelemetry/span_spec.rb
+++ b/spec/ddtrace/opentelemetry/span_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Datadog::OpenTelemetry::Span do
   context 'when implemented in Datadog::Span' do
     before { expect(Datadog::Span <= described_class).to be true }
 
-    subject(:span) { Datadog::Span.new(tracer, name) }
+    subject(:span) { Datadog::Span.new(name, tracer: tracer) }
 
     let(:tracer) { instance_double(Datadog::Tracer) }
     let(:name) { 'opentelemetry.span' }

--- a/spec/ddtrace/pipeline/support/helper.rb
+++ b/spec/ddtrace/pipeline/support/helper.rb
@@ -3,7 +3,7 @@ require 'ddtrace/span'
 
 module PipelineHelpers
   def generate_span(name, parent = nil)
-    Datadog::Span.new(nil, name).tap do |span|
+    Datadog::Span.new(name).tap do |span|
       span.parent = parent
     end
   end

--- a/spec/ddtrace/runtime/metrics_spec.rb
+++ b/spec/ddtrace/runtime/metrics_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Datadog::Runtime::Metrics do
   describe '#associate_with_span' do
     subject(:associate_with_span) { runtime_metrics.associate_with_span(span) }
 
-    let(:span) { Datadog::Span.new(nil, 'dummy', service: service) }
+    let(:span) { Datadog::SpanOperation.new('dummy', service: service) }
     let(:service) { 'parser' }
 
     context 'when enabled' do

--- a/spec/ddtrace/sampler_spec.rb
+++ b/spec/ddtrace/sampler_spec.rb
@@ -7,7 +7,7 @@ require 'ddtrace/sampler'
 RSpec.shared_examples 'sampler with sample rate' do |sample_rate|
   subject(:sampler_sample_rate) { sampler.sample_rate(span) }
 
-  let(:span) { Datadog::Span.new(nil, 'dummy') }
+  let(:span) { Datadog::SpanOperation.new('dummy') }
 
   it { is_expected.to eq(sample_rate) }
 end
@@ -22,9 +22,9 @@ RSpec.describe Datadog::AllSampler do
   describe '#sample!' do
     let(:spans) do
       [
-        Datadog::Span.new(nil, '', trace_id: 1),
-        Datadog::Span.new(nil, '', trace_id: 2),
-        Datadog::Span.new(nil, '', trace_id: 3)
+        Datadog::SpanOperation.new('', trace_id: 1),
+        Datadog::SpanOperation.new('', trace_id: 2),
+        Datadog::SpanOperation.new('', trace_id: 3)
       ]
     end
 
@@ -79,9 +79,9 @@ RSpec.describe Datadog::RateSampler do
   describe '#sample!' do
     let(:spans) do
       [
-        Datadog::Span.new(nil, '', trace_id: 1),
-        Datadog::Span.new(nil, '', trace_id: 2),
-        Datadog::Span.new(nil, '', trace_id: 3)
+        Datadog::SpanOperation.new('', trace_id: 1),
+        Datadog::SpanOperation.new('', trace_id: 2),
+        Datadog::SpanOperation.new('', trace_id: 3)
       ]
     end
 
@@ -91,7 +91,7 @@ RSpec.describe Datadog::RateSampler do
 
       let(:spans) do
         Array.new(span_count) do
-          Datadog::Span.new(nil, '', trace_id: rng.rand(Datadog::Span::EXTERNAL_MAX_ID))
+          Datadog::SpanOperation.new('', trace_id: rng.rand(Datadog::Span::EXTERNAL_MAX_ID))
         end
       end
       let(:expected_num_of_sampled_spans) { span_count * sample_rate }
@@ -131,7 +131,7 @@ RSpec.describe Datadog::RateByKeySampler do
 
   let(:default_key) { 'default-key' }
 
-  let(:span) { Datadog::Span.new(tracer, 'test-span') }
+  let(:span) { Datadog::SpanOperation.new('test-span', tracer: tracer) }
   let(:resolver) { ->(span) { span.name } } # Resolve +span.name+ to the lookup key.
 
   describe '#sample!' do
@@ -176,7 +176,7 @@ RSpec.describe Datadog::RateByServiceSampler do
   describe '#resolve' do
     subject(:resolve) { sampler.resolve(span) }
 
-    let(:span) { instance_double(Datadog::Span, service: service_name) }
+    let(:span) { instance_double(Datadog::SpanOperation, service: service_name) }
     let(:service_name) { 'my-service' }
 
     context 'when the sampler is not configured with an :env option' do
@@ -299,7 +299,7 @@ RSpec.describe Datadog::PrioritySampler do
 
     shared_examples_for 'priority sampling' do
       context 'given a span without a context' do
-        let(:span) { Datadog::Span.new(nil, '', trace_id: 1) }
+        let(:span) { Datadog::SpanOperation.new('', trace_id: 1) }
 
         it do
           expect(sample).to be true
@@ -308,7 +308,7 @@ RSpec.describe Datadog::PrioritySampler do
       end
 
       context 'given a span with a context' do
-        let(:span) { Datadog::Span.new(nil, '', trace_id: 1, context: context) }
+        let(:span) { Datadog::SpanOperation.new('', trace_id: 1, context: context) }
         let(:context) { Datadog::Context.new }
 
         context 'but no sampling priority' do

--- a/spec/ddtrace/sampling/matcher_spec.rb
+++ b/spec/ddtrace/sampling/matcher_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'ddtrace/sampling/matcher'
 
 RSpec.describe Datadog::Sampling::SimpleMatcher do
-  let(:span) { Datadog::Span.new(nil, span_name, service: span_service) }
+  let(:span) { Datadog::SpanOperation.new(span_name, service: span_service) }
   let(:span_name) { 'operation.name' }
   let(:span_service) { nil }
 
@@ -133,7 +133,7 @@ RSpec.describe Datadog::Sampling::SimpleMatcher do
 end
 
 RSpec.describe Datadog::Sampling::ProcMatcher do
-  let(:span) { Datadog::Span.new(nil, span_name, service: span_service) }
+  let(:span) { Datadog::SpanOperation.new(span_name, service: span_service) }
   let(:span_name) { 'operation.name' }
   let(:span_service) { nil }
 

--- a/spec/ddtrace/sampling/rule_sampler_spec.rb
+++ b/spec/ddtrace/sampling/rule_sampler_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Datadog::Sampling::RuleSampler do
   let(:effective_rate) { 0.9 }
   let(:allow?) { true }
 
-  let(:span) { Datadog::Span.new(nil, 'dummy') }
+  let(:span) { Datadog::SpanOperation.new('dummy') }
 
   before do
     allow(default_sampler).to receive(:sample?).with(span).and_return(nil)

--- a/spec/ddtrace/sampling/rule_spec.rb
+++ b/spec/ddtrace/sampling/rule_spec.rb
@@ -5,7 +5,7 @@ require 'ddtrace/sampling/matcher'
 require 'ddtrace/sampling/rule'
 
 RSpec.describe Datadog::Sampling::Rule do
-  let(:span) { Datadog::Span.new(nil, span_name, service: span_service) }
+  let(:span) { Datadog::SpanOperation.new(span_name, service: span_service) }
   let(:span_name) { 'operation.name' }
   let(:span_service) { nil }
 

--- a/spec/ddtrace/sync_writer_spec.rb
+++ b/spec/ddtrace/sync_writer_spec.rb
@@ -86,8 +86,8 @@ RSpec.describe Datadog::SyncWriter do
     end
 
     context 'with filtering' do
-      let(:filtered_trace) { [Datadog::Span.new(nil, 'span_1')] }
-      let(:unfiltered_trace) { [Datadog::Span.new(nil, 'span_2')] }
+      let(:filtered_trace) { [Datadog::Span.new('span_1')] }
+      let(:unfiltered_trace) { [Datadog::Span.new('span_2')] }
 
       before do
         allow(transport).to receive(:send_traces).and_call_original

--- a/spec/ddtrace/tracer_integration_spec.rb
+++ b/spec/ddtrace/tracer_integration_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe Datadog::Tracer do
 
           # And create child span from propagated context
           tracer.trace(child_span_name) do |child_span|
-            @child_span = child_span
-            @child_root_span = tracer.active_root_span
+            @child_span = child_span.span
+            @child_root_span = tracer.active_root_span.span
           end
         end
       end
@@ -147,7 +147,7 @@ RSpec.describe Datadog::Tracer do
       shared_examples_for 'a synthetics-sourced trace' do
         before do
           tracer.trace('local.operation') do |local_span|
-            @local_span = local_span
+            @local_span = local_span.span
             @local_context = tracer.call_context
           end
         end

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -12,32 +12,10 @@ RSpec.describe Datadog::Tracer do
   after { tracer.shutdown! }
 
   shared_context 'parent span' do
-    let(:trace_id) { SecureRandom.uuid }
-    let(:span_id) { SecureRandom.uuid }
+    let(:parent_span) { tracer.start_span('parent', service: service) }
     let(:service) { 'test-service' }
-
-    before do
-      allow(context).to receive(:add_span)
-    end
-
-    let(:parent_span) do
-      instance_double(
-        Datadog::Span,
-        context: context,
-        trace_id: trace_id,
-        span_id: span_id,
-        service: service,
-        sampled: true
-      )
-    end
-
-    let(:context) do
-      instance_double(
-        Datadog::Context,
-        trace_id: trace_id,
-        span_id: span_id
-      )
-    end
+    let(:trace_id) { parent_span.trace_id }
+    let(:span_id) { parent_span.span_id }
   end
 
   describe '::new' do
@@ -148,7 +126,7 @@ RSpec.describe Datadog::Tracer do
     let(:name) { 'span.name' }
     let(:options) { {} }
 
-    it { is_expected.to be_a_kind_of(Datadog::Span) }
+    it { is_expected.to be_a_kind_of(Datadog::SpanOperation) }
 
     it 'does not belong to current the context by default' do
       tracer.trace('parent') do |active_span|
@@ -272,7 +250,7 @@ RSpec.describe Datadog::Tracer do
       context 'when starting a span' do
         it 'yields span provided block' do
           expect { |b| tracer.trace(name, &b) }.to yield_with_args(
-            a_kind_of(Datadog::Span)
+            a_kind_of(Datadog::SpanOperation)
           )
         end
 
@@ -362,6 +340,111 @@ RSpec.describe Datadog::Tracer do
             tracer.trace(name) do |child_span|
               expect(child_span.get_tag('runtime-id')).to be_nil
               expect(child_span.get_tag('system.pid')).to be_nil
+            end
+          end
+        end
+
+        context 'with spans that finish out of order' do
+          context 'within a trace' do
+            subject!(:trace) do
+              tracer.trace('grandparent') do
+                child, grandchild = nil
+
+                tracer.trace('parent') do
+                  child = tracer.trace('child')
+                  grandchild = tracer.trace('grandchild')
+                end
+
+                child.finish
+                grandchild.finish
+
+                tracer.trace('uncle') do
+                  tracer.trace('nephew').finish
+                end
+              end
+            end
+
+            it 'has correct relationships' do
+              grandparent = spans.find { |s| s.name == 'grandparent' }
+              parent = spans.find { |s| s.name == 'parent' }
+              child = spans.find { |s| s.name == 'child' }
+              grandchild = spans.find { |s| s.name == 'grandchild' }
+              uncle = spans.find { |s| s.name == 'uncle' }
+              nephew = spans.find { |s| s.name == 'nephew' }
+
+              expect(spans.all? { |s| s.trace_id == grandparent.trace_id }).to be true
+
+              expect(grandparent.parent).to be nil
+              expect(parent.parent).to be grandparent
+              expect(child.parent).to be parent
+              expect(grandchild.parent).to be child
+              expect(uncle.parent).to be grandparent
+              expect(nephew.parent).to be uncle
+            end
+          end
+
+          context 'across traces' do
+            subject!(:trace) do
+              child, grandchild = nil
+              tracer.trace('grandparent') do
+                tracer.trace('parent') do
+                  child = tracer.trace('child')
+                  grandchild = tracer.trace('grandchild')
+                end
+              end
+
+              tracer.trace('great uncle') do
+                tracer.trace('second cousin').finish
+              end
+
+              child.finish
+              grandchild.finish
+            end
+
+            # TODO: Skip for now, but keep this test because it demonstrates something we should fix.
+            before { skip('There is no fix currently available for this failure.') }
+
+            it 'has correct relationships' do
+              grandparent = spans.find { |s| s.name == 'grandparent' }
+              parent = spans.find { |s| s.name == 'parent' }
+              child = spans.find { |s| s.name == 'child' }
+              grandchild = spans.find { |s| s.name == 'grandchild' }
+              great_uncle = spans.find { |s| s.name == 'great uncle' }
+              second_cousin = spans.find { |s| s.name == 'second cousin' }
+
+              expect(
+                [
+                  grandparent,
+                  parent,
+                  child,
+                  grandchild
+                ].all? { |s| s.trace_id == grandparent.trace_id }
+              ).to be true
+              expect(grandparent.parent).to be nil
+              expect(parent.parent).to be grandparent
+              expect(child.parent).to be parent
+              expect(grandchild.parent).to be child
+
+              expect(
+                [
+                  great_uncle,
+                  second_cousin
+                ].all? { |s| s.trace_id == great_uncle.trace_id }
+              ).to be true
+              expect(great_uncle.parent).to be nil
+              expect(second_cousin.parent).to be great_uncle
+
+              # Should be separate traces (can't have two root spans for a trace)
+              # TODO: This fails because when "grandparent" completes, it has unfinished
+              #       spans still present in the context. This prevents the context from resetting.
+              #       Thus when "great uncle" starts, it still shares the same trace ID as "grandparent"
+              #
+              #       When unfinished spans are present at trace complete, we need to decide what to do.
+              #       We could detach the context from the thread, and give the thread a new context.
+              #       This way unfinished spans could complete later, without holding the current context hostage.
+              #       However, this has a risk of causing Context objects to leak, if each unfinished span is
+              #       somehow held onto by instrumentation.
+              expect(grandparent.trace_id).to_not eq(great_uncle.trace_id)
             end
           end
         end
@@ -461,7 +544,7 @@ RSpec.describe Datadog::Tracer do
         context 'and the on_error option' do
           context 'is not provided' do
             it 'propagates the error' do
-              expect_any_instance_of(Datadog::Span).to receive(:set_error)
+              expect_any_instance_of(Datadog::SpanOperation).to receive(:set_error)
                 .with(error)
               expect { trace }.to raise_error(error)
             end
@@ -473,7 +556,7 @@ RSpec.describe Datadog::Tracer do
                 expect do |b|
                   tracer.trace(name, on_error: b.to_proc, &block)
                 end.to yield_with_args(
-                  a_kind_of(Datadog::Span),
+                  a_kind_of(Datadog::SpanOperation),
                   error
                 )
               end.to raise_error(error)
@@ -737,7 +820,7 @@ RSpec.describe Datadog::Tracer do
     end
 
     context 'with trace' do
-      let(:trace) { [Datadog::Span.new(tracer, 'dummy')] }
+      let(:trace) { [Datadog::Span.new('dummy')] }
 
       before do
         expect_any_instance_of(Datadog::ContextFlush::Finished)

--- a/spec/ddtrace_integration_spec.rb
+++ b/spec/ddtrace_integration_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'ddtrace integration' do
 
       it 'does not error on tracing with block' do
         value = Datadog.tracer.trace('test') do |span|
-          expect(span).to be_a(Datadog::Span)
+          expect(span).to be_a(Datadog::SpanOperation)
           :return
         end
 

--- a/spec/support/tracer_helpers.rb
+++ b/spec/support/tracer_helpers.rb
@@ -112,9 +112,9 @@ module TracerHelpers
     }
 
     n.times do
-      span1 = Datadog::Span.new(nil, 'client.testing', defaults).start.finish
-      span2 = Datadog::Span.new(nil, 'client.testing', defaults).start.finish
-      span2.set_parent(span1)
+      span1 = Datadog::Span.new('client.testing', defaults).start.stop
+      span2 = Datadog::Span.new('client.testing', defaults).start.stop
+      span2.parent = span1
       traces << [span1, span2]
     end
 


### PR DESCRIPTION
This addresses #1514 

## Summary

This pull request changes the `Tracer.trace` API to return a `SpanOperation` instead of a `Span`.

A `SpanOperation` is an "unfinished span", which wraps a `Span` struct, `Context`, and `Tracer` if available. It is meant to be entirely backwards compatible with the old usage of `Span`. Whenever a user accesses a span that hasn't been completed, they should receive a `SpanOperation` (e.g. `Tracer#active_span`, etc) When a `SpanOperation` is finished, it records the finished `Span` struct to the `Tracer`. This means the downstream span-writing is unchanged.

```ruby
# Old
span = Datadog.tracer.trace('my_task')
span.class # => Datadog::Span

Datadog.tracer.trace('my_task') do |span|
  span.class # => Datadog::Span
end

# New
span = Datadog.tracer.trace('my_task')
span.class # => Datadog::SpanOperation

Datadog.tracer.trace('my_task') do |span|
  span.class # => Datadog::SpanOperation
end
```

`Span` has had `context` and `tracer` attributes, as well `finish` removed; they now are on `Span Operation`. `Span` now implements `stop` (the old `finish` behavior), which no longer records the span (thereby affecting the tracer/context); it only stops the timing on that span. The reasoning is `finish` is ambiguous (may do more than stopping the span) whereas `stop` is much more concrete.

```ruby
span_op = Datadog.tracer.trace('my_task')
span_op.class # => Datadog::SpanOperation
span_op.set_tag('job_name', 'generate_report') # Still calls `Datadog::Span#set_tag`
span_op.finish # Completes & records to Datadog.tracer, and returns finished Datadog::Span
```

## Why these changes?

The basis for the reasoning is outlined in #1514. In short, `Span` is intended to be a simple struct, which should be easily serialized and transmitted (over wire, or between Ractors.) Possessing `tracer` and `context` attributes/behavior meant `Span` was doing more than measuring, but also managing context and writing behaviors. `Span`s should be written, not do writing.

By extracting this recording/context management behavior to `SpanOperation`, we could simplify the `Span` while still allowing for backwards compatibility, minimizing impact on user code. This wrapper may also prove useful as we continue to refine and improve our context management, so in this way it also acts as a stepping stone to future improvements.

## TODO

- [ ] Fix Sorbet type checking failure
- [ ] Test in integration apps (check for stability and performance)
- [ ] Make any required documentation changes