### PR TITLE
Deprecation:Profiling exporter.transport_options

### DIFF
--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -142,21 +142,6 @@ module Datadog
 
         settings :exporter do
           option :transport
-          option :transport_options do |o|
-            o.setter do
-              # NOTE: As of April 2021 there may be a few profiler private beta customers with this setting, but since I'm
-              # marking this as deprecated before public beta, we can remove this for 1.0 without concern.
-              Datadog.logger.warn(
-                'Configuring the profiler c.profiling.exporter.transport_options is no longer needed, as the profiler ' \
-                'will reuse your existing global or tracer configuration. ' \
-                'This setting is deprecated for removal in a future ddtrace version ' \
-                '(1.0 or profiling GA, whichever comes first).'
-              )
-              nil
-            end
-            o.default { nil }
-            o.lazy
-          end
         end
 
         settings :advanced do

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -452,30 +452,6 @@ RSpec.describe Datadog::Configuration::Settings do
             .to(transport)
         end
       end
-
-      describe '#transport_options' do
-        subject(:transport_options) { settings.profiling.exporter.transport_options }
-
-        before do
-          allow(Datadog.logger).to receive(:warn)
-        end
-
-        it { is_expected.to be nil }
-
-        it 'logs a deprecation warning' do
-          expect(Datadog.logger).to receive(:warn).with(/deprecated for removal/)
-
-          transport_options
-        end
-      end
-
-      describe '#transport_options=' do
-        it 'logs a deprecation warning' do
-          expect(Datadog.logger).to receive(:warn).with(/deprecated for removal/)
-
-          settings.profiling.exporter.transport_options = :foo
-        end
-      end
     end
 
     describe '#advanced' do


### PR DESCRIPTION
This PR removes the deprecated `c.profiling.exporter.transport_options`.
This option was no longer used by the profiler and a deprecation warning has been in place for some time.