### PR TITLE
Ensure yield for Tracer.continue_trace!

### DIFF
--- a/lib/ddtrace/tracer.rb
+++ b/lib/ddtrace/tracer.rb
@@ -213,7 +213,9 @@ module Datadog
     # @yield Optional block where this {#continue_trace!} `digest` scope is active.
     #   If no block, the `digest` remains active after {#continue_trace!} returns.
     def continue_trace!(digest, key = nil, &block)
-      return unless digest && digest.is_a?(TraceDigest)
+      # Only accept {TraceDigest} as a digest.
+      # Otherwise, create a new execution context.
+      digest = nil unless digest.is_a?(TraceDigest)
 
       trace = start_trace(continue_from: digest)
       call_context(key).activate!(trace, &block)

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -729,6 +729,26 @@ RSpec.describe Datadog::Tracer do
           )
         end
       end
+
+      context 'and a block' do
+        it do
+          expect { |b| tracer.continue_trace!(digest, &b) }
+            .to yield_control
+        end
+
+        it 'restores the original active trace afterwards' do
+          tracer.continue_trace!(digest)
+          original_trace = tracer.active_trace
+          expect(original_trace).to be_a_kind_of(Datadog::TraceOperation)
+
+          tracer.continue_trace!(digest) do
+            expect(tracer.active_trace).to be_a_kind_of(Datadog::TraceOperation)
+            expect(tracer.active_trace).to_not be original_trace
+          end
+
+          expect(tracer.active_trace).to be original_trace
+        end
+      end
     end
 
     context 'given a TraceDigest' do


### PR DESCRIPTION
Removes the early return of `continue_trace!`, as we'd like for the provided block to always execute, regardless if there was an error in setting up the tracer internal state.