### PR TITLE
Upgrade Ruby 2.3 bundler to 2.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,7 +463,7 @@ job_configuration:
   - &config-2_3
     <<: *filters_all_branches_and_tags
     ruby_version: '2.3'
-    image: ivoanjo/docker-library:ddtrace_rb_2_3_8
+    image: marcotc/docker-library:ddtrace_rb_2_3_8
   - &config-2_4
     <<: *filters_all_branches_and_tags
     ruby_version: '2.4'

--- a/.circleci/images/primary/Dockerfile-2.3.8
+++ b/.circleci/images/primary/Dockerfile-2.3.8
@@ -73,12 +73,7 @@ RUN gem update --system
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Install RubyGems
-# NOTE: Rubygems 3.0.6 is the last version that seems to work fine in this image AND not drag bundler 2 along.
-# Later versions are either broken or they force the use of bundler 2, which we can't because some of our dependencies don't like it.
-RUN gem update --system '3.0.6'
-# Ruby 2.3 can support Bundler 2+
-# But hold back to < 2 for now, because some dependencies require it.
-RUN gem install bundler -v '1.17.3'
+RUN gem update --system '3.3.4'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - bundle-2.2:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-2.3:
-    image: ivoanjo/docker-library:ddtrace_rb_2_3_8
+    image: marcotc/docker-library:ddtrace_rb_2_3_8
     command: /bin/bash
     depends_on:
       - ddagent


### PR DESCRIPTION
Ruby 2.3 builds [have been failing](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/5061/workflows/7c4b9709-4e96-4038-8843-6d1dda2a22fd/jobs/189567) with:

```
bundle install
Fetching gem metadata from https://rubygems.org/..........
google-protobuf-3.19.2-x86_64-linux requires ruby version >= 2.5, < 3.1.dev,
which is incompatible with the current version, ruby 2.3.8p459

Exited with code exit status 5
```

This happens despite https://rubygems.org/gems/google-protobuf/versions/3.19.2-x86-linux correctly advertising that it only supports Ruby `>= 2.5, < 3.1.dev`.

This is a bundler issue, and our Ruby 2.3 CI image uses [bundler 1.17.3](https://rubygems.org/gems/bundler/versions/1.17.3), the last of the 1.x series.

We had previously locked bundler to 1.x, as some of our 3rd party integrations depended on an older version of rubygems. This doesn't seem to be the case anymore.

This PR upgrades rubygems to 3.3.4 and bundler to 2.3.4, the latest version as of today.