### PR TITLE
Capture Rails exception before default error page is rendered

### DIFF
--- a/spec/ddtrace/contrib/rails/rack_spec.rb
+++ b/spec/ddtrace/contrib/rails/rack_spec.rb
@@ -137,12 +137,17 @@ RSpec.describe 'Rails Rack' do
       # We remove these during testing, as we are more interested in asserting
       # controller and template spans.
       super().reject { |s| SYNTHETIC_3_2_SPANS.include?(s.resource) }
+    # elsif true # TODO change this
+    #   super().reject { |s| SYNTHETIC_6_SPANS.include?(s.resource) }
     else
       super()
     end
   end
 
   SYNTHETIC_3_2_SPANS = %w[_request_and_response.erb missing_template.erb].freeze
+
+  # Default error page rendering spans
+  SYNTHETIC_6_SPANS = %w[_request_and_response.html.erb template_error.html.erb _source.html.erb _trace.html.erb].freeze
 
   context 'with a full request' do
     subject(:response) { get '/full' }

--- a/spec/ddtrace/contrib/rails/support/rails3.rb
+++ b/spec/ddtrace/contrib/rails/support/rails3.rb
@@ -43,7 +43,7 @@ RSpec.shared_context 'Rails 3 base application' do
       config.action_view.javascript_expansions = {}
       config.action_view.stylesheet_expansions = {}
 
-      config.middleware.delete ActionDispatch::DebugExceptions if Rails.version >= '3.2.22.5'
+      # config.middleware.delete ActionDispatch::DebugExceptions if Rails.version >= '3.2.22.5'
       instance_eval(&during_init)
     end
 

--- a/spec/ddtrace/contrib/rails/support/rails4.rb
+++ b/spec/ddtrace/contrib/rails/support/rails4.rb
@@ -38,7 +38,7 @@ RSpec.shared_context 'Rails 4 base application' do
       config.consider_all_requests_local = true
       config.active_support.test_order = :random
 
-      config.middleware.delete ActionDispatch::DebugExceptions
+      # config.middleware.delete ActionDispatch::DebugExceptions
       instance_eval(&during_init)
 
       config.active_job.queue_adapter = :inline

--- a/spec/ddtrace/contrib/rails/support/rails5.rb
+++ b/spec/ddtrace/contrib/rails/support/rails5.rb
@@ -41,7 +41,7 @@ RSpec.shared_context 'Rails 5 base application' do
       config.eager_load = false
       config.consider_all_requests_local = true
 
-      config.middleware.delete ActionDispatch::DebugExceptions
+      # config.middleware.delete ActionDispatch::DebugExceptions
       instance_eval(&during_init)
 
       config.active_job.queue_adapter = :inline

--- a/spec/ddtrace/contrib/rails/support/rails6.rb
+++ b/spec/ddtrace/contrib/rails/support/rails6.rb
@@ -45,7 +45,7 @@ RSpec.shared_context 'Rails 6 base application' do
       config.hosts.clear # Allow requests for any hostname during tests
 
       # Avoid eager-loading Rails sub-component, ActionDispatch, before initialization
-      config.middleware.delete ActionDispatch::DebugExceptions if defined?(ActionDispatch::DebugExceptions)
+      # config.middleware.delete ActionDispatch::DebugExceptions if defined?(ActionDispatch::DebugExceptions)
 
       instance_eval(&during_init)
 

--- a/spec/support/configuration_helpers.rb
+++ b/spec/support/configuration_helpers.rb
@@ -25,7 +25,7 @@ module ConfigurationHelpers
   end
 
   def decrement_gem_version(version)
-    segments = version.dup.segments
+    segments = version.segments.dup
     segments.reverse.each_with_index do |value, i|
       if value.to_i > 0
         segments[segments.length - 1 - i] -= 1


### PR DESCRIPTION
Follow up to https://github.com/DataDog/dd-trace-rb/pull/552/files#diff-22e85fccca5492ebff5fee5e488aa5b4b2e4a62862dfc12af0ba990e0076b2c2R45-R52 and #1124.

This PR ensures we capture a Rails before some of the Rails' middlewares are able to swallow it.

In https://github.com/DataDog/dd-trace-rb/pull/552/files#diff-22e85fccca5492ebff5fee5e488aa5b4b2e4a62862dfc12af0ba990e0076b2c2R45-R52, we added a `ddtrace` middleware to catch such errors, but retrieving the error before the `ActionDispatch::ShowExceptions` Rails middleware runs. This works the majority of cases.

But if the user has [action_dispatch.show_exceptions](https://github.com/rails/rails/blob/83217025a171593547d1268651b446d3533e2019/actionpack/lib/action_dispatch/http/request.rb#L186-L191) enabled, which is `true` by default, the Rails error page is rendered, like this one:

![image](https://user-images.githubusercontent.com/583503/133343990-8a3e45d2-0a63-4c19-b743-872d7aa28777.png)

This page is rendered by the `ActionDispatch::DebugExceptions` middleware, which consumes the error from the stack. This middleware swallows the error before it gets a chance to hit `ActionDispatch::ShowExceptions`, and along with it our own middleware.

This PR inserts our error handling middleware before `ActionDispatch::DebugExceptions`, instead of `ActionDispatch::ShowExceptions`. This will address all Rails error page rendering cases today.

One caveat for Rails 3.0 only: `ActionDispatch::DebugExceptions` didn't exist at the time, so `ActionDispatch::ShowExceptions` stays as our hook point for Rails 3.0.