### PR TITLE
[PROF-3814] Limit number of threads per sample

### DIFF
--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -161,6 +161,7 @@ module Datadog
         end
 
         settings :advanced do
+          # This should never be reduced, as it can cause the resulting profiles to become biased
           option :max_events, default: 32768
 
           # Controls the maximum number of frames for each thread sampled. Can be tuned to avoid omitted frames in the

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -161,7 +161,9 @@ module Datadog
         end
 
         settings :advanced do
-          # This should never be reduced, as it can cause the resulting profiles to become biased
+          # This should never be reduced, as it can cause the resulting profiles to become biased.
+          # The current default should be enough for most services, allowing 16 threads to be sampled around 30 times
+          # per second for a 60 second period.
           option :max_events, default: 32768
 
           # Controls the maximum number of frames for each thread sampled. Can be tuned to avoid omitted frames in the

--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -156,14 +156,7 @@ module Datadog
           # *before* the thread had time to finish the initialization
           return unless current_cpu_time_ns
 
-          last_cpu_time_ns = (thread.thread_variable_get(THREAD_LAST_CPU_TIME_KEY) || current_cpu_time_ns)
-          interval = current_cpu_time_ns - last_cpu_time_ns
-
-          # Update CPU time for thread
-          thread.thread_variable_set(THREAD_LAST_CPU_TIME_KEY, current_cpu_time_ns)
-
-          # Return interval
-          interval
+          get_elapsed_since_last_sample_and_set_value(thread, THREAD_LAST_CPU_TIME_KEY, current_cpu_time_ns)
         end
 
         def compute_wait_time(used_time)
@@ -250,6 +243,13 @@ module Datadog
           thread_api.list.each do |thread|
             thread.thread_variable_set(THREAD_LAST_CPU_TIME_KEY, nil)
           end
+        end
+
+        def get_elapsed_since_last_sample_and_set_value(thread, key, current_value)
+          last_value = thread.thread_variable_get(key) || current_value
+          thread.thread_variable_set(key, current_value)
+
+          current_value - last_value
         end
       end
     end

--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -98,7 +98,7 @@ module Datadog
 
         def collect_events
           events = []
-          current_wall_time_ns = Datadog::Utils::Time.get_time * 1e9
+          current_wall_time_ns = get_current_wall_time_timestamp_ns
 
           # Collect backtraces from each thread
           threads_to_sample.each do |thread|
@@ -290,6 +290,10 @@ module Datadog
           else
             all_threads
           end
+        end
+
+        def get_current_wall_time_timestamp_ns
+          Datadog::Utils::Time.get_time(:nanosecond)
         end
       end
     end

--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -19,6 +19,10 @@ module Datadog
         MIN_INTERVAL = 0.01
         THREAD_LAST_CPU_TIME_KEY = :datadog_profiler_last_cpu_time
         THREAD_LAST_WALL_CLOCK_KEY = :datadog_profiler_last_wall_clock
+
+        # This default was picked based on the current sampling performance and on expected concurrency on an average
+        # Ruby MRI application. Lowering this optimizes for latency (less impact each time we sample), and raising
+        # optimizes for coverage (less chance to miss what a given thread is doing).
         DEFAULT_MAX_THREADS_SAMPLED = 16
 
         attr_reader \

--- a/lib/ddtrace/profiling/encoding/profile.rb
+++ b/lib/ddtrace/profiling/encoding/profile.rb
@@ -24,8 +24,16 @@ module Datadog
             flush.event_groups.each { |event_group| template.add_events!(event_group.event_class, event_group.events) }
 
             Datadog.logger.debug do
+              max_events = Datadog.configuration.profiling.advanced.max_events
+              events_sampled =
+                if flush.event_count == max_events
+                  'max events limit hit, events were sampled [profile will be biased], '
+                else
+                  ''
+                end
+
               "Encoding profile covering #{flush.start.iso8601} to #{flush.finish.iso8601}, " \
-              "events: #{flush.event_count} (#{template.debug_statistics})"
+              "events: #{flush.event_count} (#{events_sampled}#{template.debug_statistics})"
             end
 
             # Build the profile and encode it

