### PR TITLE
Add YARD extensions for public API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - 'ext/**/*.rb'
     - 'test/**/*.rb'
     - 'spec/**/*.rb'
+    - 'yard/**/*.rb'
     - 'Gemfile'
     - 'Rakefile'
   Exclude:

--- a/.yardopts
+++ b/.yardopts
@@ -1,5 +1,10 @@
+--markup markdown
+--markup-provider redcarpet
 --readme docs/GettingStarted.md
---main docs/GettingStarted.md
--
-docs/GettingStarted.md
-LICENSE
+--tag='public_api:Public API'
+--hide-tag=public_api
+--files LICENSE
+--files docs/AutoInstrumentation.md
+--files docs/PublicApi.md
+--template-path=yard/templates
+-e ./yard/extensions.rb

--- a/Rakefile
+++ b/Rakefile
@@ -171,16 +171,19 @@ namespace :spec do
 end
 
 if defined?(RuboCop::RakeTask)
-  RuboCop::RakeTask.new(:rubocop) do |t|
-    t.options << ['-D', '--force-exclusion']
-    t.patterns = ['lib/**/*.rb', 'test/**/*.rb', 'spec/**/*.rb', 'Gemfile', 'Rakefile']
+  RuboCop::RakeTask.new(:rubocop) do |_t|
   end
 end
 
 YARD::Rake::YardocTask.new(:docs) do |t|
+  # Options defined in `.yardopts` are read first, then merged with
+  # options defined here.
+  #
+  # It's recommended to define options in `.yardopts` instead of here,
+  # as `.yardopts` can be read by external YARD tools, like the
+  # hot-reload YARD server `yard server --reload`.
+
   t.options += ['--title', "ddtrace #{Datadog::VERSION::STRING} documentation"]
-  t.options += ['--markup', 'markdown']
-  t.options += ['--markup-provider', 'redcarpet']
 end
 
 # Deploy tasks

--- a/docs/AutoInstrumentation.md
+++ b/docs/AutoInstrumentation.md
@@ -1,0 +1,30 @@
+# Auto Instrumentation
+
+`ddtrace` can automatically instrument all available libraries, without requiring the manual specification of each one.
+
+## Rails
+
+Add 'ddtrace', require: 'ddtrace/auto_instrument' to your Gemfile:
+
+```ruby
+source 'https://rubygems.org'
+gem 'ddtrace', require: 'ddtrace/auto_instrument'
+```
+
+## Ruby
+
+Require `'ddtrace/auto_instrument'` after all gems that you'd like to instrument have been loaded:
+
+```ruby
+# Example libraries with supported integrations
+require 'sinatra'
+require 'faraday'
+require 'redis'
+
+require 'ddtrace/auto_instrument'
+```
+
+## Additional configuration
+
+You can reconfigure, override, or disable any specific integration settings by adding
+a `Datadog.configure` call after `ddtrace/auto_instrument` is activated.

