### PR TITLE
Fix require 'datadog/ci' not loading dependencies

### DIFF
--- a/integration/apps/rspec/app/datadog.rb
+++ b/integration/apps/rspec/app/datadog.rb
@@ -1,10 +1,20 @@
 require 'datadog/demo_env'
-require 'ddtrace'
+require 'datadog/ci'
 
 Datadog.configure do |c|
+  c.service = 'acme-rspec'
   c.diagnostics.debug = true if Datadog::DemoEnv.feature?('debug')
   c.runtime_metrics.enabled = true if Datadog::DemoEnv.feature?('runtime_metrics')
-  c.tracing.analytics.enabled = true if Datadog::DemoEnv.feature?('analytics')
+
+  if Datadog::DemoEnv.feature?('tracing')
+    c.tracing.analytics.enabled = true if Datadog::DemoEnv.feature?('analytics')
+  end
+
+  if Datadog::DemoEnv.feature?('ci')
+    c.ci.enabled = true
+    c.ci.instrument :rspec
+  end
+
   if Datadog::DemoEnv.feature?('pprof_to_file')
     # Reconfigure transport to write pprof to file
     c.profiling.exporter.transport = Datadog::DemoEnv.profiler_file_transport

--- a/integration/apps/rspec/docker-compose.ci.yml
+++ b/integration/apps/rspec/docker-compose.ci.yml
@@ -20,7 +20,7 @@ services:
       - DD_PROFILING_ENABLED=true
       # Use these to choose what is run
       - DD_DEMO_ENV_PROCESS=rspec
-      - DD_DEMO_ENV_FEATURES=tracing
+      - DD_DEMO_ENV_FEATURES=ci
     stdin_open: true
     tty: true
   ddagent:

--- a/integration/apps/rspec/docker-compose.yml
+++ b/integration/apps/rspec/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - DD_PROFILING_ENABLED=true
       # Use these to choose what is run
       - DD_DEMO_ENV_PROCESS=rspec
-      - DD_DEMO_ENV_FEATURES=tracing
+      - DD_DEMO_ENV_FEATURES=ci
       # Use this for a local version of ddtrace
       - DD_DEMO_ENV_GEM_LOCAL_DDTRACE=/vendor/dd-trace-rb
       # Use these for a specific revision of ddtrace

--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -1,6 +1,7 @@
 # typed: false
 require 'datadog/core'
 require 'datadog/tracing'
+require 'datadog/tracing/contrib'
 
 module Datadog
   # Namespace for Datadog CI instrumentation:

--- a/lib/datadog/opentelemetry/extensions.rb
+++ b/lib/datadog/opentelemetry/extensions.rb
@@ -2,7 +2,9 @@
 require 'datadog/tracing/span_operation'
 require 'datadog/opentelemetry/span'
 
+# Datadog
 module Datadog
+  # Defines OpenTelemetry behavior
   module OpenTelemetry
     # Defines extensions to ddtrace for OpenTelemetry support
     module Extensions

--- a/lib/datadog/opentelemetry/extensions.rb
+++ b/lib/datadog/opentelemetry/extensions.rb
@@ -11,4 +11,7 @@ module Datadog
       end
     end
   end
+
+  # Load and extend OpenTelemetry compatibility by default
+  extend OpenTelemetry::Extensions
 end

--- a/lib/datadog/tracing/contrib.rb
+++ b/lib/datadog/tracing/contrib.rb
@@ -1,5 +1,7 @@
 # typed: true
+require 'datadog/tracing'
 require 'datadog/tracing/contrib/registry'
+require 'datadog/tracing/contrib/extensions'
 
 module Datadog
   module Tracing

--- a/lib/datadog/tracing/contrib/auto_instrument.rb
+++ b/lib/datadog/tracing/contrib/auto_instrument.rb
@@ -1,29 +1,26 @@
 # typed: false
+require 'datadog/tracing/contrib'
+require 'datadog/tracing/contrib/extensions'
 
 module Datadog
   module Tracing
     module Contrib
+      # Auto-activate instrumentation
+      def self.auto_instrument!
+        require 'datadog/tracing/contrib/rails/utils'
+
+        # Defer to Rails if this is a Rails application
+        if Datadog::Tracing::Contrib::Rails::Utils.railtie_supported?
+          require 'datadog/tracing/contrib/rails/auto_instrument_railtie'
+        else
+          AutoInstrument.patch_all!
+        end
+      end
+
       # Extensions for auto instrumentation added to the base library
       # AutoInstrumentation enables all integration
       module AutoInstrument
-        def self.extended(base)
-          base.extend(Patch)
-        end
-
-        # Patch adds method for invoking auto_instrumentation
-        module Patch
-          def add_auto_instrument
-            super
-
-            if Contrib::Rails::Utils.railtie_supported?
-              require 'datadog/tracing/contrib/rails/auto_instrument_railtie'
-            else
-              AutoInstrument.patch_all
-            end
-          end
-        end
-
-        def self.patch_all
+        def self.patch_all!
           integrations = []
 
           Contrib::REGISTRY.each do |integration|
@@ -48,3 +45,5 @@ module Datadog
     end
   end
 end
