### PR TITLE
Generate Span object from SpanOperation

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -327,9 +327,8 @@ To trace these operations, you can trace code asynchronously by calling `Datadog
 ```ruby
 # Some instrumentation framework calls this after an event finishes...
 def db_query(start, finish, query)
-  span = Datadog.tracer.trace('database.query')
+  span = Datadog.tracer.trace('database.query', start_time: start)
   span.resource = query
-  span.start_time = start
   span.finish(finish)
 end
 ```

--- a/lib/ddtrace/manual_tracing.rb
+++ b/lib/ddtrace/manual_tracing.rb
@@ -5,14 +5,16 @@ module Datadog
   # Defines analytics behavior
   module ManualTracing
     class << self
+      # TODO: Assumes it will have access to the context from the span.
+      #       This won't be true in the future. Will need to change this.
       def keep(span_op)
-        return if span_op.nil? || span_op.context.nil?
+        return if span_op.nil? || !span_op.respond_to?(:context) || span_op.context.nil?
 
         span_op.context.sampling_priority = Datadog::Ext::Priority::USER_KEEP
       end
 
       def drop(span_op)
-        return if span_op.nil? || span_op.context.nil?
+        return if span_op.nil? || !span_op.respond_to?(:context) || span_op.context.nil?
 
         span_op.context.sampling_priority = Datadog::Ext::Priority::USER_REJECT
       end

--- a/lib/ddtrace/opentelemetry/extensions.rb
+++ b/lib/ddtrace/opentelemetry/extensions.rb
@@ -7,7 +7,7 @@ module Datadog
     # Defines extensions to ddtrace for OpenTelemetry support
     module Extensions
       def self.extended(base)
-        Datadog::Span.prepend(OpenTelemetry::Span)
+        Datadog::SpanOperation.prepend(OpenTelemetry::Span)
       end
     end
   end

--- a/lib/ddtrace/pipeline.rb
+++ b/lib/ddtrace/pipeline.rb
@@ -30,6 +30,8 @@ module Datadog
 
     def self.apply_processors!(trace)
       result = @processors.inject(trace) do |current_trace, processor|
+        next nil if current_trace.nil?
+
         processor.call(current_trace)
       end
 

--- a/lib/ddtrace/span_operation.rb
+++ b/lib/ddtrace/span_operation.rb
@@ -1,97 +1,107 @@
 require 'forwardable'
+require 'time'
 
 require 'datadog/core/environment/identity'
-require 'ddtrace/ext/analytics'
 require 'ddtrace/ext/manual_tracing'
+require 'ddtrace/ext/errors'
 require 'ddtrace/ext/runtime'
 
 require 'ddtrace/span'
-require 'ddtrace/analytics'
-require 'ddtrace/manual_tracing'
+require 'ddtrace/tagging'
+require 'ddtrace/utils'
 
 module Datadog
   # Represents the act of taking a span measurement.
   # It gives a Span a context which can be used to
-  # manage and decorate the Span.
-  # When completed, it yields the Span.
+  # build a Span. When completed, it yields the Span.
+  #
+  # rubocop:disable Metrics/ClassLength
   class SpanOperation
-    extend Forwardable
+    include Tagging
 
-    FORWARDED_METHODS = [
-      :allocations,
-      :clear_metric,
-      :clear_tag,
-      :duration,
-      :duration=,
-      :end_time,
-      :end_time=,
-      :get_metric,
-      :get_tag,
-      :name,
-      :name=,
-      :parent_id,
-      :parent_id=,
-      :pretty_print,
-      :resource,
-      :resource=,
-      :sampled,
-      :sampled=,
-      :service,
-      :service=,
-      :set_error,
-      :set_metric,
-      :set_tag,
-      :set_tags,
-      :span_id,
-      :span_id=,
-      :span_type,
-      :span_type=,
-      :start_time,
-      :start_time=,
-      :started?,
-      :status,
-      :status=,
-      :stop,
-      :stopped?,
-      :to_hash,
-      :to_json,
-      :to_msgpack,
-      :to_s,
-      :trace_id,
-      :trace_id=
-    ].to_set.freeze
-
+    # Span attributes
+    # NOTE: In the future, we should drop the me
     attr_reader \
-      :events,
-      :parent
+      :end_time,
+      :id,
+      :parent_id,
+      :start_time,
+      :trace_id
 
+    attr_accessor \
+      :name,
+      :resource,
+      :sampled,
+      :service,
+      :type,
+      :status
+
+    # For backwards compatiblity
+    # TODO: Deprecate and remove these.
+    alias :span_id :id
+    alias :span_type :type
+    alias :span_type= :type=
+
+    # SpanOperation attributes
+    # TODO: Deprecate use of #parent.
+    #       Instrumentation should not inspect trace structure,
+    #       or rely upon a parent span; it might get mutated or finished.
+    #       This attribute is provided for backwards compatibility only.
     # TODO: Deprecate use of #context.
     #       Context should be accessed from the tracer.
     #       This attribute is provided for backwards compatibility only.
-    attr_accessor \
-      :context,
-      :span
+    attr_reader \
+      :parent,
+      :context
 
-    # Forward instance methods to Span except ones that would cause identity issues
-    def_delegators :span, *FORWARDED_METHODS
-
-    def initialize(span_name, options = {})
+    # TODO: Remove span_type
+    def initialize(
+      name,
+      child_of: nil,
+      context: nil,
+      parent_id: 0,
+      resource: name,
+      service: nil,
+      span_type: nil,
+      start_time: nil,
+      tags: nil,
+      trace_id: nil,
+      type: span_type
+    )
       # Resolve service name
-      parent = options[:child_of]
-      options[:service] ||= parent.service unless parent.nil?
+      parent = child_of
+      service ||= parent.service unless parent.nil?
 
-      # Build span options
-      span_options = {}
-      span_options[:parent_id] = options[:parent_id] if options.key?(:parent_id)
-      span_options[:resource] = options[:resource] if options.key?(:resource)
-      span_options[:service] = options[:service] if options.key?(:service)
-      span_options[:span_type] = options[:span_type] if options.key?(:span_type)
-      span_options[:tags] = options[:tags] if options.key?(:tags)
-      span_options[:trace_id] = options[:trace_id] if options.key?(:trace_id)
+      # Set span attributes
+      @name = name
+      @service = service
+      @resource = resource
+      @type = type
 
-      @span = Span.new(span_name, **span_options)
-      @context = options[:context]
-      @events = options[:events] || Events.new
+      @id = Utils.next_id
+      @parent_id = parent_id || 0
+      @trace_id = trace_id || Utils.next_id
+
+      @status = 0
+      @sampled = true
+
+      @allocation_count_start = now_allocations
+      @allocation_count_stop = @allocation_count_start
+
+      # start_time and end_time track wall clock. In Ruby, wall clock
+      # has less accuracy than monotonic clock, so if possible we look to only use wall clock
+      # to measure duration when a time is supplied by the user, or if monotonic clock
+      # is unsupported.
+      @start_time = nil
+      @end_time = nil
+
+      # duration_start and duration_end track monotonic clock, and may remain nil in cases where it
+      # is known that we have to use wall clock to measure duration.
+      @duration_start = nil
+      @duration_end = nil
+
+      # Set tags if provided.
+      set_tags(tags) if tags
 
       if parent.nil?
         # Root span: set default tags.
@@ -103,6 +113,14 @@ module Datadog
         # IDs if it's a distributed trace w/o a parent span.
         self.parent = parent
       end
+
+      # Some other SpanOperation-specific behavior
+      @context = context
+      @events = events || Events.new
+      @span = nil
+
+      # Start the span with start time, if given.
+      start(start_time) if start_time
     end
 
     def measure
@@ -133,13 +151,17 @@ module Datadog
       # It's not a problem since we re-raise it afterwards so for example a
       # SignalException::Interrupt would still bubble up.
       rescue Exception => e
-        # We must finish the span to trigger callbacks.
+        # Stop the span first, so timing is a more accurate.
         # If the span failed to start, timing may be inaccurate,
         # but this is not really a serious concern.
-        finish
+        stop
 
         # Trigger the on_error event
         events.on_error.publish(self, e)
+
+        # We must finish the span to trigger callbacks,
+        # and build the final span.
+        finish
 
         raise e
       # Use an ensure block here to make sure the span closes.
@@ -159,49 +181,163 @@ module Datadog
       # Don't overwrite the start time of a started span.
       return self if started?
 
+      # If time provided, set it but don't trigger
+      # "before_start" as the span has already started.
+      if start_time
+        @start_time = start_time
+        return self
+      end
+
       # Trigger before_start event
       events.before_start.publish(self)
 
       # Start the span
-      span.start(start_time)
+      @start_time = Utils::Time.now.utc
+      @duration_start = duration_marker
+
+      self
+    end
+
+    # Mark the span stopped at the current time
+    def stop(stop_time = nil)
+      # A span should not be stopped twice. Note that this is not thread-safe,
+      # stop is called from multiple threads, a given span might be stopped
+      # several times. Again, one should not do this, so this test is more a
+      # fallback to avoid very bad things and protect you in most common cases.
+      return if stopped?
+
+      @allocation_count_stop = now_allocations
+
+      now = Utils::Time.now.utc
+
+      # Provide a default start_time if unset.
+      # Using `now` here causes duration to be 0; this is expected
+      # behavior when start_time is unknown.
+      start(stop_time || now) unless started?
+
+      @end_time = stop_time || now
+      @duration_end = stop_time.nil? ? duration_marker : nil
+
+      # Trigger after_stop event
+      events.after_stop.publish(self)
+
+      self
+    end
+
+    # Return whether the duration is started or not
+    def started?
+      !@start_time.nil?
+    end
+
+    # Return whether the duration is stopped or not.
+    def stopped?
+      !@end_time.nil?
+    end
+
+    # for backwards compatibility
+    def start_time=(time)
+      time.tap { start(time) }
+    end
+
+    # for backwards compatibility
+    def end_time=(time)
+      time.tap { stop(time) }
     end
 
     def finish(end_time = nil)
+      # Returned memoized span if already finished
       return span if finished?
 
-      # Stop the span
-      span.stop(end_time)
+      # Stop timing
+      stop(end_time)
+
+      # Build span
+      # Memoize for performance reasons
+      @span = build_span
 
       # Trigger after_finish event
-      events.after_finish.publish(self)
+      events.after_finish.publish(span, self)
 
       span
     end
 
     def finished?
-      span.stopped?
+      !span.nil?
     end
 
-    # Set this span's parent, inheriting any properties not explicitly set.
-    # If the parent is nil, set the span as the root span.
-    #
-    # DEV: This method creates a false expectation that
-    # `self.parent.span_id == self.parent_id`, which is not the case
-    # for distributed traces, as the parent Span object does not exist
-    # in this application. `#parent_id` is the only reliable parent
-    # identifier. We should remove the ability to set a parent Span
-    # object in the future.
-    def parent=(parent)
-      @parent = parent
+    def duration
+      return @duration_end - @duration_start if @duration_start && @duration_end
+      return @end_time - @start_time if @start_time && @end_time
+    end
 
-      if parent.nil?
-        span.trace_id = span.span_id
-        span.parent_id = 0
-      else
-        span.trace_id = parent.trace_id
-        span.parent_id = parent.span_id
-        span.service ||= parent.service
-        span.sampled = parent.sampled
+    def allocations
+      @allocation_count_stop - @allocation_count_start
+    end
+
+    def set_error(e)
+      @status = Datadog::Ext::Errors::STATUS
+      super
+    end
+
+    # Return a string representation of the span.
+    def to_s
+      "SpanOperation(name:#{@name},sid:#{@id},tid:#{@trace_id},pid:#{@parent_id})"
+    end
+
+    # Return the hash representation of the current span.
+    def to_hash
+      h = {
+        allocations: allocations,
+        error: @status,
+        id: @id,
+        meta: meta,
+        metrics: metrics,
+        name: @name,
+        parent_id: @parent_id,
+        resource: @resource,
+        service: @service,
+        trace_id: @trace_id,
+        type: @type
+      }
+
+      if stopped?
+        h[:start] = start_time_nano
+        h[:duration] = duration_nano
+      end
+
+      h
+    end
+
+    # Return a human readable version of the span
+    def pretty_print(q)
+      start_time = (self.start_time.to_f * 1e9).to_i
+      end_time = (self.end_time.to_f * 1e9).to_i
+      q.group 0 do
+        q.breakable
+        q.text "Name: #{@name}\n"
+        q.text "Span ID: #{@id}\n"
+        q.text "Parent ID: #{@parent_id}\n"
+        q.text "Trace ID: #{@trace_id}\n"
+        q.text "Type: #{@type}\n"
+        q.text "Service: #{@service}\n"
+        q.text "Resource: #{@resource}\n"
+        q.text "Error: #{@status}\n"
+        q.text "Start: #{start_time}\n"
+        q.text "End: #{end_time}\n"
+        q.text "Duration: #{duration.to_f if stopped?}\n"
+        q.text "Allocations: #{allocations}\n"
+        q.group(2, 'Tags: [', "]\n") do
+          q.breakable
+          q.seplist meta.each do |key, value|
+            q.text "#{key} => #{value}"
+          end
+        end
+        q.group(2, 'Metrics: [', ']') do
+          q.breakable
+          q.seplist metrics.each do |key, value|
+            q.text "#{key} => #{value}"
+          end
+        end
       end
     end
 
