### PR TITLE
Deprecation:Misnamed header propagation environment variables

### DIFF
--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -95,8 +95,7 @@ module Datadog
         option :propagation_extract_style do |o|
           o.default do
             # Look for all headers by default
-            env_to_list([Ext::DistributedTracing::PROPAGATION_STYLE_EXTRACT_ENV,
-                         Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV_OLD],
+            env_to_list(Ext::DistributedTracing::PROPAGATION_STYLE_EXTRACT_ENV,
                         [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG,
                          Ext::DistributedTracing::PROPAGATION_STYLE_B3,
                          Ext::DistributedTracing::PROPAGATION_STYLE_B3_SINGLE_HEADER])
@@ -107,10 +106,10 @@ module Datadog
 
         option :propagation_inject_style do |o|
           o.default do
-            # Only inject Datadog headers by default
-            env_to_list([Ext::DistributedTracing::PROPAGATION_STYLE_INJECT_ENV,
-                         Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV_OLD],
-                        [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG])
+            env_to_list(
+              Ext::DistributedTracing::PROPAGATION_STYLE_INJECT_ENV,
+              [Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG] # Only inject Datadog headers by default
+            )
           end
 
           o.lazy

--- a/lib/ddtrace/ext/distributed.rb
+++ b/lib/ddtrace/ext/distributed.rb
@@ -23,12 +23,6 @@ module Datadog
       PROPAGATION_STYLE_B3_SINGLE_HEADER = 'B3 single header'.freeze
       PROPAGATION_STYLE_INJECT_ENV = 'DD_PROPAGATION_STYLE_INJECT'.freeze
       PROPAGATION_STYLE_EXTRACT_ENV = 'DD_PROPAGATION_STYLE_EXTRACT'.freeze
-      # NOTE: the below inject/extract values are deprecated and were defined erronously
-      # they were never part of the datadog language client standard or documentation
-      # some users may already be relying on them, but we should look to remove these in the future
-      # or before 1.0.
-      PROPAGATION_INJECT_STYLE_ENV_OLD = 'DD_PROPAGATION_INJECT_STYLE'.freeze
-      PROPAGATION_EXTRACT_STYLE_ENV_OLD = 'DD_PROPAGATION_EXTRACT_STYLE'.freeze
 
       # gRPC metadata keys for distributed tracing. https://github.com/grpc/grpc-go/blob/v1.10.x/Documentation/grpc-metadata.md
       GRPC_METADATA_TRACE_ID = 'x-datadog-trace-id'.freeze

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -254,41 +254,6 @@ RSpec.describe Datadog::Configuration::Settings do
           end
         end
       end
-
-      context "when #{Datadog::Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV_OLD}" do
-        around do |example|
-          ClimateControl.modify(Datadog::Ext::DistributedTracing::PROPAGATION_EXTRACT_STYLE_ENV_OLD => environment) do
-            example.run
-          end
-        end
-
-        context 'is not defined' do
-          let(:environment) { nil }
-
-          it do
-            is_expected.to eq(
-              [
-                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG,
-                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_B3,
-                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_B3_SINGLE_HEADER
-              ]
-            )
-          end
-        end
-
-        context 'is defined' do
-          let(:environment) { 'B3,B3 single header' }
-
-          it do
-            is_expected.to eq(
-              [
-                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_B3,
-                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_B3_SINGLE_HEADER
-              ]
-            )
-          end
-        end
-      end
     end
 
     describe '#propagation_inject_style' do
@@ -297,33 +262,6 @@ RSpec.describe Datadog::Configuration::Settings do
       context "when #{Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_INJECT_ENV}" do
         around do |example|
           ClimateControl.modify(Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_INJECT_ENV => environment) do
-            example.run
-          end
-        end
-
-        context 'is not defined' do
-          let(:environment) { nil }
-
-          it { is_expected.to eq([Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG]) }
-        end
-
-        context 'is defined' do
-          let(:environment) { 'Datadog,B3' }
-
-          it do
-            is_expected.to eq(
-              [
-                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_DATADOG,
-                Datadog::Ext::DistributedTracing::PROPAGATION_STYLE_B3
-              ]
-            )
-          end
-        end
-      end
-
-      context "when #{Datadog::Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV_OLD}" do
-        around do |example|
-          ClimateControl.modify(Datadog::Ext::DistributedTracing::PROPAGATION_INJECT_STYLE_ENV_OLD => environment) do
             example.run
           end
         end


### PR DESCRIPTION
The configuration for what [HTTP header style for `ddtrace` to use](https://docs.datadoghq.com/tracing/setup_overview/custom_instrumentation/ruby/?tab=activespan#b3-headers-extraction-and-injection) was initially performed using the misnamed environment variables `DD_PROPAGATION_INJECT_STYLE` and `DD_PROPAGATION_EXTRACT_STYLE`.

Datadog has always used `DD_PROPAGATION_STYLE_INJECT` and `DD_PROPAGATION_STYLE_EXTRACT` instead across all language traces, but the Ruby tracer had these misnamed since first implementation.

We've been supporting all four (`DD_PROPAGATION_INJECT_STYLE`, `DD_PROPAGATION_EXTRACT_STYLE`, `DD_PROPAGATION_STYLE_INJECT`, `DD_PROPAGATION_STYLE_EXTRACT`) variables since https://github.com/DataDog/dd-trace-rb/releases/tag/v0.43.0.

This PR requires configuration to be done with `DD_PROPAGATION_STYLE_INJECT` and `DD_PROPAGATION_STYLE_EXTRACT` only for the Ruby tracer from now on.