### PR TITLE
Contrib:Fix .default_configuration and .default_configuration_instance method naming

### DIFF
--- a/lib/ddtrace/contrib/action_cable/integration.rb
+++ b/lib/ddtrace/contrib/action_cable/integration.rb
@@ -34,7 +34,7 @@ module Datadog
           !Datadog::Contrib::Rails::Utils.railtie_supported?
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/action_mailer/integration.rb
+++ b/lib/ddtrace/contrib/action_mailer/integration.rb
@@ -33,7 +33,7 @@ module Datadog
           !Datadog::Contrib::Rails::Utils.railtie_supported?
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/action_pack/integration.rb
+++ b/lib/ddtrace/contrib/action_pack/integration.rb
@@ -34,7 +34,7 @@ module Datadog
           !Datadog::Contrib::Rails::Utils.railtie_supported?
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/action_view/integration.rb
+++ b/lib/ddtrace/contrib/action_view/integration.rb
@@ -41,7 +41,7 @@ module Datadog
           !Datadog::Contrib::Rails::Utils.railtie_supported?
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/active_job/integration.rb
+++ b/lib/ddtrace/contrib/active_job/integration.rb
@@ -34,7 +34,7 @@ module Datadog
           !Datadog::Contrib::Rails::Utils.railtie_supported?
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/active_model_serializers/integration.rb
+++ b/lib/ddtrace/contrib/active_model_serializers/integration.rb
@@ -29,7 +29,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/active_record/integration.rb
+++ b/lib/ddtrace/contrib/active_record/integration.rb
@@ -38,7 +38,7 @@ module Datadog
           !Datadog::Contrib::Rails::Utils.railtie_supported?
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/active_support/integration.rb
+++ b/lib/ddtrace/contrib/active_support/integration.rb
@@ -35,7 +35,7 @@ module Datadog
           !Datadog::Contrib::Rails::Utils.railtie_supported?
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/aws/integration.rb
+++ b/lib/ddtrace/contrib/aws/integration.rb
@@ -31,7 +31,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/concurrent_ruby/integration.rb
+++ b/lib/ddtrace/contrib/concurrent_ruby/integration.rb
@@ -27,7 +27,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/dalli/integration.rb
+++ b/lib/ddtrace/contrib/dalli/integration.rb
@@ -27,7 +27,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/delayed_job/integration.rb
+++ b/lib/ddtrace/contrib/delayed_job/integration.rb
@@ -27,7 +27,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/elasticsearch/integration.rb
+++ b/lib/ddtrace/contrib/elasticsearch/integration.rb
@@ -28,7 +28,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/ethon/integration.rb
+++ b/lib/ddtrace/contrib/ethon/integration.rb
@@ -28,7 +28,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/excon/integration.rb
+++ b/lib/ddtrace/contrib/excon/integration.rb
@@ -28,7 +28,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/faraday/integration.rb
+++ b/lib/ddtrace/contrib/faraday/integration.rb
@@ -28,7 +28,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/grape/integration.rb
+++ b/lib/ddtrace/contrib/grape/integration.rb
@@ -28,7 +28,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/graphql/integration.rb
+++ b/lib/ddtrace/contrib/graphql/integration.rb
@@ -28,7 +28,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/grpc/integration.rb
+++ b/lib/ddtrace/contrib/grpc/integration.rb
@@ -27,7 +27,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/http/integration.rb
+++ b/lib/ddtrace/contrib/http/integration.rb
@@ -30,7 +30,7 @@ module Datadog
           !defined?(::Net::HTTP).nil?
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/httpclient/integration.rb
+++ b/lib/ddtrace/contrib/httpclient/integration.rb
@@ -28,7 +28,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/httprb/integration.rb
+++ b/lib/ddtrace/contrib/httprb/integration.rb
@@ -28,7 +28,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/integration.rb
+++ b/lib/ddtrace/contrib/integration.rb
@@ -22,7 +22,7 @@ module Datadog
     #       defined?(::BillingApi::Client) # Check if the target for instrumentation is present.
     #     end
     #
-    #     def default_configuration
+    #     def new_configuration
     #       Settings.new
     #     end
     #

