### PR TITLE
Deprecation:Remove explicit Resque workers option

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1653,7 +1653,6 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | --- | ----------- | ------- |
 | `service_name` | Service name used for `resque` instrumentation | `'resque'` |
 | `error_handler` | Custom error handler invoked when a job raises an error. Provided `span` and `error` as arguments. Sets error on the span by default. Useful for ignoring transient errors. | `proc { |span, error| span.set_error(error) unless span.nil? }` |
-| `workers` | **[DEPRECATED]** Limits instrumented worker classes to only the ones specified in an array (e.g. `[MyJob]`). If not provided, instruments all workers. | `nil` |
 
 ### Rest Client
 

--- a/lib/ddtrace/contrib/resque/configuration/settings.rb
+++ b/lib/ddtrace/contrib/resque/configuration/settings.rb
@@ -24,23 +24,6 @@ module Datadog
           end
 
           option :service_name, default: Ext::SERVICE_NAME
-
-          # A list Ruby worker classes to be instrumented.
-          # The value of `nil` has special semantics: it instruments all workers dynamically.
-          #
-          # TODO: 1.0: Automatic patching should be the default behavior.
-          # We should not provide this option in the future,
-          # as our integrations should always instrument all possible scenarios when feasible.
-          option :workers, default: nil do |o|
-            o.on_set do |value|
-              unless value.nil?
-                Datadog.logger.warn(
-                  "DEPRECATED: Resque integration now instruments all workers. \n" \
-                  'The `workers:` option is unnecessary and will be removed in the future.'
-                )
-              end
-            end
-          end
           option :error_handler, default: Datadog::Tracer::DEFAULT_ON_ERROR
         end
       end

--- a/lib/ddtrace/contrib/resque/patcher.rb
+++ b/lib/ddtrace/contrib/resque/patcher.rb
@@ -20,9 +20,6 @@ module Datadog
           require_relative 'resque_job'
 
           ::Resque::Job.prepend(Resque::Job)
-
-          workers = Datadog.configuration[:resque][:workers] || []
-          workers.each { |worker| worker.extend(ResqueJob) }
         end
       end
     end

--- a/lib/ddtrace/contrib/resque/resque_job.rb
+++ b/lib/ddtrace/contrib/resque/resque_job.rb
@@ -11,10 +11,8 @@ module Datadog
       # Automatically configures jobs with {ResqueJob} plugin.
       module Job
         def perform
-          if Datadog.configuration[:resque][:workers].nil?
-            job = payload_class
-            job.extend(Datadog::Contrib::Resque::ResqueJob) unless job.is_a? Datadog::Contrib::Resque::ResqueJob
-          end
+          job = payload_class
+          job.extend(Datadog::Contrib::Resque::ResqueJob) unless job.is_a?(Datadog::Contrib::Resque::ResqueJob)
         ensure
           super
         end

--- a/spec/ddtrace/contrib/resque/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/resque/instrumentation_spec.rb
@@ -190,41 +190,9 @@ RSpec.describe 'Resque instrumentation' do
     end
   end
 
-  describe 'patching for workers' do
-    before do
-      # Remove the patch so it applies new patch
-      remove_patch!(:resque)
-
-      # Re-apply patch, to workers
-      Datadog.configure do |c|
-        c.use(:resque, workers: [job_class])
-      end
-    end
+  describe 'with default instrumentation of all workers' do
+    let(:configuration_options) { {} }
 
     it_behaves_like 'job execution tracing'
-  end
-
-  describe 'with auto instrumentation' do
-    let(:configuration_options) { {} } # The default is enabled
-
-    it_behaves_like 'job execution tracing'
-  end
-
-  describe 'with auto instrumentation disabled' do
-    let(:configuration_options) { { workers: [] } }
-
-    before { perform_job(job_class, job_args) }
-
-    it 'no tracing happens' do
-      expect(spans).to be_empty
-    end
-
-    it 'emits deprecation warning for explicit workers setting' do
-      expect(Datadog.logger).to receive(:warn).with(/DEPRECATED: Resque integration now instruments all workers/)
-
-      Datadog.configure do |c|
-        c.use(:resque, workers: [job_class])
-      end
-    end
   end
 end


### PR DESCRIPTION
Remove explicit `c.use :resque, workers: ...` option.

This option was necessary when `ddtrace`'s Resque support was not able to automatically instrument all Resque workers.

Since this limitation has been lifted, the option specify explicitly workers has been deprecated.