### PR TITLE
Deprecation:Datadog Rack env

### DIFF
--- a/lib/ddtrace/contrib/action_cable/instrumentation.rb
+++ b/lib/ddtrace/contrib/action_cable/instrumentation.rb
@@ -16,7 +16,7 @@ module Datadog
                 span.set_tag(Ext::TAG_CONNECTION, self.class.to_s)
 
                 # Set the resource name of the Rack request span
-                rack_request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
+                rack_request_span = env[Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
                 rack_request_span.resource = span.resource if rack_request_span
               rescue StandardError => e
                 Datadog.logger.error("Error preparing span for ActionCable::Connection: #{e}")

--- a/lib/ddtrace/contrib/action_pack/action_controller/instrumentation.rb
+++ b/lib/ddtrace/contrib/action_pack/action_controller/instrumentation.rb
@@ -96,7 +96,7 @@ module Datadog
           def try_setting_rack_request_resource(payload, resource)
             # Set the resource name of the Rack request span unless this is an exception controller.
             unless payload.fetch(:exception_controller?)
-              rack_request_span = payload.fetch(:env)[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
+              rack_request_span = payload.fetch(:env)[Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
               rack_request_span.resource = resource if rack_request_span
             end
           end

--- a/lib/ddtrace/contrib/rails/middlewares.rb
+++ b/lib/ddtrace/contrib/rails/middlewares.rb
@@ -34,7 +34,7 @@ module Datadog
             # Some exception gets handled by Rails middleware before it can be set on Rack middleware
             # The rack span is the root span of the request and should make sure it has the full exception
             # set on it.
-            env[:datadog_rack_request_span].set_error(e) if env[:datadog_rack_request_span]
+            env[Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN].set_error(e) if env[Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
           end
           raise e
         end

--- a/lib/ddtrace/contrib/sinatra/tracer.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer.rb
@@ -115,7 +115,7 @@ module Datadog
               span.set_tag(Ext::TAG_ROUTE_PATH, @datadog_route)
               span.set_tag(Ext::TAG_SCRIPT_NAME, request.script_name) if request.script_name && !request.script_name.empty?
 
-              rack_request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
+              rack_request_span = env[Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
               rack_request_span.resource = span.resource if rack_request_span
 
               sinatra_request_span =

--- a/lib/ddtrace/contrib/sinatra/tracer_middleware.rb
+++ b/lib/ddtrace/contrib/sinatra/tracer_middleware.rb
@@ -58,7 +58,7 @@ module Datadog
               # TODO: the response with that resource.
               # TODO: We should replace this backfill code with a clear `resource` that signals
               # TODO: that this Sinatra span was *not* responsible for processing the current request.
-              rack_request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
+              rack_request_span = env[Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
               span.resource = rack_request_span.resource if rack_request_span && rack_request_span.resource
 
               if response

--- a/spec/ddtrace/contrib/rack/integration_test_spec.rb
+++ b/spec/ddtrace/contrib/rack/integration_test_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe 'Rack integration tests' do
               run(proc do |env|
                 # This should be considered a web framework that can alter
                 # the request span after routing / controller processing
-                request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
+                request_span = env[Datadog::Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
                 request_span.resource = 'GET /app/'
                 request_span.set_tag('http.method', 'GET_V2')
                 request_span.set_tag('http.status_code', 201)
@@ -420,7 +420,7 @@ RSpec.describe 'Rack integration tests' do
                 run(proc do |env|
                   # this should be considered a web framework that can alter
                   # the request span after routing / controller processing
-                  request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
+                  request_span = env[Datadog::Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
                   request_span.status = 1
                   request_span.set_tag('error.stack', 'Handled exception')
 
@@ -456,7 +456,7 @@ RSpec.describe 'Rack integration tests' do
                 run(proc do |env|
                   # this should be considered a web framework that can alter
                   # the request span after routing / controller processing
-                  request_span = env[Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN]
+                  request_span = env[Datadog::Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
                   request_span.set_tag('error.stack', 'Handled exception')
 
                   [500, { 'Content-Type' => 'text/html' }, ['OK']]

--- a/spec/ddtrace/contrib/rack/middlewares_spec.rb
+++ b/spec/ddtrace/contrib/rack/middlewares_spec.rb
@@ -30,51 +30,6 @@ RSpec.describe Datadog::Contrib::Rack::TraceMiddleware do
         .and_return(response)
     end
 
-    describe 'deprecation warnings' do
-      before { allow(Datadog.logger).to receive(:warn) }
-
-      # Expect this for backwards compatibility
-      context 'backwards compatibility' do
-        before { middleware_call }
-
-        it do
-          expect(env).to include(
-            datadog_rack_request_span: kind_of(Datadog::Span),
-            'datadog.rack_request_span' => kind_of(Datadog::Span)
-          )
-        end
-      end
-
-      context 'when :datadog_rack_request_span is accessed on the span' do
-        before do
-          allow(app).to receive(:call).with(env) do |env|
-            # Trigger deprecation warning
-            env[:datadog_rack_request_span]
-            response
-          end
-
-          middleware_call
-        end
-
-        it do
-          expect(Datadog.logger).to_not have_received(:warn)
-            .with(/:datadog_rack_request_span/)
-        end
-      end
-
-      context 'when the same Rack env object is run twice' do
-        before do
-          middleware.call(env)
-          middleware.call(env)
-        end
-
-        it do
-          expect(Datadog.logger).to_not have_received(:warn)
-            .with(/:datadog_rack_request_span/)
-        end
-      end
-    end
-
     context 'with fatal exception' do
       let(:fatal_error) { stub_const('FatalError', Class.new(RuntimeError)) }
 


### PR DESCRIPTION
This PR removes the constant `Datadog::Contrib::Rack::TraceMiddleware::RACK_REQUEST_SPAN` which has been moved to `Datadog::Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN` for quite some time. Both have the same value.

This PR also stops setting `env[:datadog_rack_request_span]`, as this was the original, deprecated environment key for Datadog spans. This key has been moved to `env[Datadog::Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]` for a long time as well.