### PR TITLE
perf(ci): Adds caching of the git info

### DIFF
--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -58,8 +58,10 @@ module Datadog
             tags = {}
           end
 
+          @local_git_tags ||= extract_local_git
+
           # Fill out tags from local git as fallback
-          extract_local_git.each do |key, value|
+          @local_git_tags.each do |key, value|
             tags[key] ||= value
           end
 
@@ -472,6 +474,10 @@ module Datadog
           end
 
           [nil, name_and_email]
+        end
+
+        def flush_cache
+          @local_git_tags = nil
         end
       end
       # rubocop:enable Metrics/ModuleLength:

--- a/spec/datadog/ci/ext/environment_spec.rb
+++ b/spec/datadog/ci/ext/environment_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe Datadog::CI::Ext::Environment do
       before { allow(Open3).to receive(:capture2e).and_raise(Errno::ENOENT, 'No such file or directory - git') }
     end
 
+    before do
+      described_class.flush_cache
+    end
+
     Dir.glob("#{FIXTURE_DIR}/ci/*.json").sort.each do |filename|
       # Parse each CI provider file
       File.open(filename) do |f|


### PR DESCRIPTION
closes: #1748

This should bring a significant perf improvement, by reusing the git local info an not shell out many git commands repeatedly.

Other approaches would be possible, including caching the `Ext::Environment.tags` [here](https://github.com/flovilmart/dd-trace-rb/blob/perf/git-local/lib/datadog/ci/test.rb#L41) instead