### PR TITLE
Use USER_KEEP/USER_REJECT for RuleSampler decisions

### DIFF
--- a/lib/ddtrace/ext/priority.rb
+++ b/lib/ddtrace/ext/priority.rb
@@ -4,13 +4,15 @@ module Datadog
     # Priority is a hint given to the backend so that it knows which traces to reject or kept.
     # In a distributed context, it should be set before any context propagation (fork, RPC calls) to be effective.
     module Priority
-      # Use this to explicitely inform the backend that a trace should be rejected and not stored.
+      # Use this to explicitly inform the backend that a trace should be rejected and not stored.
+      # This includes rules and rate limits configured by the user through the {RuleSampler}.
       USER_REJECT = -1
-      # Used by the builtin sampler to inform the backend that a trace should be rejected and not stored.
+      # Used by the {PrioritySampler} to inform the backend that a trace should be rejected and not stored.
       AUTO_REJECT = 0
-      # Used by the builtin sampler to inform the backend that a trace should be kept and stored.
+      # Used by the {PrioritySampler} to inform the backend that a trace should be kept and stored.
       AUTO_KEEP = 1
-      # Use this to explicitely inform the backend that a trace should be kept and stored.
+      # Use this to explicitly inform the backend that a trace should be kept and stored.
+      # This includes rules and rate limits configured by the user through the {RuleSampler}.
       USER_KEEP = 2
     end
   end

--- a/lib/ddtrace/ext/priority.rb
+++ b/lib/ddtrace/ext/priority.rb
@@ -4,14 +4,14 @@ module Datadog
     # Priority is a hint given to the backend so that it knows which traces to reject or kept.
     # In a distributed context, it should be set before any context propagation (fork, RPC calls) to be effective.
     module Priority
-      # Use this to explicitly inform the backend that a trace should be rejected and not stored.
+      # Use this to explicitly inform the backend that a trace MUST be rejected and not stored.
       # This includes rules and rate limits configured by the user through the {RuleSampler}.
       USER_REJECT = -1
       # Used by the {PrioritySampler} to inform the backend that a trace should be rejected and not stored.
       AUTO_REJECT = 0
       # Used by the {PrioritySampler} to inform the backend that a trace should be kept and stored.
       AUTO_KEEP = 1
-      # Use this to explicitly inform the backend that a trace should be kept and stored.
+      # Use this to explicitly inform the backend that a trace MUST be kept and stored.
       # This includes rules and rate limits configured by the user through the {RuleSampler}.
       USER_KEEP = 2
     end

--- a/lib/ddtrace/sampler.rb
+++ b/lib/ddtrace/sampler.rb
@@ -214,13 +214,13 @@ module Datadog
 
       if span.sampled
         # If priority sampling has already been applied upstream, use that value.
-        return span.sampled if priority_assigned?(span)
+        return true if priority_assigned?(span)
 
         # Check with post sampler how we set the priority.
         sample = priority_sample!(span)
 
         # Check if post sampler has already assigned a priority.
-        return span.sampled if priority_assigned?(span)
+        return true if priority_assigned?(span)
 
         # If not, use agent priority values.
         priority = sample ? Datadog::Ext::Priority::AUTO_KEEP : Datadog::Ext::Priority::AUTO_REJECT

--- a/lib/ddtrace/sampler.rb
+++ b/lib/ddtrace/sampler.rb
@@ -194,6 +194,12 @@ module Datadog
   class PrioritySampler
     extend Forwardable
 
+    # NOTE: We do not advise using a pre-sampler. It can save resources,
+    # but pre-sampling at rates < 100% may result in partial traces, unless
+    # the pre-sampler knows exactly how to drop a span without dropping its ancestors.
+    #
+    # Additionally, as service metrics are calculated in the Datadog Agent,
+    # the service's throughput will be underestimated.
     attr_reader :pre_sampler, :priority_sampler
 
     SAMPLE_RATE_METRIC_KEY = '_sample_rate'.freeze
@@ -209,7 +215,6 @@ module Datadog
 
     def sample!(span)
       # If pre-sampling is configured, do it first. (By default, this will sample at 100%.)
-      # NOTE: Pre-sampling at rates < 100% may result in partial traces; not recommended.
       span.sampled = pre_sample?(span) ? @pre_sampler.sample!(span) : true
 
       if span.sampled

--- a/lib/ddtrace/sampling/rule_sampler.rb
+++ b/lib/ddtrace/sampling/rule_sampler.rb
@@ -114,11 +114,11 @@ module Datadog
       # Span priority should only be set when the {RuleSampler}
       # was responsible for the sampling decision.
       def set_priority(span, sampled)
-        if sampled
-          ForcedTracing.keep(span)
-        else
-          ForcedTracing.drop(span)
-        end
+        span.context.sampling_priority = if sampled
+                                           Datadog::Ext::Priority::USER_KEEP
+                                         else
+                                           Datadog::Ext::Priority::USER_REJECT
+                                         end
       end
 
       def set_rule_metrics(span, sample_rate)

--- a/lib/ddtrace/sampling/rule_sampler.rb
+++ b/lib/ddtrace/sampling/rule_sampler.rb
@@ -114,11 +114,11 @@ module Datadog
       # Span priority should only be set when the {RuleSampler}
       # was responsible for the sampling decision.
       def set_priority(span, sampled)
