### PR TITLE
On RSpec integration, change suite name to example group file path (i.e. "fix" shared_examples suite names)

### DIFF
--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -38,7 +38,7 @@ module Datadog
                   framework: Ext::FRAMEWORK,
                   framework_version: CI::Contrib::RSpec::Integration.version.to_s,
                   test_name: test_name,
-                  test_suite: file_path,
+                  test_suite: metadata[:example_group][:file_path],
                   test_type: Ext::TEST_TYPE
                 }
               ) do |span|

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -54,6 +54,17 @@ RSpec.describe 'RSpec hooks' do
     expect(span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::PASS)
   end
 
+  it 'creates correct span on shared examples' do
+    spec = with_new_rspec_environment do
+      require 'spec/datadog/ci/contrib/rspec/some_shared_examples'
+      spec = RSpec.describe 'some test' do
+        include_examples 'Testing shared examples'
+      end.tap(&:run)
+    end
+
+    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(spec.file_path)
+  end
+
   it 'creates spans for several examples' do
     num_examples = 20
     with_new_rspec_environment do

--- a/spec/datadog/ci/contrib/rspec/some_shared_examples.rb
+++ b/spec/datadog/ci/contrib/rspec/some_shared_examples.rb
@@ -1,0 +1,5 @@
+# typed: ignore
+
+RSpec.shared_examples 'Testing shared examples' do
+  it { expect(1 + 1).to eq(2) }
+end


### PR DESCRIPTION
Hello DataDog crew 👋 
As my first PR here, please let me know if there's anything weird on the PR (diffs or description) 😄 

## The problem
In Datadog we report all tests' suite names as the example file path, which usually is the same as the example group file path. This is not always true however, specifically for the case of tests included from a different path (usually on a shared_examples block).

Because of that, suite name would be reported as the shared examples file path, which was not not very helpful to track the files that are taking the most to run as the shared examples can be on a different path than the test file that included them.

For example, we have some test examples on a "vehicle_controller_example.rb" file that are included a few times on some other controller and, instead of that controller appearing as slow suite on DataDog, we have the shared example file as such, see:
<img width="848" alt="image" src="https://user-images.githubusercontent.com/9031589/147243199-650e96db-d412-4082-b9d7-7c5653ddf913.png">

## The solution
To address this, I'm adding the use of `metadata[:example_group][:file_path]` instead of simply `file_path`, so all test suites should be reported as the _example group file path_ (meaning that, instead of the shared examples path, I'd see the controller path on the screenshot above).