+
+Datadog::Tracing::Contrib.auto_instrument!

--- a/lib/datadog/tracing/contrib/auto_instrument.rb
+++ b/lib/datadog/tracing/contrib/auto_instrument.rb
@@ -4,6 +4,7 @@ require 'datadog/tracing/contrib/extensions'
 
 module Datadog
   module Tracing
+    # Out-of-the-box instrumentation for tracing
     module Contrib
       # Auto-activate instrumentation
       def self.auto_instrument!

--- a/lib/datadog/tracing/contrib/extensions.rb
+++ b/lib/datadog/tracing/contrib/extensions.rb
@@ -5,7 +5,9 @@ require 'set'
 require 'datadog/core/configuration/settings'
 require 'datadog/tracing/contrib'
 
+# Datadog
 module Datadog
+  # Datadog tracing
   module Tracing
     module Contrib
       # Extensions that can be added to the base library

--- a/lib/datadog/tracing/contrib/extensions.rb
+++ b/lib/datadog/tracing/contrib/extensions.rb
@@ -181,4 +181,7 @@ module Datadog
       end
     end
   end
+
+  # Load built-in Datadog integrations
+  Tracing::Contrib::Extensions.extend!
 end

--- a/lib/datadog/tracing/contrib/rails/auto_instrument_railtie.rb
+++ b/lib/datadog/tracing/contrib/rails/auto_instrument_railtie.rb
@@ -1,10 +1,11 @@
 # typed: ignore
+require 'datadog/tracing/contrib/auto_instrument'
 
 # Railtie to include AutoInstrumentation in rails loading
 class DatadogAutoInstrumentRailtie < Rails::Railtie
   # we want to load before config initializers so that any user supplied config
   # in config/initializers/datadog.rb will take precedence
   initializer 'datadog.start_tracer', before: :load_config_initializers do
-    Datadog::Tracing::Contrib::AutoInstrument.patch_all
+    Datadog::Tracing::Contrib::AutoInstrument.patch_all!
   end
 end

--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -1,23 +1,10 @@
 # Load tracing
 require 'datadog/tracing'
-
-# Load tracing extensions
 require 'datadog/tracing/contrib'
-require 'datadog/tracing/contrib/extensions'
 require 'datadog/opentelemetry/extensions'
 
 # Load appsec
 require 'datadog/appsec/autoload' # TODO: datadog/appsec?
-
-# Global namespace that includes all Datadog functionality.
-# @public_api
-module Datadog
-  # Load built-in Datadog integrations
-  Tracing::Contrib::Extensions.extend!
-
-  # Load and extend OpenTelemetry compatibility by default
-  extend OpenTelemetry::Extensions
-end
 
 # Load other products (must follow tracing)
 require 'datadog/profiling'

--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -3,10 +3,8 @@ require 'datadog/tracing'
 
 # Load tracing extensions
 require 'datadog/tracing/contrib'
-require 'datadog/tracing/contrib/auto_instrument'
 require 'datadog/tracing/contrib/extensions'
 require 'datadog/opentelemetry/extensions'
-require 'ddtrace/auto_instrument_base'
 
 # Load appsec
 require 'datadog/appsec/autoload' # TODO: datadog/appsec?
@@ -14,13 +12,8 @@ require 'datadog/appsec/autoload' # TODO: datadog/appsec?
 # Global namespace that includes all Datadog functionality.
 # @public_api
 module Datadog
-  extend AutoInstrumentBase
-
   # Load built-in Datadog integrations
   Tracing::Contrib::Extensions.extend!
-
-  # Load Contrib auto instrumentation
-  extend Tracing::Contrib::AutoInstrument
 
   # Load and extend OpenTelemetry compatibility by default
   extend OpenTelemetry::Extensions

--- a/lib/ddtrace/auto_instrument.rb
+++ b/lib/ddtrace/auto_instrument.rb
@@ -3,6 +3,6 @@
 #
 # This file's path is part of the @public_api.
 require 'ddtrace'
+require 'datadog/tracing/contrib/auto_instrument'
 
-Datadog.add_auto_instrument
 Datadog::Profiling.start_if_enabled

--- a/spec/ddtrace/auto_instrument_spec.rb
+++ b/spec/ddtrace/auto_instrument_spec.rb
@@ -107,10 +107,6 @@ end
 RSpec.describe 'Profiler startup' do
   subject(:auto_instrument) { load 'ddtrace/auto_instrument.rb' }
 
-  before do
-    allow(Datadog).to receive(:add_auto_instrument)
-  end
-
   it 'starts the profiler' do
     expect(Datadog::Profiling).to receive(:start_if_enabled)
     auto_instrument


### PR DESCRIPTION
### Problem

When only `require 'datadog/ci'` is defined, it doesn't load all the dependencies CI uses, and then raises an error. A workaround for this is `require 'ddtrace'` but it will require everything.

### Solution

We have `datadog/ci.rb` require its dependencies as well. This means we also have to have `datadog/tracing/contrib` load and apply its own extension behavior, which necessitates refactoring out the old extension behavior from `ddtrace.rb` into `contrib.rb` and elsewhere.