### PR TITLE
Namespacing: Datadog::Core::Buffer

### DIFF
--- a/lib/datadog/core/buffer/cruby.rb
+++ b/lib/datadog/core/buffer/cruby.rb
@@ -1,0 +1,54 @@
+# typed: true
+require 'datadog/core/buffer/random'
+
+module Datadog
+  module Core
+    module Buffer
+      # Buffer that stores objects, has a maximum size, and
+      # can be safely used concurrently with CRuby.
+      #
+      # Because singular +Array+ operations are thread-safe in CRuby,
+      # we can implement the buffer without an explicit lock,
+      # while making the compromise of allowing the buffer to go
+      # over its maximum limit under extreme circumstances.
+      #
+      # On the following scenario:
+      # * 4.5 million spans/second.
+      # * Pushed into a single CRubyTraceBuffer from 1000 threads.
+      #
+      # This implementation allocates less memory and is faster
+      # than {Datadog::Core::Buffer::ThreadSafe}.
+      #
+      # @see spec/ddtrace/benchmark/buffer_benchmark_spec.rb Buffer benchmarks
+      # @see https://github.com/ruby-concurrency/concurrent-ruby/blob/c1114a0c6891d9634f019f1f9fe58dcae8658964/lib/concurrent-ruby/concurrent/array.rb#L23-L27
+      class CRuby < Random
+        # A very large number to allow us to effectively
+        # drop all items when invoking `slice!(i, FIXNUM_MAX)`.
+        FIXNUM_MAX = (1 << 62) - 1
+
+        # Add a new ``item`` in the local queue. This method doesn't block the execution
+        # even if the buffer is full. In that case, a random item is discarded.
+        def replace!(item)
+          # Ensure buffer stays within +max_size+ items.
+          # This can happen when there's concurrent modification
+          # between a call the check in `full?` and the `add!` call in
+          # `full? ? replace!(item) : add!(item)`.
+          #
+          # We can still have `@items.size > @max_size` for a short period of
+          # time, but we will always try to correct it here.
+          #
+          # `slice!` is performed before `delete_at` & `<<` to avoid always
+          # removing the item that was just inserted.
+          #
+          # DEV: `slice!` with two integer arguments is ~10% faster than
+          # `slice!` with a {Range} argument.
+          @items.slice!(@max_size, FIXNUM_MAX)
+
+          # We should replace a random item with the new one
+          replace_index = rand(@max_size)
+          @items[replace_index] = item
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/buffer/random.rb
+++ b/lib/datadog/core/buffer/random.rb
@@ -1,0 +1,134 @@
+# typed: true
+
+module Datadog
+  module Core
+    module Buffer
+      # Buffer that accumulates items for a consumer.
+      # Consumption can happen from a different thread.
+
+      # Buffer that stores objects. The buffer has a maximum size and when
+      # the buffer is full, a random object is discarded.
+      class Random
+        def initialize(max_size)
+          @max_size = max_size
+          @items = []
+          @closed = false
+        end
+
+        # Add a new ``item`` in the local queue. This method doesn't block the execution
+        # even if the buffer is full.
+        #
+        # When the buffer is full, we try to ensure that we are fairly choosing newly
+        # pushed items by randomly inserting them into the buffer slots. This discards
+        # old items randomly while trying to ensure that recent items are still captured.
+        def push(item)
+          return if closed?
+
+          full? ? replace!(item) : add!(item)
+          item
+        end
+
+        # A bulk push alternative to +#push+. Use this method if
+        # pushing more than one item for efficiency.
+        def concat(items)
+          return if closed?
+
+          # Segment items into underflow and overflow
+          underflow, overflow = overflow_segments(items)
+
+          # Concatenate items do not exceed capacity.
+          add_all!(underflow) unless underflow.nil?
+
+          # Iteratively replace items, to ensure pseudo-random replacement.
+          overflow.each { |item| replace!(item) } unless overflow.nil?
+        end
+
+        # Stored items are returned and the local buffer is reset.
+        def pop
+          drain!
+        end
+
+        # Return the current number of stored items.
+        def length
+          @items.length
+        end
+
+        # Return if the buffer is empty.
+        def empty?
+          @items.empty?
+        end
+
+        # Closes this buffer, preventing further pushing.
+        # Draining is still allowed.
+        def close
+          @closed = true
+        end
+
+        def closed?
+          @closed
+        end
+
+        protected
+
+        # Segment items into two segments: underflow and overflow.
+        # Underflow are items that will fit into buffer.
+        # Overflow are items that will exceed capacity, after underflow is added.
+        # Returns each array, and nil if there is no underflow/overflow.
+        def overflow_segments(items)
+          underflow = nil
+          overflow = nil
+
+          overflow_size = @max_size > 0 ? (@items.length + items.length) - @max_size : 0
+
+          if overflow_size > 0
+            # Items will overflow
+            if overflow_size < items.length
+              # Partial overflow
+              underflow_end_index = items.length - overflow_size - 1
+              underflow = items[0..underflow_end_index]
+              overflow = items[(underflow_end_index + 1)..-1]
+            else
+              # Total overflow
+              overflow = items
+            end
+          else
+            # Items do not exceed capacity.
+            underflow = items
+          end
+
+          [underflow, overflow]
+        end
+
+        def full?
+          @max_size > 0 && @items.length >= @max_size
+        end
+
+        def add_all!(items)
+          @items.concat(items)
+        end
+
+        def add!(item)
+          @items << item
+        end
+
+        def replace!(item)
+          # Choose random item to be replaced
+          replace_index = rand(@items.length)
+
+          # Replace random item
+          discarded_item = @items[replace_index]
+          @items[replace_index] = item
+
+          # Return discarded item
+          discarded_item
+        end
+
+        def drain!
+          items = @items
+          @items = []
+          items
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/buffer/thread_safe.rb
+++ b/lib/datadog/core/buffer/thread_safe.rb
@@ -1,0 +1,57 @@
+# typed: true
+require 'datadog/core/buffer/random'
+
+module Datadog
+  module Core
+    module Buffer
+      # Buffer that stores objects, has a maximum size, and
+      # can be safely used concurrently on any environment.
+      #
+      # This implementation uses a {Mutex} around public methods, incurring
+      # overhead in order to ensure thread-safety.
+      #
+      # This is implementation is recommended for non-CRuby environments.
+      # If using CRuby, {Datadog::Core::Buffer::CRuby} is a faster implementation with minimal compromise.
+      class ThreadSafe < Random
+        def initialize(max_size)
+          super
+
+          @mutex = Mutex.new
+        end
+
+        # Add a new ``item`` in the local queue. This method doesn't block the execution
+        # even if the buffer is full. In that case, a random item is discarded.
+        def push(item)
+          synchronize { super }
+        end
+
+        def concat(items)
+          synchronize { super }
+        end
+
+        # Return the current number of stored items.
+        def length
+          synchronize { super }
+        end
+
+        # Return if the buffer is empty.
+        def empty?
+          synchronize { super }
+        end
+
+        # Stored items are returned and the local buffer is reset.
+        def pop
+          synchronize { super }
+        end
+
+        def close
+          synchronize { super }
+        end
+
+        def synchronize(&block)
+          @mutex.synchronize(&block)
+        end
+      end
+    end
+  end
+end

