### PR TITLE
perf:Avoid copying frozen objects

### DIFF
--- a/lib/datadog/core/environment/identity.rb
+++ b/lib/datadog/core/environment/identity.rb
@@ -16,10 +16,10 @@ module Datadog
 
         # Retrieves number of classes from runtime
         def id
-          @id ||= ::SecureRandom.uuid
+          @id ||= ::SecureRandom.uuid.freeze
 
           # Check if runtime has changed, e.g. forked.
-          after_fork! { @id = ::SecureRandom.uuid }
+          after_fork! { @id = ::SecureRandom.uuid.freeze }
 
           @id
         end

--- a/lib/datadog/core/environment/socket.rb
+++ b/lib/datadog/core/environment/socket.rb
@@ -13,9 +13,9 @@ module Datadog
 
         def hostname
           # Check if runtime has changed, e.g. forked.
-          after_fork! { @hostname = ::Socket.gethostname }
+          after_fork! { @hostname = ::Socket.gethostname.freeze }
 
-          @hostname ||= ::Socket.gethostname
+          @hostname ||= ::Socket.gethostname.freeze
         end
       end
     end

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -418,6 +418,19 @@ module Datadog
         :parent,
         :span
 
+      if RUBY_VERSION < '2.2' # nil.dup only fails in Ruby 2.1
+        # Ensures #initialize can call nil.dup safely
+        module RefineNil
+          refine NilClass do
+            def dup
+              self
+            end
+          end
+        end
+
+        using RefineNil
+      end
+
       # Create a Span from the operation which represents
       # the finalized measurement. We #dup here to prevent
       # mutation by reference; when this span is returned,
@@ -438,12 +451,6 @@ module Datadog
           type: @type.frozen? ? @type : @type.dup,
           trace_id: @trace_id
         )
-      end
-
-      if RUBY_VERSION < '2.2' # nil.dup only fails in Ruby 2.1
-        def nil.dup
-          self
-        end
       end
 
       # Set this span's parent, inheriting any properties not explicitly set.

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -435,18 +435,18 @@ module Datadog
       # we don't want this SpanOperation to modify it further.
       def build_span
         Span.new(
-          @name && @name.dup,
+          @name.frozen? ? @name : @name.dup,
           duration: duration,
           end_time: @end_time,
           id: @id,
-          meta: meta && meta.dup,
-          metrics: metrics && metrics.dup,
+          meta: meta.dup,
+          metrics: metrics.dup,
           parent_id: @parent_id,
-          resource: @resource && @resource.dup,
-          service: @service && @service.dup,
+          resource: @resource.frozen? ? @resource : @resource.dup,
+          service: @service.frozen? ? @service : @service.dup,
           start_time: @start_time,
           status: @status,
-          type: @type && @type.dup,
+          type: @type.frozen? ? @type : @type.dup,
           trace_id: @trace_id
         )
       end

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -451,6 +451,12 @@ module Datadog
         )
       end
 
+      if RUBY_VERSION < '2.2' # nil.dup only fails in Ruby 2.1
+        def nil.dup
+          self
+        end
+      end
+
       # Set this span's parent, inheriting any properties not explicitly set.
       # If the parent is nil, set the span as the root span.
       #

--- a/lib/datadog/tracing/trace_segment.rb
+++ b/lib/datadog/tracing/trace_segment.rb
@@ -68,6 +68,12 @@ module Datadog
         self.service = (service.frozen? ? service : service.dup)
       end
 
+      if RUBY_VERSION < '2.2' # nil.dup only fails in Ruby 2.1
+        def nil.dup
+          self
+        end
+      end
+
       def_delegators :spans, *SPANS_METHODS
 
       # Define tag accessors

--- a/lib/datadog/tracing/trace_segment.rb
+++ b/lib/datadog/tracing/trace_segment.rb
@@ -54,8 +54,8 @@ module Datadog
 
         # Set well-known tags
         self.agent_sample_rate = agent_sample_rate
-        self.hostname = (hostname.frozen? ? hostname : hostname.dup)
-        self.lang = (lang.frozen? ? lang : lang.dup)
+        self.hostname = hostname
+        self.lang = lang
         self.name = (name.frozen? ? name : name.dup)
         self.origin = (origin.frozen? ? origin : origin.dup)
         self.process_id = process_id

--- a/lib/datadog/tracing/trace_segment.rb
+++ b/lib/datadog/tracing/trace_segment.rb
@@ -17,6 +17,19 @@ module Datadog
         :spans,
         :tags
 
