### PR TITLE
Public Tracing API

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2018,7 +2018,7 @@ You can also set this priority manually to either drop a non-interesting trace o
 
 When not using [distributed tracing](#distributed-tracing), you may change the priority at any time, as long as the trace incomplete. But it has to be done before any context propagation (fork, RPC calls) to be useful in a distributed context. Changing the priority after the context has been propagated causes different parts of a distributed trace to use different priorities. Some parts might be kept, some parts might be rejected, and this can cause the trace to be partially stored and remain incomplete.
 
-For this reason, if you change the priority, we recommend you do it as soon as possible.
+For this reason, if you change the priority, we recommend you do it as early as possible.
 
 To change the sampling priority, you can use the following methods:
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2018,9 +2018,9 @@ You can also set this priority manually to either drop a non-interesting trace o
 
 When not using [distributed tracing](#distributed-tracing), you may change the priority at any time, as long as the trace incomplete. But it has to be done before any context propagation (fork, RPC calls) to be useful in a distributed context. Changing the priority after the context has been propagated causes different parts of a distributed trace to use different priorities. Some parts might be kept, some parts might be rejected, and this can cause the trace to be partially stored and remain incomplete.
 
-If you change the priority, we recommend you do it as soon as possible: distributed tracing requests will include
-the sampling decision, thus setting the sampling decision late can cause downstream services to have a different sampling
-rate than the originating service trace.
+For this reason, if you change the priority, we recommend you do it as soon as possible.
+
+To change the sampling priority, you can use the following methods:
 
 ```ruby
 # Rejects the active trace

--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -1,0 +1,198 @@
+module Datadog
+  # Datadog APM tracing public API.
+  #
+  # The Datadog teams ensures that public methods in this module
+  # only receive backwards compatible changes, and breaking changes
+  # will only occur in new major versions releases.
+  # @public_api
+  module Tracing
+    class << self
+      # (see Datadog::Tracer#trace)
+      # @public_api
+      def trace(name, continue_from: nil, **span_options, &block)
+        tracer.trace(name, continue_from: continue_from, **span_options, &block)
+      end
+
+      # (see Datadog::Tracer#continue_trace!)
+      # @public_api
+      def continue_trace!(digest, &block)
+        tracer.continue_trace!(digest, &block)
+      end
+
+      # The currently active {Datadog::Tracer} instance.
+      #
+      # The instance returned can change throughout the lifetime of the application.
+      # This means it is not advisable to cache it.
+      #
+      # The trace can be configured through {.configure},
+      # through {Datadog::Configuration::Settings::DSL::Tracer} options.
+      #
+      # TODO: This next paragraph can be better written.
+      #
+      # Most of the functionality available through the {.tracer} instance is
+      # also available in public methods in the {Datadog::Tracing} module.
+      # It is preferable to use the public methods in the {Datadog::Tracing} when possible
+      # as {Datadog::Tracing} strongly defines the tracing public API, and thus
+      # we strive to no introduce breaking changes to {Datadog::Tracing} methods.
+      #
+      # @return [Datadog::Tracer] the active tracer
+      # @!attribute [r] tracer
+      # @public_api
+      def tracer
+        components.tracer
+      end
+
+      # The tracer's internal logger instance.
+      # All tracing log output is handled by this object.
+      #
+      # The logger can be configured through {.configure},
+      # through {Datadog::Configuration::Settings::DSL::Logger} options.
+      #
+      # @!attribute [r] logger
+      # @public_api
+      def logger
+        Datadog.logger
+      end
+
+      # Current tracer configuration.
+      #
+      # To modify the configuration, use {.configure}.
+      #
+      # @return [Datadog::Configuration::Settings]
+      # @!attribute [r] configuration
+      # @public_api
+      def configuration
+        Datadog.configuration
+      end
+
+      # Apply configuration changes to `ddtrace`. An example of a {.configure} call:
+      # ```
+      # Datadog.configure do |c|
+      #   c.sampling.default_rate = 1.0
+      #   c.use :aws
+      #   c.use :rails
+      #   c.use :sidekiq
+      #   # c.diagnostics.debug = true # Enables debug output
+      # end
+      # ```
+      #
+      # Because many configuration changes require restarting internal components,
+      # invoking {.configure} is the only safe way to change `ddtrace` configuration.
+      #
+      # Successive calls to {.configure} maintain the previous configuration values:
+      # configuration is additive between {.configure} calls.
+      #
+      # The yielded configuration `c` comes pre-populated from environment variables, if
+      # any are applicable.
+      #
+      # See {Datadog::Configuration::Settings} for all available options, defaults, and
+      # available environment variables for configuration.
+      #
+      # @yieldparam [Datadog::Configuration::Settings] c the mutable configuration object
+      # @return [void]
+      # @public_api
+      def configure(&block)
+        Datadog.configure(&block)
+      end
+
+      # (see Datadog::Tracer#active_trace)
+      # @public_api
+      def active_trace
+        tracer.active_trace
+      end
+
+      # (see Datadog::Tracer#active_span)
+      # @public_api
+      def active_span
+        tracer.active_span
+      end
+
+      # (see Datadog::TraceSegment#keep!)
+      # If no trace is active, no action is taken.
+      # @public_api
+      def keep!
+        trace = active_trace
+        active_trace.keep! if trace
+      end
+
+      # (see Datadog::TraceSegment#reject!)
+      # If no trace is active, no action is taken.
+      # @public_api
+      def reject!
+        trace = active_trace
+        active_trace.reject! if trace
+      end
+
+      # (see Datadog::Tracer#active_correlation)
+      # @public_api
+      def correlation
+        tracer.active_correlation
+      end
+
+      # Textual representation of {.correlation}, which can be
+      # added to individual log lines in order to correlate them with the active
+      # trace.
+      #
+      # Example:
+      #
+      # ```
+      # MyLogger.log("#{Datadog::Tracing.log_correlation}] My log message")
+      # # dd.env=prod dd.service=billing dd.version=13.8 dd.trace_id=545847825299552251 dd.span_id=711755234730770098 My log message
+      # ```
+      #
+      # @return [String] correlation information
+      # @public_api
+      def log_correlation
+        correlation.to_log_format
+      end
+
+      # Gracefully shuts down the tracer.
+      #
+      # The public tracing API will still respond to method calls as usual
+      # but might not internally perform the expected internal work after shutdown.
+      #
+      # This avoids errors being raised across the host application
+      # during shutdown while allowing for the graceful decommission of resources.
+      #
+      # {.shutdown!} cannot be reversed.
+      # @public_api
+      def shutdown!
+        components.shutdown!
+      end
+
+      # The global integration registry.
+      #
+      # This registry holds a reference to all integrations available
+      # to the tracer.
+      #
+      # Integrations registered in the {.registry} can be activated as follows:
+      #
+      # ```
+      # Datadog.configure do |c|
+      #   c.use :my_registered_integration, **my_options
+      # end
+      # ```
+      #
+      # New integrations can be registered by implementing the {Datadog::Contrib::Integration} interface.
+      #
+      # @return [Datadog::Contrib::Registry]
+      # @!attribute [r] registry
+      # @public_api
+      def registry
+        Datadog::Contrib::REGISTRY
+      end
+
+      # (see Datadog::Pipeline.before_flush)
+      def before_flush(*processors, &processor_block)
+        Datadog::Pipeline.before_flush(*processors, &processor_block)
+      end
+
+      private
+
+      # DEV: components hosts both tracing and profiling inner objects today
+      def components
+        Datadog.send(:components)
+      end
+    end
+  end
+end

--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -136,8 +136,8 @@ module Datadog
       # Example:
       #
       # ```
-      # MyLogger.log("#{Datadog::Tracing.log_correlation}] My log message")
-      # # dd.env=prod dd.service=billing dd.version=13.8 dd.trace_id=545847825299552251 dd.span_id=711755234730770098 My log message
+      # MyLogger.log("#{Datadog::Tracing.log_correlation}] My message")
+      # # dd.env=prod dd.service=auth dd.version=13.8 dd.trace_id=5458478252992251 dd.span_id=7117552347370098 My message
       # ```
       #
       # @return [String] correlation information

--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -27,14 +27,7 @@ module Datadog
       # The tracer can be configured through {.configure},
       # through {Datadog::Configuration::Settings::DSL::Tracer} options.
       #
-      # TODO: This next paragraph can be better written.
-      #
-      # Most of the functionality available through the {.tracer} instance is
-      # also available in public methods in the {Datadog::Tracing} module.
-      # It is preferable to use the public methods in the {Datadog::Tracing} when possible
-      # as {Datadog::Tracing} strongly defines the tracing public API, and thus
-      # we strive to no introduce breaking changes to {Datadog::Tracing} methods.
-      #
+      # @deprecated Use public API methods available in {Datadog::Tracing} instead.
       # @return [Datadog::Tracer] the active tracer
       # @!attribute [r] tracer
       # @public_api

--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -180,6 +180,12 @@ module Datadog
         Datadog::Pipeline.before_flush(*processors, &processor_block)
       end
 
+      # Is the tracer collecting telemetry data in this process?
+      # @return [Boolean] `true` if the tracer is collecting data in this process, otherwise `false`.
+      def enabled?
+        tracer.enabled
+      end
+
       private
 
       # DEV: components hosts both tracing and profiling inner objects today

--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -24,7 +24,7 @@ module Datadog
       # The instance returned can change throughout the lifetime of the application.
       # This means it is not advisable to cache it.
       #
-      # The trace can be configured through {.configure},
+      # The tracer can be configured through {.configure},
       # through {Datadog::Configuration::Settings::DSL::Tracer} options.
       #
       # TODO: This next paragraph can be better written.
@@ -67,7 +67,7 @@ module Datadog
 
       # Apply configuration changes to `ddtrace`. An example of a {.configure} call:
       # ```
-      # Datadog.configure do |c|
+      # Datadog::Tracing.configure do |c|
       #   c.sampling.default_rate = 1.0
       #   c.use :aws
       #   c.use :rails
@@ -168,7 +168,7 @@ module Datadog
       # Integrations registered in the {.registry} can be activated as follows:
       #
       # ```
-      # Datadog.configure do |c|
+      # Datadog::Tracing.configure do |c|
       #   c.use :my_registered_integration, **my_options
       # end
       # ```

--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -1,7 +1,7 @@
 module Datadog
   # Datadog APM tracing public API.
   #
-  # The Datadog teams ensures that public methods in this module
+  # The Datadog team ensures that public methods in this module
   # only receive backwards compatible changes, and breaking changes
   # will only occur in new major versions releases.
   # @public_api

--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -91,12 +91,16 @@ module Datadog
       # (see Datadog::Tracer#active_trace)
       # @public_api
       def active_trace
+        return unless tracer
+
         tracer.active_trace
       end
 
       # (see Datadog::Tracer#active_span)
       # @public_api
       def active_span
+        return unless tracer
+
         tracer.active_span
       end
 
@@ -119,6 +123,8 @@ module Datadog
       # (see Datadog::Tracer#active_correlation)
       # @public_api
       def correlation
+        return unless tracer
+
         tracer.active_correlation
       end
 
@@ -150,6 +156,8 @@ module Datadog
       # {.shutdown!} cannot be reversed.
       # @public_api
       def shutdown!
+        return unless tracer
+
         tracer.shutdown!
       end
 
@@ -183,6 +191,8 @@ module Datadog
       # Is the tracer collecting telemetry data in this process?
       # @return [Boolean] `true` if the tracer is collecting data in this process, otherwise `false`.
       def enabled?
+        return false unless tracer
+
         tracer.enabled
       end
 

--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -47,47 +47,6 @@ module Datadog
         Datadog.logger
       end
 
-      # Current tracer configuration.
-      #
-      # To modify the configuration, use {.configure}.
-      #
-      # @return [Datadog::Configuration::Settings]
-      # @!attribute [r] configuration
-      # @public_api
-      def configuration
-        Datadog.configuration
-      end
-
-      # Apply configuration changes to `Datadog::Tracing`. An example of a {.configure} call:
-      # ```
-      # Datadog::Tracing.configure do |c|
-      #   c.sampling.default_rate = 1.0
-      #   c.use :aws
-      #   c.use :rails
-      #   c.use :sidekiq
-      #   # c.diagnostics.debug = true # Enables debug output
-      # end
-      # ```
-      #
-      # Because many configuration changes require restarting internal components,
-      # invoking {.configure} is the only safe way to change `ddtrace` configuration.
-      #
-      # Successive calls to {.configure} maintain the previous configuration values:
-      # configuration is additive between {.configure} calls.
-      #
-      # The yielded configuration `c` comes pre-populated from environment variables, if
-      # any are applicable.
-      #
-      # See {Datadog::Configuration::Settings} for all available options, defaults, and
-      # available environment variables for configuration.
-      #
-      # @yieldparam [Datadog::Configuration::Settings] c the mutable configuration object
-      # @return [void]
-      # @public_api
-      def configure(&block)
-        Datadog.configure(&block)
-      end
-
       # (see Datadog::Tracer#active_trace)
       # @public_api
       def active_trace

--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -150,7 +150,7 @@ module Datadog
       # {.shutdown!} cannot be reversed.
       # @public_api
       def shutdown!
-        components.shutdown!
+        tracer.shutdown!
       end
 
       # The global integration registry.

--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -58,7 +58,7 @@ module Datadog
         Datadog.configuration
       end
 
-      # Apply configuration changes to `ddtrace`. An example of a {.configure} call:
+      # Apply configuration changes to `Datadog::Tracing`. An example of a {.configure} call:
       # ```
       # Datadog::Tracing.configure do |c|
       #   c.sampling.default_rate = 1.0

--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -6,6 +6,7 @@
 # We need to ensure that any files loaded in our gemspec are also loaded here.
 require 'ddtrace/version'
 
+require 'datadog/tracing'
 require 'ddtrace/pin'
 require 'ddtrace/tracer'
 require 'ddtrace/error'

--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -306,29 +306,6 @@ module Datadog
         option :statsd
       end
 
-      # TODO: remove me. Use `c.runtime_metrics.enabled =`
-      # Backwards compatibility for configuring runtime metrics e.g. `c.runtime_metrics enabled: true`
-      def runtime_metrics(options = nil)
-        settings = get_option(:runtime_metrics)
-        return settings if options.nil?
-
-        # If options were provided (old style) then raise warnings and apply them:
-        # TODO: Raise deprecation warning
-        settings.enabled = options[:enabled] if options.key?(:enabled)
-        settings.statsd = options[:statsd] if options.key?(:statsd)
-        settings
-      end
-
-      # @deprecated Use `runtime_metrics.enabled` instead.
-      # @return [Boolean]
-      option :runtime_metrics_enabled do |o|
-        o.delegate_to { get_option(:runtime_metrics).enabled }
-        o.on_set do |value|
-          # TODO: Raise deprecation warning
-          get_option(:runtime_metrics).enabled = value
-        end
-      end
-
       # Client-side sampling configuration.
       # @public_api
       settings :sampling do

--- a/lib/ddtrace/pipeline.rb
+++ b/lib/ddtrace/pipeline.rb
@@ -1,7 +1,6 @@
 # typed: true
 module Datadog
   # Pipeline
-  # @public_api
   module Pipeline
     require_relative 'pipeline/span_filter'
     require_relative 'pipeline/span_processor'

--- a/spec/datadog/tracing_spec.rb
+++ b/spec/datadog/tracing_spec.rb
@@ -2,12 +2,14 @@
 # All the doubles in this file are simple pass through values.
 # There's no value in making them verifying doubles.
 RSpec.describe Datadog::Tracing do
+  let(:returned) { double('delegated return value') }
+
   describe '.active_span' do
     subject(:active_span) { described_class.active_span }
 
     it 'delegates to the tracer' do
-      expect(Datadog.tracer).to receive(:active_span)
-      active_span
+      expect(Datadog.tracer).to receive(:active_span).and_return(returned)
+      expect(active_span).to eq(returned)
     end
   end
 
@@ -47,8 +49,9 @@ RSpec.describe Datadog::Tracing do
     let(:block) { -> {} }
 
     it 'delegates to the tracer' do
-      expect(Datadog.tracer).to receive(:continue_trace!).with(digest) { |&b| expect(b).to be(block) }
-      continue_trace!
+      expect(Datadog.tracer).to receive(:continue_trace!)
+        .with(digest) { |&b| expect(b).to be(block) }.and_return(returned)
+      expect(continue_trace!).to eq(returned)
     end
   end
 
@@ -62,7 +65,8 @@ RSpec.describe Datadog::Tracing do
     it 'delegates to the tracer' do
       expect(Datadog.tracer).to receive(:trace)
         .with(name, continue_from: continue_from, **span_options) { |&b| expect(b).to be(block) }
-      trace
+        .and_return(returned)
+      expect(trace).to eq(returned)
     end
   end
 
@@ -74,8 +78,8 @@ RSpec.describe Datadog::Tracing do
       end
 
       it 'delegates to the active trace' do
-        expect(Datadog.tracer.active_trace).to receive(:reject!)
-        reject!
+        expect(Datadog.tracer.active_trace).to receive(:reject!).and_return(returned)
+        expect(reject!).to eq(returned)
       end
     end
 
@@ -102,7 +106,8 @@ RSpec.describe Datadog::Tracing do
       # Once we memoize `Datadog::Correlation#identifier_from_digest`, we can simplify this
       # `receive_message_chain` assertion to `expect(Datadog.tracer.active_correlation).to receive(:to_log_format)`
       expect(Datadog.tracer).to receive_message_chain(:active_correlation, :to_log_format)
-      log_correlation
+        .and_return(returned)
+      expect(log_correlation).to eq(returned)
     end
     # rubocop:enable RSpec/MessageChain
   end
@@ -152,8 +157,8 @@ RSpec.describe Datadog::Tracing do
   describe '.correlation' do
     subject(:correlation) { described_class.correlation }
     it 'delegates to the tracer' do
-      expect(Datadog.tracer).to receive(:active_correlation)
-      correlation
+      expect(Datadog.tracer).to receive(:active_correlation).and_return(returned)
+      expect(correlation).to eq(returned)
     end
   end
 

--- a/spec/datadog/tracing_spec.rb
+++ b/spec/datadog/tracing_spec.rb
@@ -122,11 +122,11 @@ RSpec.describe Datadog::Tracing do
   describe '.shutdown!' do
     subject(:shutdown!) { described_class.shutdown! }
     it 'delegates to global components' do
-      allow(Datadog.send(:components)).to receive(:shutdown!)
+      allow(Datadog.send(:components).tracer).to receive(:shutdown!)
 
       shutdown!
 
-      expect(Datadog.send(:components)).to have_received(:shutdown!)
+      expect(Datadog.send(:components).tracer).to have_received(:shutdown!)
     end
   end
 

--- a/spec/datadog/tracing_spec.rb
+++ b/spec/datadog/tracing_spec.rb
@@ -112,13 +112,6 @@ RSpec.describe Datadog::Tracing do
     # rubocop:enable RSpec/MessageChain
   end
 
-  describe '.configuration' do
-    subject(:configuration) { described_class.configuration }
-    it 'returns the global configuration' do
-      expect(configuration).to eq(Datadog.configuration)
-    end
-  end
-
   describe '.shutdown!' do
     subject(:shutdown!) { described_class.shutdown! }
     it 'delegates to global components' do
@@ -141,16 +134,6 @@ RSpec.describe Datadog::Tracing do
     subject(:registry) { described_class.registry }
     it 'returns the global registry' do
       expect(registry).to eq(Datadog::Contrib::REGISTRY)
-    end
-  end
-
-  describe '.configure' do
-    subject(:configure) { described_class.configure(&block) }
-    let(:block) { -> {} }
-
-    it 'delegates to the global configuration' do
-      expect(Datadog).to receive(:configure) { |&b| expect(b).to be(block) }
-      configure
     end
   end
 

--- a/spec/datadog/tracing_spec.rb
+++ b/spec/datadog/tracing_spec.rb
@@ -166,5 +166,13 @@ RSpec.describe Datadog::Tracing do
       before_flush
     end
   end
+
+  describe '.enabled?' do
+    subject(:enabled?) { described_class.enabled? }
+    it 'delegates to the tracer' do
+      expect(Datadog.tracer).to receive(:enabled)
+      enabled?
+    end
+  end
 end
 # rubocop:enable RSpec/VerifiedDoubles

--- a/spec/datadog/tracing_spec.rb
+++ b/spec/datadog/tracing_spec.rb
@@ -1,0 +1,214 @@
+RSpec.describe Datadog::Tracing do
+  context '.active_span' do
+    subject(:active_span) { described_class.active_span }
+
+    context 'with an active span' do
+      let!(:span) do
+        described_class.trace('test.trace')
+      end
+
+      it 'returns active span from global tracer' do
+        expect(active_span).to be(span)
+      end
+    end
+
+    context 'without an active span' do
+      it { expect(active_span).to be_nil }
+    end
+  end
+
+  context '.active_trace' do
+    subject(:active_trace) { described_class.active_trace }
+
+    context 'with an active trace' do
+      let!(:span) do
+        described_class.trace('test.trace')
+      end
+
+      it 'returns active trace from global tracer' do
+        expect(active_trace).to be(Datadog.tracer.active_trace)
+      end
+    end
+
+    context 'without an active trace' do
+      it { expect(active_trace).to be_nil }
+    end
+  end
+
+  context '.keep!' do
+    subject(:keep!) { described_class.keep! }
+    context 'with an active trace' do
+      let!(:trace) do
+        described_class.trace('test.trace')
+        described_class.active_trace.reject!
+        described_class.active_trace
+      end
+
+      it 'changes trace sampling decision to true' do
+        expect { keep! }.to change { trace.sampled? }.from(false).to(true)
+      end
+    end
+
+    context 'without an active trace' do
+      it 'does not perform any operation' do
+        expect { keep! }.to_not raise_error
+      end
+    end
+  end
+
+  context '.continue_trace!' do
+    subject(:continue_trace!) { described_class.continue_trace!(digest, &block) }
+    let(:digest) { Datadog::TraceDigest.new(span_id: span_id, trace_id: trace_id) }
+    let(:span_id) { double('span_id') }
+    let(:trace_id) { double('trace_id') }
+
+    context 'with a block' do
+      let(:block) { -> { block_result } }
+      let(:block_result) { double('result') }
+
+      it 'returns the block result' do
+        expect(continue_trace!).to eq(block_result)
+      end
+    end
+
+    context 'without a block' do
+      subject(:continue_trace!) { described_class.continue_trace!(digest) }
+
+      it 'returns an unfinished span operation' do
+        expect(continue_trace!).to be_a(Datadog::TraceOperation)
+        expect(continue_trace!.parent_span_id).to eq(span_id)
+        expect(continue_trace!.id).to eq(trace_id)
+      end
+    end
+  end
+
+  context '.trace' do
+    let(:name) { 'test-name' }
+    let(:continue_from) { nil }
+    let(:span_options) { { my: :option } }
+
+    context 'with a block' do
+      subject(:trace) { described_class.trace(name, continue_from: continue_from, **span_options, &block) }
+      let(:block) { ->(_span, _trace) { block_result } }
+      let(:block_result) { double('result') }
+
+      it 'invokes block with span and trace arguments' do
+        expect { |b| described_class.trace(name, continue_from: continue_from, **span_options, &b) }
+          .to yield_with_args(be_a(Datadog::SpanOperation), be_a(Datadog::TraceOperation))
+      end
+
+      it 'returns the block result' do
+        expect(trace).to eq(block_result)
+      end
+    end
+
+    context 'without a block' do
+      subject(:trace) { described_class.trace(name, continue_from: continue_from, **span_options) }
+
+      it 'returns an unfinished span operation' do
+        expect(Datadog.tracer).to receive(:trace)
+                                    .with(name, continue_from: continue_from, **span_options).and_call_original
+
+        expect(trace).to be_a(Datadog::SpanOperation)
+        expect(trace.name).to eq(name)
+        expect(trace.finished?).to be_falsey
+      end
+    end
+  end
+
+  context '.reject!' do
+    subject(:reject!) { described_class.reject! }
+    context 'with an active trace' do
+      let!(:trace) do
+        described_class.trace('test.trace')
+        described_class.active_trace.keep!
+        described_class.active_trace
+      end
+
+      it 'changes trace sampling decision to false' do
+        expect { reject! }.to change { trace.sampled? }.from(true).to(false)
+      end
+    end
+
+    context 'without an active trace' do
+      it 'does not perform any operation' do
+        expect { reject! }.to_not raise_error
+      end
+    end
+  end
+
+  context '.tracer' do
+    subject(:tracer) { described_class.tracer }
+    it 'returns the global tracer' do
+      expect(tracer).to be(Datadog.tracer)
+    end
+  end
+
+  context '.log_correlation' do
+    subject(:log_correlation) { described_class.log_correlation }
+    it 'returns the current trace log correlation string' do
+      expect(log_correlation).to be_a(String)
+      expect(log_correlation).to include('dd.trace_id=')
+    end
+  end
+
+  context '.configuration' do
+    subject(:configuration) { described_class.configuration }
+    it 'returns the global configuration' do
+      expect(configuration).to eq(Datadog.configuration)
+    end
+  end
+
+  context '.shutdown!' do
+    subject(:shutdown!) { described_class.shutdown! }
+    it 'shuts down global components' do
+      allow(Datadog.send(:components)).to receive(:shutdown!)
+
+      shutdown!
+
+      expect(Datadog.send(:components)).to have_received(:shutdown!)
+    end
+  end
+
+  context '.logger' do
+    subject(:logger) { described_class.logger }
+    it 'returns the global logger' do
+      expect(logger).to be(Datadog.logger)
+    end
+  end
+
+  context '.registry' do
+    subject(:registry) { described_class.registry }
+    it 'returns the global registry' do
+      expect(registry).to eq(Datadog::Contrib::REGISTRY)
+    end
+  end
+
+  context '.configure' do
+    subject(:configure) { described_class.configure(&block) }
+    let(:block) { ->(_c) { } }
+
+    it 'invokes block with the global configuration as an argument' do
+      expect { |b| described_class.configure(&b) }
+        .to yield_with_args(described_class.configuration)
+    end
+
+    it 'restarts restarts components' do
+      expect { configure }.to change{ described_class.tracer }
+                                .from(described_class.tracer).to(not_be(described_class.tracer))
+    end
+  end
+
+  context '.correlation' do
+    subject(:correlation) { described_class.correlation }
+    it 'returns the current trace correlation identifier' do
+      expect(Datadog.tracer).to receive(:active_correlation).and_call_original
+      expect(correlation).to be_a(Datadog::Correlation::Identifier)
+    end
+  end
+
+  context '.before_flush' do
+    pending do
+    end
+  end
+end

--- a/spec/datadog/tracing_spec.rb
+++ b/spec/datadog/tracing_spec.rb
@@ -1,51 +1,36 @@
+# rubocop:disable RSpec/VerifiedDoubles
+# All the doubles in this file are simple pass through values.
+# There's no value in making them verifying doubles.
 RSpec.describe Datadog::Tracing do
-  context '.active_span' do
+  describe '.active_span' do
     subject(:active_span) { described_class.active_span }
 
-    context 'with an active span' do
-      let!(:span) do
-        described_class.trace('test.trace')
-      end
-
-      it 'returns active span from global tracer' do
-        expect(active_span).to be(span)
-      end
-    end
-
-    context 'without an active span' do
-      it { expect(active_span).to be_nil }
+    it 'delegates to the tracer' do
+      expect(Datadog.tracer).to receive(:active_span)
+      active_span
     end
   end
 
-  context '.active_trace' do
+  describe '.active_trace' do
     subject(:active_trace) { described_class.active_trace }
 
-    context 'with an active trace' do
-      let!(:span) do
-        described_class.trace('test.trace')
-      end
-
-      it 'returns active trace from global tracer' do
-        expect(active_trace).to be(Datadog.tracer.active_trace)
-      end
-    end
-
-    context 'without an active trace' do
-      it { expect(active_trace).to be_nil }
+    it 'delegates to the tracer' do
+      expect(Datadog.tracer).to receive(:active_trace)
+      active_trace
     end
   end
 
-  context '.keep!' do
+  describe '.keep!' do
     subject(:keep!) { described_class.keep! }
+
     context 'with an active trace' do
       let!(:trace) do
-        described_class.trace('test.trace')
-        described_class.active_trace.reject!
-        described_class.active_trace
+        Datadog.tracer.trace('test.trace')
       end
 
-      it 'changes trace sampling decision to true' do
-        expect { keep! }.to change { trace.sampled? }.from(false).to(true)
+      it 'delegates to the active trace' do
+        expect(Datadog.tracer.active_trace).to receive(:keep!)
+        keep!
       end
     end
 
@@ -56,77 +41,41 @@ RSpec.describe Datadog::Tracing do
     end
   end
 
-  context '.continue_trace!' do
+  describe '.continue_trace!' do
     subject(:continue_trace!) { described_class.continue_trace!(digest, &block) }
-    let(:digest) { Datadog::TraceDigest.new(span_id: span_id, trace_id: trace_id) }
-    let(:span_id) { double('span_id') }
-    let(:trace_id) { double('trace_id') }
+    let(:digest) { double('digest') }
+    let(:block) { -> {} }
 
-    context 'with a block' do
-      let(:block) { -> { block_result } }
-      let(:block_result) { double('result') }
-
-      it 'returns the block result' do
-        expect(continue_trace!).to eq(block_result)
-      end
-    end
-
-    context 'without a block' do
-      subject(:continue_trace!) { described_class.continue_trace!(digest) }
-
-      it 'returns an unfinished span operation' do
-        expect(continue_trace!).to be_a(Datadog::TraceOperation)
-        expect(continue_trace!.parent_span_id).to eq(span_id)
-        expect(continue_trace!.id).to eq(trace_id)
-      end
+    it 'delegates to the tracer' do
+      expect(Datadog.tracer).to receive(:continue_trace!).with(digest) { |&b| expect(b).to be(block) }
+      continue_trace!
     end
   end
 
-  context '.trace' do
-    let(:name) { 'test-name' }
-    let(:continue_from) { nil }
-    let(:span_options) { { my: :option } }
+  describe '.trace' do
+    subject(:trace) { described_class.trace(name, continue_from: continue_from, **span_options, &block) }
+    let(:name) { double('name') }
+    let(:continue_from) { double('continue_from') }
+    let(:span_options) { { my: double('option') } }
+    let(:block) { -> {} }
 
-    context 'with a block' do
-      subject(:trace) { described_class.trace(name, continue_from: continue_from, **span_options, &block) }
-      let(:block) { ->(_span, _trace) { block_result } }
-      let(:block_result) { double('result') }
-
-      it 'invokes block with span and trace arguments' do
-        expect { |b| described_class.trace(name, continue_from: continue_from, **span_options, &b) }
-          .to yield_with_args(be_a(Datadog::SpanOperation), be_a(Datadog::TraceOperation))
-      end
-
-      it 'returns the block result' do
-        expect(trace).to eq(block_result)
-      end
-    end
-
-    context 'without a block' do
-      subject(:trace) { described_class.trace(name, continue_from: continue_from, **span_options) }
-
-      it 'returns an unfinished span operation' do
-        expect(Datadog.tracer).to receive(:trace)
-                                    .with(name, continue_from: continue_from, **span_options).and_call_original
-
-        expect(trace).to be_a(Datadog::SpanOperation)
-        expect(trace.name).to eq(name)
-        expect(trace.finished?).to be_falsey
-      end
+    it 'delegates to the tracer' do
+      expect(Datadog.tracer).to receive(:trace)
+        .with(name, continue_from: continue_from, **span_options) { |&b| expect(b).to be(block) }
+      trace
     end
   end
 
-  context '.reject!' do
+  describe '.reject!' do
     subject(:reject!) { described_class.reject! }
     context 'with an active trace' do
       let!(:trace) do
-        described_class.trace('test.trace')
-        described_class.active_trace.keep!
-        described_class.active_trace
+        Datadog.tracer.trace('test.trace')
       end
 
-      it 'changes trace sampling decision to false' do
-        expect { reject! }.to change { trace.sampled? }.from(true).to(false)
+      it 'delegates to the active trace' do
+        expect(Datadog.tracer.active_trace).to receive(:reject!)
+        reject!
       end
     end
 
@@ -137,31 +86,37 @@ RSpec.describe Datadog::Tracing do
     end
   end
 
-  context '.tracer' do
+  describe '.tracer' do
     subject(:tracer) { described_class.tracer }
     it 'returns the global tracer' do
       expect(tracer).to be(Datadog.tracer)
     end
   end
 
-  context '.log_correlation' do
+  describe '.log_correlation' do
     subject(:log_correlation) { described_class.log_correlation }
-    it 'returns the current trace log correlation string' do
-      expect(log_correlation).to be_a(String)
-      expect(log_correlation).to include('dd.trace_id=')
+
+    # rubocop:disable RSpec/MessageChain
+    it 'delegates to the active correlation' do
+      # DEV: `Datadog.tracer.active_correlation` returns a new object on every invocation.
+      # Once we memoize `Datadog::Correlation#identifier_from_digest`, we can simplify this
+      # `receive_message_chain` assertion to `expect(Datadog.tracer.active_correlation).to receive(:to_log_format)`
+      expect(Datadog.tracer).to receive_message_chain(:active_correlation, :to_log_format)
+      log_correlation
     end
+    # rubocop:enable RSpec/MessageChain
   end
 
-  context '.configuration' do
+  describe '.configuration' do
     subject(:configuration) { described_class.configuration }
     it 'returns the global configuration' do
       expect(configuration).to eq(Datadog.configuration)
     end
   end
 
-  context '.shutdown!' do
+  describe '.shutdown!' do
     subject(:shutdown!) { described_class.shutdown! }
-    it 'shuts down global components' do
+    it 'delegates to global components' do
       allow(Datadog.send(:components)).to receive(:shutdown!)
 
       shutdown!
@@ -170,45 +125,46 @@ RSpec.describe Datadog::Tracing do
     end
   end
 
-  context '.logger' do
+  describe '.logger' do
     subject(:logger) { described_class.logger }
     it 'returns the global logger' do
       expect(logger).to be(Datadog.logger)
     end
   end
 
-  context '.registry' do
+  describe '.registry' do
     subject(:registry) { described_class.registry }
     it 'returns the global registry' do
       expect(registry).to eq(Datadog::Contrib::REGISTRY)
     end
   end
 
-  context '.configure' do
+  describe '.configure' do
     subject(:configure) { described_class.configure(&block) }
-    let(:block) { ->(_c) { } }
+    let(:block) { -> {} }
 
-    it 'invokes block with the global configuration as an argument' do
-      expect { |b| described_class.configure(&b) }
-        .to yield_with_args(described_class.configuration)
-    end
-
-    it 'restarts restarts components' do
-      expect { configure }.to change{ described_class.tracer }
-                                .from(described_class.tracer).to(not_be(described_class.tracer))
+    it 'delegates to the global configuration' do
+      expect(Datadog).to receive(:configure) { |&b| expect(b).to be(block) }
+      configure
     end
   end
 
-  context '.correlation' do
+  describe '.correlation' do
     subject(:correlation) { described_class.correlation }
-    it 'returns the current trace correlation identifier' do
-      expect(Datadog.tracer).to receive(:active_correlation).and_call_original
-      expect(correlation).to be_a(Datadog::Correlation::Identifier)
+    it 'delegates to the tracer' do
+      expect(Datadog.tracer).to receive(:active_correlation)
+      correlation
     end
   end
 
-  context '.before_flush' do
-    pending do
+  describe '.before_flush' do
+    subject(:before_flush) { described_class.before_flush(*processors, &block) }
+    let(:processors) { [double('processor')] }
+    let(:block) { -> {} }
+    it 'delegates to the global pipeline' do
+      expect(Datadog::Pipeline).to receive(:before_flush).with(*processors) { |&b| expect(b).to be(block) }
+      before_flush
     end
   end
 end
+# rubocop:enable RSpec/VerifiedDoubles

--- a/spec/ddtrace/configuration/settings_spec.rb
+++ b/spec/ddtrace/configuration/settings_spec.rb
@@ -614,40 +614,6 @@ RSpec.describe Datadog::Configuration::Settings do
   end
 
   describe '#runtime_metrics' do
-    describe 'old style' do
-      context 'given nothing' do
-        subject(:runtime_metrics) { settings.runtime_metrics }
-
-        it 'returns the new settings object' do
-          is_expected.to be_a_kind_of(Datadog::Configuration::Base)
-        end
-      end
-
-      context 'given :enabled' do
-        subject(:runtime_metrics) { settings.runtime_metrics enabled: true }
-
-        it 'updates the new #enabled setting' do
-          expect { settings.runtime_metrics enabled: true }
-            .to change { settings.runtime_metrics.enabled }
-            .from(false)
-            .to(true)
-        end
-      end
-
-      context 'given :statsd' do
-        subject(:runtime_metrics) { settings.runtime_metrics statsd: statsd }
-
-        let(:statsd) { double('statsd') }
-
-        it 'updates the new #statsd setting' do
-          expect { settings.runtime_metrics statsd: statsd }
-            .to change { settings.runtime_metrics.statsd }
-            .from(nil)
-            .to(statsd)
-        end
-      end
-    end
-
     describe '#enabled' do
       subject(:enabled) { settings.runtime_metrics.enabled }
 
@@ -715,27 +681,6 @@ RSpec.describe Datadog::Configuration::Settings do
           .from(nil)
           .to(statsd)
       end
-    end
-  end
-
-  describe '#runtime_metrics_enabled' do
-    subject(:runtime_metrics_enabled) { settings.runtime_metrics_enabled }
-
-    let(:value) { double }
-
-    before { expect(settings.runtime_metrics).to receive(:enabled).and_return(value) }
-
-    it 'retrieves the value from the new setting' do
-      is_expected.to be value
-    end
-  end
-
-  describe '#runtime_metrics_enabled=' do
-    it 'changes the new #enabled setting' do
-      expect { settings.runtime_metrics_enabled = true }
-        .to change { settings.runtime_metrics.enabled }
-        .from(false)
-        .to(true)
     end
   end
 


### PR DESCRIPTION
This PR creates explicit methods in the new `Datadog::Tracing` module that expose the core functionality we want to expose for Datadog APM Tracing.

Most existing tracing-specific methods have moved from `Datadog.tracer.method` to `Datadog::Tracing.method`. The main change is that only methods that provide first-class tracing features are exposed in the `Datadog::Tracing` module.

Our hope is that the `Datadog::Tracing` module will be the point of interaction for the vast majority of interactions between the host application and APM Tracing.

The goal is for the vast majority of Datadog tracing methods that need to be interweaved with the host application to come from `Datadog::Tracing`. We'll strive to maintain concise naming and a simple but flexible API for `Datadog::Tracing` methods.

All advanced features, outside of `Datadog::Tracing.method`, are still present (e.g. custom sampling classes, processing pipeline) and fully supported.

#### TODO
- [ ] Address `TODO: This next paragraph can be better written.` I'd like some feedback on how to improve this part.
