### PR TITLE
Namespace AppSec settings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -166,6 +166,20 @@ namespace :spec do
       t.rspec_opts = args.to_a.join(' ')
     end
   end
+
+  namespace :appsec do
+    task all: [:main]
+
+    # Datadog AppSec main specs
+    RSpec::Core::RakeTask.new(:main) do |t, args|
+      t.pattern = 'spec/datadog/appsec/**/*_spec.rb'
+      t.exclude_pattern = 'spec/datadog/appsec/**/{contrib,auto_instrument}/**/*_spec.rb,'\
+                          ' spec/datadog/appsec/**/{auto_instrument,autoload}_spec.rb'
+      t.rspec_opts = args.to_a.join(' ')
+    end
+  end
+
+  task appsec: [:'appsec:all']
 end
 
 if defined?(RuboCop::RakeTask)
@@ -230,6 +244,7 @@ task :ci do
   # Main library
   declare '✅ 2.1 / ✅ 2.2 / ✅ 2.3 / ✅ 2.4 / ✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ jruby' => 'bundle exec rake spec:main'
   declare '✅ 2.1 / ✅ 2.2 / ✅ 2.3 / ✅ 2.4 / ✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ jruby' => 'bundle exec appraisal core-old rake spec:main'
+  declare '✅ 2.1 / ✅ 2.2 / ✅ 2.3 / ✅ 2.4 / ✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ jruby' => 'bundle exec rake spec:appsec:main'
   declare '✅ 2.1 / ✅ 2.2 / ✅ 2.3 / ✅ 2.4 / ✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ jruby' => 'bundle exec rake spec:contrib'
   declare '❌ 2.1 / ❌ 2.2 / ❌ 2.3 / ✅ 2.4 / ✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ jruby' => 'bundle exec rake spec:opentelemetry'
   declare '✅ 2.1 / ✅ 2.2 / ✅ 2.3 / ✅ 2.4 / ✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ jruby' => 'bundle exec rake spec:opentracer'

--- a/lib/datadog/appsec.rb
+++ b/lib/datadog/appsec.rb
@@ -1,4 +1,5 @@
 require 'datadog/appsec/configuration'
+require 'datadog/appsec/extensions'
 
 module Datadog
   # Namespace for Datadog AppSec instrumentation
@@ -8,6 +9,9 @@ module Datadog
     def self.writer
       @writer ||= Writer.new
     end
+
+    # Expose AppSec to global shared objects
+    Extensions.activate!
   end
 end
 

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -109,6 +109,10 @@ module Datadog
           end
         end
 
+        def enabled
+          @options[:enabled]
+        end
+
         def ruleset
           @options[:ruleset]
         end
@@ -123,6 +127,14 @@ module Datadog
 
         def trace_rate_limit
           @options[:trace_rate_limit]
+        end
+
+        def [](integration_name)
+          integration = Datadog::AppSec::Contrib::Integration.registry[integration_name]
+
+          raise ArgumentError, "'#{integration_name}' is not a valid integration." unless integration
+
+          integration.options if integration
         end
 
         def merge(dsl)
@@ -147,6 +159,13 @@ module Datadog
           end
 
           self
+        end
+
+        private
+
+        # Restore to original state, for testing only.
+        def reset!
+          initialize
         end
       end
     end

--- a/lib/datadog/appsec/contrib/rack/request.rb
+++ b/lib/datadog/appsec/contrib/rack/request.rb
@@ -9,7 +9,7 @@ module Datadog
           end
 
           # Rack < 2.0 does not have :each_header
-          if ::Rack::Request.instance_methods.include?(:each_header)
+          if defined?(::Rack) && ::Rack::Request.instance_methods.include?(:each_header)
             def self.headers(request)
               request.each_header.each_with_object({}) do |(k, v), h|
                 h[k.gsub(/^HTTP_/, '').downcase.tr('_', '-')] = v if k =~ /^HTTP_/

--- a/lib/datadog/appsec/contrib/rack/request.rb
+++ b/lib/datadog/appsec/contrib/rack/request.rb
@@ -9,6 +9,8 @@ module Datadog
           end
 
           # Rack < 2.0 does not have :each_header
+          # TODO: We need access to Rack here. We must make sure we are able to load AppSec without Rack,
+          # TODO: while still ensure correctness in ths code path.
           if defined?(::Rack) && ::Rack::Request.instance_methods.include?(:each_header)
             def self.headers(request)
               request.each_header.each_with_object({}) do |(k, v), h|

