### PR TITLE
RFC: Send number of allocations in span as metric

### DIFF
--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -28,7 +28,6 @@ module Datadog
     EXTERNAL_MAX_ID = 1 << 64
 
     attr_accessor \
-      :allocations,
       :end_time,
       :id,
       :meta,
@@ -62,7 +61,6 @@ module Datadog
     # TODO: Remove span_type
     def initialize(
       name,
-      allocations: 0,
       duration: nil,
       end_time: nil,
       id: nil,
@@ -89,8 +87,6 @@ module Datadog
       @meta = meta || {}
       @metrics = metrics || {}
       @status = status || 0
-
-      @allocations = allocations || 0
 
       # start_time and end_time track wall clock. In Ruby, wall clock
       # has less accuracy than monotonic clock, so if possible we look to only use wall clock
@@ -141,7 +137,6 @@ module Datadog
     # isn't handled by this method.
     def to_hash
       h = {
-        allocations: @allocations,
         error: @status,
         meta: @meta,
         metrics: @metrics,
@@ -179,7 +174,6 @@ module Datadog
         q.text "Start: #{start_time}\n"
         q.text "End: #{end_time}\n"
         q.text "Duration: #{duration.to_f}\n"
-        q.text "Allocations: #{allocations}\n"
         q.group(2, 'Tags: [', "]\n") do
           q.breakable
           q.seplist @meta.each do |key, value|

--- a/lib/ddtrace/span_operation.rb
+++ b/lib/ddtrace/span_operation.rb
@@ -182,6 +182,8 @@ module Datadog
 
       @allocation_count_stop = now_allocations
 
+      set_metric('allocations', allocations)
+
       now = Utils::Time.now.utc
 
       # Provide a default start_time if unset.
@@ -261,7 +263,6 @@ module Datadog
     # Return the hash representation of the current span.
     def to_hash
       h = {
-        allocations: allocations,
         error: @status,
         id: @id,
         meta: meta,
@@ -299,7 +300,6 @@ module Datadog
         q.text "Start: #{start_time}\n"
         q.text "End: #{end_time}\n"
         q.text "Duration: #{duration.to_f if stopped?}\n"
-        q.text "Allocations: #{allocations}\n"
         q.group(2, 'Tags: [', "]\n") do
           q.breakable
           q.seplist meta.each do |key, value|
@@ -408,7 +408,6 @@ module Datadog
     def build_span
       Span.new(
         @name && @name.dup,
-        allocations: allocations,
         duration: duration,
         end_time: @end_time,
         id: @id,
@@ -462,7 +461,7 @@ module Datadog
       (duration * 1e9).to_i
     end
 
-    if defined?(JRUBY_VERSION) || Gem::Version.new(RUBY_VERSION) < Gem::Version.new(VERSION::MINIMUM_RUBY_VERSION)
+    if defined?(JRUBY_VERSION)
       def now_allocations
         0
       end

--- a/lib/ddtrace/transport/serializable_trace.rb
+++ b/lib/ddtrace/transport/serializable_trace.rb
@@ -53,8 +53,10 @@ module Datadog
       def to_msgpack(packer = nil)
         packer ||= MessagePack::Packer.new
 
+        number_of_elements_to_write = 10
+
         if span.stopped?
-          packer.write_map_header(13) # Set header with how many elements in the map
+          packer.write_map_header(number_of_elements_to_write + 2) # Set header with how many elements in the map
 
           packer.write('start')
           packer.write(time_nano(span.start_time))
@@ -62,7 +64,7 @@ module Datadog
           packer.write('duration')
           packer.write(duration_nano(span.duration))
         else
-          packer.write_map_header(11) # Set header with how many elements in the map
+          packer.write_map_header(number_of_elements_to_write) # Set header with how many elements in the map
         end
 
         # DEV: We use strings as keys here, instead of symbols, as
@@ -86,8 +88,6 @@ module Datadog
         packer.write(span.meta)
         packer.write('metrics')
         packer.write(span.metrics)
-        packer.write('allocations')
-        packer.write(span.allocations)
         packer.write('error')
         packer.write(span.status)
         packer

--- a/spec/ddtrace/span_spec.rb
+++ b/spec/ddtrace/span_spec.rb
@@ -213,7 +213,6 @@ RSpec.describe Datadog::Span do
         type: nil,
         meta: {},
         metrics: {},
-        allocations: 0,
         error: 0
       )
     end


### PR DESCRIPTION
I recently noticed that while we usually collect the number of memory allocations on a given span, we send it as an "allocations" field to the agent and this data never seems to make it to the backend.

Instead, this refactor reports it as a span metric. Does this make sense?

This is still missing tests and whatnot, but I wanted to get a feel if I'm doing this correctly before I did the full changes.

Also, as requested by @delner I'm targeting this to the 1.0 branch.