### PR TITLE
Rename "type" field to "kind" in profiling code provenance metadata, rebased on top of 1.0 branch

### DIFF
--- a/lib/datadog/profiling/collectors/code_provenance.rb
+++ b/lib/datadog/profiling/collectors/code_provenance.rb
@@ -22,7 +22,7 @@ module Datadog
 
           record_library(
             Library.new(
-              type: 'standard library',
+              kind: 'standard library',
               name: 'stdlib',
               version: RUBY_VERSION,
               path: standard_library_path,
@@ -79,7 +79,7 @@ module Datadog
           loaded_specs.each do |spec|
             next if libraries_by_name.key?(spec.name)
 
-            record_library(Library.new(type: 'library', name: spec.name, version: spec.version, path: spec.gem_dir))
+            record_library(Library.new(kind: 'library', name: spec.name, version: spec.version, path: spec.gem_dir))
             recorded_library = true
           end
 
@@ -97,14 +97,14 @@ module Datadog
           end
         end
 
-        Library = Struct.new(:type, :name, :version, :path) do
-          def initialize(type:, name:, version:, path:)
-            super(type.freeze, name.dup.freeze, version.to_s.dup.freeze, path.dup.freeze)
+        Library = Struct.new(:kind, :name, :version, :path) do
+          def initialize(kind:, name:, version:, path:)
+            super(kind.freeze, name.dup.freeze, version.to_s.dup.freeze, path.dup.freeze)
             freeze
           end
 
           def to_json(*args)
-            { type: type, name: name, version: version, paths: [path] }.to_json(*args)
+            { kind: kind, name: name, version: version, paths: [path] }.to_json(*args)
           end
         end
       end

--- a/spec/datadog/profiling/collectors/code_provenance_spec.rb
+++ b/spec/datadog/profiling/collectors/code_provenance_spec.rb
@@ -14,19 +14,19 @@ RSpec.describe Datadog::Profiling::Collectors::CodeProvenance do
 
       expect(code_provenance.generate).to include(
         have_attributes(
-          type: 'standard library',
+          kind: 'standard library',
           name: 'stdlib',
           version: RUBY_VERSION.to_s,
           path: start_with('/'),
         ),
         have_attributes(
-          type: 'library',
+          kind: 'library',
           name: 'ddtrace',
           version: Datadog::VERSION::STRING,
           path: start_with('/'),
         ),
         have_attributes(
-          type: 'library',
+          kind: 'library',
           name: 'rspec-core',
           version: start_with('3.'), # This will one day need to be bumped for RSpec 4
           path: start_with('/'),
@@ -67,7 +67,7 @@ RSpec.describe Datadog::Profiling::Collectors::CodeProvenance do
         name: 'is_loaded',
         version: 'is_loaded_version',
         path: '/is_loaded/',
-        type: 'library',
+        kind: 'library',
       )
     end
 
@@ -125,13 +125,13 @@ RSpec.describe Datadog::Profiling::Collectors::CodeProvenance do
                             {
                                 "type": "object",
                                 "required": [
-                                    "type",
+                                    "kind",
                                     "name",
                                     "version",
                                     "paths"
                                 ],
                                 "properties": {
-                                    "type": {
+                                    "kind": {
                                         "type": "string"
                                     },
                                     "name": {
@@ -167,19 +167,19 @@ RSpec.describe Datadog::Profiling::Collectors::CodeProvenance do
       expect(JSON.parse(code_provenance.generate_json).fetch('v1')).to include(
         hash_including(
           'name' => 'stdlib',
-          'type' => 'standard library',
+          'kind' => 'standard library',
           'version' => RUBY_VERSION.to_s,
           'paths' => include(start_with('/')),
         ),
         hash_including(
           'name' => 'ddtrace',
-          'type' => 'library',
+          'kind' => 'library',
           'version' => Datadog::VERSION::STRING,
           'paths' => include(start_with('/')),
         ),
         hash_including(
           'name' => 'rspec-core',
-          'type' => 'library',
+          'kind' => 'library',
           'version' => start_with('3.'), # This will one day need to be bumped for RSpec 4
           'paths' => include(start_with('/')),
         )

--- a/spec/datadog/profiling/transport/http/adapters/net_integration_spec.rb
+++ b/spec/datadog/profiling/transport/http/adapters/net_integration_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe 'Adapters::Net profiling integration tests' do
           )
 
           expect(code_provenance_data)
-            .to include('v1' => array_including(hash_including('type' => 'library', 'name' => 'ddtrace')))
+            .to include('v1' => array_including(hash_including('kind' => 'library', 'name' => 'ddtrace')))
         end
       end
     end


### PR DESCRIPTION
This is the same as #1880, but on top of the 1.0 branch. I'm not sure which one we'll want to merge, so I just created both of them.