### PR TITLE
[PROF-4779] Refactor in prepraration for use of libddprof from profiling native extension

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,7 @@ if RUBY_PLATFORM != 'java'
     gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
   end
 end
+gem 'libddprof', '~> 0.3.0.1.0'
 
 # For type checking
 # Sorbet releases almost daily, with new checks introduced that can make a

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,10 @@ namespace :spec do
                         ' spec/**/auto_instrument_spec.rb'
     t.rspec_opts = args.to_a.join(' ')
   end
-  Rake::Task[:main].enhance([:compile]) unless %w[jruby truffleruby].include?(RUBY_ENGINE)
+  if RUBY_ENGINE == 'ruby' && RUBY_PLATFORM.start_with?('x86_64-linux')
+    # "bundle exec rake compile" currently only works on MRI+x86_64-linux
+    Rake::Task[:main].enhance([:compile])
+  end
 
   RSpec::Core::RakeTask.new(:benchmark) do |t, args|
     t.pattern = 'spec/ddtrace/benchmark/**/*_spec.rb'

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ require 'rspec/core/rake_task'
 require 'rake/extensiontask'
 require 'appraisal'
 require 'yard'
+require 'os'
 
 Dir.glob('tasks/*.rake').each { |r| import r }
 
@@ -21,8 +22,8 @@ namespace :spec do
                         ' spec/**/auto_instrument_spec.rb'
     t.rspec_opts = args.to_a.join(' ')
   end
-  if RUBY_ENGINE == 'ruby' && RUBY_PLATFORM.start_with?('x86_64-linux')
-    # "bundle exec rake compile" currently only works on MRI+x86_64-linux
+  if RUBY_ENGINE == 'ruby' && OS.linux?
+    # "bundle exec rake compile" currently only works on MRI Ruby on Linux
     Rake::Task[:main].enhance([:compile])
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     tty: true
     volumes:
       - .:/app
+      - extension-build-tmp:/app/tmp
       - bundle-2.1:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-2.2:
@@ -63,6 +64,7 @@ services:
     tty: true
     volumes:
       - .:/app
+      - extension-build-tmp:/app/tmp
       - bundle-2.2:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-2.3:
@@ -95,6 +97,7 @@ services:
     tty: true
     volumes:
       - .:/app
+      - extension-build-tmp:/app/tmp
       - bundle-2.3:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-2.4:
@@ -127,6 +130,7 @@ services:
     tty: true
     volumes:
       - .:/app
+      - extension-build-tmp:/app/tmp
       - bundle-2.4:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-2.5:
@@ -159,6 +163,7 @@ services:
     tty: true
     volumes:
       - .:/app
+      - extension-build-tmp:/app/tmp
       - bundle-2.5:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-2.6:
@@ -191,6 +196,7 @@ services:
     tty: true
     volumes:
       - .:/app
+      - extension-build-tmp:/app/tmp
       - bundle-2.6:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-2.7:
@@ -223,6 +229,7 @@ services:
     tty: true
     volumes:
       - .:/app
+      - extension-build-tmp:/app/tmp
       - bundle-2.7:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-3.0:
@@ -252,6 +259,7 @@ services:
     tty: true
     volumes:
       - .:/app
+      - extension-build-tmp:/app/tmp
       - bundle-3.0:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-3.0-arm64:
@@ -280,6 +288,7 @@ services:
     tty: true
     volumes:
       - .:/app
+      - extension-build-tmp:/app/tmp
       - bundle-3.0-arm64:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-3.1:
@@ -309,6 +318,7 @@ services:
     tty: true
     volumes:
       - .:/app
+      - extension-build-tmp:/app/tmp
       - bundle-3.1:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-3.1-arm64:
@@ -337,6 +347,7 @@ services:
     tty: true
     volumes:
       - .:/app
+      - extension-build-tmp:/app/tmp
       - bundle-3.1-arm64:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-3.2:
@@ -366,6 +377,7 @@ services:
     tty: true
     volumes:
       - .:/app
+      - extension-build-tmp:/app/tmp
       - bundle-3.2:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-3.2-arm64:
@@ -394,6 +406,7 @@ services:
     tty: true
     volumes:
       - .:/app
+      - extension-build-tmp:/app/tmp
       - bundle-3.2-arm64:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   # ADD NEW RUBIES HERE
@@ -629,3 +642,9 @@ volumes:
   bundle-jruby-9.3-latest:
   bundle-truffleruby-21.3.0:
   ddagent_var_run:
+  # Temporary folder used while compiling the profiling native extension. We place this in a volume to avoid the
+  # massive performance hit (seconds to minutes) that we get when the tmp folder is shared with the host on macOS.
+  # Hopefully this will be fixed by
+  # https://www.docker.com/blog/speed-boost-achievement-unlocked-on-docker-desktop-4-6-for-mac/
+  # (which is not available for those of us still on macOS 11).
+  extension-build-tmp:

--- a/ext/ddtrace_profiling_native_extension/NativeExtensionDesign.md
+++ b/ext/ddtrace_profiling_native_extension/NativeExtensionDesign.md
@@ -1,9 +1,11 @@
 # Profiling Native Extension Design
 
