### PR TITLE
Avoid using reserved subject name to_s

### DIFF
--- a/spec/datadog/profiling/pprof/payload_spec.rb
+++ b/spec/datadog/profiling/pprof/payload_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Datadog::Profiling::Pprof::Payload do
   end
 
   describe '#to_s' do
-    subject(:to_s) { payload.to_s }
+    subject(:to_ess) { payload.to_s }
 
     it { is_expected.to be(data) }
   end


### PR DESCRIPTION
`initialize` and `to_s` are reserved subject/let names, with `to_s` being recently introduced: https://github.com/rspec/rspec-core/pull/2886/files#diff-63ba5f25b008f3a36218395ab893c118c3f17b1bc11385f1657fb973c45f88f6R313

Because these two methods are commonly invoked in arbitrary objects (`to_s`, for example, to pretty print an object), RSpec does not guarantee that you can test with, with RSpec inadvertently calling that method internally.