### PR TITLE
Fix CI not properly breaking when integration tests failed + Fix a bunch of broken integration tests

### DIFF
--- a/integration/apps/rack/Gemfile
+++ b/integration/apps/rack/Gemfile
@@ -9,7 +9,11 @@ source 'https://rubygems.org' do
   else
     gem 'redis'
   end
-  gem 'sidekiq'
+  if RUBY_VERSION < '2.2'
+    gem 'sidekiq', '< 5' # 5.0.3 checks for older Rubies and breaks, but does not declare it on the gemspec :(
+  else
+    gem 'sidekiq'
+  end
   gem 'resque'
   gem 'rake'
 

--- a/integration/apps/rack/Gemfile
+++ b/integration/apps/rack/Gemfile
@@ -30,4 +30,5 @@ source 'https://rubygems.org' do
 
   gem 'rspec'
   gem 'rspec-wait'
+  gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick
 end

--- a/integration/apps/rack/Gemfile
+++ b/integration/apps/rack/Gemfile
@@ -4,7 +4,11 @@ source 'https://rubygems.org' do
   gem 'puma'
   gem 'unicorn'
   gem 'rack'
-  gem 'redis'
+  if RUBY_VERSION < '2.3'
+    gem 'redis', '< 4.1.1' # 4.1.1 "claims" to support 2.2 but is actually broken
+  else
+    gem 'redis'
+  end
   gem 'sidekiq'
   gem 'resque'
   gem 'rake'

--- a/integration/apps/rack/app/acme.rb
+++ b/integration/apps/rack/app/acme.rb
@@ -90,7 +90,8 @@ module Acme
         ['200', { 'Content-Type' => 'application/json'}, [JSON.pretty_generate(
           webserver_process: $PROGRAM_NAME,
           profiler_available: !!Datadog.profiler,
-          profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') }
+          # NOTE: Threads can't be named on Ruby 2.1 and 2.2
+          profiler_threads: ((Thread.list.map(&:name).select { |it| it && it.include?('Profiling') }) unless RUBY_VERSION < '2.3')
         )], "\n"]
       end
     end

--- a/integration/apps/rack/app/acme.rb
+++ b/integration/apps/rack/app/acme.rb
@@ -90,7 +90,7 @@ module Acme
         ['200', { 'Content-Type' => 'application/json'}, [JSON.pretty_generate(
           webserver_process: $PROGRAM_NAME,
           profiler_available: !!Datadog.profiler,
-          profiler_threads: Thread.list.map(&:name).filter { |it| it && it.include?('Profiling') }
+          profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') }
         )], "\n"]
       end
     end

--- a/integration/apps/rack/app/resque_background_job.rb
+++ b/integration/apps/rack/app/resque_background_job.rb
@@ -2,14 +2,14 @@ require 'redis'
 require 'resque'
 require 'json'
 
-Resque.redis = ENV.fetch('REDIS_URL')
+Resque.redis = Redis.new(url: ENV.fetch('REDIS_URL'), thread_safe: true)
 
 # To exercise resque, this class allows us to write some key and value to redis asynchronously (in a background job)
 # and to read it synchronously (so we can return its value easily in a web request).
 # This way we can simulate the full cycle of submitting something to resque, having it be executed, and its result be
 # observable.
 class ResqueBackgroundJob
-  REDIS = Redis.new(url: ENV.fetch('REDIS_URL'))
+  REDIS = Redis.new(url: ENV.fetch('REDIS_URL'), thread_safe: true)
 
   @queue = :resque_testing
 

--- a/integration/apps/rack/app/resque_background_job.rb
+++ b/integration/apps/rack/app/resque_background_job.rb
@@ -29,7 +29,7 @@ class ResqueBackgroundJob
       value: value,
       resque_process: $PROGRAM_NAME,
       profiler_available: !!Datadog.profiler,
-      profiler_threads: Thread.list.map(&:name).filter { |it| it && it.include?('Profiling') }
+      profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') }
     ))
   end
 end

--- a/integration/apps/rack/app/resque_background_job.rb
+++ b/integration/apps/rack/app/resque_background_job.rb
@@ -29,7 +29,8 @@ class ResqueBackgroundJob
       value: value,
       resque_process: $PROGRAM_NAME,
       profiler_available: !!Datadog.profiler,
-      profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') }
+      # NOTE: Threads can't be named on Ruby 2.1 and 2.2
+      profiler_threads: ((Thread.list.map(&:name).select { |it| it && it.include?('Profiling') }) unless RUBY_VERSION < '2.3')
     ))
   end
 end

--- a/integration/apps/rack/app/sidekiq_background_job.rb
+++ b/integration/apps/rack/app/sidekiq_background_job.rb
@@ -27,7 +27,7 @@ class SidekiqBackgroundJob
       value: value,
       sidekiq_process: $PROGRAM_NAME,
       profiler_available: !!Datadog.profiler,
-      profiler_threads: Thread.list.map(&:name).filter { |it| it && it.include?('Profiling') }
+      profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') }
     ))
   end
 end

--- a/integration/apps/rack/app/sidekiq_background_job.rb
+++ b/integration/apps/rack/app/sidekiq_background_job.rb
@@ -27,7 +27,8 @@ class SidekiqBackgroundJob
       value: value,
       sidekiq_process: $PROGRAM_NAME,
       profiler_available: !!Datadog.profiler,
-      profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') }
+      # NOTE: Threads can't be named on Ruby 2.1 and 2.2
+      profiler_threads: ((Thread.list.map(&:name).select { |it| it && it.include?('Profiling') }) unless RUBY_VERSION < '2.3')
     ))
   end
 end