--- a/lib/ddtrace/utils/time.rb
+++ b/lib/ddtrace/utils/time.rb
@@ -7,13 +7,12 @@ module Datadog
 
       module_function
 
-      # Current monotonic time.
-      # Falls back to `now` if monotonic clock
-      # is not available.
+      # Current monotonic time
       #
-      # @return [Float] in seconds, since some unspecified starting point
-      def get_time
-        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      # @param unit [Symbol] unit for the resulting value, same as ::Process#clock_gettime, defaults to :float_second
+      # @return [Numeric] timestamp in the requested unit, since some unspecified starting point
+      def get_time(unit = :float_second)
+        Process.clock_gettime(Process::CLOCK_MONOTONIC, unit)
       end
 
       # Current wall time.

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -164,27 +164,26 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   end
 
   describe '#collect_events' do
+    let(:options) { { **super(), thread_api: thread_api } }
+    let(:thread_api) { class_double(Thread, current: Thread.current) }
+    let(:threads) { [Thread.current] }
+
     subject(:collect_events) { collector.collect_events }
 
     before do
+      allow(thread_api).to receive(:list).and_return(threads)
       allow(recorder).to receive(:push)
     end
 
-    context 'by default' do
-      it 'produces stack events' do
-        is_expected.to be_a_kind_of(Array)
-        is_expected.to include(kind_of(Datadog::Profiling::Events::StackSample))
-      end
+    it 'produces stack events' do
+      is_expected.to be_a_kind_of(Array)
+      is_expected.to include(kind_of(Datadog::Profiling::Events::StackSample))
     end
 
     context 'when the thread' do
       let(:thread) { instance_double(Thread, alive?: alive?) }
       let(:threads) { [thread] }
       let(:alive?) { true }
-
-      before do
-        allow(Thread).to receive(:list).and_return(threads)
-      end
 
       context 'is dead' do
         let(:alive?) { false }

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   end
 
   before do
+    skip 'Profiling is not supported on JRuby.' if PlatformHelpers.jruby?
+
     allow(recorder)
       .to receive(:[])
       .with(Datadog::Profiling::Events::StackSample)

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -305,8 +305,8 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     subject(:collect_events) { collector.collect_thread_event(thread, current_wall_time) }
 
     let(:thread) { double('Thread', backtrace_locations: backtrace) }
-    let(:last_wall_time) { 42.0 }
-    let(:current_wall_time) { 123.0 }
+    let(:last_wall_time) { 42 }
+    let(:current_wall_time) { 123 }
 
     context 'when the backtrace is empty' do
       let(:backtrace) { nil }
@@ -771,6 +771,13 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
         end
       end
     end
+  end
+
+  describe '#get_current_wall_time_timestamp_ns' do
+    subject(:get_current_wall_time_timestamp_ns) { collector.send(:get_current_wall_time_timestamp_ns) }
+
+    # Must always be an Integer, as pprof does not allow for non-integer floating point values
+    it { is_expected.to be_a_kind_of(Integer) }
   end
 
   # Why? When mocking Thread.current, we break fiber-local variables (sometimes mistakenly referred to as

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -5,6 +5,8 @@ require 'ddtrace/profiling/spec_helper'
 require 'ddtrace/profiling/collectors/stack'
 require 'ddtrace/profiling/trace_identifiers/helper'
 require 'ddtrace/profiling/recorder'
+require 'set'
+require 'timeout'
 
 RSpec.describe Datadog::Profiling::Collectors::Stack do
   subject(:collector) { described_class.new(recorder, **options) }
@@ -165,9 +167,10 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   end
 
   describe '#collect_events' do
-    let(:options) { { **super(), thread_api: thread_api } }
+    let(:options) { { **super(), thread_api: thread_api, max_threads_sampled: max_threads_sampled } }
     let(:thread_api) { class_double(Thread, current: Thread.current) }
     let(:threads) { [Thread.current] }
+    let(:max_threads_sampled) { 3 }
 
     subject(:collect_events) { collector.collect_events }
 
