### PR TITLE
Correct doc for runtime_metrics

### DIFF
--- a/docs/UpgradeGuide.md
+++ b/docs/UpgradeGuide.md
@@ -97,7 +97,9 @@ Datadog.configure do |c|
 
   # Tracer settings
   c.tracing.analytics.enabled = true
-  c.tracing.runtime_metrics.enabled = true
+  
+  # Runtime metrics settings
+  c.runtime_metrics.enabled = true
 
   # CI settings
   c.ci.enabled = (ENV['DD_ENV'] == 'ci')


### PR DESCRIPTION
In 1.0beta1, the `runtime_metrics` is a base setting, not nested under tracing and the docs are incorrect.