### PR TITLE
Fix flaky SuckerPunch patcher spec on JRuby

### DIFF
--- a/spec/ddtrace/contrib/sucker_punch/patcher_spec.rb
+++ b/spec/ddtrace/contrib/sucker_punch/patcher_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'sucker_punch instrumentation' do
     it_behaves_like 'measured span for integration', true do
       before do
         dummy_worker_success
-        try_wait_until { fetch_spans.any? }
+        try_wait_until { fetch_spans.length == 2 }
       end
     end
 
@@ -84,7 +84,7 @@ RSpec.describe 'sucker_punch instrumentation' do
 
     it 'instruments successful enqueuing' do
       is_expected.to be true
-      try_wait_until { fetch_spans.any? }
+      try_wait_until { fetch_spans.length == 2 }
 
       expect(enqueue_span.service).to eq('sucker_punch')
       expect(enqueue_span.name).to eq('sucker_punch.perform_async')
@@ -103,7 +103,7 @@ RSpec.describe 'sucker_punch instrumentation' do
     it_behaves_like 'measured span for integration', true do
       before do
         dummy_worker_fail
-        try_wait_until { fetch_spans.any? }
+        try_wait_until { fetch_spans.length == 2 }
       end
     end
 
@@ -130,13 +130,13 @@ RSpec.describe 'sucker_punch instrumentation' do
     it_behaves_like 'measured span for integration', true do
       before do
         dummy_worker_delay
-        try_wait_until { fetch_spans.any? }
+        try_wait_until { fetch_spans.length == 2 }
       end
     end
 
     it 'instruments enqueuing for a delayed job' do
       dummy_worker_delay
-      try_wait_until { fetch_spans.any? }
+      try_wait_until { fetch_spans.length == 2 }
 
       expect(enqueue_span.service).to eq('sucker_punch')
       expect(enqueue_span.name).to eq('sucker_punch.perform_in')


### PR DESCRIPTION
This took me a while to hunt down, and it manifested as a `StandardError: Wait time exhausted!` in the
`try_wait_until { Thread.list.size < count }` line of the `after` cleanup block.

Example failure:
<https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/4346/workflows/88a101cc-8c06-44b6-84b6-efedef4e426a/jobs/165493/parallel-runs/1>

The issue was caused by the cleanup code assuming that the Thread list would go down after telling SuckerPunch to shut down.

This assumption was broken by test cases where we run the test so fast that SuckerPunch doesn't get to start a background thread to run the task. Thus, the number of threads in the `after` block can never go down, since none ended up being started. 

One way of simulating this issue is to comment out the `__perform_async(*args)` in the `Instrumentation` file, so that the
enqueue span gets created, but no perform ever gets called.

The fix is to ensure that the SuckerPunch task actually gets executed.