@@ -179,6 +182,53 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     it 'produces stack events' do
       is_expected.to be_a_kind_of(Array)
       is_expected.to include(kind_of(Datadog::Profiling::Events::StackSample))
+    end
+
+    describe 'max_threads_sampled behavior' do
+      context 'when number of threads to be sample is <= max_threads_sampled' do
+        let(:threads) { Array.new(max_threads_sampled) { |n| instance_double(Thread, "Thread #{n}", alive?: true) } }
+
+        it 'samples all threads' do
+          sampled_threads = []
+          expect(collector).to receive(:collect_thread_event).exactly(max_threads_sampled).times do |thread, *_|
+            sampled_threads << thread
+          end
+
+          result = collect_events
+
+          expect(result.size).to be max_threads_sampled
+          expect(sampled_threads).to eq threads
+        end
+      end
+
+      context 'when number of threads to be sample is > max_threads_sampled' do
+        let(:threads) { Array.new(max_threads_sampled + 1) { |n| instance_double(Thread, "Thread #{n}", alive?: true) } }
+
+        it 'samples exactly max_threads_sampled threads' do
+          sampled_threads = []
+          expect(collector).to receive(:collect_thread_event).exactly(max_threads_sampled).times do |thread, *_|
+            sampled_threads << thread
+          end
+
+          result = collect_events
+
+          expect(result.size).to be max_threads_sampled
+          expect(threads).to include(*sampled_threads)
+        end
+
+        it 'eventually samples all threads' do
+          sampled_threads = Set.new
+          allow(collector).to receive(:collect_thread_event) { |thread, *_| sampled_threads << thread }
+
+          begin
+            Timeout.timeout(1) { collector.collect_events while sampled_threads.size != threads.size }
+          rescue Timeout::Error
+            raise 'Failed to eventually sample all threads in time given'
+          end
+
+          expect(threads).to contain_exactly(*sampled_threads.to_a)
+        end
+      end
     end
 
     context 'when the thread' do

--- a/spec/ddtrace/profiling/ext/cthread_spec.rb
+++ b/spec/ddtrace/profiling/ext/cthread_spec.rb
@@ -258,10 +258,7 @@ if Datadog::Profiling::Ext::CPU.supported?
         end
       end
 
-      let(:process_waiter_thread) do
-        Process.detach(fork {})
-        Thread.list.find { |thread| thread.instance_of?(Process::Waiter) }
-      end
+      let(:process_waiter_thread) { Process.detach(fork { sleep }) }
 
       describe 'the crash' do
         # Let's not get surprised if this shows up in other Ruby versions

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'profiling integration test' do
   before do
     skip 'Profiling is not supported on JRuby.' if PlatformHelpers.jruby?
 
-    raise "Profiling did not loaded: #{Datadog::Profiling.unsupported_reason}" unless Datadog::Profiling.supported?
+    raise "Profiling did not load: #{Datadog::Profiling.unsupported_reason}" unless Datadog::Profiling.supported?
   end
 
   let(:tracer) { instance_double(Datadog::Tracer) }

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -14,6 +14,10 @@ require 'ddtrace/profiling/encoding/profile'
 RSpec.describe 'profiling integration test' do
   before do
     skip 'Profiling is not supported on JRuby.' if PlatformHelpers.jruby?
+
+    unless Datadog::Profiling.supported?
+      raise "Profiling did not loaded: #{Datadog::Profiling.unsupported_reason}"
+    end
   end
 
   let(:tracer) { instance_double(Datadog::Tracer) }

--- a/spec/ddtrace/profiling/integration_spec.rb
+++ b/spec/ddtrace/profiling/integration_spec.rb
@@ -15,9 +15,7 @@ RSpec.describe 'profiling integration test' do
   before do
     skip 'Profiling is not supported on JRuby.' if PlatformHelpers.jruby?
 
-    unless Datadog::Profiling.supported?
-      raise "Profiling did not loaded: #{Datadog::Profiling.unsupported_reason}"
-    end
+    raise "Profiling did not loaded: #{Datadog::Profiling.unsupported_reason}" unless Datadog::Profiling.supported?
   end
 
   let(:tracer) { instance_double(Datadog::Tracer) }

