### PR TITLE
Deprecate:Unreachable methods in MongoDB integration

### DIFF
--- a/lib/ddtrace/contrib/mongodb/parsers.rb
+++ b/lib/ddtrace/contrib/mongodb/parsers.rb
@@ -29,34 +29,6 @@ module Datadog
         base_info.merge(Quantization::Hash.format(command, options))
       end
 
-      # removes the values from the given query; this quantization recursively
-      # replace elements available in a given query, so that Arrays, Hashes and so
-      # on are compacted. It ensures a low cardinality so that it can be used
-      # as a Span resource.
-      # @deprecated
-      def quantize_statement(statement, skip = [])
-        case statement
-        when Hash
-          statement.each_with_object({}) do |(key, value), quantized|
-            quantized[key] = quantize_value(value, skip) unless skip.include?(key)
-          end
-        else
-          quantize_value(statement, skip)
-        end
-      end
-
-      # @deprecated
-      def quantize_value(value, skip = [])
-        case value
-        when Hash
-          quantize_statement(value, skip)
-        when Array
-          quantize_value(value.first, skip)
-        else
-          PLACEHOLDER
-        end
-      end
-
       def quantization_options
         Datadog::Quantization::Hash.merge_options(DEFAULT_OPTIONS, configuration[:quantize])
       end


### PR DESCRIPTION
These methods have been unused since https://github.com/DataDog/dd-trace-rb/pull/463.
They only reference each other.