### PR TITLE
Fix CI by adding workaround for upstream msgpack issue on JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,3 +90,6 @@ if RUBY_VERSION >= '2.4.0' && !Gem.win_platform?
   gem 'sorbet', '= 0.5.9120'
   gem 'spoom', '~> 1.1'
 end
+
+# Workaround for 1.4.3 being broken on Java 8, see https://github.com/msgpack/msgpack-ruby/issues/239
+gem 'msgpack', '< 1.4.3' if RUBY_PLATFORM == 'java'


### PR DESCRIPTION
See https://github.com/msgpack/msgpack-ruby/issues/239 for more details.

Example of broken CI run: <https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/5167/workflows/1808cc8b-e055-479c-a50d-f00469b260fb/jobs/193173>