### PR TITLE
Core:Fix HTTP header normalization when used as tag

### DIFF
--- a/lib/datadog/tracing/metadata/ext.rb
+++ b/lib/datadog/tracing/metadata/ext.rb
@@ -1,4 +1,6 @@
 # typed: true
+# frozen_string_literal: true
+
 module Datadog
   module Tracing
     module Metadata
@@ -65,8 +67,31 @@ module Datadog
           module Headers
             module_function
 
+            INVALID_TAG_CHARACTERS = %r{[^a-z0-9_\-:\./]}.freeze
+
+            # Normalizes an HTTP header string into a valid tag string.
             def to_tag(name)
-              name.to_s.downcase.gsub(/[-\s]/, '_')
+              # Tag normalization based on: https://docs.datadoghq.com/tagging/#defining-tags.
+              #
+              # Only the following characters are accepted.
+              #  * Alphanumerics
+              #  * Underscores
+              #  * Minuses
+              #  * Colons
+              #  * Periods
+              #  * Slashes
+              #
+              # All other characters are replaced with an underscore.
+              tag = name.to_s.strip
+              tag.downcase!
+              tag.gsub!(INVALID_TAG_CHARACTERS, '_')
+
+              # Additionally HTTP header normalization is perform based on:
+              # https://github.com/DataDog/architecture/blob/master/rfcs/apm/integrations/trace-http-headers/rfc.md#header-name-normalization
+              #
+              # Periods are replaced with an underscore.
+              tag.tr!('.', '_')
+              tag
             end
           end
 

--- a/lib/datadog/tracing/metadata/ext.rb
+++ b/lib/datadog/tracing/metadata/ext.rb
@@ -71,7 +71,7 @@ module Datadog
 
             # Normalizes an HTTP header string into a valid tag string.
             def to_tag(name)
-              # Tag normalization based on: https://docs.datadoghq.com/tagging/#defining-tags.
+              # Tag normalization based on: https://docs.datadoghq.com/getting_started/tagging/#defining-tags.
               #
               # Only the following characters are accepted.
               #  * Alphanumerics

--- a/lib/datadog/tracing/metadata/ext.rb
+++ b/lib/datadog/tracing/metadata/ext.rb
@@ -11,63 +11,63 @@ module Datadog
       # @public_api
       module Ext
         # Name of package that was instrumented
-        TAG_COMPONENT = 'component'.freeze
+        TAG_COMPONENT = 'component'
         # Type of operation being performed (e.g. )
-        TAG_OPERATION = 'operation'.freeze
+        TAG_OPERATION = 'operation'
         # Hostname of external service interacted with
-        TAG_PEER_HOSTNAME = 'peer.hostname'.freeze
+        TAG_PEER_HOSTNAME = 'peer.hostname'
         # Name of external service that performed the work
-        TAG_PEER_SERVICE = 'peer.service'.freeze
+        TAG_PEER_SERVICE = 'peer.service'
 
         # Defines constants for trace analytics
         # @public_api
         module Analytics
           DEFAULT_SAMPLE_RATE = 1.0
-          TAG_ENABLED = 'analytics.enabled'.freeze
-          TAG_MEASURED = '_dd.measured'.freeze
-          TAG_SAMPLE_RATE = '_dd1.sr.eausr'.freeze
+          TAG_ENABLED = 'analytics.enabled'
+          TAG_MEASURED = '_dd.measured'
+          TAG_SAMPLE_RATE = '_dd1.sr.eausr'
         end
 
         module AppTypes
-          TYPE_WEB = 'web'.freeze
-          TYPE_DB = 'db'.freeze
-          TYPE_CACHE = 'cache'.freeze
-          TYPE_WORKER = 'worker'.freeze
-          TYPE_CUSTOM = 'custom'.freeze
+          TYPE_WEB = 'web'
+          TYPE_DB = 'db'
+          TYPE_CACHE = 'cache'
+          TYPE_WORKER = 'worker'
+          TYPE_CUSTOM = 'custom'
         end
 
         # @public_api
         # Tags related to distributed tracing
         module Distributed
-          TAG_ORIGIN = '_dd.origin'.freeze
-          TAG_SAMPLING_PRIORITY = '_sampling_priority_v1'.freeze
+          TAG_ORIGIN = '_dd.origin'
+          TAG_SAMPLING_PRIORITY = '_sampling_priority_v1'
         end
 
         # @public_api
         module Errors
           STATUS = 1
-          TAG_MSG = 'error.msg'.freeze
-          TAG_STACK = 'error.stack'.freeze
-          TAG_TYPE = 'error.type'.freeze
+          TAG_MSG = 'error.msg'
+          TAG_STACK = 'error.stack'
+          TAG_TYPE = 'error.type'
         end
 
         # @public_api
         module HTTP
           ERROR_RANGE = (500...600).freeze
