### PR TITLE
Add YARD link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Datadog Trace Client
 
+![Gem](https://img.shields.io/gem/v/ddtrace)
 [![CircleCI](https://circleci.com/gh/DataDog/dd-trace-rb/tree/master.svg?style=svg&circle-token=b0bd5ef866ec7f7b018f48731bb495f2d1372cc1)](https://circleci.com/gh/DataDog/dd-trace-rb/tree/master)
 [![codecov](https://codecov.io/gh/DataDog/dd-trace-rb/branch/master/graph/badge.svg)](https://app.codecov.io/gh/DataDog/dd-trace-rb/branch/master)
+[![YARD documentation](https://img.shields.io/badge/YARD-documentation-blue)](https://www.rubydoc.info/gems/ddtrace/)
 
 ``ddtrace`` is Datadog’s tracing client for Ruby. It is used to trace requests as they flow across web servers,
 databases and microservices so that developers have great visiblity into bottlenecks and troublesome requests.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -9,6 +9,8 @@ For the general APM documentation, see our [setup documentation][setup docs].
 
 For more information about what APM looks like once your application is sending information to Datadog, take a look at [Visualizing your APM data][visualization docs].
 
+For the library API documentation, see our [YARD documentation][yard docs].
+
 To contribute, check out the [contribution guidelines][contribution docs] and [development guide][development docs].
 
 [setup docs]: https://docs.datadoghq.com/tracing/
@@ -16,6 +18,7 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
 [visualization docs]: https://docs.datadoghq.com/tracing/visualization/
 [contribution docs]: https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md
 [development docs]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
+[yard docs]: https://www.rubydoc.info/gems/ddtrace/
 
 ## Table of Contents
 


### PR DESCRIPTION
This PR adds a link to our YARD documentation page to both our official documentation page (https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/) and to GitHub's Readme.

As a bonus, this adds a Rubygems badge as well.