### PR TITLE
Deprecation:Datadog::Tracer#services/set_service_info

### DIFF
--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -22,23 +22,12 @@ module Datadog
   # of these function calls and sub-requests would be encapsulated within a single trace.
   # rubocop:disable Metrics/ClassLength
   class Tracer
-    SERVICES_DEPRECATION_WARN_ONLY_ONCE = Datadog::Utils::OnlyOnce.new
-    SET_SERVICE_INFO_DEPRECATION_WARN_ONLY_ONCE = Datadog::Utils::OnlyOnce.new
-
     attr_reader :sampler, :tags, :provider, :context_flush
     attr_accessor :enabled, :writer
     attr_writer :default_service
 
     ALLOWED_SPAN_OPTIONS = [:service, :resource, :span_type].freeze
     DEFAULT_ON_ERROR = proc { |span, error| span.set_error(error) unless span.nil? }
-
-    def services
-      SERVICES_DEPRECATION_WARN_ONLY_ONCE.run do
-        Datadog.logger.warn('services: Usage of Tracer.services has been deprecated')
-      end
-
-      {}
-    end
 
     # Shorthand that calls the `shutdown!` method of a registered worker.
     # It's useful to ensure that the Trace Buffer is properly flushed before
@@ -128,20 +117,6 @@ module Datadog
                          else
                            Datadog::ContextFlush::Finished.new
                          end
-      end
-    end
-
-    # Set the information about the given service. A valid example is:
-    #
-    #   tracer.set_service_info('web-application', 'rails', 'web')
-    #
-    # set_service_info is deprecated, no service information needs to be tracked
-    def set_service_info(service, app, app_type)
-      SET_SERVICE_INFO_DEPRECATION_WARN_ONLY_ONCE.run do
-        Datadog.logger.warn(%(
-          set_service_info: Usage of set_service_info has been deprecated,
-          service information no longer needs to be reported to the trace agent.
-        ))
       end
     end
 

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -703,31 +703,6 @@ RSpec.describe Datadog::Tracer do
     end
   end
 
-  describe '#set_service_info' do
-    include_context 'tracer logging'
-
-    # Ensure we have a clean OnlyOnce before and after each test
-    # so we can properly test the behavior here, and we don't pollute other tests
-    before { described_class::SET_SERVICE_INFO_DEPRECATION_WARN_ONLY_ONCE.send(:reset_ran_once_state_for_tests) }
-
-    after { described_class::SET_SERVICE_INFO_DEPRECATION_WARN_ONLY_ONCE.send(:reset_ran_once_state_for_tests) }
-
-    before do
-      # Call multiple times to assert we only log once
-      allow(Datadog.logger).to receive(:warn).and_call_original
-
-      tracer.set_service_info('service-A', 'app-A', 'app_type-A')
-      tracer.set_service_info('service-B', 'app-B', 'app_type-B')
-      tracer.set_service_info('service-C', 'app-C', 'app_type-C')
-      tracer.set_service_info('service-D', 'app-D', 'app_type-D')
-    end
-
-    it 'generates a single deprecation warning' do
-      expect(Datadog.logger).to have_received(:warn).once
-      expect(log_buffer).to contain_line_with('Usage of set_service_info has been deprecated')
-    end
-  end
-
   describe '#record' do
     subject(:record) { tracer.record(context) }
     let(:context) { instance_double(Datadog::Context) }


### PR DESCRIPTION
Remove the deprecated `Datadog::Tracer#services` and `Datadog::Tracer#set_service_info`.

Setting the tracer service explicitly hasn't been necessary for quite some time, and these APIs have been no-ops since deprecation.