### PR TITLE
Deprecate:Writer services

### DIFF
--- a/lib/ddtrace/sync_writer.rb
+++ b/lib/ddtrace/sync_writer.rb
@@ -12,8 +12,6 @@ module Datadog
   # the separate `datadog-lambda` uses it as of February 2021:
   # <https://github.com/DataDog/datadog-lambda-rb/blob/c15f0f0916c90123416dc44e7d6800ef4a7cfdbf/lib/datadog/lambda.rb#L38>
   class SyncWriter
-    DEPRECATION_WARN_ONLY_ONCE = Datadog::Utils::OnlyOnce.new
-
     attr_reader \
       :priority_sampler,
       :transport
@@ -28,16 +26,7 @@ module Datadog
       @priority_sampler = options.fetch(:priority_sampler, nil)
     end
 
-    def write(trace, services = nil)
-      unless services.nil?
-        DEPRECATION_WARN_ONLY_ONCE.run do
-          Datadog.logger.warn(%(
-            write: Writing services has been deprecated and no longer need to be provided.
-            write(traces, services) can be updated to write(traces)
-          ))
-        end
-      end
-
+    def write(trace)
       flush_trace(trace)
     rescue => e
       Datadog.logger.debug(e)

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -15,8 +15,6 @@ require 'ddtrace/utils/only_once'
 module Datadog
   # Processor that sends traces and metadata to the agent
   class Writer
-    DEPRECATION_WARN_ONLY_ONCE = Datadog::Utils::OnlyOnce.new
-
     attr_reader \
       :priority_sampler,
       :transport,
@@ -132,16 +130,7 @@ module Datadog
     end
 
     # enqueue the trace for submission to the API
-    def write(trace, services = nil)
-      unless services.nil?
-        DEPRECATION_WARN_ONLY_ONCE.run do
-          Datadog.logger.warn(%(
-            write: Writing services has been deprecated and no longer need to be provided.
-            write(traces, services) can be updated to write(traces)
-          ))
-        end
-      end
-
+    def write(trace)
       # In multiprocess environments, the main process initializes the +Writer+ instance and if
       # the process forks (i.e. a web server like Unicorn or Puma with multiple workers) the new
       # processes will share the same +Writer+ until the first write (COW). Because of that,

--- a/spec/ddtrace/sync_writer_spec.rb
+++ b/spec/ddtrace/sync_writer_spec.rb
@@ -30,10 +30,9 @@ RSpec.describe Datadog::SyncWriter do
   end
 
   describe '#write' do
-    subject(:write) { sync_writer.write(trace, services) }
+    subject(:write) { sync_writer.write(trace) }
 
     let(:trace) { get_test_traces(1).first }
-    let(:services) { nil }
 
     context 'with trace' do
       before { write }

--- a/spec/ddtrace/writer_spec.rb
+++ b/spec/ddtrace/writer_spec.rb
@@ -272,10 +272,9 @@ RSpec.describe Datadog::Writer do
       end
 
       describe '#write' do
-        subject(:write) { writer.write(trace, services) }
+        subject(:write) { writer.write(trace) }
 
         let(:trace) { instance_double(Array) }
-        let(:services) { nil }
 
         before do
           allow(Datadog.configuration.runtime_metrics)


### PR DESCRIPTION
Services had to be explicitly provided to the trace writer (`Datadog::Writer#write(..., services)`) in order to be instrumented. This has long been unnecessary, and `services` options has been ignored since then.

This PR removes the `services` argument from `Datadog::Writer#write` and `Datadog::SyncWriter#write`.