### PR TITLE
Remove namespaced configuration access

### DIFF
--- a/benchmarks/profiler_sample_loop.rb
+++ b/benchmarks/profiler_sample_loop.rb
@@ -14,11 +14,8 @@ require_relative 'dogstatsd_reporter'
 
 class ProfilerSampleLoopBenchmark
   def create_profiler
-    Datadog::Profiling.configure do |c|
+    Datadog.configure do |c|
       c.profiling.enabled = true
-    end
-
-    Datadog::Tracing.configure do |c|
       c.tracing.transport_options = proc { |t| t.adapter :test }
     end
 

--- a/benchmarks/profiler_submission.rb
+++ b/benchmarks/profiler_submission.rb
@@ -28,11 +28,8 @@ class ProfilerSubmission
   def create_profiler
     @adapter_buffer = []
 
-    Datadog::Profiling.configure do |c|
+    Datadog.configure do |c|
       c.profiling.enabled = true
-    end
-
-    Datadog::Tracing.configure do |c|
       c.tracing.transport_options = proc { |t| t.adapter :test, @adapter_buffer }
     end
 

--- a/benchmarks/sidekiq_test.rb
+++ b/benchmarks/sidekiq_test.rb
@@ -103,7 +103,7 @@ class Worker
 end
 
 
-Datadog::Tracing.configure do |d|
+Datadog.configure do |d|
   d.instrument :rails, enabled: true, tags: { 'tag' => 'value' }
   d.instrument :http
   d.instrument :sidekiq, service_name: 'service'

--- a/docs/AutoInstrumentation.md
+++ b/docs/AutoInstrumentation.md
@@ -27,7 +27,7 @@ require 'ddtrace/auto_instrument'
 ## Additional configuration
 
 You can reconfigure, override, or disable any specific integration settings by adding
