### PR TITLE
Fix manual traces not deactivating

### DIFF
--- a/lib/ddtrace/configuration/settings.rb
+++ b/lib/ddtrace/configuration/settings.rb
@@ -14,7 +14,6 @@ module Datadog
     # Global configuration settings for the trace library.
     # @public_api
     # rubocop:disable Metrics/ClassLength
-    # rubocop:disable Metrics/BlockLength
     class Settings
       include Base
 

--- a/spec/ddtrace/tracer_integration_spec.rb
+++ b/spec/ddtrace/tracer_integration_spec.rb
@@ -201,6 +201,42 @@ RSpec.describe Datadog::Tracer do
         )
       end
     end
+
+    context 'that continues from another trace' do
+      context 'without a block' do
+        before do
+          tracer.continue_trace!(digest)
+          tracer.trace('my.job').finish
+        end
+
+        context 'with state' do
+          let(:digest) do
+            Datadog::TraceDigest.new(
+              span_id: Datadog::Utils.next_id,
+              trace_id: Datadog::Utils.next_id,
+              trace_origin: 'synthetics',
+              trace_sampling_priority: Datadog::Ext::Priority::USER_KEEP
+            )
+          end
+
+          it 'clears the active trace after finishing' do
+            expect(spans).to have(1).item
+            expect(span.name).to eq('my.job')
+            expect(tracer.active_trace).to be nil
+          end
+        end
+
+        context 'without state' do
+          let(:digest) { nil }
+
+          it 'clears the active trace after finishing' do
+            expect(spans).to have(1).item
+            expect(span.name).to eq('my.job')
+            expect(tracer.active_trace).to be nil
+          end
+        end
+      end
+    end
   end
 
   describe 'synthetics' do

--- a/spec/ddtrace/tracer_spec.rb
+++ b/spec/ddtrace/tracer_spec.rb
@@ -729,6 +729,8 @@ RSpec.describe Datadog::Tracer do
             trace_id: a_kind_of(Integer)
           )
         end
+
+        expect(tracer.active_trace).to be nil
       end
 
       context 'and a block' do
@@ -776,12 +778,16 @@ RSpec.describe Datadog::Tracer do
             trace_id: digest.trace_id
           )
         end
+
+        expect(tracer.active_trace).to be nil
       end
 
       it 'is consumed by the next trace and isn\'t reused' do
         tracer.trace('first') do |span, trace|
           # Should consume the continuation
         end
+
+        expect(tracer.active_trace).to be nil
 
         tracer.trace('second') do |span, trace|
           expect(trace).to have_attributes(
@@ -792,6 +798,8 @@ RSpec.describe Datadog::Tracer do
           expect(span.trace_id).to_not eq(digest.trace_id)
           expect(span.parent_id).to eq(0)
         end
+
+        expect(tracer.active_trace).to be nil
       end
 
       context 'and a block' do


### PR DESCRIPTION
Fixes a problem introduced by #1844

### Issue

When a manual trace is preceded by `Datadog::Tracing.continue_from!`, the trace won't deactivate after finishing:

```ruby
# Typical behavior when continuing a distributed trace
trace_digest = HTTPPropagator.extract(env)
Datadog::Tracing.continue_from!(trace_digest)

# Start a manual trace
span = Datadog::Tracing.trace('http.request')
# ...
span.finish

# No trace should be active
# ...but there still is.
Datadog::Tracing.active_span
# => #<Datadog::TraceOperation:0x00005589840a82d8 @active_span=nil, @finished=true, ...>
```

### Explanation

This is because in `Tracer#manual_trace_activation!`, it has the following line:

```ruby
# Skip this, if it would have no effect.
return if original_trace == trace
```

This safeguard, is meant to prevent deactivation events from being overridden, and trace being reactivated unnecessarily. However because `Tracer#continue_trace!` in this example creates and activates a trace before the span is created, this `manual_trace_activation!` function thinks adding the deactivation event and activating the event is superfluous. Although this is true of the activation, it's not true of the deactivation event and it never subscribes as it should.

### Solution

Two possible ways of dealing with this:

1. Change the checking behavior in `manual_trace_activation!`: skip `activate!` if it's the same trace (as before), but only skip the deactivation event if it hasn't already been set.
2. Change `continue_trace!` to subscribe a deactivation event for the trace it creates if no block is given (because without a block it won't auto restore the previous state.)