### PR TITLE
RFC: Remove deprecated ability to provide `c.tracer.transport_options` as a hash, support proc only

### DIFF
--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -29,7 +29,6 @@ module Datadog
             :uds_path,
             :timeout_seconds,
             :deprecated_for_removal_transport_configuration_proc,
-            :deprecated_for_removal_transport_configuration_options
           ) do
             def initialize(
               adapter:,
@@ -38,8 +37,7 @@ module Datadog
               port:,
               uds_path:,
               timeout_seconds:,
-              deprecated_for_removal_transport_configuration_proc:,
-              deprecated_for_removal_transport_configuration_options:
+              deprecated_for_removal_transport_configuration_proc:
             )
               super(
                 adapter,
@@ -48,8 +46,7 @@ module Datadog
                 port,
                 uds_path,
                 timeout_seconds,
-                deprecated_for_removal_transport_configuration_proc,
-                deprecated_for_removal_transport_configuration_options,
+                deprecated_for_removal_transport_configuration_proc
               )
               freeze
             end
@@ -96,7 +93,6 @@ module Datadog
             # That is the main reason why it is deprecated -- it's an opaque function that may set a bunch of settings
             # that we know nothing of until we actually call it.
             deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc,
-            deprecated_for_removal_transport_configuration_options: deprecated_for_removal_transport_configuration_options
           )
         end
 
@@ -199,19 +195,6 @@ module Datadog
           settings.tracer.transport_options if settings.tracer.transport_options.is_a?(Proc)
         end
 
-        def deprecated_for_removal_transport_configuration_options
-          options = settings.tracer.transport_options
-
-          if options.is_a?(Hash) && !options.empty?
-            log_warning(
-              'Configuring the tracer via a c.tracer.transport_options hash is deprecated for removal in a future ' \
-              "ddtrace version (c.tracer.transport_options contained '#{options.inspect}')."
-            )
-
-            options
-          end
-        end
-
         # We only use the default unix socket if it is already present.
         # This is by design, as we still want to use the default host:port if no unix socket is present.
         def uds_fallback
@@ -221,7 +204,6 @@ module Datadog
             if configured_hostname.nil? &&
                configured_port.nil? &&
                deprecated_for_removal_transport_configuration_proc.nil? &&
-               deprecated_for_removal_transport_configuration_options.nil? &&
                File.exist?(Transport::Ext::UnixSocket::DEFAULT_PATH)
 
               Transport::Ext::UnixSocket::DEFAULT_PATH

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -592,16 +592,12 @@ module Datadog
 
           # @see file:docs/GettingStarted.md#configuring-the-transport-layer Configuring the transport layer
           #
-          # @overload transport_options
-          #   A custom {Hash} with keyword options to be passed to the initializer of
-          #   the tracer writer class.
-          # @overload transport_options
-          #   A {Proc} that configures a custom tracer transport.
-          #   @yield Receives a {Datadog::Transport::HTTP} that can be modified with custom adapters and settings.
-          #   @yieldparam [Datadog::Transport::HTTP] t transport to be configured.
-          # @default `{}`
-          # @return [Hash,Proc,nil]
-          option :transport_options, default: ->(_i) { {} }, lazy: true
+          # A {Proc} that configures a custom tracer transport.
+          # @yield Receives a {Datadog::Transport::HTTP} that can be modified with custom adapters and settings.
+          # @yieldparam [Datadog::Transport::HTTP] t transport to be configured.
+          # @default `nil`
+          # @return [Proc,nil]
+          option :transport_options, default: nil
 
           # A custom writer instance.
           # The object must respect the {Datadog::Tracing::Writer} interface.

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -34,12 +34,6 @@ module Datadog
           transport.adapter(agent_settings)
           transport.headers default_headers
 
