### PR TITLE
Bump debase-ruby_core_source dependency version

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   #
   # Because we only use this for older Rubies, and we consider it "feature-complete" for those older Rubies,
   # we're pinning it at the latest available version and will manually bump the dependency as needed.
-  spec.add_dependency 'debase-ruby_core_source', '= 0.10.12'
+  spec.add_dependency 'debase-ruby_core_source', '= 0.10.13'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb']
 end

--- a/gemfiles/jruby_9.2.0.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -1239,7 +1239,7 @@ GEM
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.2)
       cucumber-messages (~> 17.0, >= 17.0.1)
     dalli (2.7.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)
     delayed_job_active_record (4.1.6)

--- a/gemfiles/jruby_9.2.0.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -35,7 +35,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -35,7 +35,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/jruby_9.2.0.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_cucumber3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -52,7 +52,7 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_cucumber4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -72,7 +72,7 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.3)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_cucumber5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -72,7 +72,7 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails5_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails5_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails5_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails5_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails5_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails6_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails6_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails6_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails6_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_rails6_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -35,7 +35,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.0.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.0.0_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -35,7 +35,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -1239,7 +1239,7 @@ GEM
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.2)
       cucumber-messages (~> 17.0, >= 17.0.1)
     dalli (2.7.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)
     delayed_job_active_record (4.1.6)

--- a/gemfiles/jruby_9.2.18.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -35,7 +35,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -35,7 +35,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (4.8.3)

--- a/gemfiles/jruby_9.2.18.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -52,7 +52,7 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -72,7 +72,7 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.3)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -72,7 +72,7 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -101,7 +101,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -100,7 +100,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -35,7 +35,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/jruby_9.2.18.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -35,7 +35,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dogstatsd-ruby (5.2.0)

--- a/gemfiles/ruby_2.1.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_contrib.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack (< 1.4)
 
 GEM
@@ -73,7 +73,7 @@ GEM
     crack (0.4.5)
       rexml
     dalli (2.7.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)

--- a/gemfiles/ruby_2.1.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_core_old.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack (< 1.4)
 
 GEM
@@ -24,7 +24,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1.10_rails30_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails30_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack (< 1.4)
 
 GEM
@@ -52,7 +52,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1.10_rails30_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails30_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack (< 1.4)
 
 GEM
@@ -53,7 +53,7 @@ GEM
     connection_pool (2.2.3)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack (< 1.4)
 
 GEM
@@ -56,7 +56,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack (< 1.4)
 
 GEM
@@ -52,7 +52,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack (< 1.4)
 
 GEM
@@ -52,7 +52,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack (< 1.4)
 
 GEM
@@ -53,7 +53,7 @@ GEM
     connection_pool (2.2.3)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack (< 1.4)
 
 GEM
@@ -60,7 +60,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack (< 1.4)
 
 GEM
@@ -60,7 +60,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack (< 1.4)
 
 GEM
@@ -60,7 +60,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack (< 1.4)
 
 GEM
@@ -60,7 +60,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_contrib.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -1195,7 +1195,7 @@ GEM
     crass (1.0.6)
     daemons (1.4.1)
     dalli (2.7.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)

--- a/gemfiles/ruby_2.2.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_core_old.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -24,7 +24,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails30_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails30_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -52,7 +52,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails30_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails30_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -53,7 +53,7 @@ GEM
     connection_pool (2.2.5)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -56,7 +56,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -52,7 +52,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -52,7 +52,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -53,7 +53,7 @@ GEM
     connection_pool (2.2.5)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -60,7 +60,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -60,7 +60,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -60,7 +60,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -61,7 +61,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -60,7 +60,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -68,7 +68,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -1200,7 +1200,7 @@ GEM
     crass (1.0.6)
     daemons (1.4.1)
     dalli (2.7.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)

--- a/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -24,7 +24,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_core_old.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -24,7 +24,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -41,7 +41,7 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -60,7 +60,7 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.3)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails30_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails30_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -52,7 +52,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails30_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails30_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -53,7 +53,7 @@ GEM
     connection_pool (2.2.5)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -56,7 +56,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -52,7 +52,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -52,7 +52,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -53,7 +53,7 @@ GEM
     connection_pool (2.2.5)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -60,7 +60,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -60,7 +60,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -60,7 +60,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -61,7 +61,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -60,7 +60,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -68,7 +68,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -24,7 +24,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -24,7 +24,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -1228,7 +1228,7 @@ GEM
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
     dalli (2.7.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)

--- a/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_core_old.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -63,7 +63,7 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.3)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -70,7 +70,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.10)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -70,7 +70,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.10)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -70,7 +70,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.10)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -70,7 +70,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.10)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -71,7 +71,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.10)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -70,7 +70,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.10)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -27,7 +27,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.10)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.3.5)