@@ -211,11 +347,13 @@ module Datadog
 
       attr_reader \
         :after_finish,
+        :after_stop,
         :before_start,
         :on_error
 
       def initialize
         @after_finish = AfterFinish.new
+        @after_stop = AfterStop.new
         @before_start = BeforeStart.new
         @on_error = OnError.new
 
@@ -227,6 +365,13 @@ module Datadog
       class AfterFinish < Datadog::Event
         def initialize
           super(:after_finish)
+        end
+      end
+
+      # Triggered when the span is stopped, regardless of error.
+      class AfterStop < Datadog::Event
+        def initialize
+          super(:after_stop)
         end
       end
 
@@ -245,48 +390,101 @@ module Datadog
       end
     end
 
-    # Defines analytics behavior
-    module Analytics
-      def set_tag(key, value)
-        case key
-        when Ext::Analytics::TAG_ENABLED
-          # If true, set rate to 1.0, otherwise set 0.0.
-          value = value == true ? Ext::Analytics::DEFAULT_SAMPLE_RATE : 0.0
-          Datadog::Analytics.set_sample_rate(self, value)
-        when Ext::Analytics::TAG_SAMPLE_RATE
-          Datadog::Analytics.set_sample_rate(self, value)
-        else
-          super if defined?(super)
-        end
-      end
-    end
-
-    # Defines forced tracing behavior
-    module ManualTracing
-      def set_tag(key, value)
-        # Configure sampling priority if they give us a forced tracing tag
-        # DEV: Do not set if the value they give us is explicitly "false"
-        case key
-        when Ext::ManualTracing::TAG_KEEP
-          Datadog::ManualTracing.keep(self) unless value == false
-        when Ext::ManualTracing::TAG_DROP
-          Datadog::ManualTracing.drop(self) unless value == false
-        else
-          # Otherwise, set the tag normally.
-          super if defined?(super)
-        end
-      end
-    end
-
-    # Additional extensions
-    prepend Analytics
-    prepend ManualTracing
-
     # Error when the span attempts to start again after being started
     class AlreadyStartedError < StandardError
       def message
         'Cannot measure an already started span!'.freeze
       end
     end
+
+    private
+
+    # Keep span reference private: we don't want users
+    # modifying the finalized span from the operation after
+    # it has been finished.
+    attr_reader \
+      :span,
+      :events
+
+    attr_writer \
+      :context
+
+    # Create a Span from the operation which represents
+    # the finalized measurement. We #dup here to prevent
+    # mutation by reference; when this span is returned,
+    # we don't want this SpanOperation to modify it further.
+    def build_span
+      Span.new(
+        @name && @name.dup,
+        allocations: allocations,
+        duration: duration,
+        end_time: @end_time,
+        id: @id,
+        meta: meta && meta.dup,
+        metrics: metrics && metrics.dup,
+        parent_id: @parent_id,
+        resource: @resource && @resource.dup,
+        sampled: @sampled,
+        service: @service && @service.dup,
+        start_time: @start_time,
+        status: @status,
+        type: @type && @type.dup,
+        trace_id: @trace_id
+      )
+    end
+
+    # Set this span's parent, inheriting any properties not explicitly set.
+    # If the parent is nil, set the span as the root span.
+    #
+    # DEV: This method creates a false expectation that
+    # `self.parent.id == self.parent_id`, which is not the case
+    # for distributed traces, as the parent Span object does not exist
+    # in this application. `#parent_id` is the only reliable parent
+    # identifier. We should remove the ability to set a parent Span
+    # object in the future.
+    def parent=(parent)
+      @parent = parent
+
+      if parent.nil?
+        @trace_id = @id
+        @parent_id = 0
+      else
+        @trace_id = parent.trace_id
+        @parent_id = parent.id
+        @service ||= parent.service
+        @sampled = parent.sampled
+      end
+    end
+
+    def duration_marker
+      Utils::Time.get_time
+    end
+
+    # Used for serialization
+    # @return [Integer] in nanoseconds since Epoch
+    def start_time_nano
+      @start_time.to_i * 1000000000 + @start_time.nsec
+    end
+
+    # Used for serialization
+    # @return [Integer] in nanoseconds since Epoch
+    def duration_nano
+      (duration * 1e9).to_i
+    end
+
+    if defined?(JRUBY_VERSION) || Gem::Version.new(RUBY_VERSION) < Gem::Version.new(VERSION::MINIMUM_RUBY_VERSION)
+      def now_allocations
+        0
+      end
+    elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.0')
+      def now_allocations
+        GC.stat.fetch(:total_allocated_object)
+      end
+    else
+      def now_allocations
+        GC.stat(:total_allocated_objects)
+      end
+    end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/ddtrace/sync_writer.rb
+++ b/lib/ddtrace/sync_writer.rb
@@ -1,4 +1,5 @@
 # typed: true
+require 'ddtrace/pipeline'
 require 'ddtrace/ext/net'
 require 'datadog/core/environment/socket'
 require 'ddtrace/runtime/metrics'

--- a/lib/ddtrace/tagging.rb
+++ b/lib/ddtrace/tagging.rb
@@ -1,0 +1,16 @@
+require 'ddtrace/tagging/analytics'
+require 'ddtrace/tagging/manual_tracing'
+require 'ddtrace/tagging/metadata'
+
+module Datadog
+  # Adds common tagging behavior
+  module Tagging
+    def self.included(base)
+      base.include(Tagging::Metadata)
+
+      # Additional extensions
+      base.prepend(Tagging::Analytics)
+      base.prepend(Tagging::ManualTracing)
+    end
+  end
+end

--- a/lib/ddtrace/tagging/analytics.rb
+++ b/lib/ddtrace/tagging/analytics.rb
@@ -1,0 +1,22 @@
+require 'ddtrace/ext/analytics'
+require 'ddtrace/analytics'
+
+module Datadog
+  module Tagging
+    # Defines analytics tagging behavior
+    module Analytics
+      def set_tag(key, value)
+        case key
+        when Ext::Analytics::TAG_ENABLED
+          # If true, set rate to 1.0, otherwise set 0.0.
+          value = value == true ? Ext::Analytics::DEFAULT_SAMPLE_RATE : 0.0
+          Datadog::Analytics.set_sample_rate(self, value)
+        when Ext::Analytics::TAG_SAMPLE_RATE
+          Datadog::Analytics.set_sample_rate(self, value)
+        else
+          super if defined?(super)
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/tagging/manual_tracing.rb
+++ b/lib/ddtrace/tagging/manual_tracing.rb
@@ -1,0 +1,23 @@
+require 'ddtrace/ext/manual_tracing'
+require 'ddtrace/manual_tracing'
+
+module Datadog
+  module Tagging
+    # Defines manual tracing tag behavior
+    module ManualTracing
+      def set_tag(key, value)
+        # Configure sampling priority if they give us a forced tracing tag
+        # DEV: Do not set if the value they give us is explicitly "false"
+        case key
+        when Ext::ManualTracing::TAG_KEEP
+          Datadog::ManualTracing.keep(self) unless value == false
+        when Ext::ManualTracing::TAG_DROP
+          Datadog::ManualTracing.drop(self) unless value == false
+        else
+          # Otherwise, set the tag normally.
+          super if defined?(super)
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/tagging/metadata.rb
+++ b/lib/ddtrace/tagging/metadata.rb
@@ -92,7 +92,6 @@ module Datadog
       def set_error(e)
         e = Error.build_from(e)
 
-        @status = Ext::Errors::STATUS # TODO: Move this to Span/SpanOperation?
         set_tag(Ext::Errors::TYPE, e.type) unless e.type.empty?
         set_tag(Ext::Errors::MSG, e.message) unless e.message.empty?
         set_tag(Ext::Errors::STACK, e.backtrace) unless e.backtrace.empty?

--- a/lib/ddtrace/tagging/metadata.rb
+++ b/lib/ddtrace/tagging/metadata.rb
@@ -1,0 +1,112 @@
+require 'ddtrace/ext/distributed'
+require 'ddtrace/ext/errors'
+require 'ddtrace/ext/http'
+require 'ddtrace/ext/net'
+
+module Datadog
+  module Tagging
+    # Adds metadata & metric tag behavior
+    module Metadata
+      # This limit is for numeric tags because uint64 could end up rounded.
+      NUMERIC_TAG_SIZE_RANGE = (-1 << 53..1 << 53).freeze
+
+      # Some associated values should always be sent as Tags, never as Metrics, regardless
+      # if their value is numeric or not.
+      # The Datadog agent will look for these values only as Tags, not Metrics.
+      # @see https://github.com/DataDog/datadog-agent/blob/2ae2cdd315bcda53166dd8fa0dedcfc448087b9d/pkg/trace/stats/aggregation.go#L13-L17
+      ENSURE_AGENT_TAGS = {
+        Ext::DistributedTracing::ORIGIN_KEY => true,
+        Ext::Environment::TAG_VERSION => true,
+        Ext::HTTP::STATUS_CODE => true,
+        Ext::NET::TAG_HOSTNAME => true
+      }.freeze
+      # Return the tag with the given key, nil if it doesn't exist.
+      def get_tag(key)
+        meta[key] || metrics[key]
+      end
+
+      # Set the given key / value tag pair on the span. Keys and values
+      # must be strings. A valid example is:
+      #
+      #   span.set_tag('http.method', request.method)
+      def set_tag(key, value = nil)
+        # Keys must be unique between tags and metrics
+        metrics.delete(key)
+
+        # DEV: This is necessary because the agent looks at `meta[key]`, not `metrics[key]`.
+        value = value.to_s if ENSURE_AGENT_TAGS[key]
+
+        # NOTE: Adding numeric tags as metrics is stop-gap support
+        #       for numeric typed tags. Eventually they will become
+        #       tags again.
+        # Any numeric that is not an integer greater than max size is logged as a metric.
+        # Everything else gets logged as a tag.
+        if value.is_a?(Numeric) && !(value.is_a?(Integer) && !NUMERIC_TAG_SIZE_RANGE.cover?(value))
+          set_metric(key, value)
+        else
+          meta[key] = value.to_s
+        end
+      rescue StandardError => e
+        Datadog.logger.debug("Unable to set the tag #{key}, ignoring it. Caused by: #{e}")
+      end
+
+      # Sets tags from given hash, for each key in hash it sets the tag with that key
+      # and associated value from the hash. It is shortcut for `set_tag`. Keys and values
+      # of the hash must be strings. Note that nested hashes are not supported.
+      # A valid example is:
+      #
+      #   span.set_tags({ "http.method" => "GET", "user.id" => "234" })
+      def set_tags(tags)
+        tags.each { |k, v| set_tag(k, v) }
+      end
+
+      # This method removes a tag for the given key.
+      def clear_tag(key)
+        meta.delete(key)
+      end
+
+      # Return the metric with the given key, nil if it doesn't exist.
+      def get_metric(key)
+        metrics[key] || meta[key]
+      end
+
+      # This method sets a tag with a floating point value for the given key. It acts
+      # like `set_tag()` and it simply add a tag without further processing.
+      def set_metric(key, value)
+        # Keys must be unique between tags and metrics
+        meta.delete(key)
+
+        # enforce that the value is a floating point number
+        value = Float(value)
+        metrics[key] = value
+      rescue StandardError => e
+        Datadog.logger.debug("Unable to set the metric #{key}, ignoring it. Caused by: #{e}")
+      end
+
+      # This method removes a metric for the given key. It acts like {#remove_tag}.
+      def clear_metric(key)
+        metrics.delete(key)
+      end
+
+      # Mark the span with the given error.
+      def set_error(e)
+        e = Error.build_from(e)
+
+        @status = Ext::Errors::STATUS # TODO: Move this to Span/SpanOperation?
+        set_tag(Ext::Errors::TYPE, e.type) unless e.type.empty?
+        set_tag(Ext::Errors::MSG, e.message) unless e.message.empty?
+        set_tag(Ext::Errors::STACK, e.backtrace) unless e.backtrace.empty?
+      end
+
+      protected
+
+      def meta
+        @meta ||= {}
+      end
+
+      def metrics
+        @metrics ||= {}
+      end
+    end
+  end
+end

