### PR TITLE
Fix flaky profiling/validate_benchmarks spec

### DIFF
--- a/benchmarks/profiler_sample_loop.rb
+++ b/benchmarks/profiler_sample_loop.rb
@@ -42,7 +42,7 @@ class ProfilerSampleLoopBenchmark
 
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.001, warmup: 0.001} : {time: 70, warmup: 2}
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 70, warmup: 2}
       x.config(**benchmark_time, suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_sample_loop'))
 
       x.report("stack collector #{ENV['CONFIG']}") do

--- a/benchmarks/profiler_submission.rb
+++ b/benchmarks/profiler_submission.rb
@@ -8,6 +8,7 @@ return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
 require 'benchmark/ips'
 require 'ddtrace'
 require 'pry'
+require 'digest'
 require_relative 'dogstatsd_reporter'
 
 # This benchmark measures the performance of encoding pprofs and trying to submit them
@@ -61,7 +62,7 @@ class ProfilerSubmission
 
   def run_benchmark
     Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.001, warmup: 0.001} : {time: 70, warmup: 2}
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 70, warmup: 2}
       x.config(**benchmark_time, suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_submission_v2'))
 
       x.report("exporter #{ENV['CONFIG']}") do


### PR DESCRIPTION
The intention of the `profiling/validate_benchmarks` spec is to run the profiler benchmarks for a short amount of time as part of our test suite, to make sure they haven't broken.

But we saw some flakiness in these tests (see #1812) due to the benchmark harness failing with

```
/usr/local/bundle/gems/benchmark-ips-2.9.1/lib/benchmark/ips/job.rb:187:in `to_i': Infinity (FloatDomainError)
```

Upon investigation, this was caused by the warm up time being so small that sometimes it did not run, which benchmark-ips didn't like at all -- see https://github.com/evanphx/benchmark-ips/issues/120 .

To fix this, I've disabled the warmup (set it to 0), as we don't really care about warmup on these tests.

I've also noted (in <https://github.com/evanphx/benchmark-ips/issues/120#issuecomment-1006487480>) that benchmark-ips also doesn't like if the test time is too low, so I've bumped it a bit up so that hopefully we'll never trigger that issue either.

Fixes #1812