### PR TITLE
Trace Sidekiq server internal events (heartbeat, job fetch, and scheduled push)

### DIFF
--- a/lib/ddtrace/contrib/sidekiq/ext.rb
+++ b/lib/ddtrace/contrib/sidekiq/ext.rb
@@ -15,6 +15,9 @@ module Datadog
         SERVICE_NAME = 'sidekiq'.freeze
         SPAN_PUSH = 'sidekiq.push'.freeze
         SPAN_JOB = 'sidekiq.job'.freeze
+        SPAN_JOB_FETCH = 'sidekiq.job_fetch'.freeze
+        SPAN_HEARTBEAT = 'sidekiq.heartbeat'.freeze
+        SPAN_SCHEDULED_PUSH = 'sidekiq.scheduled_push'.freeze
         TAG_JOB_DELAY = 'sidekiq.job.delay'.freeze
         TAG_JOB_ID = 'sidekiq.job.id'.freeze
         TAG_JOB_QUEUE = 'sidekiq.job.queue'.freeze

--- a/lib/ddtrace/contrib/sidekiq/integration.rb
+++ b/lib/ddtrace/contrib/sidekiq/integration.rb
@@ -11,6 +11,7 @@ module Datadog
         include Contrib::Integration
 
         MINIMUM_VERSION = Gem::Version.new('3.5.4')
+        MINIMUM_SERVER_INTERNAL_TRACING_VERSION = Gem::Version.new('5.2.4')
 
         register_as :sidekiq
 
@@ -24,6 +25,15 @@ module Datadog
 
         def self.compatible?
           super && version >= MINIMUM_VERSION
+        end
+
+        # Only patch server internals on v5.2.4+ because that's when loading of
+        # `Sidekiq::Launcher` stabilized. Sidekiq 4+ technically can support our
+        # patches (with minor adjustments), but in order to avoid explicitly
+        # requiring `sidekiq/launcher` ourselves (which could affect gem
+        # initialization order), we are limiting this tracing to v5.2.4+.
+        def self.compatible_with_server_internal_tracing?
+          version >= MINIMUM_SERVER_INTERNAL_TRACING_VERSION
         end
 
         def default_configuration

--- a/lib/ddtrace/contrib/sidekiq/patcher.rb
+++ b/lib/ddtrace/contrib/sidekiq/patcher.rb
@@ -34,7 +34,33 @@ module Datadog
             config.server_middleware do |chain|
               chain.add(Sidekiq::ServerTracer)
             end
+
+            patch_server_internals if Integration.compatible_with_server_internal_tracing?
           end
+        end
+
+        def patch_server_internals
+          patch_server_heartbeat
+          patch_server_job_fetch
+          patch_server_scheduled_push
+        end
+
+        def patch_server_heartbeat
+          require 'ddtrace/contrib/sidekiq/server_internal_tracer/heartbeat'
+
+          ::Sidekiq::Launcher.prepend(ServerInternalTracer::Heartbeat)
+        end
+
+        def patch_server_job_fetch
+          require 'ddtrace/contrib/sidekiq/server_internal_tracer/job_fetch'
+
+          ::Sidekiq::Processor.prepend(ServerInternalTracer::JobFetch)
+        end
+
+        def patch_server_scheduled_push
+          require 'ddtrace/contrib/sidekiq/server_internal_tracer/scheduled_push'
+
+          ::Sidekiq::Scheduled::Poller.prepend(ServerInternalTracer::ScheduledPush)
         end
       end
     end

