### PR TITLE
Drop truffleruby-head testing

### DIFF
--- a/.github/workflows/test-head.yaml
+++ b/.github/workflows/test-head.yaml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [head, jruby-head, truffleruby-head]
+        ruby: [head, jruby-head]
     runs-on: ubuntu-latest
     env:
       SKIP_SIMPLECOV: 1


### PR DESCRIPTION
Unfortunately the CI output right now needs to be binary: pass, or fail. Because we don't want to block contributions due to some breakage in truffleruby-head, we set the CI to `continue-on-error: true` aka never fail.

But then we miss that truffleruby-head has been broken for quite some time. And even now that we know it, we won't be doing anything about it, since it's not a priority.

So... this testing doesn't seem to be adding any value. Thus, I propose that we delete it.

Hopefully, in the near future, we'll be able to add a stable truffleruby release to CI, and keep that one green (and care about when it breaks). See #1383 for ongoing tracking for this.