+      if RUBY_VERSION < '2.2' # nil.dup only fails in Ruby 2.1
+        # Ensures #initialize can call nil.dup safely
+        module RefineNil
+          refine NilClass do
+            def dup
+              self
+            end
+          end
+        end
+
+        using RefineNil
+      end
+
       def initialize(
         spans,
         agent_sample_rate: nil,
@@ -54,12 +67,6 @@ module Datadog
         self.sample_rate = sample_rate
         self.sampling_priority = sampling_priority
         self.service = (service.frozen? ? service : service.dup)
-      end
-
-      if RUBY_VERSION < '2.2' # nil.dup only fails in Ruby 2.1
-        def nil.dup
-          self
-        end
       end
 
       def any?

--- a/lib/datadog/tracing/trace_segment.rb
+++ b/lib/datadog/tracing/trace_segment.rb
@@ -62,7 +62,7 @@ module Datadog
         self.rate_limiter_rate = rate_limiter_rate
         self.resource = (resource.frozen? ? resource : resource.dup)
         self.rule_sample_rate = rule_sample_rate
-        self.runtime_id = (runtime_id.frozen? ? runtime_id : runtime_id.dup)
+        self.runtime_id = runtime_id
         self.sample_rate = sample_rate
         self.sampling_priority = sampling_priority
         self.service = (service.frozen? ? service : service.dup)

--- a/lib/datadog/tracing/trace_segment.rb
+++ b/lib/datadog/tracing/trace_segment.rb
@@ -54,18 +54,18 @@ module Datadog
 
         # Set well-known tags
         self.agent_sample_rate = agent_sample_rate
-        self.hostname = (hostname && hostname.dup)
-        self.lang = (lang && lang.dup)
-        self.name = (name && name.dup)
-        self.origin = (origin && origin.dup)
+        self.hostname = (hostname.frozen? ? hostname : hostname.dup)
+        self.lang = (lang.frozen? ? lang : lang.dup)
+        self.name = (name.frozen? ? name : name.dup)
+        self.origin = (origin.frozen? ? origin : origin.dup)
         self.process_id = process_id
         self.rate_limiter_rate = rate_limiter_rate
-        self.resource = (resource && resource.dup)
+        self.resource = (resource.frozen? ? resource : resource.dup)
         self.rule_sample_rate = rule_sample_rate
-        self.runtime_id = (runtime_id && runtime_id.dup)
+        self.runtime_id = (runtime_id.frozen? ? runtime_id : runtime_id.dup)
         self.sample_rate = sample_rate
         self.sampling_priority = sampling_priority
-        self.service = (service && service.dup)
+        self.service = (service.frozen? ? service : service.dup)
       end
 
       def_delegators :spans, *SPANS_METHODS

--- a/spec/datadog/tracing/trace_segment_spec.rb
+++ b/spec/datadog/tracing/trace_segment_spec.rb
@@ -61,14 +61,14 @@ RSpec.describe Datadog::Tracing::TraceSegment do
         let(:options) { { hostname: hostname } }
         let(:hostname) { 'my.host' }
 
-        it { is_expected.to have_attributes(hostname: be_a_copy_of(hostname)) }
+        it { is_expected.to have_attributes(hostname: be(hostname)) }
       end
 
       context ':lang' do
         let(:options) { { lang: lang } }
         let(:lang) { 'ruby' }
 
-        it { is_expected.to have_attributes(lang: be_a_copy_of(lang)) }
+        it { is_expected.to have_attributes(lang: be(lang)) }
       end
 
       context ':name' do
@@ -117,7 +117,7 @@ RSpec.describe Datadog::Tracing::TraceSegment do
         let(:options) { { runtime_id: runtime_id } }
         let(:runtime_id) { Datadog::Core::Environment::Identity.id }
 
-        it { is_expected.to have_attributes(runtime_id: be_a_copy_of(runtime_id)) }
+        it { is_expected.to have_attributes(runtime_id: be(runtime_id)) }
       end
 
       context ':sample_rate' do


### PR DESCRIPTION
When profiling span creation and serialization, we noticed that object duplication was responsible for a measurable part of our overhead.

This PR avoids some of that cost by only duplicating objects if they are not `.frozen?`.
Many of the values (e.g. lang, span name, span type) are normally internal `ddtrace` string constants, which are frozen.

Some of the values used by `SpanOperation#build_span` and `TraceSegment#initialize` could be frozen in other parts of `ddtrace`, but I'm keeping this PR concise, specially since the changes in this PR have been extensively tested in our internal environment.