### PR TITLE
Deprecation:c.tracer() settings

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2036,7 +2036,7 @@ Datadog's Tracing without Limits™ allows you to send all of your traffic and [
 
 We recommend setting the environment variable `DD_TRACE_SAMPLE_RATE=1.0` in all new applications using `ddtrace`.
 
-App Analytics, previously configured with the `analytics_enabled` setting, is deprecated in favor of Tracing without Limits™. Documentation for this [deprecated configuration is still available](https://docs.datadoghq.com/tracing/legacy_app_analytics/).
+App Analytics, previously configured with the `analytics.enabled` setting, is deprecated in favor of Tracing without Limits™. Documentation for this [deprecated configuration is still available](https://docs.datadoghq.com/tracing/legacy_app_analytics/).
 
 #### Application-side sampling
 

--- a/integration/apps/rack/app/datadog.rb
+++ b/integration/apps/rack/app/datadog.rb
@@ -3,7 +3,7 @@ require 'ddtrace'
 
 Datadog.configure do |c|
   c.diagnostics.debug = true if Datadog::DemoEnv.feature?('debug')
-  c.analytics_enabled = true if Datadog::DemoEnv.feature?('analytics')
+  c.analytics.enabled = true if Datadog::DemoEnv.feature?('analytics')
   c.runtime_metrics.enabled = true if Datadog::DemoEnv.feature?('runtime_metrics')
 
   if Datadog::DemoEnv.feature?('tracing')

--- a/integration/apps/rack/app/datadog.rb
+++ b/integration/apps/rack/app/datadog.rb
@@ -6,9 +6,7 @@ Datadog.configure do |c|
   c.analytics.enabled = true if Datadog::DemoEnv.feature?('analytics')
   c.runtime_metrics.enabled = true if Datadog::DemoEnv.feature?('runtime_metrics')
 
-  if Datadog::DemoEnv.feature?('tracing')
-    c.use :rack, service_name: 'acme-rack'
-  end
+  c.use :rack, service_name: 'acme-rack' if Datadog::DemoEnv.feature?('tracing')
 
   if Datadog::DemoEnv.feature?('pprof_to_file')
     # Reconfigure transport to write pprof to file

--- a/integration/apps/rails-five/config/initializers/datadog.rb
+++ b/integration/apps/rails-five/config/initializers/datadog.rb
@@ -2,7 +2,7 @@ require 'ddtrace'
 
 Datadog.configure do |c|
   c.diagnostics.debug = true if Datadog::DemoEnv.feature?('debug')
-  c.analytics_enabled = true if Datadog::DemoEnv.feature?('analytics')
+  c.analytics.enabled = true if Datadog::DemoEnv.feature?('analytics')
   c.runtime_metrics.enabled = true if Datadog::DemoEnv.feature?('runtime_metrics')
 
   if Datadog::DemoEnv.feature?('tracing')

--- a/integration/apps/rspec/app/datadog.rb
+++ b/integration/apps/rspec/app/datadog.rb
@@ -3,7 +3,7 @@ require 'ddtrace'
 
 Datadog.configure do |c|
   c.diagnostics.debug = true if Datadog::DemoEnv.feature?('debug')
-  c.analytics_enabled = true if Datadog::DemoEnv.feature?('analytics')
+  c.analytics.enabled = true if Datadog::DemoEnv.feature?('analytics')
   c.runtime_metrics.enabled = true if Datadog::DemoEnv.feature?('runtime_metrics')
 
   if Datadog::DemoEnv.feature?('pprof_to_file')

--- a/integration/apps/ruby/app/datadog.rb
+++ b/integration/apps/ruby/app/datadog.rb
@@ -3,7 +3,7 @@ require 'ddtrace'
 
 Datadog.configure do |c|
   c.diagnostics.debug = true if Datadog::DemoEnv.feature?('debug')
-  c.analytics_enabled = true if Datadog::DemoEnv.feature?('analytics')
+  c.analytics.enabled = true if Datadog::DemoEnv.feature?('analytics')
   c.runtime_metrics.enabled = true if Datadog::DemoEnv.feature?('runtime_metrics')
 
   if Datadog::DemoEnv.feature?('pprof_to_file')

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -49,14 +49,6 @@ module Datadog
         end
       end
 
-      option :analytics_enabled do |o|
-        o.delegate_to { get_option(:analytics).enabled }
-        o.on_set do |value|
-          # TODO: Raise deprecation warning
-          get_option(:analytics).enabled = value
-        end
-      end
-
       option :api_key do |o|
         o.default { ENV.fetch(Ext::Environment::ENV_API_KEY, nil) }
         o.lazy

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -335,55 +335,6 @@ module Datadog
         option :writer_options, default: ->(_i) { {} }, lazy: true # TODO: Deprecate
       end
 
-      # Backwards compatibility for configuring tracer e.g. `c.tracer debug: true`
-      def tracer(options = nil)
-        settings = get_option(:tracer)
-        return settings if options.nil?
-
-        # If options were provided (old style) then raise warnings and apply them:
-        options = options.dup
-
-        if options.key?(:log)
-          # TODO: Raise deprecation warning
-          get_option(:logger).instance = options.delete(:log)
-        end
-
-        if options.key?(:tags)
-          # TODO: Raise deprecation warning
-          set_option(:tags, options.delete(:tags))
-        end
-
-        if options.key?(:env)
-          # TODO: Raise deprecation warning
-          set_option(:env, options.delete(:env))
-        end
-
-        if options.key?(:debug)
-          # TODO: Raise deprecation warning
-          get_option(:diagnostics).debug = options.delete(:debug)
-        end
-
-        if options.key?(:partial_flush)
-          # TODO: Raise deprecation warning
-          settings.partial_flush.enabled = options.delete(:partial_flush)
-        end
-
-        if options.key?(:min_spans_before_partial_flush)
-          # TODO: Raise deprecation warning
-          settings.partial_flush.min_spans_threshold = options.delete(:min_spans_before_partial_flush)
-        end
-
-        # Forward remaining options to settings
-        options.each do |key, value|
-          setter = :"#{key}="
-          settings.send(setter, value) if settings.respond_to?(setter)
-        end
-      end
-
-      def tracer=(tracer)
-        get_option(:tracer).instance = tracer
-      end
-
       option :version do |o|
         # NOTE: version also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
         o.default { ENV.fetch(Ext::Environment::ENV_VERSION, nil) }

--- a/lib/ddtrace/opentracer/global_tracer.rb
+++ b/lib/ddtrace/opentracer/global_tracer.rb
@@ -7,7 +7,7 @@ module Datadog
         super.tap do
           if tracer.class <= Datadog::OpenTracer::Tracer
             # Update the Datadog global tracer, too.
-            Datadog.configure { |c| c.tracer = tracer.datadog_tracer }
+            Datadog.configure { |c| c.tracer.instance = tracer.datadog_tracer }
           end
         end
       end

--- a/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
+++ b/spec/ddtrace/configuration/agent_settings_resolver_spec.rb
@@ -116,16 +116,6 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
         end
       end
     end
-
-    context 'when a custom hostname is specified via code using "tracer(hostname: ...)"' do
-      before do
-        ddtrace_settings.tracer(hostname: 'custom-hostname')
-      end
-
-      it 'contacts the agent using the http adapter, using the custom hostname' do
-        expect(resolver).to have_attributes(**settings, hostname: 'custom-hostname')
-      end
-    end
   end
 
   describe 'http adapter port' do
@@ -244,16 +234,6 @@ RSpec.describe Datadog::Configuration::AgentSettingsResolver do
         it 'falls back to the defaults' do
           expect(resolver).to have_attributes settings
         end
-      end
-    end
-
-    context 'when a custom port is specified via code using "tracer(port: ...)"' do
-      before do
-        ddtrace_settings.tracer(port: 1234)
-      end
-
-      it 'contacts the agent using the http adapter, using the custom port' do
-        expect(resolver).to have_attributes(**settings, port: 1234)
       end
     end
   end

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -1164,110 +1164,6 @@ RSpec.describe Datadog::Configuration::Settings do
   end
 
   describe '#tracer' do
-    context 'old style' do
-      context 'given :debug' do
-        it 'updates the new #debug setting' do
-          expect { settings.tracer(debug: true) }
-            .to change { settings.diagnostics.debug }
-            .from(false)
-            .to(true)
-        end
-      end
-
-      context 'given :env' do
-        let(:env) { 'my-env' }
-
-        it 'updates the new #env setting' do
-          expect { settings.tracer env: env }
-            .to change { settings.env }
-            .from(nil)
-            .to(env)
-        end
-      end
-
-      context 'given :log' do
-        let(:custom_log) { Logger.new($stdout, level: Logger::INFO) }
-
-        it 'updates the new #instance setting' do
-          expect { settings.tracer(log: custom_log) }
-            .to change { settings.logger.instance }
-            .from(nil)
-            .to(custom_log)
-        end
-      end
-
-      describe 'given :min_spans_before_partial_flush' do
-        let(:value) { 1234 }
-
-        it 'updates the new #min_spans_threshold setting' do
-          expect { settings.tracer min_spans_before_partial_flush: value }
-            .to change { settings.tracer.partial_flush.min_spans_threshold }
-            .from(nil)
-            .to(value)
-        end
-      end
-
-      describe 'given :partial_flush' do
-        it 'updates the new #enabled setting' do
-          expect { settings.tracer partial_flush: true }
-            .to change { settings.tracer.partial_flush.enabled }
-            .from(false)
-            .to(true)
-        end
-      end
-
-      context 'given :tags' do
-        let(:tags) { { 'custom-tag' => 'custom-value' } }
-
-        it 'updates the new #tags setting' do
-          expect { settings.tracer tags: tags }
-            .to change { settings.tags }
-            .from({})
-            .to(tags)
-        end
-      end
-
-      context 'given :writer_options' do
-        before { settings.tracer(writer_options: { buffer_size: 1234 }) }
-
-        it 'updates the new #writer_options setting' do
-          expect(settings.tracer.writer_options).to eq(buffer_size: 1234)
-        end
-      end
-
-      context 'given some settings' do
-        let(:tracer) { Datadog::Tracer.new }
-
-        before do
-          settings.tracer(
-            enabled: false,
-            hostname: 'tracer.host.com',
-            port: 1234,
-            env: :config_test,
-            tags: { foo: :bar },
-            writer_options: { buffer_size: 1234 },
-            instance: tracer
-          )
-        end
-
-        it 'applies settings correctly' do
-          expect(settings.tracer.enabled).to be false
-          expect(settings.tracer.hostname).to eq('tracer.host.com')
-          expect(settings.tracer.port).to eq(1234)
-          expect(settings.env).to eq(:config_test)
-          expect(settings.tags['foo']).to eq(:bar)
-        end
-      end
-
-      it 'acts on the tracer option' do
-        previous_state = settings.tracer.enabled
-        settings.tracer(enabled: !previous_state)
-        expect(settings.tracer.enabled).to eq(!previous_state)
-        settings.tracer(enabled: previous_state)
-        expect(settings.tracer.enabled).to eq(previous_state)
-      end
-    end
-
     describe '#enabled' do
       subject(:enabled) { settings.tracer.enabled }
 
@@ -1491,16 +1387,6 @@ RSpec.describe Datadog::Configuration::Settings do
           .from({})
           .to(options)
       end
-    end
-  end
-
-  describe '#tracer=' do
-    let(:tracer) { instance_double(Datadog::Tracer) }
-
-    it 'sets the tracer instance' do
-      expect { settings.tracer = tracer }.to change { settings.tracer.instance }
-        .from(nil)
-        .to(tracer)
     end
   end
 

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -47,27 +47,6 @@ RSpec.describe Datadog::Configuration::Settings do
     end
   end
 
-  describe '#analytics_enabled' do
-    subject(:analytics_enabled) { settings.analytics_enabled }
-
-    let(:value) { double }
-
-    before { expect(settings.analytics).to receive(:enabled).and_return(value) }
-
-    it 'retrieves the value from the new setting' do
-      is_expected.to be value
-    end
-  end
-
-  describe '#analytics_enabled=' do
-    it 'changes the new #enabled setting' do
-      expect { settings.analytics_enabled = true }
-        .to change { settings.analytics.enabled }
-        .from(nil)
-        .to(true)
-    end
-  end
-
   describe '#api_key' do
     subject(:api_key) { settings.api_key }
 

--- a/spec/ddtrace/configuration_spec.rb
+++ b/spec/ddtrace/configuration_spec.rb
@@ -283,8 +283,8 @@ RSpec.describe Datadog::Configuration do
           before do
             expect(old_tracer).to receive(:shutdown!)
 
-            test_class.configure { |c| c.tracer = old_tracer }
-            test_class.configure { |c| c.tracer = new_tracer }
+            test_class.configure { |c| c.tracer.instance = old_tracer }
+            test_class.configure { |c| c.tracer.instance = new_tracer }
           end
 
           it 'replaces the old tracer and shuts it down' do
@@ -298,8 +298,8 @@ RSpec.describe Datadog::Configuration do
           before do
             expect(tracer).to_not receive(:shutdown!)
 
-            test_class.configure { |c| c.tracer = tracer }
-            test_class.configure { |c| c.tracer = tracer }
+            test_class.configure { |c| c.tracer.instance = tracer }
+            test_class.configure { |c| c.tracer.instance = tracer }
           end
 
           it 'reuses the same tracer' do
@@ -313,7 +313,7 @@ RSpec.describe Datadog::Configuration do
           before do
             expect(tracer).to_not receive(:shutdown!)
 
-            test_class.configure { |c| c.tracer = tracer }
+            test_class.configure { |c| c.tracer.instance = tracer }
             test_class.configure { |_c| }
           end
 

--- a/spec/ddtrace/diagnostics/environment_logger_spec.rb
+++ b/spec/ddtrace/diagnostics/environment_logger_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Datadog::Diagnostics::EnvironmentLogger do
       end
 
       context 'with analytics enabled' do
-        before { Datadog.configure { |c| c.analytics_enabled = true } }
+        before { Datadog.configure { |c| c.analytics.enabled = true } }
 
         it { is_expected.to include analytics_enabled: true }
       end

--- a/spec/ddtrace/opentracer/global_tracer_spec.rb
+++ b/spec/ddtrace/opentracer/global_tracer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Datadog::OpenTracer::GlobalTracer do
     describe '#global_tracer=' do
       subject(:global_tracer) { OpenTracing.global_tracer = tracer }
 
-      after { Datadog.configuration.tracer = Datadog::Tracer.new }
+      after { Datadog.configuration.tracer.instance = Datadog::Tracer.new }
 
       context 'when given a Datadog::OpenTracer::Tracer' do
         let(:tracer) { Datadog::OpenTracer::Tracer.new }


### PR DESCRIPTION
Removed tracer instance configuration option using the `c.tracer option: value` syntax.

The `c.tracer.option = value` syntax has been preferred for a while.