--- a/integration/apps/rack/app/sidekiq_background_job.rb
+++ b/integration/apps/rack/app/sidekiq_background_job.rb
@@ -9,7 +9,7 @@ require 'json'
 class SidekiqBackgroundJob
   include Sidekiq::Worker
 
-  REDIS = Redis.new(url: ENV.fetch('REDIS_URL'))
+  REDIS = Redis.new(url: ENV.fetch('REDIS_URL'), thread_safe: true)
 
   def self.read(key)
     REDIS.get("sidekiq-background-job-key-#{key}")

--- a/integration/apps/rack/docker-compose.ci.yml
+++ b/integration/apps/rack/docker-compose.ci.yml
@@ -102,6 +102,7 @@ services:
       - resque
       - sidekiq
     environment:
+      - BUNDLE_GEMFILE=/app/Gemfile
       - TEST_HOSTNAME=app
       - TEST_PORT=80
       - TEST_INTEGRATION=true

--- a/integration/apps/rack/script/ci
+++ b/integration/apps/rack/script/ci
@@ -51,7 +51,7 @@ do
   export DD_DEMO_ENV_PROCESS
 
   APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES run integration-tester || \
-    APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES logs # Print container logs on `run` failure
+    (APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES logs && exit -1) # Print container logs on `run` failure
 
   # Cleanup
   APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES down -t 0 --remove-orphans

--- a/integration/apps/rack/spec/integration/basic_spec.rb
+++ b/integration/apps/rack/spec/integration/basic_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe 'Basic scenarios' do
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }
   end
 
+  let(:expected_profiler_threads) do
+    # NOTE: Threads can't be named on Ruby 2.1 and 2.2
+    contain_exactly('Datadog::Profiling::Collectors::Stack', 'Datadog::Profiling::Scheduler') unless RUBY_VERSION < '2.3'
+  end
+
   context 'component checks' do
     subject { get('health/detailed') }
 
@@ -21,7 +26,7 @@ RSpec.describe 'Basic scenarios' do
     it 'should be profiling' do
       expect(json_result).to include(
         profiler_available: true,
-        profiler_threads: contain_exactly('Datadog::Profiling::Collectors::Stack', 'Datadog::Profiling::Scheduler')
+        profiler_threads: expected_profiler_threads,
       )
     end
 
@@ -45,7 +50,7 @@ RSpec.describe 'Basic scenarios' do
         key: key,
         resque_process: match(/resque/),
         profiler_available: true,
-        profiler_threads: contain_exactly('Datadog::Profiling::Collectors::Stack', 'Datadog::Profiling::Scheduler')
+        profiler_threads: expected_profiler_threads,
       )
     end
   end
@@ -65,7 +70,7 @@ RSpec.describe 'Basic scenarios' do
         key: key,
         sidekiq_process: match(/sidekiq/),
         profiler_available: true,
-        profiler_threads: contain_exactly('Datadog::Profiling::Collectors::Stack', 'Datadog::Profiling::Scheduler')
+        profiler_threads: expected_profiler_threads,
       )
     end
   end

--- a/integration/apps/rails-five/app/controllers/health_controller.rb
+++ b/integration/apps/rails-five/app/controllers/health_controller.rb
@@ -13,7 +13,7 @@ class HealthController < ApplicationController
     render json: {
       webserver_process: $PROGRAM_NAME,
       profiler_available: !!Datadog.profiler,
-      profiler_threads: Thread.list.map(&:name).filter { |it| it && it.include?('Profiling') }
+      profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') }
     }
   end
 end

--- a/integration/apps/rails-five/script/ci
+++ b/integration/apps/rails-five/script/ci
@@ -50,7 +50,7 @@ APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES build
 
 # Run the test suite
 APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES run integration-tester || \
-  APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES logs # Print container logs on `run` failure
+  (APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES logs && exit -1) # Print container logs on `run` failure
 
 # Cleanup
 APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES down -t 0 --remove-orphans

--- a/integration/apps/ruby/script/ci
+++ b/integration/apps/ruby/script/ci
@@ -48,7 +48,7 @@ APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES build
 
 # Run the test suite
 APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES run integration-tester || \
-  APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES logs # Print container logs on `run` failure
+  (APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES logs && exit -1) # Print container logs on `run` failure
 
 # Cleanup
 APP_IMAGE=$APP_IMAGE docker-compose $APP_COMPOSE_FILES down -t 0 --remove-orphans

--- a/lib/ddtrace/contrib/delayed_job/plugin.rb
+++ b/lib/ddtrace/contrib/delayed_job/plugin.rb
@@ -9,7 +9,7 @@ module Datadog
       # DelayedJob plugin that instruments invoke_job hook
       class Plugin < Delayed::Plugin
         def self.instrument_invoke(job, &block)
-          return block.call(job) unless tracer && tracer.enabled
+          return yield(job) unless tracer && tracer.enabled
 
           tracer.trace(Ext::SPAN_JOB, service: configuration[:service_name], resource: job_name(job),
                                       on_error: configuration[:error_handler]) do |span|
@@ -29,7 +29,7 @@ module Datadog
         end
 
         def self.instrument_enqueue(job, &block)
-          return block.call(job) unless tracer && tracer.enabled
+          return yield(job) unless tracer && tracer.enabled
 
           tracer.trace(Ext::SPAN_ENQUEUE, service: configuration[:client_service_name], resource: job_name(job)) do |span|
             set_sample_rate(span)


### PR DESCRIPTION
Since #1526 we've been printing the app logs when a failure is triggered, but unfortunately the behavior of using

```some failure || print logs```

breaks the bash `set -euo pipefail` behavior we use that should cause the `ci` test scripts to fail if the underlying command fails.

After I fixed this, I noticed there were a few CI tests that were broken, and fixed them as well. Luckily, the breakages were around test setup, and not (that I could see) any actual issues.