--- a/spec/ddtrace/context_flush_spec.rb
+++ b/spec/ddtrace/context_flush_spec.rb
@@ -8,7 +8,7 @@ RSpec.shared_context 'trace context' do
 
   let(:get) { [trace, sampled] }
   let(:sampled) { true }
-  let(:trace) { [double] }
+  let(:trace) { [instance_double(Array)] }
 end
 
 RSpec.shared_examples_for 'a context flusher' do
@@ -59,14 +59,14 @@ RSpec.describe Datadog::ContextFlush::Partial do
       before { allow(context).to receive(:finished_span_count).and_return(finished_span_count) }
 
       context 'with fewer than the minimum required spans' do
-        let(:finished_spans) { [double] }
+        let(:finished_spans) { [instance_double(Datadog::Span)] }
 
         it { is_expected.to be_nil }
       end
 
       context 'with at least the minimum required spans' do
         context 'with spans available' do
-          let(:finished_spans) { [double, double] }
+          let(:finished_spans) { [instance_double(Datadog::Span), instance_double(Datadog::Span)] }
 
           before do
             allow(context).to receive(:delete_span_if) do |&block|

--- a/spec/ddtrace/contrib/ethon/easy_patch_spec.rb
+++ b/spec/ddtrace/contrib/ethon/easy_patch_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Datadog::Contrib::Ethon::EasyPatch do
     end
 
     it_behaves_like 'span' do
-      let(:span) { span_op.span }
+      let(:span) { span_op }
       before { subject }
 
       let(:method) { 'N/A' }
@@ -100,7 +100,7 @@ RSpec.describe Datadog::Contrib::Ethon::EasyPatch do
     end
 
     it_behaves_like 'analytics for integration' do
-      let(:span) { span_op.span }
+      let(:span) { span_op }
       before { subject }
 
       let(:analytics_enabled_var) { Datadog::Contrib::Ethon::Ext::ENV_ANALYTICS_ENABLED }
@@ -108,7 +108,7 @@ RSpec.describe Datadog::Contrib::Ethon::EasyPatch do
     end
 
     it_behaves_like 'measured span for integration', false do
-      let(:span) { span_op.span }
+      let(:span) { span_op }
       before { subject }
     end
   end

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -354,7 +354,7 @@ RSpec.describe 'Tracer integration tests' do
       end
 
       it do
-        metric_value = parent_span.get_metric(
+        metric_value = parent_span.send(:span).get_metric(
           Datadog::Ext::DistributedTracing::SAMPLING_PRIORITY_KEY
         )
 
@@ -368,7 +368,7 @@ RSpec.describe 'Tracer integration tests' do
     let(:tracer) { get_test_tracer }
 
     context 'when #sampling_priority is set on a parent span' do
-      subject(:tag_value) { parent_span.get_tag(Datadog::Ext::DistributedTracing::ORIGIN_KEY) }
+      subject(:tag_value) { parent_span.send(:span).get_tag(Datadog::Ext::DistributedTracing::ORIGIN_KEY) }
 
       let(:parent_span) { tracer.start_span('parent span') }
 

--- a/spec/ddtrace/opentelemetry/span_spec.rb
+++ b/spec/ddtrace/opentelemetry/span_spec.rb
@@ -6,9 +6,9 @@ require 'ddtrace/opentelemetry/span'
 
 RSpec.describe Datadog::OpenTelemetry::Span do
   context 'when implemented in Datadog::Span' do
-    before { expect(Datadog::Span <= described_class).to be true }
+    before { expect(Datadog::SpanOperation <= described_class).to be true }
 
-    subject(:span) { Datadog::Span.new(name) }
+    subject(:span) { Datadog::SpanOperation.new(name) }
 
     let(:tracer) { instance_double(Datadog::Tracer) }
     let(:name) { 'opentelemetry.span' }

--- a/spec/ddtrace/opentracer/span_spec.rb
+++ b/spec/ddtrace/opentracer/span_spec.rb
@@ -6,7 +6,7 @@ require 'ddtrace/opentracer'
 RSpec.describe Datadog::OpenTracer::Span do
   subject(:span) { described_class.new(datadog_span: datadog_span, span_context: span_context) }
 
-  let(:datadog_span) { instance_double(Datadog::Span) }
+  let(:datadog_span) { instance_double(Datadog::SpanOperation) }
   let(:span_context) { instance_double(Datadog::OpenTracer::SpanContext) }
 
   describe '#operation_name=' do

--- a/spec/ddtrace/pipeline_spec.rb
+++ b/spec/ddtrace/pipeline_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe Datadog::Pipeline do
   let(:span_d) { generate_span('d') }
   let(:span_list) { [span_a, span_b, span_c, span_d] }
   let(:callable) { ->(trace) { trace } }
-  let(:custom_callable_conditional) { ->(trace) { trace if trace.size == 3 } }
-  let(:custom_callable_reverse) { ->(trace) { trace.reverse } }
 
   after do
     described_class.processors = []
@@ -79,9 +77,23 @@ RSpec.describe Datadog::Pipeline do
     end
 
     context 'with a custom callable' do
+      let(:custom_callable_conditional) { ->(trace) { trace if trace.size == 3 } }
+      let(:custom_callable_reverse) { ->(trace) { trace.reverse } }
+
+      let(:traces) do
+        [
+          [span_a],
+          [
+            span_b,
+            span_c,
+            span_d
+          ]
+        ]
+      end
+
       it 'applies custom callable to each trace' do
         subject.before_flush(custom_callable_conditional, custom_callable_reverse)
-        expect(subject.process!([[1], [1, 2], [1, 2, 3]])).to eq([[3, 2, 1]])
+        expect(subject.process!(traces)).to eq([traces[1].reverse])
       end
     end
   end

--- a/spec/ddtrace/span_operation_spec.rb
+++ b/spec/ddtrace/span_operation_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'ddtrace/span_operation'
 
 RSpec.describe Datadog::SpanOperation do
-  subject(:span_op) { described_class.new(name, options) }
+  subject(:span_op) { described_class.new(name, **options) }
   let(:name) { 'my.operation' }
   let(:options) { {} }
 
@@ -13,10 +13,6 @@ RSpec.describe Datadog::SpanOperation do
         parent_id: 0,
         parent: nil,
       )
-
-      # Because we maintain parallel "parent" state between
-      # Span and Span Operation, ensure this matches.
-      expect(span_op.span).to be_root_span
     end
 
     it 'has default tags' do
@@ -32,10 +28,6 @@ RSpec.describe Datadog::SpanOperation do
         parent_id: parent.span_id,
         trace_id: parent.trace_id
       )
-
-      # Because we maintain parallel "parent" state between
-      # Span and Span Operation, ensure this matches.
-      expect(span_op.span.parent_id).to be(parent.span.span_id)
     end
   end
 
@@ -50,104 +42,75 @@ RSpec.describe Datadog::SpanOperation do
     # rubocop:enable RSpec/VerifiedDoubles
 
     before do
+      events = span_op.send(:events)
+
       # after_finish
       allow(callback_spy).to receive(:after_finish)
-      span_op.events.after_finish.subscribe(:test) do |op|
-        callback_spy.after_finish(op)
+      events.after_finish.subscribe(:test) do |*args|
+        callback_spy.after_finish(*args)
+      end
+
+      # after_stop
+      allow(callback_spy).to receive(:after_stop)
+      events.after_stop.subscribe(:test) do |*args|
+        callback_spy.after_stop(*args)
       end
 
       # before_start
       allow(callback_spy).to receive(:before_start)
-      span_op.events.before_start.subscribe(:test) do |op|
-        callback_spy.before_start(op)
+      events.before_start.subscribe(:test) do |*args|
+        callback_spy.before_start(*args)
       end
 
       # on_error
       allow(callback_spy).to receive(:on_error)
-      span_op.events.on_error.subscribe(:test) do |op, e|
-        callback_spy.on_error(op, e)
+      events.on_error.subscribe(:test) do |*args|
+        callback_spy.on_error(*args)
       end
-    end
-  end
-
-  describe 'forwarded methods' do
-    [
-      :allocations,
-      :clear_metric,
-      :clear_tag,
-      :duration,
-      :duration=,
-      :end_time,
-      :end_time=,
-      :get_metric,
-      :get_tag,
-      :name,
-      :name=,
-      :parent_id,
-      :parent_id=,
-      :pretty_print,
-      :resource,
-      :resource=,
-      :sampled,
-      :sampled=,
-      :service,
-      :service=,
-      :set_error,
-      :set_metric,
-      :set_tag,
-      :set_tags,
-      :span_id,
-      :span_id=,
-      :span_type,
-      :span_type=,
-      :start_time,
-      :start_time=,
-      :started?,
-      :status,
-      :status=,
-      :stop,
-      :stopped?,
-      :to_hash,
-      :to_json,
-      :to_msgpack,
-      :to_s,
-      :trace_id,
-      :trace_id=
-    ].each do |forwarded_method|
-      # rubocop:disable RSpec/VerifiedDoubles
-      context "##{forwarded_method}" do
-        let!(:args) { Array.new(arg_count < 0 ? 0 : arg_count) { double('arg') } }
-        let!(:arg_count) { span_op.span.method(forwarded_method).arity }
-
-        it 'forwards to the Span' do
-          expect(span_op.span).to receive(forwarded_method).with(any_args)
-          span_op.send(forwarded_method, *args)
-        end
-      end
-      # rubocop:enable RSpec/VerifiedDoubles
     end
   end
 
   describe '::new' do
     context 'given only a name' do
-      it do
+      it 'has default attributes' do
         is_expected.to have_attributes(
           context: nil,
           end_time: nil,
-          events: kind_of(described_class::Events),
-          finished?: false,
+          id: kind_of(Integer),
           name: name,
+          parent_id: 0,
           resource: name,
           sampled: true,
           service: nil,
-          span_id: kind_of(Integer),
-          span_type: nil,
-          span: kind_of(Datadog::Span),
           start_time: nil,
-          started?: false,
-          stopped?: false,
+          status: 0,
           trace_id: kind_of(Integer),
+          type: nil
         )
+      end
+
+      it 'has default behavior' do
+        is_expected.to have_attributes(
+          allocations: 0,
+          duration: nil,
+          finished?: false,
+          started?: false,
+          stopped?: false
+        )
+      end
+
+      it 'aliases #span_id' do
+        expect(span_op.id).to eq(span_op.span_id)
+      end
+
+      it 'aliases #span_type' do
+        expect(span_op.type).to eq(span_op.span_type)
+      end
+
+      it 'aliases #span_type= to #type=' do
+        span_type = 'foo'
+        span_op.span_type = 'foo'
+        expect(span_op.type).to eq(span_type)
       end
 
       it_behaves_like 'a root span operation'
@@ -211,20 +174,6 @@ RSpec.describe Datadog::SpanOperation do
           it 'associates with the Context' do
             is_expected.to have_attributes(context: context)
           end
-        end
-      end
-
-      describe ':events' do
-        let(:options) { { events: events } }
-
-        context 'that is nil' do
-          let(:events) { nil }
-          it { is_expected.to have_attributes(events: kind_of(described_class::Events)) }
-        end
-
-        context "that is a #{described_class}::Events" do
-          let(:events) { instance_double(described_class::Events) }
-          it { is_expected.to have_attributes(events: events) }
         end
       end
 
@@ -318,6 +267,21 @@ RSpec.describe Datadog::SpanOperation do
         end
       end
 
+      describe ':start_time' do
+        let(:options) { { start_time: start_time } }
+        let(:start_time) { instance_double(Time) }
+
+        context 'that is nil' do
+          let(:start_time) { nil }
+          it { is_expected.to have_attributes(start_time: nil) }
+        end
+
+        context 'that is a Time' do
+          let(:start_time) { instance_double(Time) }
+          it { is_expected.to have_attributes(start_time: start_time) }
+        end
+      end
+
       describe ':tags' do
         let(:options) { { tags: tags } }
 
