### PR TITLE
Ensure presence of active trace when looking for root span in AppSec

### DIFF
--- a/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
@@ -25,7 +25,7 @@ module Datadog
                   # TODO: factor out
                   if defined?(Datadog::Tracing) && Datadog::Tracing.respond_to?(:active_span)
                     active_trace = Datadog::Tracing.active_trace
-                    root_span = active_trace.send(:root_span)
+                    root_span = active_trace.send(:root_span) if active_trace
                     active_span = Datadog::Tracing.active_span
 
                     Datadog.logger.debug { "active span: #{active_span.span_id}" } if active_span
@@ -75,7 +75,7 @@ module Datadog
                   # TODO: factor out
                   if defined?(Datadog::Tracing) && Datadog::Tracing.respond_to?(:active_span)
                     active_trace = Datadog::Tracing.active_trace
-                    root_span = active_trace.instance_eval { @root_span }
+                    root_span = active_trace.send(:root_span) if active_trace
                     active_span = Datadog::Tracing.active_span
 
                     Datadog.logger.debug { "active span: #{active_span.span_id}" } if active_span


### PR DESCRIPTION
No trace is present when the tracer is not setup, which led to a possible crash in AppSec.

This fixes it by adding a truth check. The remainder of the code (in `AppSec::Event`)  then handles the absence of a root span properly already.