### PR TITLE
Backport #1829 (Update debase-ruby_core_source dependency, and allow older versions) to 0.x-stable branch

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   #
   # Because we only use this for older Rubies, and we consider it "feature-complete" for those older Rubies,
   # we're pinning it at the latest available version and will manually bump the dependency as needed.
-  spec.add_dependency 'debase-ruby_core_source', '= 0.10.13'
+  spec.add_dependency 'debase-ruby_core_source', '<= 0.10.14'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb']
 end


### PR DESCRIPTION
This commit bumps our dependency on the `debase-ruby_core_source`
(used by profiling) to allow the latest released version.

Additionally, rather than forcing a specific version, I've relaxed
it to allow older versions as well, since customers may have other
gems that depend on older/specific versions of that gem.

See also https://github.com/DataDog/dd-trace-rb/pull/1829