### PR TITLE
Lock protobuf for Ruby < 2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,7 +463,7 @@ job_configuration:
   - &config-2_3
     <<: *filters_all_branches_and_tags
     ruby_version: '2.3'
-    image: marcotc/docker-library:ddtrace_rb_2_3_8
+    image: ivoanjo/docker-library:ddtrace_rb_2_3_8
   - &config-2_4
     <<: *filters_all_branches_and_tags
     ruby_version: '2.4'

--- a/.circleci/images/primary/Dockerfile-2.3.8
+++ b/.circleci/images/primary/Dockerfile-2.3.8
@@ -74,7 +74,8 @@ RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Install RubyGems
 # NOTE: Rubygems 3.0.6 is the last version that seems to work fine in this image AND not drag bundler 2 along.
-# Later versions are either broken or they force the use of bundler 2, which we can't because some of our dependencies don't like it.
+# Later versions are either broken or they force the use of bundler 2, which we can't use because some of our
+# dependencies (e.g. rails 3.0.20) don't like it.
 RUN gem update --system '3.0.6'
 # Ruby 2.3 can support Bundler 2+
 # But hold back to < 2 for now, because some dependencies require it.

--- a/.circleci/images/primary/Dockerfile-2.3.8
+++ b/.circleci/images/primary/Dockerfile-2.3.8
@@ -73,7 +73,12 @@ RUN gem update --system
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Install RubyGems
-RUN gem update --system '3.3.4'
+# NOTE: Rubygems 3.0.6 is the last version that seems to work fine in this image AND not drag bundler 2 along.
+# Later versions are either broken or they force the use of bundler 2, which we can't because some of our dependencies don't like it.
+RUN gem update --system '3.0.6'
+# Ruby 2.3 can support Bundler 2+
+# But hold back to < 2 for now, because some dependencies require it.
+RUN gem install bundler -v '1.17.3'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,13 @@ gem 'opentracing', '>= 0.4.1'
 #       lib/ddtrace/profiling.rb: it breaks for some older rubies in CI without BUNDLE_FORCE_RUBY_PLATFORM=true.
 #       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
 #       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
-gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1'] if RUBY_PLATFORM != 'java'
+if RUBY_PLATFORM != 'java'
+  if RUBY_VERSION >= '2.4.0' # Bundler 1.x fails to recognize that version >= 3.19.2 is not compatible with older rubies
+    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
+  else
+    gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
+  end
+end
 
 # For type checking
 # Sorbet releases almost daily, with new checks introduced that can make a

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - bundle-2.2:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-2.3:
-    image: marcotc/docker-library:ddtrace_rb_2_3_8
+    image: ivoanjo/docker-library:ddtrace_rb_2_3_8
     command: /bin/bash
     depends_on:
       - ddagent


### PR DESCRIPTION
This PR actually fixes the build issue regarding the latest version of protobuf. It reverts the previous attempt at #1821.

The issue is that Bundler 1.x fails to recognize that version >= 3.19.2 of protobu is not compatible with older rubies.

This PR ensures that Ruby < 2.4, which use bundler 1.x in our CI, explicitly depend on protobuf < 3.19.2.