### PR TITLE
Fix incorrect configuration mismatch warning when port is specified as String

### DIFF
--- a/lib/ddtrace/configuration/agent_settings_resolver.rb
+++ b/lib/ddtrace/configuration/agent_settings_resolver.rb
@@ -163,7 +163,7 @@ module Datadog
 
         begin
           Integer(value)
-        rescue ArgumentError
+        rescue ArgumentError, TypeError
           log_warning("Invalid value for #{friendly_name} (#{value.inspect}). Ignoring this configuration.")
 
           nil

--- a/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
+++ b/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
@@ -210,9 +210,27 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
         end
       end
 
-      context 'when the port is an invalid value' do
+      context 'when the port is an invalid string value' do
         before do
           ddtrace_settings.tracer.port = 'kaboom'
+
+          allow(logger).to receive(:warn)
+        end
+
+        it 'logs a warning' do
+          expect(logger).to receive(:warn).with(/Invalid value/)
+
+          resolver
+        end
+
+        it 'falls back to the defaults' do
+          expect(resolver).to have_attributes settings
+        end
+      end
+
+      context 'when the port is an invalid object' do
+        before do
+          ddtrace_settings.tracer.port = Object.new
 
           allow(logger).to receive(:warn)
         end

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -530,7 +530,7 @@ RSpec.describe 'Tracer integration tests' do
 
     let(:tracer) { Datadog::Tracer.new }
     let(:hostname) { double('hostname') }
-    let(:port) { double('port') }
+    let(:port) { 34567 }
     let(:settings) { Datadog::Configuration::Settings.new }
     let(:agent_settings) { Datadog::Configuration::AgentSettingsResolver.call(settings, logger: nil) }
 


### PR DESCRIPTION
I noticed a Ruby app where the configuration mismatch warning was popping up:

```
W, [2021-10-15T11:44:30.952540 #1]  WARN -- ddtrace: [ddtrace] Configuration mismatch: values differ between "c.tracer.port" ('8126') and DD_TRACE_AGENT_PORT environment variable ('8126'). Using '8126'.
```

The warning was being triggered because we convert the values read from environment variables (`DD_TRACE_AGENT_PORT` or `DD_TRACE_AGENT_URL`) into integers, but this app had `c.tracer.port` specified as a string.

Because or that, since we collect all values, call `#uniq` on them and see if we get more than one, the warning was being triggered since the `8126` integer is not the same as the `'8126'` string.