--- a/docs/PublicApi.md
+++ b/docs/PublicApi.md
@@ -1,0 +1,14 @@
+# Public API
+
+`ddtrace` respects [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
+Classes, modules, and methods marked as part of the public API will not introduce
+braking changes outside of a major version release.
+
+Objects that belong to the public API are marked with the `@public_api` YARD documentation tag.
+When navigating [`ddtrace`'s YARD documentation](https://rubydoc.info/gems/ddtrace), public API
+objects will have an explicit banner informing the user that they are part of the public API contract.
+
+Objects not marked with the `@public_api` tag are not part of the public API contract, and thus
+considered internal to `ddtrace`. These objects can receive breaking changes in minor and patch
+releases.

--- a/sorbet/config
+++ b/sorbet/config
@@ -1,3 +1,4 @@
 --dir
 .
 --ignore=/integration
+--ignore=/yard

--- a/yard/extensions.rb
+++ b/yard/extensions.rb
@@ -1,0 +1,65 @@
+#
+# Generates modules for DSL categories created by {Datadog::Configuration::Base::ClassMethods#settings}.
+# `#settings` are groups that can contain multiple `#option`s or nested `#settings.`
+#
+class DatadogConfigurationSettingsHandler < YARD::Handlers::Ruby::Base
+  handles method_call(:settings)
+
+  process do
+    next if statement.is_a?(YARD::Parser::Ruby::ReferenceNode)
+
+    name = call_params[0]
+
+    generated_module = YARD::CodeObjects::ModuleObject.new(namespace, 'DSL') do |o|
+      o.docstring = 'Namespace for dynamically generated configuration classes.'
+    end
+
+    register(generated_module)
+
+    generated_class = YARD::CodeObjects::ClassObject.new(generated_module, camelize(name)) do |o|
+      o.docstring = 'Namespace for dynamically generated configuration classes.'
+    end
+
+    register(generated_class)
+
+    statement.docstring = <<~YARD
+      #{statement.docstring}
+      @return [#{generated_class.path}] a configuration object
+    YARD
+
+    statement.block.last.each do |node|
+      parse_block(node, :namespace => generated_class)
+    end
+  end
+end
+
+#
+# Generates attributes for DSL options created by {Datadog::Configuration::Options::ClassMethods#option}.
+# `#option`s are read/write configurable attributes.
+#
+class DatadogConfigurationOptionHandler < YARD::Handlers::Ruby::Base
+  handles method_call(:option)
+
+  process do
+    next if statement.is_a?(YARD::Parser::Ruby::ReferenceNode)
+
+    # Convert this method call into a read/write attribute.
+    # The easiest way to do this is by invoking YARD's AttributeHandler.
+    # We trick AttributeHandler into thinking this is an `attr_accessor`
+    # node, instead of a method call node.
+    attr_statement = statement.dup
+    attr_statement.define_singleton_method(:method_name) { |*_args| :attr_accessor }
+
+    # Remove additional arguments to `option :name`, like `default:`.
+    # These won't parse correctly when we parse
+    # `option :name, default: 1` as `attr_accessor :name, default: 1`.
+    statement[1].slice!(1..-2)
+
+    attr = YARD::Handlers::Ruby::AttributeHandler.new(parser, attr_statement)
+    attr.process
+  end
+end
+
+def camelize(str)
+  str.split('_').collect(&:capitalize).join
+end

--- a/yard/templates/default/fulldoc/html/css/datadog.css
+++ b/yard/templates/default/fulldoc/html/css/datadog.css
@@ -1,0 +1,3 @@
+.public_api {
+    background-color: #ecf9ef; /* light green */
+}

--- a/yard/templates/default/fulldoc/html/full_list_public_api.erb
+++ b/yard/templates/default/fulldoc/html/full_list_public_api.erb
@@ -1,0 +1,11 @@
+<!-- Based on YARD's built-in templates/default/fulldoc/html/full_list_method.erb -->
+<% even_odd = 'odd'  %>
+<% @items.each do |item| %>
+  <li class="<%= even_odd %> <%= item.has_tag?(:deprecated) ? 'deprecated' : '' %>">
+    <div class="item">
+      <%= linkify item, h(item.name(true)) %>
+      <small><%= item.namespace.title %></small>
+    </div>
+  </li>
+  <% even_odd = (even_odd == 'even' ? 'odd' : 'even') %>
+<% end %>

--- a/yard/templates/default/fulldoc/html/setup.rb
+++ b/yard/templates/default/fulldoc/html/setup.rb
@@ -1,0 +1,27 @@
+# List all classes, modules, and methods that are part of the public API
+def generate_public_api_list
+  @list_title = 'Public API'
+  @list_type = 'public_api'
+
+  # Matches nodes with @public_api YARD doc tag
+  verifier = Verifier.new('@public_api')
+
+  @items = public_api_methods(verifier)
+  @items += public_api_classes(verifier)
+
+  @items.sort_by! { |m| m.name.to_s.downcase }
+
+  generate_list_contents # built-in YARD method at 'templates/default/fulldoc/html/setup.rb'
+end
+
+def public_api_methods(verifier)
+  methods = Registry.all(:method)
+  methods = run_verifier(methods) # Run global YARD verifier, in case one is configured
+  verifier.run(methods)
+end
+
+def public_api_classes(verifier)
+  classes = options.objects
+  classes = run_verifier(classes) # Run global YARD verifier, in case one is configured
+  verifier.run(classes)
+end

--- a/yard/templates/default/layout/html/setup.rb
+++ b/yard/templates/default/layout/html/setup.rb
@@ -1,0 +1,9 @@
+def menu_lists
+  # Append Public API index to the menu
+  super + [{ :type => 'public_api', :title => 'Public API', :search_title => 'Public API' }]
+end
+
+def stylesheets
+  # Append custom Datadog stylesheet
+  super + %w[css/datadog.css]
+end

--- a/yard/templates/default/tags/html/public_api.erb
+++ b/yard/templates/default/tags/html/public_api.erb
@@ -1,0 +1,6 @@
+<div class="note public_api">
+  This <%= object.type.to_s %> is part of the <%= link_file('PublicApi.md', 'Public API') %>.
+  <% if [:module, :class].include?(object.type) %>
+    All public attributes, constants, and methods defined in this <%= object.type.to_s %> are also part of the Public API.
+  <% end %>
+</div>

--- a/yard/templates/default/tags/setup.rb
+++ b/yard/templates/default/tags/setup.rb
@@ -1,0 +1,10 @@
+def init
+  super
+  sections.push :public_api
+end
+
+def public_api
+  return unless object.has_tag?(:public_api)
+
+  erb(:public_api)
+end


### PR DESCRIPTION
This PR, extracted from #1778, provides the foundation to a richer YARD documentation that will support our public API documentation. This prepares us to tag public methods with a custom `@public_api` YARD tag.

This PR adds:
1. Generate documentation for our configuration DSL, mostly defined in [dd-trace-rb/lib/ddtrace/configuration/settings.rb](https://github.com/DataDog/dd-trace-rb/blob/40b107252be3fff18e51326b85f88853a02d5efc/lib/ddtrace/configuration/settings.rb#L45-L50). The `settings :name` and `option :name` will not generate classes and module that can be documented (classes are namespaced in a new `DSL` module, in order to avoid path conflicts):
1.1  <img width="1005" alt="Screen Shot 2021-12-08 at 3 58 10 PM" src="https://user-images.githubusercontent.com/583503/145310476-13ec6180-1c22-4c82-8841-440ade57c3bc.png">
1.2  The `c.analytics.enabled` option, for example, looks like this after being documented: <img width="1066" alt="Screen Shot 2021-12-08 at 4 06 27 PM" src="https://user-images.githubusercontent.com/583503/145310784-5340d75d-30c1-47f9-8c6a-4386f1e450c0.png">


2. Added a Public API list, to the top-left menu list. This list collects all modules, classes, and methods that are part of the public API and allows users to search for them dynamically in our docs:
<img width="314" alt="Screen Shot 2021-12-08 at 4 00 54 PM" src="https://user-images.githubusercontent.com/583503/145310980-9db8b7e1-7479-4270-8718-95491566a159.png">


3. Added a few extra documentation files, to allow us to directly link YARD docs to a more expanded explanation of a topic. The most useful case so far is to hyperlink to an explanation of the "Public API", which will be added to every `@public_api` tagged object. 
<img width="262" alt="Screen Shot 2021-12-08 at 3 58 58 PM" src="https://user-images.githubusercontent.com/583503/145311084-dea10d77-79b7-4cef-8348-a9745508510f.png">
You can see an example here:
<img width="360" alt="Screen Shot 2021-12-08 at 4 00 27 PM" src="https://user-images.githubusercontent.com/583503/145311316-b99bf28c-2716-4e35-87a1-6b1eb7ff60dd.png">

4. Cleaned up YARD and Rubocop Rake tasks, moving most options to their respected dot files. Using dot files as the main source of configuration allows external tools to correctly handle the `ddtrace`, without depending exclusively on our Rake tasks. One example is `yard server --reload`, which hosts a hot-reload YARD server that reflects documentation changes very quickly, but depends on having access to all options, which are now all in `.yardopts`.
 