--- a/gemfiles/ruby_2.5.9_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -1233,7 +1233,7 @@ GEM
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.2)
       cucumber-messages (~> 17.0, >= 17.0.1)
     dalli (2.7.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)

--- a/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -37,7 +37,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -37,7 +37,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -54,7 +54,7 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -74,7 +74,7 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.3)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -74,7 +74,7 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -81,7 +81,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -80,7 +80,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -93,7 +93,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -93,7 +93,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -93,7 +93,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -93,7 +93,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -94,7 +94,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -93,7 +93,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -37,7 +37,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -37,7 +37,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -1234,7 +1234,7 @@ GEM
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.2)
       cucumber-messages (~> 17.0, >= 17.0.1)
     dalli (2.7.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)

--- a/gemfiles/ruby_2.6.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -55,7 +55,7 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -75,7 +75,7 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.3)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -75,7 +75,7 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -81,7 +81,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -81,7 +81,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -81,7 +81,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -81,7 +81,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -82,7 +82,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -81,7 +81,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -94,7 +94,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -94,7 +94,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -94,7 +94,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -94,7 +94,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -95,7 +95,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -94,7 +94,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.6.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -1234,7 +1234,7 @@ GEM
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.2)
       cucumber-messages (~> 17.0, >= 17.0.1)
     dalli (2.7.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)

--- a/gemfiles/ruby_2.7.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_contrib_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -55,7 +55,7 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -75,7 +75,7 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.3)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -75,7 +75,7 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -81,7 +81,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -81,7 +81,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -81,7 +81,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -81,7 +81,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -82,7 +82,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -81,7 +81,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -94,7 +94,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -94,7 +94,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -94,7 +94,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -94,7 +94,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -95,7 +95,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -94,7 +94,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_2.7.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.1_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -1238,7 +1238,7 @@ GEM
       cucumber-messages (~> 17.0, >= 17.0.1)
     daemons (1.4.1)
     dalli (2.7.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)

--- a/gemfiles/ruby_3.0.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.1_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.1_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.0.1_cucumber3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -55,7 +55,7 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.1_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.0.1_cucumber4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -75,7 +75,7 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.3)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.1_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.0.1_cucumber5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -75,7 +75,7 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0.1_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     digest (3.0.0)

--- a/gemfiles/ruby_3.0.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0.1_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     digest (3.0.0)

--- a/gemfiles/ruby_3.0.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0.1_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     digest (3.0.0)

--- a/gemfiles/ruby_3.0.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0.1_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     digest (3.0.0)

--- a/gemfiles/ruby_3.0.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0.1_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     digest (3.0.0)

--- a/gemfiles/ruby_3.0.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0.1_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_3.0.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0.1_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1.0_contrib.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -1286,7 +1286,7 @@ GEM
       cucumber-messages (~> 17.1, >= 17.1.1)
     daemons (1.4.1)
     dalli (3.0.4)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)

--- a/gemfiles/ruby_3.1.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.0_core_old.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.0_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.1.0_cucumber3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -55,7 +55,7 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.0_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.1.0_cucumber4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -75,7 +75,7 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.3)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.0_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.1.0_cucumber5.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -75,7 +75,7 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1.0_rails61_mysql2.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     digest (3.0.0)

--- a/gemfiles/ruby_3.1.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1.0_rails61_postgres.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     digest (3.0.0)

--- a/gemfiles/ruby_3.1.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1.0_rails61_postgres_redis.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     digest (3.0.0)

--- a/gemfiles/ruby_3.1.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1.0_rails61_postgres_sidekiq.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -99,7 +99,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     digest (3.0.0)

--- a/gemfiles/ruby_3.1.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1.0_rails61_semantic_logger.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       rexml
     crass (1.0.6)
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     digest (3.0.0)

--- a/gemfiles/ruby_3.1.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1.0_resque2_redis3.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)

--- a/gemfiles/ruby_3.1.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1.0_resque2_redis4.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     ddtrace (0.54.1)
-      debase-ruby_core_source (= 0.10.12)
+      debase-ruby_core_source (= 0.10.13)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     crack (0.4.5)
       rexml
     cri (2.15.11)
-    debase-ruby_core_source (0.10.12)
+    debase-ruby_core_source (0.10.13)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     docile (1.4.0)


### PR DESCRIPTION
Since we have a dependency on a specific version of `debase-ruby_core_source`, it's nice to keep it up-to-date, otherwise we may be blocking users from actually using it on modern rubies.

I've reviewed the diff for this version at <https://my.diffend.io/gems/debase-ruby_core_source/0.10.12/0.10.13> and it looks good.