### PR TITLE
Fix conflicing shared_example in CI test

### DIFF
--- a/spec/datadog/ci/trace_flush_spec.rb
+++ b/spec/datadog/ci/trace_flush_spec.rb
@@ -5,7 +5,7 @@ require 'ddtrace/trace_segment'
 require 'ddtrace/trace_operation'
 require 'datadog/ci/trace_flush'
 
-RSpec.shared_context 'trace operation' do
+RSpec.shared_context 'CI trace operation' do
   let(:trace_op) do
     instance_double(
       Datadog::TraceOperation,
@@ -24,7 +24,7 @@ RSpec.shared_context 'trace operation' do
   let(:spans) { Array.new(3) { |i| Datadog::Span.new("span #{i}") } }
 end
 
-RSpec.shared_examples_for 'a trace flusher' do
+RSpec.shared_examples_for 'a CI trace flusher' do
   context 'given a finished trace operation' do
     let(:finished) { true }
 
@@ -56,8 +56,8 @@ RSpec.describe Datadog::CI::TraceFlush::Finished do
   describe '#consume' do
     subject(:consume) { trace_flush.consume!(trace_op) }
 
-    include_context 'trace operation'
-    it_behaves_like 'a trace flusher'
+    include_context 'CI trace operation'
+    it_behaves_like 'a CI trace flusher'
   end
 end
 
@@ -69,7 +69,7 @@ RSpec.describe Datadog::CI::TraceFlush::Partial do
   describe '#consume' do
     subject(:consume) { trace_flush.consume!(trace_op) }
 
-    include_context 'trace operation'
-    it_behaves_like 'a trace flusher'
+    include_context 'CI trace operation'
+    it_behaves_like 'a CI trace flusher'
   end
 end


### PR DESCRIPTION
Fixes naming conflict with base tracer shared examples at `spec/ddtrace/trace_flush_spec.rb` that have the same name:
```
WARNING: Shared example group 'trace operation' has been previously defined at:
  ./spec/datadog/ci/trace_flush_spec.rb:8
and you are now defining it at:
  ./spec/ddtrace/trace_flush_spec.rb:6
The new definition will overwrite the original one.

WARNING: Shared example group 'a trace flusher' has been previously defined at:
  ./spec/datadog/ci/trace_flush_spec.rb:27
and you are now defining it at:
  ./spec/ddtrace/trace_flush_spec.rb:21
The new definition will overwrite the original one.
```