### PR TITLE
Avoid setting `:exception` on payload object, as it's never used

### DIFF
--- a/lib/ddtrace/contrib/action_pack/action_controller/instrumentation.rb
+++ b/lib/ddtrace/contrib/action_pack/action_controller/instrumentation.rb
@@ -130,7 +130,6 @@ module Datadog
                 result
               # rubocop:disable Lint/RescueException
               rescue Exception => e
-                payload[:exception] = [e.class.name, e.message]
                 payload[:exception_object] = e
                 raise e
               end

--- a/spec/ddtrace/contrib/action_pack/action_controller/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/action_pack/action_controller/instrumentation_spec.rb
@@ -57,12 +57,7 @@ RSpec.describe Datadog::Contrib::ActionPack::ActionController::Instrumentation d
           end
         end
 
-        let(:payload) do
-          super().merge(
-            exception: [error.class.name, error.message],
-            exception_object: error
-          )
-        end
+        let(:payload) { { **super(), exception_object: error } }
 
         before do
           expect(Datadog.logger).to_not receive(:error)


### PR DESCRIPTION
At some point in the past, this seems to have been used, but we no longer reference it anywhere, and instead use `:exception_object` to get the information directly.