-a [`Datadog::Tracing.configure`](GettingStarted.md#integration-instrumentation) call after `ddtrace/auto_instrument` is activated.
+a [`Datadog.configure`](GettingStarted.md#integration-instrumentation) call after `ddtrace/auto_instrument` is activated.
 
 ## Custom integrations
 

--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -246,7 +246,7 @@ Datadog::Transport::HTTP::Builder::REGISTRY.set(CustomAdapter, :custom)
 Then pass an adapter instance to the tracer configuration:
 
 ```ruby
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.tracing.transport_options = proc { |t|
     # By name
     t.adapter :custom

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -192,7 +192,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 3. Create a `config/initializers/datadog.rb` file containing:
 
     ```ruby
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       # This will activate auto-instrumentation for Rails
       c.instrument :rails
     end
@@ -226,7 +226,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 
     ```ruby
     require 'ddtrace'
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       # Configure the tracer here.
       # Activate integrations, change tracer settings, etc...
       # By default without additional configuration, nothing will be traced.
@@ -254,7 +254,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 3. (Optional) Add a configuration block to your Ruby application to configure Datadog with:
 
     ```ruby
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       # Configure the Datadog tracer here.
       # Activate integrations, change tracer settings, etc...
       # By default without additional configuration,
@@ -383,10 +383,10 @@ current_trace = Datadog::Tracing.active_trace
 
 ## Integration instrumentation
 
-Many popular libraries and frameworks are supported out-of-the-box, which can be auto-instrumented. Although they are not activated automatically, they can be easily activated and configured by using the `Datadog::Tracing.configure` API:
+Many popular libraries and frameworks are supported out-of-the-box, which can be auto-instrumented. Although they are not activated automatically, they can be easily activated and configured by using the `Datadog.configure` API:
 
 ```ruby
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   # Activates and configures an integration
   c.instrument :integration_name, options
 end
@@ -448,12 +448,12 @@ For a list of available integrations, and their configuration options, please re
 
 The Action Cable integration traces broadcast messages and channel actions.
 
-You can enable it through `Datadog::Tracing.configure`:
+You can enable it through `Datadog.configure`:
 
 ```ruby
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :action_cable
 end
 ```
@@ -462,11 +462,11 @@ end
 
 The Action Mailer integration provides tracing for Rails 5 ActionMailer actions.
 
-You can enable it through `Datadog::Tracing.configure`:
+You can enable it through `Datadog.configure`:
 
 ```ruby
 require 'ddtrace'
- Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :action_mailer, options
 end
 ```
@@ -486,7 +486,7 @@ Most of the time, Action Pack is set up as part of Rails, but it can be activate
 require 'actionpack'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :action_pack
 end
 ```
@@ -499,7 +499,7 @@ Most of the time, Action View is set up as part of Rails, but it can be activate
 require 'actionview'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :action_view, options
 end
 ```
@@ -518,7 +518,7 @@ Most of the time, Active Job is set up as part of Rails, but it can be activated
 require 'active_job'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :active_job
 end
 
@@ -533,7 +533,7 @@ The Active Model Serializers integration traces the `serialize` event for versio
 require 'active_model_serializers'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :active_model_serializers
 end
 
@@ -551,7 +551,7 @@ require 'sqlite3'
 require 'active_record'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :active_record, options
 end
 
@@ -578,7 +578,7 @@ You can configure trace settings per database connection by using the `describes
 # If a block is provided, it yields a Settings object that
 # accepts any of the configuration options listed above.
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   # Symbol matching your database connection in config/database.yml
   # Only available if you are using Rails with ActiveRecord.
   c.instrument :active_record, describes: :secondary_database, service_name: 'secondary-db'
@@ -614,7 +614,7 @@ end
 You can also create configurations based on partial matching of database connection fields:
 
 ```ruby
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   # Matches any connection on host `127.0.0.1`.
   c.instrument :active_record, describes: { host:  '127.0.0.1' }, service_name: 'local-db'
 
@@ -642,7 +642,7 @@ Most of the time, Active Support is set up as part of Rails, but it can be activ
 require 'activesupport'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :active_support, options
 end
 
@@ -664,7 +664,7 @@ The AWS integration will trace every interaction (e.g. API calls) with AWS servi
 require 'aws-sdk'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :aws, options
 end
 
@@ -683,11 +683,11 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 The Concurrent Ruby integration adds support for context propagation when using `::Concurrent::Future`.
 Making sure that code traced within the `Future#execute` will have correct parent set.
 
-To activate your integration, use the `Datadog::Tracing.configure` method:
+To activate your integration, use the `Datadog.configure` method:
 
 ```ruby
 # Inside Rails initializer or equivalent
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   # Patches ::Concurrent::Future to use ExecutorService that propagates context
   c.instrument :concurrent_ruby
 end
@@ -702,20 +702,20 @@ end
 
 Cucumber integration will trace all executions of scenarios and steps when using `cucumber` framework.
 
-To activate your integration, use the `Datadog::Tracing.configure` method:
+To activate your integration, use the `Datadog.configure` method:
 
 ```ruby
 require 'cucumber'
 require 'ddtrace'
 
 # Configure default Cucumber integration
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :cucumber, options
 end
 
 # Example of how to attach tags from scenario to active span
 Around do |scenario, block|
-  active_span = Datadog::Tracing.configuration[:cucumber][:tracer].active_span
+  active_span = Datadog.configuration[:cucumber][:tracer].active_span
   unless active_span.nil?
     scenario.tags.filter { |tag| tag.include? ':' }.each do |tag|
       active_span.set_tag(*tag.name.split(':', 2))
@@ -742,7 +742,7 @@ require 'dalli'
 require 'ddtrace'
 
 # Configure default Dalli tracing behavior
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :dalli, options
 end
 
@@ -761,12 +761,12 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 The DelayedJob integration uses lifecycle hooks to trace the job executions and enqueues.
 
-You can enable it through `Datadog::Tracing.configure`:
+You can enable it through `Datadog.configure`:
 
 ```ruby
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :delayed_job, options
 end
 ```
@@ -785,7 +785,7 @@ The Elasticsearch integration will trace any call to `perform_request` in the `C
 require 'elasticsearch/transport'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :elasticsearch, options
 end
 
@@ -808,7 +808,7 @@ The `ethon` integration will trace any HTTP request through `Easy` or `Multi` ob
 ```ruby
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :ethon, options
 
   # optionally, specify a different service name for hostnames matching a regex
@@ -836,7 +836,7 @@ require 'excon'
 require 'ddtrace'
 
 # Configure default Excon tracing behavior
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :excon, options
 
   # optionally, specify a different service name for hostnames matching a regex
@@ -893,7 +893,7 @@ require 'faraday'
 require 'ddtrace'
 
 # Configure default Faraday tracing behavior
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :faraday, options
 
   # optionally, specify a different service name for hostnames matching a regex
@@ -925,14 +925,14 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 The Grape integration adds the instrumentation to Grape endpoints and filters. This integration can work side by side with other integrations like Rack and Rails.
 
-To activate your integration, use the `Datadog::Tracing.configure` method before defining your Grape application:
+To activate your integration, use the `Datadog.configure` method before defining your Grape application:
 
 ```ruby
 # api.rb
 require 'grape'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :grape, options
 end
 
@@ -956,11 +956,11 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 The GraphQL integration activates instrumentation for GraphQL queries.
 
-To activate your integration, use the `Datadog::Tracing.configure` method:
+To activate your integration, use the `Datadog.configure` method:
 
 ```ruby
 # Inside Rails initializer or equivalent
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :graphql, schemas: [YourSchema], options
 end
 
@@ -1018,19 +1018,19 @@ YourSchema.define do
 end
 ```
 
-Do *NOT* `use :graphql` in `Datadog::Tracing.configure` if you choose to configure manually, as to avoid double tracing. These two means of configuring GraphQL tracing are considered mutually exclusive.
+Do *NOT* `use :graphql` in `Datadog.configure` if you choose to configure manually, as to avoid double tracing. These two means of configuring GraphQL tracing are considered mutually exclusive.
 
 ### gRPC
 
 The `grpc` integration adds both client and server interceptors, which run as middleware before executing the service's remote procedure call. As gRPC applications are often distributed, the integration shares trace information between client and server.
 
-To setup your integration, use the `Datadog::Tracing.configure` method like so:
+To setup your integration, use the `Datadog.configure` method like so:
 
 ```ruby
 require 'grpc'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :grpc, options
 end
 
@@ -1077,7 +1077,7 @@ The http.rb integration will trace any HTTP call using the Http.rb gem.
 ```ruby
 require 'http'
 require 'ddtrace'
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :httprb, options
   # optionally, specify a different service name for hostnames matching a regex
   c.instrument :httprb, describes: /user-[^.]+\.example\.com/ do |httprb|
@@ -1102,7 +1102,7 @@ The httpclient integration will trace any HTTP call using the httpclient gem.
 ```ruby
 require 'httpclient'
 require 'ddtrace'
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :httpclient, options
   # optionally, specify a different service name for hostnames matching a regex
   c.instrument :httpclient, describes: /user-[^.]+\.example\.com/ do |httpclient|
@@ -1128,7 +1128,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 require "ddtrace"
 require "httpx/adapters/datadog"
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :httpx
 
   # optionally, specify a different service name for hostnames matching a regex
@@ -1143,14 +1143,14 @@ end
 
 The Kafka integration provides tracing of the `ruby-kafka` gem:
 
-You can enable it through `Datadog::Tracing.configure`:
+You can enable it through `Datadog.configure`:
 
 ```ruby
 require 'active_support/notifications' # required to enable 'ruby-kafka' instrumentation
 require 'kafka'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :kafka
 end
 ```
@@ -1163,7 +1163,7 @@ The integration traces any `Command` that is sent from the [MongoDB Ruby Driver]
 require 'mongo'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :mongo, options
 end
 
@@ -1193,7 +1193,7 @@ You can configure trace settings per connection by using the `describes` option:
 # If a block is provided, it yields a Settings object that
 # accepts any of the configuration options listed above.
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   # Network connection string
   c.instrument :mongo, describes: '127.0.0.1:27017', service_name: 'mongo-primary'
 
@@ -1222,7 +1222,7 @@ The MySQL2 integration traces any SQL command sent through `mysql2` gem.
 require 'mysql2'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :mysql2, options
 end
 
@@ -1244,7 +1244,7 @@ The Net/HTTP integration will trace any HTTP call using the standard lib Net::HT
 require 'net/http'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :http, options
 
   # optionally, specify a different service name for hostnames matching a regex
@@ -1285,7 +1285,7 @@ The Presto integration traces any SQL command sent through `presto-client` gem.
 require 'presto-client'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :presto, options
 end
 
@@ -1317,7 +1317,7 @@ To add tracing to a Qless job:
 ```ruby
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :qless, options
 end
 ```
@@ -1333,12 +1333,12 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 The Que integration is a middleware which will trace job executions.
 
-You can enable it through `Datadog::Tracing.configure`:
+You can enable it through `Datadog.configure`:
 
 ```ruby
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :que, options
 end
 ```
@@ -1356,12 +1356,12 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 The Racecar integration provides tracing for Racecar jobs.
 
-You can enable it through `Datadog::Tracing.configure`:
+You can enable it through `Datadog.configure`:
 
 ```ruby
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :racecar, options
 end
 ```
@@ -1382,7 +1382,7 @@ This integration is automatically activated with web frameworks like Rails. If y
 # config.ru example
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :rack, options
 end
 
@@ -1414,7 +1414,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 **Configuring URL quantization behavior**
 
 ```ruby
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   # Default behavior: all values are quantized, fragment is removed.
   # http://example.com/path?category_id=1&sort_by=asc#featured --> http://example.com/path?category_id&sort_by
   # http://example.com/path?categories[]=1&categories[]=2 --> http://example.com/path?categories[]
@@ -1451,7 +1451,7 @@ To enable the Rails instrumentation, create an initializer file in your `config/
 # config/initializers/datadog.rb
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :rails, options
 end
 ```
@@ -1491,7 +1491,7 @@ To activate Rake task tracing, add the following to your `Rakefile`:
 require 'rake'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :rake, options
 end
 
@@ -1512,7 +1512,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 **Configuring task quantization behavior**
 
 ```ruby
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   # Given a task that accepts :one, :two, :three...
   # Invoked with 'foo', 'bar', 'baz'.
 
@@ -1551,7 +1551,7 @@ The Redis integration will trace simple calls as well as pipelines.
 require 'redis'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :redis, options
 end
 
@@ -1573,7 +1573,7 @@ You can also set *per-instance* configuration as it follows:
 require 'redis'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :redis # Enabling integration instrumentation is still required
 end
 
@@ -1599,7 +1599,7 @@ You can configure trace settings per connection by using the `describes` option:
 # If a block is provided, it yields a Settings object that
 # accepts any of the configuration options listed above.
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   # The default configuration for any redis client
   c.instrument :redis, service_name: 'redis-default'
 
@@ -1633,7 +1633,7 @@ To add tracing to a Resque job:
 require 'resque'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :resque, **options
 end
 ```
@@ -1652,7 +1652,7 @@ The `rest-client` integration is available through the `ddtrace` middleware:
 require 'rest_client'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :rest_client, options
 end
 ```
@@ -1668,14 +1668,14 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 RSpec integration will trace all executions of example groups and examples when using `rspec` test framework.
 
-To activate your integration, use the `Datadog::Tracing.configure` method:
+To activate your integration, use the `Datadog.configure` method:
 
 ```ruby
 require 'rspec'
 require 'ddtrace'
 
 # Configure default RSpec integration
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :rspec, options
 end
 ```
@@ -1705,7 +1705,7 @@ database.create_table :articles do
   String :name
 end
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :sequel, options
 end
 
@@ -1737,12 +1737,12 @@ Datadog.configure_onto(postgres_database, service_name: 'my-postgres-db')
 
 The Shoryuken integration is a server-side middleware which will trace job executions.
 
-You can enable it through `Datadog::Tracing.configure`:
+You can enable it through `Datadog.configure`:
 
 ```ruby
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :shoryuken, options
 end
 ```
@@ -1758,12 +1758,12 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 The Sidekiq integration is a client-side & server-side middleware which will trace job queuing and executions respectively.
 
-You can enable it through `Datadog::Tracing.configure`:
+You can enable it through `Datadog.configure`:
 
 ```ruby
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :sidekiq, options
 end
 ```
@@ -1787,7 +1787,7 @@ To start using the tracing client, make sure you import `ddtrace` and `use :sina
 require 'sinatra'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :sinatra, options
 end
 
@@ -1802,7 +1802,7 @@ end
 require 'sinatra/base'
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :sinatra, options
 end
 
@@ -1841,12 +1841,12 @@ Ensure you register `Datadog::Tracing::Contrib::Sinatra::Tracer` as a middleware
 
 The Sneakers integration is a server-side middleware which will trace job executions.
 
-You can enable it through `Datadog::Tracing.configure`:
+You can enable it through `Datadog.configure`:
 
 ```ruby
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :sneakers, options
 end
 ```
@@ -1866,7 +1866,7 @@ The `sucker_punch` integration traces all scheduled jobs:
 ```ruby
 require 'ddtrace'
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.instrument :sucker_punch
 end
 
@@ -1885,7 +1885,7 @@ LogJob.perform_async('login')
 - `DD_PROPAGATION_STYLE_INJECT`: Distributed tracing header formats to inject. See [Distributed Tracing](#distributed-tracing) for more details.
 - `DD_SERVICE`: Your application's default service name. See [Environment and tags](#environment-and-tags) for more details.
 - `DD_TAGS`: Custom tags for telemetry produced by your application. See [Environment and tags](#environment-and-tags) for more details.
-- `DD_TRACE_<INTEGRATION>_ENABLED`: Enables or disables an **activated** integration. Defaults to `true`.. e.g. `DD_TRACE_RAILS_ENABLED=false`. This option has no effects on integrations that have not been explicitly activated (e.g. `Datadog::Tracing.configure { |c| c.instrument :integration }`).on code. This environment variable can only be used to disable an integration.
+- `DD_TRACE_<INTEGRATION>_ENABLED`: Enables or disables an **activated** integration. Defaults to `true`.. e.g. `DD_TRACE_RAILS_ENABLED=false`. This option has no effects on integrations that have not been explicitly activated (e.g. `Datadog.configure { |c| c.instrument :integration }`).on code. This environment variable can only be used to disable an integration.
 - `DD_TRACE_AGENT_PORT`: Port to where traces will be sent. See [Tracer settings](#tracer-settings) for more details.
 - `DD_TRACE_AGENT_URL`: Sets the URL endpoint where traces are sent. Has priority over `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. e.g. `DD_TRACE_AGENT_URL=http://localhost:8126`.
 - `DD_TRACE_ANALYTICS_ENABLED`: Enables or disables trace analytics. See [Sampling](#sampling) for more details.
@@ -1978,12 +1978,12 @@ Available options are:
 
 ### Tracer settings
 
-To change the default behavior of the Datadog tracer, you can provide custom options inside the `Datadog::Tracing.configure` block as in:
+To change the default behavior of the Datadog tracer, you can provide custom options inside the `Datadog.configure` block as in:
 
 ```ruby
 # config/initializers/datadog-tracer.rb
 # Tracer settings are set here:
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.tracing.enabled = true
 
   # Ensure all traces are ingested by Datadog
@@ -2030,7 +2030,7 @@ This will **reduce visibility and is not recommended**. See [DD_TRACE_SAMPLE_RAT
 # Sample rate is between 0 (nothing sampled) to 1 (everything sampled).
 sampler = Datadog::Tracing::Sampling::RateSampler.new(0.5) # sample 50% of the traces
 
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.tracing.sampler = sampler
 end
 ```
@@ -2190,10 +2190,10 @@ Tracing supports the following distributed trace formats:
  - `Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3`
  - `Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_SINGLE_HEADER`
 
-You can enable/disable the use of these formats via `Datadog::Tracing.configure`:
+You can enable/disable the use of these formats via `Datadog.configure`:
 
 ```ruby
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   # List of header formats that should be extracted
   c.tracing.distributed_tracing.propagation_extract_style = [
     Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG,
@@ -2395,7 +2395,7 @@ Some basic settings, such as hostname and port, can be configured using [tracer 
 The `Net` adapter submits traces using `Net::HTTP` over TCP. It is the default transport adapter.
 
 ```ruby
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.tracing.transport_options = proc { |t|
     # Hostname, port, and additional options. :timeout is in seconds.
     t.adapter :net_http, '127.0.0.1', 8126, { timeout: 1 }
@@ -2410,7 +2410,7 @@ The `UnixSocket` adapter submits traces using `Net::HTTP` over Unix socket.
 To use, first configure your trace agent to listen by Unix socket, then configure the tracer with:
 
 ```ruby
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.tracing.transport_options = proc { |t|
     # Provide local path to trace agent Unix socket
     t.adapter :unix, '/tmp/ddagent/trace.sock'
@@ -2423,7 +2423,7 @@ end
 The `Test` adapter is a no-op transport that can optionally buffer requests. For use in test suites or other non-production environments.
 
 ```ruby
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.tracing.transport_options = proc { |t|
     # Set transport to no-op mode. Does not retain traces.
     t.adapter :test
@@ -2440,7 +2440,7 @@ end
 Custom adapters can be configured with:
 
 ```ruby
-Datadog::Tracing.configure do |c|
+Datadog.configure do |c|
   c.tracing.transport_options = proc { |t|
     # Initialize and pass an instance of the adapter
     custom_adapter = CustomAdapter.new
@@ -2513,7 +2513,7 @@ The underlying Datadog tracer can be configured by passing options (which match 
 OpenTracing.global_tracer = Datadog::OpenTracer::Tracer.new(**options)
 ```
 
-It can also be configured by using `Datadog::Tracing.configure` described in the [Tracer settings](#tracer-settings) section.
+It can also be configured by using `Datadog.configure` described in the [Tracer settings](#tracer-settings) section.
 
 **Activating and configuring integrations**
 

--- a/integration/apps/rack/app/datadog.rb
+++ b/integration/apps/rack/app/datadog.rb
@@ -5,16 +5,12 @@ Datadog.configure do |c|
   c.service = 'acme-rack'
   c.diagnostics.debug = true if Datadog::DemoEnv.feature?('debug')
   c.runtime_metrics.enabled = true if Datadog::DemoEnv.feature?('runtime_metrics')
-end
 
-if Datadog::DemoEnv.feature?('tracing')
-  Datadog::Tracing.configure do |c|
+  if Datadog::DemoEnv.feature?('tracing')
     c.tracing.analytics.enabled = true if Datadog::DemoEnv.feature?('analytics')
     c.instrument :rack
   end
-end
 
-Datadog::Profiling.configure do |c|
   if Datadog::DemoEnv.feature?('pprof_to_file')
     # Reconfigure transport to write pprof to file
     c.profiling.exporter.transport = Datadog::DemoEnv.profiler_file_transport

--- a/integration/apps/rails-five/config/initializers/datadog.rb
+++ b/integration/apps/rails-five/config/initializers/datadog.rb
@@ -4,19 +4,15 @@ Datadog.configure do |c|
   c.service = 'acme-rails-five'
   c.diagnostics.debug = true if Datadog::DemoEnv.feature?('debug')
   c.runtime_metrics.enabled = true if Datadog::DemoEnv.feature?('runtime_metrics')
-end
 
-if Datadog::DemoEnv.feature?('tracing')
-  Datadog::Tracing.configure do |c|
+  if Datadog::DemoEnv.feature?('tracing')
     c.tracing.analytics.enabled = true if Datadog::DemoEnv.feature?('analytics')
 
     c.instrument :rails
     c.instrument :redis, service_name: 'acme-redis'
     c.instrument :resque
   end
-end
 
-Datadog::Profiling.configure do |c|
   if Datadog::DemoEnv.feature?('pprof_to_file')
     # Reconfigure transport to write pprof to file
     c.profiling.exporter.transport = Datadog::DemoEnv.profiler_file_transport

--- a/integration/apps/rspec/app/datadog.rb
+++ b/integration/apps/rspec/app/datadog.rb
@@ -4,13 +4,7 @@ require 'ddtrace'
 Datadog.configure do |c|
   c.diagnostics.debug = true if Datadog::DemoEnv.feature?('debug')
   c.runtime_metrics.enabled = true if Datadog::DemoEnv.feature?('runtime_metrics')
-end
-
-Datadog::Tracing.configure do |c|
   c.tracing.analytics.enabled = true if Datadog::DemoEnv.feature?('analytics')
-end
-
-Datadog::Profiling.configure do |c|
   if Datadog::DemoEnv.feature?('pprof_to_file')
     # Reconfigure transport to write pprof to file
     c.profiling.exporter.transport = Datadog::DemoEnv.profiler_file_transport

--- a/integration/apps/rspec/spec/spec_helper.rb
+++ b/integration/apps/rspec/spec/spec_helper.rb
@@ -1,12 +1,9 @@
 require 'datadog/ci'
 
 # Enable CI tracing
-Datadog::Tracing.configure do |c|
-  c.instrument :rspec
-end
-
-Datadog::CI.configure do |c|
+Datadog.configure do |c|
   c.ci.enabled = true
+  c.instrument :rspec
 end
 
 RSpec.configure do |config|

--- a/integration/apps/ruby/app/datadog.rb
+++ b/integration/apps/ruby/app/datadog.rb
@@ -4,13 +4,7 @@ require 'ddtrace'
 Datadog.configure do |c|
   c.diagnostics.debug = true if Datadog::DemoEnv.feature?('debug')
   c.runtime_metrics.enabled = true if Datadog::DemoEnv.feature?('runtime_metrics')
-end
-
-Datadog::Tracing.configure do |c|
   c.tracing.analytics.enabled = true if Datadog::DemoEnv.feature?('analytics')
-end
-
-Datadog::Profiling.configure do |c|
   if Datadog::DemoEnv.feature?('pprof_to_file')
     # Reconfigure transport to write pprof to file
     c.profiling.exporter.transport = Datadog::DemoEnv.profiler_file_transport

--- a/lib/datadog/appsec/contrib/rails/patcher.rb
+++ b/lib/datadog/appsec/contrib/rails/patcher.rb
@@ -48,7 +48,7 @@ module Datadog
               # Middleware must be added before the application is initialized.
               # Otherwise the middleware stack will be frozen.
               # Sometimes we don't want to activate middleware e.g. OpenTracing, etc.
-              add_middleware(app) if Datadog::Tracing.configuration[:rails][:middleware]
+              add_middleware(app) if Datadog.configuration[:rails][:middleware]
             end
           end
 

--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -6,53 +6,6 @@ module Datadog
   # Namespace for Datadog CI instrumentation:
   # e.g. rspec, cucumber, etc...
   module CI
-    # Current CI configuration.
-    #
-    # Access to non-CI configuration will raise an error.
-    #
-    # To modify the configuration, use {.configure}.
-    #
-    # @return [Datadog::Core::Configuration::Settings]
-    # @!attribute [r] configuration
-    # @public_api
-    def configuration
-      Datadog.configuration
-    end
-
-    # Apply configuration changes to `Datadog::CI`. An example of a {.configure} call:
-    # ```
-    # Datadog::CI.configure do |c|
-    #   c.ci.enabled = true
-    # end
-    # ```
-    # See {Datadog::Core::Configuration::Settings} for all available options, defaults, and
-    # available environment variables for configuration.
-    #
-    # Only permits access to CI configuration settings; others will raise an error.
-    # If you wish to configure a global setting, use `Datadog.configure`` instead.
-    # If you wish to configure a setting for a specific Datadog component (e.g. Tracing),
-    # use the corresponding `Datadog::COMPONENT.configure` method instead.
-    #
-    # Because many configuration changes require restarting internal components,
-    # invoking {.configure} is the only safe way to change `ddtrace` configuration.
-    #
-    # Successive calls to {.configure} maintain the previous configuration values:
-    # configuration is additive between {.configure} calls.
-    #
-    # The yielded configuration `c` comes pre-populated from environment variables, if
-    # any are applicable.
-    #
-    # See {Datadog::Core::Configuration::Settings} for all available options, defaults, and
-    # available environment variables for configuration.
-    #
-    # Will raise errors if invalid setting is accessed.
-    #
-    # @yieldparam [Datadog::Core::Configuration::Settings] c the mutable configuration object
-    # @return [void]
-    # @public_api
-    def configure(&block)
-      Datadog.configure(&block)
-    end
   end
 end
 

--- a/lib/datadog/ci/contrib/cucumber/formatter.rb
+++ b/lib/datadog/ci/contrib/cucumber/formatter.rb
@@ -84,7 +84,7 @@ module Datadog
           private
 
           def configuration
-            Tracing.configuration[:cucumber]
+            Datadog.configuration[:cucumber]
           end
         end
       end

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -59,7 +59,7 @@ module Datadog
             private
 
             def configuration
-              Tracing.configuration[:rspec]
+              Datadog.configuration[:rspec]
             end
           end
         end

--- a/lib/datadog/core/diagnostics/environment_logger.rb
+++ b/lib/datadog/core/diagnostics/environment_logger.rb
@@ -92,7 +92,7 @@ module Datadog
 
         # @return [Boolean, nil]
         def enabled
-          Tracing.configuration.tracing.enabled
+          Datadog.configuration.tracing.enabled
         end
 
         # @return [String] configured application service name
@@ -130,12 +130,12 @@ module Datadog
 
         # @return [Boolean, nil] analytics enabled in configuration
         def analytics_enabled
-          !!Tracing.configuration.tracing.analytics.enabled
+          !!Datadog.configuration.tracing.analytics.enabled
         end
 
         # @return [Numeric, nil] tracer sample rate configured
         def sample_rate
-          sampler = Tracing.configuration.tracing.sampler
+          sampler = Datadog.configuration.tracing.sampler
           return nil unless sampler
 
           sampler.sample_rate(nil) rescue nil
@@ -148,7 +148,7 @@ module Datadog
         #
         # @return [Hash, nil] sample rules configured
         def sampling_rules
-          sampler = Tracing.configuration.tracing.sampler
+          sampler = Datadog.configuration.tracing.sampler
           return nil unless sampler.is_a?(Tracing::Sampling::PrioritySampler) &&
                             sampler.priority_sampler.is_a?(Tracing::Sampling::RuleSampler)
 
@@ -203,12 +203,12 @@ module Datadog
 
         # @return [Boolean, nil] partial flushing enabled in configuration
         def partial_flushing_enabled
-          !!Tracing.configuration.tracing.partial_flush.enabled
+          !!Datadog.configuration.tracing.partial_flush.enabled
         end
 
         # @return [Boolean, nil] priority sampling enabled in configuration
         def priority_sampling_enabled
-          !!Tracing.configuration.tracing.priority_sampling
+          !!Datadog.configuration.tracing.priority_sampling
         end
 
         # @return [Boolean, nil] health metrics enabled in configuration
@@ -256,7 +256,7 @@ module Datadog
         private
 
         def instrumented_integrations
-          Tracing.configuration.instrumented_integrations
+          Datadog.configuration.instrumented_integrations
         end
 
         # Capture all active integration settings into "integrationName_settingName: value" entries.

--- a/lib/datadog/opentracer/global_tracer.rb
+++ b/lib/datadog/opentracer/global_tracer.rb
@@ -7,7 +7,7 @@ module Datadog
         super.tap do
           if tracer.class <= Datadog::OpenTracer::Tracer
             # Update the Datadog global tracer, too.
-            Datadog::Tracing.configure { |c| c.tracing.instance = tracer.datadog_tracer }
+            Datadog.configure { |c| c.tracing.instance = tracer.datadog_tracer }
           end
         end
       end

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -27,54 +27,6 @@ module Datadog
         protobuf_failed_to_load?
     end
 
-    # Apply configuration changes to `Datadog::Profiling`. An example of a {.configure} call:
-    # ```
-    # Datadog::Profiling.configure do |c|
-    #   c.profiling.enabled = true
-    # end
-    # ```
-    # See {Datadog::Core::Configuration::Settings} for all available options, defaults, and
-    # available environment variables for configuration.
-    #
-    # Only permits access to profiling configuration settings; others will raise an error.
-    # If you wish to configure a global setting, use `Datadog.configure`` instead.
-    # If you wish to configure a setting for a specific Datadog component (e.g. Tracing),
-    # use the corresponding `Datadog::COMPONENT.configure` method instead.
-    #
-    # Because many configuration changes require restarting internal components,
-    # invoking {.configure} is the only safe way to change `ddtrace` configuration.
-    #
-    # Successive calls to {.configure} maintain the previous configuration values:
-    # configuration is additive between {.configure} calls.
-    #
-    # The yielded configuration `c` comes pre-populated from environment variables, if
-    # any are applicable.
-    #
-    # See {Datadog::Core::Configuration::Settings} for all available options, defaults, and
-    # available environment variables for configuration.
-    #
-    # Will raise errors if invalid setting is accessed.
-    #
-    # @yieldparam [Datadog::Core::Configuration::Settings] c the mutable configuration object
-    # @return [void]
-    # @public_api
-    def self.configure(&block)
-      Datadog.configure(&block)
-    end
-
-    # Current profiler configuration.
-    #
-    # Access to non-profiling configuration will raise an error.
-    #
-    # To modify the configuration, use {.configure}.
-    #
-    # @return [Datadog::Core::Configuration::Settings]
-    # @!attribute [r] configuration
-    # @public_api
-    def self.configuration
-      Datadog.configuration
-    end
-
     # Starts the profiler, if the profiler is supported by in
     # this runtime environment and if the profiler has been enabled
     # in configuration.

--- a/lib/datadog/profiling/encoding/profile.rb
+++ b/lib/datadog/profiling/encoding/profile.rb
@@ -25,7 +25,7 @@ module Datadog
             flush.event_groups.each { |event_group| template.add_events!(event_group.event_class, event_group.events) }
 
             Datadog.logger.debug do
-              max_events = Profiling.configuration.profiling.advanced.max_events
+              max_events = Datadog.configuration.profiling.advanced.max_events
               events_sampled =
                 if flush.event_count == max_events
                   'max events limit hit, events were sampled [profile will be biased], '

--- a/lib/datadog/profiling/tasks/setup.rb
+++ b/lib/datadog/profiling/tasks/setup.rb
@@ -29,7 +29,7 @@ module Datadog
         def activate_forking_extensions
           if Ext::Forking.supported?
             Ext::Forking.apply!
-          elsif Profiling.configuration.profiling.enabled
+          elsif Datadog.configuration.profiling.enabled
             Datadog.logger.debug('Profiler forking extensions skipped; forking not supported.')
           end
         rescue StandardError, ScriptError => e

--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -34,57 +34,6 @@ module Datadog
         Datadog.logger
       end
 
-      # Current tracer configuration.
-      #
-      # Access to non-tracer configuration will raise an error.
-      #
-      # To modify the configuration, use {.configure}.
-      #
-      # @return [Datadog::Core::Configuration::Settings]
-      # @!attribute [r] configuration
-      # @public_api
-      def configuration
-        Datadog.configuration
-      end
-
-      # Apply configuration changes to `Datadog::Tracing`. An example of a {.configure} call:
-      # ```
-      # Datadog::Tracing.configure do |c|
-      #   c.tracing.sampling.default_rate = 1.0
-      #   c.instrument :aws
-      #   c.instrument :rails
-      #   c.instrument :sidekiq
-      # end
-      # ```
-      # See {Datadog::Core::Configuration::Settings} for all available options, defaults, and
-      # available environment variables for configuration.
-      #
-      # Only permits access to tracing configuration settings; others will raise an error.
-      # If you wish to configure a global setting, use `Datadog.configure`` instead.
-      # If you wish to configure a setting for a specific Datadog component (e.g. Profiling),
-      # use the corresponding `Datadog::COMPONENT.configure` method instead.
-      #
-      # Because many configuration changes require restarting internal components,
-      # invoking {.configure} is the only safe way to change `ddtrace` configuration.
-      #
-      # Successive calls to {.configure} maintain the previous configuration values:
-      # configuration is additive between {.configure} calls.
-      #
-      # The yielded configuration `c` comes pre-populated from environment variables, if
-      # any are applicable.
-      #
-      # See {Datadog::Core::Configuration::Settings} for all available options, defaults, and
-      # available environment variables for configuration.
-      #
-      # Will raise errors if invalid setting is accessed.
-      #
-      # @yieldparam [Datadog::Core::Configuration::Settings] c the mutable configuration object
-      # @return [void]
-      # @public_api
-      def configure(&block)
-        Datadog.configure(&block)
-      end
-
       # (see Datadog::Tracing::Tracer#active_trace)
       # @public_api
       def active_trace

--- a/lib/datadog/tracing/contrib.rb
+++ b/lib/datadog/tracing/contrib.rb
@@ -19,9 +19,9 @@ module Datadog
       # The registered integrations themselves can depend on the stateful configuration
       # of the tracer.
       #
-      # `Datadog::Tracing.registry` is a helper accessor to this constant, but it's only available
+      # `Datadog.registry` is a helper accessor to this constant, but it's only available
       # after the tracer has complete initialization. Use `Datadog::Tracing::Contrib::REGISTRY` instead
-      # of `Datadog::Tracing.registry` when you code might be called during tracer initialization.
+      # of `Datadog.registry` when you code might be called during tracer initialization.
       REGISTRY = Registry.new
     end
   end

--- a/lib/datadog/tracing/contrib/action_cable/event.rb
+++ b/lib/datadog/tracing/contrib/action_cable/event.rb
@@ -27,7 +27,7 @@ module Datadog
             end
 
             def configuration
-              Tracing.configuration[:action_cable]
+              Datadog.configuration[:action_cable]
             end
           end
         end

--- a/lib/datadog/tracing/contrib/action_cable/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/action_cable/instrumentation.rb
@@ -59,7 +59,7 @@ module Datadog
             # Instrumentation for Channel hooks.
             class Tracer
               def self.trace(channel, hook)
-                configuration = Tracing.configuration[:action_cable]
+                configuration = Datadog.configuration[:action_cable]
 
                 Tracing.trace("action_cable.#{hook}") do |span|
                   span.service = configuration[:service_name] if configuration[:service_name]

--- a/lib/datadog/tracing/contrib/action_mailer/event.rb
+++ b/lib/datadog/tracing/contrib/action_mailer/event.rb
@@ -23,7 +23,7 @@ module Datadog
             end
 
             def configuration
-              Tracing.configuration[:action_mailer]
+              Datadog.configuration[:action_mailer]
             end
 
             def process(span, event, _id, payload)

--- a/lib/datadog/tracing/contrib/action_pack/action_controller/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/action_pack/action_controller/instrumentation.rb
@@ -18,7 +18,7 @@ module Datadog
 
             def start_processing(payload)
               # trace the execution
-              service = Tracing.configuration[:action_pack][:service_name]
+              service = Datadog.configuration[:action_pack][:service_name]
               type = Tracing::Metadata::Ext::HTTP::TYPE_INBOUND
               span = Tracing.trace(
                 Ext::SPAN_ACTION_CONTROLLER,
@@ -79,7 +79,7 @@ module Datadog
             end
 
             def exception_controller?(payload)
-              exception_controller_class = Tracing.configuration[:action_pack][:exception_controller]
+              exception_controller_class = Datadog.configuration[:action_pack][:exception_controller]
               controller = payload.fetch(:controller)
               headers = payload.fetch(:headers)
 

--- a/lib/datadog/tracing/contrib/action_pack/utils.rb
+++ b/lib/datadog/tracing/contrib/action_pack/utils.rb
@@ -29,7 +29,7 @@ module Datadog
             private
 
             def datadog_configuration
-              Tracing.configuration[:action_pack]
+              Datadog.configuration[:action_pack]
             end
           end
         end

--- a/lib/datadog/tracing/contrib/action_view/event.rb
+++ b/lib/datadog/tracing/contrib/action_view/event.rb
@@ -15,7 +15,7 @@ module Datadog
           # Class methods for ActionView events.
           module ClassMethods
             def configuration
-              Tracing.configuration[:action_view]
+              Datadog.configuration[:action_view]
             end
 
             def record_exception(span, payload)

--- a/lib/datadog/tracing/contrib/action_view/utils.rb
+++ b/lib/datadog/tracing/contrib/action_view/utils.rb
@@ -17,7 +17,7 @@ module Datadog
           def normalize_template_name(name)
             return if name.nil?
 
-            base_path = Tracing.configuration[:action_view][:template_base_path]
+            base_path = Datadog.configuration[:action_view][:template_base_path]
             sections_view = name.split(base_path)
 
             if sections_view.length == 1

--- a/lib/datadog/tracing/contrib/active_job/event.rb
+++ b/lib/datadog/tracing/contrib/active_job/event.rb
@@ -23,7 +23,7 @@ module Datadog
             end
 
             def configuration
-              Tracing.configuration[:active_job]
+              Datadog.configuration[:active_job]
             end
 
             def set_common_tags(span, payload)

--- a/lib/datadog/tracing/contrib/active_job/patcher.rb
+++ b/lib/datadog/tracing/contrib/active_job/patcher.rb
@@ -20,7 +20,7 @@ module Datadog
 
           def patch
             Events.subscribe!
-            inject_log_correlation if Tracing.configuration.tracing.log_injection
+            inject_log_correlation if Datadog.configuration.tracing.log_injection
           end
 
           def inject_log_correlation

--- a/lib/datadog/tracing/contrib/active_model_serializers/event.rb
+++ b/lib/datadog/tracing/contrib/active_model_serializers/event.rb
@@ -24,7 +24,7 @@ module Datadog
             end
 
             def configuration
-              Tracing.configuration[:active_model_serializers]
+              Datadog.configuration[:active_model_serializers]
             end
 
             def set_common_tags(span, payload)

--- a/lib/datadog/tracing/contrib/active_model_serializers/patcher.rb
+++ b/lib/datadog/tracing/contrib/active_model_serializers/patcher.rb
@@ -23,7 +23,7 @@ module Datadog
           end
 
           def get_option(option)
-            Tracing.configuration[:active_model_serializers].get_option(option)
+            Datadog.configuration[:active_model_serializers].get_option(option)
           end
         end
       end

--- a/lib/datadog/tracing/contrib/active_record/event.rb
+++ b/lib/datadog/tracing/contrib/active_record/event.rb
@@ -19,7 +19,7 @@ module Datadog
             end
 
             def configuration
-              Tracing.configuration[:active_record]
+              Datadog.configuration[:active_record]
             end
           end
         end

--- a/lib/datadog/tracing/contrib/active_record/events/sql.rb
+++ b/lib/datadog/tracing/contrib/active_record/events/sql.rb
@@ -30,7 +30,7 @@ module Datadog
 
             def process(span, event, _id, payload)
               config = Utils.connection_config(payload[:connection], payload[:connection_id])
-              settings = Tracing.configuration[:active_record, config]
+              settings = Datadog.configuration[:active_record, config]
               adapter_name = Contrib::Utils::Database.normalize_vendor(config[:adapter])
               service_name = if settings.service_name != Contrib::Utils::Database::VENDOR_DEFAULT
                                settings.service_name

--- a/lib/datadog/tracing/contrib/active_support/cache/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/active_support/cache/instrumentation.rb
@@ -31,7 +31,7 @@ module Datadog
               tracing_context = payload.fetch(:tracing_context)
 
               # create a new ``Span`` and add it to the tracing context
-              service = Tracing.configuration[:active_support][:cache_service]
+              service = Datadog.configuration[:active_support][:cache_service]
               type = Ext::SPAN_TYPE_CACHE
               span = Tracing.trace(Ext::SPAN_CACHE, service: service, span_type: type)
               span.resource = payload.fetch(:action)

--- a/lib/datadog/tracing/contrib/analytics.rb
+++ b/lib/datadog/tracing/contrib/analytics.rb
@@ -12,7 +12,7 @@ module Datadog
         # Checks whether analytics should be enabled.
         # `flag` is a truthy/falsey value that represents a setting on the integration.
         def enabled?(flag = nil)
-          (Tracing.configuration.tracing.analytics.enabled && flag != false) || flag == true
+          (Datadog.configuration.tracing.analytics.enabled && flag != false) || flag == true
         end
 
         def set_sample_rate(span, sample_rate)

--- a/lib/datadog/tracing/contrib/auto_instrument.rb
+++ b/lib/datadog/tracing/contrib/auto_instrument.rb
@@ -36,7 +36,7 @@ module Datadog
             integrations << integration.name
           end
 
-          Tracing.configure do |c|
+          Datadog.configure do |c|
             c.reduce_log_verbosity
             # This will activate auto-instrumentation for Rails
             integrations.each do |integration_name|

--- a/lib/datadog/tracing/contrib/aws/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/aws/instrumentation.rb
@@ -55,7 +55,7 @@ module Datadog
           end
 
           def configuration
-            Tracing.configuration[:aws]
+            Datadog.configuration[:aws]
           end
         end
 

--- a/lib/datadog/tracing/contrib/aws/patcher.rb
+++ b/lib/datadog/tracing/contrib/aws/patcher.rb
@@ -47,7 +47,7 @@ module Datadog
           end
 
           def get_option(option)
-            Tracing.configuration[:aws].get_option(option)
+            Datadog.configuration[:aws].get_option(option)
           end
         end
       end

--- a/lib/datadog/tracing/contrib/concurrent_ruby/context_composite_executor_service.rb
+++ b/lib/datadog/tracing/contrib/concurrent_ruby/context_composite_executor_service.rb
@@ -34,7 +34,7 @@ module Datadog
           end
 
           def datadog_configuration
-            Tracing.configuration[:concurrent_ruby]
+            Datadog.configuration[:concurrent_ruby]
           end
 
           delegate [:can_overflow?, :serialized?] => :composited_executor

--- a/lib/datadog/tracing/contrib/dalli/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/dalli/instrumentation.rb
@@ -47,7 +47,7 @@ module Datadog
             private
 
             def datadog_configuration
-              Tracing.configuration[:dalli, "#{hostname}:#{port}"]
+              Datadog.configuration[:dalli, "#{hostname}:#{port}"]
             end
           end
         end

--- a/lib/datadog/tracing/contrib/delayed_job/plugin.rb
+++ b/lib/datadog/tracing/contrib/delayed_job/plugin.rb
@@ -70,7 +70,7 @@ module Datadog
           end
 
           def self.configuration
-            Tracing.configuration[:delayed_job]
+            Datadog.configuration[:delayed_job]
           end
 
           def self.job_name(job)

--- a/lib/datadog/tracing/contrib/elasticsearch/patcher.rb
+++ b/lib/datadog/tracing/contrib/elasticsearch/patcher.rb
@@ -100,7 +100,7 @@ module Datadog
               end
 
               def datadog_configuration
-                Tracing.configuration[:elasticsearch]
+                Datadog.configuration[:elasticsearch]
               end
             end
             # rubocop:enable Metrics/BlockLength

--- a/lib/datadog/tracing/contrib/ethon/easy_patch.rb
+++ b/lib/datadog/tracing/contrib/ethon/easy_patch.rb
@@ -157,7 +157,7 @@ module Datadog
             # rubocop:enable Lint/SuppressedException
 
             def load_datadog_configuration_for(host = :default)
-              @datadog_configuration = Tracing.configuration[:ethon, host]
+              @datadog_configuration = Datadog.configuration[:ethon, host]
             end
 
             def analytics_enabled?

--- a/lib/datadog/tracing/contrib/ethon/multi_patch.rb
+++ b/lib/datadog/tracing/contrib/ethon/multi_patch.rb
@@ -77,7 +77,7 @@ module Datadog
             end
 
             def datadog_configuration
-              Tracing.configuration[:ethon]
+              Datadog.configuration[:ethon]
             end
 
             def analytics_enabled?

--- a/lib/datadog/tracing/contrib/excon/middleware.rb
+++ b/lib/datadog/tracing/contrib/excon/middleware.rb
@@ -160,7 +160,7 @@ module Datadog
           end
 
           def datadog_configuration(host = :default)
-            Tracing.configuration[:excon, host]
+            Datadog.configuration[:excon, host]
           end
         end
       end

--- a/lib/datadog/tracing/contrib/extensions.rb
+++ b/lib/datadog/tracing/contrib/extensions.rb
@@ -18,8 +18,8 @@ module Datadog
       # Most of this file should probably live inside the tracer core.
       module Extensions
         def self.extend!
-          Tracing.singleton_class.prepend Helpers
-          Tracing.singleton_class.prepend Configuration
+          Datadog.singleton_class.prepend Helpers
+          Datadog.singleton_class.prepend Configuration
           Core::Configuration::Settings.include Configuration::Settings
         end
 
@@ -33,7 +33,7 @@ module Datadog
           # Integrations registered in the {.registry} can be activated as follows:
           #
           # ```
-          # Datadog::Tracing.configure do |c|
+          # Datadog.configure do |c|
           #   c.instrument :my_registered_integration, **my_options
           # end
           # ```
@@ -103,9 +103,9 @@ module Datadog
             # How the matching is performed is integration-specific.
             #
             # @example
-            #   Tracing.configuration[:integration_name]
+            #   Datadog.configuration[:integration_name]
             # @example
-            #   Tracing.configuration[:integration_name][:sub_configuration]
+            #   Datadog.configuration[:integration_name][:sub_configuration]
             # @param [Symbol] integration_name the integration name
             # @param [Object] key the integration-specific lookup key
             # @return [Datadog::Tracing::Contrib::Configuration::Settings]

--- a/lib/datadog/tracing/contrib/faraday/middleware.rb
+++ b/lib/datadog/tracing/contrib/faraday/middleware.rb
@@ -83,7 +83,7 @@ module Datadog
           end
 
           def datadog_configuration(host = :default)
-            Tracing.configuration[:faraday, host]
+            Datadog.configuration[:faraday, host]
           end
         end
       end

--- a/lib/datadog/tracing/contrib/grape/endpoint.rb
+++ b/lib/datadog/tracing/contrib/grape/endpoint.rb
@@ -240,7 +240,7 @@ module Datadog
             end
 
             def datadog_configuration
-              Tracing.configuration[:grape]
+              Datadog.configuration[:grape]
             end
           end
         end

--- a/lib/datadog/tracing/contrib/graphql/patcher.rb
+++ b/lib/datadog/tracing/contrib/graphql/patcher.rb
@@ -55,7 +55,7 @@ module Datadog
           end
 
           def get_option(option)
-            Tracing.configuration[:graphql].get_option(option)
+            Datadog.configuration[:graphql].get_option(option)
           end
         end
       end

--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor.rb
@@ -41,7 +41,7 @@ module Datadog
             private
 
             def datadog_configuration
-              Tracing.configuration[:grpc]
+              Datadog.configuration[:grpc]
             end
 
             def service_name
@@ -80,7 +80,7 @@ module Datadog
                 define_method(option) do
                   return @options[option] if @options.key?(option)
 
-                  Tracing.configuration[:grpc][option]
+                  Datadog.configuration[:grpc][option]
                 end
               end
 

--- a/lib/datadog/tracing/contrib/http/circuit_breaker.rb
+++ b/lib/datadog/tracing/contrib/http/circuit_breaker.rb
@@ -34,7 +34,7 @@ module Datadog
           def should_skip_distributed_tracing?(client_config)
             return !client_config[:distributed_tracing] if client_config && client_config.key?(:distributed_tracing)
 
-            !Tracing.configuration[:http][:distributed_tracing]
+            !Datadog.configuration[:http][:distributed_tracing]
           end
         end
       end

--- a/lib/datadog/tracing/contrib/http/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/http/instrumentation.rb
@@ -120,7 +120,7 @@ module Datadog
             end
 
             def datadog_configuration(host = :default)
-              Tracing.configuration[:http, host]
+              Datadog.configuration[:http, host]
             end
 
             def analytics_enabled?(request_options)

--- a/lib/datadog/tracing/contrib/httpclient/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/httpclient/instrumentation.rb
@@ -86,7 +86,7 @@ module Datadog
             end
 
             def datadog_configuration(host = :default)
-              Tracing.configuration[:httpclient, host]
+              Datadog.configuration[:httpclient, host]
             end
 
             def analytics_enabled?(request_options)
@@ -100,7 +100,7 @@ module Datadog
             def should_skip_distributed_tracing?(client_config)
               return !client_config[:distributed_tracing] if client_config && client_config.key?(:distributed_tracing)
 
-              !Tracing.configuration[:httpclient][:distributed_tracing]
+              !Datadog.configuration[:httpclient][:distributed_tracing]
             end
 
             def set_analytics_sample_rate(span, request_options)

--- a/lib/datadog/tracing/contrib/httprb/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/httprb/instrumentation.rb
@@ -97,7 +97,7 @@ module Datadog
             end
 
             def datadog_configuration(host = :default)
-              Tracing.configuration[:httprb, host]
+              Datadog.configuration[:httprb, host]
             end
 
             def analytics_enabled?(request_options)
@@ -111,7 +111,7 @@ module Datadog
             def should_skip_distributed_tracing?(client_config)
               return !client_config[:distributed_tracing] if client_config && client_config.key?(:distributed_tracing)
 
-              !Tracing.configuration[:httprb][:distributed_tracing]
+              !Datadog.configuration[:httprb][:distributed_tracing]
             end
 
             def set_analytics_sample_rate(span, request_options)

--- a/lib/datadog/tracing/contrib/integration.rb
+++ b/lib/datadog/tracing/contrib/integration.rb
@@ -49,7 +49,7 @@ module Datadog
       #     def api_request!(env)
       #       Tracing.trace('billing.request',
       #                            type: 'http',
-      #                            service: Tracing.configuration[:billing_api][:service]) do |span|
+      #                            service: Datadog.configuration[:billing_api][:service]) do |span|
       #         span.resource = env[:route].to_s
       #         span.set_tag('client_id', env[:client][:id])
       #
@@ -59,7 +59,7 @@ module Datadog
       #   end
       # end
       #
-      # Datadog::Tracing.configure do |c|
+      # Datadog.configure do |c|
       #   c.instrument :billing_api # Settings (e.g. `service:`) can be provided as keyword arguments.
       # end
       # ```

--- a/lib/datadog/tracing/contrib/kafka/event.rb
+++ b/lib/datadog/tracing/contrib/kafka/event.rb
@@ -25,7 +25,7 @@ module Datadog
             end
 
             def configuration
-              Tracing.configuration[:kafka]
+              Datadog.configuration[:kafka]
             end
 
             def process(span, _event, _id, payload)

--- a/lib/datadog/tracing/contrib/lograge/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/lograge/instrumentation.rb
@@ -14,7 +14,7 @@ module Datadog
           # Instance methods for configuration
           module InstanceMethods
             def custom_options(event)
-              return super unless Tracing.configuration[:lograge].enabled
+              return super unless Datadog.configuration[:lograge].enabled
 
               original_custom_options = super(event)
 

--- a/lib/datadog/tracing/contrib/mongodb/parsers.rb
+++ b/lib/datadog/tracing/contrib/mongodb/parsers.rb
@@ -40,7 +40,7 @@ module Datadog
         end
 
         def configuration
-          Tracing.configuration[:mongo]
+          Datadog.configuration[:mongo]
         end
       end
     end

--- a/lib/datadog/tracing/contrib/mongodb/subscribers.rb
+++ b/lib/datadog/tracing/contrib/mongodb/subscribers.rb
@@ -15,7 +15,7 @@ module Datadog
             return unless Tracing.enabled?
 
             service = Datadog.configuration_for(event.address, :service_name) \
-                      || Tracing.configuration[:mongo, event.address.seed][:service_name]
+                      || Datadog.configuration[:mongo, event.address.seed][:service_name]
 
             # start a trace and store it in the current thread; using the `operation_id`
             # is safe since it's a unique id used to link events together. Also only one
@@ -111,7 +111,7 @@ module Datadog
           end
 
           def datadog_configuration
-            Tracing.configuration[:mongo]
+            Datadog.configuration[:mongo]
           end
         end
       end

--- a/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
@@ -43,7 +43,7 @@ module Datadog
             private
 
             def datadog_configuration
-              Tracing.configuration[:mysql2]
+              Datadog.configuration[:mysql2]
             end
 
             def analytics_enabled?

--- a/lib/datadog/tracing/contrib/presto/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/presto/instrumentation.rb
@@ -75,7 +75,7 @@ module Datadog
               private
 
               def datadog_configuration
-                Tracing.configuration[:presto]
+                Datadog.configuration[:presto]
               end
 
               def decorate!(span, operation)

--- a/lib/datadog/tracing/contrib/qless/patcher.rb
+++ b/lib/datadog/tracing/contrib/qless/patcher.rb
@@ -29,7 +29,7 @@ module Datadog
           end
 
           def get_option(option)
-            Tracing.configuration[:qless].get_option(option)
+            Datadog.configuration[:qless].get_option(option)
           end
         end
       end

--- a/lib/datadog/tracing/contrib/qless/qless_job.rb
+++ b/lib/datadog/tracing/contrib/qless/qless_job.rb
@@ -49,7 +49,7 @@ module Datadog
           end
 
           def after_fork
-            configuration = Tracing.configuration[:qless]
+            configuration = Datadog.configuration[:qless]
             return if configuration.nil?
 
             # Add a pin, marking the job as forked.
@@ -65,7 +65,7 @@ module Datadog
           end
 
           def datadog_configuration
-            Tracing.configuration[:qless]
+            Datadog.configuration[:qless]
           end
         end
       end

--- a/lib/datadog/tracing/contrib/qless/tracer_cleaner.rb
+++ b/lib/datadog/tracing/contrib/qless/tracer_cleaner.rb
@@ -22,7 +22,7 @@ module Datadog
           end
 
           def datadog_configuration
-            Tracing.configuration[:qless]
+            Datadog.configuration[:qless]
           end
         end
       end

--- a/lib/datadog/tracing/contrib/que/tracer.rb
+++ b/lib/datadog/tracing/contrib/que/tracer.rb
@@ -51,7 +51,7 @@ module Datadog
           end
 
           def configuration
-            Tracing.configuration[:que]
+            Datadog.configuration[:que]
           end
         end
       end

--- a/lib/datadog/tracing/contrib/racecar/event.rb
+++ b/lib/datadog/tracing/contrib/racecar/event.rb
@@ -30,7 +30,7 @@ module Datadog
             end
 
             def configuration
-              Tracing.configuration[:racecar]
+              Datadog.configuration[:racecar]
             end
 
             def process(span, event, _id, payload)

--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -211,7 +211,7 @@ module Datadog
           private
 
           def configuration
-            Tracing.configuration[:rack]
+            Datadog.configuration[:rack]
           end
 
           def parse_request_headers(env)

--- a/lib/datadog/tracing/contrib/rack/patcher.rb
+++ b/lib/datadog/tracing/contrib/rack/patcher.rb
@@ -61,7 +61,7 @@ module Datadog
           end
 
           def get_option(option)
-            Tracing.configuration[:rack].get_option(option)
+            Datadog.configuration[:rack].get_option(option)
           end
         end
 
@@ -99,7 +99,7 @@ module Datadog
           end
 
           def get_option(option)
-            Tracing.configuration[:rack].get_option(option)
+            Datadog.configuration[:rack].get_option(option)
           end
         end
       end

--- a/lib/datadog/tracing/contrib/rails/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rails/configuration/settings.rb
@@ -32,7 +32,7 @@ module Datadog
               o.lazy
               o.on_set do |value|
                 # Update ActionPack analytics too
-                Tracing.configuration[:action_pack][:analytics_enabled] = value
+                Datadog.configuration[:action_pack][:analytics_enabled] = value
               end
             end
 
@@ -41,7 +41,7 @@ module Datadog
               o.lazy
               o.on_set do |value|
                 # Update ActionPack analytics too
-                Tracing.configuration[:action_pack][:analytics_sample_rate] = value
+                Datadog.configuration[:action_pack][:analytics_sample_rate] = value
               end
             end
 
@@ -49,7 +49,7 @@ module Datadog
             option :exception_controller do |o|
               o.on_set do |value|
                 # Update ActionPack exception controller too
-                Tracing.configuration[:action_pack][:exception_controller] = value
+                Datadog.configuration[:action_pack][:exception_controller] = value
               end
             end
 
@@ -59,7 +59,7 @@ module Datadog
               o.default 'views/'
               o.on_set do |value|
                 # Update ActionView template base path too
-                Tracing.configuration[:action_view][:template_base_path] = value
+                Datadog.configuration[:action_view][:template_base_path] = value
               end
             end
           end

--- a/lib/datadog/tracing/contrib/rails/framework.rb
+++ b/lib/datadog/tracing/contrib/rails/framework.rb
@@ -38,14 +38,14 @@ module Datadog
               # By default, default service would be guessed from the script
               # being executed, but here we know better, get it from Rails config.
               # Don't set this if service has been explicitly provided by the user.
-              rails_service_name = Tracing.configuration[:rails][:service_name] \
+              rails_service_name = Datadog.configuration[:rails][:service_name] \
                                     || Datadog.configuration.service_without_fallback \
                                     || Utils.app_name
 
               datadog_config.service ||= rails_service_name
             end
 
-            Tracing.configure do |trace_config|
+            Datadog.configure do |trace_config|
               rails_config = trace_config[:rails]
 
               activate_rack!(trace_config, rails_config)

--- a/lib/datadog/tracing/contrib/rails/patcher.rb
+++ b/lib/datadog/tracing/contrib/rails/patcher.rb
@@ -41,8 +41,8 @@ module Datadog
               # Middleware must be added before the application is initialized.
               # Otherwise the middleware stack will be frozen.
               # Sometimes we don't want to activate middleware e.g. OpenTracing, etc.
-              add_middleware(app) if Tracing.configuration[:rails][:middleware]
-              add_logger(app) if Tracing.configuration.tracing.log_injection
+              add_middleware(app) if Datadog.configuration[:rails][:middleware]
+              add_logger(app) if Datadog.configuration.tracing.log_injection
             end
           end
 

--- a/lib/datadog/tracing/contrib/rake/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/rake/instrumentation.rb
@@ -86,7 +86,7 @@ module Datadog
             end
 
             def configuration
-              Tracing.configuration[:rake]
+              Datadog.configuration[:rake]
             end
           end
         end

--- a/lib/datadog/tracing/contrib/rake/patcher.rb
+++ b/lib/datadog/tracing/contrib/rake/patcher.rb
@@ -25,7 +25,7 @@ module Datadog
           end
 
           def get_option(option)
-            Tracing.configuration[:rake].get_option(option)
+            Datadog.configuration[:rake].get_option(option)
           end
         end
       end

--- a/lib/datadog/tracing/contrib/redis/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/redis/instrumentation.rb
@@ -67,7 +67,7 @@ module Datadog
             end
 
             def datadog_configuration
-              Tracing.configuration[:redis, options]
+              Datadog.configuration[:redis, options]
             end
           end
         end

--- a/lib/datadog/tracing/contrib/redis/tags.rb
+++ b/lib/datadog/tracing/contrib/redis/tags.rb
@@ -31,7 +31,7 @@ module Datadog
             private
 
             def datadog_configuration
-              Tracing.configuration[:redis]
+              Datadog.configuration[:redis]
             end
 
             def analytics_enabled?

--- a/lib/datadog/tracing/contrib/registerable.rb
+++ b/lib/datadog/tracing/contrib/registerable.rb
@@ -17,7 +17,7 @@ module Datadog
           # Once registered, this integration can be activated with:
           #
           # ```
-          # Datadog::Tracing.configure do |c|
+          # Datadog.configure do |c|
           #   c.instrument :name
           # end
           # ```

--- a/lib/datadog/tracing/contrib/resque/resque_job.rb
+++ b/lib/datadog/tracing/contrib/resque/resque_job.rb
@@ -76,7 +76,7 @@ module Datadog
           end
 
           def datadog_configuration
-            Tracing.configuration[:resque]
+            Datadog.configuration[:resque]
           end
         end
       end
@@ -85,7 +85,7 @@ module Datadog
 end
 
 Resque.after_fork do
-  configuration = Datadog::Tracing.configuration[:resque]
+  configuration = Datadog.configuration[:resque]
   next if configuration.nil?
 
   # Add a pin, marking the job as forked.

--- a/lib/datadog/tracing/contrib/rest_client/request_patch.rb
+++ b/lib/datadog/tracing/contrib/rest_client/request_patch.rb
@@ -86,7 +86,7 @@ module Datadog
             private
 
             def datadog_configuration
-              Tracing.configuration[:rest_client]
+              Datadog.configuration[:rest_client]
             end
 
             def analytics_enabled?

--- a/lib/datadog/tracing/contrib/semantic_logger/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/semantic_logger/instrumentation.rb
@@ -14,7 +14,7 @@ module Datadog
           # Instance methods for configuration
           module InstanceMethods
             def log(log, message = nil, progname = nil, &block)
-              return super unless Tracing.configuration[:semantic_logger].enabled
+              return super unless Datadog.configuration[:semantic_logger].enabled
 
               original_named_tags = log.named_tags || {}
 

--- a/lib/datadog/tracing/contrib/sequel/database.rb
+++ b/lib/datadog/tracing/contrib/sequel/database.rb
@@ -24,7 +24,7 @@ module Datadog
 
               Tracing.trace(Ext::SPAN_QUERY) do |span|
                 span.service =  Datadog.configuration_for(self, :service_name) \
-                                || Tracing.configuration[:sequel][:service_name] \
+                                || Datadog.configuration[:sequel][:service_name] \
                                 || adapter_name
                 span.resource = opts[:query]
                 span.span_type = Tracing::Metadata::Ext::SQL::TYPE

--- a/lib/datadog/tracing/contrib/sequel/dataset.rb
+++ b/lib/datadog/tracing/contrib/sequel/dataset.rb
@@ -41,7 +41,7 @@ module Datadog
 
               Tracing.trace(Ext::SPAN_QUERY) do |span|
                 span.service =  Datadog.configuration_for(db, :service_name) \
-                                || Tracing.configuration[:sequel][:service_name] \
+                                || Datadog.configuration[:sequel][:service_name] \
                                 || adapter_name
                 span.resource = opts[:query]
                 span.span_type = Tracing::Metadata::Ext::SQL::TYPE

--- a/lib/datadog/tracing/contrib/sequel/utils.rb
+++ b/lib/datadog/tracing/contrib/sequel/utils.rb
@@ -68,7 +68,7 @@ module Datadog
             private
 
             def datadog_configuration
-              Tracing.configuration[:sequel]
+              Datadog.configuration[:sequel]
             end
 
             def analytics_enabled?

--- a/lib/datadog/tracing/contrib/shoryuken/tracer.rb
+++ b/lib/datadog/tracing/contrib/shoryuken/tracer.rb
@@ -51,7 +51,7 @@ module Datadog
           end
 
           def configuration
-            Tracing.configuration[:shoryuken]
+            Datadog.configuration[:shoryuken]
           end
         end
       end

--- a/lib/datadog/tracing/contrib/sidekiq/client_tracer.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/client_tracer.rb
@@ -43,7 +43,7 @@ module Datadog
           private
 
           def configuration
-            Datadog::Tracing.configuration[:sidekiq]
+            Datadog.configuration[:sidekiq]
           end
         end
       end

--- a/lib/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat.rb
@@ -10,7 +10,7 @@ module Datadog
             private
 
             def ❤ # rubocop:disable Naming/AsciiIdentifiers, Naming/MethodName
-              configuration = Datadog::Tracing.configuration[:sidekiq]
+              configuration = Datadog.configuration[:sidekiq]
 
               Datadog::Tracing.trace(Ext::SPAN_HEARTBEAT, service: configuration[:service_name]) do |span|
                 span.span_type = Datadog::Tracing::Metadata::Ext::AppTypes::TYPE_WORKER

--- a/lib/datadog/tracing/contrib/sidekiq/server_internal_tracer/job_fetch.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/server_internal_tracer/job_fetch.rb
@@ -10,7 +10,7 @@ module Datadog
             private
 
             def fetch
-              configuration = Datadog::Tracing.configuration[:sidekiq]
+              configuration = Datadog.configuration[:sidekiq]
 
               Datadog::Tracing.trace(Ext::SPAN_JOB_FETCH, service: configuration[:service_name]) do |span|
                 span.span_type = Datadog::Tracing::Metadata::Ext::AppTypes::TYPE_WORKER

--- a/lib/datadog/tracing/contrib/sidekiq/server_internal_tracer/scheduled_push.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/server_internal_tracer/scheduled_push.rb
@@ -9,7 +9,7 @@ module Datadog
           # https://github.com/mperham/sidekiq/wiki/Scheduled-Jobs
           module ScheduledPush
             def enqueue
-              configuration = Datadog::Tracing.configuration[:sidekiq]
+              configuration = Datadog.configuration[:sidekiq]
 
               Datadog::Tracing.trace(Ext::SPAN_SCHEDULED_PUSH, service: configuration[:service_name]) do |span|
                 span.span_type = Datadog::Tracing::Metadata::Ext::AppTypes::TYPE_WORKER

--- a/lib/datadog/tracing/contrib/sidekiq/server_tracer.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/server_tracer.rb
@@ -58,7 +58,7 @@ module Datadog
           private
 
           def configuration
-            Datadog::Tracing.configuration[:sidekiq]
+            Datadog.configuration[:sidekiq]
           end
 
           def worker_config(resource, key)

--- a/lib/datadog/tracing/contrib/sinatra/framework.rb
+++ b/lib/datadog/tracing/contrib/sinatra/framework.rb
@@ -11,7 +11,7 @@ module Datadog
         module Framework
           # Configure Rack from Sinatra, but only if Rack has not been configured manually beforehand
           def self.setup
-            Tracing.configure do |datadog_config|
+            Datadog.configure do |datadog_config|
               sinatra_config = config_with_defaults(datadog_config)
               activate_rack!(datadog_config, sinatra_config)
             end

--- a/lib/datadog/tracing/contrib/sinatra/tracer.rb
+++ b/lib/datadog/tracing/contrib/sinatra/tracer.rb
@@ -27,7 +27,7 @@ module Datadog
               # DEV: env['sinatra.route'] already exists with very similar information,
               # DEV: but doesn't account for our `resource_script_names` logic.
               #
-              @datadog_route = if Tracing.configuration[:sinatra][:resource_script_names]
+              @datadog_route = if Datadog.configuration[:sinatra][:resource_script_names]
                                  "#{request.script_name}#{action}"
                                else
                                  action
@@ -104,7 +104,7 @@ module Datadog
             # This method yields directly to user code.
             # rubocop:disable Metrics/MethodLength
             def route_eval
-              configuration = Tracing.configuration[:sinatra]
+              configuration = Datadog.configuration[:sinatra]
               return super unless Tracing.enabled?
 
               Tracing.trace(

--- a/lib/datadog/tracing/contrib/sinatra/tracer_middleware.rb
+++ b/lib/datadog/tracing/contrib/sinatra/tracer_middleware.rb
@@ -109,7 +109,7 @@ module Datadog
           end
 
           def configuration
-            Tracing.configuration[:sinatra]
+            Datadog.configuration[:sinatra]
           end
 
           def header_to_rack_header(name)

--- a/lib/datadog/tracing/contrib/sneakers/tracer.rb
+++ b/lib/datadog/tracing/contrib/sneakers/tracer.rb
@@ -48,7 +48,7 @@ module Datadog
           private
 
           def configuration
-            Tracing.configuration[:sneakers]
+            Datadog.configuration[:sneakers]
           end
         end
       end

--- a/lib/datadog/tracing/contrib/sucker_punch/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/sucker_punch/instrumentation.rb
@@ -81,7 +81,7 @@ module Datadog
               private
 
               def datadog_configuration
-                Datadog::Tracing.configuration[:sucker_punch]
+                Datadog.configuration[:sucker_punch]
               end
 
               def __with_instrumentation(name)

--- a/lib/datadog/tracing/contrib/sucker_punch/patcher.rb
+++ b/lib/datadog/tracing/contrib/sucker_punch/patcher.rb
@@ -28,7 +28,7 @@ module Datadog
           end
 
           def get_option(option)
-            Tracing.configuration[:sucker_punch].get_option(option)
+            Datadog.configuration[:sucker_punch].get_option(option)
           end
         end
       end

--- a/lib/datadog/tracing/propagation/http.rb
+++ b/lib/datadog/tracing/propagation/http.rb
@@ -35,7 +35,7 @@ module Datadog
           digest = digest.to_digest if digest.is_a?(TraceOperation)
 
           # Inject all configured propagation styles
-          Tracing.configuration.tracing.distributed_tracing.propagation_inject_style.each do |style|
+          Datadog.configuration.tracing.distributed_tracing.propagation_inject_style.each do |style|
             propagator = PROPAGATION_STYLES[style]
             begin
               propagator.inject!(digest, env) unless propagator.nil?
@@ -54,7 +54,7 @@ module Datadog
           trace_digest = nil
           dd_trace_digest = nil
 
-          Tracing.configuration.tracing.distributed_tracing.propagation_extract_style.each do |style|
+          Datadog.configuration.tracing.distributed_tracing.propagation_extract_style.each do |style|
             propagator = PROPAGATION_STYLES[style]
             next if propagator.nil?
 

--- a/lib/datadog/tracing/sampling/rule_sampler.rb
+++ b/lib/datadog/tracing/sampling/rule_sampler.rb
@@ -29,9 +29,9 @@ module Datadog
         # @param default_sampler [Sample] fallback strategy when no rules apply to a trace
         def initialize(
           rules = [],
-          rate_limit: Tracing.configuration.tracing.sampling.rate_limit,
+          rate_limit: Datadog.configuration.tracing.sampling.rate_limit,
           rate_limiter: nil,
-          default_sample_rate: Tracing.configuration.tracing.sampling.default_rate,
+          default_sample_rate: Datadog.configuration.tracing.sampling.default_rate,
           default_sampler: nil
         )
           @rules = rules

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -313,7 +313,7 @@ module Datadog
 
       def build_trace(digest = nil)
         # Resolve hostname if configured
-        hostname = Core::Environment::Socket.hostname if Tracing.configuration.tracing.report_hostname
+        hostname = Core::Environment::Socket.hostname if Datadog.configuration.tracing.report_hostname
         hostname = hostname && !hostname.empty? ? hostname : nil
 
         if digest

--- a/spec/datadog/ci/contrib/cucumber/formatter_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/formatter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Cucumber formatter' do
   let(:cli)    { Cucumber::Cli::Main.new(args, stdin, stdout, stderr, kernel) }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :cucumber, configuration_options
     end
   end

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'RSpec hooks' do
   let(:configuration_options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :rspec, configuration_options
     end
   end

--- a/spec/datadog/core/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/core/diagnostics/environment_logger_spec.rb
@@ -154,9 +154,9 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
       end
 
       context 'with tracer disabled' do
-        before { Datadog::Tracing.configure { |c| c.tracing.enabled = false } }
+        before { Datadog.configure { |c| c.tracing.enabled = false } }
 
-        after { Datadog::Tracing.configure { |c| c.tracing.enabled = true } }
+        after { Datadog.configure { |c| c.tracing.enabled = true } }
 
         it { is_expected.to include enabled: false }
       end
@@ -192,7 +192,7 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
       end
 
       context 'with analytics enabled' do
-        before { Datadog::Tracing.configure { |c| c.tracing.analytics.enabled = true } }
+        before { Datadog.configure { |c| c.tracing.analytics.enabled = true } }
 
         it { is_expected.to include analytics_enabled: true }
       end
@@ -206,13 +206,13 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
       end
 
       context 'with partial flushing enabled' do
-        before { Datadog::Tracing.configure { |c| c.tracing.partial_flush.enabled = true } }
+        before { Datadog.configure { |c| c.tracing.partial_flush.enabled = true } }
 
         it { is_expected.to include partial_flushing_enabled: true }
       end
 
       context 'with priority sampling enabled' do
-        before { Datadog::Tracing.configure { |c| c.tracing.priority_sampling = true } }
+        before { Datadog.configure { |c| c.tracing.priority_sampling = true } }
 
         it { is_expected.to include priority_sampling_enabled: true }
       end
@@ -232,19 +232,19 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
 
       context 'with unix socket transport' do
         before do
-          Datadog::Tracing.configure do |c|
+          Datadog.configure do |c|
             c.tracing.transport_options = ->(t) { t.adapter :unix, '/tmp/trace.sock' }
           end
         end
 
-        after { Datadog::Tracing.configure { |c| c.tracing.transport_options = {} } }
+        after { Datadog.configure { |c| c.tracing.transport_options = {} } }
 
         it { is_expected.to include agent_url: include('unix') }
         it { is_expected.to include agent_url: include('/tmp/trace.sock') }
       end
 
       context 'with integrations loaded' do
-        before { Datadog::Tracing.configure { |c| c.instrument :http, options } }
+        before { Datadog.configure { |c| c.instrument :http, options } }
 
         let(:options) { {} }
 

--- a/spec/datadog/opentracer/global_tracer_spec.rb
+++ b/spec/datadog/opentracer/global_tracer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Datadog::OpenTracer::GlobalTracer do
     describe '#global_tracer=' do
       subject(:global_tracer) { OpenTracing.global_tracer = tracer }
 
-      after { Datadog::Tracing.configuration.tracing.instance = Datadog::Tracing::Tracer.new }
+      after { Datadog.configuration.tracing.instance = Datadog::Tracing::Tracer.new }
 
       context 'when given a Datadog::OpenTracer::Tracer' do
         let(:tracer) { Datadog::OpenTracer::Tracer.new }

--- a/spec/datadog/profiling/tasks/setup_spec.rb
+++ b/spec/datadog/profiling/tasks/setup_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
 
       context 'and profiling is enabled' do
         before do
-          allow(Datadog::Profiling.configuration.profiling)
+          allow(Datadog.configuration.profiling)
             .to receive(:enabled)
             .and_return(true)
         end
@@ -101,7 +101,7 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
 
       context 'and profiling is disabled' do
         before do
-          allow(Datadog::Profiling.configuration.profiling)
+          allow(Datadog.configuration.profiling)
             .to receive(:enabled)
             .and_return(false)
         end

--- a/spec/datadog/profiling_spec.rb
+++ b/spec/datadog/profiling_spec.rb
@@ -5,16 +5,6 @@ require 'datadog/profiling'
 RSpec.describe Datadog::Profiling do
   extend ConfigurationHelpers
 
-  describe '.configure' do
-    subject(:configure) { described_class.configure(&block) }
-    let(:block) { proc {} }
-
-    it 'delegates to the global configuration' do
-      expect(Datadog).to receive(:configure) { |&b| expect(b).to be_a_kind_of(Proc) }
-      configure
-    end
-  end
-
   describe '.start_if_enabled' do
     subject(:start_if_enabled) { described_class.start_if_enabled }
 

--- a/spec/datadog/tracing/contrib/action_cable/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/action_cable/instrumentation_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'ActionCable Rack override' do
   end
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :rails, options
       c.instrument :action_cable, options
     end

--- a/spec/datadog/tracing/contrib/action_cable/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/action_cable/patcher_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'ActionCable patcher' do
   end
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :action_cable, configuration_options
     end
 
@@ -36,9 +36,9 @@ RSpec.describe 'ActionCable patcher' do
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:action_cable].reset_configuration!
+    Datadog.registry[:action_cable].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:action_cable].reset_configuration!
+    Datadog.registry[:action_cable].reset_configuration!
   end
 
   context 'with server' do

--- a/spec/datadog/tracing/contrib/action_mailer/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/action_mailer/patcher_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'ActionMailer patcher' do
 
   before do
     if Datadog::Tracing::Contrib::ActionMailer::Integration.compatible?
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         c.instrument :action_mailer, configuration_options
       end
     else
@@ -31,9 +31,9 @@ RSpec.describe 'ActionMailer patcher' do
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:action_mailer].reset_configuration!
+    Datadog.registry[:action_mailer].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:action_mailer].reset_configuration!
+    Datadog.registry[:action_mailer].reset_configuration!
   end
 
   describe 'for single process.action_mailer process' do

--- a/spec/datadog/tracing/contrib/action_view/utils_spec.rb
+++ b/spec/datadog/tracing/contrib/action_view/utils_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Datadog::Tracing::Contrib::ActionView::Utils do
   describe '#normalize_template_name' do
     subject(:normalize_template_name) { described_class.normalize_template_name(name) }
 
-    after { Datadog::Tracing.configuration[:action_view].reset! }
+    after { Datadog.configuration[:action_view].reset! }
 
     context 'with template path' do
       let(:name) { '/rails/app/views/welcome/index.html.erb' }
@@ -30,7 +30,7 @@ RSpec.describe Datadog::Tracing::Contrib::ActionView::Utils do
     end
 
     context 'with a custom template base path' do
-      before { Datadog::Tracing.configuration[:action_view][:template_base_path] = 'custom/' }
+      before { Datadog.configuration[:action_view][:template_base_path] = 'custom/' }
 
       context 'with template outside of `views/` directory' do
         let(:name) { '/rails/app/custom/welcome/index.html.erb' }

--- a/spec/datadog/tracing/contrib/active_model_serializers/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/active_model_serializers/patcher_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'ActiveModelSerializers patcher' do
     # Supress active_model_serializers log output in the test run
     ActiveModelSerializersHelpers.disable_logging
 
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :active_model_serializers, configuration_options
     end
 
@@ -30,9 +30,9 @@ RSpec.describe 'ActiveModelSerializers patcher' do
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:active_model_serializers].reset_configuration!
+    Datadog.registry[:active_model_serializers].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:active_model_serializers].reset_configuration!
+    Datadog.registry[:active_model_serializers].reset_configuration!
   end
 
   describe 'on render' do

--- a/spec/datadog/tracing/contrib/active_record/multi_db_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/multi_db_spec.rb
@@ -84,9 +84,9 @@ RSpec.describe 'ActiveRecord multi-database implementation' do
   end
 
   before do
-    Datadog::Tracing.registry[:active_record].reset_configuration!
+    Datadog.registry[:active_record].reset_configuration!
 
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :active_record, configuration_options
     end
 
@@ -94,7 +94,7 @@ RSpec.describe 'ActiveRecord multi-database implementation' do
   end
 
   after do
-    Datadog::Tracing.registry[:active_record].reset_configuration!
+    Datadog.registry[:active_record].reset_configuration!
   end
 
   context 'when databases are configured with' do
@@ -136,7 +136,7 @@ RSpec.describe 'ActiveRecord multi-database implementation' do
           # Stub ActiveRecord::Base, to pretend its been configured
           allow(ActiveRecord::Base).to receive(:configurations).and_return(database_configuration_object)
 
-          Datadog::Tracing.configure do |c|
+          Datadog.configure do |c|
             c.instrument :active_record, describes: :gadget do |gadget_db|
               gadget_db.service_name = gadget_db_service_name
             end
@@ -178,7 +178,7 @@ RSpec.describe 'ActiveRecord multi-database implementation' do
     context 'a String that\'s a URL' do
       context 'for a typical server' do
         before do
-          Datadog::Tracing.configure do |c|
+          Datadog.configure do |c|
             c.instrument :active_record, describes: mysql_connection_string do |gadget_db|
               gadget_db.service_name = gadget_db_service_name
             end
@@ -204,7 +204,7 @@ RSpec.describe 'ActiveRecord multi-database implementation' do
 
       context 'for an in-memory database' do
         before do
-          Datadog::Tracing.configure do |c|
+          Datadog.configure do |c|
             c.instrument :active_record, describes: 'sqlite3::memory:' do |widget_db|
               widget_db.service_name = widget_db_service_name
             end
@@ -233,7 +233,7 @@ RSpec.describe 'ActiveRecord multi-database implementation' do
       before do
         widget_db_connection_hash = { adapter: 'sqlite3', database: ':memory:' }
 
-        Datadog::Tracing.configure do |c|
+        Datadog.configure do |c|
           c.instrument :active_record, describes: widget_db_connection_hash do |widget_db|
             widget_db.service_name = widget_db_service_name
           end

--- a/spec/datadog/tracing/contrib/active_record/performance_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/performance_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe 'ActiveRecord tracing performance' do
     skip('Performance test does not run in CI.')
 
     # Configure the tracer
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :active_record, options
     end
   end
 
-  after { Datadog::Tracing.registry[:active_record].reset_configuration! }
+  after { Datadog.registry[:active_record].reset_configuration! }
 
   describe 'for an in-memory database' do
     let!(:connection) do

--- a/spec/datadog/tracing/contrib/active_record/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/tracer_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe 'ActiveRecord instrumentation' do
     Article.count
 
     # Reset options (that might linger from other tests)
-    Datadog::Tracing.configuration[:active_record].reset!
+    Datadog.configuration[:active_record].reset!
 
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :active_record, configuration_options
     end
 
@@ -27,9 +27,9 @@ RSpec.describe 'ActiveRecord instrumentation' do
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:active_record].reset_configuration!
+    Datadog.registry[:active_record].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:active_record].reset_configuration!
+    Datadog.registry[:active_record].reset_configuration!
   end
 
   context 'when query is made' do
@@ -101,7 +101,7 @@ RSpec.describe 'ActiveRecord instrumentation' do
             Article.count
             clear_traces!
 
-            Datadog::Tracing.configure do |c|
+            Datadog.configure do |c|
               c.instrument :active_record, service_name: 'bad-no-match'
               c.instrument :active_record, describes: { makara_role: primary_role }, service_name: primary_service_name
               c.instrument :active_record, describes: { makara_role: secondary_role }, service_name: secondary_service_name

--- a/spec/datadog/tracing/contrib/analytics_examples.rb
+++ b/spec/datadog/tracing/contrib/analytics_examples.rb
@@ -4,9 +4,9 @@ require 'datadog/tracing/metadata/ext'
 RSpec.shared_examples_for 'analytics for integration' do |options = { ignore_global_flag: true }|
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    without_warnings { Datadog::Tracing.configuration.reset! }
+    without_warnings { Datadog.configuration.reset! }
     example.run
-    without_warnings { Datadog::Tracing.configuration.reset! }
+    without_warnings { Datadog.configuration.reset! }
   end
 
   context 'when not configured' do
@@ -170,9 +170,9 @@ RSpec.shared_examples_for 'analytics for integration' do |options = { ignore_glo
   shared_context 'analytics setting' do |analytics_enabled|
     let(:analytics_enabled) { defined?(super) ? super() : analytics_enabled }
 
-    before { Datadog::Tracing.configuration.tracing.analytics.enabled = analytics_enabled }
+    before { Datadog.configuration.tracing.analytics.enabled = analytics_enabled }
 
-    after { without_warnings { Datadog::Tracing.configuration.reset! } }
+    after { without_warnings { Datadog.configuration.reset! } }
   end
 
   context 'when configured by configuration options' do

--- a/spec/datadog/tracing/contrib/aws/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/aws/instrumentation_spec.rb
@@ -14,16 +14,16 @@ RSpec.describe 'AWS instrumentation' do
   let(:configuration_options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :aws, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:aws].reset_configuration!
+    Datadog.registry[:aws].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:aws].reset_configuration!
+    Datadog.registry[:aws].reset_configuration!
   end
 
   context 'with a core AWS SDK client', if: RUBY_VERSION >= '2.2.0' do

--- a/spec/datadog/tracing/contrib/concurrent_ruby/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/concurrent_ruby/integration_test_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'ConcurrentRuby integration tests' do
 
   describe 'patching' do
     subject(:patch) do
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         c.instrument :concurrent_ruby
       end
     end
@@ -83,7 +83,7 @@ RSpec.describe 'ConcurrentRuby integration tests' do
 
   context 'when context propagation is enabled' do
     before do
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         c.instrument :concurrent_ruby
       end
     end

--- a/spec/datadog/tracing/contrib/dalli/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/dalli/instrumentation_spec.rb
@@ -16,16 +16,16 @@ RSpec.describe 'Dalli instrumentation' do
 
   # Enable the test tracer
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :dalli, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:dalli].reset_configuration!
+    Datadog.registry[:dalli].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:dalli].reset_configuration!
+    Datadog.registry[:dalli].reset_configuration!
   end
 
   describe 'when a client calls #set' do
@@ -64,7 +64,7 @@ RSpec.describe 'Dalli instrumentation' do
     let(:service_name) { 'multiplex-service' }
 
     before do
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         c.instrument :dalli, describes: "#{test_host}:#{test_port}", service_name: service_name
       end
     end

--- a/spec/datadog/tracing/contrib/dalli/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/dalli/patcher_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Dalli instrumentation' do
 
   # Enable the test tracer
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :dalli, configuration_options
     end
   end

--- a/spec/datadog/tracing/contrib/delayed_job/plugin_spec.rb
+++ b/spec/datadog/tracing/contrib/delayed_job/plugin_spec.rb
@@ -30,15 +30,15 @@ RSpec.describe Datadog::Tracing::Contrib::DelayedJob::Plugin, :delayed_job_activ
   let(:configuration_options) { {} }
 
   before do
-    Datadog::Tracing.configure { |c| c.instrument :delayed_job, configuration_options }
+    Datadog.configure { |c| c.instrument :delayed_job, configuration_options }
     Delayed::Worker.delay_jobs = false
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:delayed_job].reset_configuration!
+    Datadog.registry[:delayed_job].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:delayed_job].reset_configuration!
+    Datadog.registry[:delayed_job].reset_configuration!
   end
 
   describe 'instrumenting worker execution' do

--- a/spec/datadog/tracing/contrib/elasticsearch/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/elasticsearch/patcher_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Patcher do
   let(:configuration_options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :elasticsearch, configuration_options
     end
 
@@ -24,9 +24,9 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Patcher do
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:elasticsearch].reset_configuration!
+    Datadog.registry[:elasticsearch].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:elasticsearch].reset_configuration!
+    Datadog.registry[:elasticsearch].reset_configuration!
   end
 
   describe 'cluster health request' do

