### PR TITLE
Deprecate:Contrib::Configuration#registry

### DIFF
--- a/lib/ddtrace/contrib/extensions.rb
+++ b/lib/ddtrace/contrib/extensions.rb
@@ -74,25 +74,6 @@ module Datadog
         module Settings
           InvalidIntegrationError = Class.new(StandardError)
 
-          # The registry only holds declarative constant values and cannot be modified.
-          # This option is a no-op and will be removed in the future.
-          #
-          # @deprecated Use `Datadog.registry` instead
-          def registry
-            Datadog.logger.warn('Deprecated access to `Datadog.configuration.registry`, use `Datadog.registry` instead.' \
-                                '`Datadog.configuration.registry` will be removed in a future version.')
-            Contrib::REGISTRY
-          end
-
-          # The registry only holds declarative constant values and cannot be modified.
-          # This option is a no-op and will be removed in the future.
-          #
-          # @deprecated The registry is now a global constant, and can't be overwritten.
-          def registry=(_arg)
-            Datadog.logger.warn('Setting a custom registry is no longer supported and was ignored. ' \
-                                'Remove this assignment from your configuration to stop seeing this warning.')
-          end
-
           # For the provided `integration_name`, resolves a matching configuration
           # for the provided integration from an integration-specific `key`.
           #

--- a/spec/ddtrace/contrib/extensions_spec.rb
+++ b/spec/ddtrace/contrib/extensions_spec.rb
@@ -73,25 +73,6 @@ RSpec.describe Datadog::Contrib::Extensions do
 
       before { stub_const('Datadog::Contrib::REGISTRY', registry) }
 
-      describe '.registry' do
-        it 'return global REGISTRY on deprecated access' do
-          expect(Datadog.logger).to receive(:warn).with(/Deprecated access to `Datadog.configuration.registry`/)
-
-          expect(settings.registry).to be(Datadog::Contrib::REGISTRY)
-        end
-      end
-
-      describe '.registry=' do
-        it 'to not change registry on deprecated assignment attempt' do
-          expect(Datadog.logger).to receive(:warn).with(/no longer supported and was ignored/)
-
-          settings.registry = double('Overriding registry')
-
-          allow(Datadog.logger).to receive(:warn)
-          expect(settings.registry).to be(Datadog::Contrib::REGISTRY)
-        end
-      end
-
       describe '#[]' do
         context 'when the integration doesn\'t exist' do
           it do


### PR DESCRIPTION
The integration registry has been moved from the configurable `Datadog.configuration.registry` to the global, append-only `Datadog.registry` in #1572.

With this move we deprecated access to `Datadog.configuration.registry` and `Datadog.configuration.registry=`. This PR removes those deprecated APIs. `Datadog.registry` is the recommended replacement.