--- a/lib/datadog/appsec/extensions.rb
+++ b/lib/datadog/appsec/extensions.rb
@@ -1,0 +1,55 @@
+# typed: true
+require 'forwardable'
+require 'datadog/appsec/configuration'
+
+module Datadog
+  module AppSec
+    # Extends Datadog tracing with AppSec features
+    module Extensions
+      # Inject AppSec into global objects.
+      def self.activate!
+        Core::Configuration::Settings.include(Settings)
+      end
+
+      # Global Datadog configuration mixin
+      module Settings
+        # Exposes AppSec settings through the
+        # `Datadog.configure {|c| c.appsec._option_ }`
+        # configuration path.
+        def appsec
+          @appsec ||= AppSecAdapter.new(AppSec.settings)
+        end
+      end
+
+      # Merges {Datadog::AppSec::Configuration::Settings} and {Datadog::AppSec::Configuration::DSL}
+      # into a single read/write object.
+      class AppSecAdapter
+        extend Forwardable
+
+        def initialize(settings)
+          @settings = settings
+        end
+
+        # Writer methods
+        AppSec::Configuration::DSL.instance_methods(false).each do |met|
+          define_method(met) do |*arg|
+            dsl = AppSec::Configuration::DSL.new
+            dsl.send(met, *arg)
+            @settings.merge(dsl) # `merge` ensures any required side-effects take place
+            arg
+          end
+        end
+
+        # Reader methods
+        def_delegators :@settings, *AppSec::Configuration::Settings.instance_methods(false)
+
+        private
+
+        # Restore to original state, for testing only.
+        def reset!
+          @settings.send(:reset!)
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/extensions.rb
+++ b/lib/datadog/appsec/extensions.rb
@@ -31,17 +31,82 @@ module Datadog
         end
 
         # Writer methods
-        AppSec::Configuration::DSL.instance_methods(false).each do |met|
-          define_method(met) do |*arg|
-            dsl = AppSec::Configuration::DSL.new
-            dsl.send(met, *arg)
-            @settings.merge(dsl) # `merge` ensures any required side-effects take place
-            arg
-          end
+        def trace_rate_limit=(arg)
+          dsl = AppSec::Configuration::DSL.new
+          dsl.trace_rate_limit = arg
+          @settings.merge(dsl)
+        end
+
+        def options(arg)
+          dsl = AppSec::Configuration::DSL.new
+          dsl.options arg
+          @settings.merge(dsl)
+        end
+
+        def instruments(arg)
+          dsl = AppSec::Configuration::DSL.new
+          dsl.instruments arg
+          @settings.merge(dsl)
+        end
+
+        def ruleset=(arg)
+          dsl = AppSec::Configuration::DSL.new
+          dsl.ruleset = arg
+          @settings.merge(dsl)
+        end
+
+        def instrument(*args)
+          dsl = AppSec::Configuration::DSL.new
+          dsl.instrument(*args)
+          @settings.merge(dsl)
+        end
+
+        def waf_timeout=(arg)
+          dsl = AppSec::Configuration::DSL.new
+          dsl.waf_timeout = arg
+          @settings.merge(dsl)
+        end
+
+        def enabled=(arg)
+          dsl = AppSec::Configuration::DSL.new
+          dsl.enabled = arg
+          @settings.merge(dsl)
+        end
+
+        def waf_debug=(arg)
+          dsl = AppSec::Configuration::DSL.new
+          dsl.waf_debug = arg
+          @settings.merge(dsl)
         end
 
         # Reader methods
-        def_delegators :@settings, *AppSec::Configuration::Settings.instance_methods(false)
+        def [](arg)
+          @settings[arg]
+        end
+
+        def ruleset
+          @settings.ruleset
+        end
+
+        def waf_timeout
+          @settings.waf_timeout
+        end
+
+        def enabled
+          @settings.enabled
+        end
+
+        def waf_debug
+          @settings.waf_debug
+        end
+
+        def trace_rate_limit
+          @settings.trace_rate_limit
+        end
+
+        def merge(arg)
+          @settings.merge(arg)
+        end
 
         private
 