--- a/lib/ddtrace/buffer.rb
+++ b/lib/ddtrace/buffer.rb
@@ -1,229 +1,11 @@
 # typed: true
+require 'datadog/core/environment/ext'
+require 'datadog/core/buffer/thread_safe'
+require 'datadog/core/buffer/cruby'
+
 require 'ddtrace/diagnostics/health'
 
 module Datadog
-  # Trace buffer that accumulates traces for a consumer.
-  # Consumption can happen from a different thread.
-
-  # Buffer that stores objects. The buffer has a maximum size and when
-  # the buffer is full, a random object is discarded.
-  class Buffer
-    def initialize(max_size)
-      @max_size = max_size
-      @items = []
-      @closed = false
-    end
-
-    # Add a new ``item`` in the local queue. This method doesn't block the execution
-    # even if the buffer is full.
-    #
-    # When the buffer is full, we try to ensure that we are fairly sampling newly
-    # pushed traces by randomly inserting them into the buffer slots. This discards
-    # old traces randomly while trying to ensure that recent traces are still captured.
-    def push(item)
-      return if closed?
-
-      full? ? replace!(item) : add!(item)
-      item
-    end
-
-    # A bulk push alternative to +#push+. Use this method if
-    # pushing more than one item for efficiency.
-    def concat(items)
-      return if closed?
-
-      # Segment items into underflow and overflow
-      underflow, overflow = overflow_segments(items)
-
-      # Concatenate items do not exceed capacity.
-      add_all!(underflow) unless underflow.nil?
-
-      # Iteratively replace items, to ensure pseudo-random replacement.
-      overflow.each { |item| replace!(item) } unless overflow.nil?
-    end
-
-    # Stored items are returned and the local buffer is reset.
-    def pop
-      drain!
-    end
-
-    # Return the current number of stored traces.
-    def length
-      @items.length
-    end
-
-    # Return if the buffer is empty.
-    def empty?
-      @items.empty?
-    end
-
-    # Closes this buffer, preventing further pushing.
-    # Draining is still allowed.
-    def close
-      @closed = true
-    end
-
-    def closed?
-      @closed
-    end
-
-    protected
-
-    # Segment items into two segments: underflow and overflow.
-    # Underflow are items that will fit into buffer.
-    # Overflow are items that will exceed capacity, after underflow is added.
-    # Returns each array, and nil if there is no underflow/overflow.
-    def overflow_segments(items)
-      underflow = nil
-      overflow = nil
-
-      overflow_size = @max_size > 0 ? (@items.length + items.length) - @max_size : 0
-
-      if overflow_size > 0
-        # Items will overflow
-        if overflow_size < items.length
-          # Partial overflow
-          underflow_end_index = items.length - overflow_size - 1
-          underflow = items[0..underflow_end_index]
-          overflow = items[(underflow_end_index + 1)..-1]
-        else
-          # Total overflow
-          overflow = items
-        end
-      else
-        # Items do not exceed capacity.
-        underflow = items
-      end
-
-      [underflow, overflow]
-    end
-
-    def full?
-      @max_size > 0 && @items.length >= @max_size
-    end
-
-    def add_all!(items)
-      @items.concat(items)
-    end
-
-    def add!(item)
-      @items << item
-    end
-
-    def replace!(item)
-      # Choose random item to be replaced
-      replace_index = rand(@items.length)
-
-      # Replace random item
-      discarded_item = @items[replace_index]
-      @items[replace_index] = item
-
-      # Return discarded item
-      discarded_item
-    end
-
-    def drain!
-      items = @items
-      @items = []
-      items
-    end
-  end
-
-  # Buffer that stores objects, has a maximum size, and
-  # can be safely used concurrently on any environment.
-  #
-  # This implementation uses a {Mutex} around public methods, incurring
-  # overhead in order to ensure thread-safety.
-  #
-  # This is implementation is recommended for non-CRuby environments.
-  # If using CRuby, {Datadog::CRubyBuffer} is a faster implementation with minimal compromise.
-  class ThreadSafeBuffer < Buffer
-    def initialize(max_size)
-      super
-
-      @mutex = Mutex.new
-    end
-
-    # Add a new ``item`` in the local queue. This method doesn't block the execution
-    # even if the buffer is full. In that case, a random item is discarded.
-    def push(item)
-      synchronize { super }
-    end
-
-    def concat(items)
-      synchronize { super }
-    end
-
-    # Return the current number of stored traces.
-    def length
-      synchronize { super }
-    end
-
-    # Return if the buffer is empty.
-    def empty?
-      synchronize { super }
-    end
-
-    # Stored traces are returned and the local buffer is reset.
-    def pop
-      synchronize { super }
-    end
-
-    def close
-      synchronize { super }
-    end
-
-    def synchronize(&block)
-      @mutex.synchronize(&block)
-    end
-  end
-
-  # Buffer that stores objects, has a maximum size, and
-  # can be safely used concurrently with CRuby.
-  #
-  # Because singular +Array+ operations are thread-safe in CRuby,
-  # we can implement the trace buffer without an explicit lock,
-  # while making the compromise of allowing the buffer to go
-  # over its maximum limit under extreme circumstances.
-  #
-  # On the following scenario:
-  # * 4.5 million spans/second.
-  # * Pushed into a single CRubyTraceBuffer from 1000 threads.
-  #
-  # This implementation allocates less memory and is faster
-  # than {Datadog::ThreadSafeBuffer}.
-  #
-  # @see spec/ddtrace/benchmark/buffer_benchmark_spec.rb Buffer benchmarks
-  # @see https://github.com/ruby-concurrency/concurrent-ruby/blob/c1114a0c6891d9634f019f1f9fe58dcae8658964/lib/concurrent-ruby/concurrent/array.rb#L23-L27
-  class CRubyBuffer < Buffer
-    # A very large number to allow us to effectively
-    # drop all items when invoking `slice!(i, FIXNUM_MAX)`.
-    FIXNUM_MAX = (1 << 62) - 1
-
-    # Add a new ``trace`` in the local queue. This method doesn't block the execution
-    # even if the buffer is full. In that case, a random trace is discarded.
-    def replace!(item)
-      # Ensure buffer stays within +max_size+ items.
-      # This can happen when there's concurrent modification
-      # between a call the check in `full?` and the `add!` call in
-      # `full? ? replace!(item) : add!(item)`.
-      #
-      # We can still have `@items.size > @max_size` for a short period of
-      # time, but we will always try to correct it here.
-      #
-      # `slice!` is performed before `delete_at` & `<<` to avoid always
-      # removing the item that was just inserted.
-      #
-      # DEV: `slice!` with two integer arguments is ~10% faster than
-      # `slice!` with a {Range} argument.
-      @items.slice!(@max_size, FIXNUM_MAX)
-
-      # We should replace a random trace with the new one
-      replace_index = rand(@max_size)
-      @items[replace_index] = item
-    end
-  end
-
   # Health metrics for trace buffers.
   module MeasuredBuffer
     include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