@@ -381,6 +345,26 @@ RSpec.describe Datadog::SpanOperation do
           it { is_expected.to have_attributes(trace_id: trace_id) }
         end
       end
+
+      describe ':type' do
+        let(:options) { { type: type } }
+        let(:type) { instance_double(String) }
+
+        context 'that is nil' do
+          let(:type) { nil }
+          it { is_expected.to have_attributes(type: nil) }
+
+          context 'but :span_type is given' do
+            let(:options) { { type: nil, span_type: type } }
+            it { is_expected.to have_attributes(type: type) }
+          end
+        end
+
+        context 'that is a String' do
+          let(:type) { instance_double(String) }
+          it { is_expected.to have_attributes(type: type) }
+        end
+      end
     end
   end
 
@@ -436,8 +420,9 @@ RSpec.describe Datadog::SpanOperation do
         before { measure }
 
         it do
-          expect(callback_spy).to have_received(:before_start).with(span_op)
-          expect(callback_spy).to have_received(:after_finish).with(span_op)
+          expect(callback_spy).to have_received(:before_start).with(span_op).ordered
+          expect(callback_spy).to have_received(:after_stop).with(span_op).ordered
+          expect(callback_spy).to have_received(:after_finish).with(kind_of(Datadog::Span), span_op).ordered
           expect(callback_spy).to_not have_received(:on_error)
         end
       end
@@ -461,83 +446,6 @@ RSpec.describe Datadog::SpanOperation do
     context 'when the operation has already been finished' do
       before { span_op.finish }
       it { expect { measure }.to raise_error(Datadog::SpanOperation::AlreadyStartedError) }
-    end
-
-    context 'when the operation raises a StandardError while starting' do
-      include_context 'a StandardError'
-
-      before do
-        allow(span_op).to receive(:start).and_raise(error)
-        expect(Datadog.logger).to receive(:debug).with(/Failed to start span/)
-      end
-
-      it do
-        is_expected.to be return_value
-
-        # This scenario is unlikely, but if it occurs
-        # expect it to be finished. The timing will be inaccurate,
-        # but we need to guarantee the finish event is called.
-        expect(span_op.started?).to be true
-        expect(span_op.finished?).to be true
-        expect(span_op.start_time).to_not be nil
-        expect(span_op.end_time).to_not be nil
-
-        # Technically not an error status, because the operation didn't
-        # cause the error, the tracing did. This doesn't count.
-        expect(span_op.status).to eq(0)
-      end
-
-      context 'and callbacks have been configured' do
-        include_context 'callbacks'
-
-        before { measure }
-
-        it do
-          expect(callback_spy).to_not have_received(:before_start)
-          expect(callback_spy).to have_received(:after_finish).with(span_op)
-          expect(callback_spy).to_not have_received(:on_error)
-        end
-      end
-    end
-
-    context 'when the operation raises an Exception while starting' do
-      include_context 'an Exception'
-
-      before do
-        allow(span_op).to receive(:start).and_raise(error)
-
-        # This won't catch exceptions and log them
-        expect(Datadog.logger).to_not receive(:debug).with(/Failed to start span/)
-      end
-
-      it do
-        expect { measure }.to raise_error(error)
-
-        # This scenario is unlikely, but if it occurs
-        # expect it to be finished. The timing will be inaccurate,
-        # but we need to guarantee the finish event is called.
-        expect(span_op.started?).to be true
-        expect(span_op.finished?).to be true
-        expect(span_op.start_time).to_not be nil
-        expect(span_op.end_time).to_not be nil
-
-        # Although this is technically during tracing, not operation,
-        # an exception is probably aborting the program. It's fine if
-        # this is marked as an error.
-        expect(span_op.status).to eq(1)
-      end
-
-      context 'and callbacks have been configured' do
-        include_context 'callbacks'
-
-        before { expect { measure }.to raise_error(error) }
-
-        it do
-          expect(callback_spy).to_not have_received(:before_start)
-          expect(callback_spy).to have_received(:after_finish).with(span_op)
-          expect(callback_spy).to have_received(:on_error).with(span_op, error)
-        end
-      end
     end
 
     context 'when a StandardError is raised during the operation' do
@@ -564,9 +472,10 @@ RSpec.describe Datadog::SpanOperation do
         before { expect { measure }.to raise_error(error) }
 
         it do
-          expect(callback_spy).to have_received(:before_start).with(span_op)
-          expect(callback_spy).to have_received(:after_finish).with(span_op)
-          expect(callback_spy).to have_received(:on_error).with(span_op, error)
+          expect(callback_spy).to have_received(:before_start).with(span_op).ordered
+          expect(callback_spy).to have_received(:after_stop).with(span_op).ordered
+          expect(callback_spy).to have_received(:on_error).with(span_op, error).ordered
+          expect(callback_spy).to have_received(:after_finish).with(kind_of(Datadog::Span), span_op).ordered
         end
       end
     end
@@ -595,9 +504,10 @@ RSpec.describe Datadog::SpanOperation do
         before { expect { measure }.to raise_error(error) }
 
         it do
-          expect(callback_spy).to have_received(:before_start).with(span_op)
-          expect(callback_spy).to have_received(:after_finish).with(span_op)
-          expect(callback_spy).to have_received(:on_error).with(span_op, error)
+          expect(callback_spy).to have_received(:before_start).with(span_op).ordered
+          expect(callback_spy).to have_received(:after_stop).with(span_op).ordered
+          expect(callback_spy).to have_received(:on_error).with(span_op, error).ordered
+          expect(callback_spy).to have_received(:after_finish).with(kind_of(Datadog::Span), span_op).ordered
         end
       end
     end
@@ -635,9 +545,21 @@ RSpec.describe Datadog::SpanOperation do
 
     context 'given a Time' do
       subject(:start) { span_op.start(start_time) }
+      let(:start_time) { Datadog::Utils::Time.now.utc }
 
-      it_behaves_like 'started span' do
-        let(:start_time) { Datadog::Utils::Time.now.utc }
+      it { expect { start }.to change { span_op.start_time }.from(nil).to(start_time) }
+      # Because span is still running, duration is unavailable.
+      it { expect { start }.to_not(change { span_op.duration }) }
+
+      context 'then #stop' do
+        before { start }
+        it { expect { span_op.stop }.to change { span_op.duration }.from(nil).to(kind_of(Float)) }
+      end
+
+      context 'and callbacks have been configured' do
+        include_context 'callbacks'
+        before { start }
+        it { expect(callback_spy).to_not have_received(:before_start) }
       end
     end
 
@@ -671,7 +593,123 @@ RSpec.describe Datadog::SpanOperation do
     end
   end
 
+  describe '#stop' do
+    subject(:stop) { span_op.stop }
+
+    shared_examples 'stopped span' do
+      let(:end_time) { kind_of(Time) }
+
+      context 'which wasn\'t already started' do
+        it { expect { stop }.to change { span_op.start_time }.from(nil).to(end_time) }
+        it { expect { stop }.to change { span_op.end_time }.from(nil).to(end_time) }
+        it { expect { stop }.to change { span_op.duration }.from(nil).to(kind_of(Float)) }
+
+        it { expect { stop }.to change { span_op.started? }.from(false).to(true) }
+        it { expect { stop }.to change { span_op.stopped? }.from(false).to(true) }
+        it { expect { stop }.to_not change { span_op.finished? }.from(false) }
+
+        context 'and callbacks have been configured' do
+          include_context 'callbacks'
+          before { stop }
+          it do
+            expect(callback_spy).to have_received(:after_stop).with(span_op)
+            expect(callback_spy).to_not have_received(:before_start)
+            expect(callback_spy).to_not have_received(:after_finish)
+          end
+        end
+      end
+
+      context 'when already started' do
+        let!(:start_time) { span_op.start_time = Time.now }
+
+        it { expect { stop }.to_not change { span_op.start_time }.from(start_time) }
+        it { expect { stop }.to change { span_op.end_time }.from(nil).to(end_time) }
+        it { expect { stop }.to change { span_op.duration }.from(nil).to(kind_of(Float)) }
+
+        it { expect { stop }.to_not change { span_op.started? }.from(true) }
+        it { expect { stop }.to change { span_op.stopped? }.from(false).to(true) }
+        it { expect { stop }.to_not change { span_op.finished? }.from(false) }
+
+        context 'and callbacks have been configured' do
+          include_context 'callbacks'
+          before { stop }
+          it do
+            expect(callback_spy).to have_received(:after_stop).with(span_op)
+            expect(callback_spy).to_not have_received(:before_start)
+            expect(callback_spy).to_not have_received(:after_finish)
+          end
+        end
+      end
+
+      context 'when already stopped' do
+        let!(:original_end_time) { span_op.end_time = Time.now }
+
+        it { expect { stop }.to_not change { span_op.start_time }.from(original_end_time) }
+        it { expect { stop }.to_not change { span_op.end_time }.from(original_end_time) }
+        it { expect { stop }.to_not change { span_op.duration }.from(0) }
+
+        it { expect { stop }.to_not change { span_op.started? }.from(true) }
+        it { expect { stop }.to_not change { span_op.stopped? }.from(true) }
+        it { expect { stop }.to_not change { span_op.finished? }.from(false) }
+
+        context 'and callbacks have been configured' do
+          include_context 'callbacks'
+          before { stop }
+          it do
+            expect(callback_spy).to_not have_received(:after_stop)
+            expect(callback_spy).to_not have_received(:before_start)
+            expect(callback_spy).to_not have_received(:after_finish)
+          end
+        end
+      end
+    end
+
+    context 'given nothing' do
+      subject(:stop) { span_op.stop }
+      it_behaves_like 'stopped span'
+    end
+
+    context 'given nil' do
+      subject(:stop) { span_op.stop(nil) }
+      it_behaves_like 'stopped span'
+    end
+
+    context 'given a Time' do
+      subject(:stop) { span_op.stop(end_time) }
+
+      it_behaves_like 'stopped span' do
+        let(:end_time) { Datadog::Utils::Time.now.utc }
+      end
+    end
+  end
+
+  describe '#started?' do
+    subject(:started?) { span_op.started? }
+
+    context 'when span hasn\'t been started or stopped' do
+      it { is_expected.to be false }
+    end
+
+    it { expect { span_op.start }.to change { span_op.started? }.from(false).to(true) }
+    it { expect { span_op.stop }.to change { span_op.started? }.from(false).to(true) }
+    it { expect { span_op.finish }.to change { span_op.started? }.from(false).to(true) }
+  end
+
+  describe '#stopped?' do
+    subject(:stopped?) { span_op.stopped? }
+
+    context 'when span hasn\'t been started or stopped' do
+      it { is_expected.to be false }
+    end
+
+    it { expect { span_op.start }.to_not change { span_op.stopped? }.from(false) }
+    it { expect { span_op.stop }.to change { span_op.stopped? }.from(false).to(true) }
+    it { expect { span_op.finish }.to change { span_op.stopped? }.from(false).to(true) }
+  end
+
   describe '#finish' do
+    subject(:finish) { span_op.finish }
+
     shared_examples 'finished span' do
       let(:end_time) { kind_of(Time) }
 
@@ -681,7 +719,10 @@ RSpec.describe Datadog::SpanOperation do
       context 'and callbacks have been configured' do
         include_context 'callbacks'
         before { finish }
-        it { expect(callback_spy).to have_received(:after_finish).with(span_op) }
+        it do
+          expect(callback_spy).to have_received(:after_stop).with(span_op).ordered
+          expect(callback_spy).to have_received(:after_finish).with(kind_of(Datadog::Span), span_op).ordered
+        end
       end
     end
 
@@ -709,25 +750,26 @@ RSpec.describe Datadog::SpanOperation do
     end
 
     context 'when not started' do
-      subject(:finish) { span_op.finish }
-
       it { expect { finish }.to change { span_op.end_time }.from(nil).to(kind_of(Time)) }
       it { expect { finish }.to change { span_op.duration }.from(nil).to(0) }
     end
 
     context 'when already finished' do
-      subject(:finish) { span_op.finish }
-
       let!(:original_end_time) do
         span_op.start
-        span_op.finish
+        @original_span = span_op.finish
         span_op.end_time
       end
+      let(:original_span) { @original_span }
 
       it 'does not overwrite the previous end time' do
         expect(original_end_time).to_not be nil
         expect { finish }.to_not change { span_op.end_time }.from(original_end_time)
