### PR TITLE
[PROF-4081] Make threads with empty backtrace visible

### DIFF
--- a/lib/ddtrace/profiling/collectors/stack.rb
+++ b/lib/ddtrace/profiling/collectors/stack.rb
@@ -19,6 +19,7 @@ module Datadog
         MIN_INTERVAL = 0.01
         THREAD_LAST_CPU_TIME_KEY = :datadog_profiler_last_cpu_time
         THREAD_LAST_WALL_CLOCK_KEY = :datadog_profiler_last_wall_clock
+        SYNTHETIC_STACK_IN_NATIVE_CODE = [BacktraceLocation.new('', 0, 'In native code').freeze].freeze
 
         # This default was picked based on the current sampling performance and on expected concurrency on an average
         # Ruby MRI application. Lowering this optimizes for latency (less impact each time we sample), and raising
@@ -118,6 +119,26 @@ module Datadog
         def collect_thread_event(thread, current_wall_time_ns)
           locations = thread.backtrace_locations
           return if locations.nil?
+
+          # Having empty locations means that the thread is alive, but we don't know what it's doing:
+          #
+          # 1. It can be starting up
+          #    ```
+          #    > Thread.new { sleep }.backtrace
+          #    => [] # <-- note the thread hasn't actually started running sleep yet, we got there first
+          #    ```
+          # 2. It can be running native code
+          #    ```
+          #    > t = Process.detach(fork { sleep })
+          #    => #<Process::Waiter:0x00007ffe7285f7a0 run>
+          #    > t.backtrace
+          #    => [] # <-- this can happen even minutes later, e.g. it's not a race as in 1.
+          #    ```
+          #    This effect has been observed in threads created by the Iodine web server and the ffi gem
+          #
+          # To give customers visibility into these threads, we replace the empty stack with one containing a
+          # synthetic placeholder frame, so that these threads are properly represented in the UX.
+          locations = SYNTHETIC_STACK_IN_NATIVE_CODE if locations.empty?
 
           # Get actual stack size then trim the stack
           stack_size = locations.length

--- a/spec/ddtrace/profiling/collectors/stack_spec.rb
+++ b/spec/ddtrace/profiling/collectors/stack_spec.rb
@@ -308,13 +308,13 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     let(:last_wall_time) { 42 }
     let(:current_wall_time) { 123 }
 
-    context 'when the backtrace is empty' do
+    context 'when the backtrace is nil' do
       let(:backtrace) { nil }
 
       it { is_expected.to be nil }
     end
 
-    context 'when the backtrace is not empty' do
+    context 'when the backtrace is not nil' do
       let(:backtrace) do
         Array.new(backtrace_size) do
           instance_double(
@@ -468,6 +468,20 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
             expect(frames).to be_a_kind_of(Array)
             expect(frames.length).to eq(backtrace.length)
           end
+        end
+      end
+
+      context 'when the backtrace is empty' do
+        let(:backtrace) { [] }
+
+        it 'builds an event that includes a includes a synthetic placeholder frame to mark execution in native code' do
+          is_expected.to have_attributes(
+            total_frame_count: 1,
+            frames: [Datadog::Profiling::BacktraceLocation.new('', 0, 'In native code')],
+            timestamp: kind_of(Float),
+            thread_id: thread.object_id,
+            wall_time_interval_ns: current_wall_time - last_wall_time,
+          )
         end
       end
     end


### PR DESCRIPTION
As documented in the code, there's a few situations in which a thread can have an empty backtrace. Previously, these threads were not visible in the profiling UX, which was a gap in our provided information.

(It also could be confusing, for instance, if a thread spent some time executing Ruby and some time in native code, as happens with the Iodine web server, the "wall clock time" would not add up to 60s in a regular profile, because we ignored these threads).

To fix this, we now replace empty backtraces with a fake stack that displays `(In native code)`. We currently have no way of showing what's up in native code (is the code running? is the thread idle? we don't know), but at least we know it's there.

![Screen Shot 2021-10-15 at 09 52 31](https://user-images.githubusercontent.com/2785847/137466027-dfb474ef-f72e-46ec-8cbf-47a89970c486.png)