-        span.context.sampling_priority = if sampled
-                                           Datadog::Ext::Priority::USER_KEEP
-                                         else
-                                           Datadog::Ext::Priority::USER_REJECT
-                                         end
+        if sampled
+          ForcedTracing.keep(span)
+        else
+          ForcedTracing.drop(span)
+        end
       end
 
       def set_rule_metrics(span, sample_rate)

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe 'Tracer integration tests' do
       end
 
       it_behaves_like 'flushed trace'
-      it_behaves_like 'priority sampled', Datadog::Ext::Priority::AUTO_KEEP
+      it_behaves_like 'priority sampled', Datadog::Ext::Priority::USER_KEEP
       it_behaves_like 'rule sampling rate metric', 1.0
       it_behaves_like 'rate limit metric', 1.0
 
@@ -223,7 +223,7 @@ RSpec.describe 'Tracer integration tests' do
       let(:rule_sampler) { Datadog::Sampling::RuleSampler.new(default_sample_rate: Float::MIN) }
 
       it_behaves_like 'flushed trace'
-      it_behaves_like 'priority sampled', Datadog::Ext::Priority::AUTO_REJECT
+      it_behaves_like 'priority sampled', Datadog::Ext::Priority::USER_REJECT
       it_behaves_like 'rule sampling rate metric', Float::MIN
       it_behaves_like 'rate limit metric', nil # Rate limiter is never reached, thus has no value to provide
     end
@@ -236,7 +236,7 @@ RSpec.describe 'Tracer integration tests' do
         let(:rule) { Datadog::Sampling::SimpleRule.new(name: 'my.op') }
 
         it_behaves_like 'flushed trace'
-        it_behaves_like 'priority sampled', Datadog::Ext::Priority::AUTO_KEEP
+        it_behaves_like 'priority sampled', Datadog::Ext::Priority::USER_KEEP
         it_behaves_like 'rule sampling rate metric', 1.0
         it_behaves_like 'rate limit metric', 1.0
 
@@ -244,7 +244,7 @@ RSpec.describe 'Tracer integration tests' do
           let(:rule) { Datadog::Sampling::SimpleRule.new(sample_rate: Float::MIN) }
 
           it_behaves_like 'flushed trace'
-          it_behaves_like 'priority sampled', Datadog::Ext::Priority::AUTO_REJECT
+          it_behaves_like 'priority sampled', Datadog::Ext::Priority::USER_REJECT
           it_behaves_like 'rule sampling rate metric', Float::MIN
           it_behaves_like 'rate limit metric', nil # Rate limiter is never reached, thus has no value to provide
         end
@@ -253,7 +253,7 @@ RSpec.describe 'Tracer integration tests' do
           let(:rule_sampler_opt) { { rate_limit: Float::MIN } }
 
           it_behaves_like 'flushed trace'
-          it_behaves_like 'priority sampled', Datadog::Ext::Priority::AUTO_REJECT
+          it_behaves_like 'priority sampled', Datadog::Ext::Priority::USER_REJECT
           it_behaves_like 'rule sampling rate metric', 1.0
           it_behaves_like 'rate limit metric', 0.0
         end
@@ -263,9 +263,10 @@ RSpec.describe 'Tracer integration tests' do
         let(:rule) { Datadog::Sampling::SimpleRule.new(name: 'not.my.op') }
 
         it_behaves_like 'flushed trace'
+        # The PrioritySampler was responsible for the sampling decision, not the Rule Sampler.
         it_behaves_like 'priority sampled', Datadog::Ext::Priority::AUTO_KEEP
-        it_behaves_like 'rule sampling rate metric', nil # Rule sampler is never reached, thus has no value to provide
-        it_behaves_like 'rate limit metric', nil # Rate limiter is never reached, thus has no value to provide
+        it_behaves_like 'rule sampling rate metric', nil
+        it_behaves_like 'rate limit metric', nil
       end
     end
   end


### PR DESCRIPTION
This PR changes changes how the sampling decisions yielded by the `Datadog::Sampling::RuleSampler` affect the span's `_sampling_priority_v1` tag.

Before, `0` (for rejecting) and `1` (for keeping) were used for `RuleSampler` decisions. The issue with this approach is that `0` and `1` are default sampling values that allow for the sampling decision to be altered downstream, either by the Agent or by the Datadog backend.
`0` and `1` communicate intent, not a strong decision. These works great when the sampling rate is not strictly important: for example, it is normally desirable to keep an error span, even if it's marked with a sampling decision of `0`, as that span will have valuable debugging information.

The issue with `0` and `1` is that they don't allow for strict control of sampling rates. When limiting the sampling rate is very important (e.g. network traffic constrains, strictly limiting billable costs), such sampling was not possible with the `RuleSampler`, custom code snippets were required (e.g. `Datadog::ForcedTracing.drop(span)`).

After the changes in this PR, decisions that are originated from any user configuration to the `RuleSampler` use priority values `-1` (for forced rejection) and `2` (for forced keeping). This means that `RuleSampling` sampling configurations will always be strictly respected by the whole Datadog processing pipeline.

It is possible for the `RuleSampler` to analyze a span and not make any user-configured decision (e.g. when no rules match, or not sampling rate applies). In this case, the priority is not altered.