@@ -313,7 +95,7 @@ module Datadog
   # can be safely used concurrently on any environment.
   #
   # @see Datadog::ThreadSafeBuffer
-  class ThreadSafeTraceBuffer < ThreadSafeBuffer
+  class ThreadSafeTraceBuffer < Datadog::Core::Buffer::ThreadSafe
     prepend MeasuredBuffer
   end
 
@@ -321,7 +103,7 @@ module Datadog
   # can be safely used concurrently with CRuby.
   #
   # @see Datadog::CRubyBuffer
-  class CRubyTraceBuffer < CRubyBuffer
+  class CRubyTraceBuffer < Datadog::Core::Buffer::CRuby
     prepend MeasuredBuffer
   end
 

--- a/lib/ddtrace/profiling/buffer.rb
+++ b/lib/ddtrace/profiling/buffer.rb
@@ -1,13 +1,13 @@
 # typed: true
 require 'datadog/core/utils/string_table'
 require 'datadog/core/utils/object_set'
-require 'ddtrace/buffer'
+require 'datadog/core/buffer/thread_safe'
 
 module Datadog
   module Profiling
     # Profiling buffer that stores profiling events. The buffer has a maximum size and when
     # the buffer is full, a random event is discarded. This class is thread-safe.
-    class Buffer < Datadog::ThreadSafeBuffer
+    class Buffer < Datadog::Core::Buffer::ThreadSafe
       def initialize(*args)
         super
         @caches = {}

