### PR TITLE
Run full system test matrix

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -51,7 +51,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'DataDog/system-tests'
-          ref: 'use-system-test-apps-for-ruby'
 
       - name: Checkout dd-trace-rb
         uses: actions/checkout@v2

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -8,35 +8,71 @@ on:
   schedule:
     - cron:  '00 04 * * 2-6'
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
   system-tests:
+    strategy:
+      matrix:
+        include:
+          - library: ruby
+            weblog-variant: rack
+          - library: ruby
+            weblog-variant: sinatra14
+          - library: ruby
+            weblog-variant: sinatra20
+          - library: ruby
+            weblog-variant: sinatra21
+          - library: ruby
+            weblog-variant: rails32
+          - library: ruby
+            weblog-variant: rails40
+          - library: ruby
+            weblog-variant: rails41
+          - library: ruby
+            weblog-variant: rails42
+          - library: ruby
+            weblog-variant: rails50
+          - library: ruby
+            weblog-variant: rails51
+          - library: ruby
+            weblog-variant: rails52
+          - library: ruby
+            weblog-variant: rails60
+          - library: ruby
+            weblog-variant: rails61
+          - library: ruby
+            weblog-variant: rails70
     runs-on: ubuntu-latest
+    name: System Tests (${{ matrix.weblog-variant }})
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           repository: 'DataDog/system-tests'
+          ref: 'use-system-test-apps-for-ruby'
 
       - name: Checkout dd-trace-rb
         uses: actions/checkout@v2
         with:
           path: 'binaries/dd-trace-rb'
 
-      - name: Build ruby
-        run: ./build.sh ruby
+      - name: Log in to the Container registry
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+      - name: Build
+        run: ./build.sh --library ${{ matrix.library }} --weblog-variant ${{ matrix.weblog-variant }}
 
       - name: Run
         run: ./run.sh
         env:
           DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
 
-      - name: Compress artifact
-        if: ${{ always() }}
-        run: tar -czvf artifact.tar.gz $(ls | grep logs)
-
-      - name: Upload artifact
+      - name: Archive logs
         uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: logs
-          path: artifact.tar.gz
+          name: system-tests-${{ matrix.library }}-${{ matrix.weblog-variant }}-logs-${{ github.run_id }}-${{ github.sha }}
+          path: logs

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -1,4 +1,4 @@
-name: AppSec System Tests
+name: System Tests
 
 on:
   push:


### PR DESCRIPTION
Enables the full set of Ruby system test apps, comprised of:

```
# <framework>: <ruby>
rack: 3.0
sinatra14: 2.4
sinatra20: 2.7
sinatra21: 3.1
rails32: 2.1
rails40: 2.2
rails41: 2.3
rails42: 2.4
rails50: 2.5
rails51: 2.6
rails52: 2.7
rails60: 2.7
rails61: 3.0
rails70: 3.1
```

The base app images are built from https://github.com/DataDog/system-tests-apps-ruby, currently internal but that will be made public. The system test suite then builds from those base images to use the proper ddtrace version to test against.