### PR TITLE
Clean up tracer instance spec

### DIFF
--- a/spec/ddtrace/contrib/sinatra/tracer_spec.rb
+++ b/spec/ddtrace/contrib/sinatra/tracer_spec.rb
@@ -398,7 +398,7 @@ RSpec.describe 'Sinatra instrumentation' do
     context 'when the tracer is disabled' do
       subject(:response) { get '/' }
 
-      let(:tracer) { get_test_tracer(enabled: false) }
+      let(:tracer) { new_tracer(enabled: false) }
 
       it do
         is_expected.to be_ok

--- a/spec/ddtrace/integration_spec.rb
+++ b/spec/ddtrace/integration_spec.rb
@@ -337,8 +337,6 @@ RSpec.describe 'Tracer integration tests' do
 
   describe 'sampling priority metrics' do
     # Sampling priority is enabled by default
-    let(:tracer) { get_test_tracer }
-
     context 'when #sampling_priority is set on a child span' do
       before do
         tracer.trace('parent span') do |_parent_span, _parent_trace|
@@ -356,8 +354,6 @@ RSpec.describe 'Tracer integration tests' do
 
   describe 'origin tag' do
     # Sampling priority is enabled by default
-    let(:tracer) { get_test_tracer }
-
     context 'when #sampling_priority is set on a parent span' do
       before do
         tracer.trace('parent span') do |_span, trace|

--- a/spec/ddtrace/propagation/http_propagator_spec.rb
+++ b/spec/ddtrace/propagation/http_propagator_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe Datadog::HTTPPropagator do
     without_warnings { Datadog::Tracing.configuration.reset! }
   end
 
-  let(:tracer) { get_test_tracer }
-
   describe '::inject!' do
     let(:env) { { 'something' => 'alien' } }
 

--- a/spec/support/tracer_helpers.rb
+++ b/spec/support/tracer_helpers.rb
@@ -3,7 +3,6 @@ require 'ddtrace/tracer'
 require 'ddtrace/span'
 require 'support/faux_writer'
 
-# rubocop:disable Metrics/ModuleLength
 module TracerHelpers
   # Return a test tracer instance with a faux writer.
   def tracer
@@ -18,77 +17,7 @@ module TracerHelpers
     )
 
     options = { writer: writer }.merge(options)
-    Datadog::Tracer.new(**options).tap do |tracer|
-      # TODO: Let's try to get rid of this override, which has too much
-      #       knowledge about the internal workings of the tracer.
-      #       It is done to prevent the activation of priority sampling
-      #       from wiping out the configured test writer, by replacing it.
-      tracer.define_singleton_method(:configure) do |opts = {}|
-        super(opts)
-
-        # Re-configure the tracer with a new test writer
-        # since priority sampling will wipe out the old test writer.
-        unless @writer.is_a?(FauxWriter)
-          @writer = if @sampler.is_a?(Datadog::PrioritySampler)
-                      FauxWriter.new(
-                        priority_sampler: @sampler,
-                        transport: Datadog::Transport::HTTP.default do |t|
-                          t.adapter :test
-                        end
-                      )
-                    else
-                      FauxWriter.new(
-                        transport: Datadog::Transport::HTTP.default do |t|
-                          t.adapter :test
-                        end
-                      )
-                    end
-
-          statsd = opts.fetch(:statsd, nil)
-          @writer.runtime_metrics.statsd = statsd unless statsd.nil?
-        end
-      end
-    end
-  end
-
-  # TODO: Replace references to `get_test_tracer` with `tracer`.
-  # TODO: Use `new_tracer` instead if custom options are provided.
-  alias get_test_tracer new_tracer
-
-  # Return a test tracer instance with a faux writer.
-  def get_test_tracer_with_old_transport(options = {})
-    options = { writer: FauxWriter.new }.merge(options)
-    Datadog::Tracer.new(**options).tap do |tracer|
-      # TODO: Let's try to get rid of this override, which has too much
-      #       knowledge about the internal workings of the tracer.
-      #       It is done to prevent the activation of priority sampling
-      #       from wiping out the configured test writer, by replacing it.
-      tracer.define_singleton_method(:configure) do |opts = {}|
-        super(opts)
-
-        # Re-configure the tracer with a new test writer
-        # since priority sampling will wipe out the old test writer.
-        unless @writer.is_a?(FauxWriter)
-          @writer = if @sampler.is_a?(Datadog::PrioritySampler)
-                      FauxWriter.new(priority_sampler: @sampler)
-                    else
-                      FauxWriter.new
-                    end
-
-          hostname = opts.fetch(:hostname, nil)
-          port = opts.fetch(:port, nil)
-
-          @writer.transport.hostname = hostname unless hostname.nil?
-          @writer.transport.port = port unless port.nil?
-
-          statsd = opts.fetch(:statsd, nil)
-          unless statsd.nil?
-            @writer.statsd = statsd
-            @writer.transport.statsd = statsd
-          end
-        end
-      end
-    end
+    Datadog::Tracer.new(**options)
   end
 
   def get_test_writer(options = {})


### PR DESCRIPTION
This PR performs a few tracer RSpec cleanups:
1. Remove `alias get_test_tracer new_tracer`.
2. Remove unused `get_test_tracer_with_old_transport`.
3. Remove `tracer#configure` mocking, unnecessary after #1753.