### PR TITLE
[PROF-4260] Add jitter to profile flushes

### DIFF
--- a/lib/ddtrace/profiling/scheduler.rb
+++ b/lib/ddtrace/profiling/scheduler.rb
@@ -120,6 +120,11 @@ module Datadog
         # a) it's being shutting down (and is trying to report the last profile)
         # b) it's being run as a one-shot, usually in a test
         # ...so in those cases we don't sleep
+        #
+        # During PR review (https://github.com/DataDog/dd-trace-rb/pull/1807) we discussed the possible alternative of
+        # just sleeping before starting the scheduler loop. We ended up not going with that option to avoid the first
+        # profile containing up to DEFAULT_INTERVAL_SECONDS + DEFAULT_FLUSH_JITTER_MAXIMUM_SECONDS instead of the
+        # usual DEFAULT_INTERVAL_SECONDS size.
         if run_loop?
           jitter_seconds = rand * DEFAULT_FLUSH_JITTER_MAXIMUM_SECONDS # floating point number between (0.0...maximum)
           sleep(jitter_seconds)

--- a/spec/ddtrace/profiling/scheduler_spec.rb
+++ b/spec/ddtrace/profiling/scheduler_spec.rb
@@ -209,6 +209,33 @@ RSpec.describe Datadog::Profiling::Scheduler do
           flush_events
         end
       end
+
+      context 'when being run in a loop' do
+        before { allow(scheduler).to receive(:run_loop?).and_return(true) }
+
+        it 'sleeps for up to DEFAULT_FLUSH_JITTER_MAXIMUM_SECONDS seconds before reporting' do
+          expect(scheduler).to receive(:sleep) do |sleep_amount|
+            expect(sleep_amount).to be < described_class.const_get(:DEFAULT_FLUSH_JITTER_MAXIMUM_SECONDS)
+            expect(sleep_amount).to be_a_kind_of(Float)
+          end
+
+          expect(exporters).to all(receive(:export).with(flush))
+
+          flush_events
+        end
+      end
+
+      context 'when being run as a one-off' do
+        before { allow(scheduler).to receive(:run_loop?).and_return(false) }
+
+        it 'does not sleep before reporting' do
+          expect(scheduler).to_not receive(:sleep)
+
+          expect(exporters).to all(receive(:export).with(flush))
+
+          flush_events
+        end
+      end
     end
   end
 


### PR DESCRIPTION
In Ruby applications that use multiple processes (such as webservers like puma), we start a profiler instance for each individual process.

If those applications fork all their processes at the same time (usually at start-up time), we get N processes that start profiling at the same time, and that will report profiles every minute at exacty the same time.

To spread out the impact of this reporting (both on the reporting app, as well as on the profiling backend), this PR adds a very small random sleep (at most 3 seconds) before each report is made.

Note that because we sleep AFTER we collect the events from the recorder, we still report exactly the same data as before -- we just may report it ever-so-slightly later.