--- a/spec/datadog/tracing/contrib/elasticsearch/transport_spec.rb
+++ b/spec/datadog/tracing/contrib/elasticsearch/transport_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe 'Elasticsearch::Transport::Client tracing' do
   let(:configuration_options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :elasticsearch, configuration_options
     end
   end
 
-  after { Datadog::Tracing.registry[:elasticsearch].reset_configuration! }
+  after { Datadog.registry[:elasticsearch].reset_configuration! }
 
   context 'when configured with middleware' do
     let(:client) do

--- a/spec/datadog/tracing/contrib/ethon/easy_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/easy_patch_spec.rb
@@ -13,16 +13,16 @@ RSpec.describe Datadog::Tracing::Contrib::Ethon::EasyPatch do
   let(:easy) { EthonSupport.ethon_easy_new }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :ethon, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:ethon].reset_configuration!
+    Datadog.registry[:ethon].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:ethon].reset_configuration!
+    Datadog.registry[:ethon].reset_configuration!
   end
 
   describe '#http_request' do
@@ -68,7 +68,7 @@ RSpec.describe Datadog::Tracing::Contrib::Ethon::EasyPatch do
 
       context 'and the host matches a specific configuration' do
         before do
-          Datadog::Tracing.configure do |c|
+          Datadog.configure do |c|
             c.instrument :ethon, describes: /example\.com/ do |ethon|
               ethon.service_name = 'baz'
               ethon.split_by_domain = false