--- a/spec/datadog/appsec/extensions_spec.rb
+++ b/spec/datadog/appsec/extensions_spec.rb
@@ -1,0 +1,127 @@
+require 'datadog/appsec/spec_helper'
+
+RSpec.describe Datadog::AppSec::Extensions do
+  shared_context 'registry with integration' do
+    let(:registry) { {} }
+    let(:integration_name) { :example }
+    let(:integration_options) { double('integration integration_options') }
+    let(:integration_class) { double('integration class', loaded?: false) }
+    let(:integration) do
+      instance_double(
+        Datadog::AppSec::Contrib::Integration::RegisteredIntegration,
+        klass: integration_class,
+        options: integration_options
+      )
+    end
+
+    before do
+      registry[integration_name] = integration
+
+      allow(Datadog::AppSec::Contrib::Integration).to receive(:registry).and_return(registry)
+    end
+  end
+
+  context 'for' do
+    describe Datadog do
+      after { described_class.configuration.appsec.send(:reset!) }
+      describe '#configure' do
+        include_context 'registry with integration'
+
+        context 'given a block' do
+          subject(:configure) { described_class.configure(&block) }
+
+          context 'that calls #instrument for an integration' do
+            let(:block) { proc { |c| c.appsec.instrument integration_name } }
+
+            it 'configures the integration' do
+              # If integration_class.loaded? is invoked, it means the correct integration is being activated.
+              expect(integration_class).to receive(:loaded?).and_return(false)
+
+              configure
+            end
+          end
+        end
+      end
+    end
+
+    describe Datadog::Core::Configuration::Settings do
+      include_context 'registry with integration'
+
+      subject(:settings) { described_class.new.appsec }
+
+      after { settings.send(:reset!) }
+
+      describe '#enabled' do
+        subject(:enabled) { settings.enabled }
+        it { is_expected.to eq(true) }
+      end
+
+      describe '#enabled=' do
+        subject(:enabled_) { settings.enabled = false }
+        it do
+          expect { enabled_ }.to change { settings.enabled }.from(true).to(false)
+        end
+      end
+
+      describe '#ruleset' do
+        subject(:ruleset) { settings.ruleset }
+        it { is_expected.to eq(:recommended) }
+      end
+
+      describe '#ruleset=' do
+        subject(:ruleset_) { settings.ruleset = :expert }
+        it { expect { ruleset_ }.to change { settings.ruleset }.from(:recommended).to(:expert) }
+      end
+
+      describe '#waf_timeout' do
+        subject(:waf_timeout) { settings.waf_timeout }
+        it { is_expected.to eq(5000) }
+      end
+
+      describe '#waf_timeout=' do
+        subject(:waf_timeout_) { settings.waf_timeout = 3 }
+        it { expect { waf_timeout_ }.to change { settings.waf_timeout }.from(5000).to(3) }
+      end
+
+      describe '#waf_debug' do
+        subject(:waf_debug) { settings.waf_debug }
+        it { is_expected.to eq(false) }
+      end
+
+      describe '#waf_debug=' do
+        subject(:waf_debug_) { settings.waf_debug = true }
+        it { expect { waf_debug_ }.to change { settings.waf_debug }.from(false).to(true) }
+      end
+
+      describe '#trace_rate_limit' do
+        subject(:trace_rate_limit) { settings.trace_rate_limit }
+        it { is_expected.to eq(100) }
+      end
+
+      describe '#trace_rate_limit=' do
+        subject(:trace_rate_limit_) { settings.trace_rate_limit = 2 }
+        it { expect { trace_rate_limit_ }.to change { settings.trace_rate_limit }.from(100).to(2) }
+      end
+
+      describe '#[]' do
+        describe 'when the integration exists' do
+          subject(:get) { settings[integration_name] }
+
+          let(:integration_options) { { foo: :bar } }
+
+          before { settings.instrument(integration_name, integration_options) }
+
+          it 'retrieves the described configuration' do
+            is_expected.to eq(integration_options)
+          end
+        end
+
+        context 'when the integration doesn\'t exist' do
+          it do
+            expect { settings[:foobar] }.to raise_error(ArgumentError, /foobar/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/spec_helper.rb
+++ b/spec/datadog/appsec/spec_helper.rb
@@ -1,0 +1,12 @@
+# typed: strict
+require 'ddtrace'
+require 'datadog/appsec'
+require 'spec_helper'
+
+RSpec.configure do |config|
+  # As AppSec is disabled by default, activate it using the environment variable DD_APPSEC_ENABLED.
+  config.before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('DD_APPSEC_ENABLED').and_return('true')
+  end
+end


### PR DESCRIPTION
This PR moves AppSec configuration into the `appsec` configuration namespace in the global configuration: `Datadog.configure { |c| c.appsec._option_ }`.

The existing AppSec configuration code paths still exist, but should be removed in the future. This PR only ensures that `Datadog.configure` can correctly configure AppSec.

I suggest migrating all AppSec configuration to use Core configuration DSL defined in `lib/datadog/core/configuration/*`: this way we are able to seemesly configure all products in a single block. There is a few files that duplicate `lib/datadog/core/configuration/*` behaviour, like `Datadog::AppSec::Configuration::DSL` and `Datadog::AppSec::Configuration::Settings`, so it would be good to reduce duplication and ensure consistent behaviour.