### PR TITLE
Correlate Active Job logs to the active DataDog trace

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -555,6 +555,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | Key | Description | Default |
 | --- | ----------- | ------- |
 | `service_name` | Service name used for `active_job` instrumentation | `'active_job'` |
+| `log_injection` | Automatically enables injection [Trace Correlation](#trace-correlation) information, such as `dd.trace_id`, into Active Job logs. Supports the default logger (`ActiveSupport::TaggedLogging`) and `Lograge`. Details on the format of Trace Correlation information can be found in the [Trace Correlation](#trace-correlation) section. | `false` |
 
 ### Active Record
 

--- a/lib/ddtrace/contrib/active_job/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_job/configuration/settings.rb
@@ -25,6 +25,7 @@ module Datadog
 
           option :service_name, default: Ext::SERVICE_NAME
           option :error_handler, default: Datadog::Tracer::DEFAULT_ON_ERROR
+          option :log_injection, default: false
         end
       end
     end

--- a/lib/ddtrace/contrib/active_job/log_injection.rb
+++ b/lib/ddtrace/contrib/active_job/log_injection.rb
@@ -1,0 +1,21 @@
+# typed: false
+module Datadog
+  module Contrib
+    module ActiveJob
+      # Active Job log injection wrapped around job execution
+      module LogInjection
+        def self.included(base)
+          base.class_eval do
+            around_perform do |_, block|
+              if logger.respond_to?(:tagged)
+                logger.tagged(Datadog.tracer.active_correlation.to_s, &block)
+              else
+                block.call
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/contrib/active_job/patcher.rb
+++ b/lib/ddtrace/contrib/active_job/patcher.rb
@@ -1,7 +1,8 @@
-# typed: true
+# typed: false
 require 'ddtrace/contrib/patcher'
 require 'ddtrace/contrib/active_job/ext'
 require 'ddtrace/contrib/active_job/events'
+require 'ddtrace/contrib/active_job/log_injection'
 
 module Datadog
   module Contrib
@@ -18,6 +19,13 @@ module Datadog
 
         def patch
           Events.subscribe!
+          inject_log_correlation if Datadog.configuration[:active_job][:log_injection]
+        end
+
+        def inject_log_correlation
+          ::ActiveSupport.on_load(:active_job) do
+            include LogInjection
+          end
         end
       end
     end

--- a/lib/ddtrace/contrib/rails/framework.rb
+++ b/lib/ddtrace/contrib/rails/framework.rb
@@ -132,7 +132,8 @@ module Datadog
 
           datadog_config.use(
             :active_job,
-            service_name: "#{rails_config[:service_name]}-#{Contrib::ActiveJob::Ext::SERVICE_NAME}"
+            service_name: "#{rails_config[:service_name]}-#{Contrib::ActiveJob::Ext::SERVICE_NAME}",
+            log_injection: rails_config[:log_injection]
           )
         end
 


### PR DESCRIPTION
Similar to how dd-trace hooks into the Rails web request logs, it can do the same for Active Job executions.

This is not *quite* a full solution to #1068, but it does get dd-trace most of the way there for folks who are using Sidekiq via Active Job. Since Active Job handles *most* of the work in those cases, the only logs that are not correlated to the active DataDog trace are those coming directly from Sidekiq itself (i.e. `start` and `done`).

This follows up on #1639.