### PR TITLE
Bump minimum dogstatsd-ruby 5 version accepted to 5.3

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2461,7 +2461,7 @@ The tracer and its integrations can produce some additional metrics that can pro
 To configure your application for metrics collection:
 
 1. [Configure your Datadog agent for StatsD](https://docs.datadoghq.com/developers/dogstatsd/#setup)
-2. Add `gem 'dogstatsd-ruby', '~> 5.2'` to your Gemfile
+2. Add `gem 'dogstatsd-ruby', '~> 5.3'` to your Gemfile
 
 #### For application runtime
 

--- a/lib/ddtrace/metrics.rb
+++ b/lib/ddtrace/metrics.rb
@@ -31,7 +31,7 @@ module Datadog
       !version.nil? && version >= Gem::Version.new('3.3.0') &&
         # dogstatsd-ruby >= 5.0 & < 5.2.0 has known issues with process forks
         # and do not support the single thread mode we use to avoid this problem.
-        !(version >= Gem::Version.new('5.0') && version < Gem::Version.new('5.2'))
+        !(version >= Gem::Version.new('5.0') && version < Gem::Version.new('5.3'))
     end
 
     def enabled?
@@ -274,7 +274,7 @@ module Datadog
       IGNORED_STATSD_ONLY_ONCE.run do
         Datadog.logger.warn(
           'Ignoring user-supplied statsd instance as currently-installed version of dogstastd-ruby is incompatible. ' \
-          "To fix this, ensure that you have `gem 'dogstatsd-ruby', '~> 5.2'` on your Gemfile or gems.rb file."
+          "To fix this, ensure that you have `gem 'dogstatsd-ruby', '~> 5.3'` on your Gemfile or gems.rb file."
         )
       end
     end

--- a/spec/ddtrace/metrics_spec.rb
+++ b/spec/ddtrace/metrics_spec.rb
@@ -121,13 +121,13 @@ RSpec.describe Datadog::Metrics do
         end
 
         context 'with incompatible 5.x version' do
-          let(:version) { Gem::Version.new('5.0.0') }
+          let(:version) { Gem::Version.new('5.2.0') }
 
           it { is_expected.to be false }
         end
 
         context 'with compatible 5.x version' do
-          let(:version) { Gem::Version.new('5.2.0') }
+          let(:version) { Gem::Version.new('5.3.0') }
 
           it { is_expected.to be true }
         end
@@ -153,13 +153,13 @@ RSpec.describe Datadog::Metrics do
         end
 
         context 'with incompatible 5.x version' do
-          let(:gem_version_number) { '5.0.0' }
+          let(:gem_version_number) { '5.2.0' }
 
           it { is_expected.to be false }
         end
 
         context 'with compatible 5.x version' do
-          let(:gem_version_number) { '5.2.0' }
+          let(:gem_version_number) { '5.3.0' }
 
           it { is_expected.to be true }
         end
@@ -272,8 +272,8 @@ RSpec.describe Datadog::Metrics do
 
     let(:statsd_client) { instance_double(Datadog::Statsd) }
     let(:options) do
-      # This tests is run with both ~> 4.0 and latest dogstatsd-ruby.
-      if Gem::Version.new(Datadog::Statsd::VERSION) >= Gem::Version.new('5.2.0')
+      # This test is run with both ~> 4.0 and latest dogstatsd-ruby.
+      if Gem::Version.new(Datadog::Statsd::VERSION) >= Gem::Version.new('5.3.0')
         { single_thread: true }
       else
         {}


### PR DESCRIPTION
Dogstatsd-ruby version 5.3.0 includes important fixes for applications making use of fork (see <https://github.com/DataDog/dogstatsd-ruby/releases/tag/v5.3.0>), so let's ensure that customers are moved to this version.