### PR TITLE
Restore trace debug logging output

### DIFF
--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -425,12 +425,7 @@ module Datadog
       return unless trace && @writer
 
       if Datadog.configuration.diagnostics.debug
-        Datadog.logger.debug { "Writing #{trace.length} spans (enabled: #{@enabled})" }
-
-        if Datadog.logger.debug?
-          str = String.new('')
-          PP.pp(trace.spans, str)
-        end
+        Datadog.logger.debug { "Writing #{trace.length} spans (enabled: #{@enabled})\n#{trace.spans.pretty_inspect}" }
       end
 
       @writer.write(trace)

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -213,6 +213,7 @@ RSpec.describe Datadog::Tracer do
           it 'records span flushing to logger' do
             subject
             expect(Datadog.logger).to have_lazy_debug_logged('Writing 1 span')
+            expect(Datadog.logger).to have_lazy_debug_logged('Name: span.name')
           end
         end
 


### PR DESCRIPTION
We've removed the statement that outputs the contents of `trace.spans` to the user recently by accident.

This PR restores that debug output.

The string format for `trace.spans` remains the same, I've just replaced the call to
```ruby
str = String.new('')
PP.pp(trace.spans, str)
str
```
with
```ruby
trace.spans.pretty_inspect
````
as they perform the same operation: https://github.com/ruby/ruby/blob/59a91f229b17d9664df6ff78d7aa4e13a88cdb63/lib/pp.rb#L617-L619