-        is_expected.to be(span_op.span)
+      end
+
+      # Expect Span to be memoized
+      it 'returns the same Span object' do
+        expect(span_op.finish).to be(original_span)
       end
     end
   end
@@ -750,50 +792,162 @@ RSpec.describe Datadog::SpanOperation do
     end
   end
 
-  context 'parent=' do
-    subject(:set_parent) { span_op.parent = parent }
+  describe '#duration' do
+    subject(:duration) { span_op.duration }
 
-    context 'to a span' do
-      let(:parent) { described_class.new('parent', **parent_span_options) }
-      let(:parent_span_options) { {} }
+    let(:duration_wall_time) { 0.0001 }
+
+    context 'without start or end time provided' do
+      let(:static_time) { Time.utc(2010, 9, 15, 22, 3, 15) }
 
       before do
-        parent.sampled = false
-        set_parent
+        # We set the same time no matter what.
+        # If duration is greater than zero but start_time == end_time, we can
+        # be sure we're using the monotonic time.
+        allow(Datadog::Utils::Time).to receive(:now)
+          .and_return(static_time)
       end
 
-      it do
-        expect(span_op.parent).to eq(parent)
-        expect(span_op.parent_id).to eq(parent.span_id)
-        expect(span_op.trace_id).to eq(parent.trace_id)
-        expect(span_op.sampled).to eq(false)
-      end
+      it { is_expected.to be nil }
 
-      context 'with service' do
-        let(:parent_span_options) { { service: 'parent' } }
-
-        it 'copies parent service to child' do
-          expect(span_op.service).to eq('parent')
+      context 'when started then stopped' do
+        before do
+          span_op.start
+          sleep(0.0002)
+          span_op.stop
         end
 
-        context 'with existing child service' do
-          let(:options) { { service: 'child' } }
-
-          it 'does not override child service' do
-            expect(span_op.service).to eq('child')
-          end
+        it 'uses monotonic time' do
+          expect((duration.to_f * 1e9).to_i).to be > 0
+          expect(span_op.end_time).to eq static_time
+          expect(span_op.start_time).to eq static_time
+          expect(span_op.end_time - span_op.start_time).to eq 0
         end
       end
     end
 
-    context 'to nil' do
-      let(:parent) { nil }
+    context 'with start_time provided' do
+      # set a start time considerably longer than span duration
+      # set a day in the past and then measure duration is longer than
+      # amount of time slept, which would represent monotonic
+      let!(:start_time) { Time.now - (duration_wall_time * 1e9) }
 
-      it 'removes the parent' do
-        set_parent
-        expect(span_op.parent).to be_nil
-        expect(span_op.parent_id).to be_zero
-        expect(span_op.trace_id).to eq(span_op.span_id)
+      it 'does not use monotonic time' do
+        span_op.start(start_time)
+        sleep(duration_wall_time)
+        span_op.stop
+
+        expect(duration).to be_within(1).of(duration_wall_time * 1e9)
+      end
+
+      context 'and end_time provided' do
+        let(:end_time) { start_time + 123.456 }
+
+        it 'respects the exact times provided' do
+          span_op.start(start_time)
+          sleep(duration_wall_time)
+          span_op.stop(end_time)
+
+          expect(duration).to eq(123.456)
+        end
+      end
+    end
+
+    context 'with end_time provided' do
+      # set an end time considerably ahead of than span duration
+      # set a day in the future and then measure duration is longer than
+      # amount of time slept, which would represent monotonic
+      let!(:end_time) { Time.now + (duration_wall_time * 1e9) }
+
+      it 'does not use monotonic time' do
+        span_op.start
+        sleep(duration_wall_time)
+        span_op.stop(end_time)
+
+        expect(duration).to be_within(1).of(duration_wall_time * 1e9)
+      end
+    end
+
+    context 'with time_provider set' do
+      before do
+        now = time_now # Expose variable to closure
+        Datadog.configure do |c|
+          c.time_now_provider = -> { now }
+        end
+      end
+
+      after { without_warnings { Datadog.configuration.reset! } }
+
+      let(:time_now) { ::Time.utc(2020, 1, 1) }
+
+      it 'sets the start time to the provider time' do
+        span_op.start
+        span_op.stop
+
+        expect(span_op.start_time).to eq(time_now)
+      end
+    end
+  end
+
+  describe '#allocations' do
+    subject(:allocations) { span_op.allocations }
+
+    it { is_expected.to be 0 }
+
+    context 'when span measures an operation' do
+      before do
+        skip 'Test unstable; improve stability before re-enabling.'
+        span_op.measure {}
+      end
+
+      it { is_expected.to be > 0 }
+
+      context 'compared to a span that allocates more' do
+        let(:span_op_two) { described_class.new('span_op_two') }
+
+        before do
+          span_op_two.measure { Object.new }
+        end
+
+        it { is_expected.to be < span_op_two.allocations }
+      end
+    end
+  end
+
+  describe '#set_error' do
+    subject(:set_error) { span_op.set_error(error) }
+
+    context 'given nil' do
+      let(:error) { nil }
+
+      before { set_error }
+
+      it do
+        expect(span_op.status).to eq(Datadog::Ext::Errors::STATUS)
+        expect(span_op.get_tag(Datadog::Ext::Errors::TYPE)).to be nil
+        expect(span_op.get_tag(Datadog::Ext::Errors::MSG)).to be nil
+        expect(span_op.get_tag(Datadog::Ext::Errors::STACK)).to be nil
+      end
+    end
+
+    context 'given an error' do
+      let(:error) do
+        begin
+          raise message
+        rescue => e
+          e
+        end
+      end
+
+      let(:message) { 'Test error!' }
+
+      before { set_error }
+
+      it do
+        expect(span_op.status).to eq(Datadog::Ext::Errors::STATUS)
+        expect(span_op.get_tag(Datadog::Ext::Errors::TYPE)).to eq(error.class.to_s)
+        expect(span_op.get_tag(Datadog::Ext::Errors::MSG)).to eq(message)
+        expect(span_op.get_tag(Datadog::Ext::Errors::STACK)).to be_a_kind_of(String)
       end
     end
   end
@@ -832,229 +986,5 @@ RSpec.describe Datadog::SpanOperation::Events do
     subject(:on_error) { events.on_error }
     it { is_expected.to be_a_kind_of(Datadog::Event) }
     it { expect(on_error.name).to be(:on_error) }
-  end
-end
-
-RSpec.describe Datadog::SpanOperation::Analytics do
-  subject(:test_object) { test_class.new }
-
-  describe '#set_tag' do
-    subject(:set_tag) { test_object.set_tag(key, value) }
-
-    before do
-      allow(Datadog::Analytics).to receive(:set_sample_rate)
-      set_tag
-    end
-
-    context 'when #set_tag is defined on the class' do
-      let(:test_class) do
-        Class.new do
-          prepend Datadog::SpanOperation::Analytics
-
-          # Define this method here to prove it doesn't
-          # override behavior in Datadog::Analytics::Span.
-          def set_tag(key, value)
-            [key, value]
-          end
-        end
-      end
-
-      context 'and is given' do
-        context 'some kind of tag' do
-          let(:key) { 'my.tag' }
-          let(:value) { 'my.value' }
-
-          it 'calls the super #set_tag' do
-            is_expected.to eq([key, value])
-          end
-        end
-
-        context 'TAG_ENABLED with' do
-          let(:key) { Datadog::Ext::Analytics::TAG_ENABLED }
-
-          context 'true' do
-            let(:value) { true }
-
-            it do
-              expect(Datadog::Analytics).to have_received(:set_sample_rate)
-                .with(test_object, Datadog::Ext::Analytics::DEFAULT_SAMPLE_RATE)
-            end
-          end
-
-          context 'false' do
-            let(:value) { false }
-
-            it do
-              expect(Datadog::Analytics).to have_received(:set_sample_rate)
-                .with(test_object, 0.0)
-            end
-          end
-
-          context 'nil' do
-            let(:value) { nil }
-
-            it do
-              expect(Datadog::Analytics).to have_received(:set_sample_rate)
-                .with(test_object, 0.0)
-            end
-          end
-        end
-
-        context 'TAG_SAMPLE_RATE with' do
-          let(:key) { Datadog::Ext::Analytics::TAG_SAMPLE_RATE }
-
-          context 'a Float' do
-            let(:value) { 0.5 }
-
-            it do
-              expect(Datadog::Analytics).to have_received(:set_sample_rate)
-                .with(test_object, value)
-            end
-          end
-
-          context 'a String' do
-            let(:value) { '0.5' }
-
-            it do
-              expect(Datadog::Analytics).to have_received(:set_sample_rate)
-                .with(test_object, value)
-            end
-          end
-
-          context 'nil' do
-            let(:value) { nil }
-
-            it do
-              expect(Datadog::Analytics).to have_received(:set_sample_rate)
-                .with(test_object, value)
-            end
-          end
-        end
-      end
-    end
-  end
-end
-
-RSpec.describe Datadog::SpanOperation::ManualTracing do
-  subject(:test_object) { test_class.new }
-
-  describe '#set_tag' do
-    subject(:set_tag) { test_object.set_tag(key, value) }
-
-    before do
-      allow(Datadog::ManualTracing).to receive(:keep)
-      allow(Datadog::ManualTracing).to receive(:drop)
-      set_tag
-    end
-
-    context 'when #set_tag is defined on the class' do
-      let(:span) do
-        instance_double(Datadog::Span).tap do |span|
-          allow(span).to receive(:set_tag)
-        end
-      end
-
-      let(:test_class) do
-        s = span
-
-        klass = Class.new do
-          prepend Datadog::SpanOperation::ManualTracing
-        end
-
-        klass.tap do
-          # Define this method here to prove it doesn't
-          # override behavior in Datadog::Analytics::Span.
-          klass.send(:define_method, :set_tag) do |key, value|
-            s.set_tag(key, value)
-          end
-        end
-      end
-
-      context 'and is given' do
-        context 'some kind of tag' do
-          let(:key) { 'my.tag' }
-          let(:value) { 'my.value' }
-
-          it 'calls the super #set_tag' do
-            expect(Datadog::ManualTracing).to_not have_received(:keep)
-            expect(Datadog::ManualTracing).to_not have_received(:drop)
-            expect(span).to have_received(:set_tag)
-              .with(key, value)
-          end
-        end
-
-        context 'TAG_KEEP with' do
-          let(:key) { Datadog::Ext::ManualTracing::TAG_KEEP }
-
-          context 'true' do
-            let(:value) { true }
-
-            it do
-              expect(Datadog::ManualTracing).to have_received(:keep)
-                .with(test_object)
-              expect(Datadog::ManualTracing).to_not have_received(:drop)
-              expect(span).to_not have_received(:set_tag)
-            end
-          end
-
-          context 'false' do
-            let(:value) { false }
-
-            it do
-              expect(Datadog::ManualTracing).to_not have_received(:keep)
-              expect(Datadog::ManualTracing).to_not have_received(:drop)
-              expect(span).to_not have_received(:set_tag)
-            end
-          end
-
-          context 'nil' do
-            let(:value) { nil }
-
-            it do
-              expect(Datadog::ManualTracing).to have_received(:keep)
-                .with(test_object)
-              expect(Datadog::ManualTracing).to_not have_received(:drop)
-              expect(span).to_not have_received(:set_tag)
-            end
-          end
-        end
-
-        context 'TAG_DROP with' do
-          let(:key) { Datadog::Ext::ManualTracing::TAG_DROP }
-
-          context 'true' do
-            let(:value) { true }
-
-            it do
-              expect(Datadog::ManualTracing).to_not have_received(:keep)
-              expect(Datadog::ManualTracing).to have_received(:drop)
-                .with(test_object)
-              expect(span).to_not have_received(:set_tag)
-            end
-          end
-
-          context 'false' do
-            let(:value) { false }
-
-            it do
-              expect(Datadog::ManualTracing).to_not have_received(:keep)
-              expect(Datadog::ManualTracing).to_not have_received(:drop)
-              expect(span).to_not have_received(:set_tag)
-            end
-          end
-
-          context 'nil' do
-            let(:value) { nil }
-
-            it do
-              expect(Datadog::ManualTracing).to_not have_received(:keep)
-              expect(Datadog::ManualTracing).to have_received(:drop)
-                .with(test_object)
-              expect(span).to_not have_received(:set_tag)
-            end
-          end
-        end
-      end
-    end
   end
 end

