### PR TITLE
Doc:Tag tracing existing Public API objects

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -7,6 +7,7 @@
 --hide-tag public_api
 --files LICENSE
 --files docs/AutoInstrumentation.md
+--files docs/Deprecation.md
 --files docs/PublicApi.md
 --template-path yard/templates
 -e ./yard/extensions.rb

--- a/.yardopts
+++ b/.yardopts
@@ -2,10 +2,11 @@
 --markup markdown
 --markup-provider redcarpet
 --readme docs/GettingStarted.md
---tag='public_api:Public API'
---hide-tag=public_api
+--tag default:"Defaults to"
+--tag 'public_api:Public API'
+--hide-tag public_api
 --files LICENSE
 --files docs/AutoInstrumentation.md
 --files docs/PublicApi.md
---template-path=yard/templates
+--template-path yard/templates
 -e ./yard/extensions.rb

--- a/docs/AutoInstrumentation.md
+++ b/docs/AutoInstrumentation.md
@@ -28,3 +28,9 @@ require 'ddtrace/auto_instrument'
 
 You can reconfigure, override, or disable any specific integration settings by adding
 a [`Datadog.configure`](GettingStarted.md#integration-instrumentation) call after `ddtrace/auto_instrument` is activated.
+
+## Custom integrations
+
+Custom integrations that want to support auto instrumentation need to be registered
+(e.g. invoke their {Datadog::Contrib::Registerable::ClassMethods#register_as} method) before
+the tracer requires `'ddtrace/auto_instrument'`.

--- a/docs/Deprecation.md
+++ b/docs/Deprecation.md
@@ -1,0 +1,8 @@
+# Deprecation
+
+Deprecated API objects are scheduled to be **removed in the next major version release**.
+
+Deprecated objects can still be safely used until the next major version.
+
+Objects will receive the deprecation tag in a minor version release,
+allowing for deprecation warnings to be surfaced to users before the next major release.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -287,7 +287,7 @@ And `options` is an optional `Hash` that accepts the following parameters:
 | Key | Type | Description | Default |
 | --------------- | ----------------------- | --- | --- |
 | `autostart`     | `Bool`                  | Whether the time measurement should be started automatically. If `false`, user must call `span.start`. | `true` |
-| `continue_from` | `Datadog::TraceDigest`  | Continues a trace that originated from another execution context. \TraceDigest describes the continuation point. | `nil` |
+| `continue_from` | `Datadog::TraceDigest`  | Continues a trace that originated from another execution context. TraceDigest describes the continuation point. | `nil` |
 | `on_error`      | `Proc`                  | Overrides error handling behavior, when a span raises an error. Provided `span` and `error` as arguments. Sets error on the span by default. | `proc { |span, error| span.set_error(error) unless span.nil? }` |
 | `resource`      | `String`                | Name of the resource or action being operated on. Traces with the same resource value will be grouped together for the purpose of metrics (but still independently viewable.) Usually domain specific, such as a URL, query, request, etc. (e.g. `'Article#submit'`, `http://example.com/articles/list`.) | `name` of Span. |
 | `service`       | `String`                | The service name which this span belongs (e.g. `'my-web-service'`) | Tracer `default-service`, `$PROGRAM_NAME` or `'ruby'` |

--- a/lib/datadog/ci/contrib/cucumber/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/cucumber/configuration/settings.rb
@@ -8,6 +8,7 @@ module Datadog
       module Cucumber
         module Configuration
           # Custom settings for the Cucumber integration
+          # TODO: mark as `@public_api` when GA
           class Settings < Datadog::Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/datadog/ci/contrib/cucumber/ext.rb
+++ b/lib/datadog/ci/contrib/cucumber/ext.rb
@@ -4,6 +4,7 @@ module Datadog
     module Contrib
       module Cucumber
         # Cucumber integration constants
+        # TODO: mark as `@public_api` when GA, to protect from resource and tag name changes.
         module Ext
           APP = 'cucumber'.freeze
           ENV_ENABLED = 'DD_TRACE_CUCUMBER_ENABLED'.freeze

--- a/lib/datadog/ci/contrib/rspec/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/rspec/configuration/settings.rb
@@ -8,6 +8,7 @@ module Datadog
       module RSpec
         module Configuration
           # Custom settings for the RSpec integration
+          # TODO: mark as `@public_api` when GA
           class Settings < Datadog::Contrib::Configuration::Settings
             option :enabled do |o|
               o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/datadog/ci/contrib/rspec/ext.rb
+++ b/lib/datadog/ci/contrib/rspec/ext.rb
@@ -4,6 +4,7 @@ module Datadog
     module Contrib
       module RSpec
         # RSpec integration constants
+        # TODO: mark as `@public_api` when GA, to protect from resource and tag name changes.
         module Ext
           APP = 'rspec'.freeze
           ENV_ENABLED = 'DD_TRACE_RSPEC_ENABLED'.freeze

--- a/lib/datadog/core/environment/ext.rb
+++ b/lib/datadog/core/environment/ext.rb
@@ -4,7 +4,7 @@ require 'ddtrace/version'
 module Datadog
   module Core
     module Environment
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         # Identity
         LANG = 'ruby'.freeze

--- a/lib/datadog/core/environment/ext.rb
+++ b/lib/datadog/core/environment/ext.rb
@@ -4,6 +4,7 @@ require 'ddtrace/version'
 module Datadog
   module Core
     module Environment
+      # @public_api
       module Ext
         # Identity
         LANG = 'ruby'.freeze

--- a/lib/datadog/core/environment/identity.rb
+++ b/lib/datadog/core/environment/identity.rb
@@ -7,6 +7,7 @@ module Datadog
   module Core
     module Environment
       # For runtime identity
+      # @public_api
       module Identity
         extend Datadog::Utils::Forking
 

--- a/lib/datadog/core/environment/variable_helpers.rb
+++ b/lib/datadog/core/environment/variable_helpers.rb
@@ -4,6 +4,7 @@ module Datadog
     # Namespace for handling application environment
     module Environment
       # Defines helper methods for environment
+      # @public_api
       module VariableHelpers
         extend self
 

--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -23,7 +23,7 @@ require 'ddtrace/contrib/extensions'
 
 require 'ddtrace/opentelemetry/extensions'
 
-# {Datadog} global namespace that includes all tracing functionality for Tracer and Span classes.
+# Global namespace that includes all Datadog functionality.
 # @public_api
 module Datadog
   extend Configuration

--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -23,7 +23,8 @@ require 'ddtrace/contrib/extensions'
 
 require 'ddtrace/opentelemetry/extensions'
 
-# \Datadog global namespace that includes all tracing functionality for Tracer and Span classes.
+# {Datadog} global namespace that includes all tracing functionality for Tracer and Span classes.
+# @public_api
 module Datadog
   extend Configuration
   extend AutoInstrumentBase

--- a/lib/ddtrace/auto_instrument.rb
+++ b/lib/ddtrace/auto_instrument.rb
@@ -1,4 +1,7 @@
 # typed: strict
+# Entrypoint file for auto instrumentation.
+#
+# This file's path is part of the @public_api.
 require 'ddtrace'
 
 Datadog.add_auto_instrument

--- a/lib/ddtrace/buffer.rb
+++ b/lib/ddtrace/buffer.rb
@@ -1,9 +1,10 @@
 # typed: true
 require 'ddtrace/diagnostics/health'
 
-# Trace buffer that accumulates traces for a consumer.
-# Consumption can happen from a different thread.
 module Datadog
+  # Trace buffer that accumulates traces for a consumer.
+  # Consumption can happen from a different thread.
+
   # Buffer that stores objects. The buffer has a maximum size and when
   # the buffer is full, a random object is discarded.
   class Buffer

--- a/lib/ddtrace/buffer.rb
+++ b/lib/ddtrace/buffer.rb
@@ -312,7 +312,7 @@ module Datadog
   # Trace buffer that stores application traces, has a maximum size, and
   # can be safely used concurrently on any environment.
   #
-  # @see {Datadog::ThreadSafeBuffer}
+  # @see Datadog::ThreadSafeBuffer
   class ThreadSafeTraceBuffer < ThreadSafeBuffer
     prepend MeasuredBuffer
   end
@@ -320,7 +320,7 @@ module Datadog
   # Trace buffer that stores application traces, has a maximum size, and
   # can be safely used concurrently with CRuby.
   #
-  # @see {Datadog::CRubyBuffer}
+  # @see Datadog::CRubyBuffer
   class CRubyTraceBuffer < CRubyBuffer
     prepend MeasuredBuffer
   end

--- a/lib/ddtrace/configuration/base.rb
+++ b/lib/ddtrace/configuration/base.rb
@@ -5,6 +5,7 @@ require 'ddtrace/configuration/options'
 module Datadog
   module Configuration
     # Basic configuration behavior
+    # @public_api
     module Base
       def self.included(base)
         base.extend(Datadog::Core::Environment::VariableHelpers)
@@ -16,11 +17,13 @@ module Datadog
       end
 
       # Class methods for configuration
+      # @public_api
       module ClassMethods
         protected
 
         # Allows subgroupings of settings to be defined.
         # e.g. `settings :foo { option :bar }` --> `config.foo.bar`
+        # @param [Symbol] name option name. Methods will be created based on this name.
         def settings(name, &block)
           settings_class = new_settings_class(&block)
 
@@ -44,6 +47,7 @@ module Datadog
       end
 
       # Instance methods for configuration
+      # @public_api
       module InstanceMethods
         def initialize(options = {})
           configure(options) unless options.empty?

--- a/lib/ddtrace/configuration/components.rb
+++ b/lib/ddtrace/configuration/components.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: false
 require 'ddtrace/configuration/agent_settings_resolver'
 require 'ddtrace/diagnostics/health'
 require 'ddtrace/logger'

--- a/lib/ddtrace/configuration/option.rb
+++ b/lib/ddtrace/configuration/option.rb
@@ -2,6 +2,7 @@
 module Datadog
   module Configuration
     # Represents an instance of an integration configuration option
+    # @public_api
     class Option
       attr_reader \
         :definition

--- a/lib/ddtrace/configuration/option_definition.rb
+++ b/lib/ddtrace/configuration/option_definition.rb
@@ -34,6 +34,7 @@ module Datadog
       end
 
       # Acts as DSL for building OptionDefinitions
+      # @public_api
       class Builder
         attr_reader \
           :helpers

--- a/lib/ddtrace/configuration/options.rb
+++ b/lib/ddtrace/configuration/options.rb
@@ -6,6 +6,7 @@ require 'ddtrace/configuration/option_definition_set'
 module Datadog
   module Configuration
     # Behavior for a configuration object that has options
+    # @public_api
     module Options
       def self.included(base)
         base.extend(ClassMethods)
@@ -13,6 +14,7 @@ module Datadog
       end
 
       # Class behavior for a configuration object with options
+      # @public_api
       module ClassMethods
         def options
           # Allows for class inheritance of option definitions
@@ -57,6 +59,7 @@ module Datadog
       end
 
       # Instance behavior for a configuration object with options
+      # @public_api
       module InstanceMethods
         def options
           @options ||= OptionSet.new

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -389,7 +389,7 @@ module Datadog
         o.lazy
       end
 
-      # Default tracing span tags.
+      # Default tracing and profiling span tags.
       #
       # These tags are applied to every span.
       # @default `DD_TAGS` environment variable (in the format `'tag1:value1,tag2:value2'`), otherwise `{}`

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -98,6 +98,7 @@ module Datadog
         # Internal tracer {Datadog::Statsd} metrics collection.
         #
         # The list of metrics collected can be found in {Datadog::Ext::Diagnostics::Health::Metrics}.
+        # @public_api
         settings :health_metrics do
           # Enable health metrics collection.
           #
@@ -119,6 +120,7 @@ module Datadog
         end
 
         # Tracer startup debug log statement configuration.
+        # @public_api
         settings :startup_logs do
           # Enable startup logs collection.
           #
@@ -241,10 +243,12 @@ module Datadog
           o.lazy
         end
 
+        # @public_api
         settings :exporter do
           option :transport
         end
 
+        # @public_api
         settings :advanced do
           # This should never be reduced, as it can cause the resulting profiles to become biased.
           # The current default should be enough for most services, allowing 16 threads to be sampled around 30 times
@@ -258,6 +262,7 @@ module Datadog
             o.lazy
           end
 
+          # @public_api
           settings :endpoint do
             settings :collection do
               # When using profiling together with tracing, this controls if endpoint names
@@ -273,6 +278,7 @@ module Datadog
           end
         end
 
+        # @public_api
         settings :upload do
           option :timeout_seconds do |o|
             o.setter { |value| value.nil? ? 30.0 : value.to_f }
@@ -527,6 +533,7 @@ module Datadog
         #
         # The trace flame graph will display the partial trace as it is received and constantly
         # update with new spans as they are flushed.
+        # @public_api
         settings :partial_flush do
           # Enable partial trace flushing.
           #

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -314,7 +314,6 @@ module Datadog
         settings
       end
 
-      # TODO: remove me. Use `c.runtime_metrics.enabled =`
       # @deprecated Use `runtime_metrics.enabled` instead.
       # @return [Boolean]
       option :runtime_metrics_enabled do |o|
@@ -373,7 +372,13 @@ module Datadog
         end
       end
 
-      # TODO: profiler related. Ask @ivoanjo what this is for.
+      # The Datadog site host to send data to.
+      # By default, data is sent to the Datadog US site: `app.datadoghq.com`.
+      #
+      # If your organization is on another site, you must update this value to the new site.
+      #
+      # @see https://docs.datadoghq.com/agent/troubleshooting/site/
+      # @default `DD_SITE` environment variable, otherwise `nil` which sends data to `app.datadoghq.com`
       # @return [String,nil]
       # @public_api
       option :site do |o|

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -516,8 +516,8 @@ module Datadog
 
         # A custom tracer instance.
         #
-        # It must respected the contract of {Datadog::Tracer}.
-        # It's recommended to inherit from {Datadog::Tracer} to ease the implementation
+        # It must respect the contract of {Datadog::Tracer}.
+        # It's recommended to delegate methods to {Datadog::Tracer} to ease the implementation
         # of a custom tracer.
         #
         # This option will not return the live tracer instance: it only holds a custom

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -510,7 +510,9 @@ module Datadog
           o.default { env_to_bool(Datadog::Ext::Diagnostics::DD_TRACE_ENABLED, true) }
           o.lazy
         end
-        option :hostname # TODO: Deprecate
+
+        # TODO: This setting is not tracer-specific and should be moved to top-level or to the transport.
+        option :hostname
 
         # A custom tracer instance.
         #
@@ -555,7 +557,8 @@ module Datadog
           option :min_spans_threshold, default: 500
         end
 
-        option :port # TODO: Deprecate
+        # TODO: This setting is not tracer-specific and should be moved to top-level or to the transport.
+        option :port
         option :priority_sampling # TODO: Deprecate
 
         # A custom sampler instance.

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -59,6 +59,9 @@ module Datadog
       end
 
       # Profiler API key.
+      #
+      # For internal use only.
+      #
       # @default `DD_API_KEY` environment variable, otherwise `nil`
       # @return [String,nil]
       # @public_api

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -64,7 +64,6 @@ module Datadog
       #
       # @default `DD_API_KEY` environment variable, otherwise `nil`
       # @return [String,nil]
-      # @public_api
       option :api_key do |o|
         o.default { ENV.fetch(Ext::Environment::ENV_API_KEY, nil) }
         o.lazy
@@ -191,7 +190,6 @@ module Datadog
       # @see https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging
       # @default `DD_ENV` environment variable, otherwise `nil`
       # @return [String,nil]
-      # @public_api
       option :env do |o|
         # NOTE: env also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
         o.default { ENV.fetch(Ext::Environment::ENV_ENVIRONMENT, nil) }
@@ -201,7 +199,6 @@ module Datadog
       # Automatic correlation between tracing and logging.
       # @see https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#trace-correlation
       # @return [Boolean]
-      # @public_api
       option :log_injection do |o|
         o.default { env_to_bool(Ext::Correlation::ENV_LOGS_INJECTION_ENABLED, true) }
         o.lazy
@@ -288,7 +285,6 @@ module Datadog
         end
       end
 
-      # @public_api
       option :report_hostname do |o|
         o.default { env_to_bool(Ext::NET::ENV_REPORT_HOSTNAME, false) }
         o.lazy
@@ -366,7 +362,6 @@ module Datadog
       # @see https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging
       # @default `DD_SERVICE` environment variable, otherwise the program name (e.g. `'ruby'`, `'rails'`, `'pry'`)
       # @return [String]
-      # @public_api
       option :service do |o|
         # NOTE: service also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
         o.default { ENV.fetch(Ext::Environment::ENV_SERVICE, Ext::Environment::FALLBACK_SERVICE_NAME) }
@@ -389,7 +384,6 @@ module Datadog
       # @see https://docs.datadoghq.com/agent/troubleshooting/site/
       # @default `DD_SITE` environment variable, otherwise `nil` which sends data to `app.datadoghq.com`
       # @return [String,nil]
-      # @public_api
       option :site do |o|
         o.default { ENV.fetch(Ext::Environment::ENV_SITE, nil) }
         o.lazy
@@ -400,7 +394,6 @@ module Datadog
       # These tags are applied to every span.
       # @default `DD_TAGS` environment variable (in the format `'tag1:value1,tag2:value2'`), otherwise `{}`
       # @return [Hash<String,String>]
-      # @public_api
       option :tags do |o|
         o.default do
           tags = {}
@@ -479,7 +472,6 @@ module Datadog
       #
       # @default `->{ Time.now }`
       # @return [Proc<Time>]
-      # @public_api
       option :time_now_provider do |o|
         o.default { ::Time.now }
 
@@ -575,7 +567,6 @@ module Datadog
       # @see https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging
       # @default `DD_VERSION` environment variable, otherwise `nils`
       # @return [String,nil]
-      # @public_api
       option :version do |o|
         # NOTE: version also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
         o.default { ENV.fetch(Ext::Environment::ENV_VERSION, nil) }

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -12,10 +12,12 @@ require 'ddtrace/ext/test'
 module Datadog
   module Configuration
     # Global configuration settings for the trace library.
+    # @public_api
     # rubocop:disable Metrics/ClassLength
     class Settings
       include Base
 
+      # @!visibility private
       def initialize(*_)
         super
 
@@ -42,19 +44,44 @@ module Datadog
         tags
       end
 
+      # Legacy [App Analytics](https://docs.datadoghq.com/tracing/legacy_app_analytics/) configuration.
+      #
+      # @deprecated Use [Trace Retention and Ingestion](https://docs.datadoghq.com/tracing/trace_retention_and_ingestion/)
+      #   controls.
+      # @public_api
       settings :analytics do
+        # @default `DD_TRACE_ANALYTICS_ENABLED` environment variable, otherwise `nil`
+        # @return [Boolean,nil]
         option :enabled do |o|
           o.default { env_to_bool(Ext::Analytics::ENV_TRACE_ANALYTICS_ENABLED, nil) }
           o.lazy
         end
       end
 
+      # Profiler API key.
+      # @default `DD_API_KEY` environment variable, otherwise `nil`
+      # @return [String,nil]
+      # @public_api
       option :api_key do |o|
         o.default { ENV.fetch(Ext::Environment::ENV_API_KEY, nil) }
         o.lazy
       end
 
+      # Internal tracer diagnostic settings.
+      #
+      # Enabling these surfaces debug information that can be helpful to
+      # diagnose issues related to the tracer internals.
+      # @public_api
       settings :diagnostics do
+        # Outputs all spans created by the host application to `Datadog.logger`.
+        #
+        # **This option is very verbose!** It's only recommended for non-production
+        # environments.
+        #
+        # This option is helpful when trying to understand what information the
+        # tracer is sending to the Agent or backend.
+        # @default `DD_TRACE_DEBUG` environment variable, otherwise `false`
+        # @return [Boolean]
         option :debug do |o|
           o.default { env_to_bool(Datadog::Ext::Diagnostics::DD_TRACE_DEBUG, false) }
           o.lazy
@@ -65,16 +92,38 @@ module Datadog
           end
         end
 
+        # Internal tracer {Datadog::Statsd} metrics collection.
+        #
+        # The list of metrics collected can be found in {Datadog::Ext::Diagnostics::Health::Metrics}.
         settings :health_metrics do
+          # Enable health metrics collection.
+          #
+          # @default `DD_HEALTH_METRICS_ENABLED` environment variable, otherwise `false`
+          # @return [Boolean]
           option :enabled do |o|
             o.default { env_to_bool(Datadog::Ext::Diagnostics::Health::Metrics::ENV_ENABLED, false) }
             o.lazy
           end
 
+          # {Datadog::Statsd} instance to collect health metrics.
+          #
+          # If `nil`, health metrics creates a new {Datadog::Statsd} client with default agent configuration.
+          #
+          # @default `nil`
+          # @return [Datadog::Statsd,nil] a custom {Datadog::Statsd} instance
+          # @return [nil] an instance with default agent configuration will be lazily created
           option :statsd
         end
 
+        # Tracer startup debug log statement configuration.
         settings :startup_logs do
+          # Enable startup logs collection.
+          #
+          # If `nil`, defaults to logging startup logs when `ddtrace` detects that the application
+          # is *not* running in a development environment.
+          #
+          # @default `DD_TRACE_STARTUP_LOGS` environment variable, otherwise `nil`
+          # @return [Boolean,nil]
           option :enabled do |o|
             # Defaults to nil as we want to know when the default value is being used
             o.default { env_to_bool(Datadog::Ext::Diagnostics::DD_TRACE_STARTUP_LOGS, nil) }
@@ -83,7 +132,25 @@ module Datadog
         end
       end
 
+      # [Distributed Tracing](https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#distributed-tracing) propagation
+      # style configuration.
+      #
+      # The supported formats are:
+      # * `Datadog`: Datadog propagation format, described by [Distributed Tracing](https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#distributed-tracing).
+      # * `B3`: B3 Propagation using multiple headers, described by [openzipkin/b3-propagation](https://github.com/openzipkin/b3-propagation#multiple-headers).
+      # * `B3 single header`: B3 Propagation using a single header, described by [openzipkin/b3-propagation](https://github.com/openzipkin/b3-propagation#single-header).
+      #
+      # @public_api
       settings :distributed_tracing do
+        # An ordered list of what data propagation styles the tracer will use to extract distributed tracing propagation
+        # data from incoming requests and messages.
+        #
+        # The tracer will try to find distributed headers in the order they are present in the list provided to this option.
+        # The first format to have valid data present will be used.
+        #
+        # @default `DD_PROPAGATION_STYLE_EXTRACT` environment variable (comma-separated list),
+        #   otherwise `['Datadog','B3','B3 single header']`.
+        # @return [Array<String>]
         option :propagation_extract_style do |o|
           o.default do
             # Look for all headers by default
@@ -96,6 +163,13 @@ module Datadog
           o.lazy
         end
 
+        # The data propagation styles the tracer will use to inject distributed tracing propagation
+        # data into outgoing requests and messages.
+        #
+        # The tracer will inject data from all styles specified in this option.
+        #
+        # @default `DD_PROPAGATION_STYLE_INJECT` environment variable (comma-separated list), otherwise `['Datadog']`.
+        # @return [Array<String>]
         option :propagation_inject_style do |o|
           o.default do
             env_to_list(
@@ -108,26 +182,57 @@ module Datadog
         end
       end
 
+      # The `env` tag in Datadog. Use it to separate out your staging, development, and production environments.
+      # @see https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging
+      # @default `DD_ENV` environment variable, otherwise `nil`
+      # @return [String,nil]
+      # @public_api
       option :env do |o|
         # NOTE: env also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
         o.default { ENV.fetch(Ext::Environment::ENV_ENVIRONMENT, nil) }
         o.lazy
       end
 
+      # Automatic correlation between tracing and logging.
+      # @see https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#trace-correlation
+      # @return [Boolean]
+      # @public_api
       option :log_injection do |o|
         o.default { env_to_bool(Ext::Correlation::ENV_LOGS_INJECTION_ENABLED, true) }
         o.lazy
       end
 
+      # Internal `Datadog.logger` configuration.
+      #
+      # This logger instance is only used internally by the gem.
+      # @public_api
       settings :logger do
+        # The `Datadog.logger` object.
+        #
+        # Can be overwritten with a custom logger object that respects the
+        # [built-in Ruby Logger](https://ruby-doc.org/stdlib-3.0.1/libdoc/logger/rdoc/Logger.html)
+        # interface.
+        #
+        # @return Logger::Severity
         option :instance do |o|
           o.on_set { |value| set_option(:level, value.level) unless value.nil? }
         end
 
+        # Log level for `Datadog.logger`.
+        # @see Logger::Severity
+        # @return Logger::Severity
         option :level, default: ::Logger::INFO
       end
 
+      # Datadog Profiler-specific configurations.
+      #
+      # @see https://docs.datadoghq.com/tracing/profiler/
+      # @public_api
       settings :profiling do
+        # Enable profiling.
+        #
+        # @default `DD_PROFILING_ENABLED` environment variable, otherwise `false`
+        # @return [Boolean]
         option :enabled do |o|
           o.default { env_to_bool(Ext::Profiling::ENV_ENABLED, false) }
           o.lazy
@@ -154,6 +259,9 @@ module Datadog
             settings :collection do
               # When using profiling together with tracing, this controls if endpoint names
               # are gathered and reported together with profiles.
+              #
+              # @default `DD_PROFILING_ENDPOINT_COLLECTION_ENABLED` environment variable, otherwise `true`
+              # @return [Boolean]
               option :enabled do |o|
                 o.default { env_to_bool(Ext::Profiling::ENV_ENDPOINT_COLLECTION_ENABLED, true) }
                 o.lazy
@@ -171,12 +279,19 @@ module Datadog
         end
       end
 
+      # @public_api
       option :report_hostname do |o|
         o.default { env_to_bool(Ext::NET::ENV_REPORT_HOSTNAME, false) }
         o.lazy
       end
 
+      # [Runtime Metrics](https://docs.datadoghq.com/tracing/runtime_metrics/)
+      # are StatsD metrics collected by the tracer to gain additional insights into an application's performance.
+      # @public_api
       settings :runtime_metrics do
+        # Enable runtime metrics.
+        # @default `DD_RUNTIME_METRICS_ENABLED` environment variable, otherwise `false`
+        # @return [Boolean]
         option :enabled do |o|
           o.default { env_to_bool(Ext::Runtime::Metrics::ENV_ENABLED, false) }
           o.lazy
@@ -186,6 +301,7 @@ module Datadog
         option :statsd
       end
 
+      # TODO: remove me. Use `c.runtime_metrics.enabled =`
       # Backwards compatibility for configuring runtime metrics e.g. `c.runtime_metrics enabled: true`
       def runtime_metrics(options = nil)
         settings = get_option(:runtime_metrics)
@@ -198,6 +314,9 @@ module Datadog
         settings
       end
 
+      # TODO: remove me. Use `c.runtime_metrics.enabled =`
+      # @deprecated Use `runtime_metrics.enabled` instead.
+      # @return [Boolean]
       option :runtime_metrics_enabled do |o|
         o.delegate_to { get_option(:runtime_metrics).enabled }
         o.on_set do |value|
@@ -206,18 +325,40 @@ module Datadog
         end
       end
 
+      # Client-side sampling configuration.
+      # @public_api
       settings :sampling do
+        # Default sampling rate for the tracer.
+        #
+        # If `nil`, the trace uses an automatic sampling strategy that tries to ensure
+        # the collection of traces that are considered important (e.g. traces with an error, traces
+        # for resources not seen recently).
+        #
+        # @default `DD_TRACE_SAMPLE_RATE` environment variable, otherwise `nil`.
+        # @return [Float,nil]
         option :default_rate do |o|
           o.default { env_to_float(Ext::Sampling::ENV_SAMPLE_RATE, nil) }
           o.lazy
         end
 
+        # Rate limit for number of spans per second.
+        #
+        # Spans created above the limit will contribute to service metrics, but won't
+        # have their payload stored.
+        #
+        # @default `DD_TRACE_RATE_LIMIT` environment variable, otherwise 100.
+        # @return [Numeric,nil]
         option :rate_limit do |o|
           o.default { env_to_float(Ext::Sampling::ENV_RATE_LIMIT, 100) }
           o.lazy
         end
       end
 
+      # The `service` tag in Datadog. Use it to group related traces into a service.
+      # @see https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging
+      # @default `DD_SERVICE` environment variable, otherwise the program name (e.g. `'ruby'`, `'rails'`, `'pry'`)
+      # @return [String]
+      # @public_api
       option :service do |o|
         # NOTE: service also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
         o.default { ENV.fetch(Ext::Environment::ENV_SERVICE, Ext::Environment::FALLBACK_SERVICE_NAME) }
@@ -232,11 +373,20 @@ module Datadog
         end
       end
 
+      # TODO: profiler related. Ask @ivoanjo what this is for.
+      # @return [String,nil]
+      # @public_api
       option :site do |o|
         o.default { ENV.fetch(Ext::Environment::ENV_SITE, nil) }
         o.lazy
       end
 
+      # Default tracing span tags.
+      #
+      # These tags are applied to every span.
+      # @default `DD_TAGS` environment variable (in the format `'tag1:value1,tag2:value2'`), otherwise `{}`
+      # @return [Hash<String,String>]
+      # @public_api
       option :tags do |o|
         o.default do
           tags = {}
@@ -277,23 +427,45 @@ module Datadog
         o.lazy
       end
 
+      # [Continuous Integration Visibility](https://docs.datadoghq.com/continuous_integration/) configuration.
+      # @public_api
       settings :test_mode do
+        # Enable test mode. This allows the tracer to collect spans from test runs.
+        #
+        # It also prevents the tracer from collecting spans in a production environment. Only use in a test environment.
+        #
+        # @default `DD_TRACE_TEST_MODE_ENABLED` environment variable, otherwise `false`
+        # @return [Boolean]
         option :enabled do |o|
           o.default { env_to_bool(Ext::Test::ENV_MODE_ENABLED, false) }
           o.lazy
         end
 
+        # TODO: Remove this configuration.
+        # TODO: It is not necessary, as it be configured by the default flushing trace configuration.
         option :trace_flush do |o|
           o.default { nil }
           o.lazy
         end
 
+        # TODO: Remove this configuration.
+        # TODO: It is not necessary, as it be configured by the default writer trace configuration.
         option :writer_options do |o|
           o.default { {} }
           o.lazy
         end
       end
 
+      # The time provider used by the tracer. It must respect the interface of [Time](https://ruby-doc.org/core-3.0.1/Time.html).
+      #
+      # When testing, it can be helpful to use a different time provider.
+      #
+      # For [Timecop](https://rubygems.org/gems/timecop), for example, `->{ Time.now_without_mock_time }`
+      # allows the tracer to use the real wall time when time is frozen.
+      #
+      # @default `->{ Time.now }`
+      # @return [Proc<Time>]
+      # @public_api
       option :time_now_provider do |o|
         o.default { ::Time.now }
 
@@ -310,27 +482,82 @@ module Datadog
         end
       end
 
+      # Tracer specific configurations.
+      # @public_api
       settings :tracer do
+        # Enable trace collection and span generation.
+        #
+        # You can use this option to disable tracing without having to
+        # remove the library as a whole.
+        #
+        # @default `DD_TRACE_ENABLED` environment variable, otherwise `true`
+        # @return [Boolean]
         option :enabled do |o|
           o.default { env_to_bool(Datadog::Ext::Diagnostics::DD_TRACE_ENABLED, true) }
           o.lazy
         end
         option :hostname # TODO: Deprecate
+
+        # A custom tracer instance.
+        #
+        # It must respected the contract of {Datadog::Tracer}.
+        # It's recommended to inherit from {Datadog::Tracer} to ease the implementation
+        # of a custom tracer.
+        #
+        # This option will not return the live tracer instance: it only holds a custom
+        # tracing instance, if any. The live tracer instance can be found in {Datadog.tracer}.
+        #
+        # @default `nil`
+        # @return [Object,nil]
         option :instance
 
+        # Configures an alternative trace transport behavior, where
+        # traces can be sent to the agent and backend before all spans
+        # have finished.
+        #
+        # This is useful for long-running jobs or very large traces.
+        #
+        # The trace flame graph will display the partial trace as it is received and constantly
+        # update with new spans as they are flushed.
         settings :partial_flush do
+          # Enable partial trace flushing.
+          #
+          # @default `false`
+          # @return [Boolean]
           option :enabled, default: false
-          option :min_spans_threshold
+
+          # Minimum number of finished spans required in a single unfinished trace before
+          # the tracer will consider that trace for partial flushing.
+          #
+          # This option helps preserve a minimum amount of batching in the
+          # flushing process, reducing network overhead.
+          #
+          # This threshold only applies to unfinished traces. Traces that have finished
+          # are always flushed immediately.
+          #
+          # @default 500
+          # @return [Boolean]
+          option :min_spans_threshold, default: 500
         end
 
         option :port # TODO: Deprecate
         option :priority_sampling # TODO: Deprecate
+
+        # A custom sampler instance.
+        # The object must respect the {Datadog::Sampler} interface.
+        # @default `nil`
+        # @return [Object,nil]
         option :sampler
         option :transport_options, default: ->(_i) { {} }, lazy: true # TODO: Deprecate
         option :writer # TODO: Deprecate
         option :writer_options, default: ->(_i) { {} }, lazy: true # TODO: Deprecate
       end
 
+      # The `version` tag in Datadog. Use it to enable [Deployment Tracking](https://docs.datadoghq.com/tracing/deployment_tracking/).
+      # @see https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging
+      # @default `DD_VERSION` environment variable, otherwise `nils`
+      # @return [String,nil]
+      # @public_api
       option :version do |o|
         # NOTE: version also gets set as a side effect of tags. See the WORKAROUND note in #initialize for details.
         o.default { ENV.fetch(Ext::Environment::ENV_VERSION, nil) }

--- a/lib/ddtrace/context.rb
+++ b/lib/ddtrace/context.rb
@@ -2,16 +2,16 @@
 require 'ddtrace/utils/forking'
 
 module Datadog
-  # \Context is used to keep track of a hierarchy of spans for the current
-  # execution flow. During each logical execution, the same \Context is
+  # {Datadog::Context} is used to keep track of a hierarchy of spans for the current
+  # execution flow. During each logical execution, the same {Datadog::Context} is
   # used to represent a single logical trace, even if the trace is built
   # asynchronously.
   #
-  # A single code execution may use multiple \Context if part of the execution
+  # A single code execution may use multiple {Datadog::Context} if part of the execution
   # must not be related to the current tracing. As example, a delayed job may
   # compose a standalone trace instead of being related to the same trace that
   # generates the job itself. On the other hand, if it's part of the same
-  # \Context, it will be related to the original trace.
+  # {Datadog::Context}, it will be related to the original trace.
   class Context
     include Datadog::Utils::Forking
 

--- a/lib/ddtrace/context_provider.rb
+++ b/lib/ddtrace/context_provider.rb
@@ -32,16 +32,16 @@ module Datadog
   end
 
   # ThreadLocalContext can be used as a tracer global reference to create
-  # a different \Context for each thread. In synchronous tracer, this
-  # is required to prevent multiple threads sharing the same \Context
+  # a different {Datadog::Context} for each thread. In synchronous tracer, this
+  # is required to prevent multiple threads sharing the same {Datadog::Context}
   # in different executions.
   class ThreadLocalContext
     # ThreadLocalContext can be used as a tracer global reference to create
-    # a different \Context for each thread. In synchronous tracer, this
-    # is required to prevent multiple threads sharing the same \Context
+    # a different {Datadog::Context} for each thread. In synchronous tracer, this
+    # is required to prevent multiple threads sharing the same {Datadog::Context}
     # in different executions.
     #
-    # To support multiple tracers simultaneously, each \ThreadLocalContext
+    # To support multiple tracers simultaneously, each {Datadog::ThreadLocalContext}
     # instance has its own thread-local variable.
     def initialize
       @key = "datadog_context_#{object_id}".to_sym

--- a/lib/ddtrace/contrib/action_cable/configuration/settings.rb
+++ b/lib/ddtrace/contrib/action_cable/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module ActionCable
       module Configuration
         # Custom settings for the ActionCable integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/action_cable/ext.rb
+++ b/lib/ddtrace/contrib/action_cable/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module ActionCable
       # ActionCable integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'action_cable'.freeze
         ENV_ENABLED = 'DD_TRACE_ACTION_CABLE_ENABLED'.freeze

--- a/lib/ddtrace/contrib/action_cable/ext.rb
+++ b/lib/ddtrace/contrib/action_cable/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module ActionCable
       # ActionCable integration constants
+      # @public_api
       module Ext
         APP = 'action_cable'.freeze
         ENV_ENABLED = 'DD_TRACE_ACTION_CABLE_ENABLED'.freeze

--- a/lib/ddtrace/contrib/action_cable/integration.rb
+++ b/lib/ddtrace/contrib/action_cable/integration.rb
@@ -13,6 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('5.0.0')
 
+        # @public_api
         register_as :action_cable, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/action_cable/integration.rb
+++ b/lib/ddtrace/contrib/action_cable/integration.rb
@@ -13,7 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('5.0.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :action_cable, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/action_mailer/configuration/settings.rb
+++ b/lib/ddtrace/contrib/action_mailer/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module ActionMailer
       module Configuration
         # Custom settings for the ActionMailer integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/action_mailer/ext.rb
+++ b/lib/ddtrace/contrib/action_mailer/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module ActionMailer
       # ActionMailer integration constants
+      # @public_api
       module Ext
         APP = 'action_mailer'.freeze
         ENV_ENABLED = 'DD_TRACE_ACTION_MAILER_ENABLED'.freeze

--- a/lib/ddtrace/contrib/action_mailer/ext.rb
+++ b/lib/ddtrace/contrib/action_mailer/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module ActionMailer
       # ActionMailer integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'action_mailer'.freeze
         ENV_ENABLED = 'DD_TRACE_ACTION_MAILER_ENABLED'.freeze

--- a/lib/ddtrace/contrib/action_mailer/integration.rb
+++ b/lib/ddtrace/contrib/action_mailer/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('5.0.0')
 
+        # @public_api
         register_as :action_mailer, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/action_mailer/integration.rb
+++ b/lib/ddtrace/contrib/action_mailer/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('5.0.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :action_mailer, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/action_pack/configuration/settings.rb
+++ b/lib/ddtrace/contrib/action_pack/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module ActionPack
       module Configuration
         # Custom settings for the ActionPack integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/action_pack/ext.rb
+++ b/lib/ddtrace/contrib/action_pack/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module ActionPack
       # ActionPack integration constants
+      # @public_api
       module Ext
         APP = 'action_pack'.freeze
         ENV_ENABLED = 'DD_TRACE_ACTION_PACK_ENABLED'.freeze

--- a/lib/ddtrace/contrib/action_pack/ext.rb
+++ b/lib/ddtrace/contrib/action_pack/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module ActionPack
       # ActionPack integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'action_pack'.freeze
         ENV_ENABLED = 'DD_TRACE_ACTION_PACK_ENABLED'.freeze

--- a/lib/ddtrace/contrib/action_pack/integration.rb
+++ b/lib/ddtrace/contrib/action_pack/integration.rb
@@ -13,7 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('3.2')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :action_pack, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/action_pack/integration.rb
+++ b/lib/ddtrace/contrib/action_pack/integration.rb
@@ -13,6 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('3.2')
 
+        # @public_api
         register_as :action_pack, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/action_view/configuration/settings.rb
+++ b/lib/ddtrace/contrib/action_view/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module ActionView
       module Configuration
         # Custom settings for the ActionView integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/action_view/ext.rb
+++ b/lib/ddtrace/contrib/action_view/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module ActionView
       # ActionView integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'action_view'.freeze
         ENV_ENABLED = 'DD_TRACE_ACTION_VIEW_ENABLED'.freeze

--- a/lib/ddtrace/contrib/action_view/ext.rb
+++ b/lib/ddtrace/contrib/action_view/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module ActionView
       # ActionView integration constants
+      # @public_api
       module Ext
         APP = 'action_view'.freeze
         ENV_ENABLED = 'DD_TRACE_ACTION_VIEW_ENABLED'.freeze

--- a/lib/ddtrace/contrib/action_view/integration.rb
+++ b/lib/ddtrace/contrib/action_view/integration.rb
@@ -13,7 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('3.2')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :action_view, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/action_view/integration.rb
+++ b/lib/ddtrace/contrib/action_view/integration.rb
@@ -13,6 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('3.2')
 
+        # @public_api
         register_as :action_view, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/active_job/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_job/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module ActiveJob
       module Configuration
         # Custom settings for the DelayedJob integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/active_job/ext.rb
+++ b/lib/ddtrace/contrib/active_job/ext.rb
@@ -2,6 +2,7 @@
 module Datadog
   module Contrib
     module ActiveJob
+      # @public_api
       module Ext
         APP = 'active_job'.freeze
         SERVICE_NAME = 'active_job'.freeze

--- a/lib/ddtrace/contrib/active_job/ext.rb
+++ b/lib/ddtrace/contrib/active_job/ext.rb
@@ -2,7 +2,7 @@
 module Datadog
   module Contrib
     module ActiveJob
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'active_job'.freeze
         SERVICE_NAME = 'active_job'.freeze

--- a/lib/ddtrace/contrib/active_job/integration.rb
+++ b/lib/ddtrace/contrib/active_job/integration.rb
@@ -13,7 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('4.2')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :active_job, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/active_job/integration.rb
+++ b/lib/ddtrace/contrib/active_job/integration.rb
@@ -13,6 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('4.2')
 
+        # @public_api
         register_as :active_job, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/active_model_serializers/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module ActiveModelSerializers
       module Configuration
         # Custom settings for the ActiveModelSerializers integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/active_model_serializers/ext.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module ActiveModelSerializers
       # ActiveModelSerializers integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'active_model_serializers'.freeze
         ENV_ENABLED = 'DD_TRACE_ACTIVE_MODEL_SERIALIZERS_ENABLED'.freeze

--- a/lib/ddtrace/contrib/active_model_serializers/ext.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module ActiveModelSerializers
       # ActiveModelSerializers integration constants
+      # @public_api
       module Ext
         APP = 'active_model_serializers'.freeze
         ENV_ENABLED = 'DD_TRACE_ACTIVE_MODEL_SERIALIZERS_ENABLED'.freeze

--- a/lib/ddtrace/contrib/active_model_serializers/integration.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.9.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :active_model_serializers
 
         def self.version

--- a/lib/ddtrace/contrib/active_model_serializers/integration.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.9.0')
 
+        # @public_api
         register_as :active_model_serializers
 
         def self.version

--- a/lib/ddtrace/contrib/active_record/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_record/configuration/settings.rb
@@ -8,6 +8,7 @@ module Datadog
     module ActiveRecord
       module Configuration
         # Custom settings for the ActiveRecord integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/active_record/ext.rb
+++ b/lib/ddtrace/contrib/active_record/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module ActiveRecord
       # ActiveRecord integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'active_record'.freeze
         ENV_ENABLED = 'DD_TRACE_ACTIVE_RECORD_ENABLED'.freeze

--- a/lib/ddtrace/contrib/active_record/ext.rb
+++ b/lib/ddtrace/contrib/active_record/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module ActiveRecord
       # ActiveRecord integration constants
+      # @public_api
       module Ext
         APP = 'active_record'.freeze
         ENV_ENABLED = 'DD_TRACE_ACTIVE_RECORD_ENABLED'.freeze

--- a/lib/ddtrace/contrib/active_record/integration.rb
+++ b/lib/ddtrace/contrib/active_record/integration.rb
@@ -17,7 +17,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('3.2')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :active_record, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/active_record/integration.rb
+++ b/lib/ddtrace/contrib/active_record/integration.rb
@@ -17,6 +17,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('3.2')
 
+        # @public_api
         register_as :active_record, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/active_support/configuration/settings.rb
+++ b/lib/ddtrace/contrib/active_support/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module ActiveSupport
       module Configuration
         # Custom settings for the ActiveSupport integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/active_support/ext.rb
+++ b/lib/ddtrace/contrib/active_support/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module ActiveSupport
       # ActiveSupport integration constants
+      # @public_api
       module Ext
         APP = 'active_support'.freeze
         ENV_ENABLED = 'DD_TRACE_ACTIVE_SUPPORT_ENABLED'.freeze

--- a/lib/ddtrace/contrib/active_support/ext.rb
+++ b/lib/ddtrace/contrib/active_support/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module ActiveSupport
       # ActiveSupport integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'active_support'.freeze
         ENV_ENABLED = 'DD_TRACE_ACTIVE_SUPPORT_ENABLED'.freeze

--- a/lib/ddtrace/contrib/active_support/integration.rb
+++ b/lib/ddtrace/contrib/active_support/integration.rb
@@ -14,6 +14,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('3.2')
 
+        # @public_api
         register_as :active_support, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/active_support/integration.rb
+++ b/lib/ddtrace/contrib/active_support/integration.rb
@@ -14,7 +14,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('3.2')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :active_support, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/analytics.rb
+++ b/lib/ddtrace/contrib/analytics.rb
@@ -4,6 +4,7 @@ require 'ddtrace/analytics'
 module Datadog
   module Contrib
     # Defines analytics behavior for integrations
+    # @public_api
     module Analytics
       module_function
 

--- a/lib/ddtrace/contrib/aws/configuration/settings.rb
+++ b/lib/ddtrace/contrib/aws/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Aws
       module Configuration
         # Custom settings for the AWS integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/aws/ext.rb
+++ b/lib/ddtrace/contrib/aws/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Aws
       # AWS integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'aws'.freeze
         ENV_ENABLED = 'DD_TRACE_AWS_ENABLED'.freeze

--- a/lib/ddtrace/contrib/aws/ext.rb
+++ b/lib/ddtrace/contrib/aws/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Aws
       # AWS integration constants
+      # @public_api
       module Ext
         APP = 'aws'.freeze
         ENV_ENABLED = 'DD_TRACE_AWS_ENABLED'.freeze

--- a/lib/ddtrace/contrib/aws/integration.rb
+++ b/lib/ddtrace/contrib/aws/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('2.0')
 
+        # @public_api
         register_as :aws, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/aws/integration.rb
+++ b/lib/ddtrace/contrib/aws/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('2.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :aws, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/aws/patcher.rb
+++ b/lib/ddtrace/contrib/aws/patcher.rb
@@ -23,7 +23,7 @@ module Datadog
           add_plugin(Seahorse::Client::Base, *loaded_constants)
 
           # Special handling for S3 URL Presigning.
-          # @see {Datadog::Contrib::Aws::S3Presigner}
+          # @see Datadog::Contrib::Aws::S3Presigner
           ::Aws::S3::Presigner.prepend(S3Presigner) if defined?(::Aws::S3::Presigner)
         end
 

--- a/lib/ddtrace/contrib/concurrent_ruby/configuration/settings.rb
+++ b/lib/ddtrace/contrib/concurrent_ruby/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module ConcurrentRuby
       module Configuration
         # Custom settings for the ConcurrentRuby integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/concurrent_ruby/ext.rb
+++ b/lib/ddtrace/contrib/concurrent_ruby/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module ConcurrentRuby
       # ConcurrentRuby integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'concurrent-ruby'.freeze
         SERVICE_NAME = 'concurrent-ruby'.freeze

--- a/lib/ddtrace/contrib/concurrent_ruby/ext.rb
+++ b/lib/ddtrace/contrib/concurrent_ruby/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module ConcurrentRuby
       # ConcurrentRuby integration constants
+      # @public_api
       module Ext
         APP = 'concurrent-ruby'.freeze
         SERVICE_NAME = 'concurrent-ruby'.freeze

--- a/lib/ddtrace/contrib/concurrent_ruby/integration.rb
+++ b/lib/ddtrace/contrib/concurrent_ruby/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.9')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :concurrent_ruby
 
         def self.version

--- a/lib/ddtrace/contrib/concurrent_ruby/integration.rb
+++ b/lib/ddtrace/contrib/concurrent_ruby/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.9')
 
+        # @public_api
         register_as :concurrent_ruby
 
         def self.version

--- a/lib/ddtrace/contrib/configurable.rb
+++ b/lib/ddtrace/contrib/configurable.rb
@@ -31,7 +31,6 @@ module Datadog
         # DEV(1.0): Unfortunately, change this would be a breaking change for all custom integrations,
         # DEV(1.0): thus we have to be very intentional with the right time to make this change.
         # DEV(1.0): Currently marking this for a 1.0 milestone.
-        # @public_api
         def default_configuration
           Configuration::Settings.new
         end

--- a/lib/ddtrace/contrib/configurable.rb
+++ b/lib/ddtrace/contrib/configurable.rb
@@ -31,6 +31,7 @@ module Datadog
         # DEV(1.0): Unfortunately, change this would be a breaking change for all custom integrations,
         # DEV(1.0): thus we have to be very intentional with the right time to make this change.
         # DEV(1.0): Currently marking this for a 1.0 milestone.
+        # @public_api
         def default_configuration
           Configuration::Settings.new
         end

--- a/lib/ddtrace/contrib/configuration/settings.rb
+++ b/lib/ddtrace/contrib/configuration/settings.rb
@@ -12,16 +12,11 @@ module Datadog
 
         DEPRECATION_WARN_ONLY_ONCE = Datadog::Utils::OnlyOnce.new
 
-        # @public_api
         option :analytics_enabled, default: false
-        # @public_api
         option :analytics_sample_rate, default: 1.0
-        # @public_api
         option :enabled, default: true
-        # @public_api
         option :service_name # TODO: remove suffix "_name"
 
-        # @public_api
         def configure(options = {})
           self.class.options.dependency_order.each do |name|
             self[name] = options[name] if options.key?(name)
@@ -30,12 +25,10 @@ module Datadog
           yield(self) if block_given?
         end
 
-        # @public_api
         def [](name)
           respond_to?(name) ? send(name) : get_option(name)
         end
 
-        # @public_api
         def []=(name, value)
           respond_to?("#{name}=") ? send("#{name}=", value) : set_option(name, value)
         end

--- a/lib/ddtrace/contrib/configuration/settings.rb
+++ b/lib/ddtrace/contrib/configuration/settings.rb
@@ -6,16 +6,22 @@ module Datadog
   module Contrib
     module Configuration
       # Common settings for all integrations
+      # @public_api
       class Settings
         include Datadog::Configuration::Base
 
         DEPRECATION_WARN_ONLY_ONCE = Datadog::Utils::OnlyOnce.new
 
+        # @public_api
         option :analytics_enabled, default: false
+        # @public_api
         option :analytics_sample_rate, default: 1.0
+        # @public_api
         option :enabled, default: true
+        # @public_api
         option :service_name # TODO: remove suffix "_name"
 
+        # @public_api
         def configure(options = {})
           self.class.options.dependency_order.each do |name|
             self[name] = options[name] if options.key?(name)
@@ -24,10 +30,12 @@ module Datadog
           yield(self) if block_given?
         end
 
+        # @public_api
         def [](name)
           respond_to?(name) ? send(name) : get_option(name)
         end
 
+        # @public_api
         def []=(name, value)
           respond_to?("#{name}=") ? send("#{name}=", value) : set_option(name, value)
         end

--- a/lib/ddtrace/contrib/dalli/configuration/settings.rb
+++ b/lib/ddtrace/contrib/dalli/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Dalli
       module Configuration
         # Custom settings for the Dalli integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/dalli/ext.rb
+++ b/lib/ddtrace/contrib/dalli/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Dalli
       # Dalli integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'dalli'.freeze
         ENV_ENABLED = 'DD_TRACE_DALLI_ENABLED'.freeze

--- a/lib/ddtrace/contrib/dalli/ext.rb
+++ b/lib/ddtrace/contrib/dalli/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Dalli
       # Dalli integration constants
+      # @public_api
       module Ext
         APP = 'dalli'.freeze
         ENV_ENABLED = 'DD_TRACE_DALLI_ENABLED'.freeze

--- a/lib/ddtrace/contrib/dalli/integration.rb
+++ b/lib/ddtrace/contrib/dalli/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('2.0.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :dalli, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/dalli/integration.rb
+++ b/lib/ddtrace/contrib/dalli/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('2.0.0')
 
+        # @public_api
         register_as :dalli, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/delayed_job/configuration/settings.rb
+++ b/lib/ddtrace/contrib/delayed_job/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module DelayedJob
       module Configuration
         # Custom settings for the DelayedJob integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/delayed_job/ext.rb
+++ b/lib/ddtrace/contrib/delayed_job/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module DelayedJob
       # DelayedJob integration constants
+      # @public_api
       module Ext
         APP = 'delayed_job'.freeze
         ENV_ENABLED = 'DD_TRACE_DELAYED_JOB_ENABLED'.freeze

--- a/lib/ddtrace/contrib/delayed_job/ext.rb
+++ b/lib/ddtrace/contrib/delayed_job/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module DelayedJob
       # DelayedJob integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'delayed_job'.freeze
         ENV_ENABLED = 'DD_TRACE_DELAYED_JOB_ENABLED'.freeze

--- a/lib/ddtrace/contrib/delayed_job/integration.rb
+++ b/lib/ddtrace/contrib/delayed_job/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('4.1')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :delayed_job
 
         def self.version

--- a/lib/ddtrace/contrib/delayed_job/integration.rb
+++ b/lib/ddtrace/contrib/delayed_job/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('4.1')
 
+        # @public_api
         register_as :delayed_job
 
         def self.version

--- a/lib/ddtrace/contrib/elasticsearch/configuration/settings.rb
+++ b/lib/ddtrace/contrib/elasticsearch/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Elasticsearch
       module Configuration
         # Custom settings for the Elasticsearch integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/elasticsearch/ext.rb
+++ b/lib/ddtrace/contrib/elasticsearch/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Elasticsearch
       # Elasticsearch integration constants
+      # @public_api
       module Ext
         APP = 'elasticsearch'.freeze
         ENV_ENABLED = 'DD_TRACE_ELASTICSEARCH_ENABLED'.freeze

--- a/lib/ddtrace/contrib/elasticsearch/ext.rb
+++ b/lib/ddtrace/contrib/elasticsearch/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Elasticsearch
       # Elasticsearch integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'elasticsearch'.freeze
         ENV_ENABLED = 'DD_TRACE_ELASTICSEARCH_ENABLED'.freeze

--- a/lib/ddtrace/contrib/elasticsearch/integration.rb
+++ b/lib/ddtrace/contrib/elasticsearch/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.0.0')
 
+        # @public_api
         register_as :elasticsearch, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/elasticsearch/integration.rb
+++ b/lib/ddtrace/contrib/elasticsearch/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.0.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :elasticsearch, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/ethon/configuration/settings.rb
+++ b/lib/ddtrace/contrib/ethon/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Ethon
       module Configuration
         # Custom settings for the Ethon integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/ethon/easy_patch.rb
+++ b/lib/ddtrace/contrib/ethon/easy_patch.rb
@@ -85,7 +85,7 @@ module Datadog
           # the +parent_span+ parameter with the parent Multi span. This correctly
           # assigns all open Easy spans to the currently executing Multi context.
           #
-          # @param parent_span [Datadog::Span] the Multi span, if executing in a Multi context.
+          # @param [Datadog::Span] continue_from the Multi span, if executing in a Multi context.
           def datadog_before_request(continue_from: nil)
             load_datadog_configuration_for(url)
 

--- a/lib/ddtrace/contrib/ethon/ext.rb
+++ b/lib/ddtrace/contrib/ethon/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Ethon
       # Ethon integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'ethon'.freeze
         ENV_ENABLED = 'DD_TRACE_ETHON_ENABLED'.freeze

--- a/lib/ddtrace/contrib/ethon/ext.rb
+++ b/lib/ddtrace/contrib/ethon/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Ethon
       # Ethon integration constants
+      # @public_api
       module Ext
         APP = 'ethon'.freeze
         ENV_ENABLED = 'DD_TRACE_ETHON_ENABLED'.freeze

--- a/lib/ddtrace/contrib/ethon/integration.rb
+++ b/lib/ddtrace/contrib/ethon/integration.rb
@@ -13,7 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.11.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :ethon
 
         def self.version

--- a/lib/ddtrace/contrib/ethon/integration.rb
+++ b/lib/ddtrace/contrib/ethon/integration.rb
@@ -13,6 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.11.0')
 
+        # @public_api
         register_as :ethon
 
         def self.version

--- a/lib/ddtrace/contrib/excon/configuration/settings.rb
+++ b/lib/ddtrace/contrib/excon/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Excon
       module Configuration
         # Custom settings for the Excon integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/excon/ext.rb
+++ b/lib/ddtrace/contrib/excon/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Excon
       # Excon integration constants
+      # @public_api
       module Ext
         APP = 'excon'.freeze
         ENV_ENABLED = 'DD_TRACE_EXCON_ENABLED'.freeze

--- a/lib/ddtrace/contrib/excon/ext.rb
+++ b/lib/ddtrace/contrib/excon/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Excon
       # Excon integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'excon'.freeze
         ENV_ENABLED = 'DD_TRACE_EXCON_ENABLED'.freeze

--- a/lib/ddtrace/contrib/excon/integration.rb
+++ b/lib/ddtrace/contrib/excon/integration.rb
@@ -13,6 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.50.0')
 
+        # @public_api
         register_as :excon
 
         def self.version

--- a/lib/ddtrace/contrib/excon/integration.rb
+++ b/lib/ddtrace/contrib/excon/integration.rb
@@ -13,7 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.50.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :excon
 
         def self.version

--- a/lib/ddtrace/contrib/extensions.rb
+++ b/lib/ddtrace/contrib/extensions.rb
@@ -76,6 +76,7 @@ module Datadog
         end
 
         # Extensions for Datadog::Configuration::Settings
+        # @public_api
         module Settings
           InvalidIntegrationError = Class.new(StandardError)
 
@@ -84,10 +85,13 @@ module Datadog
           #
           # How the matching is performed is integration-specific.
           #
+          # @example
+          #   Datadog.configuration[:integration_name]
+          # @example
+          #   Datadog.configuration[:integration_name][:sub_configuration]
           # @param [Symbol] integration_name the integration name
           # @param [Object] key the integration-specific lookup key
           # @return [Datadog::Contrib::Configuration::Settings]
-          # @public_api Used for Datadog.configuration[:my_integration]
           def [](integration_name, key = :default)
             integration = fetch_integration(integration_name)
             integration.resolve(key) unless integration.nil?
@@ -103,6 +107,7 @@ module Datadog
           # @param [Object] describes the previously configured `describes:` object. If `nil`,
           #   fetches the default configuration
           # @return [Datadog::Contrib::Configuration::Settings]
+          # @!visibility private
           def configuration(integration_name, describes = nil)
             integration = fetch_integration(integration_name)
             integration.configuration(describes) unless integration.nil?
@@ -124,24 +129,29 @@ module Datadog
 
           alias_method :use, :instrument
 
+          # @!visibility private
           def integrations_pending_activation
             @integrations_pending_activation ||= Set.new
           end
 
+          # @!visibility private
           def instrumented_integrations
             @instrumented_integrations ||= {}
           end
 
+          # @!visibility private
           def reset!
             instrumented_integrations.clear
             super
           end
 
+          # @!visibility private
           def fetch_integration(name)
             Contrib::REGISTRY[name] ||
               raise(InvalidIntegrationError, "'#{name}' is not a valid integration.")
           end
 
+          # @!visibility private
           def reduce_verbosity?
             defined?(@reduce_verbosity) ? @reduce_verbosity : false
           end

--- a/lib/ddtrace/contrib/extensions.rb
+++ b/lib/ddtrace/contrib/extensions.rb
@@ -87,7 +87,7 @@ module Datadog
           # @param [Symbol] integration_name the integration name
           # @param [Object] key the integration-specific lookup key
           # @return [Datadog::Contrib::Configuration::Settings]
-          # @public_api
+          # @public_api Used for Datadog.configuration[:my_integration]
           def [](integration_name, key = :default)
             integration = fetch_integration(integration_name)
             integration.resolve(key) unless integration.nil?

--- a/lib/ddtrace/contrib/extensions.rb
+++ b/lib/ddtrace/contrib/extensions.rb
@@ -87,6 +87,7 @@ module Datadog
           # @param [Symbol] integration_name the integration name
           # @param [Object] key the integration-specific lookup key
           # @return [Datadog::Contrib::Configuration::Settings]
+          # @public_api
           def [](integration_name, key = :default)
             integration = fetch_integration(integration_name)
             integration.resolve(key) unless integration.nil?

--- a/lib/ddtrace/contrib/faraday/configuration/settings.rb
+++ b/lib/ddtrace/contrib/faraday/configuration/settings.rb
@@ -8,6 +8,7 @@ module Datadog
     module Faraday
       module Configuration
         # Custom settings for the Faraday integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           DEFAULT_ERROR_HANDLER = lambda do |env|
             Datadog::Ext::HTTP::ERROR_RANGE.cover?(env[:status])

--- a/lib/ddtrace/contrib/faraday/ext.rb
+++ b/lib/ddtrace/contrib/faraday/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Faraday
       # Faraday integration constants
+      # @public_api
       module Ext
         APP = 'faraday'.freeze
         ENV_ENABLED = 'DD_TRACE_FARADAY_ENABLED'.freeze

--- a/lib/ddtrace/contrib/faraday/ext.rb
+++ b/lib/ddtrace/contrib/faraday/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Faraday
       # Faraday integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'faraday'.freeze
         ENV_ENABLED = 'DD_TRACE_FARADAY_ENABLED'.freeze

--- a/lib/ddtrace/contrib/faraday/integration.rb
+++ b/lib/ddtrace/contrib/faraday/integration.rb
@@ -13,7 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.14.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :faraday, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/faraday/integration.rb
+++ b/lib/ddtrace/contrib/faraday/integration.rb
@@ -13,6 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.14.0')
 
+        # @public_api
         register_as :faraday, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/grape/configuration/settings.rb
+++ b/lib/ddtrace/contrib/grape/configuration/settings.rb
@@ -9,6 +9,7 @@ module Datadog
     module Grape
       module Configuration
         # Custom settings for the Grape integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/grape/ext.rb
+++ b/lib/ddtrace/contrib/grape/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Grape
       # Grape integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'grape'.freeze
         ENV_ENABLED = 'DD_TRACE_GRAPE_ENABLED'.freeze

--- a/lib/ddtrace/contrib/grape/ext.rb
+++ b/lib/ddtrace/contrib/grape/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Grape
       # Grape integration constants
+      # @public_api
       module Ext
         APP = 'grape'.freeze
         ENV_ENABLED = 'DD_TRACE_GRAPE_ENABLED'.freeze

--- a/lib/ddtrace/contrib/grape/integration.rb
+++ b/lib/ddtrace/contrib/grape/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :grape, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/grape/integration.rb
+++ b/lib/ddtrace/contrib/grape/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.0')
 
+        # @public_api
         register_as :grape, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/graphql/configuration/settings.rb
+++ b/lib/ddtrace/contrib/graphql/configuration/settings.rb
@@ -8,6 +8,7 @@ module Datadog
     module GraphQL
       module Configuration
         # Custom settings for the GraphQL integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/graphql/ext.rb
+++ b/lib/ddtrace/contrib/graphql/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module GraphQL
       # GraphQL integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'ruby-graphql'.freeze
         ENV_ENABLED = 'DD_TRACE_GRAPHQL_ENABLED'.freeze

--- a/lib/ddtrace/contrib/graphql/ext.rb
+++ b/lib/ddtrace/contrib/graphql/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module GraphQL
       # GraphQL integration constants
+      # @public_api
       module Ext
         APP = 'ruby-graphql'.freeze
         ENV_ENABLED = 'DD_TRACE_GRAPHQL_ENABLED'.freeze

--- a/lib/ddtrace/contrib/graphql/integration.rb
+++ b/lib/ddtrace/contrib/graphql/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.7.9')
 
+        # @public_api
         register_as :graphql, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/graphql/integration.rb
+++ b/lib/ddtrace/contrib/graphql/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.7.9')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :graphql, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/grpc/configuration/settings.rb
+++ b/lib/ddtrace/contrib/grpc/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module GRPC
       module Configuration
         # Custom settings for the gRPC integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/grpc/ext.rb
+++ b/lib/ddtrace/contrib/grpc/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module GRPC
       # gRPC integration constants
+      # @public_api
       module Ext
         APP = 'grpc'.freeze
         ENV_ENABLED = 'DD_TRACE_GRPC_ENABLED'.freeze

--- a/lib/ddtrace/contrib/grpc/ext.rb
+++ b/lib/ddtrace/contrib/grpc/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module GRPC
       # gRPC integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'grpc'.freeze
         ENV_ENABLED = 'DD_TRACE_GRPC_ENABLED'.freeze

--- a/lib/ddtrace/contrib/grpc/integration.rb
+++ b/lib/ddtrace/contrib/grpc/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.7.0')
 
+        # @public_api
         register_as :grpc, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/grpc/integration.rb
+++ b/lib/ddtrace/contrib/grpc/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.7.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :grpc, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/http/configuration/settings.rb
+++ b/lib/ddtrace/contrib/http/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module HTTP
       module Configuration
         # Custom settings for the HTTP integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/http/ext.rb
+++ b/lib/ddtrace/contrib/http/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module HTTP
       # HTTP integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'net/http'.freeze
         ENV_ENABLED = 'DD_TRACE_HTTP_ENABLED'.freeze

--- a/lib/ddtrace/contrib/http/ext.rb
+++ b/lib/ddtrace/contrib/http/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module HTTP
       # HTTP integration constants
+      # @public_api
       module Ext
         APP = 'net/http'.freeze
         ENV_ENABLED = 'DD_TRACE_HTTP_ENABLED'.freeze

--- a/lib/ddtrace/contrib/http/integration.rb
+++ b/lib/ddtrace/contrib/http/integration.rb
@@ -19,6 +19,7 @@ module Datadog
 
         MINIMUM_VERSION = Datadog::VERSION::MINIMUM_RUBY_VERSION
 
+        # @public_api
         register_as :http, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/http/integration.rb
+++ b/lib/ddtrace/contrib/http/integration.rb
@@ -19,7 +19,7 @@ module Datadog
 
         MINIMUM_VERSION = Datadog::VERSION::MINIMUM_RUBY_VERSION
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :http, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/httpclient/configuration/settings.rb
+++ b/lib/ddtrace/contrib/httpclient/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Httpclient
       module Configuration
         # Custom settings for the Httpclient integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/httpclient/ext.rb
+++ b/lib/ddtrace/contrib/httpclient/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Httpclient
       # Httpclient integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'httpclient'.freeze
         ENV_ENABLED = 'DD_TRACE_HTTPCLIENT_ENABLED'.freeze

--- a/lib/ddtrace/contrib/httpclient/ext.rb
+++ b/lib/ddtrace/contrib/httpclient/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Httpclient
       # Httpclient integration constants
+      # @public_api
       module Ext
         APP = 'httpclient'.freeze
         ENV_ENABLED = 'DD_TRACE_HTTPCLIENT_ENABLED'.freeze

--- a/lib/ddtrace/contrib/httpclient/integration.rb
+++ b/lib/ddtrace/contrib/httpclient/integration.rb
@@ -13,6 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('2.2.0')
 
+        # @public_api
         register_as :httpclient
 
         def self.version

--- a/lib/ddtrace/contrib/httpclient/integration.rb
+++ b/lib/ddtrace/contrib/httpclient/integration.rb
@@ -13,7 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('2.2.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :httpclient
 
         def self.version

--- a/lib/ddtrace/contrib/httprb/configuration/settings.rb
+++ b/lib/ddtrace/contrib/httprb/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Httprb
       module Configuration
         # Custom settings for the Httprb integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/httprb/ext.rb
+++ b/lib/ddtrace/contrib/httprb/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Httprb
       # Httprb integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'httprb'.freeze
         ENV_ENABLED = 'DD_TRACE_HTTPRB_ENABLED'.freeze

--- a/lib/ddtrace/contrib/httprb/ext.rb
+++ b/lib/ddtrace/contrib/httprb/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Httprb
       # Httprb integration constants
+      # @public_api
       module Ext
         APP = 'httprb'.freeze
         ENV_ENABLED = 'DD_TRACE_HTTPRB_ENABLED'.freeze

--- a/lib/ddtrace/contrib/httprb/integration.rb
+++ b/lib/ddtrace/contrib/httprb/integration.rb
@@ -13,6 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('2.0.0')
 
+        # @public_api
         register_as :httprb
 
         def self.version

--- a/lib/ddtrace/contrib/httprb/integration.rb
+++ b/lib/ddtrace/contrib/httprb/integration.rb
@@ -13,7 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('2.0.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :httprb
 
         def self.version

--- a/lib/ddtrace/contrib/integration.rb
+++ b/lib/ddtrace/contrib/integration.rb
@@ -5,7 +5,65 @@ require 'ddtrace/contrib/registerable'
 
 module Datadog
   module Contrib
-    # Base provides features that are shared across all integrations
+    # {Integration} provides the basic contract of a tracing integration.
+    #
+    # An example for a simple instrumentation of a fictional `BillingApi::Client`:
+    #
+    # ```
+    # require 'ddtrace'
+    #
+    # module BillingApi
+    #   class Integration
+    #     include ::Datadog::Contrib::Integration
+    #
+    #     register_as :billing_api # Register in the global tracing registry
+    #
+    #     def self.available?
+    #       defined?(::BillingApi::Client) # Check if the target for instrumentation is present.
+    #     end
+    #
+    #     def default_configuration
+    #       Settings.new
+    #     end
+    #
+    #     def patcher
+    #       Patcher
+    #     end
+    #   end
+    #
+    #   class Settings < ::Datadog::Contrib::Configuration::Settings
+    #     # Custom service name, if a separate service is desirable for BillingApi calls.
+    #     option :service, default: nil
+    #   end
+    #
+    #   module Patcher
+    #     include ::Datadog::Contrib::Patcher
+    #
+    #     def self.patch
+    #       ::BillingApi::Client.prepend(Instrumentation)
+    #     end
+    #   end
+    #
+    #   module Instrumentation
+    #     def api_request!(env)
+    #       Datadog.tracer.trace('billing.request',
+    #                            type: 'http',
+    #                            service: Datadog.configuration[:billing_api][:service]) do |span|
+    #         span.resource = env[:route].to_s
+    #         span.set_tag('client_id', env[:client][:id])
+    #
+    #         super
+    #       end
+    #     end
+    #   end
+    # end
+    #
+    # Datadog.configure do |c|
+    #   c.use :billing_api # Settings (e.g. `service:`) can be provided as keyword arguments.
+    # end
+    # ```
+    #
+    # @public_api
     module Integration
       def self.included(base)
         base.include(Configurable)

--- a/lib/ddtrace/contrib/kafka/configuration/settings.rb
+++ b/lib/ddtrace/contrib/kafka/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Kafka
       module Configuration
         # Custom settings for the Kafka integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/kafka/ext.rb
+++ b/lib/ddtrace/contrib/kafka/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Kafka
       # Kafka integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'kafka'.freeze
         ENV_ENABLED = 'DD_TRACE_KAFKA_ENABLED'.freeze

--- a/lib/ddtrace/contrib/kafka/ext.rb
+++ b/lib/ddtrace/contrib/kafka/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Kafka
       # Kafka integration constants
+      # @public_api
       module Ext
         APP = 'kafka'.freeze
         ENV_ENABLED = 'DD_TRACE_KAFKA_ENABLED'.freeze

--- a/lib/ddtrace/contrib/kafka/integration.rb
+++ b/lib/ddtrace/contrib/kafka/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.7.10')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :kafka, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/kafka/integration.rb
+++ b/lib/ddtrace/contrib/kafka/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.7.10')
 
+        # @public_api
         register_as :kafka, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/lograge/configuration/settings.rb
+++ b/lib/ddtrace/contrib/lograge/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Lograge
       module Configuration
         # Custom settings for the Lograge integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/lograge/ext.rb
+++ b/lib/ddtrace/contrib/lograge/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Lograge
       # Lograge integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         ENV_ENABLED = 'DD_TRACE_LOGRAGE_ENABLED'.freeze
       end

--- a/lib/ddtrace/contrib/lograge/ext.rb
+++ b/lib/ddtrace/contrib/lograge/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Lograge
       # Lograge integration constants
+      # @public_api
       module Ext
         ENV_ENABLED = 'DD_TRACE_LOGRAGE_ENABLED'.freeze
       end

--- a/lib/ddtrace/contrib/lograge/integration.rb
+++ b/lib/ddtrace/contrib/lograge/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.11.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :lograge
 
         def self.version

--- a/lib/ddtrace/contrib/lograge/integration.rb
+++ b/lib/ddtrace/contrib/lograge/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.11.0')
 
+        # @public_api
         register_as :lograge
 
         def self.version

--- a/lib/ddtrace/contrib/mongodb/configuration/settings.rb
+++ b/lib/ddtrace/contrib/mongodb/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module MongoDB
       module Configuration
         # Custom settings for the MongoDB integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           DEFAULT_QUANTIZE = { show: [:collection, :database, :operation] }.freeze
 

--- a/lib/ddtrace/contrib/mongodb/ext.rb
+++ b/lib/ddtrace/contrib/mongodb/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module MongoDB
       # MongoDB integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'mongodb'.freeze
         ENV_ENABLED = 'DD_TRACE_MONGO_ENABLED'.freeze

--- a/lib/ddtrace/contrib/mongodb/ext.rb
+++ b/lib/ddtrace/contrib/mongodb/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module MongoDB
       # MongoDB integration constants
+      # @public_api
       module Ext
         APP = 'mongodb'.freeze
         ENV_ENABLED = 'DD_TRACE_MONGO_ENABLED'.freeze

--- a/lib/ddtrace/contrib/mongodb/integration.rb
+++ b/lib/ddtrace/contrib/mongodb/integration.rb
@@ -13,7 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('2.1.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :mongo, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/mongodb/integration.rb
+++ b/lib/ddtrace/contrib/mongodb/integration.rb
@@ -13,6 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('2.1.0')
 
+        # @public_api
         register_as :mongo, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/mysql2/configuration/settings.rb
+++ b/lib/ddtrace/contrib/mysql2/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Mysql2
       module Configuration
         # Custom settings for the Mysql2 integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/mysql2/ext.rb
+++ b/lib/ddtrace/contrib/mysql2/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Mysql2
       # Mysql2 integration constants
+      # @public_api
       module Ext
         APP = 'mysql2'.freeze
         ENV_ENABLED = 'DD_TRACE_MYSQL2_ENABLED'.freeze

--- a/lib/ddtrace/contrib/mysql2/ext.rb
+++ b/lib/ddtrace/contrib/mysql2/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Mysql2
       # Mysql2 integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'mysql2'.freeze
         ENV_ENABLED = 'DD_TRACE_MYSQL2_ENABLED'.freeze

--- a/lib/ddtrace/contrib/mysql2/integration.rb
+++ b/lib/ddtrace/contrib/mysql2/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.3.21')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :mysql2
 
         def self.version

--- a/lib/ddtrace/contrib/mysql2/integration.rb
+++ b/lib/ddtrace/contrib/mysql2/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.3.21')
 
+        # @public_api
         register_as :mysql2
 
         def self.version

--- a/lib/ddtrace/contrib/patchable.rb
+++ b/lib/ddtrace/contrib/patchable.rb
@@ -11,31 +11,50 @@ module Datadog
       # Class methods for integrations
       # @public_api
       module ClassMethods
-        # Version of the integration target code in the host application.
+        # Version of the integration target code in the environment.
         #
         # This is the gem version, when the instrumentation target is a Ruby gem.
+        #
+        # If the target for instrumentation has concept of versioning, override {.version},
+        # otherwise override {.available?} and implement a custom target presence check.
+        # @return [Object] the target version
         def version
           nil
         end
 
-        # Is the target available? (e.g. gem installed?)
+        # Is the target available to be instrumented? (e.g. gem installed?)
+        #
+        # The target doesn't have to be loaded (e.g. `require`) yet, but needs to be able
+        # to be loaded before instrumentation can commence.
+        #
+        # By default, {.available?} checks if {.version} returned a non-nil object.
+        #
+        # If the target for instrumentation has concept of versioning, override {.version},
+        # otherwise override {.available?} and implement a custom target presence check.
+        # @return [Boolean] is the target available for instrumentation in this Ruby environment?
         def available?
           !version.nil?
         end
 
-        # Is the target loaded into the application? (e.g. gem loaded? Constants defined?)
+        # Is the target loaded into the application? (e.g. gem required? Constant defined?)
+        #
+        # The target's objects should be ready to be referenced by the instrumented when {.loaded}
+        # returns `true`.
+        #
+        # @return [Boolean] is the target ready to be referenced during instrumentation?
         def loaded?
           true
         end
 
-        # Is the loaded code compatible with this integration? (e.g. minimum version met?)
+        # Is this instrumentation compatible with the available target? (e.g. minimum version met?)
+        # @return [Boolean] is the available target compatible with this instrumentation?
         def compatible?
           available? && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(VERSION::MINIMUM_RUBY_VERSION)
         end
 
         # Can the patch for this integration be applied?
         #
-        # By default, this depends on {#available?}, {#loaded?}, and {#compatible?}
+        # By default, this is equivalent to {#available?}, {#loaded?}, and {#compatible?}
         # all being truthy.
         def patchable?
           available? && loaded? && compatible?
@@ -45,10 +64,17 @@ module Datadog
       # Instance methods for integrations
       # @public_api
       module InstanceMethods
+        # The patcher module to inject instrumented objects into the instrumentation target.
+        #
+        # {Contrib::Patcher} includes the basic functionality of a patcher. `include`ing
+        # {Contrib::Patcher} into a new module is the recommend way to create a custom patcher.
+        #
+        # @return [Contrib::Patcher] a module that `include`s {Contrib::Patcher}
         def patcher
           nil
         end
 
+        # @!visibility private
         def patch
           if !self.class.patchable? || patcher.nil?
             return {
@@ -70,6 +96,7 @@ module Datadog
         # and rails sub-modules are auto-instrumented by enabling rails
         # so auto-instrumenting them on their own will cause changes in
         # service naming behavior
+        # @return [Boolean] can the tracer activate this instrumentation without explicit user input?
         def auto_instrument?
           true
         end

--- a/lib/ddtrace/contrib/patchable.rb
+++ b/lib/ddtrace/contrib/patchable.rb
@@ -9,7 +9,11 @@ module Datadog
       end
 
       # Class methods for integrations
+      # @public_api
       module ClassMethods
+        # Version of the integration target code in the host application.
+        #
+        # This is the gem version, when the instrumentation target is a Ruby gem.
         def version
           nil
         end
@@ -19,7 +23,7 @@ module Datadog
           !version.nil?
         end
 
-        # Is the target loaded into the application? (e.g. constants defined?)
+        # Is the target loaded into the application? (e.g. gem loaded? Constants defined?)
         def loaded?
           true
         end
@@ -30,12 +34,16 @@ module Datadog
         end
 
         # Can the patch for this integration be applied?
+        #
+        # By default, this depends on {#available?}, {#loaded?}, and {#compatible?}
+        # all being truthy.
         def patchable?
           available? && loaded? && compatible?
         end
       end
 
       # Instance methods for integrations
+      # @public_api
       module InstanceMethods
         def patcher
           nil

--- a/lib/ddtrace/contrib/patcher.rb
+++ b/lib/ddtrace/contrib/patcher.rb
@@ -11,6 +11,7 @@ module Datadog
       end
 
       # Prepended instance methods for all patchers
+      # @public_api
       module CommonMethods
         def patch_name
           self.class != Class && self.class != Module ? self.class.name : name

--- a/lib/ddtrace/contrib/patcher.rb
+++ b/lib/ddtrace/contrib/patcher.rb
@@ -3,7 +3,10 @@ require 'ddtrace/utils/only_once'
 
 module Datadog
   module Contrib
-    # Common behavior for patcher modules
+    # Common behavior for patcher modules.
+    #
+    # `include`ing {Contrib::Patcher} into a new module is the recommend way to create a custom patcher.
+    # The patcher can then be provided to a custom {Datadog::Contrib::Integration} for instrumentation.
     module Patcher
       def self.included(base)
         base.singleton_class.prepend(CommonMethods)

--- a/lib/ddtrace/contrib/presto/configuration/settings.rb
+++ b/lib/ddtrace/contrib/presto/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Presto
       module Configuration
         # Custom settings for the Presto integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/presto/ext.rb
+++ b/lib/ddtrace/contrib/presto/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Presto
       # Presto integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'presto'.freeze
         ENV_ENABLED = 'DD_TRACE_PRESTO_ENABLED'.freeze

--- a/lib/ddtrace/contrib/presto/ext.rb
+++ b/lib/ddtrace/contrib/presto/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Presto
       # Presto integration constants
+      # @public_api
       module Ext
         APP = 'presto'.freeze
         ENV_ENABLED = 'DD_TRACE_PRESTO_ENABLED'.freeze

--- a/lib/ddtrace/contrib/presto/integration.rb
+++ b/lib/ddtrace/contrib/presto/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.5.14')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :presto
 
         def self.version

--- a/lib/ddtrace/contrib/presto/integration.rb
+++ b/lib/ddtrace/contrib/presto/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.5.14')
 
+        # @public_api
         register_as :presto
 
         def self.version

--- a/lib/ddtrace/contrib/qless/configuration/settings.rb
+++ b/lib/ddtrace/contrib/qless/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Qless
       module Configuration
         # Custom settings for the Qless integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :analytics_enabled do |o|
             o.default { env_to_bool(Ext::ENV_ANALYTICS_ENABLED, false) }

--- a/lib/ddtrace/contrib/qless/ext.rb
+++ b/lib/ddtrace/contrib/qless/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Qless
       # Qless integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'qless'.freeze
         ENV_ANALYTICS_ENABLED = 'DD_TRACE_QLESS_ANALYTICS_ENABLED'.freeze

--- a/lib/ddtrace/contrib/qless/ext.rb
+++ b/lib/ddtrace/contrib/qless/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Qless
       # Qless integration constants
+      # @public_api
       module Ext
         APP = 'qless'.freeze
         ENV_ANALYTICS_ENABLED = 'DD_TRACE_QLESS_ANALYTICS_ENABLED'.freeze

--- a/lib/ddtrace/contrib/qless/integration.rb
+++ b/lib/ddtrace/contrib/qless/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.10.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :qless, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/qless/integration.rb
+++ b/lib/ddtrace/contrib/qless/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.10.0')
 
+        # @public_api
         register_as :qless, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/que/ext.rb
+++ b/lib/ddtrace/contrib/que/ext.rb
@@ -5,6 +5,7 @@ module Datadog
   module Contrib
     module Que
       # Que integration constants
+      # @public_api
       module Ext
         APP = 'que'
         ENV_ANALYTICS_ENABLED = 'DD_TRACE_QUE_ANALYTICS_ENABLED'

--- a/lib/ddtrace/contrib/que/ext.rb
+++ b/lib/ddtrace/contrib/que/ext.rb
@@ -5,7 +5,7 @@ module Datadog
   module Contrib
     module Que
       # Que integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'que'
         ENV_ANALYTICS_ENABLED = 'DD_TRACE_QUE_ANALYTICS_ENABLED'

--- a/lib/ddtrace/contrib/que/integration.rb
+++ b/lib/ddtrace/contrib/que/integration.rb
@@ -15,7 +15,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.0.0.beta2')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :que, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/que/integration.rb
+++ b/lib/ddtrace/contrib/que/integration.rb
@@ -15,6 +15,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.0.0.beta2')
 
+        # @public_api
         register_as :que, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/racecar/configuration/settings.rb
+++ b/lib/ddtrace/contrib/racecar/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Racecar
       module Configuration
         # Custom settings for the Racecar integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/racecar/ext.rb
+++ b/lib/ddtrace/contrib/racecar/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Racecar
       # Racecar integration constants
+      # @public_api
       module Ext
         APP = 'racecar'.freeze
         ENV_ENABLED = 'DD_TRACE_RACECAR_ENABLED'.freeze

--- a/lib/ddtrace/contrib/racecar/ext.rb
+++ b/lib/ddtrace/contrib/racecar/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Racecar
       # Racecar integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'racecar'.freeze
         ENV_ENABLED = 'DD_TRACE_RACECAR_ENABLED'.freeze

--- a/lib/ddtrace/contrib/racecar/integration.rb
+++ b/lib/ddtrace/contrib/racecar/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.3.5')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :racecar, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/racecar/integration.rb
+++ b/lib/ddtrace/contrib/racecar/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('0.3.5')
 
+        # @public_api
         register_as :racecar, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/rack/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rack/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Rack
       module Configuration
         # Custom settings for the Rack integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           DEFAULT_HEADERS = {
             response: %w[

--- a/lib/ddtrace/contrib/rack/ext.rb
+++ b/lib/ddtrace/contrib/rack/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Rack
       # Rack integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'rack'.freeze
         ENV_ENABLED = 'DD_TRACE_RACK_ENABLED'.freeze

--- a/lib/ddtrace/contrib/rack/ext.rb
+++ b/lib/ddtrace/contrib/rack/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Rack
       # Rack integration constants
+      # @public_api
       module Ext
         APP = 'rack'.freeze
         ENV_ENABLED = 'DD_TRACE_RACK_ENABLED'.freeze

--- a/lib/ddtrace/contrib/rack/integration.rb
+++ b/lib/ddtrace/contrib/rack/integration.rb
@@ -13,7 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.1.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :rack, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/rack/integration.rb
+++ b/lib/ddtrace/contrib/rack/integration.rb
@@ -13,6 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.1.0')
 
+        # @public_api
         register_as :rack, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/rails/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rails/configuration/settings.rb
@@ -6,6 +6,7 @@ module Datadog
     module Rails
       module Configuration
         # Custom settings for the Rails integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           def initialize(options = {})
             super(options)

--- a/lib/ddtrace/contrib/rails/ext.rb
+++ b/lib/ddtrace/contrib/rails/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Rails
       # Rails integration constants
+      # @public_api
       module Ext
         APP = 'rails'.freeze
         ENV_ENABLED = 'DD_TRACE_RAILS_ENABLED'.freeze

--- a/lib/ddtrace/contrib/rails/ext.rb
+++ b/lib/ddtrace/contrib/rails/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Rails
       # Rails integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'rails'.freeze
         ENV_ENABLED = 'DD_TRACE_RAILS_ENABLED'.freeze

--- a/lib/ddtrace/contrib/rails/integration.rb
+++ b/lib/ddtrace/contrib/rails/integration.rb
@@ -14,7 +14,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('3.2')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :rails, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/rails/integration.rb
+++ b/lib/ddtrace/contrib/rails/integration.rb
@@ -14,6 +14,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('3.2')
 
+        # @public_api
         register_as :rails, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/rake/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rake/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Rake
       module Configuration
         # Custom settings for the Rake integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/rake/ext.rb
+++ b/lib/ddtrace/contrib/rake/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Rake
       # Rake integration constants
+      # @public_api
       module Ext
         APP = 'rake'.freeze
         ENV_ENABLED = 'DD_TRACE_RAKE_ENABLED'.freeze

--- a/lib/ddtrace/contrib/rake/ext.rb
+++ b/lib/ddtrace/contrib/rake/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Rake
       # Rake integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'rake'.freeze
         ENV_ENABLED = 'DD_TRACE_RAKE_ENABLED'.freeze

--- a/lib/ddtrace/contrib/rake/integration.rb
+++ b/lib/ddtrace/contrib/rake/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('12.0')
 
+        # @public_api
         register_as :rake
 
         def self.version

--- a/lib/ddtrace/contrib/rake/integration.rb
+++ b/lib/ddtrace/contrib/rake/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('12.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :rake
 
         def self.version

--- a/lib/ddtrace/contrib/redis/configuration/settings.rb
+++ b/lib/ddtrace/contrib/redis/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Redis
       module Configuration
         # Custom settings for the Redis integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/redis/ext.rb
+++ b/lib/ddtrace/contrib/redis/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Redis
       # Redis integration constants
+      # @public_api
       module Ext
         APP = 'redis'.freeze
         ENV_ENABLED = 'DD_TRACE_REDIS_ENABLED'.freeze

--- a/lib/ddtrace/contrib/redis/ext.rb
+++ b/lib/ddtrace/contrib/redis/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Redis
       # Redis integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'redis'.freeze
         ENV_ENABLED = 'DD_TRACE_REDIS_ENABLED'.freeze

--- a/lib/ddtrace/contrib/redis/integration.rb
+++ b/lib/ddtrace/contrib/redis/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('3.2')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :redis, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/redis/integration.rb
+++ b/lib/ddtrace/contrib/redis/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('3.2')
 
+        # @public_api
         register_as :redis, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/registerable.rb
+++ b/lib/ddtrace/contrib/registerable.rb
@@ -29,7 +29,6 @@ module Datadog
         #   a custom {Registerable} instrumentation
         # @see Datadog::Contrib::Integration
         def register_as(name, registry: Datadog::Contrib::REGISTRY, auto_patch: false, **options)
-          Integration
           registry.add(name, new(name, **options), auto_patch)
         end
       end

--- a/lib/ddtrace/contrib/registerable.rb
+++ b/lib/ddtrace/contrib/registerable.rb
@@ -27,7 +27,9 @@ module Datadog
         #   {file:docs/AutoInstrumentation.md Auto Instrumentation}?
         # @param [Hash] options additional keyword options passed to the initializer of
         #   a custom {Registerable} instrumentation
+        # @see Datadog::Contrib::Integration
         def register_as(name, registry: Datadog::Contrib::REGISTRY, auto_patch: false, **options)
+          Integration
           registry.add(name, new(name, **options), auto_patch)
         end
       end

--- a/lib/ddtrace/contrib/registerable.rb
+++ b/lib/ddtrace/contrib/registerable.rb
@@ -10,12 +10,25 @@ module Datadog
       end
 
       # Class methods for registerable behavior
+      # @public_api
       module ClassMethods
-        def register_as(name, options = {})
-          registry = options.fetch(:registry, Contrib::REGISTRY)
-          auto_patch = options.fetch(:auto_patch, false)
-
-          registry.add(name, new(name, options), auto_patch)
+        # Registers this integration in the global tracer registry.
+        # Once registered, this integration can be activated with:
+        #
+        # ```
+        # Datadog.configure do |c|
+        #   c.use :name
+        # end
+        # ```
+        #
+        # @param [Symbol] name integration name. Used during activation.
+        # @param [Datadog::Contrib::Registry] registry a custom registry. Defaults to the global tracing registry.
+        # @param [Boolean] auto_patch will this integration be activated during
+        #   {file:docs/AutoInstrumentation.md Auto Instrumentation}?
+        # @param [Hash] options additional keyword options passed to the initializer of
+        #   a custom {Registerable} instrumentation
+        def register_as(name, registry: Datadog::Contrib::REGISTRY, auto_patch: false, **options)
+          registry.add(name, new(name, **options), auto_patch)
         end
       end
 
@@ -24,7 +37,7 @@ module Datadog
         attr_reader \
           :name
 
-        def initialize(name, options = {})
+        def initialize(name, **options)
           @name = name
         end
       end

--- a/lib/ddtrace/contrib/registry.rb
+++ b/lib/ddtrace/contrib/registry.rb
@@ -1,17 +1,23 @@
 # typed: true
 module Datadog
   module Contrib
-    # Registry is a collection of integrations.
+    # Registry is a collection of tracing integrations.
+    # @public_api
     class Registry
       include Enumerable
 
       Entry = Struct.new(:name, :klass, :auto_patch)
 
+      # @!visibility private
       def initialize
         @data = {}
         @mutex = Mutex.new
       end
 
+      # @param name [Symbol] instrumentation name, to be used when activating this integration
+      # @param klass [Object] instrumentation implementation
+      # @param auto_patch [Boolean] is the tracer allowed to automatically patch
+      #   the host application with this instrumentation?
       def add(name, klass, auto_patch = false)
         @mutex.synchronize do
           @data[name] = Entry.new(name, klass, auto_patch).freeze

--- a/lib/ddtrace/contrib/resque/configuration/settings.rb
+++ b/lib/ddtrace/contrib/resque/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Resque
       module Configuration
         # Custom settings for the Resque integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/resque/ext.rb
+++ b/lib/ddtrace/contrib/resque/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Resque
       # Resque integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'resque'.freeze
         ENV_ENABLED = 'DD_TRACE_RESQUE_ENABLED'.freeze

--- a/lib/ddtrace/contrib/resque/ext.rb
+++ b/lib/ddtrace/contrib/resque/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Resque
       # Resque integration constants
+      # @public_api
       module Ext
         APP = 'resque'.freeze
         ENV_ENABLED = 'DD_TRACE_RESQUE_ENABLED'.freeze

--- a/lib/ddtrace/contrib/resque/integration.rb
+++ b/lib/ddtrace/contrib/resque/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.0')
 
+        # @public_api
         register_as :resque, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/resque/integration.rb
+++ b/lib/ddtrace/contrib/resque/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :resque, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/rest_client/configuration/settings.rb
+++ b/lib/ddtrace/contrib/rest_client/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module RestClient
       module Configuration
         # Custom settings for the RestClient integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/rest_client/ext.rb
+++ b/lib/ddtrace/contrib/rest_client/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module RestClient
       # RestClient integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'rest_client'.freeze
         ENV_ENABLED = 'DD_TRACE_REST_CLIENT_ENABLED'.freeze

--- a/lib/ddtrace/contrib/rest_client/ext.rb
+++ b/lib/ddtrace/contrib/rest_client/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module RestClient
       # RestClient integration constants
+      # @public_api
       module Ext
         APP = 'rest_client'.freeze
         ENV_ENABLED = 'DD_TRACE_REST_CLIENT_ENABLED'.freeze

--- a/lib/ddtrace/contrib/rest_client/integration.rb
+++ b/lib/ddtrace/contrib/rest_client/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.8')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :rest_client
 
         def self.version

--- a/lib/ddtrace/contrib/rest_client/integration.rb
+++ b/lib/ddtrace/contrib/rest_client/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.8')
 
+        # @public_api
         register_as :rest_client
 
         def self.version

--- a/lib/ddtrace/contrib/semantic_logger/configuration/settings.rb
+++ b/lib/ddtrace/contrib/semantic_logger/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module SemanticLogger
       module Configuration
         # Custom settings for the SemanticLogger integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/semantic_logger/ext.rb
+++ b/lib/ddtrace/contrib/semantic_logger/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module SemanticLogger
       # SemanticLogger integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         ENV_ENABLED = 'DD_TRACE_SEMANTIC_LOGGER_ENABLED'.freeze
       end

--- a/lib/ddtrace/contrib/semantic_logger/ext.rb
+++ b/lib/ddtrace/contrib/semantic_logger/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module SemanticLogger
       # SemanticLogger integration constants
+      # @public_api
       module Ext
         ENV_ENABLED = 'DD_TRACE_SEMANTIC_LOGGER_ENABLED'.freeze
       end

--- a/lib/ddtrace/contrib/semantic_logger/integration.rb
+++ b/lib/ddtrace/contrib/semantic_logger/integration.rb
@@ -15,7 +15,7 @@ module Datadog
         # it's probably reasonable to nudge users to using modern ruby libs
         MINIMUM_VERSION = Gem::Version.new('4.0.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :semantic_logger
 
         def self.version

--- a/lib/ddtrace/contrib/semantic_logger/integration.rb
+++ b/lib/ddtrace/contrib/semantic_logger/integration.rb
@@ -15,6 +15,7 @@ module Datadog
         # it's probably reasonable to nudge users to using modern ruby libs
         MINIMUM_VERSION = Gem::Version.new('4.0.0')
 
+        # @public_api
         register_as :semantic_logger
 
         def self.version

--- a/lib/ddtrace/contrib/sequel/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sequel/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Sequel
       module Configuration
         # Custom settings for the Sequel integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/sequel/ext.rb
+++ b/lib/ddtrace/contrib/sequel/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Sequel
       # Sequel integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'sequel'.freeze
         ENV_ENABLED = 'DD_TRACE_SEQUEL_ENABLED'.freeze

--- a/lib/ddtrace/contrib/sequel/ext.rb
+++ b/lib/ddtrace/contrib/sequel/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Sequel
       # Sequel integration constants
+      # @public_api
       module Ext
         APP = 'sequel'.freeze
         ENV_ENABLED = 'DD_TRACE_SEQUEL_ENABLED'.freeze

--- a/lib/ddtrace/contrib/sequel/integration.rb
+++ b/lib/ddtrace/contrib/sequel/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('3.41')
 
+        # @public_api
         register_as :sequel, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/sequel/integration.rb
+++ b/lib/ddtrace/contrib/sequel/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('3.41')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :sequel, auto_patch: false
 
         def self.version

--- a/lib/ddtrace/contrib/shoryuken/configuration/settings.rb
+++ b/lib/ddtrace/contrib/shoryuken/configuration/settings.rb
@@ -6,6 +6,7 @@ module Datadog
     module Shoryuken
       module Configuration
         # Default settings for the Shoryuken integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/shoryuken/ext.rb
+++ b/lib/ddtrace/contrib/shoryuken/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Shoryuken
       # Shoryuken integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'shoryuken'.freeze
         ENV_ENABLED = 'DD_TRACE_SHORYUKEN_ENABLED'.freeze

--- a/lib/ddtrace/contrib/shoryuken/ext.rb
+++ b/lib/ddtrace/contrib/shoryuken/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Shoryuken
       # Shoryuken integration constants
+      # @public_api
       module Ext
         APP = 'shoryuken'.freeze
         ENV_ENABLED = 'DD_TRACE_SHORYUKEN_ENABLED'.freeze

--- a/lib/ddtrace/contrib/shoryuken/integration.rb
+++ b/lib/ddtrace/contrib/shoryuken/integration.rb
@@ -13,7 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('3.2')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :shoryuken
 
         def self.version

--- a/lib/ddtrace/contrib/shoryuken/integration.rb
+++ b/lib/ddtrace/contrib/shoryuken/integration.rb
@@ -13,6 +13,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('3.2')
 
+        # @public_api
         register_as :shoryuken
 
         def self.version

--- a/lib/ddtrace/contrib/sidekiq/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sidekiq/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module Sidekiq
       module Configuration
         # Custom settings for the Sidekiq integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/sidekiq/ext.rb
+++ b/lib/ddtrace/contrib/sidekiq/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Sidekiq
       # Sidekiq integration constants
+      # @public_api
       module Ext
         APP = 'sidekiq'.freeze
         CLIENT_SERVICE_NAME = 'sidekiq-client'.freeze

--- a/lib/ddtrace/contrib/sidekiq/ext.rb
+++ b/lib/ddtrace/contrib/sidekiq/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Sidekiq
       # Sidekiq integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'sidekiq'.freeze
         CLIENT_SERVICE_NAME = 'sidekiq-client'.freeze

--- a/lib/ddtrace/contrib/sidekiq/integration.rb
+++ b/lib/ddtrace/contrib/sidekiq/integration.rb
@@ -13,6 +13,7 @@ module Datadog
         MINIMUM_VERSION = Gem::Version.new('3.5.4')
         MINIMUM_SERVER_INTERNAL_TRACING_VERSION = Gem::Version.new('5.2.4')
 
+        # @public_api
         register_as :sidekiq
 
         def self.version

--- a/lib/ddtrace/contrib/sidekiq/integration.rb
+++ b/lib/ddtrace/contrib/sidekiq/integration.rb
@@ -13,7 +13,7 @@ module Datadog
         MINIMUM_VERSION = Gem::Version.new('3.5.4')
         MINIMUM_SERVER_INTERNAL_TRACING_VERSION = Gem::Version.new('5.2.4')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :sidekiq
 
         def self.version

--- a/lib/ddtrace/contrib/sinatra/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sinatra/configuration/settings.rb
@@ -8,6 +8,7 @@ module Datadog
     module Sinatra
       module Configuration
         # Custom settings for the Sinatra integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           DEFAULT_HEADERS = {
             response: %w[Content-Type X-Request-ID]

--- a/lib/ddtrace/contrib/sinatra/ext.rb
+++ b/lib/ddtrace/contrib/sinatra/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module Sinatra
       # Sinatra integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'sinatra'.freeze
         ENV_ENABLED = 'DD_TRACE_SINATRA_ENABLED'.freeze

--- a/lib/ddtrace/contrib/sinatra/ext.rb
+++ b/lib/ddtrace/contrib/sinatra/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module Sinatra
       # Sinatra integration constants
+      # @public_api
       module Ext
         APP = 'sinatra'.freeze
         ENV_ENABLED = 'DD_TRACE_SINATRA_ENABLED'.freeze

--- a/lib/ddtrace/contrib/sinatra/integration.rb
+++ b/lib/ddtrace/contrib/sinatra/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.4')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :sinatra
 
         def self.version

--- a/lib/ddtrace/contrib/sinatra/integration.rb
+++ b/lib/ddtrace/contrib/sinatra/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('1.4')
 
+        # @public_api
         register_as :sinatra
 
         def self.version

--- a/lib/ddtrace/contrib/sneakers/ext.rb
+++ b/lib/ddtrace/contrib/sneakers/ext.rb
@@ -5,6 +5,7 @@ module Datadog
   module Contrib
     module Sneakers
       # Sneakers integration constants
+      # @public_api
       module Ext
         APP = 'sneakers'
         ENV_ENABLED = 'DD_TRACE_SNEAKERS_ENABLED'

--- a/lib/ddtrace/contrib/sneakers/ext.rb
+++ b/lib/ddtrace/contrib/sneakers/ext.rb
@@ -5,7 +5,7 @@ module Datadog
   module Contrib
     module Sneakers
       # Sneakers integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'sneakers'
         ENV_ENABLED = 'DD_TRACE_SNEAKERS_ENABLED'

--- a/lib/ddtrace/contrib/sneakers/integration.rb
+++ b/lib/ddtrace/contrib/sneakers/integration.rb
@@ -15,6 +15,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('2.12.0')
 
+        # @public_api
         register_as :sneakers, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/sneakers/integration.rb
+++ b/lib/ddtrace/contrib/sneakers/integration.rb
@@ -15,7 +15,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('2.12.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :sneakers, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/status_code_matcher.rb
+++ b/lib/ddtrace/contrib/status_code_matcher.rb
@@ -5,7 +5,6 @@ require 'ddtrace/ext/http'
 module Datadog
   module Contrib
     # Contains methods helpful for tracing/annotating HTTP request libraries
-    # @public_api
     class StatusCodeMatcher
       REGEX_PARSER = /^\d{3}(?:-\d{3})?(?:,\d{3}(?:-\d{3})?)*$/.freeze
 

--- a/lib/ddtrace/contrib/status_code_matcher.rb
+++ b/lib/ddtrace/contrib/status_code_matcher.rb
@@ -5,6 +5,7 @@ require 'ddtrace/ext/http'
 module Datadog
   module Contrib
     # Contains methods helpful for tracing/annotating HTTP request libraries
+    # @public_api
     class StatusCodeMatcher
       REGEX_PARSER = /^\d{3}(?:-\d{3})?(?:,\d{3}(?:-\d{3})?)*$/.freeze
 

--- a/lib/ddtrace/contrib/sucker_punch/configuration/settings.rb
+++ b/lib/ddtrace/contrib/sucker_punch/configuration/settings.rb
@@ -7,6 +7,7 @@ module Datadog
     module SuckerPunch
       module Configuration
         # Custom settings for the SuckerPunch integration
+        # @public_api
         class Settings < Contrib::Configuration::Settings
           option :enabled do |o|
             o.default { env_to_bool(Ext::ENV_ENABLED, true) }

--- a/lib/ddtrace/contrib/sucker_punch/ext.rb
+++ b/lib/ddtrace/contrib/sucker_punch/ext.rb
@@ -3,7 +3,7 @@ module Datadog
   module Contrib
     module SuckerPunch
       # SuckerPunch integration constants
-      # @public_api
+      # @public_api Changing resource names, tag names, or environment variables creates breaking changes.
       module Ext
         APP = 'sucker_punch'.freeze
         ENV_ENABLED = 'DD_TRACE_SUCKER_PUNCH_ENABLED'.freeze

--- a/lib/ddtrace/contrib/sucker_punch/ext.rb
+++ b/lib/ddtrace/contrib/sucker_punch/ext.rb
@@ -3,6 +3,7 @@ module Datadog
   module Contrib
     module SuckerPunch
       # SuckerPunch integration constants
+      # @public_api
       module Ext
         APP = 'sucker_punch'.freeze
         ENV_ENABLED = 'DD_TRACE_SUCKER_PUNCH_ENABLED'.freeze

--- a/lib/ddtrace/contrib/sucker_punch/integration.rb
+++ b/lib/ddtrace/contrib/sucker_punch/integration.rb
@@ -12,6 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('2.0.0')
 
+        # @public_api
         register_as :sucker_punch, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/contrib/sucker_punch/integration.rb
+++ b/lib/ddtrace/contrib/sucker_punch/integration.rb
@@ -12,7 +12,7 @@ module Datadog
 
         MINIMUM_VERSION = Gem::Version.new('2.0.0')
 
-        # @public_api
+        # @public_api Changing the integration name or integration options can cause breaking changes
         register_as :sucker_punch, auto_patch: true
 
         def self.version

--- a/lib/ddtrace/correlation.rb
+++ b/lib/ddtrace/correlation.rb
@@ -7,8 +7,8 @@ module Datadog
   # e.g. Retrieve a correlation to the current trace for logging, etc.
   module Correlation
     # Represents current trace state with key identifiers
+    # @public_api
     class Identifier
-      # @public_api
       attr_reader \
         :env,
         :service,
@@ -25,6 +25,7 @@ module Datadog
 
       # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/PerceivedComplexity
+      # @!visibility private
       def initialize(
         env: nil,
         service: nil,
@@ -80,6 +81,7 @@ module Datadog
     #
     # DEV: can we memoize this object, give it can be common to
     # use a correlation multiple times, specially in the context of logging?
+    # @!visibility private
     def identifier_from_digest(digest)
       return Identifier.new unless digest
 

--- a/lib/ddtrace/correlation.rb
+++ b/lib/ddtrace/correlation.rb
@@ -8,6 +8,7 @@ module Datadog
   module Correlation
     # Represents current trace state with key identifiers
     class Identifier
+      # @public_api
       attr_reader \
         :env,
         :service,
@@ -76,8 +77,11 @@ module Datadog
     module_function
 
     # Produces a CorrelationIdentifier from the TraceDigest provided
+    #
+    # DEV: can we memoize this object, give it can be common to
+    # use a correlation multiple times, specially in the context of logging?
     def identifier_from_digest(digest)
-      return Identifier.new.freeze unless digest
+      return Identifier.new unless digest
 
       Identifier.new(
         span_id: digest.span_id,

--- a/lib/ddtrace/encoding.rb
+++ b/lib/ddtrace/encoding.rb
@@ -6,6 +6,7 @@ module Datadog
   # Encoding module that encodes data for the AgentTransport
   module Encoding
     # Encoder interface that provides the logic to encode traces and service
+    # @abstract
     module Encoder
       include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
 

--- a/lib/ddtrace/error.rb
+++ b/lib/ddtrace/error.rb
@@ -1,7 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-# Datadog global namespace
 module Datadog
   # Error is a value-object responsible for sanitizing/encapsulating error data
   class Error

--- a/lib/ddtrace/ext/analytics.rb
+++ b/lib/ddtrace/ext/analytics.rb
@@ -2,6 +2,7 @@
 module Datadog
   module Ext
     # Defines constants for trace analytics
+    # @public_api
     module Analytics
       DEFAULT_SAMPLE_RATE = 1.0
       ENV_TRACE_ANALYTICS_ENABLED = 'DD_TRACE_ANALYTICS_ENABLED'.freeze

--- a/lib/ddtrace/ext/app_types.rb
+++ b/lib/ddtrace/ext/app_types.rb
@@ -1,6 +1,7 @@
 # typed: true
 module Datadog
   module Ext
+    # @public_api
     module AppTypes
       WEB = 'web'.freeze
       DB = 'db'.freeze

--- a/lib/ddtrace/ext/correlation.rb
+++ b/lib/ddtrace/ext/correlation.rb
@@ -1,6 +1,7 @@
 # typed: true
 module Datadog
   module Ext
+    # @public_api
     module Correlation
       ATTR_ENV = 'dd.env'.freeze
       ATTR_SERVICE = 'dd.service'.freeze

--- a/lib/ddtrace/ext/diagnostics.rb
+++ b/lib/ddtrace/ext/diagnostics.rb
@@ -1,6 +1,7 @@
 # typed: true
 module Datadog
   module Ext
+    # @public_api
     module Diagnostics
       DD_TRACE_STARTUP_LOGS = 'DD_TRACE_STARTUP_LOGS'.freeze
       DD_TRACE_DEBUG = 'DD_TRACE_DEBUG'.freeze

--- a/lib/ddtrace/ext/distributed.rb
+++ b/lib/ddtrace/ext/distributed.rb
@@ -1,6 +1,7 @@
 # typed: true
 module Datadog
   module Ext
+    # @public_api
     module DistributedTracing
       # HTTP headers one should set for distributed tracing.
       # These are cross-language (eg: Python, Go and other implementations should honor these)

--- a/lib/ddtrace/ext/environment.rb
+++ b/lib/ddtrace/ext/environment.rb
@@ -1,6 +1,7 @@
 # typed: true
 module Datadog
   module Ext
+    # @public_api
     module Environment
       ENV_API_KEY = 'DD_API_KEY'.freeze
       ENV_ENVIRONMENT = 'DD_ENV'.freeze

--- a/lib/ddtrace/ext/errors.rb
+++ b/lib/ddtrace/ext/errors.rb
@@ -1,6 +1,7 @@
 # typed: true
 module Datadog
   module Ext
+    # @public_api
     module Errors
       STATUS = 1
       MSG = 'error.msg'.freeze

--- a/lib/ddtrace/ext/http.rb
+++ b/lib/ddtrace/ext/http.rb
@@ -1,6 +1,7 @@
 # typed: true
 module Datadog
   module Ext
+    # @public_api
     module HTTP
       BASE_URL = 'http.base_url'.freeze
       ERROR_RANGE = (500...600).freeze

--- a/lib/ddtrace/ext/integration.rb
+++ b/lib/ddtrace/ext/integration.rb
@@ -1,6 +1,7 @@
 # typed: true
 module Datadog
   module Ext
+    # @public_api
     module Integration
       # Name of external service that performed the work
       TAG_PEER_SERVICE = 'peer.service'.freeze

--- a/lib/ddtrace/ext/metrics.rb
+++ b/lib/ddtrace/ext/metrics.rb
@@ -1,6 +1,7 @@
 # typed: true
 module Datadog
   module Ext
+    # @public_api
     module Metrics
       DEFAULT_HOST = '127.0.0.1'.freeze
       DEFAULT_PORT = 8125

--- a/lib/ddtrace/ext/net.rb
+++ b/lib/ddtrace/ext/net.rb
@@ -1,6 +1,7 @@
 # typed: true
 module Datadog
   module Ext
+    # @public_api
     module NET
       ENV_REPORT_HOSTNAME = 'DD_TRACE_REPORT_HOSTNAME'.freeze
       TAG_HOSTNAME = '_dd.hostname'.freeze

--- a/lib/ddtrace/ext/priority.rb
+++ b/lib/ddtrace/ext/priority.rb
@@ -6,14 +6,14 @@ module Datadog
     # @public_api
     module Priority
       # Use this to explicitly inform the backend that a trace MUST be rejected and not stored.
-      # This includes rules and rate limits configured by the user through the {RuleSampler}.
+      # This includes rules and rate limits configured by the user through the {Datadog::Sampling::RuleSampler}.
       USER_REJECT = -1
       # Used by the {PrioritySampler} to inform the backend that a trace should be rejected and not stored.
       AUTO_REJECT = 0
       # Used by the {PrioritySampler} to inform the backend that a trace should be kept and stored.
       AUTO_KEEP = 1
       # Use this to explicitly inform the backend that a trace MUST be kept and stored.
-      # This includes rules and rate limits configured by the user through the {RuleSampler}.
+      # This includes rules and rate limits configured by the user through the {Datadog::Sampling::RuleSampler}.
       USER_KEEP = 2
     end
   end

--- a/lib/ddtrace/ext/priority.rb
+++ b/lib/ddtrace/ext/priority.rb
@@ -3,6 +3,7 @@ module Datadog
   module Ext
     # Priority is a hint given to the backend so that it knows which traces to reject or kept.
     # In a distributed context, it should be set before any context propagation (fork, RPC calls) to be effective.
+    # @public_api
     module Priority
       # Use this to explicitly inform the backend that a trace MUST be rejected and not stored.
       # This includes rules and rate limits configured by the user through the {RuleSampler}.

--- a/lib/ddtrace/ext/runtime.rb
+++ b/lib/ddtrace/ext/runtime.rb
@@ -3,12 +3,14 @@ require 'ddtrace/version'
 
 module Datadog
   module Ext
+    # @public_api
     module Runtime
       TAG_ID = 'runtime-id'.freeze
       TAG_LANG = 'language'.freeze
       TAG_PID = 'system.pid'.freeze
 
       # Metrics
+      # @public_api
       module Metrics
         ENV_ENABLED = 'DD_RUNTIME_METRICS_ENABLED'.freeze
 

--- a/lib/ddtrace/ext/sampling.rb
+++ b/lib/ddtrace/ext/sampling.rb
@@ -1,6 +1,7 @@
 # typed: true
 module Datadog
   module Ext
+    # @public_api
     module Sampling
       ENV_SAMPLE_RATE = 'DD_TRACE_SAMPLE_RATE'.freeze
       ENV_RATE_LIMIT = 'DD_TRACE_RATE_LIMIT'.freeze

--- a/lib/ddtrace/ext/sql.rb
+++ b/lib/ddtrace/ext/sql.rb
@@ -1,6 +1,7 @@
 # typed: true
 module Datadog
   module Ext
+    # @public_api
     module SQL
       TYPE = 'sql'.freeze
       QUERY = 'sql.query'.freeze

--- a/lib/ddtrace/ext/test.rb
+++ b/lib/ddtrace/ext/test.rb
@@ -2,6 +2,7 @@
 module Datadog
   module Ext
     # Defines constants for test behavior
+    # @public_api
     module Test
       ENV_MODE_ENABLED = 'DD_TRACE_TEST_MODE_ENABLED'.freeze
     end

--- a/lib/ddtrace/ext/transport.rb
+++ b/lib/ddtrace/ext/transport.rb
@@ -1,7 +1,9 @@
 # typed: true
 module Datadog
   module Ext
+    # @public_api
     module Transport
+      # @public_api
       module HTTP
         ADAPTER = :net_http # DEV: Rename to simply `:http`, as Net::HTTP is an implementation detail.
         DEFAULT_HOST = '127.0.0.1'.freeze
@@ -18,10 +20,12 @@ module Datadog
         HEADER_META_TRACER_VERSION = 'Datadog-Meta-Tracer-Version'.freeze
       end
 
+      # @public_api
       module Test
         ADAPTER = :test
       end
 
+      # @public_api
       module UnixSocket
         ADAPTER = :unix
         DEFAULT_PATH = '/var/run/datadog/apm.socket'.freeze

--- a/lib/ddtrace/logger.rb
+++ b/lib/ddtrace/logger.rb
@@ -5,6 +5,7 @@ module Datadog
   # A custom logger with minor enhancements:
   # - progname defaults to ddtrace to clearly identify Datadog dd-trace-rb related messages
   # - adds last caller stack-trace info to know where the message comes from
+  # @public_api
   class Logger < ::Logger
     PREFIX = 'ddtrace'.freeze
 

--- a/lib/ddtrace/opentelemetry/extensions.rb
+++ b/lib/ddtrace/opentelemetry/extensions.rb
@@ -5,7 +5,6 @@ require 'ddtrace/opentelemetry/span'
 module Datadog
   module OpenTelemetry
     # Defines extensions to ddtrace for OpenTelemetry support
-    # @public_api
     module Extensions
       def self.extended(base)
         Datadog::SpanOperation.prepend(OpenTelemetry::Span)

--- a/lib/ddtrace/opentelemetry/extensions.rb
+++ b/lib/ddtrace/opentelemetry/extensions.rb
@@ -5,6 +5,7 @@ require 'ddtrace/opentelemetry/span'
 module Datadog
   module OpenTelemetry
     # Defines extensions to ddtrace for OpenTelemetry support
+    # @public_api
     module Extensions
       def self.extended(base)
         Datadog::SpanOperation.prepend(OpenTelemetry::Span)

--- a/lib/ddtrace/opentelemetry/span.rb
+++ b/lib/ddtrace/opentelemetry/span.rb
@@ -8,7 +8,6 @@ module Datadog
       TAG_SERVICE_NAME = 'service.name'.freeze
       TAG_SERVICE_VERSION = 'service.version'.freeze
 
-      # @public_api
       def set_tag(key, value)
         # Configure sampling priority if they give us a forced tracing tag
         # DEV: Do not set if the value they give us is explicitly "false"

--- a/lib/ddtrace/opentelemetry/span.rb
+++ b/lib/ddtrace/opentelemetry/span.rb
@@ -8,6 +8,7 @@ module Datadog
       TAG_SERVICE_NAME = 'service.name'.freeze
       TAG_SERVICE_VERSION = 'service.version'.freeze
 
+      # @public_api
       def set_tag(key, value)
         # Configure sampling priority if they give us a forced tracing tag
         # DEV: Do not set if the value they give us is explicitly "false"

--- a/lib/ddtrace/opentracer/binary_propagator.rb
+++ b/lib/ddtrace/opentracer/binary_propagator.rb
@@ -2,7 +2,6 @@
 module Datadog
   module OpenTracer
     # OpenTracing propagator for Datadog::OpenTracer::Tracer
-    # @public_api
     module BinaryPropagator
       extend Propagator
 
@@ -10,7 +9,6 @@ module Datadog
       #
       # @param span_context [SpanContext]
       # @param carrier [Carrier] A carrier object of Binary type
-      # @public_api
       def self.inject(span_context, carrier)
         nil
       end
@@ -19,7 +17,6 @@ module Datadog
       #
       # @param carrier [Carrier] A carrier object of Binary type
       # @return [SpanContext, nil] the extracted SpanContext or nil if none could be found
-      # @public_api
       def self.extract(carrier)
         SpanContext::NOOP_INSTANCE
       end

--- a/lib/ddtrace/opentracer/binary_propagator.rb
+++ b/lib/ddtrace/opentracer/binary_propagator.rb
@@ -2,6 +2,7 @@
 module Datadog
   module OpenTracer
     # OpenTracing propagator for Datadog::OpenTracer::Tracer
+    # @public_api
     module BinaryPropagator
       extend Propagator
 
@@ -9,6 +10,7 @@ module Datadog
       #
       # @param span_context [SpanContext]
       # @param carrier [Carrier] A carrier object of Binary type
+      # @public_api
       def self.inject(span_context, carrier)
         nil
       end
@@ -17,6 +19,7 @@ module Datadog
       #
       # @param carrier [Carrier] A carrier object of Binary type
       # @return [SpanContext, nil] the extracted SpanContext or nil if none could be found
+      # @public_api
       def self.extract(carrier)
         SpanContext::NOOP_INSTANCE
       end

--- a/lib/ddtrace/opentracer/carrier.rb
+++ b/lib/ddtrace/opentracer/carrier.rb
@@ -1,6 +1,7 @@
 # typed: strict
 module Datadog
   module OpenTracer
+    # @public_api
     class Carrier < ::OpenTracing::Carrier
     end
   end

--- a/lib/ddtrace/opentracer/distributed_headers.rb
+++ b/lib/ddtrace/opentracer/distributed_headers.rb
@@ -9,28 +9,23 @@ module Datadog
     class DistributedHeaders
       include Datadog::Ext::DistributedTracing
 
-      # @public_api
       def initialize(carrier)
         @carrier = carrier
       end
 
-      # @public_api
       def valid?
         # Sampling priority is optional.
         !trace_id.nil? && !parent_id.nil?
       end
 
-      # @public_api
       def trace_id
         id HTTP_HEADER_TRACE_ID
       end
 
-      # @public_api
       def parent_id
         id HTTP_HEADER_PARENT_ID
       end
 
-      # @public_api
       def sampling_priority
         hdr = @carrier[HTTP_HEADER_SAMPLING_PRIORITY]
         # It's important to make a difference between no header,
@@ -43,7 +38,6 @@ module Datadog
         value
       end
 
-      # @public_api
       def origin
         hdr = @carrier[HTTP_HEADER_ORIGIN]
         # Only return the value if it is not an empty string

--- a/lib/ddtrace/opentracer/distributed_headers.rb
+++ b/lib/ddtrace/opentracer/distributed_headers.rb
@@ -5,26 +5,32 @@ require 'ddtrace/ext/distributed'
 module Datadog
   module OpenTracer
     # DistributedHeaders provides easy access and validation to headers
+    # @public_api
     class DistributedHeaders
       include Datadog::Ext::DistributedTracing
 
+      # @public_api
       def initialize(carrier)
         @carrier = carrier
       end
 
+      # @public_api
       def valid?
         # Sampling priority is optional.
         !trace_id.nil? && !parent_id.nil?
       end
 
+      # @public_api
       def trace_id
         id HTTP_HEADER_TRACE_ID
       end
 
+      # @public_api
       def parent_id
         id HTTP_HEADER_PARENT_ID
       end
 
+      # @public_api
       def sampling_priority
         hdr = @carrier[HTTP_HEADER_SAMPLING_PRIORITY]
         # It's important to make a difference between no header,
@@ -37,6 +43,7 @@ module Datadog
         value
       end
 
+      # @public_api
       def origin
         hdr = @carrier[HTTP_HEADER_ORIGIN]
         # Only return the value if it is not an empty string

--- a/lib/ddtrace/opentracer/propagator.rb
+++ b/lib/ddtrace/opentracer/propagator.rb
@@ -2,6 +2,8 @@
 module Datadog
   module OpenTracer
     # OpenTracing propagator for Datadog::OpenTracer::Tracer
+    # @abstract
+    # @public_api
     module Propagator
       # Inject a SpanContext into the given carrier
       #

--- a/lib/ddtrace/opentracer/scope.rb
+++ b/lib/ddtrace/opentracer/scope.rb
@@ -2,11 +2,14 @@
 module Datadog
   module OpenTracer
     # OpenTracing adapter for scope
+    # @public_api
     class Scope < ::OpenTracing::Scope
+      # @public_api
       attr_reader \
         :manager,
         :span
 
+      # @public_api
       def initialize(manager:, span:)
         @manager = manager
         @span = span

--- a/lib/ddtrace/opentracer/scope.rb
+++ b/lib/ddtrace/opentracer/scope.rb
@@ -4,12 +4,10 @@ module Datadog
     # OpenTracing adapter for scope
     # @public_api
     class Scope < ::OpenTracing::Scope
-      # @public_api
       attr_reader \
         :manager,
         :span
 
-      # @public_api
       def initialize(manager:, span:)
         @manager = manager
         @span = span

--- a/lib/ddtrace/opentracer/scope_manager.rb
+++ b/lib/ddtrace/opentracer/scope_manager.rb
@@ -1,6 +1,7 @@
 # typed: strict
 module Datadog
   module OpenTracer
+    # @public_api
     class ScopeManager < ::OpenTracing::ScopeManager
     end
   end

--- a/lib/ddtrace/opentracer/span.rb
+++ b/lib/ddtrace/opentracer/span.rb
@@ -4,11 +4,9 @@ module Datadog
     # OpenTracing adapter for Datadog::Span
     # @public_api
     class Span < ::OpenTracing::Span
-      # @public_api
       attr_reader \
         :datadog_span
 
-      # @public_api
       def initialize(datadog_span:, span_context:)
         @datadog_span = datadog_span
         @span_context = span_context
@@ -17,7 +15,6 @@ module Datadog
       # Set the name of the operation
       #
       # @param [String] name
-      # @public_api
       def operation_name=(name)
         datadog_span.name = name
       end
@@ -25,7 +22,6 @@ module Datadog
       # Span Context
       #
       # @return [SpanContext]
-      # @public_api
       def context
         @span_context
       end
@@ -34,7 +30,6 @@ module Datadog
       # @param key [String] the key of the tag
       # @param value [String, Numeric, Boolean] the value of the tag. If it's not
       # a String, Numeric, or Boolean it will be encoded with to_s
-      # @public_api
       def set_tag(key, value)
         # Special cases to convert opentracing tags to datadog tags
         case key
@@ -50,7 +45,6 @@ module Datadog
       # Set a baggage item on the span
       # @param key [String] the key of the baggage item
       # @param value [String] the value of the baggage item
-      # @public_api
       def set_baggage_item(key, value)
         tap do
           # SpanContext is immutable, so to make changes
@@ -65,7 +59,6 @@ module Datadog
       # Get a baggage item
       # @param key [String] the key of the baggage item
       # @return [String] value of the baggage item
-      # @public_api
       def get_baggage_item(key)
         context.baggage[key]
       end
@@ -78,7 +71,6 @@ module Datadog
       # @param event [String] event name for the log
       # @param timestamp [Time] time of the log
       # @param fields [Hash] Additional information to log
-      # @public_api
       def log(event: nil, timestamp: Time.now, **fields)
         super # Log deprecation warning
 
@@ -89,7 +81,6 @@ module Datadog
       # Add a log entry to this span
       # @param timestamp [Time] time of the log
       # @param fields [Hash] Additional information to log
-      # @public_api
       def log_kv(timestamp: Time.now, **fields)
         # If the fields specify an error
         datadog_span.set_error(fields[:'error.object']) if fields.key?(:'error.object')
@@ -97,7 +88,6 @@ module Datadog
 
       # Finish the {Span}
       # @param end_time [Time] custom end time, if not now
-      # @public_api
       def finish(end_time: Time.now)
         datadog_span.finish(end_time)
       end

--- a/lib/ddtrace/opentracer/span.rb
+++ b/lib/ddtrace/opentracer/span.rb
@@ -2,10 +2,13 @@
 module Datadog
   module OpenTracer
     # OpenTracing adapter for Datadog::Span
+    # @public_api
     class Span < ::OpenTracing::Span
+      # @public_api
       attr_reader \
         :datadog_span
 
+      # @public_api
       def initialize(datadog_span:, span_context:)
         @datadog_span = datadog_span
         @span_context = span_context
@@ -14,6 +17,7 @@ module Datadog
       # Set the name of the operation
       #
       # @param [String] name
+      # @public_api
       def operation_name=(name)
         datadog_span.name = name
       end
@@ -21,6 +25,7 @@ module Datadog
       # Span Context
       #
       # @return [SpanContext]
+      # @public_api
       def context
         @span_context
       end
@@ -29,6 +34,7 @@ module Datadog
       # @param key [String] the key of the tag
       # @param value [String, Numeric, Boolean] the value of the tag. If it's not
       # a String, Numeric, or Boolean it will be encoded with to_s
+      # @public_api
       def set_tag(key, value)
         # Special cases to convert opentracing tags to datadog tags
         case key
@@ -44,6 +50,7 @@ module Datadog
       # Set a baggage item on the span
       # @param key [String] the key of the baggage item
       # @param value [String] the value of the baggage item
+      # @public_api
       def set_baggage_item(key, value)
         tap do
           # SpanContext is immutable, so to make changes
@@ -58,6 +65,7 @@ module Datadog
       # Get a baggage item
       # @param key [String] the key of the baggage item
       # @return [String] value of the baggage item
+      # @public_api
       def get_baggage_item(key)
         context.baggage[key]
       end
@@ -70,6 +78,7 @@ module Datadog
       # @param event [String] event name for the log
       # @param timestamp [Time] time of the log
       # @param fields [Hash] Additional information to log
+      # @public_api
       def log(event: nil, timestamp: Time.now, **fields)
         super # Log deprecation warning
 
@@ -80,6 +89,7 @@ module Datadog
       # Add a log entry to this span
       # @param timestamp [Time] time of the log
       # @param fields [Hash] Additional information to log
+      # @public_api
       def log_kv(timestamp: Time.now, **fields)
         # If the fields specify an error
         datadog_span.set_error(fields[:'error.object']) if fields.key?(:'error.object')
@@ -87,6 +97,7 @@ module Datadog
 
       # Finish the {Span}
       # @param end_time [Time] custom end time, if not now
+      # @public_api
       def finish(end_time: Time.now)
         datadog_span.finish(end_time)
       end

--- a/lib/ddtrace/opentracer/span_context.rb
+++ b/lib/ddtrace/opentracer/span_context.rb
@@ -2,10 +2,13 @@
 module Datadog
   module OpenTracer
     # OpenTracing adapter for SpanContext
+    # @public_api
     class SpanContext < ::OpenTracing::SpanContext
+      # @public_api
       attr_reader \
         :datadog_context
 
+      # @public_api
       def initialize(datadog_context:, baggage: {})
         @datadog_context = datadog_context
         @baggage = baggage.freeze

--- a/lib/ddtrace/opentracer/span_context.rb
+++ b/lib/ddtrace/opentracer/span_context.rb
@@ -4,11 +4,9 @@ module Datadog
     # OpenTracing adapter for SpanContext
     # @public_api
     class SpanContext < ::OpenTracing::SpanContext
-      # @public_api
       attr_reader \
         :datadog_context
 
-      # @public_api
       def initialize(datadog_context:, baggage: {})
         @datadog_context = datadog_context
         @baggage = baggage.freeze

--- a/lib/ddtrace/opentracer/thread_local_scope.rb
+++ b/lib/ddtrace/opentracer/thread_local_scope.rb
@@ -4,11 +4,9 @@ module Datadog
     # OpenTracing adapter for thread local scopes
     # @public_api
     class ThreadLocalScope < Scope
-      # @public_api
       attr_reader \
         :finish_on_close
 
-      # @public_api
       def initialize(
         manager:,
         span:,
@@ -24,7 +22,6 @@ module Datadog
       #
       # NOTE: Calling close more than once on a single Scope instance leads to
       # undefined behavior.
-      # @public_api
       def close
         return unless equal?(manager.active)
 

--- a/lib/ddtrace/opentracer/thread_local_scope.rb
+++ b/lib/ddtrace/opentracer/thread_local_scope.rb
@@ -2,10 +2,13 @@
 module Datadog
   module OpenTracer
     # OpenTracing adapter for thread local scopes
+    # @public_api
     class ThreadLocalScope < Scope
+      # @public_api
       attr_reader \
         :finish_on_close
 
+      # @public_api
       def initialize(
         manager:,
         span:,
@@ -21,6 +24,7 @@ module Datadog
       #
       # NOTE: Calling close more than once on a single Scope instance leads to
       # undefined behavior.
+      # @public_api
       def close
         return unless equal?(manager.active)
 

--- a/lib/ddtrace/opentracer/thread_local_scope_manager.rb
+++ b/lib/ddtrace/opentracer/thread_local_scope_manager.rb
@@ -2,6 +2,7 @@
 module Datadog
   module OpenTracer
     # OpenTracing adapter for thread local scope management
+    # @public_api
     class ThreadLocalScopeManager < ScopeManager
       # Make a span instance active.
       #
@@ -11,6 +12,7 @@ module Datadog
       # @return [Scope] instance to control the end of the active period for the
       #  Span. It is a programming error to neglect to call Scope#close on the
       #  returned instance.
+      # @public_api
       def activate(span, finish_on_close: true)
         ThreadLocalScope.new(
           manager: self,
@@ -27,6 +29,7 @@ module Datadog
       # If there is a non-null Scope, its wrapped Span becomes an implicit parent
       # (as Reference#CHILD_OF) of any newly-created Span at Tracer#start_active_span
       # or Tracer#start_span time.
+      # @public_api
       def active
         Thread.current[object_id.to_s]
       end

--- a/lib/ddtrace/opentracer/thread_local_scope_manager.rb
+++ b/lib/ddtrace/opentracer/thread_local_scope_manager.rb
@@ -12,7 +12,6 @@ module Datadog
       # @return [Scope] instance to control the end of the active period for the
       #  Span. It is a programming error to neglect to call Scope#close on the
       #  returned instance.
-      # @public_api
       def activate(span, finish_on_close: true)
         ThreadLocalScope.new(
           manager: self,
@@ -29,7 +28,6 @@ module Datadog
       # If there is a non-null Scope, its wrapped Span becomes an implicit parent
       # (as Reference#CHILD_OF) of any newly-created Span at Tracer#start_active_span
       # or Tracer#start_span time.
-      # @public_api
       def active
         Thread.current[object_id.to_s]
       end

--- a/lib/ddtrace/opentracer/tracer.rb
+++ b/lib/ddtrace/opentracer/tracer.rb
@@ -28,7 +28,8 @@ module Datadog
       #
       # If `scope_manager.active` is not nil, no explicit references
       # are provided, and `ignore_active_scope` is false, then an inferred
-      # {OpenTracing::Reference#CHILD_OF} reference is created to the `scope_manager.active`'s
+      # {https://www.rubydoc.info/gems/opentracing/0.5.0/OpenTracing/Reference OpenTracing::Reference#CHILD_OF}
+      # reference is created to the `scope_manager.active`'s
       # {SpanContext} when {#start_active_span} is invoked.
       #
       # @param operation_name [String] The operation name for the Span

--- a/lib/ddtrace/opentracer/tracer.rb
+++ b/lib/ddtrace/opentracer/tracer.rb
@@ -10,19 +10,16 @@ module Datadog
 
       # (see Datadog::Tracer)
       # @return [Datadog::Tracer]
-      # @public_api
       attr_reader \
         :datadog_tracer
 
       # (see Datadog::Tracer#initialize)
-      # @public_api
       def initialize(**options)
         super()
         @datadog_tracer = Datadog::Tracer.new(**options)
       end
 
       # @return [ScopeManager] the current ScopeManager.
-      # @public_api
       def scope_manager
         @scope_manager ||= ThreadLocalScopeManager.new
       end
@@ -52,7 +49,6 @@ module Datadog
       #   yield the newly-started Scope. If `finish_on_close` is true then the
       #   Span will be finished automatically after the block is executed.
       # @return [Scope] The newly-started and activated Scope
-      # @public_api
       def start_active_span(operation_name,
                             child_of: nil,
                             references: nil,
@@ -125,7 +121,6 @@ module Datadog
       #   References#CHILD_OF reference to the ScopeManager#active.
       # @return [Span] the newly-started Span instance, which has not been
       #   automatically registered via the ScopeManager
-      # @public_api
       def start_span(operation_name,
                      child_of: nil,
                      references: nil,
@@ -163,7 +158,6 @@ module Datadog
       # @param span_context [SpanContext]
       # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK]
       # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
-      # @public_api
       def inject(span_context, format, carrier)
         case format
         when OpenTracing::FORMAT_TEXT_MAP
@@ -182,7 +176,6 @@ module Datadog
       # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK]
       # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
       # @return [SpanContext, nil] the extracted SpanContext or nil if none could be found
-      # @public_api
       def extract(format, carrier)
         case format
         when OpenTracing::FORMAT_TEXT_MAP

--- a/lib/ddtrace/opentracer/tracer.rb
+++ b/lib/ddtrace/opentracer/tracer.rb
@@ -4,52 +4,55 @@ require 'ddtrace/tracer'
 module Datadog
   module OpenTracer
     # OpenTracing adapter for Datadog::Tracer
+    # @public_api
     class Tracer < ::OpenTracing::Tracer
       extend Forwardable
 
+      # (see Datadog::Tracer)
+      # @return [Datadog::Tracer]
+      # @public_api
       attr_reader \
         :datadog_tracer
 
-      def_delegators \
-        :datadog_tracer,
-        :configure
-
+      # (see Datadog::Tracer#initialize)
+      # @public_api
       def initialize(**options)
         super()
         @datadog_tracer = Datadog::Tracer.new(**options)
       end
 
       # @return [ScopeManager] the current ScopeManager.
+      # @public_api
       def scope_manager
         @scope_manager ||= ThreadLocalScopeManager.new
       end
 
-      # Returns a newly started and activated Scope.
+      # Returns a newly started and activated {Scope}.
       #
-      # If the Tracer's ScopeManager#active is not nil, no explicit references
+      # If `scope_manager.active` is not nil, no explicit references
       # are provided, and `ignore_active_scope` is false, then an inferred
-      # References#CHILD_OF reference is created to the ScopeManager#active's
-      # SpanContext when start_active is invoked.
+      # {OpenTracing::Reference#CHILD_OF} reference is created to the `scope_manager.active`'s
+      # {SpanContext} when {#start_active_span} is invoked.
       #
       # @param operation_name [String] The operation name for the Span
       # @param child_of [SpanContext, Span] SpanContext that acts as a parent to
-      #        the newly-started Span. If a Span instance is provided, its
-      #        context is automatically substituted. See [Reference] for more
-      #        information.
-      #
+      #   the newly-started Span. If a Span instance is provided, its
+      #   context is automatically substituted. See [OpenTracing::Reference] for more
+      #   information.
       #   If specified, the `references` parameter must be omitted.
-      # @param references [Array<Reference>] An array of reference
+      # @param references [Array<OpenTracing::Reference>] An array of reference
       #   objects that identify one or more parent SpanContexts.
       # @param start_time [Time] When the Span started, if not now
       # @param tags [Hash] Tags to assign to the Span at start time
       # @param ignore_active_scope [Boolean] whether to create an implicit
-      #   References#CHILD_OF reference to the ScopeManager#active.
+      #   OpenTracing::Reference#CHILD_OF reference to the ScopeManager#active.
       # @param finish_on_close [Boolean] whether span should automatically be
       #   finished when Scope#close is called
       # @yield [Scope] If an optional block is passed to start_active it will
       #   yield the newly-started Scope. If `finish_on_close` is true then the
       #   Span will be finished automatically after the block is executed.
       # @return [Scope] The newly-started and activated Scope
+      # @public_api
       def start_active_span(operation_name,
                             child_of: nil,
                             references: nil,
@@ -105,15 +108,14 @@ module Datadog
         end
       end
 
-      # Like #start_active_span, but the returned Span has not been registered via the
-      # ScopeManager.
+      # Like {#start_active_span}, but the returned {Span} has not been registered via the
+      # {ScopeManager}.
       #
       # @param operation_name [String] The operation name for the Span
       # @param child_of [SpanContext, Span] SpanContext that acts as a parent to
-      #        the newly-started Span. If a Span instance is provided, its
-      #        context is automatically substituted. See [Reference] for more
-      #        information.
-      #
+      #   the newly-started Span. If a Span instance is provided, its
+      #   context is automatically substituted. See [Reference] for more
+      #   information.
       #   If specified, the `references` parameter must be omitted.
       # @param references [Array<Reference>] An array of reference
       #   objects that identify one or more parent SpanContexts.
@@ -123,6 +125,7 @@ module Datadog
       #   References#CHILD_OF reference to the ScopeManager#active.
       # @return [Span] the newly-started Span instance, which has not been
       #   automatically registered via the ScopeManager
+      # @public_api
       def start_span(operation_name,
                      child_of: nil,
                      references: nil,
@@ -155,11 +158,12 @@ module Datadog
         Span.new(datadog_span: datadog_span, span_context: span_context)
       end
 
-      # Inject a SpanContext into the given carrier
+      # Inject a {SpanContext} into the given carrier.
       #
       # @param span_context [SpanContext]
       # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK]
       # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
+      # @public_api
       def inject(span_context, format, carrier)
         case format
         when OpenTracing::FORMAT_TEXT_MAP
@@ -173,11 +177,12 @@ module Datadog
         end
       end
 
-      # Extract a SpanContext in the given format from the given carrier.
+      # Extract a {SpanContext} in the given format from the given carrier.
       #
       # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK]
       # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
       # @return [SpanContext, nil] the extracted SpanContext or nil if none could be found
+      # @public_api
       def extract(format, carrier)
         case format
         when OpenTracing::FORMAT_TEXT_MAP

--- a/lib/ddtrace/pin.rb
+++ b/lib/ddtrace/pin.rb
@@ -2,7 +2,7 @@
 require 'ddtrace/utils/only_once'
 
 module Datadog
-  # A \Pin (a.k.a Patch INfo) is a small class which is used to
+  # A {Datadog::Pin} (a.k.a Patch INfo) is a small class which is used to
   # set tracing metadata on a particular traced object.
   # This is useful if you wanted to, say, trace two different
   # database clusters.

--- a/lib/ddtrace/pin.rb
+++ b/lib/ddtrace/pin.rb
@@ -1,7 +1,6 @@
 # typed: true
 require 'ddtrace/utils/only_once'
 
-# \Datadog global namespace that includes all tracing functionality for Tracer and Span classes.
 module Datadog
   # A \Pin (a.k.a Patch INfo) is a small class which is used to
   # set tracing metadata on a particular traced object.

--- a/lib/ddtrace/pipeline.rb
+++ b/lib/ddtrace/pipeline.rb
@@ -1,6 +1,7 @@
 # typed: true
 module Datadog
   # Pipeline
+  # @public_api
   module Pipeline
     require_relative 'pipeline/span_filter'
     require_relative 'pipeline/span_processor'

--- a/lib/ddtrace/pipeline/span_filter.rb
+++ b/lib/ddtrace/pipeline/span_filter.rb
@@ -2,6 +2,7 @@
 module Datadog
   module Pipeline
     # SpanFilter implements a processor that filters entire span subtrees
+    # @public_api
     class SpanFilter
       def initialize(filter = nil, &block)
         callable = filter || block
@@ -14,6 +15,7 @@ module Datadog
       # NOTE: this SpanFilter implementation only handles traces in which child spans appear
       # after parent spans in the trace array. If in the future child spans can be before
       # parent spans, then the code below will need to be updated.
+      # @!visibility private
       def call(trace)
         deleted = Set.new
 

--- a/lib/ddtrace/pipeline/span_processor.rb
+++ b/lib/ddtrace/pipeline/span_processor.rb
@@ -2,6 +2,7 @@
 module Datadog
   module Pipeline
     # SpanProcessor
+    # @public_api
     class SpanProcessor
       def initialize(operation = nil, &block)
         callable = operation || block
@@ -11,6 +12,7 @@ module Datadog
         @operation = operation || block
       end
 
+      # @!visibility private
       def call(trace)
         trace.spans.each do |span|
           @operation.call(span) rescue next

--- a/lib/ddtrace/propagation/grpc_propagator.rb
+++ b/lib/ddtrace/propagation/grpc_propagator.rb
@@ -8,7 +8,6 @@ module Datadog
   # between two or more distributed services. Note this is very close
   # to the HTTPPropagator; the key difference is the way gRPC handles
   # header information (called "metadata") as it operates over HTTP2
-  # @public_api
   module GRPCPropagator
     include Ext::DistributedTracing
 

--- a/lib/ddtrace/propagation/grpc_propagator.rb
+++ b/lib/ddtrace/propagation/grpc_propagator.rb
@@ -8,6 +8,7 @@ module Datadog
   # between two or more distributed services. Note this is very close
   # to the HTTPPropagator; the key difference is the way gRPC handles
   # header information (called "metadata") as it operates over HTTP2
+  # @public_api
   module GRPCPropagator
     include Ext::DistributedTracing
 

--- a/lib/ddtrace/propagation/http_propagator.rb
+++ b/lib/ddtrace/propagation/http_propagator.rb
@@ -9,6 +9,7 @@ require 'ddtrace/trace_digest'
 
 module Datadog
   # HTTPPropagator helps extracting and injecting HTTP headers.
+  # @public_api
   module HTTPPropagator
     include Ext::DistributedTracing
 

--- a/lib/ddtrace/sampler.rb
+++ b/lib/ddtrace/sampler.rb
@@ -6,22 +6,44 @@ require 'ddtrace/ext/sampling'
 require 'ddtrace/diagnostics/health'
 
 module Datadog
-  # \Sampler performs client-side trace sampling.
+  # Interface for client-side trace sampling.
+  # @abstract
   class Sampler
+    # Returns `true` if the provided trace should be kept.
+    # Otherwise, `false`.
+    #
+    # This method *must not* modify the `trace`.
+    #
+    # @param [Datadog::Trace] trace
+    # @return [Boolean] should this trace be kept?
     def sample?(_trace)
       raise NotImplementedError, 'Samplers must implement the #sample? method'
     end
 
+    # Returns `true` if the provided trace should be kept.
+    # Otherwise, `false`.
+    #
+    # This method *may* modify the `trace`, in case changes are necessary based on the
+    # sampling decision.
+    #
+    # @param [Datadog::Trace] trace
+    # @return [Boolean] should this trace be kept?
     def sample!(_trace)
       raise NotImplementedError, 'Samplers must implement the #sample! method'
     end
 
+    # The sampling rate, if this sampler has such concept.
+    # Otherwise, `nil`.
+    #
+    # @param [Datadog::Trace] trace
+    # @return [Float,nil] sampling ratio between 0.0 and 1.0 (inclusive), or `nil` if not applicable
     def sample_rate(_trace)
       raise NotImplementedError, 'Samplers must implement the #sample_rate method'
     end
   end
 
   # \AllSampler samples all the traces.
+  # @public_api
   class AllSampler < Sampler
     def sample?(_trace)
       true
@@ -37,6 +59,7 @@ module Datadog
   end
 
   # \RateSampler is based on a sample rate.
+  # @public_api
   class RateSampler < Sampler
     KNUTH_FACTOR = 1111111111111111111
 
@@ -77,6 +100,7 @@ module Datadog
   end
 
   # Samples at different rates by key.
+  # @public_api
   class RateByKeySampler < Sampler
     attr_reader \
       :default_key
@@ -161,6 +185,7 @@ module Datadog
   end
 
   # \RateByServiceSampler samples different services at different rates
+  # @public_api
   class RateByServiceSampler < RateByKeySampler
     DEFAULT_KEY = 'service:,env:'.freeze
 
@@ -191,6 +216,7 @@ module Datadog
   end
 
   # \PrioritySampler
+  # @public_api
   class PrioritySampler
     extend Forwardable
 

--- a/lib/ddtrace/sampler.rb
+++ b/lib/ddtrace/sampler.rb
@@ -8,6 +8,7 @@ require 'ddtrace/diagnostics/health'
 module Datadog
   # Interface for client-side trace sampling.
   # @abstract
+  # @public_api
   class Sampler
     # Returns `true` if the provided trace should be kept.
     # Otherwise, `false`.
@@ -16,7 +17,7 @@ module Datadog
     #
     # @param [Datadog::Trace] trace
     # @return [Boolean] should this trace be kept?
-    def sample?(_trace)
+    def sample?(trace)
       raise NotImplementedError, 'Samplers must implement the #sample? method'
     end
 
@@ -28,7 +29,7 @@ module Datadog
     #
     # @param [Datadog::Trace] trace
     # @return [Boolean] should this trace be kept?
-    def sample!(_trace)
+    def sample!(trace)
       raise NotImplementedError, 'Samplers must implement the #sample! method'
     end
 
@@ -37,7 +38,7 @@ module Datadog
     #
     # @param [Datadog::Trace] trace
     # @return [Float,nil] sampling ratio between 0.0 and 1.0 (inclusive), or `nil` if not applicable
-    def sample_rate(_trace)
+    def sample_rate(trace)
       raise NotImplementedError, 'Samplers must implement the #sample_rate method'
     end
   end

--- a/lib/ddtrace/sampler.rb
+++ b/lib/ddtrace/sampler.rb
@@ -42,7 +42,7 @@ module Datadog
     end
   end
 
-  # \AllSampler samples all the traces.
+  # {Datadog::AllSampler} samples all the traces.
   # @public_api
   class AllSampler < Sampler
     def sample?(_trace)
@@ -58,16 +58,16 @@ module Datadog
     end
   end
 
-  # \RateSampler is based on a sample rate.
+  # {Datadog::RateSampler} is based on a sample rate.
   # @public_api
   class RateSampler < Sampler
     KNUTH_FACTOR = 1111111111111111111
 
-    # Initialize a \RateSampler.
+    # Initialize a {Datadog::RateSampler}.
     # This sampler keeps a random subset of the traces. Its main purpose is to
     # reduce the instrumentation footprint.
     #
-    # * +sample_rate+: the sample rate as a \Float between 0.0 and 1.0. 0.0
+    # * +sample_rate+: the sample rate as a {Float} between 0.0 and 1.0. 0.0
     #   means that no trace will be sampled; 1.0 means that all traces will be
     #   sampled.
     def initialize(sample_rate = 1.0)
@@ -184,7 +184,7 @@ module Datadog
     end
   end
 
-  # \RateByServiceSampler samples different services at different rates
+  # {Datadog::RateByServiceSampler} samples different services at different rates
   # @public_api
   class RateByServiceSampler < RateByKeySampler
     DEFAULT_KEY = 'service:,env:'.freeze
@@ -215,7 +215,7 @@ module Datadog
     end
   end
 
-  # \PrioritySampler
+  # {Datadog::PrioritySampler}
   # @public_api
   class PrioritySampler
     extend Forwardable

--- a/lib/ddtrace/sampling/matcher.rb
+++ b/lib/ddtrace/sampling/matcher.rb
@@ -2,10 +2,11 @@
 module Datadog
   module Sampling
     # Checks if a trace conforms to a matching criteria.
+    # @abstract
+    # @public_api
     class Matcher
       # Returns `true` if the trace should conforms to this rule, `false` otherwise
       #
-      # @abstract
       # @param [TraceOperation] trace
       # @return [Boolean]
       def match?(trace)
@@ -15,6 +16,7 @@ module Datadog
 
     # A \Matcher that supports matching a trace by
     # trace name and/or service name.
+    # @public_api
     class SimpleMatcher < Matcher
       # Returns `true` for case equality (===) with any object
       MATCH_ALL = Class.new do
@@ -41,6 +43,7 @@ module Datadog
 
     # A \Matcher that allows for arbitrary trace matching
     # based on the return value of a provided block.
+    # @public_api
     class ProcMatcher < Matcher
       attr_reader :block
 

--- a/lib/ddtrace/sampling/matcher.rb
+++ b/lib/ddtrace/sampling/matcher.rb
@@ -14,7 +14,7 @@ module Datadog
       end
     end
 
-    # A \Matcher that supports matching a trace by
+    # A {Datadog::Sampling::Matcher} that supports matching a trace by
     # trace name and/or service name.
     # @public_api
     class SimpleMatcher < Matcher
@@ -41,7 +41,7 @@ module Datadog
       end
     end
 
-    # A \Matcher that allows for arbitrary trace matching
+    # A {Datadog::Sampling::Matcher} that allows for arbitrary trace matching
     # based on the return value of a provided block.
     # @public_api
     class ProcMatcher < Matcher

--- a/lib/ddtrace/sampling/rate_limiter.rb
+++ b/lib/ddtrace/sampling/rate_limiter.rb
@@ -162,7 +162,7 @@ module Datadog
       end
     end
 
-    # \RateLimiter that accepts all resources,
+    # {Datadog::Sampling::RateLimiter} that accepts all resources,
     # with no limits.
     # @public_api
     class UnlimitedLimiter < RateLimiter

--- a/lib/ddtrace/sampling/rate_limiter.rb
+++ b/lib/ddtrace/sampling/rate_limiter.rb
@@ -4,6 +4,7 @@ require 'ddtrace/utils/time'
 module Datadog
   module Sampling
     # Checks for rate limiting on a resource.
+    # @public_api
     class RateLimiter
       # Checks if resource of specified size can be
       # conforms with the current limit.
@@ -25,6 +26,7 @@ module Datadog
     # for rate limiting.
     #
     # @see https://en.wikipedia.org/wiki/Token_bucket Token bucket
+    # @public_api
     class TokenBucket < RateLimiter
       attr_reader :rate, :max_tokens
 
@@ -162,6 +164,7 @@ module Datadog
 
     # \RateLimiter that accepts all resources,
     # with no limits.
+    # @public_api
     class UnlimitedLimiter < RateLimiter
       # @return [Boolean] always +true+
       def allow?(_)

--- a/lib/ddtrace/sampling/rule.rb
+++ b/lib/ddtrace/sampling/rule.rb
@@ -9,6 +9,7 @@ module Datadog
     # Sampling rule that dictates if a trace matches
     # a specific criteria and what sampling strategy to
     # apply in case of a positive match.
+    # @public_api
     class Rule
       extend Forwardable
 
@@ -39,6 +40,7 @@ module Datadog
     # A \Rule that matches a trace based on
     # trace name and/or service name and
     # applies a fixed sampling to matching spans.
+    # @public_api
     class SimpleRule < Rule
       # @param name [String,Regexp,Proc] Matcher for case equality (===) with the trace name, defaults to always match
       # @param service [String,Regexp,Proc] Matcher for case equality (===) with the service name, defaults to always match

--- a/lib/ddtrace/sampling/rule.rb
+++ b/lib/ddtrace/sampling/rule.rb
@@ -37,7 +37,7 @@ module Datadog
       def_delegators :@sampler, :sample?, :sample_rate
     end
 
-    # A \Rule that matches a trace based on
+    # A {Datadog::Sampling::Rule} that matches a trace based on
     # trace name and/or service name and
     # applies a fixed sampling to matching spans.
     # @public_api
@@ -46,13 +46,13 @@ module Datadog
       # @param service [String,Regexp,Proc] Matcher for case equality (===) with the service name, defaults to always match
       # @param sample_rate [Float] Sampling rate between +[0,1]+
       def initialize(name: SimpleMatcher::MATCH_ALL, service: SimpleMatcher::MATCH_ALL, sample_rate: 1.0)
-        # We want to allow 0.0 to drop all traces, but \RateSampler
+        # We want to allow 0.0 to drop all traces, but {Datadog::RateSampler}
         # considers 0.0 an invalid rate and falls back to 100% sampling.
         #
         # We address that here by not setting the rate in the constructor,
         # but using the setter method.
         #
-        # We don't want to make this change directly to \RateSampler
+        # We don't want to make this change directly to {Datadog::RateSampler}
         # because it breaks its current contract to existing users.
         sampler = Datadog::RateSampler.new
         sampler.sample_rate = sample_rate

--- a/lib/ddtrace/sampling/rule_sampler.rb
+++ b/lib/ddtrace/sampling/rule_sampler.rb
@@ -15,6 +15,7 @@ module Datadog
     #
     # If a trace does not conform to any rules, a default
     # sampling strategy is applied.
+    # @public_api
     class RuleSampler
       extend Forwardable
 
@@ -76,6 +77,7 @@ module Datadog
         trace.sampled = sampled
       end
 
+      # @!visibility private
       def update(*args)
         return false unless @default_sampler.respond_to?(:update)
 

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -15,7 +15,7 @@ module Datadog
   class Span
     include Tagging
 
-    # The max value for a \Span identifier.
+    # The max value for a {Datadog::Span} identifier.
     # Span and trace identifiers should be strictly positive and strictly inferior to this limit.
     #
     # Limited to +2<<62-1+ positive integers, as Ruby is able to represent such numbers "inline",

--- a/lib/ddtrace/span.rb
+++ b/lib/ddtrace/span.rb
@@ -11,6 +11,7 @@ module Datadog
   # spent on a distributed call on a separate machine, or the time spent in a small component
   # within a larger operation. Spans can be nested within each other, and in those instances
   # will have a parent-child relationship.
+  # @public_api
   class Span
     include Tagging
 

--- a/lib/ddtrace/span_operation.rb
+++ b/lib/ddtrace/span_operation.rb
@@ -15,6 +15,7 @@ module Datadog
   # build a Span. When completed, it yields the Span.
   #
   # rubocop:disable Metrics/ClassLength
+  # @public_api
   class SpanOperation
     include Tagging
 

--- a/lib/ddtrace/sync_writer.rb
+++ b/lib/ddtrace/sync_writer.rb
@@ -42,7 +42,7 @@ module Datadog
       Datadog.logger.debug(e)
     end
 
-    # Added for interface completeness.
+    # Does nothing.
     # The {SyncWriter} does not need to be stopped as it holds no state.
     # @public_api
     def stop

--- a/lib/ddtrace/sync_writer.rb
+++ b/lib/ddtrace/sync_writer.rb
@@ -11,6 +11,7 @@ module Datadog
   # Note: If you're wondering if this class is used at all, since there are no other references to it on the codebase,
   # the separate `datadog-lambda` uses it as of February 2021:
   # <https://github.com/DataDog/datadog-lambda-rb/blob/c15f0f0916c90123416dc44e7d6800ef4a7cfdbf/lib/datadog/lambda.rb#L38>
+  # @public_api
   class SyncWriter
     attr_reader \
       :events,
@@ -21,7 +22,6 @@ module Datadog
     # @param [Hash<Symbol,Object>] transport_options options for the default transport instance.
     # @param [Datadog::Configuration::AgentSettingsResolver::AgentSettings] agent_settings agent options for
     #   the default transport instance.
-    # @public_api
     def initialize(transport: nil, transport_options: {}, agent_settings: nil)
       @transport = transport || begin
         transport_options[:agent_settings] = agent_settings if agent_settings
@@ -34,8 +34,6 @@ module Datadog
     # Sends traces to the configured transport.
     #
     # Traces are flushed immediately.
-    #
-    # @public_api
     def write(trace)
       flush_trace(trace)
     rescue => e
@@ -44,7 +42,6 @@ module Datadog
 
     # Does nothing.
     # The {SyncWriter} does not need to be stopped as it holds no state.
-    # @public_api
     def stop
       # No cleanup to do for the SyncWriter
       true

--- a/lib/ddtrace/sync_writer.rb
+++ b/lib/ddtrace/sync_writer.rb
@@ -16,23 +16,35 @@ module Datadog
       :events,
       :transport
 
-    def initialize(options = {})
-      @transport = options.fetch(:transport) do
-        transport_options = options.fetch(:transport_options, {})
-        transport_options[:agent_settings] = options[:agent_settings] if options.key?(:agent_settings)
+    # @param [Datadog::Transport::Traces::Transport] transport a custom transport instance.
+    #   If provided, overrides `transport_options` and `agent_settings`.
+    # @param [Hash<Symbol,Object>] transport_options options for the default transport instance.
+    # @param [Datadog::Configuration::AgentSettingsResolver::AgentSettings] agent_settings agent options for
+    #   the default transport instance.
+    # @public_api
+    def initialize(transport: nil, transport_options: {}, agent_settings: nil)
+      @transport = transport || begin
+        transport_options[:agent_settings] = agent_settings if agent_settings
         Transport::HTTP.default(**transport_options)
       end
 
       @events = Writer::Events.new
     end
 
+    # Sends traces to the configured transport.
+    #
+    # Traces are flushed immediately.
+    #
+    # @public_api
     def write(trace)
       flush_trace(trace)
     rescue => e
       Datadog.logger.debug(e)
     end
 
-    # Added for interface completeness
+    # Added for interface completeness.
+    # The {SyncWriter} does not need to be stopped as it holds no state.
+    # @public_api
     def stop
       # No cleanup to do for the SyncWriter
       true

--- a/lib/ddtrace/tagging/metadata.rb
+++ b/lib/ddtrace/tagging/metadata.rb
@@ -84,7 +84,7 @@ module Datadog
         Datadog.logger.debug("Unable to set the metric #{key}, ignoring it. Caused by: #{e}")
       end
 
-      # This method removes a metric for the given key. It acts like {#remove_tag}.
+      # This method removes a metric for the given key. It acts like {#clear_tag}.
       def clear_metric(key)
         metrics.delete(key)
       end

--- a/lib/ddtrace/tagging/metadata.rb
+++ b/lib/ddtrace/tagging/metadata.rb
@@ -6,6 +6,7 @@ require 'ddtrace/ext/net'
 module Datadog
   module Tagging
     # Adds metadata & metric tag behavior
+    # @public_api
     module Metadata
       # This limit is for numeric tags because uint64 could end up rounded.
       NUMERIC_TAG_SIZE_RANGE = (-1 << 53..1 << 53).freeze

--- a/lib/ddtrace/trace_digest.rb
+++ b/lib/ddtrace/trace_digest.rb
@@ -1,6 +1,7 @@
 module Datadog
   # Trace digest that represents the important parts of an active trace.
   # Used to propagate context and continue traces across execution boundaries.
+  # @public_api
   class TraceDigest
     attr_reader \
       :span_id,

--- a/lib/ddtrace/trace_operation.rb
+++ b/lib/ddtrace/trace_operation.rb
@@ -14,7 +14,7 @@ module Datadog
   #
   # Supports synchronous code flow *only*. Usage across
   # multiple threads will result in incorrect relationships.
-  # For async support, a \TraceOperation should be employed
+  # For async support, a {Datadog::TraceOperation} should be employed
   # per execution context (e.g. Thread, etc.)
   #
   # rubocop:disable Metrics/ClassLength

--- a/lib/ddtrace/trace_operation.rb
+++ b/lib/ddtrace/trace_operation.rb
@@ -18,6 +18,7 @@ module Datadog
   # per execution context (e.g. Thread, etc.)
   #
   # rubocop:disable Metrics/ClassLength
+  # @public_api
   class TraceOperation
     DEFAULT_MAX_LENGTH = 100_000
 

--- a/lib/ddtrace/trace_segment.rb
+++ b/lib/ddtrace/trace_segment.rb
@@ -5,6 +5,7 @@ require 'ddtrace/ext/sampling'
 
 module Datadog
   # Serializable construct representing a trace
+  # @public_api
   class TraceSegment
     extend Forwardable
 
@@ -88,10 +89,20 @@ module Datadog
       end
     end
 
+    # If an active trace is present, forces it to be retained by the Datadog backend.
+    #
+    # Any sampling logic will not be able to change this decision.
+    #
+    # @return [void]
     def keep!
       self.sampling_priority = Datadog::Ext::Priority::USER_KEEP
     end
 
+    # If an active trace is present, forces it to be dropped and not stored by the Datadog backend.
+    #
+    # Any sampling logic will not be able to change this decision.
+    #
+    # @return [void]
     def reject!
       self.sampling_priority = Datadog::Ext::Priority::USER_REJECT
     end

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -160,8 +160,7 @@ module Datadog
 
     # Set the given key / value tag pair at the tracer level. These tags will be
     # appended to each span created by the tracer. Keys and values must be strings.
-    # A valid example is:
-    #
+    # @example
     #   tracer.set_tags('env' => 'prod', 'component' => 'core')
     # @public_api
     def set_tags(tags)
@@ -252,14 +251,12 @@ module Datadog
     # It's useful to ensure that the Trace Buffer is properly flushed before
     # shutting down the application.
     #
-    # For instance:
-    #
+    # @example
     #   tracer.trace('operation_name', service='rake_tasks') do |span_op|
     #     span_op.set_tag('task.name', 'script')
     #   end
     #
     #   tracer.shutdown!
-    #
     # @public_api
     def shutdown!
       return unless @enabled

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -227,6 +227,7 @@ module Datadog
       call_context(key).activate!(trace, &block)
     end
 
+    # @!visibility private
     # TODO: make this private
     def trace_completed
       @trace_completed ||= TraceCompleted.new

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -104,7 +104,7 @@ module Datadog
     #   Used for linking traces that are executed asynchronously.
     # @param [Boolean] autostart whether to autostart the span, if no block is provided.
     # @param [Proc] on_error a block that overrides error handling behavior for this operation.
-    # @param [String] resource the resource this span refers, or {name} if it's missing
+    # @param [String] resource the resource this span refers, or `name` if it's missing
     # @param [String] service the service name for this span.
     # @param [Time] start_time time which the span should have started.
     # @param [Hash<String,String>] tags extra tags which should be added to the span.

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -114,7 +114,6 @@ module Datadog
     # @yield Optional block where new newly created {Datadog::SpanOperation} captures the execution.
     # @yieldparam [Datadog::SpanOperation] span_op the newly created and active [Datadog::SpanOperation]
     # @yieldparam [Datadog::TraceOperation] trace_op the active [Datadog::TraceOperation]
-    # @public_api
     # rubocop:disable Lint/UnderscorePrefixedVariableName
     def trace(
       name,
@@ -162,7 +161,6 @@ module Datadog
     # appended to each span created by the tracer. Keys and values must be strings.
     # @example
     #   tracer.set_tags('env' => 'prod', 'component' => 'core')
-    # @public_api
     def set_tags(tags)
       string_tags = tags.collect { |k, v| [k.to_s, v] }.to_h
       @tags = @tags.merge(string_tags)
@@ -175,7 +173,6 @@ module Datadog
     # @param [Thread] key Thread to retrieve trace from. Defaults to current thread. For internal use only.
     # @return [Datadog::TraceSegment] the active trace
     # @return [nil] if no trace is active
-    # @public_api
     def active_trace(key = nil)
       call_context(key).active_trace
     end
@@ -187,7 +184,6 @@ module Datadog
     # @param [Thread] key Thread to retrieve trace from. Defaults to current thread. For internal use only.
     # @return [Datadog::SpanOperation] the active span
     # @return [nil] if no trace is active, and thus no span is active
-    # @public_api
     def active_span(key = nil)
       trace = active_trace(key)
       trace.active_span if trace
@@ -199,7 +195,6 @@ module Datadog
     #
     # @param [Thread] key Thread to retrieve trace from. Defaults to current thread. For internal use only.
     # @return [Datadog::Correlation::Identifier] correlation object
-    # @public_api
     def active_correlation(key = nil)
       trace = active_trace(key)
       Datadog::Correlation.identifier_from_digest(
@@ -218,7 +213,6 @@ module Datadog
     # @return [Datadog::TraceOperation] If no block, the active {Datadog::TraceOperation}.
     # @yield Optional block where this {#continue_trace!} `digest` scope is active.
     #   If no block, the `digest` remains active after {#continue_trace!} returns.
-    # @public_api
     def continue_trace!(digest, key = nil, &block)
       return unless digest && digest.is_a?(TraceDigest)
 
@@ -257,7 +251,6 @@ module Datadog
     #   end
     #
     #   tracer.shutdown!
-    # @public_api
     def shutdown!
       return unless @enabled
 

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -88,7 +88,7 @@ module Datadog
     # Remember that in this case, calling {Datadog::SpanOperation#finish} is mandatory.
     #
     # When a Trace is started, {#trace} will store the created span; subsequent spans will
-    # become it's children and will inherit some properties:
+    # become its children and will inherit some properties:
     # ```
     # parent = tracer.trace('parent')   # has no parent span
     # child  = tracer.trace('child')    # is a child of 'parent'

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -173,6 +173,7 @@ module Datadog
     #
     # The active trace is thread-local.
     #
+    # @param [Thread] key Thread to retrieve trace from. Defaults to current thread. For internal use only.
     # @return [Datadog::TraceSegment] the active trace
     # @return [nil] if no trace is active
     # @public_api
@@ -184,6 +185,7 @@ module Datadog
     #
     # The active span belongs to an {.active_trace}.
     #
+    # @param [Thread] key Thread to retrieve trace from. Defaults to current thread. For internal use only.
     # @return [Datadog::SpanOperation] the active span
     # @return [nil] if no trace is active, and thus no span is active
     # @public_api
@@ -196,6 +198,7 @@ module Datadog
     #
     # The most common use cases are tagging log messages and metrics.
     #
+    # @param [Thread] key Thread to retrieve trace from. Defaults to current thread. For internal use only.
     # @return [Datadog::Correlation::Identifier] correlation object
     # @public_api
     def active_correlation(key = nil)
@@ -211,7 +214,7 @@ module Datadog
     # Used to continue distributed or async traces.
     #
     # @param [Datadog::TraceDigest] digest continue from the {Datadog::TraceDigest}.
-    # @param [Thread] key thread-local context holder
+    # @param [Thread] key Thread to retrieve trace from. Defaults to current thread. For internal use only.
     # @return [Object] If a block is provided, the result of the block execution.
     # @return [Datadog::TraceOperation] If no block, the active {Datadog::TraceOperation}.
     # @yield Optional block where this {#continue_trace!} `digest` scope is active.
@@ -271,6 +274,8 @@ module Datadog
     #
     # This method makes use of a {ContextProvider} that is automatically set during the tracer
     # initialization, or while using a library instrumentation.
+    #
+    # @param [Thread] key Thread to retrieve tracer from. Defaults to current thread.
     def call_context(key = nil)
       @provider.context(key)
     end

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -100,7 +100,8 @@ module Datadog
     #
     # @param [String] name {Datadog::Span} operation name.
     #   See {https://docs.datadoghq.com/tracing/guide/configuring-primary-operation/ Primary Operations in Services}.
-    # @param [Datadog::TraceDigest] continue_from continue a trace from a {Datadog::TraceDigest}. Used for async.
+    # @param [Datadog::TraceDigest] continue_from continue a trace from a {Datadog::TraceDigest}.
+    #   Used for linking traces that are executed asynchronously.
     # @param [Boolean] autostart whether to autostart the span, if no block is provided.
     # @param [Proc] on_error a block that overrides error handling behavior for this operation.
     # @param [String] resource the resource this span refers, or {name} if it's missing

--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -112,8 +112,6 @@ module Datadog
     # @return [Object] If a block is provided, returns the result of the block execution.
     # @return [Datadog::SpanOperation] If no block is provided, returns the active, unfinished {Datadog::SpanOperation}.
     # @yield Optional block where new newly created {Datadog::SpanOperation} captures the execution.
-    #   The span_op is {Datadog::SpanOperation#finish}ed when the block ends.
-    #   If no block, the active, unfinished {Datadog::SpanOperation} is returned instead.
     # @yieldparam [Datadog::SpanOperation] span_op the newly created and active [Datadog::SpanOperation]
     # @yieldparam [Datadog::TraceOperation] trace_op the active [Datadog::TraceOperation]
     # @public_api

--- a/lib/ddtrace/transport/parcel.rb
+++ b/lib/ddtrace/transport/parcel.rb
@@ -2,6 +2,7 @@
 module Datadog
   module Transport
     # Data transfer object for generic data
+    # @abstract
     module Parcel
       include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
 

--- a/lib/ddtrace/transport/serializable_trace.rb
+++ b/lib/ddtrace/transport/serializable_trace.rb
@@ -3,7 +3,7 @@ require 'msgpack'
 
 module Datadog
   module Transport
-    # Adds serialization functions to a \TraceSegment
+    # Adds serialization functions to a {Datadog::TraceSegment}
     class SerializableTrace
       attr_reader \
         :trace
@@ -32,7 +32,7 @@ module Datadog
       end
     end
 
-    # Adds serialization functions to a \Span
+    # Adds serialization functions to a {Datadog::Span}
     class SerializableSpan
       attr_reader \
         :span

--- a/lib/ddtrace/utils.rb
+++ b/lib/ddtrace/utils.rb
@@ -14,6 +14,7 @@ module Datadog
 
     # Return a randomly generated integer, valid as a Span ID or Trace ID.
     # This method is thread-safe and fork-safe.
+    # @public_api
     def self.next_id
       after_fork! { reset! }
       id_rng.rand(Datadog::Span::RUBY_MAX_ID) # TODO: This should never return zero

--- a/lib/ddtrace/utils.rb
+++ b/lib/ddtrace/utils.rb
@@ -4,6 +4,7 @@ require 'ddtrace/utils/forking'
 
 module Datadog
   # Utils contains low-level utilities, typically to provide pseudo-random trace IDs.
+  # @public_api
   module Utils
     extend Utils::Forking
 
@@ -14,7 +15,6 @@ module Datadog
 
     # Return a randomly generated integer, valid as a Span ID or Trace ID.
     # This method is thread-safe and fork-safe.
-    # @public_api
     def self.next_id
       after_fork! { reset! }
       id_rng.rand(Datadog::Span::RUBY_MAX_ID) # TODO: This should never return zero
@@ -38,6 +38,7 @@ module Datadog
     #
     # If `omission.size` is larger than `size`, the output
     # will still be `omission.size` in length.
+    # @!visibility private
     def self.truncate(value, size, omission = '...'.freeze)
       string = value.to_s
 
@@ -56,6 +57,7 @@ module Datadog
 
     # Ensure `str` is a valid UTF-8, ready to be
     # sent through the tracer transport.
+    # @!visibility private
     def self.utf8_encode(str, options = {})
       str = str.to_s
 
@@ -78,6 +80,7 @@ module Datadog
       options.fetch(:placeholder, EMPTY_STRING)
     end
 
+    # @!visibility private
     def self.without_warnings
       # This is typically used when monkey patching functions such as
       # intialize, which Ruby advices you not to. Use cautiously.

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -11,6 +11,7 @@ require 'ddtrace/utils/only_once'
 
 module Datadog
   # Processor that sends traces and metadata to the agent
+  # DEV: Our goal is for {Datadog::Workers::TraceWriter} to replace this class in the future
   class Writer
     attr_reader \
       :transport,

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -51,9 +51,9 @@ module Datadog
       @events = Events.new
     end
 
-    # Starts the internal {Writer} thread.
+    # Explicitly starts the {Writer}'s internal worker.
     #
-    # The {Writer} is also automatically started when necessary during calls to {.send_spans}.
+    # The {Writer} is also automatically started when necessary during calls to {.write}.
     def start
       @mutex_after_fork.synchronize do
         return false if @stopped

--- a/lib/ddtrace/writer.rb
+++ b/lib/ddtrace/writer.rb
@@ -17,6 +17,7 @@ module Datadog
       :worker,
       :events
 
+    # @public_api
     def initialize(options = {})
       # writer and transport parameters
       @buff_size = options.fetch(:buffer_size, Workers::AsyncTransport::DEFAULT_BUFFER_MAX_SIZE)
@@ -49,6 +50,11 @@ module Datadog
       @events = Events.new
     end
 
+    # Starts the internal {Writer} thread.
+    #
+    # The {Writer} is also automatically started when necessary during calls to {.send_spans}.
+    #
+    # @public_api
     def start
       @mutex_after_fork.synchronize do
         return false if @stopped
@@ -82,6 +88,7 @@ module Datadog
     # no internal work will be performed.
     #
     # It is not possible to restart a stopped writer instance.
+    # @public_api
     def stop
       @mutex_after_fork.synchronize { stop_worker }
     end
@@ -118,6 +125,7 @@ module Datadog
     end
 
     # enqueue the trace for submission to the API
+    # @public_api
     def write(trace)
       # In multiprocess environments, the main process initializes the +Writer+ instance and if
       # the process forks (i.e. a web server like Unicorn or Puma with multiple workers) the new
@@ -144,6 +152,7 @@ module Datadog
     end
 
     # stats returns a dictionary of stats about the writer.
+    # @public_api
     def stats
       {
         traces_flushed: @traces_flushed,

--- a/spec/ddtrace/configuration/components_spec.rb
+++ b/spec/ddtrace/configuration/components_spec.rb
@@ -676,7 +676,7 @@ RSpec.describe Datadog::Configuration::Components do
               end
 
               context 'are set' do
-                let(:writer_options) { { foo: :bar } }
+                let(:writer_options) { { transport_options: :bar } }
 
                 it_behaves_like 'new tracer' do
                   let(:options) do

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -1248,7 +1248,7 @@ RSpec.describe Datadog::Configuration::Settings do
       describe '#min_spans_threshold' do
         subject(:min_spans_threshold) { settings.tracer.partial_flush.min_spans_threshold }
 
-        it { is_expected.to be nil }
+        it { is_expected.to eq(500) }
       end
 
       describe '#min_spans_threshold=' do
@@ -1257,7 +1257,7 @@ RSpec.describe Datadog::Configuration::Settings do
         it 'updates the #min_spans_before_partial_flush setting' do
           expect { settings.tracer.partial_flush.min_spans_threshold = value }
             .to change { settings.tracer.partial_flush.min_spans_threshold }
-            .from(nil)
+            .from(500)
             .to(value)
         end
       end

--- a/spec/ddtrace/contrib/registerable_spec.rb
+++ b/spec/ddtrace/contrib/registerable_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Datadog::Contrib::Registerable do
 
     describe 'class behavior' do
       describe '#register_as' do
-        subject(:register_as) { registerable_class.register_as(name, options) }
+        subject(:register_as) { registerable_class.register_as(name, **options) }
 
         let(:name) { :foo }
         let(:options) { {} }
@@ -62,7 +62,7 @@ RSpec.describe Datadog::Contrib::Registerable do
     end
 
     describe 'instance behavior' do
-      subject(:registerable_object) { registerable_class.new(name, options) }
+      subject(:registerable_object) { registerable_class.new(name, **options) }
 
       let(:name) { :foo }
       let(:options) { {} }

--- a/spec/ddtrace/sync_writer_spec.rb
+++ b/spec/ddtrace/sync_writer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Datadog::SyncWriter do
   let(:buffer) { [] }
 
   describe '::new' do
-    subject(:sync_writer) { described_class.new(options) }
+    subject(:sync_writer) { described_class.new(**options) }
 
     context 'given :agent_settings' do
       let(:options) { { agent_settings: agent_settings } }

--- a/yard/extensions.rb
+++ b/yard/extensions.rb
@@ -32,7 +32,17 @@ end
 # Hides all objects that are not part of the Public API from YARD docs.
 YARD::Parser::SourceParser.after_parse_list do
   YARD::Registry.each do |obj|
-    obj.visibility = :private unless obj.has_tag?('public_api')
+    unless obj.has_tag?('public_api')
+      obj.visibility = :private
+      next
+    end
+
+    # Ensure the ancestor module chain of `obj` is also
+    # made visisble in the documentation.
+    while obj
+      obj.visibility = :public
+      obj = obj.namespace
+    end
   end
 end
 

--- a/yard/extensions.rb
+++ b/yard/extensions.rb
@@ -88,7 +88,9 @@ class DatadogConfigurationSettingsHandler < YARD::Handlers::Ruby::Base
 
     name = call_params[0]
 
-    if namespace.has_tag?(:dsl) # Check if we are already nested inside the DSL namespace
+    # Check if we are already nested inside the DSL namespace
+    if namespace.has_tag?(:dsl)
+      # If yes, do not add a second, nested DSL module. Use the parent directly.
       parent_module = namespace
     else
       # If not, create a DSL module to host generated classes
@@ -100,11 +102,11 @@ class DatadogConfigurationSettingsHandler < YARD::Handlers::Ruby::Base
     end
 
     # The generated class inherits the docstring from the current statement.
-    generated_class = YARD::CodeObjects::ClassObject.new(parent_module, camelize(name)) do |o|
-      o.add_tag(YARD::Tags::Tag.new(:dsl, 'dsl'))
-    end
+    generated_class = YARD::CodeObjects::ClassObject.new(parent_module, camelize(name))
 
     register(generated_class)
+
+    generated_class.add_tag(YARD::Tags::Tag.new(:dsl, 'dsl'))
 
     # Remove @public_api tag from this statement, as `setting :option` is a method call
     # and @public_api tags should only exists in modules and classes.

--- a/yard/extensions.rb
+++ b/yard/extensions.rb
@@ -36,6 +36,17 @@ YARD::Parser::SourceParser.after_parse_list do
   end
 end
 
+# Remove magic comments from documentation (e.g. Rubocop directives, TODOs, DEVs)
+YARD::Parser::SourceParser.after_parse_list do
+  YARD::Registry.each do |obj|
+    docstring = obj.docstring
+    next if docstring.empty?
+
+    docstring.replace(docstring.all.gsub(/^[A-Z]+: .*/, '')) # Removes TODO:, DEV:
+    docstring.replace(docstring.all.gsub(/^rubocop:.*/, '')) # Removes rubocop:...
+  end
+end
+
 #
 # Generates modules for DSL categories created by {Datadog::Configuration::Base::ClassMethods#settings}.
 # `#settings` are groups that can contain multiple `#option`s or nested `#settings.`

--- a/yard/extensions.rb
+++ b/yard/extensions.rb
@@ -42,6 +42,15 @@ YARD::Parser::SourceParser.after_parse_list do
     else
       # Do not change visibility of individual objects.
       # We'll handle their visibility in their encompassing modules and classes instead.
+
+      if obj.has_tag?('public_api')
+        log.warn(
+          "The @public_api tag should be added to modules and classes only: #{obj.files.join(':')}.\n" \
+          'Please move the tag to the encompassing module or class. ' \
+          'You can hide non-public methods, attributes, and constants with the `@!visibility private` directive.'
+        )
+      end
+
       next
     end
 

--- a/yard/extensions.rb
+++ b/yard/extensions.rb
@@ -1,5 +1,34 @@
 # frozen_string_literal: true
 
+TOP_LEVEL_MODULE_FILE = 'lib/ddtrace.rb'
+
+# The top-level `Datadog` module gets its docstring overwritten by
+# on almost every file in the repo, due to comments at the top of the file
+# (e.g. '# typed: true' or from vendor files 'Copyright (c) 2001-2010 Not Datadog.')
+#
+# This module ensures that only the comment provided by 'lib/ddtrace.rb'
+# is used as documentation for the top-level `Datadog` module.
+#
+# For non-top-level documentation, this can be solved by removing duplicate module/class
+# documentation. But for top-level it's tricky, as it is common to leave general comments
+# and directives in the first lines of a file.
+module EnsureTopLevelModuleCommentConsistency
+  def register_docstring(object, *args)
+    if object.is_a?(YARD::CodeObjects::ModuleObject) && object.path == 'Datadog' && parser.file != TOP_LEVEL_MODULE_FILE
+      super(object, nil)
+    else
+      super
+    end
+  end
+end
+YARD::Handlers::Base.prepend(EnsureTopLevelModuleCommentConsistency)
+
+# Sanity check to ensure we haven't renamed the top-level module definition file.
+YARD::Parser::SourceParser.before_parse_list do |files, _global_state|
+  raise "Top-level module file not found: #{TOP_LEVEL_MODULE_FILE}. Has it been moved?" unless
+    files.include?(TOP_LEVEL_MODULE_FILE)
+end
+
 # Hides all objects that are not part of the Public API from YARD docs.
 YARD::Parser::SourceParser.after_parse_list do
   YARD::Registry.each do |obj|

--- a/yard/templates/default/docstring/html/deprecated.erb
+++ b/yard/templates/default/docstring/html/deprecated.erb
@@ -1,0 +1,1 @@
+<div class="note deprecated"><strong>Deprecated <%= link_file('Deprecation.md', 'for removal') %>.</strong> <%= htmlify_line object.tag(:deprecated).text %></div>

--- a/yard/templates/default/docstring/setup.rb
+++ b/yard/templates/default/docstring/setup.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# def init
+#   return if object.docstring.blank? && !object.has_tag?(:api)
+#   sections :index, [:private, :deprecated, :abstract, :todo, :note, :returns_void, :text], T('tags')
+# end
+
+def deprecated
+  return unless object.has_tag?(:deprecated)
+  erb(:deprecated)
+end

--- a/yard/templates/default/docstring/setup.rb
+++ b/yard/templates/default/docstring/setup.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # def init
 #   return if object.docstring.blank? && !object.has_tag?(:api)
 #   sections :index, [:private, :deprecated, :abstract, :todo, :note, :returns_void, :text], T('tags')
@@ -6,5 +7,6 @@
 
 def deprecated
   return unless object.has_tag?(:deprecated)
+
   erb(:deprecated)
 end


### PR DESCRIPTION
This PR adds the `@public_api` tag, introduced in #1809, to existing objects in `ddtrace`'s core and "tracing" product that will now be under strict semver come 1.0.

Our docs look this now:


![Screen Shot 2021-12-21 at 5 28 07 PM](https://user-images.githubusercontent.com/583503/147019371-187040d1-7f24-4b44-9aae-2dda5692b211.png)



Notably, this PR does not include CI-App and Profiling API tagging. These will be done in their own PRs.

Also, the new main [`Datadog::Tracing` public API module](https://github.com/DataDog/dd-trace-rb/pull/1778/files#diff-5d787c2112f23c092e017ace55b113a3cd5098404246b3d1c5434f6c27602915) is also missing, as it is an entirely new module, and thus will be introduced in a separate PR, along with its respective test suite.

This PR adds a new tag `@default default_value_here`, which creates a section for attribute default values. This is useful for settings documentation: 
![Screen Shot 2021-12-13 at 1 35 16 PM](https://user-images.githubusercontent.com/583503/145892579-cf6d1e95-e816-479a-a641-b582454a7b99.png)

This PR also expands the documentation on any public API methods that I was confident enough to tackle :)

## Functional changes

There are a couple non-doc changes
1. The default value for the `partial_flush.min_spans_threshold` setting has been changed from `nil` to `500`. This effectively causes no changes as `500` is the default when `nil` is provided in the partial flusher. This change only exposes the default to the user, as opposed to hiding it behind an implementation detail.
2. The SyncWriter initializer now accepts formal keyword arguments, instead of a generic `options = {}`.