### PR TITLE
debug logs when unable to patch

### DIFF
--- a/lib/datadog/tracing/contrib/extensions.rb
+++ b/lib/datadog/tracing/contrib/extensions.rb
@@ -83,7 +83,7 @@ module Datadog
                 desc += ", Compatible? #{patch_results[:compatible]}"
                 desc += ", Patchable? #{patch_results[:patchable]}"
 
-                Datadog.logger.warn("Unable to patch #{patch_results[:name]} (#{desc})")
+                Datadog.logger.debug("Unable to patch #{patch_results[:name]} (#{desc})")
               end
 
               configuration.integrations_pending_activation.clear


### PR DESCRIPTION
`warn` seems excessive, doesn't it?

There are a few other integrations that have their own rescue. Is the intent to roll those up into this, or should I update those while I'm at it?

We have a common gem that sets up a bunch of defaults for ddtrace. This would avoid a bunch of superfluous conditionals 

```
c.use :rails if defined?(Rails)
c.use :shoryuken, { service_name: service } if defined?(Shoryuken)
```

This even spurred a debate about the differences between `defined?(Rails)` and `Gem.loaded_specs.key?(:rails)`. `debug` would put those conversations to rest =)