### PR TITLE
Namespace c.instrument to c.tracing.instrument and c.ci.instrument

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -194,7 +194,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
     ```ruby
     Datadog.configure do |c|
       # This will activate auto-instrumentation for Rails
-      c.instrument :rails
+      c.tracing.instrument :rails
     end
     ```
 
@@ -454,7 +454,7 @@ You can enable it through `Datadog.configure`:
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :action_cable
+  c.tracing.instrument :action_cable
 end
 ```
 
@@ -467,7 +467,7 @@ You can enable it through `Datadog.configure`:
 ```ruby
 require 'ddtrace'
 Datadog.configure do |c|
-  c.instrument :action_mailer, options
+  c.tracing.instrument :action_mailer, options
 end
 ```
 
@@ -487,7 +487,7 @@ require 'actionpack'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :action_pack
+  c.tracing.instrument :action_pack
 end
 ```
 
@@ -500,7 +500,7 @@ require 'actionview'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :action_view, options
+  c.tracing.instrument :action_view, options
 end
 ```
 
@@ -519,7 +519,7 @@ require 'active_job'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :active_job
+  c.tracing.instrument :active_job
 end
 
 ExampleJob.perform_later
@@ -534,7 +534,7 @@ require 'active_model_serializers'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :active_model_serializers
+  c.tracing.instrument :active_model_serializers
 end
 
 my_object = MyModel.new(name: 'my object')
@@ -552,7 +552,7 @@ require 'active_record'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :active_record, options
+  c.tracing.instrument :active_record, options
 end
 
 Dir::Tmpname.create(['test', '.sqlite']) do |db|
@@ -581,22 +581,22 @@ You can configure trace settings per database connection by using the `describes
 Datadog.configure do |c|
   # Symbol matching your database connection in config/database.yml
   # Only available if you are using Rails with ActiveRecord.
-  c.instrument :active_record, describes: :secondary_database, service_name: 'secondary-db'
+  c.tracing.instrument :active_record, describes: :secondary_database, service_name: 'secondary-db'
 
   # Block configuration pattern.
-  c.instrument :active_record, describes: :secondary_database do |second_db|
+  c.tracing.instrument :active_record, describes: :secondary_database do |second_db|
     second_db.service_name = 'secondary-db'
   end
 
   # Connection string with the following connection settings:
   # adapter, username, host, port, database
   # Other fields are ignored.
-  c.instrument :active_record, describes: 'mysql2://root@127.0.0.1:3306/mysql', service_name: 'secondary-db'
+  c.tracing.instrument :active_record, describes: 'mysql2://root@127.0.0.1:3306/mysql', service_name: 'secondary-db'
 
   # Hash with following connection settings:
   # adapter, username, host, port, database
   # Other fields are ignored.