-          TAG_BASE_URL = 'http.base_url'.freeze
-          TAG_METHOD = 'http.method'.freeze
-          TAG_STATUS_CODE = 'http.status_code'.freeze
-          TAG_URL = 'http.url'.freeze
+          TAG_BASE_URL = 'http.base_url'
+          TAG_METHOD = 'http.method'
+          TAG_STATUS_CODE = 'http.status_code'
+          TAG_URL = 'http.url'
           TYPE_INBOUND = AppTypes::TYPE_WEB.freeze
-          TYPE_OUTBOUND = 'http'.freeze
-          TYPE_PROXY = 'proxy'.freeze
-          TYPE_TEMPLATE = 'template'.freeze
+          TYPE_OUTBOUND = 'http'
+          TYPE_PROXY = 'proxy'
+          TYPE_TEMPLATE = 'template'
 
           # General header functionality
           module Headers
             module_function
 
-            INVALID_TAG_CHARACTERS = %r{[^a-z0-9_\-:\./]}.freeze
+            INVALID_TAG_CHARACTERS = %r{[^a-z0-9_\-:./]}.freeze
 
             # Normalizes an HTTP header string into a valid tag string.
             def to_tag(name)
@@ -97,7 +97,7 @@ module Datadog
 
           # Request headers
           module RequestHeaders
-            PREFIX = 'http.request.headers'.freeze
+            PREFIX = 'http.request.headers'
 
             module_function
 
@@ -108,7 +108,7 @@ module Datadog
 
           # Response headers
           module ResponseHeaders
-            PREFIX = 'http.response.headers'.freeze
+            PREFIX = 'http.response.headers'
 
             module_function
 
@@ -120,30 +120,30 @@ module Datadog
 
         # @public_api
         module NET
-          TAG_HOSTNAME = '_dd.hostname'.freeze
-          TAG_TARGET_HOST = 'out.host'.freeze
-          TAG_TARGET_PORT = 'out.port'.freeze
+          TAG_HOSTNAME = '_dd.hostname'
+          TAG_TARGET_HOST = 'out.host'
+          TAG_TARGET_PORT = 'out.port'
         end
 
         # @public_api
         module Sampling
-          TAG_AGENT_RATE = '_dd.agent_psr'.freeze
+          TAG_AGENT_RATE = '_dd.agent_psr'
 
           # If rule sampling is applied to a span, set this metric the sample rate configured for that rule.
           # This should be done regardless of sampling outcome.
-          TAG_RULE_SAMPLE_RATE = '_dd.rule_psr'.freeze
+          TAG_RULE_SAMPLE_RATE = '_dd.rule_psr'
 
           # If rate limiting is checked on a span, set this metric the effective rate limiting rate applied.
           # This should be done regardless of rate limiting outcome.
-          TAG_RATE_LIMITER_RATE = '_dd.limit_psr'.freeze
+          TAG_RATE_LIMITER_RATE = '_dd.limit_psr'
 
-          TAG_SAMPLE_RATE = '_sample_rate'.freeze
+          TAG_SAMPLE_RATE = '_sample_rate'
         end
 
         # @public_api
         module SQL
-          TYPE = 'sql'.freeze
-          TAG_QUERY = 'sql.query'.freeze
+          TYPE = 'sql'
+          TAG_QUERY = 'sql.query'
         end
       end
     end

--- a/lib/datadog/tracing/metadata/ext.rb
+++ b/lib/datadog/tracing/metadata/ext.rb
@@ -86,8 +86,7 @@ module Datadog
               tag.downcase!
               tag.gsub!(INVALID_TAG_CHARACTERS, '_')
 
-              # Additionally HTTP header normalization is perform based on:
-              # https://github.com/DataDog/architecture/blob/master/rfcs/apm/integrations/trace-http-headers/rfc.md#header-name-normalization
+              # Additional HTTP header normalization.
               #
               # Periods are replaced with an underscore.
               tag.tr!('.', '_')

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -599,19 +599,19 @@ RSpec.describe 'Rack integration tests' do
               expect(span).to be_root_span
 
               # Request headers
-              expect(span.get_tag('http.request.headers.cache_control')).to eq('no-cache')
+              expect(span.get_tag('http.request.headers.cache-control')).to eq('no-cache')
               # Make sure non-whitelisted headers don't become tags.
-              expect(span.get_tag('http.request.headers.x_request_id')).to be nil
-              expect(span.get_tag('http.request.headers.x_fake_request')).to be nil
+              expect(span.get_tag('http.request.headers.x-request-id')).to be nil
+              expect(span.get_tag('http.request.headers.x-fake-request')).to be nil
 
               # Response headers
-              expect(span.get_tag('http.response.headers.content_type')).to eq('text/html')
-              expect(span.get_tag('http.response.headers.cache_control')).to eq('max-age=3600')
+              expect(span.get_tag('http.response.headers.content-type')).to eq('text/html')
+              expect(span.get_tag('http.response.headers.cache-control')).to eq('max-age=3600')
               expect(span.get_tag('http.response.headers.etag')).to eq('"737060cd8c284d8af7ad3082f209582d"')