--- a/lib/ddtrace/contrib/sidekiq/server_internal_tracer/heartbeat.rb
+++ b/lib/ddtrace/contrib/sidekiq/server_internal_tracer/heartbeat.rb
@@ -1,0 +1,30 @@
+# typed: true
+
+module Datadog
+  module Contrib
+    module Sidekiq
+      module ServerInternalTracer
+        # Trace when a Sidekiq process has a heartbeat
+        module Heartbeat
+          private
+
+          def ❤ # rubocop:disable Naming/AsciiIdentifiers, Naming/MethodName
+            configuration = Datadog.configuration[:sidekiq]
+
+            configuration[:tracer].trace(Ext::SPAN_HEARTBEAT) do |span|
+              span.service = configuration[:service_name]
+              span.span_type = Datadog::Ext::AppTypes::WORKER
+
+              # Set analytics sample rate
+              if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
+                Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])
+              end
+
+              super
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/sidekiq/server_internal_tracer/job_fetch.rb
+++ b/lib/ddtrace/contrib/sidekiq/server_internal_tracer/job_fetch.rb
@@ -1,0 +1,30 @@
+# typed: true
+
+module Datadog
+  module Contrib
+    module Sidekiq
+      module ServerInternalTracer
+        # Trace when Sidekiq looks for another job to work
+        module JobFetch
+          private
+
+          def fetch
+            configuration = Datadog.configuration[:sidekiq]
+
+            configuration[:tracer].trace(Ext::SPAN_JOB_FETCH) do |span|
+              span.service = configuration[:service_name]
+              span.span_type = Datadog::Ext::AppTypes::WORKER
+
+              # Set analytics sample rate
+              if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
+                Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])
+              end
+
+              super
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/sidekiq/server_internal_tracer/scheduled_push.rb
+++ b/lib/ddtrace/contrib/sidekiq/server_internal_tracer/scheduled_push.rb
@@ -1,0 +1,29 @@
+# typed: true
+
+module Datadog
+  module Contrib
+    module Sidekiq
+      module ServerInternalTracer
+        # Trace when Sidekiq checks to see if there are scheduled jobs that need to be worked
+        # https://github.com/mperham/sidekiq/wiki/Scheduled-Jobs
+        module ScheduledPush
+          def enqueue
+            configuration = Datadog.configuration[:sidekiq]
+
+            configuration[:tracer].trace(Ext::SPAN_SCHEDULED_PUSH) do |span|
+              span.service = configuration[:service_name]
+              span.span_type = Datadog::Ext::AppTypes::WORKER
+
+              # Set analytics sample rate
+              if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
+                Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])
+              end
+
+              super
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -68,6 +68,10 @@ module ::Sequel::SQL::Expression; end
 module ::Sequel::VERSION; end
 module ::Shoryuken; end
 module ::Sidekiq; end
+module ::Sidekiq::Launcher; end
+module ::Sidekiq::Processor; end
+module ::Sidekiq::Scheduled; end
+module ::Sidekiq::Scheduled::Poller; end
 module ::Sinatra; end
 module ::Sinatra::Application; end
 module ::Sinatra::Base; end

--- a/spec/ddtrace/contrib/sidekiq/patcher_spec.rb
+++ b/spec/ddtrace/contrib/sidekiq/patcher_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe Datadog::Contrib::Sidekiq::Patcher do
 
     allow(Sidekiq).to receive(:server?).and_return(server)
 
+    # these are only loaded when `Sidekiq::CLI` is actually loaded,
+    # which we don't want to do here because it mutates global state
+    stub_const('Sidekiq::Launcher', Class.new)
+    stub_const('Sidekiq::Processor', Class.new)
+    stub_const('Sidekiq::Scheduled::Poller', Class.new)
+
     # NB: This is needed because we want to patch multiple times.
     if described_class.instance_variable_get(:@patch_only_once)
       described_class.instance_variable_get(:@patch_only_once).send(:reset_ran_once_state_for_tests)