--- a/spec/datadog/tracing/contrib/ethon/integration_context.rb
+++ b/spec/datadog/tracing/contrib/ethon/integration_context.rb
@@ -70,15 +70,15 @@ RSpec.shared_context 'integration context' do
   let(:configuration_options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :ethon, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:ethon].reset_configuration!
+    Datadog.registry[:ethon].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:ethon].reset_configuration!
+    Datadog.registry[:ethon].reset_configuration!
   end
 end

--- a/spec/datadog/tracing/contrib/ethon/multi_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/multi_patch_spec.rb
@@ -12,16 +12,16 @@ RSpec.describe Datadog::Tracing::Contrib::Ethon::MultiPatch do
   let(:configuration_options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :ethon, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:ethon].reset_configuration!
+    Datadog.registry[:ethon].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:ethon].reset_configuration!
+    Datadog.registry[:ethon].reset_configuration!
   end
 
   describe '#add' do

--- a/spec/datadog/tracing/contrib/excon/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/excon/instrumentation_spec.rb
@@ -34,16 +34,16 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
   end
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :excon, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:excon].reset_configuration!
+    Datadog.registry[:excon].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:excon].reset_configuration!
+    Datadog.registry[:excon].reset_configuration!
     Excon.stubs.clear
   end
 
@@ -167,7 +167,7 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
     let(:configuration_options) { super().merge(error_handler: custom_handler) }
     let(:custom_handler) { ->(env) { (400...600).cover?(env[:status]) } }
 
