### PR TITLE
Deprecation:Tracer#configure

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2465,7 +2465,7 @@ The underlying Datadog tracer can be configured by passing options (which match 
 
 ```ruby
 # Where `options` is a Hash of options provided to Datadog::Tracer
-OpenTracing.global_tracer = Datadog::OpenTracer::Tracer.new(options)
+OpenTracing.global_tracer = Datadog::OpenTracer::Tracer.new(**options)
 ```
 
 It can also be configured by using `Datadog.configure` described in the [Tracer settings](#tracer-settings) section.

--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -95,7 +95,7 @@ module Datadog
             if settings.tracer.priority_sampling == false
               sampler
             else
-              ensure_priority_sampling(sampler)
+              ensure_priority_sampling(sampler, settings)
             end
           elsif settings.tracer.priority_sampling == false
             Sampling::RuleSampler.new(
@@ -113,13 +113,16 @@ module Datadog
           end
         end
 
-        def ensure_priority_sampling(sampler = nil)
+        def ensure_priority_sampling(sampler, settings)
           if sampler.is_a?(PrioritySampler)
             sampler
           else
             PrioritySampler.new(
               base_sampler: sampler,
-              post_sampler: Sampling::RuleSampler.new
+              post_sampler: Sampling::RuleSampler.new(
+                rate_limit: settings.sampling.rate_limit,
+                default_sample_rate: settings.sampling.default_rate
+              )
             )
           end
         end

--- a/lib/ddtrace/context_flush.rb
+++ b/lib/ddtrace/context_flush.rb
@@ -26,6 +26,8 @@ module Datadog
       # Start flushing partial trace after this many active spans in one trace
       DEFAULT_MIN_SPANS_FOR_PARTIAL_FLUSH = 500
 
+      attr_reader :min_spans_for_partial
+
       def initialize(options = {})
         @min_spans_for_partial = options.fetch(:min_spans_before_partial_flush, DEFAULT_MIN_SPANS_FOR_PARTIAL_FLUSH)
       end

--- a/lib/ddtrace/opentracer/tracer.rb
+++ b/lib/ddtrace/opentracer/tracer.rb
@@ -16,7 +16,7 @@ module Datadog
 
       def initialize(options = {})
         super()
-        @datadog_tracer = Datadog::Tracer.new(options)
+        @datadog_tracer = Datadog::Tracer.new(**options)
       end
 
       # @return [ScopeManager] the current ScopeManager.

--- a/lib/ddtrace/opentracer/tracer.rb
+++ b/lib/ddtrace/opentracer/tracer.rb
@@ -14,7 +14,7 @@ module Datadog
         :datadog_tracer,
         :configure
 
-      def initialize(options = {})
+      def initialize(**options)
         super()
         @datadog_tracer = Datadog::Tracer.new(**options)
       end

--- a/lib/ddtrace/opentracer/tracer.rb
+++ b/lib/ddtrace/opentracer/tracer.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: false
 require 'ddtrace/tracer'
 
 module Datadog

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -374,20 +374,5 @@ module Datadog
       @writer.write(trace)
       trace_completed.publish(trace)
     end
-
-    def activate_priority_sampling!(base_sampler = nil)
-      @sampler = if base_sampler.is_a?(PrioritySampler)
-                   base_sampler
-                 else
-                   PrioritySampler.new(
-                     base_sampler: base_sampler,
-                     post_sampler: Sampling::RuleSampler.new
-                   )
-                 end
-    end
-
-    def deactivate_priority_sampling!(base_sampler = nil)
-      @sampler = base_sampler || Datadog::AllSampler.new if @sampler.is_a?(PrioritySampler)
-    end
   end
 end

--- a/spec/ddtrace/contrib/http/request_spec.rb
+++ b/spec/ddtrace/contrib/http/request_spec.rb
@@ -277,7 +277,6 @@ RSpec.describe 'net/http requests' do
     context 'by default' do
       context 'and the tracer is enabled' do
         before do
-          tracer.configure(enabled: true)
           tracer.trace('foo.bar') do |span|
             span.context.sampling_priority = sampling_priority
             client.get(path)
@@ -314,7 +313,6 @@ RSpec.describe 'net/http requests' do
       # The goal here is to ensure we do not add multiple values for a given header
       context 'with existing distributed tracing headers' do
         before do
-          tracer.configure(enabled: true)
           tracer.trace('foo.bar') do |span|
             span.context.sampling_priority = sampling_priority
 
@@ -357,7 +355,10 @@ RSpec.describe 'net/http requests' do
 
       context 'but the tracer is disabled' do
         before do
-          tracer.configure(enabled: false)
+          Datadog.configure do |c|
+            c.tracer.enabled = false
+          end
+
           client.get(path)
         end
 

--- a/spec/ddtrace/contrib/sidekiq/disabled_tracer_spec.rb
+++ b/spec/ddtrace/contrib/sidekiq/disabled_tracer_spec.rb
@@ -10,9 +10,12 @@ RSpec.describe 'Disabled tracer' do
   let(:job_class) { EmptyWorker }
 
   before do
+    Datadog.configure do |c|
+      c.tracer.enabled = false
+    end
+
     Sidekiq::Testing.server_middleware.clear
     Sidekiq::Testing.server_middleware do |chain|
-      Datadog.tracer.configure(enabled: false)
       chain.add(Datadog::Contrib::Sidekiq::ServerTracer)
     end
   end

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -421,20 +421,16 @@ RSpec.describe 'Tracer integration tests' do
     let(:out) { instance_double(IO) } # Dummy output so we don't pollute STDOUT
 
     before do
-      tracer.configure(
-        enabled: true,
-        priority_sampling: true,
-        writer: writer
-      )
+      Datadog.configure do |c|
+        c.tracer.writer = writer
+      end
 
       # Verify Transport::IO is configured
       expect(tracer.writer.transport).to be_a_kind_of(Datadog::Transport::IO::Client)
       expect(tracer.writer.transport.encoder).to be(Datadog::Encoding::JSONEncoder)
 
       # Verify sampling is configured properly
-      expect(tracer.writer.priority_sampler).to_not be nil
       expect(tracer.sampler).to be_a_kind_of(Datadog::PrioritySampler)
-      expect(tracer.sampler).to be(tracer.writer.priority_sampler)
 
       # Verify IO is written to
       allow(out).to receive(:puts)
@@ -444,7 +440,11 @@ RSpec.describe 'Tracer integration tests' do
     end
 
     # Reset the writer
-    after { tracer.configure(writer: Datadog::Writer.new) }
+    after do
+      Datadog.configure do |c|
+        c.tracer.reset!
+      end
+    end
 
     it do
       3.times do |i|
@@ -473,23 +473,20 @@ RSpec.describe 'Tracer integration tests' do
   describe 'Transport::HTTP' do
     include_context 'agent-based test'
 
-    let(:writer) { Datadog::Writer.new(transport: transport, priority_sampler: Datadog::PrioritySampler.new) }
+    let(:writer) { Datadog::Writer.new(transport: transport) }
     let(:transport) { Datadog::Transport::HTTP.default }
 
     before do
-      tracer.configure(
-        enabled: true,
-        priority_sampling: true,
-        writer: writer
-      )
+      Datadog.configure do |c|
+        c.tracer.priority_sampling = true
+        c.tracer.writer = writer
+      end
 
       # Verify Transport::HTTP is configured
       expect(tracer.writer.transport).to be_a_kind_of(Datadog::Transport::Traces::Transport)
 
       # Verify sampling is configured properly
-      expect(tracer.writer.priority_sampler).to_not be nil
       expect(tracer.sampler).to be_a_kind_of(Datadog::PrioritySampler)
-      expect(tracer.sampler).to be(tracer.writer.priority_sampler)
 
       # Verify priority sampler is configured and rates are updated
       expect(tracer.sampler).to receive(:update)
@@ -522,43 +519,36 @@ RSpec.describe 'Tracer integration tests' do
 
   describe 'tracer transport' do
     subject(:configure) do
-      tracer.configure(
-        priority_sampling: true,
-        agent_settings: agent_settings
-      )
+      Datadog.configure do |c|
+        c.tracer.hostname = hostname
+        c.tracer.port = port
+        c.tracer.priority_sampling = true
+      end
     end
 
-    let(:tracer) { Datadog::Tracer.new }
+    let(:tracer) { Datadog.tracer }
     let(:hostname) { double('hostname') }
     let(:port) { 34567 }
-    let(:settings) { Datadog::Configuration::Settings.new }
-    let(:agent_settings) { Datadog::Configuration::AgentSettingsResolver.call(settings, logger: nil) }
-
-    before do
-      settings.tracer.hostname = hostname
-      settings.tracer.port = port
-    end
 
     context 'when :transport_options' do
       before do
-        settings.tracer.transport_options = transport_options
+        Datadog.configure do |c|
+          c.tracer.transport_options = transport_options
+        end
       end
 
       context 'is a Proc' do
         let(:transport_options) { proc { |t| on_build.call(t) } }
-        let(:on_build) { double('on_build') }
-
-        before do
-          expect(on_build).to receive(:call)
-            .with(kind_of(Datadog::Transport::HTTP::Builder))
+        let(:on_build) do
+          double('on_build').tap do |double|
+            expect(double).to receive(:call)
+              .with(kind_of(Datadog::Transport::HTTP::Builder))
+              .at_least(1)
+          end
         end
 
         it do
           configure
-
-          tracer.writer.tap do |writer|
-            expect(writer.priority_sampler).to be_a_kind_of(Datadog::PrioritySampler)
-          end
 
           tracer.writer.transport.tap do |transport|
             expect(transport).to be_a_kind_of(Datadog::Transport::Traces::Transport)
@@ -581,10 +571,6 @@ RSpec.describe 'Tracer integration tests' do
 
         it do
           configure
-
-          tracer.writer.tap do |writer|
-            expect(writer.priority_sampler).to be_a_kind_of(Datadog::PrioritySampler)
-          end
 
           tracer.writer.transport.tap do |transport|
             expect(transport).to be_a_kind_of(Datadog::Transport::Traces::Transport)

--- a/spec/ddtrace/opentracer/tracer_spec.rb
+++ b/spec/ddtrace/opentracer/tracer_spec.rb
@@ -35,19 +35,6 @@ RSpec.describe Datadog::OpenTracer::Tracer do
     it { is_expected.to be_a_kind_of(Datadog::Tracer) }
   end
 
-  describe '#configure' do
-    subject(:configure) { tracer.configure(options) }
-
-    let(:options) { double('options') }
-
-    before do
-      expect(tracer.datadog_tracer).to receive(:configure)
-        .with(options)
-    end
-
-    it { expect { configure }.to_not raise_error }
-  end
-
   ### Implemented OpenTracing::Tracer behavior ###
 
   describe '#scope_manager' do

--- a/spec/ddtrace/opentracer/tracer_spec.rb
+++ b/spec/ddtrace/opentracer/tracer_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe Datadog::OpenTracer::Tracer do
 
   describe '#initialize' do
     context 'when given options' do
-      subject(:tracer) { described_class.new(options) }
+      subject(:tracer) { described_class.new(**options) }
 
-      let(:options) { double('options') }
+      let(:options) { { enabled: double } }
       let(:datadog_tracer) { double('datadog_tracer') }
 
       before do
         expect(Datadog::Tracer).to receive(:new)
-          .with(options)
+          .with(**options)
           .and_return(datadog_tracer)
       end
 

--- a/spec/ddtrace/sync_writer_spec.rb
+++ b/spec/ddtrace/sync_writer_spec.rb
@@ -110,6 +110,13 @@ RSpec.describe Datadog::SyncWriter do
           .with([unfiltered_trace])
       end
     end
+
+    it 'publishes after_send event' do
+      expect(sync_writer.events.after_send)
+        .to receive(:publish)
+        .with(sync_writer, match_array(be_a(Datadog::Transport::HTTP::Traces::Response)))
+      write
+    end
   end
 
   describe '#stop' do
@@ -121,14 +128,6 @@ RSpec.describe Datadog::SyncWriter do
   describe 'integration' do
     context 'when initializing a tracer' do
       subject(:tracer) { Datadog::Tracer.new(writer: sync_writer) }
-
-      it { expect(tracer.writer).to be sync_writer }
-    end
-
-    context 'when configuring a tracer' do
-      subject(:tracer) { Datadog::Tracer.new }
-
-      before { tracer.configure(writer: sync_writer) }
 
       it { expect(tracer.writer).to be sync_writer }
 

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -26,49 +26,6 @@ RSpec.describe Datadog::Tracer do
     end
   end
 
-  describe '#configure' do
-    context 'by default' do
-      subject!(:configure) { tracer.configure(options) }
-
-      let(:options) { {} }
-
-      it { expect(tracer.context_flush).to be_a(Datadog::ContextFlush::Finished) }
-    end
-
-    context 'with context flush' do
-      subject!(:configure) { tracer.configure(options) }
-
-      let(:options) { { context_flush: context_flush } }
-      let(:context_flush) { instance_double(Datadog::ContextFlush::Finished) }
-
-      it { expect(tracer.context_flush).to be(context_flush) }
-    end
-
-    context 'with partial flushing' do
-      subject!(:configure) { tracer.configure(options) }
-
-      let(:options) { { partial_flush: true } }
-
-      it { expect(tracer.context_flush).to be_a(Datadog::ContextFlush::Partial) }
-    end
-
-    context 'with agent_settings' do
-      subject(:configure) { tracer.configure(options) }
-
-      let(:agent_settings) { double('agent_settings') }
-      let(:options) { { agent_settings: agent_settings } }
-
-      it 'creates a new writer using the given agent_settings' do
-        # create writer first, to avoid colliding with the below expectation
-        writer
-
-        expect(Datadog::Writer).to receive(:new).with(hash_including(agent_settings: agent_settings))
-
-        configure
-      end
-    end
-  end
-
   describe '#tags' do
     subject(:tags) { tracer.tags }
 

--- a/spec/ddtrace/transport/http/integration_spec.rb
+++ b/spec/ddtrace/transport/http/integration_spec.rb
@@ -43,20 +43,6 @@ RSpec.describe 'Datadog::Transport::HTTP integration tests' do
       let(:traces) { get_test_traces(1) }
 
       it { is_expected.to be true }
-
-      context 'with priority sampling' do
-        let(:writer_options) { super().merge!(priority_sampler: sampler) }
-        let(:sampler) { Datadog::PrioritySampler.new }
-
-        # Verify the priority sampler gets updated
-        before do
-          expect(sampler).to receive(:update)
-            .with(kind_of(Hash))
-            .and_call_original
-        end
-
-        it { is_expected.to be true }
-      end
     end
   end
 end

--- a/spec/ddtrace/workers_integration_spec.rb
+++ b/spec/ddtrace/workers_integration_spec.rb
@@ -40,10 +40,11 @@ RSpec.describe 'Datadog::Workers::AsyncTransport integration tests' do
   let(:flush_interval) { 0.1 }
   let(:buffer_size) { 10 }
 
-  let(:tracer) do
-    Datadog::Tracer.new.tap do |t|
-      t.configure(enabled: true, hostname: hostname, port: port)
-      t.writer = writer
+  let(:tracer) { Datadog.tracer }
+
+  before do
+    Datadog.configure do |c|
+      c.tracer.writer = writer
     end
   end
 

--- a/spec/support/tracer_helpers.rb
+++ b/spec/support/tracer_helpers.rb
@@ -18,7 +18,7 @@ module TracerHelpers
     )
 
     options = { writer: writer }.merge(options)
-    Datadog::Tracer.new(options).tap do |tracer|
+    Datadog::Tracer.new(**options).tap do |tracer|
       # TODO: Let's try to get rid of this override, which has too much
       #       knowledge about the internal workings of the tracer.
       #       It is done to prevent the activation of priority sampling
@@ -58,7 +58,7 @@ module TracerHelpers
   # Return a test tracer instance with a faux writer.
   def get_test_tracer_with_old_transport(options = {})
     options = { writer: FauxWriter.new }.merge(options)
-    Datadog::Tracer.new(options).tap do |tracer|
+    Datadog::Tracer.new(**options).tap do |tracer|
       # TODO: Let's try to get rid of this override, which has too much
       #       knowledge about the internal workings of the tracer.
       #       It is done to prevent the activation of priority sampling


### PR DESCRIPTION
This PR deprecates the `Datadog::Tracer#configure` method, which partially reconfigured the live tracer at any point of the host application execution. This flexibility created many complications, as the trace writer and sampler could be changed at any point in time, creating possibility for race conditions in many points of interactions of the internal `ddtrace` components.

The functionality from `Datadog::Tracer#configure` has been migrated to `Datadog::Tracer#new`.
Because `#configure` was invoked in the regular `ddtrace` initialization (at [`Components#build_tracer`](https://github.com/DataDog/dd-trace-rb/blob/148dfaeac9a890d8d9ec4fd74abfd3621869f33c/lib/ddtrace/configuration/components.rb#L71-L76)), there was quite a bit of refactoring to do to consolidate all tracer initialization into `Tracer#new`.

The main changes are the decoupling of the Writer and Sampler initialization from the Tracer class.
In today's state, Writer and Sampler would ideally be their own components as they are fully configurable not strictly dependent on the Tracer. The initialization logic for the Writer and Sampler has been extracted (now living in `Components`), but I deemed promoting them to their own components as out of scope for this PR, given how many changes are already in place here. I left comments in our source code around the future of these components and a rationale for it.

One noteworthy issue that was tackled is the coupling between Writer and Sampler today: the Writer updates the Sampler's service rates, if the sampler is a `PrioritySampler`. This wiring was done by the Tracer, but this has now been extracted: the Writer emits events, to which a subscriber listens to and updates the sampler if needed.

All `ddtrace` behaviour, except for the deprecation of `Tracer#configure`, should remain the same after this change.