### PR TITLE
Use the merge request branch on merge requests

### DIFF
--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -230,7 +230,7 @@ module Datadog
         def extract_gitlab(env)
           url = env['CI_PIPELINE_URL']
           {
-            Datadog::Ext::Git::TAG_BRANCH => env['CI_PIPELINE_SOURCE'] == 'merge_request_event' ? env['CI_MERGE_REQUEST_SOURCE_BRANCH_NAME'] : env['CI_COMMIT_BRANCH'],
+            Datadog::Ext::Git::TAG_BRANCH => env['CI_COMMIT_REF_NAME'],
             Datadog::Ext::Git::TAG_COMMIT_SHA => env['CI_COMMIT_SHA'],
             Datadog::Ext::Git::TAG_REPOSITORY_URL => env['CI_REPOSITORY_URL'],
             Datadog::Ext::Git::TAG_TAG => env['CI_COMMIT_TAG'],

--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -230,7 +230,7 @@ module Datadog
         def extract_gitlab(env)
           url = env['CI_PIPELINE_URL']
           {
-            Datadog::Ext::Git::TAG_BRANCH => env['CI_COMMIT_BRANCH'],
+            Datadog::Ext::Git::TAG_BRANCH => env['CI_PIPELINE_SOURCE'] == 'merge_request_event' ? env['CI_MERGE_REQUEST_SOURCE_BRANCH_NAME'] : env['CI_COMMIT_BRANCH'],
             Datadog::Ext::Git::TAG_COMMIT_SHA => env['CI_COMMIT_SHA'],
             Datadog::Ext::Git::TAG_REPOSITORY_URL => env['CI_REPOSITORY_URL'],
             Datadog::Ext::Git::TAG_TAG => env['CI_COMMIT_TAG'],

--- a/spec/datadog/ci/ext/fixtures/ci/gitlab.json
+++ b/spec/datadog/ci/ext/fixtures/ci/gitlab.json
@@ -1,7 +1,7 @@
 [
   [
     {
-      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -31,7 +31,7 @@
   ],
   [
     {
-      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -63,7 +63,7 @@
   ],
   [
     {
-      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -95,7 +95,7 @@
   ],
   [
     {
-      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -127,7 +127,7 @@
   ],
   [
     {
-      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -161,7 +161,7 @@
   ],
   [
     {
-      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -195,7 +195,7 @@
   ],
   [
     {
-      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -229,7 +229,7 @@
   ],
   [
     {
-      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -261,7 +261,7 @@
   ],
   [
     {
-      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -291,7 +291,7 @@
   ],
   [
     {
-      "CI_COMMIT_BRANCH": "refs/heads/master",
+      "CI_COMMIT_REF_NAME": "refs/heads/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -323,7 +323,7 @@
   ],
   [
     {
-      "CI_COMMIT_BRANCH": "refs/heads/feature/one",
+      "CI_COMMIT_REF_NAME": "refs/heads/feature/one",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -451,7 +451,7 @@
   ],
   [
     {
-      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -483,7 +483,7 @@
   ],
   [
     {
-      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -515,7 +515,7 @@
   ],
   [
     {
-      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -547,7 +547,7 @@
   ],
   [
     {
-      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -579,7 +579,7 @@
   ],
   [
     {
-      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_JOB_NAME": "gitlab-job-name",


### PR DESCRIPTION
When a pipeline runs on a merge request it should tag the branch of the merge request