-          if agent_settings.deprecated_for_removal_transport_configuration_options
-            # The deprecated_for_removal_transport_configuration_options take precedence over any options the caller
-            # specifies
-            options = options.merge(**agent_settings.deprecated_for_removal_transport_configuration_options)
-          end
-
           apis = API.defaults
 
           transport.api API::V4, apis[API::V4], fallback: API::V3, default: true

--- a/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
       uds_path: uds_path,
       timeout_seconds: nil,
       deprecated_for_removal_transport_configuration_proc: nil,
-      deprecated_for_removal_transport_configuration_options: nil,
     }
   end
 
@@ -335,28 +334,6 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
         **settings,
         deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc
       )
-    end
-  end
-
-  context 'when a non-empty hash is configured in tracer.transport_options' do
-    let(:deprecated_for_removal_transport_configuration_options) { { batman: :cool } }
-
-    before do
-      ddtrace_settings.tracer.transport_options = deprecated_for_removal_transport_configuration_options
-      allow(logger).to receive(:warn)
-    end
-
-    it 'includes the given hash in the resolved settings as the deprecated_for_removal_transport_configuration_options' do
-      expect(resolver).to have_attributes(
-        **settings,
-        deprecated_for_removal_transport_configuration_options: deprecated_for_removal_transport_configuration_options
-      )
-    end
-
-    it 'logs a deprecation warning' do
-      expect(logger).to receive(:warn).with(/deprecated for removal/)
-
-      resolver
     end
   end
 

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -1299,25 +1299,17 @@ RSpec.describe Datadog::Core::Configuration::Settings do
     describe '#transport_options' do
       subject(:transport_options) { settings.tracer.transport_options }
 
-      it { is_expected.to eq({}) }
-
-      context 'when modified' do
-        it 'does not modify the default by reference' do
-          settings.tracer.transport_options[:foo] = :bar
-          expect(settings.tracer.transport_options).to_not be_empty
-          expect(settings.tracer.options[:transport_options].default_value).to be_empty
-        end
-      end
+      it { is_expected.to be nil }
     end
 
     describe '#transport_options=' do
-      let(:options) { { hostname: 'my-agent' } }
+      let(:config_proc) { proc { |t| t.adapter :test } }
 
       it 'updates the #transport_options setting' do
-        expect { settings.tracer.transport_options = options }
+        expect { settings.tracer.transport_options = config_proc }
           .to change { settings.tracer.transport_options }
-          .from({})
-          .to(options)
+          .from(nil)
+          .to(config_proc)
       end
     end
 

--- a/spec/datadog/profiling/transport/http_spec.rb
+++ b/spec/datadog/profiling/transport/http_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe Datadog::Profiling::Transport::HTTP do
         uds_path: uds_path,
         timeout_seconds: nil,
         deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc,
-        deprecated_for_removal_transport_configuration_options: nil,
       )
     end
     let(:adapter) { :net_http }

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -532,7 +532,7 @@ RSpec.describe 'Tracer integration tests' do
         end
       end
 
-      context 'is a Proc' do
+      context 'is provided' do
         let(:transport_options) { proc { |t| on_build.call(t) } }
         let(:on_build) do
           double('on_build').tap do |double|
@@ -549,30 +549,6 @@ RSpec.describe 'Tracer integration tests' do
             expect(transport).to be_a_kind_of(Datadog::Transport::Traces::Transport)
             expect(transport.current_api.adapter.hostname).to be hostname
             expect(transport.current_api.adapter.port).to be port
-          end
-        end
-      end
-
-      context 'is a Hash' do
-        let(:transport_options) do
-          {
-            api_version: api_version,
-            headers: headers
-          }
-        end
-
-        let(:api_version) { Datadog::Transport::HTTP::API::V4 }
-        let(:headers) { { 'Test-Header' => 'test' } }
-
-        it do
-          configure
-
-          tracer.writer.transport.tap do |transport|
-            expect(transport).to be_a_kind_of(Datadog::Transport::Traces::Transport)
-            expect(transport.current_api_id).to be api_version
-            expect(transport.current_api.adapter.hostname).to be hostname
-            expect(transport.current_api.adapter.port).to be port
-            expect(transport.current_api.headers).to include(headers)
           end
         end
       end

