### PR TITLE
Allow private invocation of ruby2_keywords

### DIFF
--- a/lib/ddtrace/profiling/ext/cthread.rb
+++ b/lib/ddtrace/profiling/ext/cthread.rb
@@ -85,7 +85,7 @@ module Datadog
             update_native_ids
             yield(*t_args)
           end
-          wrapped_block.ruby2_keywords if wrapped_block.respond_to?(:ruby2_keywords, true)
+          wrapped_block.send(:ruby2_keywords) if wrapped_block.respond_to?(:ruby2_keywords, true)
 
           super(*args, &wrapped_block)
         end
@@ -143,7 +143,7 @@ module Datadog
             ::Thread.current.send(:update_native_ids)
             yield(*t_args)
           end
-          wrapped_block.ruby2_keywords if wrapped_block.respond_to?(:ruby2_keywords, true)
+          wrapped_block.send(:ruby2_keywords) if wrapped_block.respond_to?(:ruby2_keywords, true)
 
           super(*args, &wrapped_block)
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -220,7 +220,7 @@ module DatadogThreadDebugger
     wrapped = lambda do |*thread_args|
       block.call(*thread_args) # rubocop:disable Performance/RedundantBlockCall
     end
-    wrapped.ruby2_keywords if wrapped.respond_to?(:ruby2_keywords, true)
+    wrapped.send(:ruby2_keywords) if wrapped.respond_to?(:ruby2_keywords, true)
 
     super(*args, &wrapped)
   end


### PR DESCRIPTION
Fixes #1712 

`#ruby2_keywords` can be sometimes private: https://github.com/ruby/ruby2_keywords/blob/92ad9c5c3fff591b8383ada8b93c3da1279d24ad/lib/ruby2_keywords.rb#L1-L12

We already accounted for this by passing `true` to `respond_to?(:ruby2_keywords, true)`, but we didn't invoke it with a private-safe way in case it was actually private. This PR makes such change.