--- a/spec/datadog/core/buffer/cruby_spec.rb
+++ b/spec/datadog/core/buffer/cruby_spec.rb
@@ -1,0 +1,12 @@
+# typed: false
+require 'spec_helper'
+require 'datadog/core/buffer/shared_examples'
+
+require 'datadog/core/buffer/cruby'
+
+RSpec.describe Datadog::Core::Buffer::CRuby do
+  before { skip unless PlatformHelpers.mri? }
+
+  it_behaves_like 'thread-safe buffer'
+  it_behaves_like 'performance'
+end

--- a/spec/datadog/core/buffer/random_spec.rb
+++ b/spec/datadog/core/buffer/random_spec.rb
@@ -1,0 +1,288 @@
+# typed: false
+require 'spec_helper'
+
+require 'benchmark'
+require 'datadog/core/buffer/random'
+
+RSpec.describe Datadog::Core::Buffer::Random do
+  subject(:buffer) { described_class.new(max_size) }
+
+  let(:max_size) { 0 }
+
+  def get_test_items(n = 1)
+    Array.new(n) { Object.new }
+  end
+
+  describe '#initialize' do
+    it { is_expected.to be_a_kind_of(described_class) }
+  end
+
+  describe '#push' do
+    let(:output) { buffer.pop }
+
+    context 'given no limit' do
+      let(:items) { get_test_items(4) }
+      let(:max_size) { 0 }
+
+      it 'retains all items' do
+        items.each { |t| buffer.push(t) }
+        expect(output.length).to eq(4)
+      end
+    end
+
+    context 'given a max size' do
+      let(:items) { get_test_items(max_size + 1) }
+      let(:max_size) { 3 }
+
+      it 'does not exceed it' do
+        items.each { |t| buffer.push(t) }
+
+        expect(output.length).to eq(max_size)
+        expect(output).to include(items.last)
+      end
+    end
+
+    context 'when closed' do
+      let(:max_size) { 0 }
+      let(:items) { get_test_items(6) }
+
+      let(:output) { buffer.pop }
+
+      it 'retains items up to close' do
+        items.first(4).each { |t| buffer.push(t) }
+        buffer.close
+        items.last(2).each { |t| buffer.push(t) }
+
+        expect(output.length).to eq(4)
+        expect(output).to_not include(*items.last(2))
+      end
+    end
+  end
+
+  describe '#concat' do
+    let(:output) { buffer.pop }
+
+    context 'given no limit' do
+      let(:items) { get_test_items(4) }
+      let(:max_size) { 0 }
+
+      it 'retains all items' do
+        buffer.concat(items)
+        expect(output.length).to eq(4)
+      end
+    end
+
+    context 'given a max size' do
+      let(:items) { get_test_items(max_size + 1) }
+      let(:max_size) { 3 }
+
+      it 'does not exceed it' do
+        buffer.concat(items)
+
+        expect(output.length).to eq(max_size)
+        expect(output).to include(items.last)
+      end
+    end
+
+    context 'when closed' do
+      let(:max_size) { 0 }
+      let(:items) { get_test_items(6) }
+
+      let(:output) { buffer.pop }
+
+      it 'retains items up to close' do
+        buffer.concat(items[0..3])
+        buffer.close
+        buffer.concat(items[4..5])
+
+        expect(output.length).to eq(4)
+        expect(output).to_not include(*items.last(2))
+      end
+    end
+  end
+
+  describe '#length' do
+    subject(:length) { buffer.length }
+
+    context 'given no items' do
+      it { is_expected.to eq(0) }
+    end
+
+    context 'given an item' do
+      before { buffer.push([1]) }
+
+      it { is_expected.to eq(1) }
+    end
+  end
+
+  describe '#empty?' do
+    subject(:empty?) { buffer.empty? }
+
+    context 'given no items' do
+      it { is_expected.to be true }
+    end
+
+    context 'given an item' do
+      before { buffer.push([1]) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#pop' do
+    subject(:pop) { buffer.pop }
+
+    let(:items) { get_test_items(2) }
+
+    before do
+      items.each { |t| buffer.push(t) }
+    end
+
+    it do
+      expect(pop.length).to eq(items.length)
+      expect(pop).to include(*items)
+      expect(buffer.empty?).to be true
+    end
+  end
+
+  describe '#close' do
+    subject(:close) { buffer.close }
+
+    it do
+      expect { close }
+        .to change { buffer.closed? }
+        .from(false)
+        .to(true)
+    end
+  end
+
+  describe '#closed?' do
+    subject(:closed?) { buffer.closed? }
+
+    context 'when the buffer has not been closed' do
+      it { is_expected.to be false }
+    end
+
+    context 'when the buffer is closed' do
+      before { buffer.close }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  # :nocov:
+  describe 'performance' do
+    require 'benchmark'
+    let(:n) { 10_000 }
+    let(:test_item_count) { 20 }
+
+    before { skip('Performance test does not run in CI.') }
+
+    context 'no max_size' do
+      it do
+        Benchmark.bmbm do |x|
+          x.report('No max #push') do
+            n.times do
+              buffer = described_class.new(max_size)
+              items = get_test_items(test_item_count)
+
+              items.each { |item| buffer.push(item) }
+            end
+          end
+
+          x.report('No max #concat') do
+            n.times do
+              buffer = described_class.new(max_size)
+              items = get_test_items(test_item_count)
+
+              buffer.concat(items)
+            end
+          end
+        end
+      end
+    end
+
+    context 'max size' do
+      let(:max_size) { 20 }
+
+      context 'no overflow' do
+        let(:test_item_count) { max_size }
+
+        it do
+          Benchmark.bmbm do |x|
+            x.report('Max no overflow #push') do
+              n.times do
+                buffer = described_class.new(max_size)
+                items = get_test_items(test_item_count)
+
+                items.each { |item| buffer.push(item) }
+              end
+            end
+
+            x.report('Max no overflow #concat') do
+              n.times do
+                buffer = described_class.new(max_size)
+                items = get_test_items(test_item_count)
+
+                buffer.concat(items)
+              end
+            end
+          end
+        end
+      end
+
+      context 'partial overflow' do
+        let(:test_item_count) { max_size + super() }
+
+        it do
+          Benchmark.bmbm do |x|
+            x.report('Max partial overflow #push') do
+              n.times do
+                buffer = described_class.new(max_size)
+                items = get_test_items(test_item_count)
+
+                items.each { |item| buffer.push(item) }
+              end
+            end
+
+            x.report('Max partial overflow #concat') do
+              n.times do
+                buffer = described_class.new(max_size)
+                items = get_test_items(test_item_count)
+
+                buffer.concat(items)
+              end
+            end
+          end
+        end
+      end
+
+      context 'total overflow' do
+        it do
+          Benchmark.bmbm do |x|
+            x.report('Max total overflow #push') do
+              n.times do
+                buffer = described_class.new(max_size)
+                buffer.instance_variable_set(:@items, get_test_items(max_size))
+                items = get_test_items(test_item_count)
+
+                items.each { |item| buffer.push(item) }
+              end
+            end
+
+            x.report('Max total overflow #concat') do
+              n.times do
+                buffer = described_class.new(max_size)
+                buffer.instance_variable_set(:@items, get_test_items(max_size))
+                items = get_test_items(test_item_count)
+
+                buffer.concat(items)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+  # :nocov:
+end

--- a/spec/datadog/core/buffer/shared_examples.rb
+++ b/spec/datadog/core/buffer/shared_examples.rb
@@ -1,33 +1,14 @@
 # typed: false
 require 'spec_helper'
 
-require 'ddtrace'
-require 'ddtrace/buffer'
-
 require 'benchmark'
 require 'concurrent'
-
-RSpec.describe Datadog::TraceBuffer do
-  subject(:buffer_class) { described_class }
-
-  context 'with CRuby' do
-    before { skip unless PlatformHelpers.mri? }
-
-    it { is_expected.to eq Datadog::CRubyTraceBuffer }
-  end
-
-  context 'with JRuby' do
-    before { skip unless PlatformHelpers.jruby? }
-
-    it { is_expected.to eq Datadog::ThreadSafeTraceBuffer }
-  end
-end
 
 RSpec.shared_examples 'thread-safe buffer' do
   subject(:buffer) { described_class.new(max_size) }
 
   let(:max_size) { 0 }
-  let(:items) { defined?(super) ? super() : Array.new(items_count) { double('item') } }
+  let(:items) { defined?(super) ? super() : Array.new(items_count) { Object.new } }
   let(:items_count) { 10 }
 
   describe '#push' do
@@ -46,9 +27,6 @@ RSpec.shared_examples 'thread-safe buffer' do
         end
       end
     end
-    let(:output) { buffer.pop }
-
-    let(:push) { wait_for_threads }
 
     subject(:push) { threads.each(&:join) }
 
@@ -123,7 +101,6 @@ RSpec.shared_examples 'thread-safe buffer' do
         end
       end
     end
-    let(:output) { buffer.pop }
 
     subject(:concat) { wait_for_threads }
 
@@ -185,135 +162,13 @@ RSpec.shared_examples 'thread-safe buffer' do
   describe '#pop' do
     subject(:pop) { buffer.pop }
 
-    let(:traces) { get_test_traces(2) }
+    let(:items) { Array.new(2) { Object.new } }
 
     before do
-      traces.each { |t| buffer.push(t) }
-    end
-  end
-end
-
-RSpec.shared_examples 'trace buffer' do
-  include_context 'health metrics'
-
-  subject(:buffer) { described_class.new(max_size) }
-
-  let(:max_size) { 0 }
-
-  def measure_traces_size(traces)
-    traces.inject(ObjectSpaceHelper.estimate_bytesize(traces)) do |sum, trace|
-      sum + measure_trace_size(trace)
-    end
-  end
-
-  def measure_trace_size(trace)
-    trace.inject(ObjectSpaceHelper.estimate_bytesize(trace)) do |sum, span|
-      sum + ObjectSpaceHelper.estimate_bytesize(span)
-    end
-  end
-
-  describe '#initialize' do
-    it { is_expected.to be_a_kind_of(described_class) }
-  end
-
-  describe '#push' do
-    subject(:push) { items.each { |t| buffer.push(t) } }
-
-    let(:items_count) { max_size + 1 }
-    let(:pop) { buffer.pop }
-
-    context 'given a max size' do
-      let(:max_size) { 3 }
-
-      it 'records health metrics' do
-        push
-
-        accepted_spans = items.inject(0) { |sum, t| sum + t.length }
-
-        # A trace will be dropped at random, except the trace
-        # that triggered the overflow.
-        dropped_traces = items.reject { |t| pop.include?(t) }
-
-        expected_traces = items - dropped_traces
-        net_spans = expected_traces.inject(0) { |sum, t| sum + t.length }
-
-        # Calling #pop produces metrics:
-        # Accept events for every #push, and one drop event for overflow
-        expect(health_metrics).to have_received(:queue_accepted)
-          .with(items.length)
-        expect(health_metrics).to have_received(:queue_accepted_lengths)
-          .with(accepted_spans)
-
-        expect(health_metrics).to have_received(:queue_dropped)
-          .with(dropped_traces.length)
-
-        # Metrics for queue gauges.
-        expect(health_metrics).to have_received(:queue_max_length)
-          .with(max_size)
-        expect(health_metrics).to have_received(:queue_spans)
-          .with(net_spans)
-        expect(health_metrics).to have_received(:queue_length)
-          .with(max_size)
-      end
-    end
-  end
-
-  describe '#concat' do
-    let(:output) { buffer.pop }
-
-    context 'given no limit' do
-      let(:items) { get_test_traces(4) }
-      let(:max_size) { 0 }
-
-      it 'retains all items' do
-        buffer.concat(items)
-        expect(output.length).to eq(4)
-      end
+      items.each { |i| buffer.push(i) }
     end
 
-    context 'given a max size' do
-      let(:items) { get_test_traces(max_size + 1) }
-      let(:max_size) { 3 }
-
-      it 'does not exceed it' do
-        buffer.concat(items)
-
-        expect(output.length).to eq(max_size)
-        expect(output).to include(items.last)
-      end
-    end
-  end
-
-  describe '#pop' do
-    subject(:pop) { buffer.pop }
-
-    let(:traces) { get_test_traces(2) }
-
-    before { traces.each { |t| buffer.push(t) } }
-
-    it 'records health metrics' do
-      pop
-
-      expected_spans = traces.inject(0) { |sum, t| sum + t.length }
-
-      # Calling #pop produces metrics:
-      # Metrics for accept events and one drop event
-      expect(health_metrics).to have_received(:queue_accepted)
-        .with(traces.length)
-      expect(health_metrics).to have_received(:queue_accepted_lengths)
-        .with(expected_spans)
-
-      expect(health_metrics).to have_received(:queue_dropped)
-        .with(0)
-
-      # Metrics for queue gauges.
-      expect(health_metrics).to have_received(:queue_max_length)
-        .with(max_size)
-      expect(health_metrics).to have_received(:queue_spans)
-        .with(expected_spans)
-      expect(health_metrics).to have_received(:queue_length)
-        .with(traces.length)
-    end
+    it { is_expected.to eq(items) }
   end
 end
 
@@ -328,7 +183,7 @@ RSpec.shared_examples 'performance' do
   let(:test_item_count) { 20 }
 
   def get_test_items(n = 1)
-    Array.new(n) { double('item') }
+    Array.new(n) { Object.new }
   end
 
   before { skip('Performance test does not run in CI.') }
@@ -440,21 +295,3 @@ RSpec.shared_examples 'performance' do
   end
 end
 # :nocov:
-
-RSpec.describe Datadog::ThreadSafeTraceBuffer do
-  let(:items) { get_test_traces(items_count) }
-
-  it_behaves_like 'trace buffer'
-  it_behaves_like 'thread-safe buffer'
-  it_behaves_like 'performance'
-end
-
-RSpec.describe Datadog::CRubyTraceBuffer do
-  before { skip unless PlatformHelpers.mri? }
-
-  let(:items) { get_test_traces(items_count) }
-
-  it_behaves_like 'trace buffer'
-  it_behaves_like 'thread-safe buffer'
-  it_behaves_like 'performance'
-end

--- a/spec/datadog/core/buffer/thread_safe_spec.rb
+++ b/spec/datadog/core/buffer/thread_safe_spec.rb
@@ -1,0 +1,10 @@
+# typed: false
+require 'spec_helper'
+require 'datadog/core/buffer/shared_examples'
+
+require 'datadog/core/buffer/thread_safe'
+
+RSpec.describe Datadog::Core::Buffer::ThreadSafe do
+  it_behaves_like 'thread-safe buffer'
+  it_behaves_like 'performance'
+end

--- a/spec/ddtrace/profiling/buffer_spec.rb
+++ b/spec/ddtrace/profiling/buffer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Datadog::Profiling::Buffer do
 
   let(:max_size) { 0 }
 
-  it { is_expected.to be_a_kind_of(Datadog::ThreadSafeBuffer) }
+  it { is_expected.to be_a_kind_of(Datadog::Core::Buffer::ThreadSafe) }
 
   describe '#cache' do
     subject(:cache) { buffer.cache(name) }


### PR DESCRIPTION
This pull request moves some `Buffer` classes to `Datadog::Core::Buffer`.

### Related PRs

It's part of a series of `Core` namespacing PRs derived from `refactor/core-namespacing`:

1. #1847
2. #1848
3. #1850 
4. #1851
5. #1852 
6. #1853 
7. #1854 
8. #1855 
9. **=> Namespacing: Datadog::Core::Buffer**
10. #1857
11. #1858
12. #1859 
13. #1860 
14. #1861 
15. #1862