### PR TITLE
RFC: Add deprecation warning for Ruby 2.1 support

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -107,7 +107,7 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
 |       |                            | 2.4     | Full                                 | Latest              |
 |       |                            | 2.3     | Full                                 | Latest              |
 |       |                            | 2.2     | Full                                 | Latest              |
-|       |                            | 2.1     | Full                                 | Latest              |
+|       |                            | 2.1     | Deprecated                           | < 1.0.0             |
 |       |                            | 2.0     | EOL since June 7th, 2021             | < 0.50.0            |
 |       |                            | 1.9.3   | EOL since August 6th, 2020           | < 0.27.0            |
 |       |                            | 1.9.1   | EOL since August 6th, 2020           | < 0.27.0            |

--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -8,6 +8,7 @@ module Datadog
 
     STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.')
 
+    # Support for Ruby < 2.2 is being phased out and will be dropped in the near future.
     MINIMUM_RUBY_VERSION = '2.1.0'.freeze
 
     # Ruby 3.2 is not supported: Ruby 3.x support as implemented using *args

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -373,6 +373,34 @@ RSpec.describe Datadog::Configuration do
           end
         end
       end
+
+      context 'deprecation warning' do
+        before { described_class.const_get('RUBY_VERSION_DEPRECATION_ONLY_ONCE').send(:reset_ran_once_state_for_tests) }
+
+        after { described_class.const_get('RUBY_VERSION_DEPRECATION_ONLY_ONCE').send(:reset_ran_once_state_for_tests) }
+
+        context 'with a deprecated Ruby version' do
+          before { skip 'Spec only runs on Ruby < 2.2' unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2') }
+
+          it 'emits deprecation warning once' do
+            expect(Datadog.logger).to receive(:warn)
+              .with(/Support for Ruby versions < 2\.2 in dd-trace-rb is DEPRECATED/).once
+
+            test_class.configure
+            test_class.configure
+          end
+        end
+
+        context 'with a supported Ruby version' do
+          before { skip 'Spec only runs on Ruby >= 2.2' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2') }
+
+          it 'emits no warnings' do
+            expect(Datadog.logger).to_not receive(:warn)
+
+            configure
+          end
+        end
+      end
     end
 
     describe '#health_metrics' do


### PR DESCRIPTION
This PR, modelled on #1441, adds a deprecation warning for Ruby 2.1 users of ddtrace.

Ruby 2.1 has not received security updates since the [1st of April, 2017](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/) and we, like the core team, highly recommend upgrading to a later version.

Support for Ruby 2.1 will be dropped in a future release, probably `0.54.0`.

Users are welcome to continue to use `< 1.0.0` for their Ruby 2.1 deployments going forward.

@marcotc @delner thoughts on adding the deprecation warning? We can always decide to keep 2.1 support for 1.0.0 (or later), but having the deprecation warning in sets the stage for us to drop it sometime during Q4/Q1 2022.