### PR TITLE
Deprecation:Transport v0.2

### DIFF
--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -42,8 +42,7 @@ module Datadog
           apis = API.defaults
 
           transport.api API::V4, apis[API::V4], fallback: API::V3, default: true
-          transport.api API::V3, apis[API::V3], fallback: API::V2
-          transport.api API::V2, apis[API::V2]
+          transport.api API::V3, apis[API::V3]
 
           # Apply any settings given by options
           unless options.empty?

--- a/lib/ddtrace/transport/http/api.rb
+++ b/lib/ddtrace/transport/http/api.rb
@@ -14,7 +14,6 @@ module Datadog
         # Default API versions
         V4 = 'v0.4'.freeze
         V3 = 'v0.3'.freeze
-        V2 = 'v0.2'.freeze
 
         module_function
 
@@ -33,13 +32,7 @@ module Datadog
                 Encoding::MsgpackEncoder
               )
             end,
-            V2 => Spec.new do |s|
-              s.traces = Traces::API::Endpoint.new(
-                '/v0.2/traces'.freeze,
-                Encoding::JSONEncoder
-              )
-            end
-          ].with_fallbacks(V4 => V3, V3 => V2)
+          ].with_fallbacks(V4 => V3)
         end
       end
     end

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -576,7 +576,7 @@ RSpec.describe 'Tracer integration tests' do
           }
         end
 
-        let(:api_version) { Datadog::Transport::HTTP::API::V2 }
+        let(:api_version) { Datadog::Transport::HTTP::API::V4 }
         let(:headers) { { 'Test-Header' => 'test' } }
 
         it do

--- a/spec/ddtrace/transport/http/api_spec.rb
+++ b/spec/ddtrace/transport/http/api_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Datadog::Transport::HTTP::API do
       is_expected.to include(
         described_class::V4 => kind_of(Datadog::Transport::HTTP::API::Spec),
         described_class::V3 => kind_of(Datadog::Transport::HTTP::API::Spec),
-        described_class::V2 => kind_of(Datadog::Transport::HTTP::API::Spec)
       )
 
       defaults[described_class::V4].tap do |v4|
@@ -29,23 +28,13 @@ RSpec.describe Datadog::Transport::HTTP::API do
         expect(v3.traces.service_rates?).to be false
         expect(v3.traces.encoder).to be Datadog::Encoding::MsgpackEncoder
       end
-
-      defaults[described_class::V2].tap do |v2|
-        expect(v2).to be_a_kind_of(Datadog::Transport::HTTP::Traces::API::Spec)
-        expect(v2.traces).to be_a_kind_of(Datadog::Transport::HTTP::Traces::API::Endpoint)
-        expect(v2.traces.service_rates?).to be false
-        expect(v2.traces.encoder).to be Datadog::Encoding::JSONEncoder
-      end
     end
 
     describe '#fallbacks' do
       subject(:fallbacks) { defaults.fallbacks }
 
       it do
-        is_expected.to include(
-          described_class::V4 => described_class::V3,
-          described_class::V3 => described_class::V2
-        )
+        is_expected.to include(described_class::V4 => described_class::V3)
       end
     end
   end

--- a/spec/ddtrace/transport/http_spec.rb
+++ b/spec/ddtrace/transport/http_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe Datadog::Transport::HTTP do
         [
           Datadog::Transport::HTTP::API::V4,
           Datadog::Transport::HTTP::API::V3,
-          Datadog::Transport::HTTP::API::V2
         ]
       )
 
@@ -117,7 +116,7 @@ RSpec.describe Datadog::Transport::HTTP do
         let(:deprecated_for_removal_transport_configuration_options) { { api_version: api_version } }
 
         context 'that is defined' do
-          let(:api_version) { Datadog::Transport::HTTP::API::V2 }
+          let(:api_version) { Datadog::Transport::HTTP::API::V4 }
 
           it { expect(default.current_api_id).to eq(api_version) }
         end
@@ -129,7 +128,7 @@ RSpec.describe Datadog::Transport::HTTP do
         end
 
         context 'when the options also try to set the api_version' do
-          let(:api_version) { Datadog::Transport::HTTP::API::V2 }
+          let(:api_version) { Datadog::Transport::HTTP::API::V3 }
           let(:options) { { api_version: Datadog::Transport::HTTP::API::V4 } }
 
           it 'prioritizes the version in the agent_settings' do
@@ -181,7 +180,7 @@ RSpec.describe Datadog::Transport::HTTP do
         let(:options) { { api_version: api_version } }
 
         context 'that is defined' do
-          let(:api_version) { Datadog::Transport::HTTP::API::V2 }
+          let(:api_version) { Datadog::Transport::HTTP::API::V4 }
 
           it { expect(default.current_api_id).to eq(api_version) }
         end


### PR DESCRIPTION
This PR removes the tracer->agent transport protocol `v0.2`.
This protocol has been [deprecated for 5 years](https://github.com/DataDog/datadog-trace-agent/commit/aec7e47545950115b4026c1b5f4b679ffad90cea#diff-50e34095109654a35ffab205b9540bf8f13347174e5a91415d2fcffe0758873fR28-R31), and no other Datadog APM tracer supports this protocol except for Ruby today.

This change has no impact on clients that are not explicitly configuring `ddtrace` to use the transport v0.2, which is something I've never seen before.