-    after { Datadog::Tracing.configuration[:excon][:error_handler] = nil }
+    after { Datadog.configuration[:excon][:error_handler] = nil }
 
     it { expect(request_span).to have_error }
   end
@@ -177,7 +177,7 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
 
     let(:configuration_options) { super().merge(split_by_domain: true) }
 
-    after { Datadog::Tracing.configuration[:excon][:split_by_domain] = false }
+    after { Datadog.configuration[:excon][:split_by_domain] = false }
 
     it do
       response
@@ -192,7 +192,7 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
 
     context 'and the host matches a specific configuration' do
       before do
-        Datadog::Tracing.configure do |c|
+        Datadog.configure do |c|
           c.instrument :excon, describes: /example\.com/ do |excon|
             excon.service_name = 'bar'
             excon.split_by_domain = false
@@ -244,7 +244,7 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
   context 'when distributed tracing is disabled' do
     let(:configuration_options) { super().merge(distributed_tracing: false) }
 
-    after { Datadog::Tracing.configuration[:excon][:distributed_tracing] = true }
+    after { Datadog.configuration[:excon][:distributed_tracing] = true }
 
     subject!(:response) do
       expect_any_instance_of(described_class).to receive(:request_call)
@@ -302,11 +302,11 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
     let(:service_name) { 'excon-global' }
 
     before do
