### PR TITLE
Remove splat behavior from tracer

### DIFF
--- a/lib/datadog/ci/contrib/cucumber/formatter.rb
+++ b/lib/datadog/ci/contrib/cucumber/formatter.rb
@@ -33,7 +33,6 @@ module Datadog
               configuration[:operation_name],
               {
                 span_options: {
-                  app: Ext::APP,
                   resource: event.test_case.name,
                   service: configuration[:service_name]
                 },

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -31,7 +31,6 @@ module Datadog
                 configuration[:operation_name],
                 {
                   span_options: {
-                    app: Ext::APP,
                     resource: test_name,
                     service: configuration[:service_name]
                   },

--- a/lib/datadog/tracing/contrib/presto/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/presto/instrumentation.rb
@@ -18,7 +18,10 @@ module Datadog
             # Instance methods for Presto::Client
             module InstanceMethods
               def run(query)
-                Tracing.trace(Ext::SPAN_QUERY, **span_options) do |span|
+                Tracing.trace(
+                  Ext::SPAN_QUERY,
+                  service: datadog_configuration[:service_name]
+                ) do |span|
                   begin
                     decorate!(span, Ext::TAG_OPERATION_QUERY)
                     span.resource = query
@@ -33,7 +36,10 @@ module Datadog
               end
 
               def query(query, &blk)
-                Tracing.trace(Ext::SPAN_QUERY, **span_options) do |span|
+                Tracing.trace(
+                  Ext::SPAN_QUERY,
+                  service: datadog_configuration[:service_name]
+                ) do |span|
                   begin
                     decorate!(span, Ext::TAG_OPERATION_QUERY)
                     span.resource = query
@@ -48,7 +54,10 @@ module Datadog
               end
 
               def kill(query_id)
-                Tracing.trace(Ext::SPAN_KILL, **span_options) do |span|
+                Tracing.trace(
+                  Ext::SPAN_KILL,
+                  service: datadog_configuration[:service_name]
+                ) do |span|
                   begin
                     decorate!(span, Ext::TAG_OPERATION_KILL)
                     span.resource = Ext::SPAN_KILL
@@ -67,14 +76,6 @@ module Datadog
 
               def datadog_configuration
                 Tracing.configuration[:presto]
-              end
-
-              def span_options
-                {
-                  service: datadog_configuration[:service_name],
-                  app: Ext::TAG_COMPONENT,
-                  app_type: Tracing::Metadata::Ext::AppTypes::TYPE_DB
-                }
               end
 
               def decorate!(span, operation)

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -996,10 +996,18 @@ RSpec.describe Datadog::Tracing::TraceOperation do
     end
 
     context 'when building the span fails' do
+      let(:span_options) { { resource: 'my-span' } }
       let(:error) { error_class.new('error message') }
 
       before do
-        allow(trace_op).to receive(:build_span_options).and_raise(error)
+        allow(Datadog::Tracing::SpanOperation).to receive(:new) do
+          # Unstub (so it only raises an error once)
+          allow(Datadog::Tracing::SpanOperation).to receive(:new).and_call_original
+
+          # Trigger error
+          raise error
+        end
+
         allow(Datadog.logger).to receive(:debug)
       end
 

--- a/spec/datadog/tracing_spec.rb
+++ b/spec/datadog/tracing_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Datadog::Tracing do
     subject(:trace) { described_class.trace(name, continue_from: continue_from, **span_options, &block) }
     let(:name) { double('name') }
     let(:continue_from) { double('continue_from') }
-    let(:span_options) { { my: double('option') } }
+    let(:span_options) { { resource: double('option') } }
     let(:block) { -> {} }
 
     it 'delegates to the tracer' do


### PR DESCRIPTION
# Abstract

How we define and call methods can have a significant impact on performance. "Splatting" (use of `*` or `**`) is the most expensive, and utilized a few places as a shorthand. This pull request replaces this behavior with more efficient calls.

## Background

Testing many different ways of invoking a function and returning the same output in Ruby 3.0 yields:

```
Comparison:
          positional: 10655656.3 i/s
   positional kwargs:  9624532.0 i/s - 1.11x  (± 0.00) slower
              kwargs:  8061702.1 i/s - 1.32x  (± 0.00) slower
     positional opts:  7387281.3 i/s - 1.44x  (± 0.00) slower
explicit **positional:  7131263.9 i/s - 1.49x  (± 0.00) slower
        **positional:  6964865.1 i/s - 1.53x  (± 0.00) slower
 positional **kwargs:  6907537.6 i/s - 1.54x  (± 0.00) slower
       kwargs unused:  5474591.5 i/s - 1.95x  (± 0.00) slower
   explicit **kwargs:  4695832.9 i/s - 2.27x  (± 0.00) slower
            **kwargs:  4589379.2 i/s - 2.32x  (± 0.00) slower
             options:  3259426.9 i/s - 3.27x  (± 0.00) slower
              Struct:  2994563.1 i/s - 3.56x  (± 0.00) slower
```

General takeaways here are:

 - Use positional args over `kwargs` when possible
- Use `kwargs` over `options` when possible
- Avoid splatting `Array`/`Hash` (unless your input is already an `Array`/`Hash`, in which case it makes no difference)
- Don't define `**kwargs` as an arg

Code to reproduce the test results:

```ruby
require 'benchmark/ips'

S = Struct.new(:a, :b, :c)

def foo_pos(a, b, c)
  [a, b, c]
end

def foo_pos_options(a, b, c, opts = {})
  [a, b, c]
end

def foo_pos_kwargs(a, b, c, d: nil, e: nil, f: nil)
  [a, b, c]
end

def foo_pos_kwargs_splat(a, b, c, **kwargs)
  [a, b, c]
end

def foo_kwargs(a:, b:, c:)
  [a, b, c]
end

def foo_unused_kwargs(a:, b:, c:, **kwargs)
  [a, b, c]
end

def foo_options(opts = {})
  [opts[:a], opts[:b], opts[:c]]
end

def foo_struct(args)
  [args.a, args.b, args.c]
end

Benchmark.ips do |x|
  x.time = 3
  x.warmup = 1

  x.report('positional') do
    foo_pos(1, 2, 3)
  end

  x.report('**positional') do
    a = [1, 2, 3]
    foo_pos(*a)
  end

  x.report('explicit **positional') do
    a = [1, 2, 3]
    foo_pos(a[0], a[1], a[2])
  end

  x.report('positional opts') do
    foo_pos_options(1, 2, 3)
  end

  x.report('positional kwargs') do
    foo_pos_kwargs(1, 2, 3)
  end

  x.report('positional **kwargs') do
    foo_pos_kwargs_splat(1, 2, 3)
  end

  x.report('kwargs') do
    foo_kwargs(a: 1, b: 2, c: 3)
  end

  x.report('kwargs unused') do
    foo_unused_kwargs(a: 1, b: 2, c: 3)
  end

  x.report('**kwargs') do
    s = { a: 1, b: 2, c: 3 }
    foo_kwargs(**s)
  end

  x.report('explicit **kwargs') do
    s = { a: 1, b: 2, c: 3 }
    foo_kwargs(a: s[:a], b: s[:b], c: s[:c])
  end

  x.report('options') do
    foo_options(a: 1, b: 2, c: 3)
  end

  x.report('Struct') do
    s = S.new(1,2,3)
    foo_struct(s)
  end

  x.compare!
end
```
