### PR TITLE
Remove maximum resque version support

### DIFF
--- a/lib/ddtrace/contrib/resque/integration.rb
+++ b/lib/ddtrace/contrib/resque/integration.rb
@@ -11,8 +11,6 @@ module Datadog
         include Contrib::Integration
 
         MINIMUM_VERSION = Gem::Version.new('1.0')
-        # Maximum is first version it's NOT compatible with (not inclusive)
-        MAXIMUM_VERSION = Gem::Version.new('3.0')
 
         register_as :resque, auto_patch: true
 
@@ -25,9 +23,7 @@ module Datadog
         end
 
         def self.compatible?
-          super \
-            && version >= MINIMUM_VERSION \
-            && version < MAXIMUM_VERSION
+          super && version >= MINIMUM_VERSION
         end
 
         def default_configuration

--- a/spec/ddtrace/contrib/resque/integration_spec.rb
+++ b/spec/ddtrace/contrib/resque/integration_spec.rb
@@ -51,11 +51,6 @@ RSpec.describe Datadog::Contrib::Resque::Integration do
         include_context 'loaded gems', resque: described_class::MINIMUM_VERSION
         it { is_expected.to be true }
       end
-
-      context 'that exceeds the maximum version' do
-        include_context 'loaded gems', resque: described_class::MAXIMUM_VERSION
-        it { is_expected.to be false }
-      end
     end
 
     context 'when gem is not loaded' do


### PR DESCRIPTION
The maximum version limit of 3.0 was mistakenly added in #1213.
Since we support the latest Resque versions (https://rubygems.org/gems/resque/versions), there's no reason to limit the supported version to an upper bound, as we are not aware of any incompatibilities with future Resque versions.