--- a/spec/ddtrace/contrib/sidekiq/server_internal_tracer/heartbeat_spec.rb
+++ b/spec/ddtrace/contrib/sidekiq/server_internal_tracer/heartbeat_spec.rb
@@ -1,0 +1,27 @@
+# typed: ignore
+require 'ddtrace/contrib/support/spec_helper'
+require_relative '../support/helper'
+
+RSpec.describe 'Server internal tracer' do
+  include SidekiqServerExpectations
+
+  before do
+    unless Datadog::Contrib::Sidekiq::Integration.compatible_with_server_internal_tracing?
+      skip 'Sidekiq internal server tracing is not support on this version.'
+    end
+
+    skip 'Fork not supported on current platform' unless Process.respond_to?(:fork)
+  end
+
+  it 'traces the looping heartbeat' do
+    expect_in_sidekiq_server do
+      span = spans.find { |s| s.service == 'sidekiq' && s.name == 'sidekiq.heartbeat' }
+
+      expect(span.service).to eq('sidekiq')
+      expect(span.name).to eq('sidekiq.heartbeat')
+      expect(span.span_type).to eq('worker')
+      expect(span.resource).to eq('sidekiq.heartbeat')
+      expect(span).to_not have_error
+    end
+  end
+end

--- a/spec/ddtrace/contrib/sidekiq/server_internal_tracer/job_fetch_spec.rb
+++ b/spec/ddtrace/contrib/sidekiq/server_internal_tracer/job_fetch_spec.rb
@@ -1,0 +1,30 @@
+# typed: ignore
+require 'ddtrace/contrib/support/spec_helper'
+require_relative '../support/helper'
+
+RSpec.describe 'Server internal tracer' do
+  include SidekiqServerExpectations
+
+  before do
+    unless Datadog::Contrib::Sidekiq::Integration.compatible_with_server_internal_tracing?
+      skip 'Sidekiq internal server tracing is not support on this version.'
+    end
+
+    skip 'Fork not supported on current platform' unless Process.respond_to?(:fork)
+  end
+
+  it 'traces the looping job fetching' do
+    # fetches block for 2 seconds when there is nothing in the queue
+    # https://github.com/mperham/sidekiq/blob/v6.2.2/lib/sidekiq/fetch.rb#L7-L9
+    # https://redis.io/commands/blpop#blocking-behavior
+    expect_in_sidekiq_server(duration: 3) do
+      span = spans.find { |s| s.service == 'sidekiq' && s.name == 'sidekiq.job_fetch' }
+
+      expect(span.service).to eq('sidekiq')
+      expect(span.name).to eq('sidekiq.job_fetch')
+      expect(span.span_type).to eq('worker')
+      expect(span.resource).to eq('sidekiq.job_fetch')
+      expect(span).to_not have_error
+    end
+  end
+end

--- a/spec/ddtrace/contrib/sidekiq/server_internal_tracer/scheduled_push_spec.rb
+++ b/spec/ddtrace/contrib/sidekiq/server_internal_tracer/scheduled_push_spec.rb
@@ -1,0 +1,36 @@
+# typed: ignore
+require 'ddtrace/contrib/support/spec_helper'
+require_relative '../support/helper'
+
+RSpec.describe 'Server internal tracer' do
+  include SidekiqServerExpectations
+
+  before do
+    unless Datadog::Contrib::Sidekiq::Integration.compatible_with_server_internal_tracing?
+      skip 'Sidekiq internal server tracing is not support on this version.'
+    end
+
+    skip 'Fork not supported on current platform' unless Process.respond_to?(:fork)
+  end
+
+  around do |example|
+    original_poll_interval_average = Sidekiq.options[:poll_interval_average]
+    Sidekiq.options[:poll_interval_average] = 0
+
+    example.run
+
+    Sidekiq.options[:poll_interval_average] = original_poll_interval_average
+  end
+
+  it 'traces the looping scheduled push' do
+    expect_in_sidekiq_server(duration: 6) do
+      span = spans.find { |s| s.service == 'sidekiq' && s.name == 'sidekiq.scheduled_push' }
+
+      expect(span.service).to eq('sidekiq')
+      expect(span.name).to eq('sidekiq.scheduled_push')
+      expect(span.span_type).to eq('worker')
+      expect(span.resource).to eq('sidekiq.scheduled_push')
+      expect(span).to_not have_error
+    end
+  end
+end

