### PR TITLE
Remove impossible Ruby version check

### DIFF
--- a/lib/ddtrace/contrib/patchable.rb
+++ b/lib/ddtrace/contrib/patchable.rb
@@ -49,7 +49,7 @@ module Datadog
         # Is this instrumentation compatible with the available target? (e.g. minimum version met?)
         # @return [Boolean] is the available target compatible with this instrumentation?
         def compatible?
-          available? && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(VERSION::MINIMUM_RUBY_VERSION)
+          available?
         end
 
         # Can the patch for this integration be applied?

--- a/spec/ddtrace/contrib/patchable_spec.rb
+++ b/spec/ddtrace/contrib/patchable_spec.rb
@@ -57,17 +57,7 @@ RSpec.describe Datadog::Contrib::Patchable do
           context 'is true' do
             before { allow(patchable_class).to receive(:available?).and_return(true) }
 
-            context 'and the Ruby version' do
-              context 'is below the minimum' do
-                before { stub_const('RUBY_VERSION', '1.9.3') }
-
-                it { is_expected.to be false }
-              end
-
-              context 'is meets the minimum' do
-                it { is_expected.to be true }
-              end
-            end
+            it { is_expected.to be true }
           end
         end
       end


### PR DESCRIPTION
`ddtrace` can't be correctly installed if `Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(VERSION::MINIMUM_RUBY_VERSION)` fails, thus this condition is impossible in a correctly configured environment.