### PR TITLE
Better naming for Tracer#call_context argument

### DIFF
--- a/lib/ddtrace/context_provider.rb
+++ b/lib/ddtrace/context_provider.rb
@@ -15,8 +15,8 @@ module Datadog
     end
 
     # Return the local context.
-    def context(key = nil)
-      current_context = key.nil? ? @context.local : @context.local(key)
+    def context(thread = nil)
+      current_context = @context.local(thread)
 
       # Rebuild/reset context after a fork
       #
@@ -55,7 +55,10 @@ module Datadog
     end
 
     # Return the thread-local context.
-    def local(thread = Thread.current)
+    #
+    # @param thread [Thread] defaults to current thread if +nil+
+    def local(thread = nil)
+      thread ||= Thread.current
       thread[@key] ||= Datadog::Context.new
     end
   end

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -64,8 +64,10 @@ module Datadog
     #
     # This method makes use of a \ContextProvider that is automatically set during the tracer
     # initialization, or while using a library instrumentation.
-    def call_context(key = nil)
-      @provider.context(key)
+    #
+    # @param thread [Thread] the thread to retrieve the context from. Defaults to current thread.
+    def call_context(thread = nil)
+      @provider.context(thread)
     end
 
     # Initialize a new \Tracer used to create, sample and submit spans that measure the

--- a/spec/ddtrace/context_provider_spec.rb
+++ b/spec/ddtrace/context_provider_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Datadog::DefaultContextProvider do
       it do
         expect(local_context)
           .to receive(:local)
+          .with(nil)
           .and_return(trace_context)
 
         subject
@@ -137,11 +138,18 @@ RSpec.describe Datadog::ThreadLocalContext do
     context 'given a thread' do
       subject(:local) { thread_local_context.local(thread) }
 
-      let(:thread) { Thread.new {} }
-
       it 'retrieves the context for the provided thread' do
         is_expected.to be_a_kind_of(Datadog::Context)
         expect(local).to_not be(thread_local_context.local)
+      end
+
+      context 'that is nil' do
+        let(:thread) { nil }
+
+        it 'retrieves the context from the current thread' do
+          is_expected.to be_a_kind_of(Datadog::Context)
+          expect(local).to be(thread_local_context.local)
+        end
       end
     end
   end


### PR DESCRIPTION
In `Datadog::Tracer`, this PR renames the argument
```ruby
def call_context(key = nil)
```
to 
```ruby
def call_context(thread = nil)
```
to clarify that we are extracting the call context from a thread.

By default, the current thread's context is retrieved, which is now documented in RDoc.

I made a small change to ContextProvider to clean up the handling of the default value, for when a `thread` is not provided, but there are not functional changes from this modification.