### PR TITLE
Use writers for appsec config

### DIFF
--- a/lib/datadog/security/configuration.rb
+++ b/lib/datadog/security/configuration.rb
@@ -22,24 +22,24 @@ module Datadog
           @instruments << Instrument.new(name, options)
         end
 
-        def enabled(value)
+        def enabled=(value)
           options[:enabled] = value
         end
 
-        def ruleset(value)
+        def ruleset=(value)
           options[:ruleset] = value
         end
 
         # in microseconds
-        def waf_timeout(value)
+        def waf_timeout=(value)
           options[:waf_timeout] = value
         end
 
-        def waf_debug(value)
+        def waf_debug=(value)
           options[:waf_debug] = value
         end
 
-        def trace_rate_limit(value)
+        def trace_rate_limit=(value)
           options[:trace_rate_limit] = value
         end
 


### PR DESCRIPTION
Seeing the CI product mention an example of its config around recent namespace changes I realised the AppSec configuration DSL was not consistent with other products.

This PR makes it use `c.enabled = true` instead of `c.enabled true`.