### PR TITLE
Fix dependabot warnings

### DIFF
--- a/integration/apps/rails-five/Gemfile
+++ b/integration/apps/rails-five/Gemfile
@@ -1,7 +1,6 @@
 require 'datadog/demo_env'
 
 source 'https://rubygems.org' do
-  # Framework dependent gems
   # gem 'rails', '5.2.2'
 
   google_protobuf_versions = [
@@ -33,9 +32,7 @@ source 'https://rubygems.org' do
 
   gem 'dogstatsd-ruby'
   gem 'ffi'
-  gem 'google-protobuf', *google_protobuf_versions # Ruby 2.2 compatibility
-  # gem 'rbtrace'
-  # gem 'ruby-prof'
+  gem 'google-protobuf', *google_protobuf_versions
 
   # Fixes conflict with profiling (patch overwrite in Thread)
   # Upgrade this to latest when this patch is merged & released.
@@ -58,8 +55,6 @@ source 'https://rubygems.org' do
   gem 'hawk-auth'
   gem 'httparty'
   gem 'ipaddress'
-  # gem 'i18n', '1.5.1' # Ruby 2.2 compatibility
-  # gem 'newrelic_rpm', platform: :ruby
   gem 'rabl', platform: :ruby
   gem 'rack-cors'
   gem 'rake'
@@ -92,10 +87,6 @@ source 'https://rubygems.org' do
   end
 
   group :test, :development do
-    # gem 'pry-rails', platform: :ruby
-    # gem 'pry-rescue', platform: :ruby
-    # gem 'pry-stack_explorer', platform: :ruby
-    # gem 'pry-byebug', platform: :ruby
     gem 'byebug', platform: :ruby
     gem 'mock_redis', '0.19.0'
     gem 'parallel_tests'

--- a/integration/apps/rails-five/Gemfile
+++ b/integration/apps/rails-five/Gemfile
@@ -13,15 +13,16 @@ source 'https://rubygems.org' do
     '!= 3.8.0.rc.1'
   ]
 
-  # gem 'rack', '2.1.4' # Ruby 2.2 compatibility
-  gem 'actioncable', '5.2.2'
-  gem 'actionmailer', '5.2.2'
-  gem 'actionpack', '5.2.2'
-  gem 'actionview', '5.2.2'
-  gem 'activejob', '5.2.2'
-  gem 'activemodel', '5.2.2'
-  gem 'activerecord', '5.2.2'
-  gem 'railties', '5.2.2'
+  rails_version = ['~> 5.2', '>= 5.2.6']
+
+  gem 'actioncable', *rails_version
+  gem 'actionmailer', *rails_version
+  gem 'actionpack', *rails_version
+  gem 'actionview', *rails_version
+  gem 'activejob', *rails_version
+  gem 'activemodel', *rails_version
+  gem 'activerecord', *rails_version
+  gem 'railties', *rails_version
 
   gem 'mysql2'
   gem 'puma'


### PR DESCRIPTION
Bump Rails dependencies used for integration testing to make dependabot happy.