--- a/spec/ddtrace/transport/http/builder_spec.rb
+++ b/spec/ddtrace/transport/http/builder_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Datadog::Transport::HTTP::Builder do
           uds_path: nil,
           timeout_seconds: nil,
           deprecated_for_removal_transport_configuration_proc: nil,
-          deprecated_for_removal_transport_configuration_options: nil,
         )
       end
       let(:config_adapter) { :adapter_foo }

--- a/spec/ddtrace/transport/http_spec.rb
+++ b/spec/ddtrace/transport/http_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe Datadog::Transport::HTTP do
       let(:uds_path) { nil }
       let(:timeout_seconds) { nil }
       let(:deprecated_for_removal_transport_configuration_proc) { nil }
-      let(:deprecated_for_removal_transport_configuration_options) { nil }
 
       let(:agent_settings) do
         Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings.new(
@@ -91,7 +90,6 @@ RSpec.describe Datadog::Transport::HTTP do
           uds_path: uds_path,
           timeout_seconds: timeout_seconds,
           deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc,
-          deprecated_for_removal_transport_configuration_options: deprecated_for_removal_transport_configuration_options
         )
       end
 
@@ -108,55 +106,6 @@ RSpec.describe Datadog::Transport::HTTP do
             expect(api.adapter.port).to eq(port)
             expect(api.adapter.timeout).to be(timeout_seconds)
             expect(api.adapter.ssl).to be true
-          end
-        end
-      end
-
-      context 'that specifies an API version' do
-        let(:deprecated_for_removal_transport_configuration_options) { { api_version: api_version } }
-
-        context 'that is defined' do
-          let(:api_version) { Datadog::Transport::HTTP::API::V4 }
-
-          it { expect(default.current_api_id).to eq(api_version) }
-        end
-
-        context 'that is not defined' do
-          let(:api_version) { double('non-existent API') }
-
-          it { expect { default }.to raise_error(Datadog::Transport::HTTP::Builder::UnknownApiError) }
-        end
-
-        context 'when the options also try to set the api_version' do
-          let(:api_version) { Datadog::Transport::HTTP::API::V3 }
-          let(:options) { { api_version: Datadog::Transport::HTTP::API::V4 } }
-
-          it 'prioritizes the version in the agent_settings' do
-            expect(default.current_api_id).to eq(api_version)
-          end
-        end
-      end
-
-      context 'that specifies headers' do
-        let(:deprecated_for_removal_transport_configuration_options) { { headers: headers } }
-
-        let(:headers) { { 'Test-Header' => 'foo' } }
-
-        it do
-          default.apis.each_value do |api|
-            expect(api.headers).to include(described_class.default_headers)
-            expect(api.headers).to include(headers)
-          end
-        end
-
-        context 'when the options also try to set the headers' do
-          let(:options) { { headers: { 'Some-Other-Test-Header' => 'foo' } } }
-
-          it 'prioritizes the headers in the agent_settings' do
-            default.apis.each_value do |api|
-              expect(api.headers).to include(described_class.default_headers)
-              expect(api.headers).to include(headers)
-            end
           end
         end
       end


### PR DESCRIPTION
Up until now, we supported two ways of passing custom configurations to `transport_options`: either a hash, or as a proc.

The hash variant is not (that I could find) documented anywhere, and is a subset of the proc variant, so I propose that we remove it in time for 1.0.0.

This allows us to remove a lot of extra complexity around configuring our transports, while keeping the same flexibility in place (the proc variant).

(As a reminder, despite its legacy name, `c.tracer.transport_options` is handled by the `AgentSettingsResolver` and can be used by every product to configure its transport).