### PR TITLE
[PROF-4197] Fix missing thread id in Linux profiles for threads created using `rb_thread_create`

### DIFF
--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -126,7 +126,7 @@ module Datadog
           # Convert backtrace locations into structs
           locations = convert_backtrace_locations(locations)
 
-          thread_id = thread.respond_to?(:pthread_thread_id) ? thread.pthread_thread_id : thread.object_id
+          thread_id = thread.object_id
           trace_id, span_id, trace_resource = trace_identifiers_helper.trace_identifiers_for(thread)
           cpu_time = get_cpu_time_interval!(thread)
           wall_time_interval_ns =


### PR DESCRIPTION
On Linux, we monkey patch the `Thread` class to be able to extract CPU-time information for profiles.

As part of that monkey patching, we add a `#pthread_thread_id` method, that returns a lower-level "thread id", which we also used, when present, to identify threads.

Unfortunately, and as documented in the comments of the `#warn_about_missing_cpu_time_instrumentation` method, with our current implementation we can't always get this identifier.

In particular, one of the cases where we can't get this identifier is when threads get created using the `rb_thread_create` API (as used by the [Iodine](https://github.com/boazsegev/iodine) web server, or the [FFI](https://github.com/ffi/ffi/) gem).

Thus, for these threads, we were getting a `nil` thread id, which somewhat broke browsing profiles by thread id, as threads with no id just disappeared in this case.

To fix this, I've decided to just simplify our approach: outside of Linux, we already used the regular `#object_id` to identify threads, and it works fine, so let's just use it always. It's not like showing the `#pthread_thread_id` in the UX was especially relevant.