-      @old_service_name = Datadog::Tracing.configuration[:excon][:service_name]
-      Datadog::Tracing.configure { |c| c.instrument :excon, service_name: service_name }
+      @old_service_name = Datadog.configuration[:excon][:service_name]
+      Datadog.configure { |c| c.instrument :excon, service_name: service_name }
     end
 
-    after { Datadog::Tracing.configure { |c| c.instrument :excon, service_name: @old_service_name } }
+    after { Datadog.configure { |c| c.instrument :excon, service_name: @old_service_name } }
 
     it do
       subject

--- a/spec/datadog/tracing/contrib/extensions_spec.rb
+++ b/spec/datadog/tracing/contrib/extensions_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Datadog::Tracing::Contrib::Extensions do
   end
 
   context 'for' do
-    describe Datadog::Tracing do
+    describe Datadog do
       describe '#configure' do
         include_context 'registry with integration' do
           before { stub_const('Datadog::Tracing::Contrib::REGISTRY', registry) }

--- a/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
@@ -31,16 +31,16 @@ RSpec.describe 'Faraday middleware' do
   end
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :faraday, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:faraday].reset_configuration!
+    Datadog.registry[:faraday].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:faraday].reset_configuration!
+    Datadog.registry[:faraday].reset_configuration!
   end
 
   context 'without explicit middleware configured' do
@@ -250,7 +250,7 @@ RSpec.describe 'Faraday middleware' do
 
     context 'and the host matches a specific configuration' do
       before do
-        Datadog::Tracing.configure do |c|
+        Datadog.configure do |c|
           c.instrument :faraday, describes: /example\.com/ do |faraday|
             faraday.service_name = 'bar'
             faraday.split_by_domain = false
@@ -309,11 +309,11 @@ RSpec.describe 'Faraday middleware' do
     let(:service_name) { 'faraday-global' }
 
     before do
-      @old_service_name = Datadog::Tracing.configuration[:faraday][:service_name]
-      Datadog::Tracing.configure { |c| c.instrument :faraday, service_name: service_name }
+      @old_service_name = Datadog.configuration[:faraday][:service_name]
+      Datadog.configure { |c| c.instrument :faraday, service_name: service_name }
     end
 
-    after { Datadog::Tracing.configure { |c| c.instrument :faraday, service_name: @old_service_name } }
+    after { Datadog.configure { |c| c.instrument :faraday, service_name: @old_service_name } }
 
     subject { client.get('/success') }
 
@@ -357,7 +357,7 @@ RSpec.describe 'Faraday middleware' do
 
       context 'and per-host configuration' do
         before do
-          Datadog::Tracing.configure do |c|
+          Datadog.configure do |c|
             c.instrument :faraday, describes: /example\.com/, service_name: 'host'
           end
         end

--- a/spec/datadog/tracing/contrib/faraday/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/faraday/patcher_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Faraday instrumentation' do
 
   # Enable the test tracer
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :faraday, configuration_options
     end
   end

--- a/spec/datadog/tracing/contrib/grape/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/grape/tracer_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe 'Grape instrumentation' do
   end
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :rack, configuration_options if with_rack
       c.instrument :grape, configuration_options
     end
@@ -129,11 +129,11 @@ RSpec.describe 'Grape instrumentation' do
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:rack].reset_configuration!
-    Datadog::Tracing.registry[:grape].reset_configuration!
+    Datadog.registry[:rack].reset_configuration!
+    Datadog.registry[:grape].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:rack].reset_configuration!
-    Datadog::Tracing.registry[:grape].reset_configuration!
+    Datadog.registry[:rack].reset_configuration!
+    Datadog.registry[:grape].reset_configuration!
   end
 
   context 'without rack' do

--- a/spec/datadog/tracing/contrib/graphql/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/graphql/tracer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'GraphQL patcher' do
   RSpec.shared_examples 'Schema patcher' do
     before do
       remove_patch!(:graphql)
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         c.instrument :graphql, schemas: [schema]
       end
     end

--- a/spec/datadog/tracing/contrib/grpc/datadog_interceptor/client_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/datadog_interceptor/client_spec.rb
@@ -15,16 +15,16 @@ RSpec.describe 'tracing on the client connection' do
   let(:port) { 0 }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :grpc, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:grpc].reset_configuration!
+    Datadog.registry[:grpc].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:grpc].reset_configuration!
+    Datadog.registry[:grpc].reset_configuration!
   end
 
   context 'using client-specific configurations' do

--- a/spec/datadog/tracing/contrib/grpc/datadog_interceptor/server_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/datadog_interceptor/server_spec.rb
@@ -12,16 +12,16 @@ RSpec.describe 'tracing on the server connection' do
   let(:configuration_options) { { service_name: 'rspec' } }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :grpc, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:grpc].reset_configuration!
+    Datadog.registry[:grpc].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:grpc].reset_configuration!
+    Datadog.registry[:grpc].reset_configuration!
   end
 
   shared_examples 'span data contents' do

--- a/spec/datadog/tracing/contrib/grpc/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/integration_test_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'gRPC integration test' do
   include GRPCHelper
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :grpc, service_name: 'rspec'
     end
   end

--- a/spec/datadog/tracing/contrib/grpc/interception_context_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/interception_context_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe GRPC::InterceptionContext do
 
   describe '#intercept!' do
     before do
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         c.instrument :grpc, configuration_options
       end
 
@@ -22,9 +22,9 @@ RSpec.describe GRPC::InterceptionContext do
 
     around do |example|
       # Reset before and after each example; don't allow global state to linger.
-      Datadog::Tracing.registry[:grpc].reset_configuration!
+      Datadog.registry[:grpc].reset_configuration!
       example.run
-      Datadog::Tracing.registry[:grpc].reset_configuration!
+      Datadog.registry[:grpc].reset_configuration!
     end
 
     context 'when intercepting on the client' do

--- a/spec/datadog/tracing/contrib/grpc/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/patcher_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'GRPC instrumentation' do
 
   # Enable the test tracer
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :grpc, configuration_options
     end
   end

--- a/spec/datadog/tracing/contrib/http/miniapp_spec.rb
+++ b/spec/datadog/tracing/contrib/http/miniapp_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'net/http miniapp tests' do
   let(:client) { Net::HTTP.new(host, port) }
 
   before do
-    Datadog::Tracing.configure { |c| c.instrument :http }
+    Datadog.configure { |c| c.instrument :http }
   end
 
   context 'when performing a trace around HTTP calls' do

--- a/spec/datadog/tracing/contrib/http/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/http/patcher_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe 'net/http patcher' do
 
     stub_request(:any, host)
 
-    Datadog::Tracing.configuration[:http].reset!
-    Datadog::Tracing.configure do |c|
+    Datadog.configuration[:http].reset!
+    Datadog.configure do |c|
       c.instrument :http
     end
   end
@@ -39,13 +39,13 @@ RSpec.describe 'net/http patcher' do
     let(:new_service_name) { 'new_service_name' }
 
     before do
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         c.instrument :http, service_name: new_service_name
       end
     end
 
     after do
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         c.instrument :http, service_name: Datadog::Tracing::Contrib::HTTP::Ext::DEFAULT_PEER_SERVICE_NAME
       end
     end

--- a/spec/datadog/tracing/contrib/http/request_spec.rb
+++ b/spec/datadog/tracing/contrib/http/request_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe 'net/http requests' do
   let(:configuration_options) { {} }
 
   before do
-    Datadog::Tracing.configure { |c| c.instrument :http, configuration_options }
+    Datadog.configure { |c| c.instrument :http, configuration_options }
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:http].reset_configuration!
+    Datadog.registry[:http].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:http].reset_configuration!
+    Datadog.registry[:http].reset_configuration!
   end
 
   describe '#get' do
@@ -243,7 +243,7 @@ RSpec.describe 'net/http requests' do
 
     context 'and the host matches a specific configuration' do
       before do
-        Datadog::Tracing.configure do |c|
+        Datadog.configure do |c|
           c.instrument :http, configuration_options
           c.instrument :http, describes: /127.0.0.1/ do |http|
             http.service_name = 'bar'
@@ -365,7 +365,7 @@ RSpec.describe 'net/http requests' do
 
       context 'but the tracer is disabled' do
         before do
-          Datadog::Tracing.configure do |c|
+          Datadog.configure do |c|
             c.tracing.enabled = false
           end
 
@@ -381,12 +381,12 @@ RSpec.describe 'net/http requests' do
 
     context 'when disabled' do
       before do
-        Datadog::Tracing.configure { |c| c.instrument :http, distributed_tracing: false }
+        Datadog.configure { |c| c.instrument :http, distributed_tracing: false }
         client.get(path)
       end
 
       after do
-        Datadog::Tracing.configure { |c| c.instrument :http, distributed_tracing: true }
+        Datadog.configure { |c| c.instrument :http, distributed_tracing: true }
       end
 
       let(:span) { spans.last }

--- a/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
@@ -52,16 +52,16 @@ RSpec.describe Datadog::Tracing::Contrib::Httpclient::Instrumentation do
   let(:configuration_options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :httpclient, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:httpclient].reset_configuration!
+    Datadog.registry[:httpclient].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:httpclient].reset_configuration!
+    Datadog.registry[:httpclient].reset_configuration!
   end
 
   describe 'instrumented request' do
@@ -254,7 +254,7 @@ RSpec.describe Datadog::Tracing::Contrib::Httpclient::Instrumentation do
 
           context 'and the host matches a specific configuration' do
             before do
-              Datadog::Tracing.configure do |c|
+              Datadog.configure do |c|
                 c.instrument :httpclient, describes: /localhost/ do |httpclient|
                   httpclient.service_name = 'bar'
                   httpclient.split_by_domain = false

--- a/spec/datadog/tracing/contrib/httprb/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httprb/instrumentation_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Datadog::Tracing::Contrib::Httprb::Instrumentation do
   let(:configuration_options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :httprb, configuration_options
     end
 
@@ -65,9 +65,9 @@ RSpec.describe Datadog::Tracing::Contrib::Httprb::Instrumentation do
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:httprb].reset_configuration!
+    Datadog.registry[:httprb].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:httprb].reset_configuration!
+    Datadog.registry[:httprb].reset_configuration!
   end
 
   describe 'instrumented request' do
@@ -261,7 +261,7 @@ RSpec.describe Datadog::Tracing::Contrib::Httprb::Instrumentation do
 
           context 'and the host matches a specific configuration' do
             before do
-              Datadog::Tracing.configure do |c|
+              Datadog.configure do |c|
                 c.instrument :httprb, describes: /localhost/ do |httprb|
                   httprb.service_name = 'bar'
                   httprb.split_by_domain = false

--- a/spec/datadog/tracing/contrib/kafka/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/kafka/patcher_spec.rb
@@ -14,16 +14,16 @@ RSpec.describe 'Kafka patcher' do
   end
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :kafka, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:kafka].reset_configuration!
+    Datadog.registry[:kafka].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:kafka].reset_configuration!
+    Datadog.registry[:kafka].reset_configuration!
   end
 
   describe 'connection.request' do

--- a/spec/datadog/tracing/contrib/mongodb/client_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/client_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
     # Disable Mongo logging
     Mongo::Logger.logger.level = ::Logger::WARN
 
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :mongo, configuration_options
     end
   end
@@ -32,9 +32,9 @@ RSpec.describe 'Mongo::Client instrumentation' do
   around do |example|
     without_warnings do
       # Reset before and after each example; don't allow global state to linger.
-      Datadog::Tracing.registry[:mongo].reset_configuration!
+      Datadog.registry[:mongo].reset_configuration!
       example.run
-      Datadog::Tracing.registry[:mongo].reset_configuration!
+      Datadog.registry[:mongo].reset_configuration!
       client.database.drop if drop_database?
       client.close
     end
@@ -76,7 +76,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
       let(:secondary_host) { 'localhost' }
 
       before do
-        Datadog::Tracing.configure do |c|
+        Datadog.configure do |c|
           c.instrument :mongo, describes: /#{host}/ do |mongo|
             mongo.service_name = primary_service
           end
@@ -105,9 +105,9 @@ RSpec.describe 'Mongo::Client instrumentation' do
         around do |example|
           without_warnings do
             # Reset before and after each example; don't allow global state to linger.
-            Datadog::Tracing.registry[:mongo].reset_configuration!
+            Datadog.registry[:mongo].reset_configuration!
             example.run
-            Datadog::Tracing.registry[:mongo].reset_configuration!
+            Datadog.registry[:mongo].reset_configuration!
             secondary_client.database.drop if drop_database?
             secondary_client.close
           end

--- a/spec/datadog/tracing/contrib/mongodb/regression_issue_1235_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/regression_issue_1235_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Mongo crash regression #1235' do
     # Disable Mongo logging
     Mongo::Logger.logger.level = ::Logger::WARN
 
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :mongo
     end
   end

--- a/spec/datadog/tracing/contrib/mysql2/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/mysql2/patcher_spec.rb
@@ -27,16 +27,16 @@ RSpec.describe 'Mysql2::Client patcher' do
   let(:password) { ENV.fetch('TEST_MYSQL_PASSWORD') { 'root' } }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :mysql2, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:mysql2].reset_configuration!
+    Datadog.registry[:mysql2].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:mysql2].reset_configuration!
+    Datadog.registry[:mysql2].reset_configuration!
   end
 
   describe 'tracing' do

--- a/spec/datadog/tracing/contrib/presto/client_spec.rb
+++ b/spec/datadog/tracing/contrib/presto/client_spec.rb
@@ -57,28 +57,28 @@ RSpec.describe 'Presto::Client instrumentation' do
   end
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :presto, configuration_options
     end
   end
 
   around do |example|
     without_warnings do
