### PR TITLE
Fix AppSec after c.instrument namespacing

### DIFF
--- a/lib/datadog/appsec/contrib/rails/framework.rb
+++ b/lib/datadog/appsec/contrib/rails/framework.rb
@@ -17,7 +17,7 @@ module Datadog
 
           # Apply relevant configuration from Sinatra to Rack
           def self.activate_rack!(datadog_config, sinatra_config)
-            datadog_config.tracing.instrument(
+            datadog_config.instrument(
               :rack,
             )
           end

--- a/lib/datadog/appsec/contrib/sinatra/framework.rb
+++ b/lib/datadog/appsec/contrib/sinatra/framework.rb
@@ -21,7 +21,7 @@ module Datadog
 
           # Apply relevant configuration from Sinatra to Rack
           def self.activate_rack!(datadog_config, sinatra_config)
-            datadog_config.tracing.instrument(
+            datadog_config.instrument(
               :rack,
             )
           end


### PR DESCRIPTION
These two lines were mistakenly identified as enabling Tracing instrumentation, but they are AppSec instrumentation.