-              expect(span.get_tag('http.response.headers.last_modified')).to eq('Tue, 15 Nov 1994 12:45:26 GMT')
-              expect(span.get_tag('http.response.headers.x_request_id')).to eq('f058ebd6-02f7-4d3f-942e-904344e8cde5')
+              expect(span.get_tag('http.response.headers.last-modified')).to eq('Tue, 15 Nov 1994 12:45:26 GMT')
+              expect(span.get_tag('http.response.headers.x-request-id')).to eq('f058ebd6-02f7-4d3f-942e-904344e8cde5')
               # Make sure non-whitelisted headers don't become tags.
-              expect(span.get_tag('http.request.headers.x_fake_response')).to be nil
+              expect(span.get_tag('http.request.headers.x-fake-response')).to be nil
             end
           end
         end

--- a/spec/datadog/tracing/contrib/sinatra/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sinatra/tracer_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe 'Sinatra instrumentation' do
             it do
               subject
               skip('not matching app span') unless span.get_tag(Datadog::Tracing::Contrib::Sinatra::Ext::TAG_ROUTE_PATH)
-              expect(span.get_tag('http.response.headers.x_request_id')).to eq('test id')
+              expect(span.get_tag('http.response.headers.x-request-id')).to eq('test id')
             end
           end
         end
@@ -427,14 +427,14 @@ RSpec.describe 'Sinatra instrumentation' do
         let(:headers) { { 'HTTP_X_REQUEST_HEADER' => header_value } }
         let(:header_value) { SecureRandom.uuid }
 
-        it { expect(span.get_tag('http.request.headers.x_request_header')).to eq(header_value) }
+        it { expect(span.get_tag('http.request.headers.x-request-header')).to eq(header_value) }
       end
 
       context 'with a header that should not be tagged' do
         let(:headers) { { 'HTTP_X_REQUEST_HEADER' => header_value } }
         let(:header_value) { SecureRandom.uuid }
 
-        it { expect(span.get_tag('http.request.headers.x_request_header')).to be nil }
+        it { expect(span.get_tag('http.request.headers.x-request-header')).to be nil }
       end
     end
   end
@@ -660,7 +660,7 @@ RSpec.describe 'Sinatra instrumentation' do
       expect(span.resource).to eq(opts[:resource] || resource)
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::HTTP::TAG_METHOD)).to eq(http_method) if opts[:http_tags]
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::HTTP::TAG_URL)).to eq(url) if opts[:http_tags]
-      expect(span.get_tag('http.response.headers.content_type')).to eq('text/html;charset=utf-8') if opts[:http_tags]
+      expect(span.get_tag('http.response.headers.content-type')).to eq('text/html;charset=utf-8') if opts[:http_tags]
       expect(span.get_tag(Datadog::Tracing::Contrib::Sinatra::Ext::TAG_APP_NAME)).to eq(app_name)
       expect(span.get_tag(Datadog::Tracing::Contrib::Sinatra::Ext::TAG_ROUTE_PATH)).to eq(url) if app_name == self.app_name
       expect(span.get_tag(Datadog::Tracing::Contrib::Sinatra::Ext::TAG_SCRIPT_NAME)).to be_nil

--- a/spec/datadog/tracing/metadata/ext_spec.rb
+++ b/spec/datadog/tracing/metadata/ext_spec.rb
@@ -1,0 +1,42 @@
+# typed: ignore
+require 'spec_helper'
+
+require 'datadog/tracing/metadata/ext'
+
+RSpec.describe Datadog::Tracing::Metadata::Ext::HTTP::Headers do
+  describe '.to_tag' do
+    subject(:to_tag) { described_class.to_tag(tag) }
+
+    context 'with alphanumeric characters' do
+      let(:tag) { 'MyTag01' }
+
+      it 'converts them to lowercase' do
+        is_expected.to eq('mytag01')
+      end
+    end
+
+    context 'with a period' do
+      let(:tag) { 'a.b.' }
+
+      it 'replaces period with underscore' do
+        is_expected.to eq('a_b_')
+      end
+    end
+
+    context 'with supported special characters' do
+      let(:tag) { '_-:/' }
+
+      it 'preserves them' do
+        is_expected.to eq(tag)
+      end
+    end
+
+    context 'with unsupported characters' do
+      let(:tag) { "\\ \t!@?" }
+
+      it 'replaces each with an underscore' do
+        is_expected.to eq('_' * tag.size)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses HTTP 


### Breaking changes

- **Changed**: Normalization of `http.response.headers.*` span tags for the Rack and Sinatra integrations have changed to respect [the Datadog standard tagging requirements](https://docs.datadoghq.com/getting_started/tagging/#defining-tags). Additionally, periods (`.`) are replaced with underscores (`_`). For example, a tag that was previously `http.response.headers.content_type` will now become `http.response.headers.content-type`.