### PR TITLE
[fix] rack middleware close trace via body proxy (Rack::CommonLogger compatibility)

### DIFF
--- a/lib/ddtrace/contrib/delayed_job/plugin.rb
+++ b/lib/ddtrace/contrib/delayed_job/plugin.rb
@@ -9,7 +9,7 @@ module Datadog
       # DelayedJob plugin that instruments invoke_job hook
       class Plugin < Delayed::Plugin
         def self.instrument_invoke(job, &block)
-          return block.call(job) unless tracer && tracer.enabled
+          return yield(job) unless tracer && tracer.enabled
 
           tracer.trace(Ext::SPAN_JOB, service: configuration[:service_name], resource: job_name(job),
                                       on_error: configuration[:error_handler]) do |span|
@@ -29,7 +29,7 @@ module Datadog
         end
 
         def self.instrument_enqueue(job, &block)
-          return block.call(job) unless tracer && tracer.enabled
+          return yield(job) unless tracer && tracer.enabled
 
           tracer.trace(Ext::SPAN_ENQUEUE, service: configuration[:client_service_name], resource: job_name(job)) do |span|
             set_sample_rate(span)

--- a/lib/ddtrace/contrib/rack/patcher.rb
+++ b/lib/ddtrace/contrib/rack/patcher.rb
@@ -14,6 +14,7 @@ module Datadog
 
         def patch
           # Patch middleware
+          require 'rack'
           require_relative 'middlewares'
         end
       end

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -101,6 +101,7 @@ module Datadog::Vendor::ActiveRecord::ConnectionHandling::DEFAULT_ENV; end
 module Datadog::Vendor::ActiveRecord::ConnectionHandling::Rails; end
 module EthonSupport::Ethon::Easy; end
 module Rack::Request; end
+module Rack::BodyProxy; end
 module T::CompatibilityPatches::RSpecCompatibility::MethodDoubleExtensions; end
 module T::CompatibilityPatches::RSpecCompatibility::RecorderExtensions; end
 module T::InterfaceWrapper::Helpers; end


### PR DESCRIPTION
# What is the issue?
`Hanami` framework is Rack-based framework. It uses `Rack::CommonLogger` middleware for printing out request/response logs. The issue is, current span/trace is not associated with these logs because `Datadog rack middleware` closes trace too early. If we take a look at [Rack::CommonLogger](https://github.com/rack/rack/blob/master/lib/rack/common_logger.rb#L40) we can observe that `Rack::CommonLogger` uses `Rack::BodyProxy` to guarantee that log is printed only when everything else is done (datadog trace as well) as a result we don't have an `active correlation` in logs formatter.
So I implemented the same approach for closing current span/trace in `Datadog rack middleware`.