--- a/spec/ddtrace/utils/time_spec.rb
+++ b/spec/ddtrace/utils/time_spec.rb
@@ -7,7 +7,22 @@ RSpec.describe Datadog::Utils::Time do
   describe '#get_time' do
     subject(:get_time) { described_class.get_time }
 
-    it { is_expected.to be_a_kind_of(Float) }
+    it 'returns a monotonic timestamp in float seconds' do
+      is_expected.to be_a_kind_of(Float)
+    end
+
+    context 'when a unit is specified' do
+      it 'returns a monotonic timestamp using that unit' do
+        float_seconds_timestamp = described_class.get_time
+        nanoseconds_timestamp = described_class.get_time(:nanosecond)
+
+        expect(float_seconds_timestamp * 1_000_000_000).to be_within(10_000_000).of(nanoseconds_timestamp)
+      end
+
+      it 'returns an integer value for nanoseconds' do
+        expect(described_class.get_time(:nanosecond)).to be_a_kind_of(Integer)
+      end
+    end
   end
 
   describe '#measure' do


### PR DESCRIPTION
Prior to this change, the profiler tried to sample all threads each time it decided to sample.

This could have a negative impact on the latency of Ruby services with a lot of threads, because each sampling pass would be quite expensive.

Just as an illustration, consider the `benchmarks/profiler_sample_loop` benchmark which tries to sample as
fast as possible 4 threads with very deep (500 frames+) stacks.

As the number of threads to sample increases, so does the performance of sampling degrade:

| Sampled threads | Iterations per second                               |
|-----------------|-----------------------------------------------------|
| 4 threads       | 390.921  (± 6.1%) i/s -      3.920k in  10.075624s  |
| 16 threads      |  97.037  (± 6.2%) i/s -    972.000  in  10.072298s  |
| 32 threads      |  49.576  (± 4.0%) i/s -    496.000  in  10.038491s  |
| 64 threads      |  24.060  (± 8.3%) i/s -    240.000  in  10.033481s  |

(All numbers from my laptop: i7-1068NG7 + ruby 2.7.4p191 [x86_64-darwin19])

When combined with our dynamic sampling mechanism, if the profiler starts to take longer to sample, it just samples less often.

BUT this means that it can impact service latency because suddenly we may be spending 40ms+ of CPU time (64 thread example + 500 frames, very extreme) each time the profiler decides to sample, which from experience (#1511, #1522) is not good.

Instead, this PR changes the stack sampler to sample up to a set maximum of threads (16), randomly selected among all threads.

This means that adding more threads to the system means very little degradation:

| Sampled threads | Iterations per second                              |
|-----------------|----------------------------------------------------|
| 16 threads      | 104.859  (± 6.7%) i/s -      1.050k in  10.068781s |
| 32 threads      | 100.957  (± 5.9%) i/s -      1.010k in  10.047250s |
| 64 threads      |  98.098  (± 5.1%) i/s -    981.000  in  10.038244s |
| 256 threads     |  84.740  (± 8.3%) i/s -    848.000  in  10.074037s |

There's still a bit of degradation that I suspect is from pure VM overhead -- 256+ threads on a single Ruby VM adds up.

Because we pick the threads to sample randomly, we'll eventually sample all threads -- just not at once.

Finally, regarding the dynamic sampling mechanism, because the profiler will not take longer to sample, it will sample more often, and thus over a longer period we should take sample roughly the same samples.

One downside of this approach is that if there really are many threads, the resulting wall clock times in a one minute profile may "drift" around the 60 second mark, e.g. maybe we only sampled a thread once per second and only 59 times, so we'll report 59s, but on the next report we'll include the missing one, so then the result will be 61s.
I've observed 60 +- 1.68 secs for an app with ~65 threads, given the default maximum of 16 threads.
This seems a reasonable enough margin of error given the improvement to latency (especially on such a large application! -> even bigger latency impact if we tried to sample all threads).

Also included is a change to track the wall clock time per-thread, bringing it in line with what we already did for cpu time (otherwise the resulting profile would be incorrect).