--- a/lib/ddtrace/contrib/kafka/integration.rb
+++ b/lib/ddtrace/contrib/kafka/integration.rb
@@ -28,7 +28,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/lograge/integration.rb
+++ b/lib/ddtrace/contrib/lograge/integration.rb
@@ -34,7 +34,7 @@ module Datadog
           false
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/mongodb/integration.rb
+++ b/lib/ddtrace/contrib/mongodb/integration.rb
@@ -28,7 +28,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/mysql2/integration.rb
+++ b/lib/ddtrace/contrib/mysql2/integration.rb
@@ -27,7 +27,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/presto/integration.rb
+++ b/lib/ddtrace/contrib/presto/integration.rb
@@ -27,7 +27,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/qless/integration.rb
+++ b/lib/ddtrace/contrib/qless/integration.rb
@@ -27,7 +27,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/que/integration.rb
+++ b/lib/ddtrace/contrib/que/integration.rb
@@ -30,7 +30,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/racecar/integration.rb
+++ b/lib/ddtrace/contrib/racecar/integration.rb
@@ -28,7 +28,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/rack/integration.rb
+++ b/lib/ddtrace/contrib/rack/integration.rb
@@ -34,7 +34,7 @@ module Datadog
           !Datadog::Contrib::Rails::Utils.railtie_supported?
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/rails/integration.rb
+++ b/lib/ddtrace/contrib/rails/integration.rb
@@ -33,7 +33,7 @@ module Datadog
           super && !ENV.key?(Ext::ENV_DISABLE)
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/rake/integration.rb
+++ b/lib/ddtrace/contrib/rake/integration.rb
@@ -27,7 +27,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/redis/integration.rb
+++ b/lib/ddtrace/contrib/redis/integration.rb
@@ -27,7 +27,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/resque/integration.rb
+++ b/lib/ddtrace/contrib/resque/integration.rb
@@ -27,7 +27,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/rest_client/integration.rb
+++ b/lib/ddtrace/contrib/rest_client/integration.rb
@@ -27,7 +27,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/semantic_logger/integration.rb
+++ b/lib/ddtrace/contrib/semantic_logger/integration.rb
@@ -36,7 +36,7 @@ module Datadog
           false
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/sequel/integration.rb
+++ b/lib/ddtrace/contrib/sequel/integration.rb
@@ -27,7 +27,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/shoryuken/integration.rb
+++ b/lib/ddtrace/contrib/shoryuken/integration.rb
@@ -28,7 +28,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/sidekiq/integration.rb
+++ b/lib/ddtrace/contrib/sidekiq/integration.rb
@@ -37,7 +37,7 @@ module Datadog
           version >= MINIMUM_SERVER_INTERNAL_TRACING_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/sinatra/integration.rb
+++ b/lib/ddtrace/contrib/sinatra/integration.rb
@@ -27,7 +27,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/sneakers/integration.rb
+++ b/lib/ddtrace/contrib/sneakers/integration.rb
@@ -30,7 +30,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/lib/ddtrace/contrib/sucker_punch/integration.rb
+++ b/lib/ddtrace/contrib/sucker_punch/integration.rb
@@ -27,7 +27,7 @@ module Datadog
           super && version >= MINIMUM_VERSION
         end
 
-        def default_configuration
+        def new_configuration
           Configuration::Settings.new
         end
 

--- a/spec/ddtrace/contrib/configurable_spec.rb
+++ b/spec/ddtrace/contrib/configurable_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe Datadog::Contrib::Configurable do
       subject(:configurable_object) { configurable_class.new }
 
       describe '#default_configuration' do
-        subject(:configuration) { configurable_object.default_configuration }
+        subject(:default_configuration) { configurable_object.default_configuration }
 
         it { is_expected.to be_a_kind_of(Datadog::Contrib::Configuration::Settings) }
 
         it 'defaults to being enabled' do
-          expect(configuration[:enabled]).to be true
+          expect(default_configuration[:enabled]).to be true
         end
       end
 


### PR DESCRIPTION
`lib/ddtrace/contrib/configurable.rb` had a method renaming TODO note, this PR addresses that note.

In sum, previously the `default_configuration` integration method returned a brand new configuration object while `default_configuration_instance` actually returned the default configuration object.

**Breaking changes**

- Changed: The public `Datadog::Contrib::Configurable#default_configuration` method has been renamed to 
`Datadog::Contrib::Configurable#new_configuration` and made protected.
- Changed: The protected `Datadog::Contrib::Configurable#default_configuration_instance` method has been renamed to `Datadog::Contrib::Configurable#default_configuration` and made public.

For custom integrations, rename `default_configuration` to `new_configuration`, if this method is present:

```diff
-def default_configuration
+def new_configuration
   Configuration::Settings.new
 end
```