### PR TITLE
Increase profiler microbenchmark run time

### DIFF
--- a/benchmarks/profiler_sample_loop.rb
+++ b/benchmarks/profiler_sample_loop.rb
@@ -42,7 +42,7 @@ class ProfilerSampleLoopBenchmark
 
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.001, warmup: 0.001} : {time: 10, warmup: 2}
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.001, warmup: 0.001} : {time: 70, warmup: 2}
       x.config(**benchmark_time, suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_sample_loop'))
 
       x.report("stack collector #{ENV['CONFIG']}") do

--- a/benchmarks/profiler_submission.rb
+++ b/benchmarks/profiler_submission.rb
@@ -61,7 +61,7 @@ class ProfilerSubmission
 
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.001, warmup: 0.001} : {time: 10, warmup: 2}
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.001, warmup: 0.001} : {time: 70, warmup: 2}
       x.config(**benchmark_time, suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_submission_v2'))
 
       x.report("exporter #{ENV['CONFIG']}") do


### PR DESCRIPTION
This makes it easier to explore these microbenchmarks in the reliability environment (see PR #564 on the private relenv repository).