### PR TITLE
Refactor:Remove Span#parent= usage in Ethon

### DIFF
--- a/lib/ddtrace/contrib/ethon/multi_patch.rb
+++ b/lib/ddtrace/contrib/ethon/multi_patch.rb
@@ -49,7 +49,9 @@ module Datadog
           end
 
           def datadog_multi_span
-            @datadog_multi_span ||= Datadog.tracer.trace(
+            return @datadog_multi_span if datadog_multi_performing?
+
+            @datadog_multi_span = Datadog.tracer.trace(
               Ext::SPAN_MULTI_REQUEST,
               service: datadog_configuration[:service_name]
             )

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -225,7 +225,7 @@ module Datadog
     # * +resource+: the resource this span refers, or \name if it's missing
     # * +span_type+: the type of the span (such as \http, \db and so on)
     # * +child_of+: a \Span or a \Context instance representing the parent for this span.
-    #   If not set, defaults to Tracer.call_context
+    #   If not set, defaults to Tracer.call_context. If +nil+, a fresh \Context is created.
     # * +tags+: extra tags which should be added to the span.
     def trace(name, options = {}, &block)
       if block

--- a/spec/ddtrace/contrib/ethon/integration_context.rb
+++ b/spec/ddtrace/contrib/ethon/integration_context.rb
@@ -18,7 +18,7 @@ RSpec.shared_context 'integration context' do
     )
 
     server.mount_proc '/' do |req, res|
-      sleep(1) if req.query['simulate_timeout']
+      sleep(0.001) if req.query['simulate_timeout']
       res.status = (req.query['status'] || req.body['status']).to_i
       if req.query['return_headers']
         headers = {}

--- a/spec/ddtrace/contrib/ethon/shared_examples.rb
+++ b/spec/ddtrace/contrib/ethon/shared_examples.rb
@@ -104,6 +104,7 @@ RSpec.shared_examples_for 'instrumented request' do
 
       context 'request timed out' do
         let(:simulate_timeout) { true }
+        let(:timeout) { 0.001 }
 
         before { request }
 
@@ -112,7 +113,11 @@ RSpec.shared_examples_for 'instrumented request' do
         end
 
         it 'has error set' do
-          expect(span).to have_error_message('Request has failed: Timeout was reached')
+          expect(span).to have_error_message(
+            eq("Request has failed: Couldn't connect to server").or( # Connection timeout
+              eq('Request has failed: Timeout was reached') # Response timeout
+            )
+          )
         end
       end
     end

--- a/spec/ddtrace/contrib/ethon/typhoeus_integration_spec.rb
+++ b/spec/ddtrace/contrib/ethon/typhoeus_integration_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Datadog::Contrib::Ethon do
 
     let(:url_1) { "http://#{host}:#{@port}#{path}?status=200&simulate_timeout=true" }
     let(:url_2) { "http://#{host}:#{@port}#{path}" }
-    let(:request_1) { Typhoeus::Request.new(url_1, timeout: timeout) }
+    let(:request_1) { Typhoeus::Request.new(url_1, timeout: 0.001) }
     let(:request_2) { Typhoeus::Request.new(url_2, method: :post, timeout: timeout, body: { status: 404 }) }
 
     subject(:request) do


### PR DESCRIPTION
The last production usage of `Datadog::SpanOperation#parent=` was in the Ethon integration.

That usage was necessary to allow for Ethon Multi request to properly parent their "multi" execution context:
```ruby
multi = Ethon::Multi.new

easy_1 = Ethon::Easy.new
easy_1.http_request(url_1, 'GET')
multi.add(easy_1)

easy_2 = Ethon::Easy.new
easy_2.http_request(url_2, 'GET')
multi.add(easy_2)

multi.perform
```

In this example, both `easy_1` and `easy_2` are children requests for the a `multi` span. But because `easy_1` and `easy_2` run concurrently, both will have an open span at the same time.
The timeline is as follows: `multi` span created, `easy_1` span created, , `easy_2` span created, `easy_1` span finished, `easy_2` span finished, `multi` span finished. ("`easy_1` span finished" and "`easy_2` span finished" can swap places depending on how long each request takes to execute)

So when "`easy_2` span created" the currently open span is `easy_1`, `easy_2` will be the child of `easy_1`, which is not correct.

To address that, today we perform `easy_2_span.parent = multi_span` after the `easy_2` span is created.
This PR changes that to `child_of: multi_span` on the `Tracer#trace` span creation call for `easy_2`.

There are no changes in behaviour in this PR.

All testing related changes were only introduced to reduce the testing time from 18 seconds to 1.5 seconds for the Ethon suite. (Reverting these testing changes will still yield a successful test run)