-  c.instrument :active_record, describes: {
+  c.tracing.instrument :active_record, describes: {
       adapter:  'mysql2',
       host:     '127.0.0.1',
       port:     '3306',
@@ -606,8 +606,8 @@ Datadog.configure do |c|
     service_name: 'secondary-db'
 
   # If using the `makara` gem, it's possible to match on connection `role`:
-  c.instrument :active_record, describes: { makara_role: 'primary' }, service_name: 'primary-db'
-  c.instrument :active_record, describes: { makara_role: 'replica' }, service_name: 'secondary-db'
+  c.tracing.instrument :active_record, describes: { makara_role: 'primary' }, service_name: 'primary-db'
+  c.tracing.instrument :active_record, describes: { makara_role: 'replica' }, service_name: 'secondary-db'
 end
 ```
 
@@ -616,23 +616,23 @@ You can also create configurations based on partial matching of database connect
 ```ruby
 Datadog.configure do |c|
   # Matches any connection on host `127.0.0.1`.
-  c.instrument :active_record, describes: { host:  '127.0.0.1' }, service_name: 'local-db'
+  c.tracing.instrument :active_record, describes: { host:  '127.0.0.1' }, service_name: 'local-db'
 
   # Matches any `mysql2` connection.
-  c.instrument :active_record, describes: { adapter: 'mysql2'}, service_name: 'mysql-db'
+  c.tracing.instrument :active_record, describes: { adapter: 'mysql2'}, service_name: 'mysql-db'
 
   # Matches any `mysql2` connection to the `reports` database.
   #
   # In case of multiple matching `describe` configurations, the latest one applies.
   # In this case a connection with both adapter `mysql` and database `reports`
   # will be configured `service_name: 'reports-db'`, not `service_name: 'mysql-db'`.
-  c.instrument :active_record, describes: { adapter: 'mysql2', database:  'reports'}, service_name: 'reports-db'
+  c.tracing.instrument :active_record, describes: { adapter: 'mysql2', database:  'reports'}, service_name: 'reports-db'
 end
 ```
 
 When multiple `describes` configurations match a connection, the latest configured rule that matches will be applied.
 
-If ActiveRecord traces an event that uses a connection that matches a key defined by `describes`, it will use the trace settings assigned to that connection. If the connection does not match any of the described connections, it will use default settings defined by `c.instrument :active_record` instead.
+If ActiveRecord traces an event that uses a connection that matches a key defined by `describes`, it will use the trace settings assigned to that connection. If the connection does not match any of the described connections, it will use default settings defined by `c.tracing.instrument :active_record` instead.
 
 ### Active Support
 
@@ -643,7 +643,7 @@ require 'activesupport'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :active_support, options
+  c.tracing.instrument :active_support, options
 end
 
 cache = ActiveSupport::Cache::MemoryStore.new
@@ -665,7 +665,7 @@ require 'aws-sdk'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :aws, options
+  c.tracing.instrument :aws, options
 end
 
 # Perform traced call
@@ -689,7 +689,7 @@ To activate your integration, use the `Datadog.configure` method:
 # Inside Rails initializer or equivalent
 Datadog.configure do |c|
   # Patches ::Concurrent::Future to use ExecutorService that propagates context
-  c.instrument :concurrent_ruby
+  c.tracing.instrument :concurrent_ruby
 end
 
 # Pass context into code executed within Concurrent::Future
@@ -743,7 +743,7 @@ require 'ddtrace'
 
 # Configure default Dalli tracing behavior
 Datadog.configure do |c|
-  c.instrument :dalli, options
+  c.tracing.instrument :dalli, options
 end
 
 # Configure Dalli tracing behavior for single client
@@ -767,7 +767,7 @@ You can enable it through `Datadog.configure`:
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :delayed_job, options
+  c.tracing.instrument :delayed_job, options
 end
 ```
 
@@ -786,7 +786,7 @@ require 'elasticsearch/transport'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :elasticsearch, options
+  c.tracing.instrument :elasticsearch, options
 end
 
 # Perform a query to Elasticsearch
@@ -809,10 +809,10 @@ The `ethon` integration will trace any HTTP request through `Easy` or `Multi` ob
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :ethon, options
+  c.tracing.instrument :ethon, options
 
   # optionally, specify a different service name for hostnames matching a regex
-  c.instrument :ethon, describes: /user-[^.]+\.example\.com/ do |ethon|
+  c.tracing.instrument :ethon, describes: /user-[^.]+\.example\.com/ do |ethon|
     ethon.service_name = 'user.example.com'
     ethon.split_by_domain = false # Only necessary if split_by_domain is true by default
   end
@@ -837,10 +837,10 @@ require 'ddtrace'
 
 # Configure default Excon tracing behavior
 Datadog.configure do |c|
-  c.instrument :excon, options
+  c.tracing.instrument :excon, options
 
   # optionally, specify a different service name for hostnames matching a regex
-  c.instrument :excon, describes: /user-[^.]+\.example\.com/ do |excon|
+  c.tracing.instrument :excon, describes: /user-[^.]+\.example\.com/ do |excon|
     excon.service_name = 'user.example.com'
     excon.split_by_domain = false # Only necessary if split_by_domain is true by default
   end
@@ -894,10 +894,10 @@ require 'ddtrace'
 
 # Configure default Faraday tracing behavior
 Datadog.configure do |c|
-  c.instrument :faraday, options
+  c.tracing.instrument :faraday, options
 
   # optionally, specify a different service name for hostnames matching a regex
-  c.instrument :faraday, describes: /user-[^.]+\.example\.com/ do |faraday|
+  c.tracing.instrument :faraday, describes: /user-[^.]+\.example\.com/ do |faraday|
     faraday.service_name = 'user.example.com'
     faraday.split_by_domain = false # Only necessary if split_by_domain is true by default
   end
@@ -933,7 +933,7 @@ require 'grape'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :grape, options
+  c.tracing.instrument :grape, options
 end
 
 # Then define your application
@@ -961,7 +961,7 @@ To activate your integration, use the `Datadog.configure` method:
 ```ruby
 # Inside Rails initializer or equivalent
 Datadog.configure do |c|
-  c.instrument :graphql, schemas: [YourSchema], options
+  c.tracing.instrument :graphql, schemas: [YourSchema], options
 end
 
 # Then run a GraphQL query
@@ -1031,7 +1031,7 @@ require 'grpc'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :grpc, options
+  c.tracing.instrument :grpc, options
 end
 
 # Server side
@@ -1078,9 +1078,9 @@ The http.rb integration will trace any HTTP call using the Http.rb gem.
 require 'http'
 require 'ddtrace'
 Datadog.configure do |c|
-  c.instrument :httprb, options
+  c.tracing.instrument :httprb, options
   # optionally, specify a different service name for hostnames matching a regex
-  c.instrument :httprb, describes: /user-[^.]+\.example\.com/ do |httprb|
+  c.tracing.instrument :httprb, describes: /user-[^.]+\.example\.com/ do |httprb|
     httprb.service_name = 'user.example.com'
     httprb.split_by_domain = false # Only necessary if split_by_domain is true by default
   end
@@ -1103,9 +1103,9 @@ The httpclient integration will trace any HTTP call using the httpclient gem.
 require 'httpclient'
 require 'ddtrace'
 Datadog.configure do |c|
-  c.instrument :httpclient, options
+  c.tracing.instrument :httpclient, options
   # optionally, specify a different service name for hostnames matching a regex
-  c.instrument :httpclient, describes: /user-[^.]+\.example\.com/ do |httpclient|
+  c.tracing.instrument :httpclient, describes: /user-[^.]+\.example\.com/ do |httpclient|
     httpclient.service_name = 'user.example.com'
     httpclient.split_by_domain = false # Only necessary if split_by_domain is true by default
   end
@@ -1129,10 +1129,10 @@ require "ddtrace"
 require "httpx/adapters/datadog"
 
 Datadog.configure do |c|
-  c.instrument :httpx
+  c.tracing.instrument :httpx
 
   # optionally, specify a different service name for hostnames matching a regex
-  c.instrument :httpx, describes: /user-[^.]+\.example\.com/ do |http|
+  c.tracing.instrument :httpx, describes: /user-[^.]+\.example\.com/ do |http|
     http.service_name = 'user.example.com'
     http.split_by_domain = false # Only necessary if split_by_domain is true by default
   end
@@ -1151,7 +1151,7 @@ require 'kafka'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :kafka
+  c.tracing.instrument :kafka
 end
 ```
 
@@ -1164,7 +1164,7 @@ require 'mongo'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :mongo, options
+  c.tracing.instrument :mongo, options
 end
 
 # Create a MongoDB client and use it as usual
@@ -1195,10 +1195,10 @@ You can configure trace settings per connection by using the `describes` option:
 
 Datadog.configure do |c|
   # Network connection string
-  c.instrument :mongo, describes: '127.0.0.1:27017', service_name: 'mongo-primary'
+  c.tracing.instrument :mongo, describes: '127.0.0.1:27017', service_name: 'mongo-primary'
 
   # Network connection regular expression
-  c.instrument :mongo, describes: /localhost.*/, service_name: 'mongo-secondary'
+  c.tracing.instrument :mongo, describes: /localhost.*/, service_name: 'mongo-secondary'
 end
 
 client = Mongo::Client.new([ '127.0.0.1:27017' ], :database => 'artists')
@@ -1223,7 +1223,7 @@ require 'mysql2'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :mysql2, options
+  c.tracing.instrument :mysql2, options
 end
 
 client = Mysql2::Client.new(:host => "localhost", :username => "root")
@@ -1245,10 +1245,10 @@ require 'net/http'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :http, options
+  c.tracing.instrument :http, options
 
   # optionally, specify a different service name for hostnames matching a regex
-  c.instrument :http, describes: /user-[^.]+\.example\.com/ do |http|
+  c.tracing.instrument :http, describes: /user-[^.]+\.example\.com/ do |http|
     http.service_name = 'user.example.com'
     http.split_by_domain = false # Only necessary if split_by_domain is true by default
   end
@@ -1286,7 +1286,7 @@ require 'presto-client'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :presto, options
+  c.tracing.instrument :presto, options
 end
 
 client = Presto::Client.new(
@@ -1318,7 +1318,7 @@ To add tracing to a Qless job:
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :qless, options
+  c.tracing.instrument :qless, options
 end
 ```
 
@@ -1339,7 +1339,7 @@ You can enable it through `Datadog.configure`:
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :que, options
+  c.tracing.instrument :que, options
 end
 ```
 
@@ -1362,7 +1362,7 @@ You can enable it through `Datadog.configure`:
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :racecar, options
+  c.tracing.instrument :racecar, options
 end
 ```
 
@@ -1383,7 +1383,7 @@ This integration is automatically activated with web frameworks like Rails. If y
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :rack, options
+  c.tracing.instrument :rack, options
 end
 
 use Datadog::Tracing::Contrib::Rack::TraceMiddleware
@@ -1421,23 +1421,23 @@ Datadog.configure do |c|
 
   # Show values for any query string parameter matching 'category_id' exactly
   # http://example.com/path?category_id=1&sort_by=asc#featured --> http://example.com/path?category_id=1&sort_by
-  c.instrument :rack, quantize: { query: { show: ['category_id'] } }
+  c.tracing.instrument :rack, quantize: { query: { show: ['category_id'] } }
 
   # Show all values for all query string parameters
   # http://example.com/path?category_id=1&sort_by=asc#featured --> http://example.com/path?category_id=1&sort_by=asc
-  c.instrument :rack, quantize: { query: { show: :all } }
+  c.tracing.instrument :rack, quantize: { query: { show: :all } }
 
   # Totally exclude any query string parameter matching 'sort_by' exactly
   # http://example.com/path?category_id=1&sort_by=asc#featured --> http://example.com/path?category_id
-  c.instrument :rack, quantize: { query: { exclude: ['sort_by'] } }
+  c.tracing.instrument :rack, quantize: { query: { exclude: ['sort_by'] } }
 
   # Remove the query string entirely
   # http://example.com/path?category_id=1&sort_by=asc#featured --> http://example.com/path
-  c.instrument :rack, quantize: { query: { exclude: :all } }
+  c.tracing.instrument :rack, quantize: { query: { exclude: :all } }
 
   # Show URL fragments
   # http://example.com/path?category_id=1&sort_by=asc#featured --> http://example.com/path?category_id&sort_by#featured
-  c.instrument :rack, quantize: { fragment: :show }
+  c.tracing.instrument :rack, quantize: { fragment: :show }
 end
 ```
 
@@ -1452,7 +1452,7 @@ To enable the Rails instrumentation, create an initializer file in your `config/
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :rails, options
+  c.tracing.instrument :rails, options
 end
 ```
 
@@ -1492,7 +1492,7 @@ require 'rake'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :rake, options
+  c.tracing.instrument :rake, options
 end
 
 task :my_task do
@@ -1519,27 +1519,27 @@ Datadog.configure do |c|
   # Default behavior: all arguments are quantized.
   # `rake.invoke.args` tag  --> ['?']
   # `rake.execute.args` tag --> { one: '?', two: '?', three: '?' }
-  c.instrument :rake
+  c.tracing.instrument :rake
 
   # Show values for any argument matching :two exactly
   # `rake.invoke.args` tag  --> ['?']
   # `rake.execute.args` tag --> { one: '?', two: 'bar', three: '?' }
-  c.instrument :rake, quantize: { args: { show: [:two] } }
+  c.tracing.instrument :rake, quantize: { args: { show: [:two] } }
 
   # Show all values for all arguments.
   # `rake.invoke.args` tag  --> ['foo', 'bar', 'baz']
   # `rake.execute.args` tag --> { one: 'foo', two: 'bar', three: 'baz' }
-  c.instrument :rake, quantize: { args: { show: :all } }
+  c.tracing.instrument :rake, quantize: { args: { show: :all } }
 
   # Totally exclude any argument matching :three exactly
   # `rake.invoke.args` tag  --> ['?']
   # `rake.execute.args` tag --> { one: '?', two: '?' }
-  c.instrument :rake, quantize: { args: { exclude: [:three] } }
+  c.tracing.instrument :rake, quantize: { args: { exclude: [:three] } }
 
   # Remove the arguments entirely
   # `rake.invoke.args` tag  --> ['?']
   # `rake.execute.args` tag --> {}
-  c.instrument :rake, quantize: { args: { exclude: :all } }
+  c.tracing.instrument :rake, quantize: { args: { exclude: :all } }
 end
 ```
 
@@ -1552,7 +1552,7 @@ require 'redis'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :redis, options
+  c.tracing.instrument :redis, options
 end
 
 # Perform Redis commands
@@ -1574,7 +1574,7 @@ require 'redis'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :redis # Enabling integration instrumentation is still required
+  c.tracing.instrument :redis # Enabling integration instrumentation is still required
 end
 
 customer_cache = Redis.new
@@ -1601,23 +1601,23 @@ You can configure trace settings per connection by using the `describes` option:
 
 Datadog.configure do |c|
   # The default configuration for any redis client
-  c.instrument :redis, service_name: 'redis-default'
+  c.tracing.instrument :redis, service_name: 'redis-default'
 
   # The configuration matching a given unix socket.
-  c.instrument :redis, describes: { url: 'unix://path/to/file' }, service_name: 'redis-unix'
+  c.tracing.instrument :redis, describes: { url: 'unix://path/to/file' }, service_name: 'redis-unix'
 
   # For network connections, only these fields are considered during matching:
   # scheme, host, port, db
   # Other fields are ignored.
 
   # Network connection string
-  c.instrument :redis, describes: 'redis://127.0.0.1:6379/0', service_name: 'redis-connection-string'
-  c.instrument :redis, describes: { url: 'redis://127.0.0.1:6379/1' }, service_name: 'redis-connection-url'
+  c.tracing.instrument :redis, describes: 'redis://127.0.0.1:6379/0', service_name: 'redis-connection-string'
+  c.tracing.instrument :redis, describes: { url: 'redis://127.0.0.1:6379/1' }, service_name: 'redis-connection-url'
   # Network client hash
-  c.instrument :redis, describes: { host: 'my-host.com', port: 6379, db: 1, scheme: 'redis' }, service_name: 'redis-connection-hash'
+  c.tracing.instrument :redis, describes: { host: 'my-host.com', port: 6379, db: 1, scheme: 'redis' }, service_name: 'redis-connection-hash'
   # Only a subset of the connection hash
-  c.instrument :redis, describes: { host: ENV['APP_CACHE_HOST'], port: ENV['APP_CACHE_PORT'] }, service_name: 'redis-cache'
-  c.instrument :redis, describes: { host: ENV['SIDEKIQ_CACHE_HOST'] }, service_name: 'redis-sidekiq'
+  c.tracing.instrument :redis, describes: { host: ENV['APP_CACHE_HOST'], port: ENV['APP_CACHE_PORT'] }, service_name: 'redis-cache'
+  c.tracing.instrument :redis, describes: { host: ENV['SIDEKIQ_CACHE_HOST'] }, service_name: 'redis-sidekiq'
 end
 ```
 
@@ -1634,7 +1634,7 @@ require 'resque'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :resque, **options
+  c.tracing.instrument :resque, **options
 end
 ```
 
@@ -1653,7 +1653,7 @@ require 'rest_client'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :rest_client, options
+  c.tracing.instrument :rest_client, options
 end
 ```
 
@@ -1706,7 +1706,7 @@ database.create_table :articles do
 end
 
 Datadog.configure do |c|
-  c.instrument :sequel, options
+  c.tracing.instrument :sequel, options
 end
 
 # Perform a query
@@ -1743,7 +1743,7 @@ You can enable it through `Datadog.configure`:
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :shoryuken, options
+  c.tracing.instrument :shoryuken, options
 end
 ```
 
@@ -1764,7 +1764,7 @@ You can enable it through `Datadog.configure`:
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :sidekiq, options
+  c.tracing.instrument :sidekiq, options
 end
 ```
 
@@ -1788,7 +1788,7 @@ require 'sinatra'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :sinatra, options
+  c.tracing.instrument :sinatra, options
 end
 
 get '/' do
@@ -1803,7 +1803,7 @@ require 'sinatra/base'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :sinatra, options
+  c.tracing.instrument :sinatra, options
 end
 
 class NestedApp < Sinatra::Base
@@ -1847,7 +1847,7 @@ You can enable it through `Datadog.configure`:
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :sneakers, options
+  c.tracing.instrument :sneakers, options
 end
 ```
 
@@ -1867,7 +1867,7 @@ The `sucker_punch` integration traces all scheduled jobs:
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.instrument :sucker_punch
+  c.tracing.instrument :sucker_punch
 end
 
 # Execution of this job is traced
@@ -1885,7 +1885,7 @@ LogJob.perform_async('login')
 - `DD_PROPAGATION_STYLE_INJECT`: Distributed tracing header formats to inject. See [Distributed Tracing](#distributed-tracing) for more details.
 - `DD_SERVICE`: Your application's default service name. See [Environment and tags](#environment-and-tags) for more details.
 - `DD_TAGS`: Custom tags for telemetry produced by your application. See [Environment and tags](#environment-and-tags) for more details.
-- `DD_TRACE_<INTEGRATION>_ENABLED`: Enables or disables an **activated** integration. Defaults to `true`.. e.g. `DD_TRACE_RAILS_ENABLED=false`. This option has no effects on integrations that have not been explicitly activated (e.g. `Datadog.configure { |c| c.instrument :integration }`).on code. This environment variable can only be used to disable an integration.
+- `DD_TRACE_<INTEGRATION>_ENABLED`: Enables or disables an **activated** integration. Defaults to `true`.. e.g. `DD_TRACE_RAILS_ENABLED=false`. This option has no effects on integrations that have not been explicitly activated (e.g. `Datadog.configure { |c| c.tracing.instrument :integration }`).on code. This environment variable can only be used to disable an integration.
 - `DD_TRACE_AGENT_PORT`: Port to where traces will be sent. See [Tracer settings](#tracer-settings) for more details.
 - `DD_TRACE_AGENT_URL`: Sets the URL endpoint where traces are sent. Has priority over `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. e.g. `DD_TRACE_AGENT_URL=http://localhost:8126`.
 - `DD_TRACE_ANALYTICS_ENABLED`: Enables or disables trace analytics. See [Sampling](#sampling) for more details.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -388,7 +388,7 @@ Many popular libraries and frameworks are supported out-of-the-box, which can be
 ```ruby
 Datadog.configure do |c|
   # Activates and configures an integration
-  c.instrument :integration_name, options
+  c.tracing.instrument :integration_name, options
 end
 ```
 
@@ -408,7 +408,6 @@ For a list of available integrations, and their configuration options, please re
 | Active Support             | `active_support`           | `>= 3.2`                 | `>= 3.2`                  | *[Link](#active-support)*           | *[Link](https://github.com/rails/rails/tree/master/activesupport)*             |
 | AWS                        | `aws`                      | `>= 2.0`                 | `>= 2.0`                  | *[Link](#aws)*                      | *[Link](https://github.com/aws/aws-sdk-ruby)*                                  |
 | Concurrent Ruby            | `concurrent_ruby`          | `>= 0.9`                 | `>= 0.9`                  | *[Link](#concurrent-ruby)*          | *[Link](https://github.com/ruby-concurrency/concurrent-ruby)*                  |
-| Cucumber                   | `cucumber`                 | `>= 3.0`                 | `>= 1.7.16`               | *[Link](#cucumber)*                 | *[Link](https://github.com/cucumber/cucumber-ruby)*                            |
 | Dalli                      | `dalli`                    | `>= 2.0`                 | `>= 2.0`                  | *[Link](#dalli)*                    | *[Link](https://github.com/petergoldstein/dalli)*                              |
 | DelayedJob                 | `delayed_job`              | `>= 4.1`                 | `>= 4.1`                  | *[Link](#delayedjob)*               | *[Link](https://github.com/collectiveidea/delayed_job)*                        |
 | Elasticsearch              | `elasticsearch`            | `>= 1.0`                 | `>= 1.0`                  | *[Link](#elasticsearch)*            | *[Link](https://github.com/elastic/elasticsearch-ruby)*                        |
@@ -436,13 +435,32 @@ For a list of available integrations, and their configuration options, please re
 | Redis                      | `redis`                    | `>= 3.2`                 | `>= 3.2`                  | *[Link](#redis)*                    | *[Link](https://github.com/redis/redis-rb)*                                    |
 | Resque                     | `resque`                   | `>= 1.0`                 | `>= 1.0`                  | *[Link](#resque)*                   | *[Link](https://github.com/resque/resque)*                                     |
 | Rest Client                | `rest-client`              | `>= 1.8`                 | `>= 1.8`                  | *[Link](#rest-client)*              | *[Link](https://github.com/rest-client/rest-client)*                           |
-| RSpec                      | `rspec`.                   | `>= 3.0.0`               | `>= 3.0.0`                | *[Link](#rspec)*.                   | *[Link](https://github.com/rspec/rspec)*                                       |
 | Sequel                     | `sequel`                   | `>= 3.41`                | `>= 3.41`                 | *[Link](#sequel)*                   | *[Link](https://github.com/jeremyevans/sequel)*                                |
 | Shoryuken                  | `shoryuken`                | `>= 3.2`                 | `>= 3.2`                  | *[Link](#shoryuken)*                | *[Link](https://github.com/phstc/shoryuken)*                                   |
 | Sidekiq                    | `sidekiq`                  | `>= 3.5.4`               | `>= 3.5.4`                | *[Link](#sidekiq)*                  | *[Link](https://github.com/mperham/sidekiq)*                                   |
 | Sinatra                    | `sinatra`                  | `>= 1.4`                 | `>= 1.4`                  | *[Link](#sinatra)*                  | *[Link](https://github.com/sinatra/sinatra)*                                   |
 | Sneakers                   | `sneakers`                 | `>= 2.12.0`              | `>= 2.12.0`               | *[Link](#sneakers)*                 | *[Link](https://github.com/jondot/sneakers)*                                   |
 | Sucker Punch               | `sucker_punch`             | `>= 2.0`                 | `>= 2.0`                  | *[Link](#sucker-punch)*             | *[Link](https://github.com/brandonhilkert/sucker_punch)*                       |
+
+#### CI Visibility
+
+For Datadog CI Visibility, library instrumentation can be activated and configured by using the following `Datadog.configure` API:
+
+```ruby
+Datadog.configure do |c|
+  # Activates and configures an integration
+  c.ci.instrument :integration_name, options
+end
+```
+
+`options` is a `Hash` of integration-specific configuration settings.
+
+These are the available CI Visibility integrations:
+
+| Name      | Key        | Versions Supported: MRI | Versions Supported: JRuby | How to configure    | Gem source                                          |
+|-----------|------------|-------------------------|---------------------------|---------------------|-----------------------------------------------------|
+| Cucumber  | `cucumber` | `>= 3.0`                | `>= 1.7.16`               | *[Link](#cucumber)* | *[Link](https://github.com/cucumber/cucumber-ruby)* |
+| RSpec     | `rspec`    | `>= 3.0.0`              | `>= 3.0.0`                | *[Link](#rspec)*    | *[Link](https://github.com/rspec/rspec)*            |
 
 ### Action Cable
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -710,7 +710,7 @@ require 'ddtrace'
 
 # Configure default Cucumber integration
 Datadog.configure do |c|
-  c.instrument :cucumber, options
+  c.ci.instrument :cucumber, options
 end
 
 # Example of how to attach tags from scenario to active span
@@ -1676,7 +1676,7 @@ require 'ddtrace'
 
 # Configure default RSpec integration
 Datadog.configure do |c|
-  c.instrument :rspec, options
+  c.ci.instrument :rspec, options
 end
 ```
 

--- a/integration/apps/rack/app/datadog.rb
+++ b/integration/apps/rack/app/datadog.rb
@@ -8,7 +8,7 @@ Datadog.configure do |c|
 
   if Datadog::DemoEnv.feature?('tracing')
     c.tracing.analytics.enabled = true if Datadog::DemoEnv.feature?('analytics')
-    c.instrument :rack
+    c.tracing.instrument :rack
   end
 
   if Datadog::DemoEnv.feature?('pprof_to_file')

--- a/integration/apps/rails-five/config/initializers/datadog.rb
+++ b/integration/apps/rails-five/config/initializers/datadog.rb
@@ -8,9 +8,9 @@ Datadog.configure do |c|
   if Datadog::DemoEnv.feature?('tracing')
     c.tracing.analytics.enabled = true if Datadog::DemoEnv.feature?('analytics')
 
-    c.instrument :rails
-    c.instrument :redis, service_name: 'acme-redis'
-    c.instrument :resque
+    c.tracing.instrument :rails
+    c.tracing.instrument :redis, service_name: 'acme-redis'
+    c.tracing.instrument :resque
   end
 
   if Datadog::DemoEnv.feature?('pprof_to_file')

--- a/integration/apps/rspec/spec/spec_helper.rb
+++ b/integration/apps/rspec/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'datadog/ci'
 # Enable CI tracing
 Datadog.configure do |c|
   c.ci.enabled = true
-  c.instrument :rspec
+  c.ci.instrument :rspec
 end
 
 RSpec.configure do |config|

--- a/lib/datadog/appsec/contrib/rails/framework.rb
+++ b/lib/datadog/appsec/contrib/rails/framework.rb
@@ -17,7 +17,7 @@ module Datadog
 
           # Apply relevant configuration from Sinatra to Rack
           def self.activate_rack!(datadog_config, sinatra_config)
-            datadog_config.instrument(
+            datadog_config.tracing.instrument(
               :rack,
             )
           end

--- a/lib/datadog/appsec/contrib/sinatra/framework.rb
+++ b/lib/datadog/appsec/contrib/sinatra/framework.rb
@@ -21,7 +21,7 @@ module Datadog
 
           # Apply relevant configuration from Sinatra to Rack
           def self.activate_rack!(datadog_config, sinatra_config)
-            datadog_config.instrument(
+            datadog_config.tracing.instrument(
               :rack,
             )
           end

--- a/lib/datadog/ci/configuration/settings.rb
+++ b/lib/datadog/ci/configuration/settings.rb
@@ -19,6 +19,12 @@ module Datadog
                 o.lazy
               end
 
+              # DEV: Alias to Datadog::Tracing::Contrib::Extensions::Configuration::Settings#instrument.
+              # DEV: Should be removed when `c.ci.instrument` namespacing is complete.
+              define_method(:instrument) do |integration_name, options = {}, &block|
+                Datadog.configuration.send(:instrument, integration_name, options, &block)
+              end
+
               option :trace_flush do |o|
                 o.default { nil }
                 o.lazy

--- a/lib/datadog/ci/configuration/settings.rb
+++ b/lib/datadog/ci/configuration/settings.rb
@@ -25,6 +25,9 @@ module Datadog
                 Datadog.configuration.send(:instrument, integration_name, options, &block)
               end
 
+              # TODO: Deprecate in the next major version, as `instrument` better describes this method's purpose
+              alias_method :use, :instrument
+
               option :trace_flush do |o|
                 o.default { nil }
                 o.lazy

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -463,6 +463,12 @@ module Datadog
           # @return [Object,nil]
           option :instance
 
+          # DEV: Alias to Datadog::Tracing::Contrib::Extensions::Configuration::Settings#instrument.
+          # DEV: Should be removed when `c.tracing.instrument` namespacing is complete.
+          define_method(:instrument) do |integration_name, options = {}, &block|
+            Datadog.configuration.send(:instrument, integration_name, options, &block)
+          end
+
           # Automatic correlation between tracing and logging.
           # @see https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#trace-correlation
           # @return [Boolean]

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -469,6 +469,9 @@ module Datadog
             Datadog.configuration.send(:instrument, integration_name, options, &block)
           end
 
+          # TODO: Deprecate in the next major version, as `instrument` better describes this method's purpose
+          alias_method :use, :instrument
+
           # Automatic correlation between tracing and logging.
           # @see https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#trace-correlation
           # @return [Boolean]

--- a/lib/datadog/tracing/contrib/auto_instrument.rb
+++ b/lib/datadog/tracing/contrib/auto_instrument.rb
@@ -40,7 +40,7 @@ module Datadog
             c.reduce_log_verbosity
             # This will activate auto-instrumentation for Rails
             integrations.each do |integration_name|
-              c.instrument integration_name
+              c.tracing.instrument integration_name
             end
           end
         end

--- a/lib/datadog/tracing/contrib/extensions.rb
+++ b/lib/datadog/tracing/contrib/extensions.rb
@@ -130,23 +130,6 @@ module Datadog
               integration.configuration(describes) unless integration.nil?
             end
 
-            def instrument(integration_name, options = {}, &block)
-              integration = fetch_integration(integration_name)
-
-              unless integration.nil? || !integration.default_configuration.enabled
-                configuration_name = options[:describes] || :default
-                filtered_options = options.reject { |k, _v| k == :describes }
-                integration.configure(configuration_name, filtered_options, &block)
-                instrumented_integrations[integration_name] = integration
-
-                # Add to activation list
-                integrations_pending_activation << integration
-              end
-            end
-
-            # TODO: Deprecate in the next major version, as `instrument` better describes this method's purpose
-            alias_method :use, :instrument
-
             # @!visibility private
             def integrations_pending_activation
               @integrations_pending_activation ||= Set.new
@@ -176,6 +159,22 @@ module Datadog
 
             def reduce_log_verbosity
               @reduce_verbosity ||= true
+            end
+
+            private
+
+            def instrument(integration_name, options = {}, &block)
+              integration = fetch_integration(integration_name)
+
+              unless integration.nil? || !integration.default_configuration.enabled
+                configuration_name = options[:describes] || :default
+                filtered_options = options.reject { |k, _v| k == :describes }
+                integration.configure(configuration_name, filtered_options, &block)
+                instrumented_integrations[integration_name] = integration
+
+                # Add to activation list
+                integrations_pending_activation << integration
+              end
             end
           end
         end

--- a/lib/datadog/tracing/contrib/extensions.rb
+++ b/lib/datadog/tracing/contrib/extensions.rb
@@ -34,7 +34,7 @@ module Datadog
           #
           # ```
           # Datadog.configure do |c|
-          #   c.instrument :my_registered_integration, **my_options
+          #   c.tracing.instrument :my_registered_integration, **my_options
           # end
           # ```
           #
@@ -144,8 +144,7 @@ module Datadog
               end
             end
 
-            # TODO: Deprecate in the next major version, as `instrument` better describes
-            # TODO: what `c.instrument` does internally in the tracer.
+            # TODO: Deprecate in the next major version, as `instrument` better describes this method's purpose
             alias_method :use, :instrument
 
             # @!visibility private

--- a/lib/datadog/tracing/contrib/integration.rb
+++ b/lib/datadog/tracing/contrib/integration.rb
@@ -60,7 +60,7 @@ module Datadog
       # end
       #
       # Datadog.configure do |c|
-      #   c.instrument :billing_api # Settings (e.g. `service:`) can be provided as keyword arguments.
+      #   c.tracing.instrument :billing_api # Settings (e.g. `service:`) can be provided as keyword arguments.
       # end
       # ```
       #

--- a/lib/datadog/tracing/contrib/patchable.rb
+++ b/lib/datadog/tracing/contrib/patchable.rb
@@ -93,7 +93,7 @@ module Datadog
 
           # Can the patch for this integration be applied automatically?
           # For example: test integrations should only be applied
-          # by the user explicitly setting `c.instrument :rspec`
+          # by the user explicitly setting `c.ci.instrument :rspec`
           # and rails sub-modules are auto-instrumented by enabling rails
           # so auto-instrumenting them on their own will cause changes in
           # service naming behavior

--- a/lib/datadog/tracing/contrib/rails/framework.rb
+++ b/lib/datadog/tracing/contrib/rails/framework.rb
@@ -62,7 +62,7 @@ module Datadog
           end
 
           def self.activate_rack!(trace_config, rails_config)
-            trace_config.instrument(
+            trace_config.tracing.instrument(
               :rack,
               application: ::Rails.application,
               service_name: rails_config[:service_name],
@@ -74,19 +74,19 @@ module Datadog
           def self.activate_active_support!(trace_config, rails_config)
             return unless defined?(::ActiveSupport)
 
-            trace_config.instrument(:active_support)
+            trace_config.tracing.instrument(:active_support)
           end
 
           def self.activate_action_cable!(trace_config, rails_config)
             return unless defined?(::ActionCable)
 
-            trace_config.instrument(:action_cable)
+            trace_config.tracing.instrument(:action_cable)
           end
 
           def self.activate_action_mailer!(trace_config, rails_config)
             return unless defined?(::ActionMailer)
 
-            trace_config.instrument(
+            trace_config.tracing.instrument(
               :action_mailer,
               service_name: rails_config[:service_name]
             )
@@ -95,7 +95,7 @@ module Datadog
           def self.activate_action_pack!(trace_config, rails_config)
             return unless defined?(::ActionPack)
 
-            trace_config.instrument(
+            trace_config.tracing.instrument(
               :action_pack,
               service_name: rails_config[:service_name]
             )
@@ -104,7 +104,7 @@ module Datadog
           def self.activate_action_view!(trace_config, rails_config)
             return unless defined?(::ActionView)
 
-            trace_config.instrument(
+            trace_config.tracing.instrument(
               :action_view,
               service_name: rails_config[:service_name]
             )
@@ -113,7 +113,7 @@ module Datadog
           def self.activate_active_job!(trace_config, rails_config)
             return unless defined?(::ActiveJob)
 
-            trace_config.instrument(
+            trace_config.tracing.instrument(
               :active_job,
               service_name: rails_config[:service_name]
             )
@@ -122,14 +122,14 @@ module Datadog
           def self.activate_active_record!(trace_config, rails_config)
             return unless defined?(::ActiveRecord)
 
-            trace_config.instrument(:active_record)
+            trace_config.tracing.instrument(:active_record)
           end
 
           def self.activate_lograge!(trace_config, rails_config)
             return unless defined?(::Lograge)
 
             if trace_config.tracing.log_injection
-              trace_config.instrument(
+              trace_config.tracing.instrument(
                 :lograge
               )
             end
@@ -139,7 +139,7 @@ module Datadog
             return unless defined?(::SemanticLogger)
 
             if trace_config.tracing.log_injection
-              trace_config.instrument(
+              trace_config.tracing.instrument(
                 :semantic_logger
               )
             end

--- a/lib/datadog/tracing/contrib/registerable.rb
+++ b/lib/datadog/tracing/contrib/registerable.rb
@@ -18,7 +18,7 @@ module Datadog
           #
           # ```
           # Datadog.configure do |c|
-          #   c.instrument :name
+          #   c.tracing.instrument :name
           # end
           # ```
           #

--- a/lib/datadog/tracing/contrib/sinatra/framework.rb
+++ b/lib/datadog/tracing/contrib/sinatra/framework.rb
@@ -23,7 +23,7 @@ module Datadog
 
           # Apply relevant configuration from Sinatra to Rack
           def self.activate_rack!(datadog_config, sinatra_config)
-            datadog_config.instrument(
+            datadog_config.tracing.instrument(
               :rack,
               service_name: sinatra_config[:service_name],
               distributed_tracing: sinatra_config[:distributed_tracing],

--- a/spec/datadog/ci/contrib/cucumber/formatter_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/formatter_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Cucumber formatter' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :cucumber, configuration_options
+      c.ci.instrument :cucumber, configuration_options
     end
   end
 

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'RSpec hooks' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :rspec, configuration_options
+      c.ci.instrument :rspec, configuration_options
     end
   end
 

--- a/spec/datadog/core/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/core/diagnostics/environment_logger_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
       end
 
       context 'with integrations loaded' do
-        before { Datadog.configure { |c| c.instrument :http, options } }
+        before { Datadog.configure { |c| c.tracing.instrument :http, options } }
 
         let(:options) { {} }
 

--- a/spec/datadog/tracing/contrib/action_cable/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/action_cable/instrumentation_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe 'ActionCable Rack override' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :rails, options
-      c.instrument :action_cable, options
+      c.tracing.instrument :rails, options
+      c.tracing.instrument :action_cable, options
     end
 
     rails_test_application.instance.routes.draw do

--- a/spec/datadog/tracing/contrib/action_cable/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/action_cable/patcher_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'ActionCable patcher' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :action_cable, configuration_options
+      c.tracing.instrument :action_cable, configuration_options
     end
 
     raise_on_rails_deprecation!

--- a/spec/datadog/tracing/contrib/action_mailer/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/action_mailer/patcher_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'ActionMailer patcher' do
   before do
     if Datadog::Tracing::Contrib::ActionMailer::Integration.compatible?
       Datadog.configure do |c|
-        c.instrument :action_mailer, configuration_options
+        c.tracing.instrument :action_mailer, configuration_options
       end
     else
       skip

--- a/spec/datadog/tracing/contrib/active_model_serializers/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/active_model_serializers/patcher_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'ActiveModelSerializers patcher' do
     ActiveModelSerializersHelpers.disable_logging
 
     Datadog.configure do |c|
-      c.instrument :active_model_serializers, configuration_options
+      c.tracing.instrument :active_model_serializers, configuration_options
     end
 
     raise_on_rails_deprecation!

--- a/spec/datadog/tracing/contrib/active_record/multi_db_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/multi_db_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'ActiveRecord multi-database implementation' do
     Datadog.registry[:active_record].reset_configuration!
 
     Datadog.configure do |c|
-      c.instrument :active_record, configuration_options
+      c.tracing.instrument :active_record, configuration_options
     end
 
     raise_on_rails_deprecation!
@@ -137,11 +137,11 @@ RSpec.describe 'ActiveRecord multi-database implementation' do
           allow(ActiveRecord::Base).to receive(:configurations).and_return(database_configuration_object)
 
           Datadog.configure do |c|
-            c.instrument :active_record, describes: :gadget do |gadget_db|
+            c.tracing.instrument :active_record, describes: :gadget do |gadget_db|
               gadget_db.service_name = gadget_db_service_name
             end
 
-            c.instrument :active_record, describes: :widget do |widget_db|
+            c.tracing.instrument :active_record, describes: :widget do |widget_db|
               widget_db.service_name = widget_db_service_name
             end
           end
@@ -179,7 +179,7 @@ RSpec.describe 'ActiveRecord multi-database implementation' do
       context 'for a typical server' do
         before do
           Datadog.configure do |c|
-            c.instrument :active_record, describes: mysql_connection_string do |gadget_db|
+            c.tracing.instrument :active_record, describes: mysql_connection_string do |gadget_db|
               gadget_db.service_name = gadget_db_service_name
             end
           end
@@ -205,7 +205,7 @@ RSpec.describe 'ActiveRecord multi-database implementation' do
       context 'for an in-memory database' do
         before do
           Datadog.configure do |c|
-            c.instrument :active_record, describes: 'sqlite3::memory:' do |widget_db|
+            c.tracing.instrument :active_record, describes: 'sqlite3::memory:' do |widget_db|
               widget_db.service_name = widget_db_service_name
             end
           end
@@ -234,7 +234,7 @@ RSpec.describe 'ActiveRecord multi-database implementation' do
         widget_db_connection_hash = { adapter: 'sqlite3', database: ':memory:' }
 
         Datadog.configure do |c|
-          c.instrument :active_record, describes: widget_db_connection_hash do |widget_db|
+          c.tracing.instrument :active_record, describes: widget_db_connection_hash do |widget_db|
             widget_db.service_name = widget_db_service_name
           end
         end

--- a/spec/datadog/tracing/contrib/active_record/performance_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/performance_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'ActiveRecord tracing performance' do
 
     # Configure the tracer
     Datadog.configure do |c|
-      c.instrument :active_record, options
+      c.tracing.instrument :active_record, options
     end
   end
 

--- a/spec/datadog/tracing/contrib/active_record/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/tracer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'ActiveRecord instrumentation' do
     Datadog.configuration[:active_record].reset!
 
     Datadog.configure do |c|
-      c.instrument :active_record, configuration_options
+      c.tracing.instrument :active_record, configuration_options
     end
 
     raise_on_rails_deprecation!
@@ -102,9 +102,11 @@ RSpec.describe 'ActiveRecord instrumentation' do
             clear_traces!
 
             Datadog.configure do |c|
-              c.instrument :active_record, service_name: 'bad-no-match'
-              c.instrument :active_record, describes: { makara_role: primary_role }, service_name: primary_service_name
-              c.instrument :active_record, describes: { makara_role: secondary_role }, service_name: secondary_service_name
+              c.tracing.instrument :active_record, service_name: 'bad-no-match'
+              c.tracing.instrument :active_record, describes: { makara_role: primary_role },
+                                                   service_name: primary_service_name
+              c.tracing.instrument :active_record, describes: { makara_role: secondary_role },
+                                                   service_name: secondary_service_name
             end
           end
 

--- a/spec/datadog/tracing/contrib/aws/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/aws/instrumentation_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'AWS instrumentation' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :aws, configuration_options
+      c.tracing.instrument :aws, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/concurrent_ruby/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/concurrent_ruby/integration_test_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'ConcurrentRuby integration tests' do
   describe 'patching' do
     subject(:patch) do
       Datadog.configure do |c|
-        c.instrument :concurrent_ruby
+        c.tracing.instrument :concurrent_ruby
       end
     end
 
@@ -84,7 +84,7 @@ RSpec.describe 'ConcurrentRuby integration tests' do
   context 'when context propagation is enabled' do
     before do
       Datadog.configure do |c|
-        c.instrument :concurrent_ruby
+        c.tracing.instrument :concurrent_ruby
       end
     end
 

--- a/spec/datadog/tracing/contrib/dalli/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/dalli/instrumentation_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Dalli instrumentation' do
   # Enable the test tracer
   before do
     Datadog.configure do |c|
-      c.instrument :dalli, configuration_options
+      c.tracing.instrument :dalli, configuration_options
     end
   end
 
@@ -65,7 +65,7 @@ RSpec.describe 'Dalli instrumentation' do
 
     before do
       Datadog.configure do |c|
-        c.instrument :dalli, describes: "#{test_host}:#{test_port}", service_name: service_name
+        c.tracing.instrument :dalli, describes: "#{test_host}:#{test_port}", service_name: service_name
       end
     end
 

--- a/spec/datadog/tracing/contrib/dalli/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/dalli/patcher_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Dalli instrumentation' do
   # Enable the test tracer
   before do
     Datadog.configure do |c|
-      c.instrument :dalli, configuration_options
+      c.tracing.instrument :dalli, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/delayed_job/plugin_spec.rb
+++ b/spec/datadog/tracing/contrib/delayed_job/plugin_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Datadog::Tracing::Contrib::DelayedJob::Plugin, :delayed_job_activ
   let(:configuration_options) { {} }
 
   before do
-    Datadog.configure { |c| c.instrument :delayed_job, configuration_options }
+    Datadog.configure { |c| c.tracing.instrument :delayed_job, configuration_options }
     Delayed::Worker.delay_jobs = false
   end
 

--- a/spec/datadog/tracing/contrib/elasticsearch/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/elasticsearch/patcher_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Patcher do
 
   before do
     Datadog.configure do |c|
-      c.instrument :elasticsearch, configuration_options
+      c.tracing.instrument :elasticsearch, configuration_options
     end
 
     wait_http_server(server, 60)

--- a/spec/datadog/tracing/contrib/elasticsearch/transport_spec.rb
+++ b/spec/datadog/tracing/contrib/elasticsearch/transport_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Elasticsearch::Transport::Client tracing' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :elasticsearch, configuration_options
+      c.tracing.instrument :elasticsearch, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/ethon/easy_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/easy_patch_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Datadog::Tracing::Contrib::Ethon::EasyPatch do
 
   before do
     Datadog.configure do |c|
-      c.instrument :ethon, configuration_options
+      c.tracing.instrument :ethon, configuration_options
     end
   end
 
@@ -69,12 +69,12 @@ RSpec.describe Datadog::Tracing::Contrib::Ethon::EasyPatch do
       context 'and the host matches a specific configuration' do
         before do
           Datadog.configure do |c|
-            c.instrument :ethon, describes: /example\.com/ do |ethon|
+            c.tracing.instrument :ethon, describes: /example\.com/ do |ethon|
               ethon.service_name = 'baz'
               ethon.split_by_domain = false
             end
 
-            c.instrument :ethon, describes: /badexample\.com/ do |ethon|
+            c.tracing.instrument :ethon, describes: /badexample\.com/ do |ethon|
               ethon.service_name = 'baz_bad'
               ethon.split_by_domain = false
             end

--- a/spec/datadog/tracing/contrib/ethon/integration_context.rb
+++ b/spec/datadog/tracing/contrib/ethon/integration_context.rb
@@ -71,7 +71,7 @@ RSpec.shared_context 'integration context' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :ethon, configuration_options
+      c.tracing.instrument :ethon, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/ethon/multi_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/multi_patch_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Datadog::Tracing::Contrib::Ethon::MultiPatch do
 
   before do
     Datadog.configure do |c|
-      c.instrument :ethon, configuration_options
+      c.tracing.instrument :ethon, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/excon/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/excon/instrumentation_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
 
   before do
     Datadog.configure do |c|
-      c.instrument :excon, configuration_options
+      c.tracing.instrument :excon, configuration_options
     end
   end
 
@@ -193,12 +193,12 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
     context 'and the host matches a specific configuration' do
       before do
         Datadog.configure do |c|
-          c.instrument :excon, describes: /example\.com/ do |excon|
+          c.tracing.instrument :excon, describes: /example\.com/ do |excon|
             excon.service_name = 'bar'
             excon.split_by_domain = false
           end
 
-          c.instrument :excon, describes: /badexample\.com/ do |excon|
+          c.tracing.instrument :excon, describes: /badexample\.com/ do |excon|
             excon.service_name = 'bar_bad'
             excon.split_by_domain = false
           end
@@ -303,10 +303,10 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
 
     before do
       @old_service_name = Datadog.configuration[:excon][:service_name]
-      Datadog.configure { |c| c.instrument :excon, service_name: service_name }
+      Datadog.configure { |c| c.tracing.instrument :excon, service_name: service_name }
     end
 
-    after { Datadog.configure { |c| c.instrument :excon, service_name: @old_service_name } }
+    after { Datadog.configure { |c| c.tracing.instrument :excon, service_name: @old_service_name } }
 
     it do
       subject

--- a/spec/datadog/tracing/contrib/extensions_spec.rb
+++ b/spec/datadog/tracing/contrib/extensions_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Datadog::Tracing::Contrib::Extensions do
           subject(:configure) { described_class.configure(&block) }
 
           context 'that calls #instrument for an integration' do
-            let(:block) { proc { |c| c.instrument integration_name } }
+            let(:block) { proc { |c| c.tracing.instrument integration_name } }
 
             it 'configures & patches the integration' do
               expect(integration).to receive(:configure).with(:default, any_args)

--- a/spec/datadog/tracing/contrib/extensions_spec.rb
+++ b/spec/datadog/tracing/contrib/extensions_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Datadog::Tracing::Contrib::Extensions do
         let(:options) { {} }
         let(:default_settings) { settings.configuration(integration_name) }
 
-        before { settings.instrument(integration_name, options) }
+        before { settings.send(:instrument, integration_name, options) }
 
         context 'with a matching described configuration' do
           let(:options) { { describes: matcher } }
@@ -92,7 +92,7 @@ RSpec.describe Datadog::Tracing::Contrib::Extensions do
       end
 
       describe '#instrument' do
-        subject(:result) { settings.instrument(integration_name, options) }
+        subject(:result) { settings.send(:instrument, integration_name, options) }
 
         let(:options) { {} }
 
@@ -148,14 +148,14 @@ RSpec.describe Datadog::Tracing::Contrib::Extensions do
           context 'which is provided only a name' do
             it do
               expect(integration).to receive(:configure).with(:default, {})
-              settings.instrument(integration_name)
+              settings.send(:instrument, integration_name)
             end
           end
 
           context 'which is provided a block' do
             it do
               expect(integration).to receive(:configure).with(:default, {}).and_call_original
-              expect { |b| settings.instrument(integration_name, options, &b) }.to yield_with_args(
+              expect { |b| settings.send(:instrument, integration_name, options, &b) }.to yield_with_args(
                 a_kind_of(Datadog::Tracing::Contrib::Configuration::Settings)
               )
             end

--- a/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Faraday middleware' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :faraday, configuration_options
+      c.tracing.instrument :faraday, configuration_options
     end
   end
 
@@ -251,12 +251,12 @@ RSpec.describe 'Faraday middleware' do
     context 'and the host matches a specific configuration' do
       before do
         Datadog.configure do |c|
-          c.instrument :faraday, describes: /example\.com/ do |faraday|
+          c.tracing.instrument :faraday, describes: /example\.com/ do |faraday|
             faraday.service_name = 'bar'
             faraday.split_by_domain = false
           end
 
-          c.instrument :faraday, describes: /badexample\.com/ do |faraday|
+          c.tracing.instrument :faraday, describes: /badexample\.com/ do |faraday|
             faraday.service_name = 'bar_bad'
             faraday.split_by_domain = false
           end
@@ -310,10 +310,10 @@ RSpec.describe 'Faraday middleware' do
 
     before do
       @old_service_name = Datadog.configuration[:faraday][:service_name]
-      Datadog.configure { |c| c.instrument :faraday, service_name: service_name }
+      Datadog.configure { |c| c.tracing.instrument :faraday, service_name: service_name }
     end
 
-    after { Datadog.configure { |c| c.instrument :faraday, service_name: @old_service_name } }
+    after { Datadog.configure { |c| c.tracing.instrument :faraday, service_name: @old_service_name } }
 
     subject { client.get('/success') }
 
@@ -358,7 +358,7 @@ RSpec.describe 'Faraday middleware' do
       context 'and per-host configuration' do
         before do
           Datadog.configure do |c|
-            c.instrument :faraday, describes: /example\.com/, service_name: 'host'
+            c.tracing.instrument :faraday, describes: /example\.com/, service_name: 'host'
           end
         end
 

--- a/spec/datadog/tracing/contrib/faraday/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/faraday/patcher_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Faraday instrumentation' do
   # Enable the test tracer
   before do
     Datadog.configure do |c|
-      c.instrument :faraday, configuration_options
+      c.tracing.instrument :faraday, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/grape/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/grape/tracer_spec.rb
@@ -122,8 +122,8 @@ RSpec.describe 'Grape instrumentation' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :rack, configuration_options if with_rack
-      c.instrument :grape, configuration_options
+      c.tracing.instrument :rack, configuration_options if with_rack
+      c.tracing.instrument :grape, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/graphql/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/graphql/tracer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'GraphQL patcher' do
     before do
       remove_patch!(:graphql)
       Datadog.configure do |c|
-        c.instrument :graphql, schemas: [schema]
+        c.tracing.instrument :graphql, schemas: [schema]
       end
     end
 

--- a/spec/datadog/tracing/contrib/grpc/datadog_interceptor/client_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/datadog_interceptor/client_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'tracing on the client connection' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :grpc, configuration_options
+      c.tracing.instrument :grpc, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/grpc/datadog_interceptor/server_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/datadog_interceptor/server_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'tracing on the server connection' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :grpc, configuration_options
+      c.tracing.instrument :grpc, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/grpc/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/integration_test_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'gRPC integration test' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :grpc, service_name: 'rspec'
+      c.tracing.instrument :grpc, service_name: 'rspec'
     end
   end
 

--- a/spec/datadog/tracing/contrib/grpc/interception_context_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/interception_context_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe GRPC::InterceptionContext do
   describe '#intercept!' do
     before do
       Datadog.configure do |c|
-        c.instrument :grpc, configuration_options
+        c.tracing.instrument :grpc, configuration_options
       end
 
       subject.intercept!(type, keywords) {}

--- a/spec/datadog/tracing/contrib/grpc/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/patcher_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'GRPC instrumentation' do
   # Enable the test tracer
   before do
     Datadog.configure do |c|
-      c.instrument :grpc, configuration_options
+      c.tracing.instrument :grpc, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/http/miniapp_spec.rb
+++ b/spec/datadog/tracing/contrib/http/miniapp_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'net/http miniapp tests' do
   let(:client) { Net::HTTP.new(host, port) }
 
   before do
-    Datadog.configure { |c| c.instrument :http }
+    Datadog.configure { |c| c.tracing.instrument :http }
   end
 
   context 'when performing a trace around HTTP calls' do

--- a/spec/datadog/tracing/contrib/http/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/http/patcher_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'net/http patcher' do
 
     Datadog.configuration[:http].reset!
     Datadog.configure do |c|
-      c.instrument :http
+      c.tracing.instrument :http
     end
   end
 
@@ -40,13 +40,13 @@ RSpec.describe 'net/http patcher' do
 
     before do
       Datadog.configure do |c|
-        c.instrument :http, service_name: new_service_name
+        c.tracing.instrument :http, service_name: new_service_name
       end
     end
 
     after do
       Datadog.configure do |c|
-        c.instrument :http, service_name: Datadog::Tracing::Contrib::HTTP::Ext::DEFAULT_PEER_SERVICE_NAME
+        c.tracing.instrument :http, service_name: Datadog::Tracing::Contrib::HTTP::Ext::DEFAULT_PEER_SERVICE_NAME
       end
     end
 

--- a/spec/datadog/tracing/contrib/http/request_spec.rb
+++ b/spec/datadog/tracing/contrib/http/request_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'net/http requests' do
   let(:configuration_options) { {} }
 
   before do
-    Datadog.configure { |c| c.instrument :http, configuration_options }
+    Datadog.configure { |c| c.tracing.instrument :http, configuration_options }
   end
 
   around do |example|
@@ -244,13 +244,13 @@ RSpec.describe 'net/http requests' do
     context 'and the host matches a specific configuration' do
       before do
         Datadog.configure do |c|
-          c.instrument :http, configuration_options
-          c.instrument :http, describes: /127.0.0.1/ do |http|
+          c.tracing.instrument :http, configuration_options
+          c.tracing.instrument :http, describes: /127.0.0.1/ do |http|
             http.service_name = 'bar'
             http.split_by_domain = false
           end
 
-          c.instrument :http, describes: /badexample\.com/ do |http|
+          c.tracing.instrument :http, describes: /badexample\.com/ do |http|
             http.service_name = 'bar_bad'
             http.split_by_domain = false
           end
@@ -381,12 +381,12 @@ RSpec.describe 'net/http requests' do
 
     context 'when disabled' do
       before do
-        Datadog.configure { |c| c.instrument :http, distributed_tracing: false }
+        Datadog.configure { |c| c.tracing.instrument :http, distributed_tracing: false }
         client.get(path)
       end
 
       after do
-        Datadog.configure { |c| c.instrument :http, distributed_tracing: true }
+        Datadog.configure { |c| c.tracing.instrument :http, distributed_tracing: true }
       end
 
       let(:span) { spans.last }

--- a/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Datadog::Tracing::Contrib::Httpclient::Instrumentation do
 
   before do
     Datadog.configure do |c|
-      c.instrument :httpclient, configuration_options
+      c.tracing.instrument :httpclient, configuration_options
     end
   end
 
@@ -255,12 +255,12 @@ RSpec.describe Datadog::Tracing::Contrib::Httpclient::Instrumentation do
           context 'and the host matches a specific configuration' do
             before do
               Datadog.configure do |c|
-                c.instrument :httpclient, describes: /localhost/ do |httpclient|
+                c.tracing.instrument :httpclient, describes: /localhost/ do |httpclient|
                   httpclient.service_name = 'bar'
                   httpclient.split_by_domain = false
                 end
 
-                c.instrument :httpclient, describes: /random/ do |httpclient|
+                c.tracing.instrument :httpclient, describes: /random/ do |httpclient|
                   httpclient.service_name = 'barz'
                   httpclient.split_by_domain = false
                 end

--- a/spec/datadog/tracing/contrib/httprb/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httprb/instrumentation_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Datadog::Tracing::Contrib::Httprb::Instrumentation do
 
   before do
     Datadog.configure do |c|
-      c.instrument :httprb, configuration_options
+      c.tracing.instrument :httprb, configuration_options
     end
 
     # LibFFI native thread
@@ -262,12 +262,12 @@ RSpec.describe Datadog::Tracing::Contrib::Httprb::Instrumentation do
           context 'and the host matches a specific configuration' do
             before do
               Datadog.configure do |c|
-                c.instrument :httprb, describes: /localhost/ do |httprb|
+                c.tracing.instrument :httprb, describes: /localhost/ do |httprb|
                   httprb.service_name = 'bar'
                   httprb.split_by_domain = false
                 end
 
-                c.instrument :httprb, describes: /random/ do |httprb|
+                c.tracing.instrument :httprb, describes: /random/ do |httprb|
                   httprb.service_name = 'barz'
                   httprb.split_by_domain = false
                 end

--- a/spec/datadog/tracing/contrib/kafka/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/kafka/patcher_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Kafka patcher' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :kafka, configuration_options
+      c.tracing.instrument :kafka, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/mongodb/client_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/client_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
     Mongo::Logger.logger.level = ::Logger::WARN
 
     Datadog.configure do |c|
-      c.instrument :mongo, configuration_options
+      c.tracing.instrument :mongo, configuration_options
     end
   end
 
@@ -77,11 +77,11 @@ RSpec.describe 'Mongo::Client instrumentation' do
 
       before do
         Datadog.configure do |c|
-          c.instrument :mongo, describes: /#{host}/ do |mongo|
+          c.tracing.instrument :mongo, describes: /#{host}/ do |mongo|
             mongo.service_name = primary_service
           end
 
-          c.instrument :mongo, describes: /#{secondary_host}/ do |mongo|
+          c.tracing.instrument :mongo, describes: /#{secondary_host}/ do |mongo|
             mongo.service_name = secondary_service
           end
         end

--- a/spec/datadog/tracing/contrib/mongodb/regression_issue_1235_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/regression_issue_1235_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Mongo crash regression #1235' do
     Mongo::Logger.logger.level = ::Logger::WARN
 
     Datadog.configure do |c|
-      c.instrument :mongo
+      c.tracing.instrument :mongo
     end
   end
 

--- a/spec/datadog/tracing/contrib/mysql2/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/mysql2/patcher_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Mysql2::Client patcher' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :mysql2, configuration_options
+      c.tracing.instrument :mysql2, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/presto/client_spec.rb
+++ b/spec/datadog/tracing/contrib/presto/client_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Presto::Client instrumentation' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :presto, configuration_options
+      c.tracing.instrument :presto, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/qless/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/qless/instrumentation_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Qless instrumentation' do
 
     # Patch Qless
     Datadog.configure do |c|
-      c.instrument :qless, configuration_options
+      c.tracing.instrument :qless, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/que/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/que/tracer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Datadog::Tracing::Contrib::Que::Tracer do
 
   before do
     Datadog.configure do |c|
-      c.instrument :que, configuration_options
+      c.tracing.instrument :que, configuration_options
     end
 
     Que::Job.run_synchronously = true

--- a/spec/datadog/tracing/contrib/racecar/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/racecar/patcher_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Racecar patcher' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :racecar, configuration_options
+      c.tracing.instrument :racecar, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/rack/configuration_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/configuration_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Rack integration configuration' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :rack, configuration_options
+      c.tracing.instrument :rack, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/rack/distributed_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/distributed_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Rack integration distributed tracing' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :rack, rack_options
+      c.tracing.instrument :rack, rack_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Rack integration tests' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :rack, rack_options
+      c.tracing.instrument :rack, rack_options
     end
   end
 
@@ -548,7 +548,7 @@ RSpec.describe 'Rack integration tests' do
       context 'when configured to tag headers' do
         before do
           Datadog.configure do |c|
-            c.instrument :rack, headers: {
+            c.tracing.instrument :rack, headers: {
               request: [
                 'Cache-Control'
               ],
@@ -570,7 +570,7 @@ RSpec.describe 'Rack integration tests' do
         after do
           # Reset to default headers
           Datadog.configure do |c|
-            c.instrument :rack, headers: {}
+            c.tracing.instrument :rack, headers: {}
           end
         end
 

--- a/spec/datadog/tracing/contrib/rack/middlewares_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/middlewares_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Datadog::Tracing::Contrib::Rack::TraceMiddleware do
 
   before do
     Datadog.configure do |c|
-      c.instrument :rack, configuration_options
+      c.tracing.instrument :rack, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/rack/resource_name_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/resource_name_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Rack integration with other middleware' do
     end
 
     Datadog.configure do |c|
-      c.instrument :rack, rack_options
+      c.tracing.instrument :rack, rack_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/rails/action_controller_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/action_controller_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe 'Rails ActionController' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :rails, rails_options
+      c.tracing.instrument :rails, rails_options
       # Manually activate ActionPack to trigger patching.
       # This is because Rails instrumentation normally defers patching until #after_initialize
       # when it activates and configures each of the Rails components with application details.
       # We aren't initializing a full Rails application here, so the patch doesn't auto-apply.
-      c.instrument :action_pack
+      c.tracing.instrument :action_pack
     end
   end
 

--- a/spec/datadog/tracing/contrib/rails/analytics_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/analytics_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe 'Rails trace analytics' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :rails, configuration_options
+      c.tracing.instrument :rails, configuration_options
       # Manually activate ActionPack to trigger patching.
       # This is because Rails instrumentation normally defers patching until #after_initialize
       # when it activates and configures each of the Rails components with application details.
       # We aren't initializing a full Rails application here, so the patch doesn't auto-apply.
-      c.instrument :action_pack, configuration_options
+      c.tracing.instrument :action_pack, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/rails/database_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/database_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe 'Rails database' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :rails
-      c.instrument :active_record, service_name: database_service
+      c.tracing.instrument :rails
+      c.tracing.instrument :active_record, service_name: database_service
     end
   end
 

--- a/spec/datadog/tracing/contrib/rails/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/middleware_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe 'Rails middleware' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :rack if use_rack
-      c.instrument :rails, rails_options
+      c.tracing.instrument :rack if use_rack
+      c.tracing.instrument :rails, rails_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/rails/rails_active_job_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/rails_active_job_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'ActiveJob' do
 
     before do
       Datadog.configure do |c|
-        c.instrument :active_job
+        c.tracing.instrument :active_job
       end
 
       allow(ENV).to receive(:[]).and_call_original
@@ -271,7 +271,7 @@ RSpec.describe 'ActiveJob' do
       context 'when active_job tracing is also enabled' do
         before do
           Datadog.configure do |c|
-            c.instrument :active_job
+            c.tracing.instrument :active_job
           end
         end
 

--- a/spec/datadog/tracing/contrib/rails/rails_log_auto_injection_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/rails_log_auto_injection_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Rails Log Auto Injection' do
   before do
     Datadog.configuration[:rails].reset_options!
     Datadog.configure do |c|
-      c.instrument :rails
+      c.tracing.instrument :rails
       c.tracing.log_injection = log_injection
     end
 

--- a/spec/datadog/tracing/contrib/rails/rails_semantic_logger_auto_injection_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/rails_semantic_logger_auto_injection_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Rails Log Auto Injection' do
   before do
     Datadog.configuration[:rails].reset_options!
     Datadog.configure do |c|
-      c.instrument :rails
+      c.tracing.instrument :rails
       c.tracing.log_injection = log_injection
     end
 
@@ -59,7 +59,7 @@ RSpec.describe 'Rails Log Auto Injection' do
           c.env = test_env
           c.version = test_version
           c.service = test_service
-          c.instrument :rails
+          c.tracing.instrument :rails
           c.tracing.log_injection = log_injection
         end
 
@@ -132,7 +132,7 @@ RSpec.describe 'Rails Log Auto Injection' do
           c.env = test_env
           c.version = test_version
           c.service = test_service
-          c.instrument :rails
+          c.tracing.instrument :rails
           c.tracing.log_injection = log_injection
         end
 

--- a/spec/datadog/tracing/contrib/rails/railtie_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/railtie_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Rails Railtie' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :rails, rails_options
+      c.tracing.instrument :rails, rails_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/rails/redis_cache_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/redis_cache_spec.rb
@@ -47,7 +47,7 @@ MESSAGE
   before { app }
 
   before do
-    Datadog.configure { |c| c.instrument :redis }
+    Datadog.configure { |c| c.tracing.instrument :redis }
     Datadog.configure_onto(client_from_driver(driver))
   end
 

--- a/spec/datadog/tracing/contrib/rails/support/rails3.rb
+++ b/spec/datadog/tracing/contrib/rails/support/rails3.rb
@@ -63,8 +63,8 @@ RSpec.shared_context 'Rails 3 base application' do
       else
         # Enables the auto-instrumentation for the testing application
         Datadog.configure do |c|
-          c.instrument :rails
-          c.instrument :redis if Gem.loaded_specs['redis'] && defined?(::Redis)
+          c.tracing.instrument :rails
+          c.tracing.instrument :redis if Gem.loaded_specs['redis'] && defined?(::Redis)
         end
       end
 

--- a/spec/datadog/tracing/contrib/rails/support/rails4.rb
+++ b/spec/datadog/tracing/contrib/rails/support/rails4.rb
@@ -63,8 +63,8 @@ RSpec.shared_context 'Rails 4 base application' do
       else
         # Enables the auto-instrumentation for the testing application
         Datadog.configure do |c|
-          c.instrument :rails
-          c.instrument :redis if Gem.loaded_specs['redis'] && defined?(::Redis)
+          c.tracing.instrument :rails
+          c.tracing.instrument :redis if Gem.loaded_specs['redis'] && defined?(::Redis)
         end
       end
 

--- a/spec/datadog/tracing/contrib/rails/support/rails5.rb
+++ b/spec/datadog/tracing/contrib/rails/support/rails5.rb
@@ -66,8 +66,8 @@ RSpec.shared_context 'Rails 5 base application' do
       else
         # Enables the auto-instrumentation for the testing application
         Datadog.configure do |c|
-          c.instrument :rails
-          c.instrument :redis if Gem.loaded_specs['redis'] && defined?(::Redis)
+          c.tracing.instrument :rails
+          c.tracing.instrument :redis if Gem.loaded_specs['redis'] && defined?(::Redis)
         end
       end
 

--- a/spec/datadog/tracing/contrib/rails/support/rails6.rb
+++ b/spec/datadog/tracing/contrib/rails/support/rails6.rb
@@ -69,8 +69,8 @@ RSpec.shared_context 'Rails 6 base application' do
       else
         # Enables the auto-instrumentation for the testing application
         Datadog.configure do |c|
-          c.instrument :rails
-          c.instrument :redis if Gem.loaded_specs['redis'] && defined?(::Redis)
+          c.tracing.instrument :rails
+          c.tracing.instrument :redis if Gem.loaded_specs['redis'] && defined?(::Redis)
         end
       end
 

--- a/spec/datadog/tracing/contrib/rake/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/rake/instrumentation_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Datadog::Tracing::Contrib::Rake::Instrumentation do
 
     # Patch Rake
     Datadog.configure do |c|
-      c.instrument :rake, configuration_options
+      c.tracing.instrument :rake, configuration_options
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.describe Datadog::Tracing::Contrib::Rake::Instrumentation do
     Datadog.registry[:rake].reset_configuration!
 
     # We don't want instrumentation enabled during the rest of the test suite...
-    Datadog.configure { |c| c.instrument :rake, enabled: false }
+    Datadog.configure { |c| c.tracing.instrument :rake, enabled: false }
   end
 
   def reset_task!(task_name)

--- a/spec/datadog/tracing/contrib/redis/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/instrumentation_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe 'Redis instrumentation test' do
 
     before do
       Datadog.configure do |c|
-        c.instrument :redis, service_name: default_service_name
-        c.instrument :redis, describes: { url: redis_url }, service_name: service_name
+        c.tracing.instrument :redis, service_name: default_service_name
+        c.tracing.instrument :redis, describes: { url: redis_url }, service_name: service_name
       end
     end
 
@@ -65,8 +65,8 @@ RSpec.describe 'Redis instrumentation test' do
 
     before do
       Datadog.configure do |c|
-        c.instrument :redis, service_name: default_service_name
-        c.instrument :redis, describes: { host: test_host, port: test_port }, service_name: service_name
+        c.tracing.instrument :redis, service_name: default_service_name
+        c.tracing.instrument :redis, describes: { host: test_host, port: test_port }, service_name: service_name
       end
     end
 

--- a/spec/datadog/tracing/contrib/redis/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/integration_test_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Redis integration test' do
     use_real_tracer!
 
     Datadog.configure do |c|
-      c.instrument :redis
+      c.tracing.instrument :redis
     end
   end
 

--- a/spec/datadog/tracing/contrib/redis/miniapp_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/miniapp_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Redis mini app test' do
   before { skip unless ENV['TEST_DATADOG_INTEGRATION'] }
 
   before do
-    Datadog.configure { |c| c.instrument :redis }
+    Datadog.configure { |c| c.tracing.instrument :redis }
 
     # Configure client instance with custom options
     Datadog.configure_onto(client, service_name: 'test-service')

--- a/spec/datadog/tracing/contrib/redis/redis_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/redis_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Redis test' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :redis, configuration_options
+      c.tracing.instrument :redis, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/resque/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/resque/instrumentation_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Resque instrumentation' do
 
     # Patch Resque
     Datadog.configure do |c|
-      c.instrument :resque, configuration_options
+      c.tracing.instrument :resque, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/rest_client/request_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/rest_client/request_patch_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Datadog::Tracing::Contrib::RestClient::RequestPatch do
 
   before do
     Datadog.configure do |c|
-      c.instrument :rest_client, configuration_options
+      c.tracing.instrument :rest_client, configuration_options
     end
 
     WebMock.disable_net_connect!

--- a/spec/datadog/tracing/contrib/sequel/configuration_spec.rb
+++ b/spec/datadog/tracing/contrib/sequel/configuration_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Sequel configuration' do
       context 'only with defaults' do
         # Expect it to be the normalized adapter name.
         before do
-          Datadog.configure { |c| c.instrument :sequel }
+          Datadog.configure { |c| c.tracing.instrument :sequel }
           perform_query!
         end
 
@@ -56,7 +56,7 @@ RSpec.describe 'Sequel configuration' do
         let(:service_name) { 'my-sequel' }
 
         before do
-          Datadog.configure { |c| c.instrument :sequel, service_name: service_name }
+          Datadog.configure { |c| c.tracing.instrument :sequel, service_name: service_name }
           perform_query!
         end
 
@@ -71,9 +71,9 @@ RSpec.describe 'Sequel configuration' do
         let(:service_name) { 'custom-sequel' }
 
         before do
-          Datadog.configure { |c| c.instrument :sequel }
+          Datadog.configure { |c| c.tracing.instrument :sequel }
           Datadog.configure_onto(sequel, service_name: service_name)
-          Datadog.configure { |c| c.instrument :sequel }
+          Datadog.configure { |c| c.tracing.instrument :sequel }
           perform_query!
         end
 
@@ -90,7 +90,7 @@ RSpec.describe 'Sequel configuration' do
         #       no way to unpatch it once its happened in other tests.
         before do
           sequel
-          Datadog.configure { |c| c.instrument :sequel }
+          Datadog.configure { |c| c.tracing.instrument :sequel }
           perform_query!
         end
 

--- a/spec/datadog/tracing/contrib/sequel/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/sequel/instrumentation_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Sequel instrumentation' do
 
     # Patch Sequel
     Datadog.configure do |c|
-      c.instrument :sequel, configuration_options
+      c.tracing.instrument :sequel, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/shoryuken/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/shoryuken/tracer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Datadog::Tracing::Contrib::Shoryuken::Tracer do
     Shoryuken.worker_executor = Shoryuken::Worker::InlineExecutor
 
     Datadog.configure do |c|
-      c.instrument :shoryuken, configuration_options
+      c.tracing.instrument :shoryuken, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
@@ -21,7 +21,7 @@ end
 module SidekiqTestingConfiguration
   def configure_sidekiq
     Datadog.configure do |c|
-      c.instrument :sidekiq
+      c.tracing.instrument :sidekiq
     end
 
     redis_host = ENV.fetch('TEST_REDIS_HOST', '127.0.0.1')

--- a/spec/datadog/tracing/contrib/sinatra/activerecord_spec.rb
+++ b/spec/datadog/tracing/contrib/sinatra/activerecord_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe 'Sinatra instrumentation with ActiveRecord' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :sinatra, options
-      c.instrument :active_record, options
+      c.tracing.instrument :sinatra, options
+      c.tracing.instrument :active_record, options
     end
   end
 

--- a/spec/datadog/tracing/contrib/sinatra/multi_app_spec.rb
+++ b/spec/datadog/tracing/contrib/sinatra/multi_app_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :sinatra, options
+      c.tracing.instrument :sinatra, options
     end
   end
 

--- a/spec/datadog/tracing/contrib/sinatra/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sinatra/tracer_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'Sinatra instrumentation' do
 
   before do
     Datadog.configure do |c|
-      c.instrument :sinatra, configuration_options
+      c.tracing.instrument :sinatra, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/sneakers/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sneakers/tracer_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Datadog::Tracing::Contrib::Sneakers::Tracer do
     allow(queue).to receive(:exchange).and_return(exchange)
     Sneakers.configure(daemonize: true, log: '/tmp/sneakers.log')
     Datadog.configure do |c|
-      c.instrument :sneakers, configuration_options
+      c.tracing.instrument :sneakers, configuration_options
     end
   end
 

--- a/spec/datadog/tracing/contrib/sucker_punch/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/sucker_punch/patcher_spec.rb
@@ -7,7 +7,7 @@ require 'ddtrace'
 RSpec.describe 'sucker_punch instrumentation' do
   before do
     Datadog.configure do |c|
-      c.instrument :sucker_punch
+      c.tracing.instrument :sucker_punch
     end
 
     SuckerPunch::RUNNING.make_true

--- a/spec/datadog/tracing/contrib/suite/transport_spec.rb
+++ b/spec/datadog/tracing/contrib/suite/transport_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe 'transport with integrations' do
         # Activate all outbound integrations...
         # Although the transport by default only uses Net/HTTP
         # its possible for other adapters to be used instead.
-        c.instrument :ethon
-        c.instrument :excon
-        c.instrument :faraday
-        c.instrument :grpc
-        c.instrument :http
-        c.instrument :rest_client
+        c.tracing.instrument :ethon
+        c.tracing.instrument :excon
+        c.tracing.instrument :faraday
+        c.tracing.instrument :grpc
+        c.tracing.instrument :http
+        c.tracing.instrument :rest_client
       end
 
       # Requests may produce an error (because the transport cannot connect)


### PR DESCRIPTION
### Breaking Change

As part of our efforts to completely namespace different products instrumentation and configuration, this PR moves `c.instrument` calls to `c.tracing.instrument` and `c.ci.instrument`.

It also hides public access to `c.instrument`.

A complete refactor wasn't performed: `c.tracing.instrument` and `c.ci.instrument` still invoke `c.instrument` internally, but making such change would require a large effort throughout all our integrations. This work can be done as a strict refactor in the future, without any user-facing changes.