-      Datadog::Tracing.registry[:presto].reset_configuration!
+      Datadog.registry[:presto].reset_configuration!
       example.run
-      Datadog::Tracing.registry[:presto].reset_configuration!
-      Datadog::Tracing.configuration.reset!
+      Datadog.registry[:presto].reset_configuration!
+      Datadog.configuration.reset!
     end
   end
 
   context 'when the tracer is disabled' do
     before do
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         c.tracing.enabled = false
       end
     end
 
-    after { Datadog::Tracing.configuration.tracing.reset! }
+    after { Datadog.configuration.tracing.reset! }
 
     it 'does not produce spans' do
       client.run('SELECT 1')

--- a/spec/datadog/tracing/contrib/qless/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/qless/instrumentation_spec.rb
@@ -15,16 +15,16 @@ RSpec.describe 'Qless instrumentation' do
     delete_all_redis_keys
 
     # Patch Qless
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :qless, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:qless].reset_configuration!
+    Datadog.registry[:qless].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:qless].reset_configuration!
+    Datadog.registry[:qless].reset_configuration!
   end
 
   shared_examples 'job execution tracing' do

--- a/spec/datadog/tracing/contrib/que/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/que/tracer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Datadog::Tracing::Contrib::Que::Tracer do
   end
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :que, configuration_options
     end
 
@@ -35,9 +35,9 @@ RSpec.describe Datadog::Tracing::Contrib::Que::Tracer do
   end
 
   around do |example|
-    Datadog::Tracing.registry[:que].reset_configuration!
+    Datadog.registry[:que].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:que].reset_configuration!
+    Datadog.registry[:que].reset_configuration!
   end
 
   describe '#call' do

--- a/spec/datadog/tracing/contrib/racecar/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/racecar/patcher_spec.rb
@@ -16,16 +16,16 @@ RSpec.describe 'Racecar patcher' do
   let(:configuration_options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :racecar, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:racecar].reset_configuration!
+    Datadog.registry[:racecar].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:racecar].reset_configuration!
+    Datadog.registry[:racecar].reset_configuration!
   end
 
   describe 'for both single and batch message processing' do

--- a/spec/datadog/tracing/contrib/rack/configuration_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/configuration_spec.rb
@@ -13,16 +13,16 @@ RSpec.describe 'Rack integration configuration' do
   let(:configuration_options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :rack, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:rack].reset_configuration!
+    Datadog.registry[:rack].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:rack].reset_configuration!
+    Datadog.registry[:rack].reset_configuration!
   end
 
   shared_context 'an incoming HTTP request' do
@@ -75,7 +75,7 @@ RSpec.describe 'Rack integration configuration' do
         is_expected.to be_ok
         expect(spans).to have(2).items
 
-        web_service_name = Datadog::Tracing.configuration[:rack][:web_service_name]
+        web_service_name = Datadog.configuration[:rack][:web_service_name]
         expect(queue_span.name).to eq('http_server.queue')
         expect(queue_span.span_type).to eq('proxy')
         expect(queue_span.service).to eq(web_service_name)

--- a/spec/datadog/tracing/contrib/rack/distributed_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/distributed_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe 'Rack integration distributed tracing' do
   let(:rack_options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :rack, rack_options
     end
   end
 
-  after { Datadog::Tracing.registry[:rack].reset_configuration! }
+  after { Datadog.registry[:rack].reset_configuration! }
 
   shared_context 'an incoming HTTP request' do
     subject(:response) { get '/' }

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Rack integration tests' do
   let(:rack_options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :rack, rack_options
     end
   end
@@ -547,7 +547,7 @@ RSpec.describe 'Rack integration tests' do
 
       context 'when configured to tag headers' do
         before do
-          Datadog::Tracing.configure do |c|
+          Datadog.configure do |c|
             c.instrument :rack, headers: {
               request: [
                 'Cache-Control'
@@ -569,7 +569,7 @@ RSpec.describe 'Rack integration tests' do
 
         after do
           # Reset to default headers
-          Datadog::Tracing.configure do |c|
+          Datadog.configure do |c|
             c.instrument :rack, headers: {}
           end
         end

--- a/spec/datadog/tracing/contrib/rack/middlewares_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/middlewares_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Datadog::Tracing::Contrib::Rack::TraceMiddleware do
   let(:configuration_options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :rack, configuration_options
     end
   end
@@ -35,7 +35,7 @@ RSpec.describe Datadog::Tracing::Contrib::Rack::TraceMiddleware do
 
       before do
         # Raise error at first line of #call
-        expect(Datadog::Tracing.configuration[:rack]).to receive(:[]).and_raise(fatal_error)
+        expect(Datadog.configuration[:rack]).to receive(:[]).and_raise(fatal_error)
       end
 
       it 'reraises exception' do

--- a/spec/datadog/tracing/contrib/rack/resource_name_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/resource_name_spec.rb
@@ -18,17 +18,17 @@ RSpec.describe 'Rack integration with other middleware' do
 
   before do
     # Undo the Rack middleware name patch
-    Datadog::Tracing.registry[:rack].patcher::PATCHERS.each do |patcher|
+    Datadog.registry[:rack].patcher::PATCHERS.each do |patcher|
       remove_patch!(patcher)
     end
 
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :rack, rack_options
     end
   end
 
   after do
-    Datadog::Tracing.registry[:rack].reset_configuration!
+    Datadog.registry[:rack].reset_configuration!
   end
 
   shared_context 'app with middleware' do

--- a/spec/datadog/tracing/contrib/rails/action_controller_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/action_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Rails ActionController' do
   let(:base_class) { ActionController::Base }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :rails, rails_options
       # Manually activate ActionPack to trigger patching.
       # This is because Rails instrumentation normally defers patching until #after_initialize

--- a/spec/datadog/tracing/contrib/rails/analytics_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/analytics_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Rails trace analytics' do
   let(:configuration_options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :rails, configuration_options
       # Manually activate ActionPack to trigger patching.
       # This is because Rails instrumentation normally defers patching until #after_initialize
@@ -18,11 +18,11 @@ RSpec.describe 'Rails trace analytics' do
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:rails].reset_configuration!
-    Datadog::Tracing.registry[:action_pack].reset_configuration!
+    Datadog.registry[:rails].reset_configuration!
+    Datadog.registry[:action_pack].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:rails].reset_configuration!
-    Datadog::Tracing.registry[:action_pack].reset_configuration!
+    Datadog.registry[:rails].reset_configuration!
+    Datadog.registry[:action_pack].reset_configuration!
   end
 
   describe 'for a controller action' do

--- a/spec/datadog/tracing/contrib/rails/cache_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/cache_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe 'Rails cache' do
   include_context 'Rails test application'
 
   before do
-    Datadog::Tracing.configuration[:active_support][:cache_service] = 'rails-cache'
+    Datadog.configuration[:active_support][:cache_service] = 'rails-cache'
   end
 
   after do
-    Datadog::Tracing.configuration[:active_support].reset!
+    Datadog.configuration[:active_support].reset!
   end
 
   before { app }
@@ -130,7 +130,7 @@ RSpec.describe 'Rails cache' do
     end
 
     context 'with custom cache_service' do
-      before { Datadog::Tracing.configuration[:active_support][:cache_service] = 'service-cache' }
+      before { Datadog.configuration[:active_support][:cache_service] = 'service-cache' }
 
       it 'uses the proper service name' do
         write
@@ -183,7 +183,7 @@ RSpec.describe 'Rails cache' do
       end
 
       context 'with custom cache_service' do
-        before { Datadog::Tracing.configuration[:active_support][:cache_service] = 'service-cache' }
+        before { Datadog.configuration[:active_support][:cache_service] = 'service-cache' }
 
         it 'uses the proper service name' do
           write_multi

--- a/spec/datadog/tracing/contrib/rails/database_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/database_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Rails database' do
   let(:database_service) { adapter_name }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :rails
       c.instrument :active_record, service_name: database_service
     end

--- a/spec/datadog/tracing/contrib/rails/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/middleware_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Rails middleware' do
   end
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :rack if use_rack
       c.instrument :rails, rails_options
     end

--- a/spec/datadog/tracing/contrib/rails/rails_active_job_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/rails_active_job_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'ActiveJob' do
     end
 
     before do
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         c.instrument :active_job
       end
 
@@ -270,7 +270,7 @@ RSpec.describe 'ActiveJob' do
 
       context 'when active_job tracing is also enabled' do
         before do
-          Datadog::Tracing.configure do |c|
+          Datadog.configure do |c|
             c.instrument :active_job
           end
         end

--- a/spec/datadog/tracing/contrib/rails/rails_auto_instrument_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/rails_auto_instrument_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe 'Datadog::Tracing::Contrib::AutoInstrument' do
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    without_warnings { Datadog::Tracing.configuration.reset! }
+    without_warnings { Datadog.configuration.reset! }
 
     ClimateControl.modify('TEST_AUTO_INSTRUMENT' => 'true') do
       example.run
     end
 
-    without_warnings { Datadog::Tracing.configuration.reset! }
+    without_warnings { Datadog.configuration.reset! }
   end
 
   context 'when auto patching is included' do
@@ -20,7 +20,7 @@ RSpec.describe 'Datadog::Tracing::Contrib::AutoInstrument' do
       skip 'Fork not supported on current platform' unless Process.respond_to?(:fork)
     end
 
-    let(:config) { Datadog::Tracing.configuration[:rails] }
+    let(:config) { Datadog.configuration[:rails] }
 
     it 'configurations application correctly' do
       expect_in_fork do

--- a/spec/datadog/tracing/contrib/rails/rails_log_auto_injection_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/rails_log_auto_injection_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe 'Rails Log Auto Injection' do
   end
 
   before do
-    Datadog::Tracing.configuration[:rails].reset_options!
-    Datadog::Tracing.configure do |c|
+    Datadog.configuration[:rails].reset_options!
+    Datadog.configure do |c|
       c.instrument :rails
       c.tracing.log_injection = log_injection
     end
@@ -48,8 +48,8 @@ RSpec.describe 'Rails Log Auto Injection' do
   end
 
   after do
-    Datadog::Tracing.configuration[:rails].reset_options!
-    Datadog::Tracing.configuration[:lograge].reset_options!
+    Datadog.configuration[:rails].reset_options!
+    Datadog.configuration[:lograge].reset_options!
   end
 
   context 'with log injection enabled' do
@@ -176,7 +176,7 @@ RSpec.describe 'Rails Log Auto Injection' do
     let(:logs) { log_output.string }
 
     before do
-      Datadog::Tracing.configuration[:lograge].enabled = false
+      Datadog.configuration[:lograge].enabled = false
     end
 
     context 'with Tagged Logging' do

--- a/spec/datadog/tracing/contrib/rails/rails_semantic_logger_auto_injection_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/rails_semantic_logger_auto_injection_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe 'Rails Log Auto Injection' do
   end
 
   before do
-    Datadog::Tracing.configuration[:rails].reset_options!
-    Datadog::Tracing.configure do |c|
+    Datadog.configuration[:rails].reset_options!
+    Datadog.configure do |c|
       c.instrument :rails
       c.tracing.log_injection = log_injection
     end
@@ -37,8 +37,8 @@ RSpec.describe 'Rails Log Auto Injection' do
   end
 
   after do
-    Datadog::Tracing.configuration[:rails].reset_options!
-    Datadog::Tracing.configuration[:semantic_logger].reset_options!
+    Datadog.configuration[:rails].reset_options!
+    Datadog.configuration[:semantic_logger].reset_options!
   end
 
   context 'with log injection enabled', if: Rails.version >= '4.0' do
@@ -59,9 +59,6 @@ RSpec.describe 'Rails Log Auto Injection' do
           c.env = test_env
           c.version = test_version
           c.service = test_service
-        end
-
-        Datadog::Tracing.configure do |c|
           c.instrument :rails
           c.tracing.log_injection = log_injection
         end
@@ -122,7 +119,7 @@ RSpec.describe 'Rails Log Auto Injection' do
     let(:test_service) { 'test-service' }
 
     before do
-      Datadog::Tracing.configuration[:semantic_logger].enabled = false
+      Datadog.configuration[:semantic_logger].enabled = false
     end
 
     context 'with Semantic Logger' do
@@ -135,9 +132,6 @@ RSpec.describe 'Rails Log Auto Injection' do
           c.env = test_env
           c.version = test_version
           c.service = test_service
-        end
-
-        Datadog::Tracing.configure do |c|
           c.instrument :rails
           c.tracing.log_injection = log_injection
         end

--- a/spec/datadog/tracing/contrib/rails/railtie_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/railtie_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Rails Railtie' do
   end
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :rails, rails_options
     end
   end
@@ -55,7 +55,7 @@ RSpec.describe 'Rails Railtie' do
     context 'set to false' do
       let(:rails_options) { super().merge(middleware: false) }
 
-      after { Datadog::Tracing.configuration[:rails][:middleware] = true }
+      after { Datadog.configuration[:rails][:middleware] = true }
 
       it { expect(app).to_not have_kind_of_middleware(Datadog::Tracing::Contrib::Rack::TraceMiddleware) }
       it { expect(app).to_not have_kind_of_middleware(Datadog::Tracing::Contrib::Rails::ExceptionMiddleware) }

--- a/spec/datadog/tracing/contrib/rails/redis_cache_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/redis_cache_spec.rb
@@ -47,7 +47,7 @@ MESSAGE
   before { app }
 
   before do
-    Datadog::Tracing.configure { |c| c.instrument :redis }
+    Datadog.configure { |c| c.instrument :redis }
     Datadog.configure_onto(client_from_driver(driver))
   end
 

--- a/spec/datadog/tracing/contrib/rails/support/application.rb
+++ b/spec/datadog/tracing/contrib/rails/support/application.rb
@@ -22,10 +22,10 @@ RSpec.shared_context 'Rails test application' do
       Rails.cache = nil
     end
 
-    without_warnings { Datadog::Tracing.configuration.reset! }
-    Datadog::Tracing.configuration[:rails].reset_options!
-    Datadog::Tracing.configuration[:rack].reset_options!
-    Datadog::Tracing.configuration[:redis].reset_options!
+    without_warnings { Datadog.configuration.reset! }
+    Datadog.configuration[:rails].reset_options!
+    Datadog.configuration[:rack].reset_options!
+    Datadog.configuration[:redis].reset_options!
   end
 
   let(:app) do

--- a/spec/datadog/tracing/contrib/rails/support/rails3.rb
+++ b/spec/datadog/tracing/contrib/rails/support/rails3.rb
@@ -62,7 +62,7 @@ RSpec.shared_context 'Rails 3 base application' do
         require 'ddtrace/auto_instrument'
       else
         # Enables the auto-instrumentation for the testing application
-        Datadog::Tracing.configure do |c|
+        Datadog.configure do |c|
           c.instrument :rails
           c.instrument :redis if Gem.loaded_specs['redis'] && defined?(::Redis)
         end

--- a/spec/datadog/tracing/contrib/rails/support/rails4.rb
+++ b/spec/datadog/tracing/contrib/rails/support/rails4.rb
@@ -62,7 +62,7 @@ RSpec.shared_context 'Rails 4 base application' do
         require 'ddtrace/auto_instrument'
       else
         # Enables the auto-instrumentation for the testing application
-        Datadog::Tracing.configure do |c|
+        Datadog.configure do |c|
           c.instrument :rails
           c.instrument :redis if Gem.loaded_specs['redis'] && defined?(::Redis)
         end

--- a/spec/datadog/tracing/contrib/rails/support/rails5.rb
+++ b/spec/datadog/tracing/contrib/rails/support/rails5.rb
@@ -65,7 +65,7 @@ RSpec.shared_context 'Rails 5 base application' do
         require 'ddtrace/auto_instrument'
       else
         # Enables the auto-instrumentation for the testing application
-        Datadog::Tracing.configure do |c|
+        Datadog.configure do |c|
           c.instrument :rails
           c.instrument :redis if Gem.loaded_specs['redis'] && defined?(::Redis)
         end

--- a/spec/datadog/tracing/contrib/rails/support/rails6.rb
+++ b/spec/datadog/tracing/contrib/rails/support/rails6.rb
@@ -68,7 +68,7 @@ RSpec.shared_context 'Rails 6 base application' do
         require 'ddtrace/auto_instrument'
       else
         # Enables the auto-instrumentation for the testing application
-        Datadog::Tracing.configure do |c|
+        Datadog.configure do |c|
           c.instrument :rails
           c.instrument :redis if Gem.loaded_specs['redis'] && defined?(::Redis)
         end

--- a/spec/datadog/tracing/contrib/rails/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/tracer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Rails tracer' do
 
   before { app }
 
-  let(:config) { Datadog::Tracing.configuration[:rails] }
+  let(:config) { Datadog.configuration[:rails] }
 
   it 'configurations application correctly' do
     expect(config[:template_base_path]).to eq('views/')

--- a/spec/datadog/tracing/contrib/rake/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/rake/instrumentation_spec.rb
@@ -28,22 +28,22 @@ RSpec.describe Datadog::Tracing::Contrib::Rake::Instrumentation do
     skip('Rake integration incompatible.') unless Datadog::Tracing::Contrib::Rake::Integration.compatible?
 
     # Reset options (that might linger from other tests)
-    Datadog::Tracing.configuration[:rake].reset!
+    Datadog.configuration[:rake].reset!
 
     # Patch Rake
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :rake, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:rake].reset_configuration!
+    Datadog.registry[:rake].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:rake].reset_configuration!
+    Datadog.registry[:rake].reset_configuration!
 
     # We don't want instrumentation enabled during the rest of the test suite...
-    Datadog::Tracing.configure { |c| c.instrument :rake, enabled: false }
+    Datadog.configure { |c| c.instrument :rake, enabled: false }
   end
 
   def reset_task!(task_name)

--- a/spec/datadog/tracing/contrib/redis/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/instrumentation_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe 'Redis instrumentation test' do
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:redis].reset_configuration!
+    Datadog.registry[:redis].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:redis].reset_configuration!
+    Datadog.registry[:redis].reset_configuration!
   end
 
   before do