--- a/spec/ddtrace/contrib/sidekiq/support/helper.rb
+++ b/spec/ddtrace/contrib/sidekiq/support/helper.rb
@@ -5,13 +5,26 @@ require 'ddtrace/contrib/sidekiq/client_tracer'
 require 'ddtrace/contrib/sidekiq/server_tracer'
 
 RSpec.shared_context 'Sidekiq testing' do
-  let(:redis_host) { ENV.fetch('TEST_REDIS_HOST', '127.0.0.1') }
-  let(:redis_port) { ENV.fetch('TEST_REDIS_PORT', 6379) }
+  include SidekiqTestingConfiguration
 
-  before do
+  before { configure_sidekiq }
+
+  let!(:empty_worker) do
+    stub_const('EmptyWorker', Class.new do
+      include Sidekiq::Worker
+      def perform; end
+    end)
+  end
+end
+
+module SidekiqTestingConfiguration
+  def configure_sidekiq
     Datadog.configure do |c|
       c.use :sidekiq
     end
+
+    redis_host = ENV.fetch('TEST_REDIS_HOST', '127.0.0.1')
+    redis_port = ENV.fetch('TEST_REDIS_PORT', 6379)
 
     redis_url = "redis://#{redis_host}:#{redis_port}"
 
@@ -25,11 +38,48 @@ RSpec.shared_context 'Sidekiq testing' do
 
     Sidekiq::Testing.inline!
   end
+end
 
-  let!(:empty_worker) do
-    stub_const('EmptyWorker', Class.new do
-      include Sidekiq::Worker
-      def perform; end
-    end)
+module SidekiqServerExpectations
+  include SidekiqTestingConfiguration
+
+  def expect_in_sidekiq_server(duration: 2, &expectations)
+    app_tempfile = Tempfile.new(['sidekiq-server-app', '.rb'])
+
+    expect_in_fork(
+      # Due to the expectations being run in an `at_exit` hook, to have visibility into the
+      # spans created in the forked process, the exit status will be 0 even if our expectations fail.
+      # Instead, look at `STDERR`, ignoring warnings.
+      fork_expectations: proc do |status:, stdout:, stderr:|
+        expect(status).to be_success, "STDOUT:`#{stdout}` STDERR:`#{stderr}"
+
+        non_warning_testing_stderr = stderr.split("\n").reject { |line| line.include?(': warning:') }
+
+        expect(non_warning_testing_stderr).to be_empty, "STDOUT:`#{stdout}` STDERR:`#{stderr}"
+      end
+    ) do
+      at_exit(&expectations)
+
+      # NB: This is needed because we want to patch within a forked process.
+      if Datadog::Contrib::Sidekiq::Patcher.instance_variable_get(:@patch_only_once)
+        Datadog::Contrib::Sidekiq::Patcher.instance_variable_get(:@patch_only_once).send(:reset_ran_once_state_for_tests)
+      end
+
+      require 'sidekiq/cli'
+
+      configure_sidekiq
+
+      Thread.new do
+        cli = Sidekiq::CLI.instance
+        cli.parse(['--require', app_tempfile.path]) # boot the "app"
+        cli.run
+      end
+
+      sleep duration
+      exit
+    end
+  ensure
+    app_tempfile.close
+    app_tempfile.unlink
   end
 end


### PR DESCRIPTION
These 3 areas of the open source version of Sidekiq are not wrapped in high-level spans, resulting in a *lot* of one-off Redis spans that are not related to one another in any way.

The most important change to call out here is the bump in the supported Sidekiq version. There were some significant underlying code changes between Sidekiq v3 and v4, and with Sidekiq 3.5.4 being over 5 years old (released 2016-01-13), that seemed to be a reasonable decision.

That said, I'm open to keeping v3 support, with this new internal tracing focused only on v4+.

Closes #1673.