-The profiling native extension is used to implement features which are expensive (in terms of resources) or otherwise
-impossible to implement using Ruby code.
+The profiling native extension is used to:
+1. Implement features which are expensive (in terms of resources) or otherwise impossible to implement using Ruby code.
+2. Bridge between Ruby-specific profiling features and [`libddprof`](https://github.com/DataDog/libddprof), a Rust-based
+library with common profiling functionality.
 
-This extension is quite coupled with MRI Ruby ("C Ruby") internals, and is not intended to support other rubies such as
+Due to (1), this extension is quite coupled with MRI Ruby ("C Ruby") internals, and is not intended to support other rubies such as
 JRuby or TruffleRuby. When below we say "Ruby", read it as "MRI Ruby".
 
 ## Disabling
@@ -21,7 +23,7 @@ in future releases -- e.g. disabling the extension will disable profiling entire
 The profiling native extension is (and must always be) designed to **not cause failures** during gem installation, even
 if some features, Ruby versions, or operating systems are not supported.
 
-E.g. the extension must cleanly build on Ruby 2.1 (or the oldest Ruby version we support at the time) on Windows,
+E.g. the extension must not break installation on Ruby 2.1 (or the oldest Ruby version we support at the time) on 64-bit ARM macOS,
 even if at run time it will effectively do nothing for such a setup.
 
 We have a CI setup to help validate this, but this is really important to keep in mind when adding to or changing the

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -38,10 +38,14 @@ $stderr.puts(%(
 # that may fail on an environment not properly setup for building Ruby extensions.
 require 'mkmf'
 
-# IMPORTANT: When adding flags, remember that our customers compile with a wide range of gcc/clang versions, so
-# doublecheck that what you're adding can be reasonably expected to work on their systems.
+# mkmf on modern Rubies actually has an append_cflags that does something similar
+# (see https://github.com/ruby/ruby/pull/5760), but as usual we need a bit more boilerplate to deal with legacy Rubies
 def add_compiler_flag(flag)
-  $CFLAGS << ' ' << flag
+  if try_cflags(flag)
+    $CFLAGS << ' ' << flag
+  else
+    $stderr.puts("WARNING: '#{flag}' not accepted by compiler, skipping it")
+  end
 end
 
 # Gets really noisy when we include the MJIT header, let's omit it

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -78,22 +78,24 @@ if RUBY_PLATFORM.include?('linux')
 end
 
 # If we got here, libddprof is available and loaded
-ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libddprof.pkgconfig_folder}"
-unless pkg_config('ddprof_ffi')
-  $stderr.puts(%(
-+------------------------------------------------------------------------------+
-| Skipping build of profiling native extension:                                |
-| failed to configure `libddprof` for compilation.                             |
-|                                                                              |
-| The Datadog Continuous Profiler will not be available,                       |
-| but all other ddtrace features will work fine!                               |
-|                                                                              |
-| For help solving this issue, please contact Datadog support at               |
-| <https://docs.datadoghq.com/help/>.                                          |
-+------------------------------------------------------------------------------+
-))
-  skip_building_extension!
-end
+
+# TODO: Temporarily disabled for PR https://github.com/DataDog/dd-trace-rb/pull/1885; will be re-enabled in a follow-up PR
+# ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libddprof.pkgconfig_folder}"
+# unless pkg_config('ddprof_ffi')
+#   $stderr.puts(%(
+# +------------------------------------------------------------------------------+
+# | Skipping build of profiling native extension:                                |
+# | failed to configure `libddprof` for compilation.                             |
+# |                                                                              |
+# | The Datadog Continuous Profiler will not be available,                       |
+# | but all other ddtrace features will work fine!                               |
+# |                                                                              |
+# | For help solving this issue, please contact Datadog support at               |
+# | <https://docs.datadoghq.com/help/>.                                          |
+# +------------------------------------------------------------------------------+
+# ))
+#   skip_building_extension!
+# end
 
 # Tag the native extension library with the Ruby version and Ruby platform.
 # This makes it easier for development (avoids "oops I forgot to rebuild when I switched my Ruby") and ensures that

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -3,91 +3,29 @@
 # rubocop:disable Style/StderrPuts
 # rubocop:disable Style/GlobalVars
 
-# Older Rubies don't have the MJIT header, used by the JIT compiler, so we need to use a different approach
-CAN_USE_MJIT_HEADER = RUBY_VERSION >= '2.6'
-
-def on_jruby?
-  # We don't support JRuby for profiling, and JRuby doesn't support native extensions, so let's just skip this entire
-  # thing so that JRuby users of dd-trace-rb aren't impacted.
-  RUBY_ENGINE == 'jruby'
-end
-
-def on_truffleruby?
-  # We don't officially support TruffleRuby for dd-trace-rb at all BUT let's not break adventurous customers that
-  # want to give it a try.
-  RUBY_ENGINE == 'truffleruby'
-end
-
-def on_windows?
-  # Microsoft Windows is unsupported, so let's not build the extension there.
-  Gem.win_platform?
-end
-
-def expected_to_use_mjit_but_mjit_is_disabled?
-  # On some Rubies, we require the mjit header to be present. If Ruby was installed without MJIT support, we also skip
-  # building the extension.
-  mjit_disabled = CAN_USE_MJIT_HEADER && RbConfig::CONFIG['MJIT_SUPPORT'] != 'yes'
-
-  if mjit_disabled
-    $stderr.puts(%(
-+------------------------------------------------------------------------------+
-| Your Ruby has been compiled without JIT support (--disable-jit-support).     |
-| The profiling native extension requires a Ruby compiled with JIT support,    |
-| even if the JIT is not in use by the application itself.                     |
-|                                                                              |
-| WARNING: Without the profiling native extension, some profiling features     |
-| will not be available.                                                       |
-+------------------------------------------------------------------------------+
-
-))
-  end
-
-  mjit_disabled
-end
-
-def disabled_via_env?
-  # Experimental toggle to disable building the extension.
-  # Disabling the extension will lead to the profiler not working in future releases.
-  # If you needed to use this, please tell us why on <https://github.com/DataDog/dd-trace-rb/issues/new>.
-  ENV['DD_PROFILING_NO_EXTENSION'].to_s.downcase == 'true'
-end
-
-def skip_building_extension?
-  disabled_via_env? || on_jruby? || on_truffleruby? || on_windows? || expected_to_use_mjit_but_mjit_is_disabled?
-end
-
-# IMPORTANT: When adding flags, remember that our customers compile with a wide range of gcc/clang versions, so
-# doublecheck that what you're adding can be reasonably expected to work on their systems.
-def add_compiler_flag(flag)
-  $CFLAGS << ' ' << flag
-end
+require_relative 'native_extension_helpers'
 
 def skip_building_extension!
   File.write('Makefile', 'all install clean: # dummy makefile that does nothing')
   exit
 end
 
-if skip_building_extension?
-  $stderr.puts(%(
-+------------------------------------------------------------------------------+
-| Skipping build of profiling native extension and replacing it with a no-op   |
-| Makefile                                                                     |
-+------------------------------------------------------------------------------+
-
-))
+unless Datadog::Profiling::NativeExtensionHelpers::Supported.supported?
+  $stderr.puts(Datadog::Profiling::NativeExtensionHelpers::Supported.unsupported_reason)
   skip_building_extension!
 end
 
 $stderr.puts(%(
 +------------------------------------------------------------------------------+
-| ** Preparing to build the ddtrace native extension... **                     |
+| ** Preparing to build the ddtrace profiling native extension... **           |
 |                                                                              |
 | If you run into any failures during this step, you can set the               |
 | `DD_PROFILING_NO_EXTENSION` environment variable to `true` e.g.              |
 | `$ DD_PROFILING_NO_EXTENSION=true bundle install` to skip this step.         |
 |                                                                              |
-| Disabling the extension will lead to the ddtrace profiling features not      |
-| working in future releases.                                                  |
+| If you disable this extension, the Datadog Continuous Profiler will          |
+| not be available, but all other ddtrace features will work fine!             |
+|                                                                              |
 | If you needed to use this, please tell us why on                             |
 | <https://github.com/DataDog/dd-trace-rb/issues/new> so we can fix it :\)      |
 |                                                                              |
@@ -99,6 +37,12 @@ $stderr.puts(%(
 # NOTE: we MUST NOT require 'mkmf' before we check the #skip_building_extension? because the require triggers checks
 # that may fail on an environment not properly setup for building Ruby extensions.
 require 'mkmf'
+
+# IMPORTANT: When adding flags, remember that our customers compile with a wide range of gcc/clang versions, so
+# doublecheck that what you're adding can be reasonably expected to work on their systems.
+def add_compiler_flag(flag)
+  $CFLAGS << ' ' << flag
+end
 
 # Gets really noisy when we include the MJIT header, let's omit it
 add_compiler_flag '-Wno-unused-function'
@@ -135,7 +79,7 @@ end
 # When requiring, we need to use the exact same string, including the version and the platform.
 EXTENSION_NAME = "ddtrace_profiling_native_extension.#{RUBY_VERSION}_#{RUBY_PLATFORM}".freeze
 
-if CAN_USE_MJIT_HEADER
+if Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER
   mjit_header_file_name = "rb_mjit_min_header-#{RUBY_VERSION}.h"
 
   # Validate that the mjit header can actually be compiled on this system. We learned via
@@ -152,8 +96,8 @@ if CAN_USE_MJIT_HEADER
 | WARNING: Unable to compile a needed component for ddtrace native extension.  |
 | Your C compiler or Ruby VM just-in-time compiler seems to be broken.         |
 |                                                                              |
-| You will be NOT be able to use ddtrace profiling features,                   |
-| but all other features will work fine!                                       |
+| The Datadog Continuous Profiler will not be available,                       |
+| but all other ddtrace features will work fine!                               |
 |                                                                              |
 | For help solving this issue, please contact Datadog support at               |
 | <https://docs.datadoghq.com/help/>.                                          |

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -73,6 +73,24 @@ if RUBY_PLATFORM.include?('linux')
   $defs << '-DHAVE_PTHREAD_GETCPUCLOCKID'
 end
 
+# If we got here, libddprof is available and loaded
+ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libddprof.pkgconfig_folder}"
+unless pkg_config('ddprof_ffi')
+    $stderr.puts(%(
++------------------------------------------------------------------------------+
+| Skipping build of profiling native extension:                                |
+| failed to configure `libddprof` for compilation.                             |
+|                                                                              |
+| The Datadog Continuous Profiler will not be available,                       |
+| but all other ddtrace features will work fine!                               |
+|                                                                              |
+| For help solving this issue, please contact Datadog support at               |
+| <https://docs.datadoghq.com/help/>.                                          |
++------------------------------------------------------------------------------+
+))
+  skip_building_extension!
+end
+
 # Tag the native extension library with the Ruby version and Ruby platform.
 # This makes it easier for development (avoids "oops I forgot to rebuild when I switched my Ruby") and ensures that
 # the wrong library is never loaded.

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -76,7 +76,7 @@ end
 # If we got here, libddprof is available and loaded
 ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libddprof.pkgconfig_folder}"
 unless pkg_config('ddprof_ffi')
-    $stderr.puts(%(
+  $stderr.puts(%(
 +------------------------------------------------------------------------------+
 | Skipping build of profiling native extension:                                |
 | failed to configure `libddprof` for compilation.                             |

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -21,6 +21,7 @@ module Datadog
             on_truffleruby? ||
             on_windows? ||
             on_unknown_os? ||
+            not_on_x86_64? ||
             expected_to_use_mjit_but_mjit_is_disabled? ||
             libddprof_not_usable?
         end
@@ -56,7 +57,7 @@ module Datadog
 |                                                                              |
 | All other ddtrace features will work fine!                                   |
 |                                                                              |
-| Get in touch with us if you're interested on profiling JRuby!                |
+| Get in touch with us if you're interested in profiling JRuby!                |
 )
         end
 
@@ -67,7 +68,7 @@ module Datadog
           skipping_build_banner %(
 | TruffleRuby is not supported by the ddtrace gem.                             |
 |                                                                              |
-| Get in touch with us if you're interested on profiling TruffleRuby!          |
+| Get in touch with us if you're interested in profiling TruffleRuby!          |
 )
         end
 
@@ -79,7 +80,7 @@ module Datadog
           skipping_build_banner %(
 | Microsoft Windows is not supported by the Datadog Continuous Profiler.       |
 |                                                                              |
-| Get in touch with us if you're interested on profiling Ruby on Windows!      |
+| Get in touch with us if you're interested in profiling Ruby on Windows!      |
 )
         end
 
@@ -88,6 +89,16 @@ module Datadog
 
           skipping_build_banner %(
 | Current operating system is not supported by the Datadog Continuous Profiler.|
+)
+        end
+
+        private_class_method def self.not_on_x86_64?
+          return if RUBY_PLATFORM.start_with?('x86_64')
+
+          skipping_build_banner %(
+| Your CPU architecture is not supported by the Datadog Continuous Profiler.   |
+|                                                                              |
+| Get in touch with us if you're interested in profiling Ruby!                 |
 )
         end
 

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module Profiling
@@ -10,6 +10,7 @@ module Datadog
 
       # Used to check if profiler is supported, including user-visible clear messages explaining why their
       # system may not be supported.
+      # rubocop:disable Metrics/ModuleLength
       module Supported
         def self.supported?
           unsupported_reason.nil?
@@ -26,127 +27,54 @@ module Datadog
             libddprof_not_usable?
         end
 
-        private_class_method def self.skipping_build_banner(details)
-          %(
-+------------------------------------------------------------------------------+
-| Skipping build of profiling native extension:                                |
-#{details.strip}
-+------------------------------------------------------------------------------+
-)
-        end
-
         private_class_method def self.disabled_via_env?
           return unless ENV[ENV_NO_EXTENSION].to_s.strip.downcase == 'true'
 
-          skipping_build_banner %(
-| `DD_PROFILING_NO_EXTENSION` environment variable is set to `true`.           |
-|                                                                              |
-| The Datadog Continuous Profiler will not be available,                       |
-| but all other ddtrace features will work fine!                               |
-|                                                                              |
-| If you needed to use this, please tell us why on                             |
-| <https://github.com/DataDog/dd-trace-rb/issues/new> so we can fix it :\)      |
-)
+          DISABLED_VIA_ENV
         end
 
         private_class_method def self.on_jruby?
-          return unless RUBY_ENGINE == 'jruby'
-
-          skipping_build_banner %(
-| JRuby is not supported by the Datadog Continuous Profiler.                   |
-|                                                                              |
-| All other ddtrace features will work fine!                                   |
-|                                                                              |
-| Get in touch with us if you're interested in profiling JRuby!                |
-)
+          JRUBY_NOT_SUPPORTED if RUBY_ENGINE == 'jruby'
         end
 
-        # We don't officially support using TruffleRuby, but we don't want to break adventurous customers either.
         private_class_method def self.on_truffleruby?
-          return unless RUBY_ENGINE == 'truffleruby'
-
-          skipping_build_banner %(
-| TruffleRuby is not supported by the ddtrace gem.                             |
-|                                                                              |
-| Get in touch with us if you're interested in profiling TruffleRuby!          |
-)
+          TRUFFLERUBY_NOT_SUPPORTED if RUBY_ENGINE == 'truffleruby'
         end
 
         # See https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#microsoft-windows-support for current
         # state of Windows support in ddtrace.
         private_class_method def self.on_windows?
-          return unless Gem.win_platform?
-
-          skipping_build_banner %(
-| Microsoft Windows is not supported by the Datadog Continuous Profiler.       |
-|                                                                              |
-| Get in touch with us if you're interested in profiling Ruby on Windows!      |
-)
+          WINDOWS_NOT_SUPPORTED if Gem.win_platform?
         end
 
         private_class_method def self.on_unknown_os?
-          return if RUBY_PLATFORM.include?('darwin') || RUBY_PLATFORM.include?('linux')
-
-          skipping_build_banner %(
-| Current operating system is not supported by the Datadog Continuous Profiler.|
-)
+          UNKNOWN_OS_NOT_SUPPORTED unless RUBY_PLATFORM.include?('darwin') || RUBY_PLATFORM.include?('linux')
         end
 
         private_class_method def self.not_on_x86_64?
-          return if RUBY_PLATFORM.start_with?('x86_64')
-
-          skipping_build_banner %(
-| Your CPU architecture is not supported by the Datadog Continuous Profiler.   |
-|                                                                              |
-| Get in touch with us if you're interested in profiling Ruby!                 |
-)
+          ARCHITECTURE_NOT_SUPPORTED unless RUBY_PLATFORM.start_with?('x86_64')
         end
 
         # On some Rubies, we require the mjit header to be present. If Ruby was installed without MJIT support, we also skip
         # building the extension.
         private_class_method def self.expected_to_use_mjit_but_mjit_is_disabled?
-          return unless CAN_USE_MJIT_HEADER && RbConfig::CONFIG['MJIT_SUPPORT'] != 'yes'
-
-          skipping_build_banner %(
-| Your Ruby has been compiled without JIT support (--disable-jit-support).     |
-| The profiling native extension requires a Ruby compiled with JIT support,    |
-| even if the JIT is not in use by the application itself.                     |
-|                                                                              |
-| The Datadog Continuous Profiler will not be available,                       |
-| but all other ddtrace features will work fine!                               |
-)
+          RUBY_WITHOUT_MJIT if CAN_USE_MJIT_HEADER && RbConfig::CONFIG['MJIT_SUPPORT'] != 'yes'
         end
 
         private_class_method def self.libddprof_not_usable?
           begin
             require 'libddprof'
           rescue LoadError
-            return skipping_build_banner %(
-| `libddprof` gem is not available.                                            |
-|                                                                              |
-| The Datadog Continuous Profiler will not be available,                       |
-| but all other ddtrace features will work fine!                               |
-)
+            return LIBDDPROF_NOT_AVAILABLE
           end
 
-          unless Libddprof.binaries?
-            return skipping_build_banner %(
-| `libddprof` gem installed on your system is missing platform-specific        |
-| binaries. Make sure you install a platform-specific version of the gem,      |
-| and that you are not enabling the `force_ruby_platform` bundler option,      |
-| nor the `BUNDLE_FORCE_RUBY_PLATFORM` environment variable.                   |
-|                                                                              |
-| The Datadog Continuous Profiler will not be available,                       |
-| but all other ddtrace features will work fine!                               |
-|                                                                              |
-| For help solving this issue, please contact Datadog support at               |
-| <https://docs.datadoghq.com/help/>.                                          |
-)
-          end
+          return LIBDDPROF_NO_BINARIES unless Libddprof.binaries?
 
           unless Libddprof.pkgconfig_folder
             current_platform = Gem::Platform.local.to_s
-            return skipping_build_banner %(
+            %(
++------------------------------------------------------------------------------+
+| Skipping build of profiling native extension:                                |
 | `libddprof` gem installed on your system is missing binaries for your        |
 | platform variant.                                                            |
 | (Your platform: `#{current_platform}`)
@@ -157,10 +85,108 @@ module Datadog
 |                                                                              |
 | For help solving this issue, please contact Datadog support at               |
 | <https://docs.datadoghq.com/help/>.                                          |
++------------------------------------------------------------------------------+
 )
           end
         end
+
+        DISABLED_VIA_ENV = %(
++------------------------------------------------------------------------------+
+| Skipping build of profiling native extension:                                |
+| `DD_PROFILING_NO_EXTENSION` environment variable is set to `true`.           |
+|                                                                              |
+| The Datadog Continuous Profiler will not be available,                       |
+| but all other ddtrace features will work fine!                               |
+|                                                                              |
+| If you needed to use this, please tell us why on                             |
+| <https://github.com/DataDog/dd-trace-rb/issues/new> so we can fix it :\)      |
++------------------------------------------------------------------------------+
+).freeze
+
+        JRUBY_NOT_SUPPORTED = %(
++------------------------------------------------------------------------------+
+| Skipping build of profiling native extension:                                |
+| JRuby is not supported by the Datadog Continuous Profiler.                   |
+|                                                                              |
+| All other ddtrace features will work fine!                                   |
+|                                                                              |
+| Get in touch with us if you're interested in profiling JRuby!                |
++------------------------------------------------------------------------------+
+ ).freeze
+
+        TRUFFLERUBY_NOT_SUPPORTED = %(
++------------------------------------------------------------------------------+
+| Skipping build of profiling native extension:                                |
+| TruffleRuby is not supported by the ddtrace gem.                             |
+|                                                                              |
+| Get in touch with us if you're interested in profiling TruffleRuby!          |
++------------------------------------------------------------------------------+
+).freeze
+
+        WINDOWS_NOT_SUPPORTED = %(
++------------------------------------------------------------------------------+
+| Skipping build of profiling native extension:                                |
+| Microsoft Windows is not supported by the Datadog Continuous Profiler.       |
+|                                                                              |
+| Get in touch with us if you're interested in profiling Ruby on Windows!      |
++------------------------------------------------------------------------------+
+).freeze
+
+        UNKNOWN_OS_NOT_SUPPORTED = %(
++------------------------------------------------------------------------------+
+| Skipping build of profiling native extension:                                |
+| Current operating system is not supported by the Datadog Continuous Profiler.|
++------------------------------------------------------------------------------+
+).freeze
+
+        ARCHITECTURE_NOT_SUPPORTED = %(
++------------------------------------------------------------------------------+
+| Skipping build of profiling native extension:                                |
+| Your CPU architecture is not supported by the Datadog Continuous Profiler.   |
+|                                                                              |
+| Get in touch with us if you're interested in profiling Ruby!                 |
++------------------------------------------------------------------------------+
+).freeze
+
+        RUBY_WITHOUT_MJIT = %(
++------------------------------------------------------------------------------+
+| Skipping build of profiling native extension:                                |
+| Your Ruby has been compiled without JIT support (--disable-jit-support).     |
+| The profiling native extension requires a Ruby compiled with JIT support,    |
+| even if the JIT is not in use by the application itself.                     |
+|                                                                              |
+| The Datadog Continuous Profiler will not be available,                       |
+| but all other ddtrace features will work fine!                               |
++------------------------------------------------------------------------------+
+).freeze
+
+        LIBDDPROF_NOT_AVAILABLE = %(
++------------------------------------------------------------------------------+
+| Skipping build of profiling native extension:                                |
+| `libddprof` gem is not available.                                            |
+|                                                                              |
+| The Datadog Continuous Profiler will not be available,                       |
+| but all other ddtrace features will work fine!                               |
++------------------------------------------------------------------------------+
+).freeze
+
+        LIBDDPROF_NO_BINARIES = %(
++------------------------------------------------------------------------------+
+| Skipping build of profiling native extension:                                |
+| `libddprof` gem installed on your system is missing platform-specific        |
+| binaries. Make sure you install a platform-specific version of the gem,      |
+| and that you are not enabling the `force_ruby_platform` bundler option,      |
+| nor the `BUNDLE_FORCE_RUBY_PLATFORM` environment variable.                   |
+|                                                                              |
+| The Datadog Continuous Profiler will not be available,                       |
+| but all other ddtrace features will work fine!                               |
+|                                                                              |
+| For help solving this issue, please contact Datadog support at               |
+| <https://docs.datadoghq.com/help/>.                                          |
++------------------------------------------------------------------------------+
+).freeze
       end
+      # rubocop:enable Metrics/ModuleLength
     end
   end
 end

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -20,6 +20,7 @@ module Datadog
             on_jruby? ||
             on_truffleruby? ||
             on_windows? ||
+            on_unknown_os? ||
             expected_to_use_mjit_but_mjit_is_disabled? ||
             libddprof_not_usable?
         end
@@ -79,6 +80,14 @@ module Datadog
 | Microsoft Windows is not supported by the Datadog Continuous Profiler.       |
 |                                                                              |
 | Get in touch with us if you're interested on profiling Ruby on Windows!      |
+)
+        end
+
+        private_class_method def self.on_unknown_os?
+          return if RUBY_PLATFORM.include?('darwin') || RUBY_PLATFORM.include?('linux')
+
+          skipping_build_banner %(
+| Current operating system is not supported by the Datadog Continuous Profiler.|
 )
         end
 

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -22,9 +22,13 @@ module Datadog
             on_truffleruby? ||
             on_windows? ||
             on_unknown_os? ||
-            not_on_x86_64? ||
-            expected_to_use_mjit_but_mjit_is_disabled? ||
-            libddprof_not_usable?
+            # TODO: Temporarily disabled for PR https://github.com/DataDog/dd-trace-rb/pull/1885; will be updated in
+            # follow-up PR
+            # not_on_x86_64? ||
+            expected_to_use_mjit_but_mjit_is_disabled?
+          # TODO: Temporarily disabled for PR https://github.com/DataDog/dd-trace-rb/pull/1885; will be updated in
+          # follow-up PR
+          # libddprof_not_usable?
         end
 
         private_class_method def self.disabled_via_env?

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -1,6 +1,7 @@
 # typed: false
 
 require 'spec_helper'
+require 'datadog/profiling/spec_helper'
 
 require 'logger'
 
@@ -893,10 +894,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
     end
 
     context 'given settings' do
-      before do
-        skip 'Profiling is not supported on JRuby' if PlatformHelpers.jruby?
-        skip 'Profiling is not supported on TruffleRuby' if PlatformHelpers.truffleruby?
-      end
+      before { skip_if_profiling_not_supported(self) }
 
       shared_examples_for 'disabled profiler' do
         it { is_expected.to be nil }

--- a/spec/datadog/core/configuration_spec.rb
+++ b/spec/datadog/core/configuration_spec.rb
@@ -1,6 +1,7 @@
 # typed: false
 
 require 'spec_helper'
+require 'datadog/profiling/spec_helper'
 
 require 'datadog/core/configuration'
 require 'datadog/core/pin'
@@ -308,10 +309,7 @@ RSpec.describe Datadog::Core::Configuration do
 
       context 'when the profiler' do
         context 'is not changed' do
-          before do
-            skip 'Profiling is not supported on JRuby' if PlatformHelpers.jruby?
-            skip 'Profiling is not supported on TruffleRuby' if PlatformHelpers.truffleruby?
-          end
+          before { skip_if_profiling_not_supported(self) }
 
           context 'and profiling is enabled' do
             before do

--- a/spec/datadog/profiling/integration_spec.rb
+++ b/spec/datadog/profiling/integration_spec.rb
@@ -15,8 +15,7 @@ require 'datadog/profiling/encoding/profile'
 
 RSpec.describe 'profiling integration test' do
   before do
-    skip 'Profiling is not supported on JRuby' if PlatformHelpers.jruby?
-    skip 'Profiling is not supported on TruffleRuby' if PlatformHelpers.truffleruby?
+    skip_if_profiling_not_supported(self)
 
     raise "Profiling did not load: #{Datadog::Profiling.unsupported_reason}" unless Datadog::Profiling.supported?
   end

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -1,0 +1,79 @@
+# typed: ignore
+
+require 'ext/ddtrace_profiling_native_extension/native_extension_helpers'
+
+RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
+  describe '.supported?' do
+    subject(:supported?) { described_class.supported? }
+
+    context 'when there is an unsupported_reason' do
+      before { allow(described_class).to receive(:unsupported_reason).and_return('Unsupported, sorry :(') }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when there is no unsupported_reason' do
+      before { allow(described_class).to receive(:unsupported_reason).and_return(nil) }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '.unsupported_reason' do
+    subject(:unsupported_reason) { described_class.unsupported_reason }
+
+    context 'when disabled via the DD_PROFILING_NO_EXTENSION environment variable' do
+      around { |example| ClimateControl.modify('DD_PROFILING_NO_EXTENSION' => 'true') { example.run } }
+
+      it { is_expected.to include 'DD_PROFILING_NO_EXTENSION' }
+    end
+
+    context 'when JRuby is used' do
+      before { stub_const('RUBY_ENGINE', 'jruby') }
+
+      it { is_expected.to include 'JRuby' }
+    end
+
+    context 'when TruffleRuby is used' do
+      before { stub_const('RUBY_ENGINE', 'truffleruby') }
+
+      it { is_expected.to include 'TruffleRuby' }
+    end
+
+    context 'when not on JRuby or TruffleRuby' do
+      before { stub_const('RUBY_ENGINE', 'ruby') }
+
+      context 'when on Windows' do
+        before { expect(Gem).to receive(:win_platform?).and_return(true) }
+
+        it { is_expected.to include 'Windows' }
+      end
+
+      context 'when not on Windows' do
+        before { allow(Gem).to receive(:win_platform?).and_return(false) }
+
+        context 'when Ruby CAN NOT use the MJIT header' do
+          before { stub_const('Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER', false) }
+
+          it { is_expected.to be nil }
+        end
+
+        context 'when Ruby CAN use the MJIT header' do
+          before { stub_const('Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER', true) }
+
+          context 'when Ruby DOES NOT have MJIT support' do
+            before { allow(RbConfig::CONFIG).to receive(:[]).with('MJIT_SUPPORT').and_return('no') }
+
+            it { is_expected.to include 'without JIT' }
+          end
+
+          context 'when Ruby DOES have MJIT support' do
+            before { allow(RbConfig::CONFIG).to receive(:[]).with('MJIT_SUPPORT').and_return('yes') }
+
+            it { is_expected.to be nil }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -63,63 +63,73 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
           it { is_expected.to include 'operating system is not supported' }
         end
 
-        shared_examples 'libddprof usable' do
-          context 'when libddprof is not available' do
-            before do
-              allow(described_class)
-                .to receive(:require).with('libddprof').and_raise(LoadError.new('Testing failed require'))
+        context 'when not on x86-64' do
+          before { stub_const('RUBY_PLATFORM', 'aarch64-linux') }
+
+          it { is_expected.to include 'architecture is not supported' }
+        end
+
+        context 'when on x86-64 linux' do
+          before { stub_const('RUBY_PLATFORM', 'x86_64-linux') }
+
+          shared_examples 'libddprof usable' do
+            context 'when libddprof is not available' do
+              before do
+                allow(described_class)
+                  .to receive(:require).with('libddprof').and_raise(LoadError.new('Testing failed require'))
+              end
+
+              it { is_expected.to include '`libddprof` gem is not available' }
             end
 
-            it { is_expected.to include '`libddprof` gem is not available' }
-          end
+            context 'when libddprof is available' do
+              context 'but DOES NOT have binaries' do
+                before { expect(Libddprof).to receive(:binaries?).and_return(false) }
 
-          context 'when libddprof is available' do
-            context 'but DOES NOT have binaries' do
-              before { expect(Libddprof).to receive(:binaries?).and_return(false) }
+                it { is_expected.to include 'gem installed on your system is missing platform-specific' }
+              end
 
-              it { is_expected.to include 'gem installed on your system is missing platform-specific' }
-            end
+              context 'and DOES have binaries' do
+                before { expect(Libddprof).to receive(:binaries?).and_return(true) }
 
-            context 'and DOES have binaries' do
-              before { expect(Libddprof).to receive(:binaries?).and_return(true) }
+                context 'but DOES NOT HAVE binaries for the current platform' do
+                  before do
+                    expect(Libddprof).to receive(:pkgconfig_folder).and_return(nil)
+                    expect(Libddprof).to receive(:available_binaries).and_return(%w[fooarch-linux bararch-linux-musl])
+                  end
 
-              context 'but DOES NOT HAVE binaries for the current platform' do
-                before do
-                  expect(Libddprof).to receive(:pkgconfig_folder).and_return(nil)
-                  expect(Libddprof).to receive(:available_binaries).and_return(['fooarch-linux', 'bararch-linux-musl'])
+                  it { is_expected.to include 'platform variant' }
                 end
 
-                it { is_expected.to include 'platform variant' }
-              end
+                context 'and HAS BINARIES for the current platform' do
+                  before { expect(Libddprof).to receive(:pkgconfig_folder).and_return('/simulated/pkgconfig_folder') }
 
-              context 'and HAS BINARIES for the current platform' do
-                before { expect(Libddprof).to receive(:pkgconfig_folder).and_return('/simulated/pkgconfig_folder') }
-
-                it { is_expected.to be nil }
+                  it { is_expected.to be nil }
+                end
               end
             end
           end
-        end
 
-        context 'when Ruby CAN NOT use the MJIT header' do
-          before { stub_const('Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER', false) }
-
-          include_examples 'libddprof usable'
-        end
-
-        context 'when Ruby CAN use the MJIT header' do
-          before { stub_const('Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER', true) }
-
-          context 'but DOES NOT have MJIT support' do
-            before { expect(RbConfig::CONFIG).to receive(:[]).with('MJIT_SUPPORT').and_return('no') }
-
-            it { is_expected.to include 'without JIT' }
-          end
-
-          context 'and DOES have MJIT support' do
-            before { expect(RbConfig::CONFIG).to receive(:[]).with('MJIT_SUPPORT').and_return('yes') }
+          context 'when Ruby CAN NOT use the MJIT header' do
+            before { stub_const('Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER', false) }
 
             include_examples 'libddprof usable'
+          end
+
+          context 'when Ruby CAN use the MJIT header' do
+            before { stub_const('Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER', true) }
+
+            context 'but DOES NOT have MJIT support' do
+              before { expect(RbConfig::CONFIG).to receive(:[]).with('MJIT_SUPPORT').and_return('no') }
+
+              it { is_expected.to include 'without JIT' }
+            end
+
+            context 'and DOES have MJIT support' do
+              before { expect(RbConfig::CONFIG).to receive(:[]).with('MJIT_SUPPORT').and_return('yes') }
+
+              include_examples 'libddprof usable'
+            end
           end
         end
       end

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -63,51 +63,53 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
           it { is_expected.to include 'operating system is not supported' }
         end
 
-        context 'when not on x86-64' do
-          before { stub_const('RUBY_PLATFORM', 'aarch64-linux') }
+        # TODO: Temporarily disabled for PR https://github.com/DataDog/dd-trace-rb/pull/1885; will be updated in
+        # follow-up PR
+        # context 'when not on x86-64' do
+        #   before { stub_const('RUBY_PLATFORM', 'aarch64-linux') }
 
-          it { is_expected.to include 'architecture is not supported' }
-        end
+        #   it { is_expected.to include 'architecture is not supported' }
+        # end
 
         context 'when on x86-64 linux' do
           before { stub_const('RUBY_PLATFORM', 'x86_64-linux') }
 
           shared_examples 'libddprof usable' do
-            context 'when libddprof is not available' do
-              before do
-                allow(described_class)
-                  .to receive(:require).with('libddprof').and_raise(LoadError.new('Testing failed require'))
-              end
+            # context 'when libddprof is not available' do
+            #   before do
+            #     allow(described_class)
+            #       .to receive(:require).with('libddprof').and_raise(LoadError.new('Testing failed require'))
+            #   end
 
-              it { is_expected.to include '`libddprof` gem is not available' }
-            end
+            #   it { is_expected.to include '`libddprof` gem is not available' }
+            # end
 
-            context 'when libddprof is available' do
-              context 'but DOES NOT have binaries' do
-                before { expect(Libddprof).to receive(:binaries?).and_return(false) }
+            # context 'when libddprof is available' do
+            #   context 'but DOES NOT have binaries' do
+            #     before { expect(Libddprof).to receive(:binaries?).and_return(false) }
 
-                it { is_expected.to include 'gem installed on your system is missing platform-specific' }
-              end
+            #     it { is_expected.to include 'gem installed on your system is missing platform-specific' }
+            #   end
 
-              context 'and DOES have binaries' do
-                before { expect(Libddprof).to receive(:binaries?).and_return(true) }
+            #   context 'and DOES have binaries' do
+            #     before { expect(Libddprof).to receive(:binaries?).and_return(true) }
 
-                context 'but DOES NOT HAVE binaries for the current platform' do
-                  before do
-                    expect(Libddprof).to receive(:pkgconfig_folder).and_return(nil)
-                    expect(Libddprof).to receive(:available_binaries).and_return(%w[fooarch-linux bararch-linux-musl])
-                  end
+            #     context 'but DOES NOT HAVE binaries for the current platform' do
+            #       before do
+            #         expect(Libddprof).to receive(:pkgconfig_folder).and_return(nil)
+            #         expect(Libddprof).to receive(:available_binaries).and_return(%w[fooarch-linux bararch-linux-musl])
+            #       end
 
-                  it { is_expected.to include 'platform variant' }
-                end
+            #       it { is_expected.to include 'platform variant' }
+            #     end
 
-                context 'and HAS BINARIES for the current platform' do
-                  before { expect(Libddprof).to receive(:pkgconfig_folder).and_return('/simulated/pkgconfig_folder') }
+            #     context 'and HAS BINARIES for the current platform' do
+            #       before { expect(Libddprof).to receive(:pkgconfig_folder).and_return('/simulated/pkgconfig_folder') }
 
-                  it { is_expected.to be nil }
-                end
-              end
-            end
+            it { is_expected.to be nil }
+            #     end
+            #   end
+            # end
           end
 
           context 'when Ruby CAN NOT use the MJIT header' do

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -1,6 +1,7 @@
 # typed: ignore
 
 require 'ext/ddtrace_profiling_native_extension/native_extension_helpers'
+require 'libddprof'
 
 RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
   describe '.supported?' do
@@ -21,6 +22,10 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
 
   describe '.unsupported_reason' do
     subject(:unsupported_reason) { described_class.unsupported_reason }
+
+    before do
+      allow(RbConfig::CONFIG).to receive(:[]).and_call_original
+    end
 
     context 'when disabled via the DD_PROFILING_NO_EXTENSION environment variable' do
       around { |example| ClimateControl.modify('DD_PROFILING_NO_EXTENSION' => 'true') { example.run } }
@@ -50,27 +55,65 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
       end
 
       context 'when not on Windows' do
-        before { allow(Gem).to receive(:win_platform?).and_return(false) }
+        before { expect(Gem).to receive(:win_platform?).and_return(false) }
+
+        shared_examples 'libddprof usable' do
+          context 'when libddprof is not available' do
+            before do
+              allow(described_class)
+                .to receive(:require).with('libddprof').and_raise(LoadError.new('Testing failed require'))
+            end
+
+            it { is_expected.to include '`libddprof` gem is not available' }
+          end
+
+          context 'when libddprof is available' do
+            context 'but DOES NOT have binaries' do
+              before { expect(Libddprof).to receive(:binaries?).and_return(false) }
+
+              it { is_expected.to include 'gem installed on your system is missing platform-specific' }
+            end
+
+            context 'and DOES have binaries' do
+              before { expect(Libddprof).to receive(:binaries?).and_return(true) }
+
+              context 'but DOES NOT HAVE binaries for the current platform' do
+                before do
+                  expect(Libddprof).to receive(:pkgconfig_folder).and_return(nil)
+                  expect(Libddprof).to receive(:available_binaries).and_return(['fooarch-linux', 'bararch-linux-musl'])
+                end
+
+                it { is_expected.to include 'platform variant' }
+              end
+
+              context 'and HAS BINARIES for the current platform' do
+                before { expect(Libddprof).to receive(:pkgconfig_folder).and_return('/simulated/pkgconfig_folder') }
+
+                it { is_expected.to be nil }
+              end
+            end
+          end
+        end
 
         context 'when Ruby CAN NOT use the MJIT header' do
           before { stub_const('Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER', false) }
 
-          it { is_expected.to be nil }
+          include_examples 'libddprof usable'
         end
 
         context 'when Ruby CAN use the MJIT header' do
           before { stub_const('Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER', true) }
 
-          context 'when Ruby DOES NOT have MJIT support' do
-            before { allow(RbConfig::CONFIG).to receive(:[]).with('MJIT_SUPPORT').and_return('no') }
+          context 'but DOES NOT have MJIT support' do
+            before { expect(RbConfig::CONFIG).to receive(:[]).with('MJIT_SUPPORT').and_return('no') }
 
             it { is_expected.to include 'without JIT' }
           end
 
-          context 'when Ruby DOES have MJIT support' do
-            before { allow(RbConfig::CONFIG).to receive(:[]).with('MJIT_SUPPORT').and_return('yes') }
+          context 'and DOES have MJIT support' do
+            before { expect(RbConfig::CONFIG).to receive(:[]).with('MJIT_SUPPORT').and_return('yes') }
 
-            it { is_expected.to be nil }
+            include_examples 'libddprof usable'
           end
         end
       end

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -57,6 +57,12 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
       context 'when not on Windows' do
         before { expect(Gem).to receive(:win_platform?).and_return(false) }
 
+        context 'when not on macOS or Linux' do
+          before { stub_const('RUBY_PLATFORM', 'sparc-opensolaris') }
+
+          it { is_expected.to include 'operating system is not supported' }
+        end
+
         shared_examples 'libddprof usable' do
           context 'when libddprof is not available' do
             before do

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -10,8 +10,15 @@ RSpec.describe Datadog::Profiling::NativeExtension do
     begin
       require "ddtrace_profiling_native_extension.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
     rescue LoadError
-      raise 'Profiling native extension does not seem to be compiled. ' \
-        'Try running `bundle exec rake compile` before running this test.'
+      if PlatformHelpers.mac?
+        skip 'Skipping profiling native extension specs: extension does not seem' \
+          'to be available. (Note that on macOS the extension can only be built if ' \
+          'libddprof is also manually rebuilt from source, since there are no ' \
+          'precompiled macOS binaries for libddprof).'
+      else
+        raise 'Profiling native extension does not seem to be compiled. ' \
+          'Try running `bundle exec rake compile` before running this test.'
+      end
     end
   end
 

--- a/spec/datadog/profiling/pprof/builder_spec.rb
+++ b/spec/datadog/profiling/pprof/builder_spec.rb
@@ -1,16 +1,14 @@
 # typed: false
 
 require 'spec_helper'
+require 'datadog/profiling/spec_helper'
 
 require 'datadog/profiling'
 require 'datadog/profiling/events/stack'
 require 'datadog/profiling/pprof/builder'
 
 RSpec.describe Datadog::Profiling::Pprof::Builder do
-  before do
-    skip 'Profiling is not supported on JRuby' if PlatformHelpers.jruby?
-    skip 'Profiling is not supported on TruffleRuby' if PlatformHelpers.truffleruby?
-  end
+  before { skip_if_profiling_not_supported(self) }
 
   subject(:builder) { described_class.new }
 

--- a/spec/datadog/profiling/pprof/stack_sample_spec.rb
+++ b/spec/datadog/profiling/pprof/stack_sample_spec.rb
@@ -8,10 +8,7 @@ require 'datadog/profiling/events/stack'
 require 'datadog/profiling/pprof/stack_sample'
 
 RSpec.describe Datadog::Profiling::Pprof::StackSample do
-  before do
-    skip 'Profiling is not supported on JRuby' if PlatformHelpers.jruby?
-    skip 'Profiling is not supported on TruffleRuby' if PlatformHelpers.truffleruby?
-  end
+  before { skip_if_profiling_not_supported(self) }
 
   subject(:converter) { described_class.new(builder, sample_type_mappings) }
 

--- a/spec/datadog/profiling/pprof/template_spec.rb
+++ b/spec/datadog/profiling/pprof/template_spec.rb
@@ -1,15 +1,13 @@
 # typed: false
 
 require 'spec_helper'
+require 'datadog/profiling/spec_helper'
 
 require 'datadog/profiling'
 require 'datadog/profiling/pprof/template'
 
 RSpec.describe Datadog::Profiling::Pprof::Template do
-  before do
-    skip 'Profiling is not supported on JRuby' if PlatformHelpers.jruby?
-    skip 'Profiling is not supported on TruffleRuby' if PlatformHelpers.truffleruby?
-  end
+  before { skip_if_profiling_not_supported(self) }
 
   subject(:template) { described_class.new(mappings) }
 

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -65,6 +65,12 @@ module ProfileHelpers
       wall_time_ns || rand(1e9)
     )
   end
+
+  def skip_if_profiling_not_supported(testcase)
+    testcase.skip('Profiling is not supported on JRuby') if PlatformHelpers.jruby?
+    testcase.skip('Profiling is not supported on TruffleRuby') if PlatformHelpers.truffleruby?
+    testcase.skip('Profiling is not supported on macOS') if PlatformHelpers.mac?
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/datadog/profiling/transport/http/adapters/net_integration_spec.rb
+++ b/spec/datadog/profiling/transport/http/adapters/net_integration_spec.rb
@@ -13,10 +13,7 @@ require 'datadog/profiling/transport/http'
 require 'ddtrace/transport/http/adapters/net'
 
 RSpec.describe 'Adapters::Net profiling integration tests' do
-  before do
-    skip 'Profiling is not supported on JRuby' if PlatformHelpers.jruby?
-    skip 'Profiling is not supported on TruffleRuby' if PlatformHelpers.truffleruby?
-  end
+  before { skip_if_profiling_not_supported(self) }
 
   let(:settings) { Datadog::Core::Configuration::Settings.new }
 

--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -1,6 +1,9 @@
 # typed: false
+require 'datadog/profiling/spec_helper'
 
-RSpec.describe 'Profiling benchmarks', if: (RUBY_VERSION >= '2.4.0' && PlatformHelpers.supports_fork?) do
+RSpec.describe 'Profiling benchmarks', if: (RUBY_VERSION >= '2.4.0') do
+  before { skip_if_profiling_not_supported(self) }
+
   around do |example|
     ClimateControl.modify('VALIDATE_BENCHMARK' => 'true') do
       example.run


### PR DESCRIPTION
[`libddprof`](https://github.com/DataDog/libddprof) is a Rust-based library that implements common functionality used by our profilers:

* aggregation of profiling data
* serialization of profiling data
* reporting of profiling data to backend

This PR adds the scaffolding to enable usage of libddprof from dd-trace-rb, **but does not yet make use of any of its functionality**.

Currently, libddprof works for all supported Rubies (2.1 to 3.2 dev) but only on x86-64 and 64-bit ARM Linux. The current integration has been set up in such a way that on other platforms we print a nice banner telling customers that they won't have profiling **but do not otherwise impact the customer in using all other Datadog products** (tracing, ci, appsec, ...).

This PR includes a nice refactoring + addition of tests to make sure this safe installation behavior is working correctly.

**Note**: To allow this PR to be merged in more quickly, I've commented out the actual libddprof linking bits in `extconf.rb`; I'll re-enable that in a later PR.