### PR TITLE
Relax version constraint for Ruby HEAD testing

### DIFF
--- a/.github/workflows/test-head.yaml
+++ b/.github/workflows/test-head.yaml
@@ -12,6 +12,10 @@ jobs:
       JRUBY_OPTS: --dev
     steps:
       - uses: actions/checkout@v2
+      # bundler appears to match both prerelease and release rubies when we
+      # want the former only. relax the constraint to allow any version for
+      # head rubies
+      - run: sed -i~ -e '/spec\.required_ruby_version/d' ddtrace.gemspec
       - uses: ruby/setup-ruby@77ca66ce2792fb05b8b204a203328e12593a64f3 # v1.72.1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -12,6 +12,11 @@ jobs:
       SKIP_SIMPLECOV: 1
     steps:
       - uses: actions/checkout@v2
+      # bundler appears to match both prerelease and release rubies when we
+      # want the former only. relax the constraint to allow any version for
+      # head rubies
+      - if: ${{ matrix.ruby == 'head' }}
+        run: sed -i~ -e '/spec\.required_ruby_version/d' ddtrace.gemspec
       - uses: ruby/setup-ruby@f20f1eae726df008313d2e0d78c5e602562a1bcf # v1.86.0
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,8 @@ gem 'pimpmychangelog', '>= 0.1.2'
 gem 'pry'
 if RUBY_PLATFORM != 'java'
   # There's a few incompatibilities between pry/pry-byebug on older Rubies
-  gem 'pry-byebug' if RUBY_VERSION >= '2.6.0' && RUBY_ENGINE != 'truffleruby'
+  # There's also a few temproary incompatibilities with newer rubies
+  gem 'pry-byebug' if RUBY_VERSION >= '2.6.0' && RUBY_ENGINE != 'truffleruby' && RUBY_VERSION < '3.2.0'
   gem 'pry-nav' if RUBY_VERSION < '2.6.0'
   gem 'pry-stack_explorer'
 else


### PR DESCRIPTION
### Problem

```
  Bundler found conflicting requirements for the Ruby version:
    In Gemfile:
      Ruby
  
      ddtrace was resolved to 0.54.1, which depends on
        Ruby (>= 2.1.0, < 3.2)
  
  Ruby (>= 2.1.0, < 3.2), which is required by gem 'ddtrace', is not available in
```

The reason for this version constraint is because `ruby2_keywords` is expected to disappear on 3.2 but the current code relies on it.

### Suggestions by @ivoanjo 

- Disable testing of ruby-head in CI
- Bump maximum Ruby version to 3.3
- Other?

### Opinions by @lloeki 

> Disable testing of ruby-head in CI

Not too fond of this, maybe make it as "allow failure" (if that's not already the case) so as not to block dependent jobs, but GHA is terrible and the UI would mark the whole build as failure even though it's OK (I wish it had a "warning" visual state as in GitLab CI)

> Bump maximum Ruby version to 3.3

I'd be OK with that for CI, I mean it's consistent to allow for the final release version when you also allow for dev/preview. But it's also kind of misleading to customers.

> Other?

Keep it in source control as what it should be for a public release + add a step to the HEAD job that either seds to 3.3 or outright removes the `spec.required_ruby_version` line.

### Cause

Although this version constraint should work ([doc](https://guides.rubygems.org/specification-reference/#required_ruby_version=), tested on 3.1 instead of 3.2 for ease of docker image pulling, but that's largely inconsequential)

```
$ ruby -e 'p Gem::Requirement.new("< 3.1.0").satisfied_by?(Gem.ruby_version)'
true # on 3.1.0-preview1
false # on 3.1.0
```

(for the sake of being thorough, appending .a to the requirement is how you're supposed to exclude prereleases:)

```
$ ruby -e 'p Gem::Requirement.new("< 3.1.0.a").satisfied_by?(Gem.ruby_version)'
false # on both 3.1.0-preview1 and 3.1.0
```

... it appears it does not: currently the following fails on both `3.1.0` and `3.1.0-preview1`, which baffles me.

```
# Gemfile
source 'https://rubygems.org'

gemspec
```

and:

```
# foo.gemspec
Gem::Specification.new do |spec|
  spec.name                  = 'foo'
  spec.version               = '0.0.1'
  spec.required_ruby_version = '< 3.1.0'
  spec.required_rubygems_version = '>= 2.0.0'
  spec.summary = 'foo'
  spec.authors = ['foo']
  spec.files = ['foo.rb']
end
```