### PR TITLE
Document partial support (non-production) of macOS

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -135,9 +135,13 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
 
 *EOL* indicates support is no longer provided.
 
+### Apple macOS support
+
+Use of `ddtrace` on macOS is supported for development, but not for production deployments.
+
 ### Microsoft Windows support
 
-Using `ddtrace ` on Microsoft Windows is currently unsupported. We'll still accept community contributions and issues,
+Using `ddtrace` on Microsoft Windows is currently unsupported. We'll still accept community contributions and issues,
 but will consider them as having low priority.
 
 ## Installation


### PR DESCRIPTION
As discussed during the last Ruby guild meeting with @delner.

We had discussed making this entry into a table, like we have for interpreters/web servers/etc but on closer look I don't think a table has the space to include the support details, especially the ones for Windows.