@@ -30,7 +30,7 @@ RSpec.describe 'Redis instrumentation test' do
     let(:client) { Redis.new(url: redis_url) }
 
     before do
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         c.instrument :redis, service_name: default_service_name
         c.instrument :redis, describes: { url: redis_url }, service_name: service_name
       end
@@ -64,7 +64,7 @@ RSpec.describe 'Redis instrumentation test' do
     let(:client) { Redis.new(host: test_host, port: test_port) }
 
     before do
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         c.instrument :redis, service_name: default_service_name
         c.instrument :redis, describes: { host: test_host, port: test_port }, service_name: service_name
       end

--- a/spec/datadog/tracing/contrib/redis/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/integration_test_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe 'Redis integration test' do
 
     use_real_tracer!
 
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :redis
     end
   end
 
   after do
-    Datadog::Tracing.registry[:redis].reset_configuration!
-    without_warnings { Datadog::Tracing.configuration.reset! }
+    Datadog.registry[:redis].reset_configuration!
+    without_warnings { Datadog.configuration.reset! }
   end
 
   let(:redis) { Redis.new(host: host, port: port) }

--- a/spec/datadog/tracing/contrib/redis/miniapp_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/miniapp_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Redis mini app test' do
   before { skip unless ENV['TEST_DATADOG_INTEGRATION'] }
 
   before do
-    Datadog::Tracing.configure { |c| c.instrument :redis }
+    Datadog.configure { |c| c.instrument :redis }
 
     # Configure client instance with custom options
     Datadog.configure_onto(client, service_name: 'test-service')

--- a/spec/datadog/tracing/contrib/redis/redis_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/redis_spec.rb
@@ -12,16 +12,16 @@ RSpec.describe 'Redis test' do
   let(:configuration_options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :redis, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:redis].reset_configuration!
+    Datadog.registry[:redis].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:redis].reset_configuration!
+    Datadog.registry[:redis].reset_configuration!
   end
 
   shared_examples_for 'a Redis driver' do |driver|

--- a/spec/datadog/tracing/contrib/registerable_spec.rb
+++ b/spec/datadog/tracing/contrib/registerable_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Datadog::Tracing::Contrib::Registerable do
 
           context 'is not provided' do
             it do
-              expect(Datadog::Tracing.registry).to receive(:add)
+              expect(Datadog.registry).to receive(:add)
                 .with(name, a_kind_of(registerable_class), false)
               register_as
             end
@@ -44,7 +44,7 @@ RSpec.describe Datadog::Tracing::Contrib::Registerable do
             let(:options) { { auto_patch: true } }
 
             it do
-              expect(Datadog::Tracing.registry).to receive(:add)
+              expect(Datadog.registry).to receive(:add)
                 .with(name, a_kind_of(registerable_class), true)
               register_as
             end
@@ -52,7 +52,7 @@ RSpec.describe Datadog::Tracing::Contrib::Registerable do
 
           context 'is not provided' do
             it do
-              expect(Datadog::Tracing.registry).to receive(:add)
+              expect(Datadog.registry).to receive(:add)
                 .with(name, a_kind_of(registerable_class), false)
               register_as
             end

--- a/spec/datadog/tracing/contrib/resque/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/resque/instrumentation_spec.rb
@@ -44,16 +44,16 @@ RSpec.describe 'Resque instrumentation' do
     ::Resque::Failure.clear
 
     # Patch Resque
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :resque, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:resque].reset_configuration!
+    Datadog.registry[:resque].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:resque].reset_configuration!
+    Datadog.registry[:resque].reset_configuration!
   end
 
   shared_examples 'job execution tracing' do

--- a/spec/datadog/tracing/contrib/rest_client/request_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/rest_client/request_patch_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Datadog::Tracing::Contrib::RestClient::RequestPatch do
   let(:configuration_options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :rest_client, configuration_options
     end
 
@@ -26,9 +26,9 @@ RSpec.describe Datadog::Tracing::Contrib::RestClient::RequestPatch do
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:rest_client].reset_configuration!
+    Datadog.registry[:rest_client].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:rest_client].reset_configuration!
+    Datadog.registry[:rest_client].reset_configuration!
   end
 
   describe 'instrumented request' do

--- a/spec/datadog/tracing/contrib/sequel/configuration_spec.rb
+++ b/spec/datadog/tracing/contrib/sequel/configuration_spec.rb
@@ -36,12 +36,12 @@ RSpec.describe 'Sequel configuration' do
     end
 
     describe 'when configured' do
-      after { Datadog::Tracing.configuration[:sequel].reset! }
+      after { Datadog.configuration[:sequel].reset! }
 
       context 'only with defaults' do
         # Expect it to be the normalized adapter name.
         before do
-          Datadog::Tracing.configure { |c| c.instrument :sequel }
+          Datadog.configure { |c| c.instrument :sequel }
           perform_query!
         end
 
@@ -56,7 +56,7 @@ RSpec.describe 'Sequel configuration' do
         let(:service_name) { 'my-sequel' }
 
         before do
-          Datadog::Tracing.configure { |c| c.instrument :sequel, service_name: service_name }
+          Datadog.configure { |c| c.instrument :sequel, service_name: service_name }
           perform_query!
         end
 
@@ -71,9 +71,9 @@ RSpec.describe 'Sequel configuration' do
         let(:service_name) { 'custom-sequel' }
 
         before do
-          Datadog::Tracing.configure { |c| c.instrument :sequel }
+          Datadog.configure { |c| c.instrument :sequel }
           Datadog.configure_onto(sequel, service_name: service_name)
-          Datadog::Tracing.configure { |c| c.instrument :sequel }
+          Datadog.configure { |c| c.instrument :sequel }
           perform_query!
         end
 
@@ -90,7 +90,7 @@ RSpec.describe 'Sequel configuration' do
         #       no way to unpatch it once its happened in other tests.
         before do
           sequel
-          Datadog::Tracing.configure { |c| c.instrument :sequel }
+          Datadog.configure { |c| c.instrument :sequel }
           perform_query!
         end
 

--- a/spec/datadog/tracing/contrib/sequel/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/sequel/instrumentation_spec.rb
@@ -28,17 +28,17 @@ RSpec.describe 'Sequel instrumentation' do
     skip('Sequel not compatible.') unless Datadog::Tracing::Contrib::Sequel::Integration.compatible?
 
     # Patch Sequel
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :sequel, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:sequel].reset_configuration!
+    Datadog.registry[:sequel].reset_configuration!
     Sequel::DATABASES.each(&:disconnect)
     example.run
-    Datadog::Tracing.registry[:sequel].reset_configuration!
+    Datadog.registry[:sequel].reset_configuration!
   end
 
   shared_context 'instrumented queries' do

--- a/spec/datadog/tracing/contrib/shoryuken/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/shoryuken/tracer_spec.rb
@@ -12,16 +12,16 @@ RSpec.describe Datadog::Tracing::Contrib::Shoryuken::Tracer do
   before do
     Shoryuken.worker_executor = Shoryuken::Worker::InlineExecutor
 
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :shoryuken, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:shoryuken].reset_configuration!
+    Datadog.registry[:shoryuken].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:shoryuken].reset_configuration!
+    Datadog.registry[:shoryuken].reset_configuration!
   end
 
   shared_context 'Shoryuken::Worker' do

--- a/spec/datadog/tracing/contrib/sidekiq/disabled_tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/disabled_tracer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Disabled tracer' do
   let(:job_class) { EmptyWorker }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.tracing.enabled = false
     end
 

--- a/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
@@ -20,7 +20,7 @@ end
 
 module SidekiqTestingConfiguration
   def configure_sidekiq
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :sidekiq
     end
 

--- a/spec/datadog/tracing/contrib/sinatra/activerecord_spec.rb
+++ b/spec/datadog/tracing/contrib/sinatra/activerecord_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe 'Sinatra instrumentation with ActiveRecord' do
   let(:options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :sinatra, options
       c.instrument :active_record, options
     end
   end
 
-  after { Datadog::Tracing.registry[:sinatra].reset_configuration! }
+  after { Datadog.registry[:sinatra].reset_configuration! }
 
   shared_context 'ActiveRecord database' do
     let(:application_record_class) do

--- a/spec/datadog/tracing/contrib/sinatra/multi_app_spec.rb
+++ b/spec/datadog/tracing/contrib/sinatra/multi_app_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
   let(:options) { {} }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :sinatra, options
     end
   end
 
-  after { Datadog::Tracing.registry[:sinatra].reset_configuration! }
+  after { Datadog.registry[:sinatra].reset_configuration! }
 
   shared_context 'multi-app' do
     let(:app) do

--- a/spec/datadog/tracing/contrib/sinatra/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sinatra/tracer_spec.rb
@@ -98,16 +98,16 @@ RSpec.describe 'Sinatra instrumentation' do
   let(:rack_span) { sorted_spans.reverse.find { |x| x.name == Datadog::Tracing::Contrib::Rack::Ext::SPAN_REQUEST } }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :sinatra, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:sinatra].reset_configuration!
+    Datadog.registry[:sinatra].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:sinatra].reset_configuration!
+    Datadog.registry[:sinatra].reset_configuration!
   end
 
   shared_examples 'sinatra examples' do |opts = {}|

--- a/spec/datadog/tracing/contrib/sneakers/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sneakers/tracer_spec.rb
@@ -36,17 +36,17 @@ RSpec.describe Datadog::Tracing::Contrib::Sneakers::Tracer do
     allow(queue).to receive(:opts).and_return({})
     allow(queue).to receive(:exchange).and_return(exchange)
     Sneakers.configure(daemonize: true, log: '/tmp/sneakers.log')
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :sneakers, configuration_options
     end
   end
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:sneakers].reset_configuration!
+    Datadog.registry[:sneakers].reset_configuration!
     Sneakers.clear!
     example.run
-    Datadog::Tracing.registry[:sneakers].reset_configuration!
+    Datadog.registry[:sneakers].reset_configuration!
     Sneakers.clear!
   end
 

--- a/spec/datadog/tracing/contrib/sucker_punch/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/sucker_punch/patcher_spec.rb
@@ -6,7 +6,7 @@ require 'ddtrace'
 
 RSpec.describe 'sucker_punch instrumentation' do
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.instrument :sucker_punch
     end
 
@@ -34,9 +34,9 @@ RSpec.describe 'sucker_punch instrumentation' do
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
-    Datadog::Tracing.registry[:sucker_punch].reset_configuration!
+    Datadog.registry[:sucker_punch].reset_configuration!
     example.run
-    Datadog::Tracing.registry[:sucker_punch].reset_configuration!
+    Datadog.registry[:sucker_punch].reset_configuration!
   end
 
   let(:expect_thread?) { true }

--- a/spec/datadog/tracing/contrib/suite/transport_spec.rb
+++ b/spec/datadog/tracing/contrib/suite/transport_spec.rb
@@ -26,7 +26,7 @@ require 'ddtrace/transport/io'
 RSpec.describe 'transport with integrations' do
   describe 'when sending traces' do
     before do
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         # Activate all outbound integrations...
         # Although the transport by default only uses Net/HTTP
         # its possible for other adapters to be used instead.

--- a/spec/datadog/tracing/contrib/support/spec_helper.rb
+++ b/spec/datadog/tracing/contrib/support/spec_helper.rb
@@ -22,6 +22,6 @@ RSpec.configure do |config|
   # +expect(Datadog).to receive(:shutdown!).once+
   config.before do
     Datadog.shutdown!
-    without_warnings { Datadog::Tracing.configuration.reset! }
+    without_warnings { Datadog.configuration.reset! }
   end
 end

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'Tracer integration tests' do
         # @see https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
         skip("Can't share docker volume to access unix socket in CircleCI currently") if PlatformHelpers.ci?
 
-        Datadog::Tracing.configure do |c|
+        Datadog.configure do |c|
           c.tracing.transport_options = proc { |t|
             t.adapter :unix, ENV['TEST_DDAGENT_UNIX_SOCKET']
           }
@@ -159,13 +159,13 @@ RSpec.describe 'Tracer integration tests' do
     include_context 'agent-based test'
 
     before do
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         c.tracing.sampler = sampler if sampler
       end
     end
 
     after do
-      Datadog::Tracing.configuration.tracing.sampling.reset!
+      Datadog.configuration.tracing.sampling.reset!
     end
 
     shared_examples 'priority sampled' do |sampling_priority|
@@ -417,7 +417,7 @@ RSpec.describe 'Tracer integration tests' do
     let(:out) { instance_double(IO) } # Dummy output so we don't pollute STDOUT
 
     before do
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         c.tracing.writer = writer
       end
 
@@ -437,7 +437,7 @@ RSpec.describe 'Tracer integration tests' do
 
     # Reset the writer
     after do
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         c.tracing.reset!
       end
     end
@@ -471,7 +471,7 @@ RSpec.describe 'Tracer integration tests' do
     let(:transport) { Datadog::Transport::HTTP.default }
 
     before do
-      Datadog::Tracing.configure do |c|
+      Datadog.configure do |c|
         c.tracing.priority_sampling = true
         c.tracing.writer = writer
       end
@@ -514,9 +514,6 @@ RSpec.describe 'Tracer integration tests' do
       Datadog.configure do |c|
         c.agent.host = hostname
         c.agent.port = port
-      end
-
-      Datadog::Tracing.configure do |c|
         c.tracing.priority_sampling = true
       end
     end
@@ -527,7 +524,7 @@ RSpec.describe 'Tracer integration tests' do
 
     context 'when :transport_options' do
       before do
-        Datadog::Tracing.configure do |c|
+        Datadog.configure do |c|
           c.tracing.transport_options = transport_options
         end
       end

--- a/spec/datadog/tracing/sampling/rule_sampler_spec.rb
+++ b/spec/datadog/tracing/sampling/rule_sampler_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Datadog::Tracing::Sampling::RuleSampler do
 
     context 'with rate_limit ENV' do
       before do
-        allow(Datadog::Tracing.configuration.tracing.sampling).to receive(:rate_limit)
+        allow(Datadog.configuration.tracing.sampling).to receive(:rate_limit)
           .and_return(20.0)
       end
 
@@ -48,7 +48,7 @@ RSpec.describe Datadog::Tracing::Sampling::RuleSampler do
 
     context 'with default_sample_rate ENV' do
       before do
-        allow(Datadog::Tracing.configuration.tracing.sampling).to receive(:default_rate)
+        allow(Datadog.configuration.tracing.sampling).to receive(:default_rate)
           .and_return(0.5)
       end
 

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe Datadog::Tracing::Tracer do
         context 'when #report_hostname' do
           context 'is enabled' do
             before do
-              allow(Datadog::Tracing.configuration.tracing).to receive(:report_hostname).and_return(true)
+              allow(Datadog.configuration.tracing).to receive(:report_hostname).and_return(true)
             end
 
             it 'adds a hostname to the trace' do
@@ -253,7 +253,7 @@ RSpec.describe Datadog::Tracing::Tracer do
           end
 
           context 'is disabled' do
-            before { allow(Datadog::Tracing.configuration.tracing).to receive(:report_hostname).and_return(false) }
+            before { allow(Datadog.configuration.tracing).to receive(:report_hostname).and_return(false) }
 
             it 'adds a hostname to the trace' do
               tracer.trace(name) do |_span, trace|

--- a/spec/datadog/tracing/workers_integration_spec.rb
+++ b/spec/datadog/tracing/workers_integration_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Datadog::Workers::AsyncTransport integration tests' do
   let(:tracer) { Datadog::Tracing.send(:tracer) }
 
   before do
-    Datadog::Tracing.configure do |c|
+    Datadog.configure do |c|
       c.tracing.writer = writer
     end
   end

--- a/spec/datadog/tracing_spec.rb
+++ b/spec/datadog/tracing_spec.rb
@@ -126,23 +126,6 @@ RSpec.describe Datadog::Tracing do
     end
   end
 
-  describe '.registry' do
-    subject(:registry) { described_class.registry }
-    it 'returns the global registry' do
-      expect(registry).to eq(Datadog::Tracing::Contrib::REGISTRY)
-    end
-  end
-
-  describe '.configure' do
-    subject(:configure) { described_class.configure(&block) }
-    let(:block) { proc {} }
-
-    it 'delegates to the global configuration' do
-      expect(Datadog).to receive(:configure) { |&b| expect(b).to be_a_kind_of(Proc) }
-      configure
-    end
-  end
-
   describe '.correlation' do
     subject(:correlation) { described_class.correlation }
     it 'delegates to the tracer' do

--- a/spec/ddtrace/auto_instrument_spec.rb
+++ b/spec/ddtrace/auto_instrument_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Auto Instrumentation of non Rails' do
     require 'ddtrace/auto_instrument'
   end
 
-  after { Datadog::Tracing.registry[:sinatra].reset_configuration! }
+  after { Datadog.registry[:sinatra].reset_configuration! }
 
   shared_context 'ActiveRecord database' do
     let(:application_record_class) do

--- a/spec/support/configuration_helpers.rb
+++ b/spec/support/configuration_helpers.rb
@@ -41,8 +41,8 @@ module ConfigurationHelpers
       if integration.respond_to?(:patch_only_once, true)
         integration.send(:patch_only_once).send(:reset_ran_once_state_for_tests)
       end
-    elsif Datadog::Tracing.registry[integration].respond_to?(:patcher)
-      Datadog::Tracing.registry[integration].patcher.tap do |patcher|
+    elsif Datadog.registry[integration].respond_to?(:patcher)
+      Datadog.registry[integration].patcher.tap do |patcher|
         patcher::PATCH_ONLY_ONCE.send(:reset_ran_once_state_for_tests) if defined?(patcher::PATCH_ONLY_ONCE)
         patcher.send(:patch_only_once).send(:reset_ran_once_state_for_tests) if patcher.respond_to?(:patch_only_once, true)
       end


### PR DESCRIPTION
This PR reverts back to using `Datadog.configure` and `Datadog.configuration` for configuring all products.

The change to namespace each products' configuration turned out to make configuration much more verbose, and hard to learn (into which `#configure` block does `c.api_key` go?).