### PR TITLE
Memoize environment tags to improve performance

### DIFF
--- a/lib/datadog/ci/test.rb
+++ b/lib/datadog/ci/test.rb
@@ -38,7 +38,10 @@ module Datadog
         span.context.origin = Ext::Test::CONTEXT_ORIGIN if span.context
         Datadog::Contrib::Analytics.set_measured(span)
         span.set_tag(Ext::Test::TAG_SPAN_KIND, Ext::AppTypes::TEST)
-        Ext::Environment.tags(ENV).each { |k, v| span.set_tag(k, v) }
+
+        # Set environment tags
+        @environment_tags ||= Ext::Environment.tags(ENV)
+        @environment_tags.each { |k, v| span.set_tag(k, v) }
 
         # Set contextual tags
         span.set_tag(Ext::Test::TAG_FRAMEWORK, tags[:framework]) if tags[:framework]


### PR DESCRIPTION
Fixes #1748

Environment tags do not change during the life of the test process, so we should calculate them only once.