### PR TITLE
Fix Active Job integration example code

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -540,7 +540,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 Most of the time, Active Job is set up as part of Rails, but it can be activated separately:
 
 ```ruby
-require 'activejob'
+require 'active_job'
 require 'ddtrace'
 
 Datadog.configure do |c|


### PR DESCRIPTION
Unfortunately, `activejob` doesn't exist.

```ruby 
require 'activejob'
# => LoadError: cannot load such file -- activejob
```