### PR TITLE
Auto-build profiling native extension before running integration apps locally

### DIFF
--- a/integration/apps/rack/Dockerfile-ci
+++ b/integration/apps/rack/Dockerfile-ci
@@ -8,7 +8,6 @@ COPY . /vendor/dd-trace-rb
 # Install dependencies
 ENV DD_DEMO_ENV_GEM_LOCAL_DDTRACE /vendor/dd-trace-rb
 
-# Build the ddtrace profiling native extension
-RUN export BUNDLE_GEMFILE=/vendor/dd-trace-rb/Gemfile && cd /vendor/dd-trace-rb && bundle install && bundle exec rake compile
+RUN /vendor/dd-demo/build_ddtrace_profiling_native_extension.rb
 
 RUN bundle install

--- a/integration/apps/rack/bin/run
+++ b/integration/apps/rack/bin/run
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require '/vendor/dd-demo/build_ddtrace_profiling_native_extension' if ENV['DD_DEMO_ENV_BUILD_PROFILING_EXTENSION'] == 'true'
+
 puts "\n== Starting application process =="
 
 process = (ARGV[0] || Datadog::DemoEnv.process)

--- a/integration/apps/rack/docker-compose.yml
+++ b/integration/apps/rack/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       # Use these for a specific revision of ddtrace
       # - DD_DEMO_ENV_GEM_GIT_DDTRACE=https://github.com/DataDog/dd-trace-rb.git
       # - DD_DEMO_ENV_GEM_REF_DDTRACE=f233336994315bfa04dac581387a8152bab8b85a
+      # Enable building the profiling native extension
+      - DD_DEMO_ENV_BUILD_PROFILING_EXTENSION=true
     expose:
       - "80"
     stdin_open: true

--- a/integration/apps/rails-five/Dockerfile-ci
+++ b/integration/apps/rails-five/Dockerfile-ci
@@ -8,7 +8,6 @@ COPY . /vendor/dd-trace-rb
 # Install dependencies
 ENV DD_DEMO_ENV_GEM_LOCAL_DDTRACE /vendor/dd-trace-rb
 
-# Build the ddtrace profiling native extension
-RUN export BUNDLE_GEMFILE=/vendor/dd-trace-rb/Gemfile && cd /vendor/dd-trace-rb && bundle install && bundle exec rake compile
+RUN /vendor/dd-demo/build_ddtrace_profiling_native_extension.rb
 
 RUN bundle install

--- a/integration/apps/rails-five/bin/run
+++ b/integration/apps/rails-five/bin/run
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require '/vendor/dd-demo/build_ddtrace_profiling_native_extension' if ENV['DD_DEMO_ENV_BUILD_PROFILING_EXTENSION'] == 'true'
+
 # Start application process
 puts "\n== Starting application process =="
 

--- a/integration/apps/rails-five/docker-compose.yml
+++ b/integration/apps/rails-five/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       # Use these for a specific revision of ddtrace
       # - DD_DEMO_ENV_GEM_GIT_DDTRACE=https://github.com/DataDog/dd-trace-rb.git
       # - DD_DEMO_ENV_GEM_REF_DDTRACE=f233336994315bfa04dac581387a8152bab8b85a
+      # Enable building the profiling native extension
+      - DD_DEMO_ENV_BUILD_PROFILING_EXTENSION=true
     expose:
       - "80"
     stdin_open: true

--- a/integration/images/include/build_ddtrace_profiling_native_extension.rb
+++ b/integration/images/include/build_ddtrace_profiling_native_extension.rb
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+if local_gem_path = ENV['DD_DEMO_ENV_GEM_LOCAL_DDTRACE']
+  puts "\n== Building profiler native extension =="
+  success =
+    system("export BUNDLE_GEMFILE=#{local_gem_path}/Gemfile && cd #{local_gem_path} && bundle install && bundle exec rake compile")
+  raise 'Failure to compile profiler native extension' unless success
+else
+  puts "\n== Skipping build of profiler native extension, no DD_DEMO_ENV_GEM_LOCAL_DDTRACE set =="
+end


### PR DESCRIPTION
In #1615 I added profiler tests to the integration test apps, and made sure that the profiling native extension was built when running the ci scripts.

I completely missed that the extension was not built when running the integration apps locally.

I've now extracted the "build the native extension" into a separate script in the shared folder, as well as made sure that it runs for both CI and also when running the apps locally using docker.