--- a/spec/ddtrace/span_spec.rb
+++ b/spec/ddtrace/span_spec.rb
@@ -69,467 +69,129 @@ RSpec.describe Datadog::Span do
     end
   end
 
-  describe '#stop' do
-    subject(:stop) { span.stop }
+  describe '#started?' do
+    subject(:started?) { span.started? }
 
-    it 'calculates duration' do
-      expect(span.start_time).to be_nil
-      expect(span.end_time).to be_nil
-
-      subject
-
-      expect(span.end_time).to be <= Time.now
-      expect(span.start_time).to be <= span.end_time
-      expect(span.to_hash[:duration]).to be >= 0
+    context 'when span hasn\'t been started or stopped' do
+      it { is_expected.to be false }
     end
 
-    context 'with multiple calls to stop' do
-      it 'does not flush the span more than once' do
-        subject
-        expect(span.stop).to be_falsey
-      end
+    it { expect { span.start_time = Time.now }.to change { span.started? }.from(false).to(true) }
+    it { expect { span.end_time = Time.now }.to_not change { span.started? }.from(false) }
+  end
 
-      it 'does not modify the span' do
-        end_time = subject.end_time
+  describe '#stopped?' do
+    subject(:stopped?) { span.stopped? }
 
-        expect(span.stop).to be_falsey
-        expect(span.end_time).to eq(end_time)
-      end
+    context 'when span hasn\'t been started or stopped' do
+      it { is_expected.to be false }
     end
 
-    context 'with stop time provided' do
-      subject(:stop) { span.stop(time) }
-
-      let(:time) { Time.now }
-
-      it 'does not use wall time' do
-        sleep(0.0001)
-        subject
-
-        expect(span.end_time).to eq(time)
-      end
-    end
-
-    describe '#stopped?' do
-      it { expect { subject }.to change { span.stopped? }.from(false).to(true) }
-    end
-
-    # DEPRECATED: Use #stopped? instead.
-    describe '#finished?' do
-      it { expect { subject }.to change { span.finished? }.from(false).to(true) }
-    end
-
-    context 'when service' do
-      subject(:service) do
-        stop
-        span.service
-      end
-
-      context 'is set' do
-        let(:service_value) { 'span-service' }
-        before { span.service = service_value }
-        it { is_expected.to eq service_value }
-      end
-    end
+    it { expect { span.start_time = Time.now }.to_not change { span.stopped? }.from(false) }
+    it { expect { span.end_time = Time.now }.to change { span.stopped? }.from(false).to(true) }
   end
 
   describe '#duration' do
     subject(:duration) { span.duration }
 
-    let(:duration_wall_time) { 0.0001 }
+    it { is_expected.to be nil }
 
-    context 'without start or end time provided' do
-      let(:static_time) { Time.utc(2010, 9, 15, 22, 3, 15) }
+    context 'when :duration is set' do
+      let(:duration_value) { instance_double(Float) }
+      before { span.duration = duration_value }
+      it { is_expected.to be duration_value }
+    end
+
+    context 'when only :start_time is set' do
+      let(:start_time) { Time.now }
+      before { span.start_time = start_time }
+      it { is_expected.to be nil }
+    end
+
+    context 'when only :end_time is set' do
+      let(:end_time) { Time.now }
+      before { span.end_time = end_time }
+      it { is_expected.to be nil }
+    end
+
+    context 'when :start_time and :end_time are set' do
+      let(:start_time) { Time.now }
+      let(:end_time) { Time.now }
 
       before do
-        # We set the same time no matter what.
-        # If duration is greater than zero but start_time == end_time, we can
-        # be sure we're using the monotonic time.
-        allow(Datadog::Utils::Time).to receive(:now)
-          .and_return(static_time)
+        span.start_time = start_time
+        span.end_time = end_time
       end
 
-      it 'uses monotonic time' do
-        span.start
-        sleep(0.0002)
-        span.stop
-        expect((subject.to_f * 1e9).to_i).to be > 0
-
-        expect(span.end_time).to eq static_time
-        expect(span.start_time).to eq static_time
-        expect(span.end_time - span.start_time).to eq 0
-      end
-    end
-
-    context 'with start_time provided' do
-      # set a start time considerably longer than span duration
-      # set a day in the past and then measure duration is longer than
-      # amount of time slept, which would represent monotonic
-      let!(:start_time) { Time.now - (duration_wall_time * 1e9) }
-
-      it 'does not use monotonic time' do
-        span.start(start_time)
-        sleep(duration_wall_time)
-        span.stop
-
-        expect(subject).to be_within(1).of(duration_wall_time * 1e9)
-      end
-
-      context 'and end_time provided' do
-        let(:end_time) { start_time + 123.456 }
-
-        it 'respects the exact times provided' do
-          span.start(start_time)
-          sleep(duration_wall_time)
-          span.stop(end_time)
-
-          expect(subject).to eq(123.456)
-        end
-      end
-    end
-
-    context 'with end_time provided' do
-      # set an end time considerably ahead of than span duration
-      # set a day in the future and then measure duration is longer than
-      # amount of time slept, which would represent monotonic
-      let!(:end_time) { Time.now + (duration_wall_time * 1e9) }
-
-      it 'does not use monotonic time' do
-        span.start
-        sleep(duration_wall_time)
-        span.stop(end_time)
-
-        expect(subject).to be_within(1).of(duration_wall_time * 1e9)
-      end
-    end
-
-    context 'with time_provider set' do
-      before do
-        now = time_now # Expose variable to closure
-        Datadog.configure do |c|
-          c.time_now_provider = -> { now }
-        end
-      end
-
-      after { without_warnings { Datadog.configuration.reset! } }
-
-      let(:time_now) { ::Time.utc(2020, 1, 1) }
-
-      it 'sets the start time to the provider time' do
-        span.start
-        span.stop
-
-        expect(span.start_time).to eq(time_now)
-      end
-    end
-  end
-
-  describe '#clear_tag' do
-    subject(:clear_tag) { span.clear_tag(key) }
-
-    let(:key) { 'key' }
-    let(:value) { 'value' }
-
-    before { span.set_tag(key, value) }
-
-    it do
-      expect { subject }.to change { span.get_tag(key) }.from(value).to(nil)
-    end
-
-    it 'removes value, instead of setting to nil, to ensure correct deserialization by agent' do
-      subject
-      expect(span.instance_variable_get(:@meta)).to_not have_key(key)
-    end
-  end
-
-  describe '#clear_metric' do
-    subject(:clear_metric) { span.clear_metric(key) }
-
-    let(:key) { 'key' }
-    let(:value) { 1.0 }
-
-    before { span.set_metric(key, value) }
-
-    it do
-      expect { subject }.to change { span.get_metric(key) }.from(value).to(nil)
-    end
-
-    it 'removes value, instead of setting to nil, to ensure correct deserialization by agent' do
-      subject
-      expect(span.instance_variable_get(:@metrics)).to_not have_key(key)
-    end
-  end
-
-  describe '#get_metric' do
-    subject(:get_metric) { span.get_metric(key) }
-
-    let(:key) { 'key' }
-
-    context 'with no metrics' do
-      it { is_expected.to be_nil }
-    end
-
-    context 'with a metric' do
-      let(:value) { 1.0 }
-
-      before { span.set_metric(key, value) }
-
-      it { is_expected.to eq(1.0) }
-    end
-
-    context 'with a tag' do
-      let(:value) { 'tag' }
-
-      before { span.set_tag(key, value) }
-
-      it { is_expected.to eq('tag') }
-    end
-  end
-
-  describe '#set_metric' do
-    subject(:set_metric) { span.set_metric(key, value) }
-
-    let(:key) { 'key' }
-
-    let(:metrics) { span.to_hash[:metrics] }
-    let(:metric) { metrics[key] }
-
-    shared_examples 'a metric' do |value, expected|
-      let(:value) { value }
-
-      it do
-        subject
-        expect(metric).to eq(expected)
-      end
-    end
-
-    context 'with a valid value' do
-      context 'with an integer' do
-        it_behaves_like 'a metric', 0, 0.0
-      end
-
-      context 'with a float' do
-        it_behaves_like 'a metric', 12.34, 12.34
-      end
-
-      context 'with a number as string' do
-        it_behaves_like 'a metric', '12.34', 12.34
-      end
-    end
-
-    context 'with an invalid value' do
-      context 'with nil' do
-        it_behaves_like 'a metric', nil, nil
-      end
-
-      context 'with a string' do
-        it_behaves_like 'a metric', 'foo', nil
-      end
-
-      context 'with a complex object' do
-        it_behaves_like 'a metric', [], nil
-      end
-    end
-  end
-
-  describe '#set_tag' do
-    subject(:set_tag) { span.set_tag(key, value) }
-
-    shared_examples_for 'meta tag' do
-      let(:old_value) { nil }
-
-      it 'sets a tag' do
-        expect { set_tag }.to change { span.instance_variable_get(:@meta)[key] }
-          .from(old_value)
-          .to(value.to_s)
-      end
-
-      it 'does not set a metric' do
-        expect { set_tag }.to_not change { span.instance_variable_get(:@metrics)[key] }
-          .from(old_value)
-      end
-    end
-
-    shared_examples_for 'metric tag' do
-      let(:old_value) { nil }
-
-      it 'does not set a tag' do
-        expect { set_tag }.to_not change { span.instance_variable_get(:@meta)[key] }
-          .from(old_value)
-      end
-
-      it 'sets a metric' do
-        expect { set_tag }.to change { span.instance_variable_get(:@metrics)[key] }
-          .from(old_value)
-          .to(value.to_f)
-      end
-    end
-
-    context 'given _dd.hostname' do
-      let(:key) { '_dd.hostname' }
-      let(:value) { 1 }
-
-      it_behaves_like 'meta tag'
-    end
-
-    context 'given _dd.origin' do
-      let(:key) { '_dd.origin' }
-      let(:value) { 2 }
-
-      it_behaves_like 'meta tag'
-    end
-
-    context 'given http.status_code' do
-      let(:key) { 'http.status_code' }
-      let(:value) { 200 }
-
-      it_behaves_like 'meta tag'
-    end
-
-    context 'given version' do
-      let(:key) { 'version' }
-      let(:value) { 3 }
-
-      it_behaves_like 'meta tag'
-    end
-
-    context 'given a numeric tag' do
-      let(:key) { 'system.pid' }
-      let(:value) { 123 }
-
-      context 'which is an integer' do
-        context 'that exceeds the upper limit' do
-          let(:value) { described_class::NUMERIC_TAG_SIZE_RANGE.max.to_i + 1 }
-
-          it_behaves_like 'meta tag'
-        end
-
-        context 'at the upper limit' do
-          let(:value) { described_class::NUMERIC_TAG_SIZE_RANGE.max.to_i }
-
-          it_behaves_like 'metric tag'
-        end
-
-        context 'at the lower limit' do
-          let(:value) { described_class::NUMERIC_TAG_SIZE_RANGE.min.to_i }
-
-          it_behaves_like 'metric tag'
-        end
-
-        context 'that is below the lower limit' do
-          let(:value) { described_class::NUMERIC_TAG_SIZE_RANGE.min.to_i - 1 }
-
-          it_behaves_like 'meta tag'
-        end
-      end
-
-      context 'which is a float' do
-        context 'that exceeds the upper limit' do
-          let(:value) { described_class::NUMERIC_TAG_SIZE_RANGE.max.to_f + 1.0 }
-
-          it_behaves_like 'metric tag'
-        end
-
-        context 'at the upper limit' do
-          let(:value) { described_class::NUMERIC_TAG_SIZE_RANGE.max.to_f }
-
-          it_behaves_like 'metric tag'
-        end
-
-        context 'at the lower limit' do
-          let(:value) { described_class::NUMERIC_TAG_SIZE_RANGE.min.to_f }
-
-          it_behaves_like 'metric tag'
-        end
-
-        context 'that is below the lower limit' do
-          let(:value) { described_class::NUMERIC_TAG_SIZE_RANGE.min.to_f - 1.0 }
-
-          it_behaves_like 'metric tag'
-        end
-      end
-
-      context 'that conflicts with an existing tag' do
-        before { span.set_tag(key, 'old value') }
-
-        it 'removes the tag' do
-          expect { set_tag }.to change { span.instance_variable_get(:@meta)[key] }
-            .from('old value')
-            .to(nil)
-        end
-
-        it 'adds a new metric' do
-          expect { set_tag }.to change { span.instance_variable_get(:@metrics)[key] }
-            .from(nil)
-            .to(value)
-        end
-      end
-
-      context 'that conflicts with an existing metric' do
-        before { span.set_metric(key, 404) }
-
-        it 'replaces the metric' do
-          expect { set_tag }.to change { span.instance_variable_get(:@metrics)[key] }
-            .from(404)
-            .to(value)
-
-          expect(span.instance_variable_get(:@meta)[key]).to be nil
-        end
-      end
-    end
-  end
-
-  describe '#set_tags' do
-    subject(:set_tags) { span.set_tags(tags) }
-
-    context 'with empty hash' do
-      let(:tags) { {} }
-
-      it 'does not change tags' do
-        expect(span).to_not receive(:set_tag)
-        expect { set_tags }.to_not change { span.instance_variable_get(:@meta) }.from({})
-      end
-    end
-
-    context 'with multiple tags' do
-      let(:tags) { { 'user.id' => 123, 'user.domain' => 'datadog.com' } }
-
-      it 'sets the tags from hash keys' do
-        expect { set_tags }.to change { tags.map { |k, _| span.get_tag(k) } }.from([nil, nil]).to([123, 'datadog.com'])
-      end
-    end
-
-    context 'with nested hashes' do
-      let(:tags) do
-        {
-          'user' => {
-            'id' => 123
-          }
-        }
-      end
-
-      it 'does not support it - it sets stringified nested hash as value' do
-        expect { set_tags }.to change { span.get_tag('user') }.from(nil).to('{"id"=>123}')
-      end
+      it { is_expected.to eq(end_time - start_time) }
     end
   end
 
   describe '#set_error' do
     subject(:set_error) { span.set_error(error) }
 
-    let(:error) { RuntimeError.new('oops') }
-    let(:backtrace) { %w[method1 method2 method3] }
+    context 'given nil' do
+      let(:error) { nil }
 
-    before { error.set_backtrace(backtrace) }
+      before { set_error }
 
-    it do
-      subject
+      it do
+        expect(span.status).to eq(Datadog::Ext::Errors::STATUS)
+        expect(span.get_tag(Datadog::Ext::Errors::TYPE)).to be nil
+        expect(span.get_tag(Datadog::Ext::Errors::MSG)).to be nil
+        expect(span.get_tag(Datadog::Ext::Errors::STACK)).to be nil
+      end
+    end
 
-      expect(span).to have_error
-      expect(span).to have_error_message('oops')
-      expect(span).to have_error_type('RuntimeError')
-      backtrace.each do |method|
-        expect(span).to have_error_stack(include(method))
+    context 'given an error' do
+      let(:error) do
+        begin
+          raise message
+        rescue => e
+          e
+        end
+      end
+
+      let(:message) { 'Test error!' }
+
+      before { set_error }
+
+      it do
+        expect(span.status).to eq(Datadog::Ext::Errors::STATUS)
+        expect(span.get_tag(Datadog::Ext::Errors::TYPE)).to eq(error.class.to_s)
+        expect(span.get_tag(Datadog::Ext::Errors::MSG)).to eq(message)
+        expect(span.get_tag(Datadog::Ext::Errors::STACK)).to be_a_kind_of(String)
+      end
+    end
+  end
+
+  describe '#==' do
+    subject(:equals?) { span_one == span_two }
+    let(:span_one) { described_class.new('span') }
+    let(:span_two) { described_class.new('span') }
+
+    # Because #id auto-generates, this is false.
+    it { is_expected.to be false }
+
+    context 'when the #id doesn\'t match' do
+      let(:span_one) { described_class.new('span', id: 1) }
+      let(:span_two) { described_class.new('span', id: 2) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the #id matches' do
+      let(:span_one) { described_class.new('span', id: 1) }
+      let(:span_two) { described_class.new('span', id: 1) }
+
+      it { is_expected.to be true }
+
+      context 'but other properties do not' do
+        let(:span_one) { described_class.new('one', id: 1) }
+        let(:span_two) { described_class.new('two', id: 1) }
+
+        # Because only #id matters, this is true.
+        it { is_expected.to be true }
       end
     end
   end
@@ -539,7 +201,7 @@ RSpec.describe Datadog::Span do
 
     let(:span_options) { { trace_id: 12 } }
 
-    before { span.span_id = 34 }
+    before { span.id = 34 }
 
     it do
       is_expected.to eq(
@@ -558,7 +220,10 @@ RSpec.describe Datadog::Span do
     end
 
     context 'with a stopped span' do
-      before { span.stop }
+      before do
+        span.start_time = Datadog::Utils::Time.now.utc
+        span.end_time = Datadog::Utils::Time.now.utc
+      end
 
       it 'includes timing information' do
         is_expected.to include(

--- a/spec/ddtrace/tagging/analytics_spec.rb
+++ b/spec/ddtrace/tagging/analytics_spec.rb
@@ -1,0 +1,104 @@
+# typed: ignore
+require 'spec_helper'
+
+require 'ddtrace/tagging/analytics'
+
+RSpec.describe Datadog::Tagging::Analytics do
+  subject(:test_object) { test_class.new }
+
+  describe '#set_tag' do
+    subject(:set_tag) { test_object.set_tag(key, value) }
+
+    before do
+      allow(Datadog::Analytics).to receive(:set_sample_rate)
+      set_tag
+    end
+
+    context 'when #set_tag is defined on the class' do
+      let(:test_class) do
+        Class.new do
+          prepend Datadog::Tagging::Analytics
+
+          # Define this method here to prove it doesn't
+          # override behavior in Datadog::Analytics::Span.
+          def set_tag(key, value)
+            [key, value]
+          end
+        end
+      end
+
+      context 'and is given' do
+        context 'some kind of tag' do
+          let(:key) { 'my.tag' }
+          let(:value) { 'my.value' }
+
+          it 'calls the super #set_tag' do
+            is_expected.to eq([key, value])
+          end
+        end
+
+        context 'TAG_ENABLED with' do
+          let(:key) { Datadog::Ext::Analytics::TAG_ENABLED }
+
+          context 'true' do
+            let(:value) { true }
+
+            it do
+              expect(Datadog::Analytics).to have_received(:set_sample_rate)
+                .with(test_object, Datadog::Ext::Analytics::DEFAULT_SAMPLE_RATE)
+            end
+          end
+
+          context 'false' do
+            let(:value) { false }
+
+            it do
+              expect(Datadog::Analytics).to have_received(:set_sample_rate)
+                .with(test_object, 0.0)
+            end
+          end
+
+          context 'nil' do
+            let(:value) { nil }
+
+            it do
+              expect(Datadog::Analytics).to have_received(:set_sample_rate)
+                .with(test_object, 0.0)
+            end
+          end
+        end
+
+        context 'TAG_SAMPLE_RATE with' do
+          let(:key) { Datadog::Ext::Analytics::TAG_SAMPLE_RATE }
+
+          context 'a Float' do
+            let(:value) { 0.5 }
+
+            it do
+              expect(Datadog::Analytics).to have_received(:set_sample_rate)
+                .with(test_object, value)
+            end
+          end
+
+          context 'a String' do
+            let(:value) { '0.5' }
+
+            it do
+              expect(Datadog::Analytics).to have_received(:set_sample_rate)
+                .with(test_object, value)
+            end
+          end
+
+          context 'nil' do
+            let(:value) { nil }
+
+            it do
+              expect(Datadog::Analytics).to have_received(:set_sample_rate)
+                .with(test_object, value)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/tagging/manual_tracing_spec.rb
+++ b/spec/ddtrace/tagging/manual_tracing_spec.rb
@@ -1,0 +1,128 @@
+# typed: ignore
+require 'spec_helper'
+
+require 'ddtrace/tagging/manual_tracing'
+
+RSpec.describe Datadog::SpanOperation::ManualTracing do
+  subject(:test_object) { test_class.new }
+
+  describe '#set_tag' do
+    subject(:set_tag) { test_object.set_tag(key, value) }
+
+    before do
+      allow(Datadog::ManualTracing).to receive(:keep)
+      allow(Datadog::ManualTracing).to receive(:drop)
+      set_tag
+    end
+
+    context 'when #set_tag is defined on the class' do
+      let(:span) do
+        instance_double(Datadog::Span).tap do |span|
+          allow(span).to receive(:set_tag)
+        end
+      end
+
+      let(:test_class) do
+        s = span
+
+        klass = Class.new do
+          prepend Datadog::Tagging::ManualTracing
+        end
+
+        klass.tap do
+          # Define this method here to prove it doesn't
+          # override behavior in Datadog::Analytics::Span.
+          klass.send(:define_method, :set_tag) do |key, value|
+            s.set_tag(key, value)
+          end
+        end
+      end
+
+      context 'and is given' do
+        context 'some kind of tag' do
+          let(:key) { 'my.tag' }
+          let(:value) { 'my.value' }
+
+          it 'calls the super #set_tag' do
+            expect(Datadog::ManualTracing).to_not have_received(:keep)
+            expect(Datadog::ManualTracing).to_not have_received(:drop)
+            expect(span).to have_received(:set_tag)
+              .with(key, value)
+          end
+        end
+
+        context 'TAG_KEEP with' do
+          let(:key) { Datadog::Ext::ManualTracing::TAG_KEEP }
+
+          context 'true' do
+            let(:value) { true }
+
+            it do
+              expect(Datadog::ManualTracing).to have_received(:keep)
+                .with(test_object)
+              expect(Datadog::ManualTracing).to_not have_received(:drop)
+              expect(span).to_not have_received(:set_tag)
+            end
+          end
+
+          context 'false' do
+            let(:value) { false }
+
+            it do
+              expect(Datadog::ManualTracing).to_not have_received(:keep)
+              expect(Datadog::ManualTracing).to_not have_received(:drop)
+              expect(span).to_not have_received(:set_tag)
+            end
+          end
+
+          context 'nil' do
+            let(:value) { nil }
+
+            it do
+              expect(Datadog::ManualTracing).to have_received(:keep)
+                .with(test_object)
+              expect(Datadog::ManualTracing).to_not have_received(:drop)
+              expect(span).to_not have_received(:set_tag)
+            end
+          end
+        end
+
+        context 'TAG_DROP with' do
+          let(:key) { Datadog::Ext::ManualTracing::TAG_DROP }
+
+          context 'true' do
+            let(:value) { true }
+
+            it do
+              expect(Datadog::ManualTracing).to_not have_received(:keep)
+              expect(Datadog::ManualTracing).to have_received(:drop)
+                .with(test_object)
+              expect(span).to_not have_received(:set_tag)
+            end
+          end
+
+          context 'false' do
+            let(:value) { false }
+
+            it do
+              expect(Datadog::ManualTracing).to_not have_received(:keep)
+              expect(Datadog::ManualTracing).to_not have_received(:drop)
+              expect(span).to_not have_received(:set_tag)
+            end
+          end
+
+          context 'nil' do
+            let(:value) { nil }
+
+            it do
+              expect(Datadog::ManualTracing).to_not have_received(:keep)
+              expect(Datadog::ManualTracing).to have_received(:drop)
+                .with(test_object)
+              expect(span).to_not have_received(:set_tag)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ddtrace/tagging/metadata_spec.rb
+++ b/spec/ddtrace/tagging/metadata_spec.rb
@@ -1,0 +1,348 @@
+# typed: ignore
+require 'spec_helper'
+
+require 'ddtrace/tagging/metadata'
+
+RSpec.describe Datadog::Tagging::Metadata do
+  subject(:test_object) { test_class.new }
+  let(:test_class) { Class.new { include Datadog::Tagging::Metadata } }
+
+  describe '#get_tag' do
+    subject(:get_tag) { test_object.get_tag(key) }
+    let(:key) { 'test_tag' }
+    let(:value) { 'test_value' }
+
+    context 'when no tag exists' do
+      it { is_expected.to be nil }
+    end
+
+    context 'when a meta tag exists' do
+      before { test_object.send(:meta)[key] = value }
+      it { is_expected.to be value }
+    end
+
+    context 'when a metric exists' do
+      before { test_object.send(:metrics)[key] = value }
+      it { is_expected.to be value }
+    end
+  end
+
+  describe '#set_tag' do
+    subject(:set_tag) { test_object.set_tag(key, value) }
+
+    shared_examples_for 'meta tag' do
+      let(:old_value) { nil }
+
+      it 'sets a tag' do
+        expect { set_tag }.to change { test_object.send(:meta)[key] }
+          .from(old_value)
+          .to(value.to_s)
+      end
+
+      it 'does not set a metric' do
+        expect { set_tag }.to_not change { test_object.send(:metrics)[key] }
+          .from(old_value)
+      end
+    end
+
+    shared_examples_for 'metric tag' do
+      let(:old_value) { nil }
+
+      it 'does not set a tag' do
+        expect { set_tag }.to_not change { test_object.send(:meta)[key] }
+          .from(old_value)
+      end
+
+      it 'sets a metric' do
+        expect { set_tag }.to change { test_object.send(:metrics)[key] }
+          .from(old_value)
+          .to(value.to_f)
+      end
+    end
+
+    context "given #{Datadog::Ext::NET::TAG_HOSTNAME}" do
+      let(:key) { Datadog::Ext::NET::TAG_HOSTNAME }
+
+      context 'as a numeric value' do
+        let(:value) { 1 }
+        it_behaves_like 'meta tag'
+      end
+    end
+
+    context "given #{Datadog::Ext::DistributedTracing::ORIGIN_KEY}" do
+      let(:key) { Datadog::Ext::DistributedTracing::ORIGIN_KEY }
+
+      context 'as a numeric value' do
+        let(:value) { 2 }
+        it_behaves_like 'meta tag'
+      end
+    end
+
+    context "given #{Datadog::Ext::HTTP::STATUS_CODE}" do
+      let(:key) { Datadog::Ext::HTTP::STATUS_CODE }
+
+      context 'as a numeric value' do
+        let(:value) { 200 }
+        it_behaves_like 'meta tag'
+      end
+    end
+
+    context "given #{Datadog::Ext::Environment::TAG_VERSION}" do
+      let(:key) { Datadog::Ext::Environment::TAG_VERSION }
+
+      context 'as a numeric value' do
+        let(:value) { 3 }
+        it_behaves_like 'meta tag'
+      end
+    end
+
+    context 'given a numeric tag' do
+      let(:key) { 'system.pid' }
+      let(:value) { 123 }
+
+      context 'which is an integer' do
+        context 'that exceeds the upper limit' do
+          let(:value) { described_class::NUMERIC_TAG_SIZE_RANGE.max.to_i + 1 }
+
+          it_behaves_like 'meta tag'
+        end
+
+        context 'at the upper limit' do
+          let(:value) { described_class::NUMERIC_TAG_SIZE_RANGE.max.to_i }
+
+          it_behaves_like 'metric tag'
+        end
+
+        context 'at the lower limit' do
+          let(:value) { described_class::NUMERIC_TAG_SIZE_RANGE.min.to_i }
+
+          it_behaves_like 'metric tag'
+        end
+
+        context 'that is below the lower limit' do
+          let(:value) { described_class::NUMERIC_TAG_SIZE_RANGE.min.to_i - 1 }
+
+          it_behaves_like 'meta tag'
+        end
+      end
+
+      context 'which is a float' do
+        context 'that exceeds the upper limit' do
+          let(:value) { described_class::NUMERIC_TAG_SIZE_RANGE.max.to_f + 1.0 }
+
+          it_behaves_like 'metric tag'
+        end
+
+        context 'at the upper limit' do
+          let(:value) { described_class::NUMERIC_TAG_SIZE_RANGE.max.to_f }
+
+          it_behaves_like 'metric tag'
+        end
+
+        context 'at the lower limit' do
+          let(:value) { described_class::NUMERIC_TAG_SIZE_RANGE.min.to_f }
+
+          it_behaves_like 'metric tag'
+        end
+
+        context 'that is below the lower limit' do
+          let(:value) { described_class::NUMERIC_TAG_SIZE_RANGE.min.to_f - 1.0 }
+
+          it_behaves_like 'metric tag'
+        end
+      end
+
+      context 'that conflicts with an existing tag' do
+        before { test_object.set_tag(key, 'old value') }
+
+        it 'removes the tag' do
+          expect { set_tag }.to change { test_object.send(:meta)[key] }
+            .from('old value')
+            .to(nil)
+        end
+
+        it 'adds a new metric' do
+          expect { set_tag }.to change { test_object.send(:metrics)[key] }
+            .from(nil)
+            .to(value)
+        end
+      end
+
+      context 'that conflicts with an existing metric' do
+        before { test_object.set_metric(key, 404) }
+
+        it 'replaces the metric' do
+          expect { set_tag }.to change { test_object.send(:metrics)[key] }
+            .from(404)
+            .to(value)
+
+          expect(test_object.send(:meta)[key]).to be nil
+        end
+      end
+    end
+  end
+
+  describe '#set_tags' do
+    subject(:set_tags) { test_object.set_tags(tags) }
+
+    context 'with empty hash' do
+      let(:tags) { {} }
+
+      it 'does not change tags' do
+        expect(test_object).to_not receive(:set_tag)
+        set_tags
+      end
+    end
+
+    context 'with multiple tags' do
+      let(:tags) { { 'user.id' => 123, 'user.domain' => 'datadog.com' } }
+
+      it 'sets the tags from hash keys' do
+        expect { set_tags }
+          .to change { tags.map { |k, _| test_object.get_tag(k) } }
+          .from([nil, nil]).to([123, 'datadog.com'])
+      end
+    end
+
+    context 'with nested hashes' do
+      let(:tags) do
+        {
+          'user' => {
+            'id' => 123
+          }
+        }
+      end
+
+      it 'does not support it - it sets stringified nested hash as value' do
+        expect { set_tags }.to change { test_object.get_tag('user') }.from(nil).to('{"id"=>123}')
+      end
+    end
+  end
+
+  describe '#clear_tag' do
+    subject(:clear_tag) { test_object.clear_tag(key) }
+
+    let(:key) { 'key' }
+    let(:value) { 'value' }
+
+    before { test_object.set_tag(key, value) }
+
+    it do
+      expect { clear_tag }.to change { test_object.get_tag(key) }.from(value).to(nil)
+    end
+
+    it 'removes value, instead of setting to nil, to ensure correct deserialization by agent' do
+      clear_tag
+      expect(test_object.send(:meta)).to_not have_key(key)
+    end
+  end
+
+  describe '#get_metric' do
+    subject(:get_metric) { test_object.get_metric(key) }
+
+    let(:key) { 'key' }
+
+    context 'with no metrics' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'with a metric' do
+      let(:value) { 1.0 }
+
+      before { test_object.set_metric(key, value) }
+
+      it { is_expected.to eq(1.0) }
+    end
+
+    context 'with a tag' do
+      let(:value) { 'tag' }
+
+      before { test_object.set_tag(key, value) }
+
+      it { is_expected.to eq('tag') }
+    end
+  end
+
+  describe '#set_metric' do
+    subject(:set_metric) { test_object.set_metric(key, value) }
+
+    let(:key) { 'key' }
+
+    let(:metrics) { test_object.send(:metrics) }
+    let(:metric) { metrics[key] }
+
+    shared_examples 'a metric' do |value, expected|
+      let(:value) { value }
+
+      it do
+        subject
+        expect(metric).to eq(expected)
+      end
+    end
+
+    context 'with a valid value' do
+      context 'with an integer' do
+        it_behaves_like 'a metric', 0, 0.0
+      end
+
+      context 'with a float' do
+        it_behaves_like 'a metric', 12.34, 12.34
+      end
+
+      context 'with a number as string' do
+        it_behaves_like 'a metric', '12.34', 12.34
+      end
+    end
+
+    context 'with an invalid value' do
+      context 'with nil' do
+        it_behaves_like 'a metric', nil, nil
+      end
+
+      context 'with a string' do
+        it_behaves_like 'a metric', 'foo', nil
+      end
+
+      context 'with a complex object' do
+        it_behaves_like 'a metric', [], nil
+      end
+    end
+  end
+
+  describe '#clear_metric' do
+    subject(:clear_metric) { test_object.clear_metric(key) }
+
+    let(:key) { 'key' }
+    let(:value) { 1.0 }
+
+    before { test_object.set_metric(key, value) }
+
+    it do
+      expect { clear_metric }.to change { test_object.get_metric(key) }.from(value).to(nil)
+    end
+
+    it 'removes value, instead of setting to nil, to ensure correct deserialization by agent' do
+      clear_metric
+      expect(test_object.send(:metrics)).to_not have_key(key)
+    end
+  end
+
+  describe '#set_error' do
+    subject(:set_error) { test_object.set_error(error) }
+
+    let(:error) { RuntimeError.new('oops') }
+    let(:backtrace) { %w[method1 method2 method3] }
+
+    before { error.set_backtrace(backtrace) }
+
+    it do
+      set_error
+
+      expect(test_object).to have_error_message('oops')
+      expect(test_object).to have_error_type('RuntimeError')
+      backtrace.each do |method|
+        expect(test_object).to have_error_stack(include(method))
+      end
+    end
+  end
+end

--- a/spec/ddtrace/tagging_spec.rb
+++ b/spec/ddtrace/tagging_spec.rb
@@ -1,0 +1,26 @@
+# typed: ignore
+require 'spec_helper'
+
+require 'ddtrace/tagging'
+
+RSpec.describe Datadog::Tagging do
+  context 'when included' do
+    subject(:test_class) { Class.new { include Datadog::Tagging } }
+
+    describe '::ancestors' do
+      subject(:ancestors) { test_class.ancestors }
+
+      it 'has all of the tagging behavior in correct order' do
+        expect(ancestors.first(5)).to eq(
+          [
+            described_class::ManualTracing,
+            described_class::Analytics,
+            test_class,
+            described_class::Metadata,
+            described_class
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Datadog::Tracer do
       let(:handler_spy) { spy('handler') }
 
       context 'and Events#on_error is published' do
-        subject(:publish_error) { span.events.on_error.publish(span, error) }
+        subject(:publish_error) { span.send(:events).on_error.publish(span, error) }
         let(:error) { error_class.new }
         let(:error_class) { Class.new(StandardError) }
 
@@ -299,7 +299,7 @@ RSpec.describe Datadog::Tracer do
             end
 
             it 'subscribes to the :after_finish event' do
-              expect(span.events.after_finish.subscriptions).to include(:tracer_span_finished)
+              expect(span.send(:events).after_finish.subscriptions).to include(:tracer_span_finished)
             end
           end
 
@@ -313,7 +313,7 @@ RSpec.describe Datadog::Tracer do
             end
 
             it 'does not subscribe to the :after_finish event' do
-              expect(span.events.after_finish.subscriptions).to_not include(:tracer_span_finished)
+              expect(span.send(:events).after_finish.subscriptions).to_not include(:tracer_span_finished)
             end
           end
 

--- a/spec/support/tracer_helpers.rb
+++ b/spec/support/tracer_helpers.rb
@@ -108,12 +108,18 @@ module TracerHelpers
     defaults = {
       service: 'test-app',
       resource: '/traces',
-      span_type: 'web'
+      type: 'web'
     }
 
     n.times do
-      span1 = Datadog::Span.new('client.testing', **defaults).start.stop
-      span2 = Datadog::Span.new('client.testing', **defaults, parent_id: span1.span_id).start.stop
+      span_op1 = Datadog::SpanOperation.new('client.testing', **defaults)
+      span_op2 = Datadog::SpanOperation.new('client.testing', **defaults, child_of: span_op2)
+
+      span_op1.start
+      span_op2.start
+      span2 = span_op2.finish
+      span1 = span_op1.finish
+
       traces << [span1, span2]
     end
 


### PR DESCRIPTION
Expanding upon the implementation of `SpanOperation`, this pull request seeks to change its behavior from wrapping and mutating a `Span`, to building a copy of a `Span` only on `SpanOperation#finish`. In effect, the `SpanOperation` acts as a builder or factory pattern.

The main motivation to do this is to:

1. Simplify `Span` objects into basic structs suitable for wire serialization
2. Prevent their mutation after completion so that instrumentation does not produce race conditions or other unexpected behavior by modifying a completed `Span` by reference. (Eventually, we'd like to make `Span` outright immutable, but for now this is an intermediate step.)
3. Reduce the references held on the `Tracer` side of instrumentation, to reduce the likelihood of memory leaks.

In doing so, much of the timing behavior (`start`, `stop`) and `Span` state have migrated to `SpanOperation`. While refining `SpanOperation`, I also decided to privatize a few functions (`context=`, `parent=`, `events`, `span`) to dissuade public use, as there are plans to refactor or eliminate them entirely in the future. Each of these should have sufficient alternatives through other APIs we prefer users to use.
