### PR TITLE
1.0 upgrade guide restructure

### DIFF
--- a/docs/UpgradeGuide.md
+++ b/docs/UpgradeGuide.md
@@ -2,57 +2,52 @@
 
 # From 0.x to 1.0
 
-- [Namespacing & the public API](#namespacing--the-public-api)
-- [Configuration](#configuration)
-- [Instrumentation](#instrumentation)
-- [Full list of breaking changes](#full-list-of-breaking-changes)
-
 Upgrading `ddtrace` from 0.x to 1.x introduces some changes to namespacing, the public API, and the underlying trace data structure.
 
-Here's a list of the most common changes you may encounter:
+**How to upgrade basic usage** *(Out-of-the-box instrumentation)*
 
-## Namespacing & the public API
+- [Configuration](#1.0-configuration)
+  - [Settings have been renamed](#1.0-configuration-settings)
+  - [Activating instrumentation](#1.0-configuration-instrumentation)
+- [Instrumentation](#1.0-instrumentation)
+  - [Service naming](#1.0-instrumentation-service-naming)
 
-To avoid naming conflicts with new Datadog features and products, many of the tracing constants and functions defined directly under `Datadog` have moved to `Datadog::Tracing`.
+**Addtional upgrades for advanced usage** *(Manual instrumentation)*
 
-You can access most common functions through our [public API](https://www.rubydoc.info/gems/ddtrace/) within `Datadog::Tracing`. Use of some of the functions in the public API will be described in use cases below. Here's a few examples:
+- [Namespacing](#1.0-namespacing)
+- [Trace API](#1.0-trace-api)
+  - [Removed `Datadog.tracer`](#1.0-trace-api-removed-tracer)
+  - [Removed access to `Datadog::Context`](#1.0-trace-api-removed-context)
+  - [Manual tracing & trace model](#1.0-trace-api-manual-tracing)
+  - [Accessing trace state](#1.0-trace-api-trace-state)
+  - [Distributed tracing](#1.0-trace-api-distributed)
+    - [Over HTTP](#1.0-trace-api-distributed-http)
+    - [Over gRPC](#1.0-trace-api-distributed-grpc)
+    - [Between threads](#1.0-trace-api-distributed-threads)
+  - [Sampling](#1.0-trace-api-sampling)
+  - [Processing pipeline](#1.0-trace-api-pipeline)
 
-```ruby
-### Old 0.x ###
-Datadog.tracer.trace
-Datadog.tracer.active_span
-Datadog.tracer.active_correlation.to_s
+**Appendix**
 
+  - [Namespace mappings](#1.0-appendix-namespace)
+    - [`require` paths](#1.0-appendix-namespace-requires)
+    - [Constants](#1.0-appendix-namespace-constants)
+  - [Breaking changes](#1.0-appendix-breaking-changes)
 
-### New 1.0 ###
-Datadog::Tracing.trace
-Datadog::Tracing.active_span
-Datadog::Tracing.log_correlation
-# ...and more...
-```
+<h1 id="1.0-basic-upgrade">Upgrading basic usage</h1>
 
-Check out our [complete list of namespacing changes](#appendix-namespacing) for more details.
+<h2 id="1.0-configuration">Configuration</h2>
 
-### Removed `Datadog.tracer`
+<h3 id="1.0-configuration-settings">Settings have been renamed</h3>
 
-Many of the functions accessed directly through `Datadog.tracer` have been moved to `Datadog::Tracing` instead.
-
-### Removed access to `Datadog::Context`
-
-Direct usage of `Datadog::Context` has been removed. Previously, it was used to modify or access active trace state. Most use cases have been replaced by our public trace API.
-
-## Configuration
-
-### Settings have been namespaced
-
-Configuration settings have been sorted into smaller configuration groups, by product.
+Configuration settings have been sorted into smaller configuration groups, by feature.
 
  - `Datadog.configure { |c| c.* }`: Datadog configuration settings
  - `Datadog.configure { |c| c.tracing.* }`: Tracing configuration settings
  - `Datadog.configure { |c| c.profiling.* }`: Profiling configuration settings
  - `Datadog.configure { |c| c.ci.* }`: CI configuration settings
 
-Existing applications should update their configuration files and settings accordingly. For example:
+For existing applications, configuration files should be updated accordingly. For example:
 
 ```ruby
 # config/initializers/datadog.rb
@@ -110,11 +105,36 @@ Datadog.configure do |c|
 end
 ```
 
-Check out our [complete list of configuration changes](#appendix-configuration) for more details.
+Check out the table below for a list of common mappings:
 
-### Activating instrumentation
+| 0.x setting                            | 1.0 setting                   |
+|----------------------------------------|-------------------------------|
+| `analytics.enabled`                    | `tracing.analytics.enabled`   |
+| `ci_mode.context_flush`                | `ci.context_flush`            |
+| `ci_mode.enabled`                      | `ci.enabled`                  |
+| `ci_mode.writer_options`               | `ci.writer_options`           |
+| `distributed_tracing`                  | `tracing.distributed_tracing` |
+| `logger=`                              | `logger.instance=`            |
+| `profiling.exporter.transport_options` | Removed                       |
+| `report_hostname`                      | `tracing.report_hostname`     |
+| `runtime_metrics_enabled`              | `runtime_metrics.enabled`     |
+| `runtime_metrics(options)`             | Removed                       |
+| `sampling`                             | `tracing.sampling`            |
+| `test_mode`                            | `tracing.test_mode`           |
+| `tracer.enabled`                       | `tracing.enabled`             |
+| `tracer.hostname`                      | `agent.hostname`              |
+| `tracer.instance`                      | `tracing.instance`            |
+| `tracer.partial_flush`                 | `tracing.partial_flush`       |
+| `tracer.port`                          | `agent.port`                  |
+| `tracer.sampler`                       | `tracing.sampler`             |
+| `tracer.transport_options`             | `tracing.transport_options`   |
+| `tracer.transport_options(options)`    | Removed                       |
+| `tracer.writer`                        | `tracing.writer`              |
+| `tracer.writer_options`                | `tracing.writer_options`      |
 
-The `use` function has been renamed to `instrument`. Also, `instrument` has been namespaced to the specific product:
+<h3 id="1.0-configuration-instrumentation">Activating instrumentation</h3>
+
+The `use` function has been renamed to `instrument`. Also, `instrument` has been namespaced to the specific feature:
 
 ```ruby
 ### Old 0.x ###
@@ -137,17 +157,21 @@ Datadog.configure do |c|
 end
 ```
 
-## Instrumentation
+<h2 id="1.0-instrumentation">Instrumentation</h2>
 
-### Service naming
+<h3 id="1.0-instrumentation-service-naming">Service naming</h3>
 
-In 0.x, The `service` field on spans generated by Datadog integrations would typically default to the package name, e.g. `http` or `sidekiq`. This would often result in many "services" being generated by one application, one for each instrumented package. Users would often rectify this by overriding the `service_name` setting on each integration to get matching `service` names.
+**In version 0.x ...**
+
+The `service` field on spans generated by Datadog integrations would typically default to the package name, e.g. `http` or `sidekiq`. This would often result in many "services" being generated by one application, one for each instrumented package. Users would often rectify this by overriding the `service_name` setting on each integration to get matching `service` names.
 
 To remedy this in later 0.x versions, we introduced the global `service` name setting (also set via `DD_SERVICE`), which is the recommended way to set the name of your application. However, the Datadog integrations (with the exception of Rails) still did not employ this field.
 
-In 1.0, spans now inherit the global `service` name by default, unless otherwise explicitly set. This means for spans generated by Datadog integrations, they will default to the global `service` name, unless the `service_name` setting is configured for that integration.
+**In version 1.0 ...**
 
-Spans that describe external services (e.g. `mysql`), will default to some other name that describes the external service instead.
+Spans now inherit the global `service` name by default, unless otherwise explicitly set. This means spans generated by Datadog integrations will default to the global `service` name, unless the `service_name` setting is configured for that integration.
+
+Spans that describe external services (e.g. `mysql`) will default to some other name that describes the external service instead.
 
 As an example, expect the following code & trace in 0.x:
 
@@ -177,7 +201,78 @@ end
 
 ![1.0 trace](./1.0-trace.png)
 
-### Manual tracing & trace model
+<h1 id="1.0-advanced-upgrade">Upgrading advanced usage</h1>
+
+<h2 id="1.0-namespacing">Namespacing</h2>
+
+Many files and constants within `ddtrace` have been recategorized by feature. The new categorization scheme is as follows:
+
+| Feature          | Namespace                | File path               |
+|------------------|--------------------------|-------------------------|
+| Globals          | `Datadog`                | `ddtrace`               |
+|                  |                          |                         |
+| CI               | `Datadog::CI`            | `datadog/ci`            |
+| Core (Internals) | `Datadog::Core`          | `datadog/core`          |
+| OpenTelemetry    | `Datadog::OpenTelemetry` | `datadog/opentelemetry` |
+| OpenTracing      | `Datadog::OpenTracer`    | `datadog/opentracer`    |
+| Profiling        | `Datadog::Profiling`     | `datadog/profiling`     |
+| Security         | `Datadog::AppSec`        | `datadog/appsec`        |
+| Tracing          | `Datadog::Tracing`       | `datadog/trace`         |
+
+As a result, if your application referenced file paths or constants affected by this change, they will need to be updated. Check out the [namespace mappings](#1.0-appendix-namespace) for some common cases and how to update them.
+
+<h2 id="1.0-trace-api">Trace API</h2>
+
+Usage of `Datadog.tracer` has been replaced with the `Datadog::Tracing` trace API. This module contains most of the functions that `Datadog.tracer` had, and most use cases will map one-to-one.
+
+For example:
+
+```ruby
+### Old 0.x ###
+Datadog.tracer.trace
+Datadog.tracer.active_span
+Datadog.tracer.active_correlation.to_s
+
+
+### New 1.0 ###
+Datadog::Tracing.trace
+Datadog::Tracing.active_span
+Datadog::Tracing.log_correlation
+
+# ...and more...
+```
+
+See the table below for most common mappings:
+
+| 0.x usage                                                                                    | 1.0 usage                                   | Note                                                                |
+|----------------------------------------------------------------------------------------------|---------------------------------------------|---------------------------------------------------------------------|
+| `Datadog.tracer.active_correlation.to_s`                                                     | `Datadog::Tracing.log_correlation`          | Returns `String` with trace identifiers for logging.                |
+| `Datadog.tracer.active_correlation`                                                          | `Datadog::Tracing.correlation`              | Returns `#<Datadog::Tracing::Correlation::Identifier>`              |
+| `Datadog.tracer.active_root_span`                                                            | Removed                                     | Consider `Datadog::Tracing.active_trace` instead.                   |
+| `Datadog.tracer.active_span.context.sampling_priority = Datadog::Ext::Priority::USER_KEEP`   | `Datadog::Tracing.keep!`                    | See [sampling](#1.0-trace-api-sampling) for details.                |
+| `Datadog.tracer.active_span.context.sampling_priority = Datadog::Ext::Priority::USER_REJECT` | `Datadog::Tracing.reject!`                  | See [sampling](#1.0-trace-api-sampling) for details.                |
+| `Datadog.tracer.active_span.context`                                                         | Removed                                     | Consider `Datadog::Tracing.active_trace` instead.                   |
+| `Datadog.tracer.active_span`                                                                 | `Datadog::Tracing.active_span`              | See [trace state](#1.0-trace-api-trace-state) for details.          |
+| `Datadog.tracer.call_context`                                                                | Removed                                     | See [trace state](#1.0-trace-api-trace-state) for details.          |
+| `Datadog.tracer.configure(options)`                                                          | `Datadog.configure { \|c\| ... }`           | Use configuration API instead.                                      |
+| `Datadog.tracer.provider.context = context`                                                  | `Datadog::Tracing.continue_from!(digest)`   | See [distributed tracing](#1.0-trace-api-distributed) for details.  |
+| `Datadog.tracer.set_tags(tags)`                                                              | `Datadog.configure { \|c\| c.tags = tags }` |                                                                     |
+| `Datadog.tracer.shutdown!`                                                                   | `Datadog::Tracing.shutdown!`                |                                                                     |
+| `Datadog.tracer.start_span`                                                                  | `Datadog::Tracing.trace`                    | See [manual tracing](#1.0-trace-api-manual-tracing) for details.    |
+| `Datadog.tracer.trace`                                                                       | `Datadog::Tracing.trace`                    | See [manual tracing](#1.0-trace-api-manual-tracing) for details.    |
+
+
+Also check out the functions defined within `Datadog::Tracing` in our [public API](https://www.rubydoc.info/gems/ddtrace/) for more details on their usage.
+
+<h3 id="1.0-trace-api-removed-tracer">Removed `Datadog.tracer`</h3>
+
+Many of the functions accessed directly through `Datadog.tracer` have been moved to `Datadog::Tracing` instead.
+
+<h3 id="1.0-trace-api-removed-context">Removed access to `Datadog::Context`</h3>
+
+Direct usage of `Datadog::Context` has been removed. Previously, it was used to modify or access active trace state. Most use cases have been replaced by our public trace API.
+
+<h3 id="1.0-trace-api-manual-tracing">Manual tracing & trace model</h3>
 
 Manual tracing is now done through the public API.
 
@@ -203,7 +298,7 @@ The yielded `span` is nearly identical in behavior, except access to some fields
 
 For more details about new behaviors and the trace model, see [this pull request](https://github.com/DataDog/dd-trace-rb/pull/1783).
 
-### Accessing trace state
+<h3 id="1.0-trace-api-trace-state">Accessing trace state</h3>
 
 The public API provides new functions to access active trace data:
 
@@ -228,11 +323,11 @@ Datadog::Tracing.correlation
 
 Use of `active_root_span` has been removed.
 
-### Distributed tracing
+<h3 id="1.0-trace-api-distributed">Distributed tracing</h3>
 
 Previously, distributed tracing required building new `Datadog::Context` objects, then replacing the context within the tracer.
 
-Instead, users utilize `TraceDigest` objects derived from a trace. This object represents the state of a trace. It can be used to propagate a trace across execution boundaries (processes, threads), or to continue a trace locally.
+Instead, users utilize `TraceDigest` objects derived from a trace. This object represents the state of a trace. It can be used to propagate a trace across execution boundaries (processes, threads) or to continue a trace locally.
 
 ```ruby
 ### Old 0.x ###
@@ -254,12 +349,6 @@ end
 # Get trace continuation from active trace
 trace_digest = Datadog::Tracing.active_trace.to_digest
 
-# Continue a trace: explicit continuation
-# Inherits trace properties from the trace digest
-Datadog::Tracing.trace('my.job', continue_from: trace_digest) do |span, trace|
-  trace.id == trace_digest.trace_id
-end
-
 # Continue a trace: implicit continuation
 # Digest will be "consumed" by the next `trace` operation
 Datadog::Tracing.continue_trace!(trace_digest)
@@ -275,62 +364,91 @@ Datadog::Tracing.trace('my.job') do |span, trace|
 end
 ```
 
-#### Propagation over HTTP/gRPC
+New in 1.0, it's also possible to explicitly assign a trace block to continue from a specific trace, rather than implicitly inherit an active context. This gives users fine-grained control in applications where multiple traces run concurrently in the same execution context:
 
-To propagate a local trace to a remote service:
+```ruby
+### New 1.0 ###
+# Get trace continuation from active trace
+trace_digest = Datadog::Tracing.active_trace.to_digest
+
+# Continue a trace: explicit continuation
+# Inherits trace properties from the trace digest
+Datadog::Tracing.trace('my.job', continue_from: trace_digest) do |span, trace|
+  trace.id == trace_digest.trace_id
+end
+
+# Continue a trace: explicit continuation (using #continue_from!)
+Datadog::Tracing.continue_from!(trace_digest) do
+  # Traces implicitly continue within the block
+  Datadog::Tracing.trace('my.job') do |span, trace|
+    trace.id == trace_digest.trace_id
+  end
+end
+```
+
+<h4 id="1.0-trace-api-distributed-http">Over HTTP</h4>
+
+*To propagate active trace to a remote service:*
+
+```ruby
+### Old 0.x ###
+headers = {}
+context = Datadog.tracer.call_context
+Datadog::HTTPPropagator.inject!(context, headers)
+
+outgoing = Net::HTTP::Get.new(uri)
+headers.each { |name, value| outgoing[name] = value }
+
+### New 1.0 ###
+headers = {}
+trace_digest = Datadog::Tracing.active_trace.to_digest
+Datadog::Tracing::Propagation::HTTP.inject!(trace_digest, headers)
+
+outgoing = Net::HTTP::Get.new(uri)
+headers.each { |name, value| outgoing[name] = value }
+```
+
+*To continue a trace from a remote service:*
+
+```ruby
+### Old 0.x ###
+incoming = Rack::Request.new(env)
+context = Datadog::HTTPPropagator.extract(incoming.env)
+Datadog.tracer.provider.context = context
+
+### New 1.0 ###
+incoming = Rack::Request.new(env)
+trace_digest = Datadog::Tracing::Propagation::HTTP.extract(incoming.env)
+Datadog::Tracing.continue_trace!(trace_digest)
+```
+
+<h4 id="1.0-trace-api-distributed-grpc">Over gRPC</h4>
+
+*To propagate active trace to a remote service:*
 
 ```ruby
 ### Old 0.x ###
 context = Datadog.tracer.call_context
-
-# HTTP
-headers = {}
-Datadog::HTTPPropagator.inject!(context, headers)
-# Inject `headers` into your HTTP headers
-
-# gRPC
-headers = {}
-Datadog::GRPCPropagator.inject!(context, headers)
-# Inject `headers` into your headers
-
+Datadog::GRPCPropagator.inject!(context, metadata)
 
 ### New 1.0 ###
 trace_digest = Datadog::Tracing.active_trace.to_digest
-
-# HTTP
-headers = {}
-Datadog::Tracing::Propagation::HTTP.inject!(trace_digest, headers)
-# Inject `headers` into your HTTP headers
-
-# gRPC
-headers = {}
-Datadog::Tracing::Propagation::GRPC.inject!(trace_digest, headers)
-# Inject `headers` into your headers
+Datadog::Tracing::Propagation::GRPC.inject!(trace_digest, metadata)
 ```
 
-To continue a propagated trace locally:
+*To continue a trace from a remote service:*
 
 ```ruby
 ### Old 0.x ###
-# HTTP
-context = Datadog::HTTPPropagator.extract(request.env)
-Datadog.tracer.provider.context = context
-
-# gRPC
 context = Datadog::GRPCPropagator.extract(metadata)
 Datadog.tracer.provider.context = context
 
 ### New 1.0 ###
-# HTTP
-digest = Datadog::Tracing::Propagation::HTTP.extract(request.env)
-Datadog::Tracing.continue_trace!(digest)
-
-# gRPC
-digest = Datadog::Tracing::Propagation::GRPC.extract(metadata)
-Datadog::Tracing.continue_trace!(digest)
+trace_digest = Datadog::Tracing::Propagation::GRPC.extract(metadata)
+Datadog::Tracing.continue_trace!(trace_digest)
 ```
 
-#### Propagation between threads
+<h4 id="1.0-trace-api-distributed-threads">Between threads</h4>
 
 Traces do not implicitly propagate across threads, as they are considered different execution contexts.
 
@@ -339,6 +457,7 @@ However, if you wish to do this, trace propagation across threads is similar to 
 NOTE: The same `TraceOperation` object should never be shared between threads; this would create race conditions.
 
 ```ruby
+### New 1.0 ###
 # Get trace digest
 trace = Datadog::Tracing.active_trace
 
@@ -355,7 +474,7 @@ Thread.new do
 end
 ```
 
-### Sampling
+<h3 id="1.0-trace-api-sampling">Sampling</h3>
 
 Accessing `call_context` to set explicit sampling has been removed.
 
@@ -369,8 +488,10 @@ Datadog.tracer.trace('web.request') do |span|
 end
 
 # From outside the trace:
-Datadog.tracer.active_span.context.sampling_priority = Datadog::Ext::Priority::USER_KEEP # Keeps current trace
-Datadog.tracer.active_span.context.sampling_priority = Datadog::Ext::Priority::USER_REJECT # Drops current trace
+# Keeps current trace
+Datadog.tracer.active_span.context.sampling_priority = Datadog::Ext::Priority::USER_KEEP
+# Drops current trace
+Datadog.tracer.active_span.context.sampling_priority = Datadog::Ext::Priority::USER_REJECT
 
 
 ### New 1.0 ###
@@ -384,7 +505,7 @@ Datadog::Tracing.keep! # Keeps current trace
 Datadog::Tracing.reject! # Drops current trace
 ```
 
-### Processing pipeline
+<h3 id="1.0-trace-api-pipeline">Processing pipeline</h3>
 
 When using a trace processor in the processing pipeline, the block yields a `TraceSegment` as `trace` instead of `Array[Datadog::Span]`. This object can be modified by reference.
 
@@ -403,11 +524,11 @@ Datadog::Tracing.before_flush do |trace|
 end
 ```
 
-## Appendix
+<h2 id="1.0-appendix">Appendix</h2>
 
-<h3 id="appendix-namespacing">Namespacing</h3>
+<h3 id="1.0-appendix-namespace">Namespace mappings</h3>
 
-#### `require` paths
+<h4 id="1.0-appendix-namespace-requires">`require` paths</h3>
 
 | `0.x require path`          | `1.0 require path`          |
 |-----------------------------|-----------------------------|
@@ -415,7 +536,7 @@ end
 | `ddtrace/profiling/preload` | `datadog/profiling/preload` |
 
 
-#### Constants
+<h4 id="1.0-appendix-namespace-constants">Constants</h3>
 
 | `0.x Constant`                                                  | `1.0 Constant`                                                                          |
 |-----------------------------------------------------------------|-----------------------------------------------------------------------------------------|
@@ -482,43 +603,15 @@ end
 | `Datadog::Worker`                                               | `Datadog::Core::Worker`                                                                 |
 | `Datadog::Workers`                                              | `Datadog::Core::Workers`                                                                |
 
-
-<h3 id="appendix-configuration">Configuration</h3>
-
-| 0.x setting                            | 1.0 setting                   |
-|----------------------------------------|-------------------------------|
-| `analytics.enabled`                    | `tracing.analytics.enabled`   |
-| `ci_mode.context_flush`                | `ci.context_flush`            |
-| `ci_mode.enabled`                      | `ci.enabled`                  |
-| `ci_mode.writer_options`               | `ci.writer_options`           |
-| `distributed_tracing`                  | `tracing.distributed_tracing` |
-| `logger=`                              | `logger.instance=`            |
-| `profiling.exporter.transport_options` | Removed                       |
-| `report_hostname`                      | `tracing.report_hostname`     |
-| `runtime_metrics_enabled`              | `runtime_metrics.enabled`     |
-| `runtime_metrics(options)`             | Removed                       |
-| `sampling`                             | `tracing.sampling`            |
-| `test_mode`                            | `tracing.test_mode`           |
-| `tracer.enabled`                       | `tracing.enabled`             |
-| `tracer.hostname`                      | `agent.hostname`              |
-| `tracer.instance`                      | `tracing.instance`            |
-| `tracer.partial_flush`                 | `tracing.partial_flush`       |
-| `tracer.port`                          | `agent.port`                  |
-| `tracer.sampler`                       | `tracing.sampler`             |
-| `tracer.transport_options`             | `tracing.transport_options`   |
-| `tracer.transport_options(options)`    | Removed                       |
-| `tracer.writer`                        | `tracing.writer`              |
-| `tracer.writer_options`                | `tracing.writer_options`      |
-
-<h3 id="appendix-breaking-changes">Breaking changes</h3>
+<h3 id="1.0-appendix-breaking-changes">Breaking changes</h3>
 
 | **Category**  | **Type** | **Description**                                                                                                      | **Change / Alternative**                                                                                                                                                  |
 |---------------|----------|----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| General       | Changed  | Many constants have been moved from `Datadog` to `Datadog::Core`, `Datadog::Tracing`, `Datadog::Profiling`           | Update your references to these [new namespaces](#appendix-namespacing) where appropriate.                                                                                |
-| General       | Removed  | `Datadog.tracer`                                                                                                     | Use methods in `Datadog::Tracing` instead.                                                                                                                                |
+| General       | Changed  | Some `require` paths have been moved from `ddtrace` to `datadog`                                                     | Update your references to these [new paths](#1.0-appendix-namespace-requires) where appropriate.                                                                              |
+| General       | Changed  | Many constants have been moved from `Datadog` to `Datadog::Core`, `Datadog::Tracing`, `Datadog::Profiling`           | Update your references to these [new namespaces](#1.0-appendix-namespace-constants) where appropriate.                                                                        |
 | General       | Removed  | Support for trace agent API v0.2                                                                                     | Use v0.4 instead (default behavior.)                                                                                                                                      |
 | CI API        | Changed  | `DD_TRACE_CI_MODE_ENABLED` environment variable is now `DD_TRACE_CI_ENABLED`                                         | Use `DD_TRACE_CI_ENABLED` instead.                                                                                                                                        |
-| Configuration | Changed  | Many settings have been namespaced under specific categories                                                         | Update your configuration to these [new settings](#appendix-configuration) where appropriate.                                                                             |
+| Configuration | Changed  | Many settings have been namespaced under specific categories                                                         | Update your configuration to these [new settings](#1.0-configuration-settings) where appropriate.                                                                             |
 | Configuration | Removed  | `Datadog.configure(client, options)`                                                                                 | Use `Datadog::Tracing.configure_onto(client, options)` instead.                                                                                                           |
 | Configuration | Removed  | `DD_#{integration}_ANALYTICS_ENABLED` and `DD_#{integration}_ANALYTICS_SAMPLE_RATE` environment variables            | Use `DD_TRACE_#{integration}_ANALYTICS_ENABLED` and `DD_TRACE_#{integration}_ANALYTICS_SAMPLE_RATE` instead.                                                              |
 | Configuration | Removed  | `DD_PROPAGATION_INJECT_STYLE` and `DD_PROPAGATION_EXTRACT_STYLE` environment variables                               | Use `DD_PROPAGATION_STYLE_INJECT` and `DD_PROPAGATION_STYLE_EXTRACT` instead.                                                                                             |
@@ -538,6 +631,7 @@ end
 | Integrations  | Removed  | Rails: `log_injection` option.                                                                                       | Use global `c.tracing.log_injection` instead.                                                                                                                             |
 | Integrations  | Removed  | Rails: `orm_service_name` option.                                                                                    | Remove this option from your configuration.                                                                                                                               |
 | Integrations  | Removed  | Resque: `workers` option. (All Resque workers are now automatically instrumented.)                                   | Remove this option from your configuration.                                                                                                                               |
+| Tracing API   | Removed  | `Datadog.tracer`                                                                                                     | Use methods in `Datadog::Tracing` instead.                                                                                                                                |
 | Tracing API   | Changed  | `Correlation#to_s` to `Correlation#to_log_format`                                                                    | Use `Datadog::Tracing.log_correlation` instead.                                                                                                                           |
 | Tracing API   | Changed  | `Tracer#trace` implements keyword args                                                                               | Omit invalid options from `trace` calls.                                                                                                                                  |
 | Tracing API   | Changed  | Distributed tracing takes and yields `TraceDigest` instead of `Context`                                              | Update your usage of distributed tracing to use `continue_from` and `to_digest`.                                                                                          |

--- a/docs/UpgradeGuide.md
+++ b/docs/UpgradeGuide.md
@@ -90,6 +90,7 @@ Datadog.configure do |c|
   c.agent.hostname = '127.0.0.1'
   c.agent.port = 8126
   c.diagnostics.debug = true
+  c.runtime_metrics.enabled = true
   c.service = 'billing-api'
 
   # Profiling settings
@@ -97,7 +98,6 @@ Datadog.configure do |c|
 
   # Tracer settings
   c.tracing.analytics.enabled = true
-  c.tracing.runtime_metrics.enabled = true
 
   # CI settings
   c.ci.enabled = (ENV['DD_ENV'] == 'ci')
@@ -119,14 +119,20 @@ The `use` function has been renamed to `instrument`. Also, `instrument` has been
 ```ruby
 ### Old 0.x ###
 Datadog.configure do |c|
+  # Tracing instrumentation
   c.use :rails
+
+  # CI instrumentation
   c.use :cucumber
 end
 
 
 ### New 1.0 ###
 Datadog.configure do |c|
+  # Tracing instrumentation
   c.tracing.instrument :rails
+
+  # CI instrumentation
   c.ci.instrument :cucumber
 end
 ```
@@ -492,7 +498,7 @@ end
 | `runtime_metrics_enabled`              | `runtime_metrics.enabled`     |
 | `runtime_metrics(options)`             | Removed                       |
 | `sampling`                             | `tracing.sampling`            |
-| `test_moade`                           | `tracing.test_mode`           |
+| `test_mode`                            | `tracing.test_mode`           |
 | `tracer.enabled`                       | `tracing.enabled`             |
 | `tracer.hostname`                      | `agent.hostname`              |
 | `tracer.instance`                      | `tracing.instance`            |


### PR DESCRIPTION
To try to improve comprehension and ease of use, I've restructured the 1.0 upgrade guide a bit here.

- Table of contents at beginning outlines a `Basic usage` and `Advanced usage` path.
- Reorganized some existing sections
- Added `Trace API` section with table of common mappings.
- Rewrote `Namespacing` section, added table.
- Updated code blocks for improved legibility.
- Fixed some errors in examples
- Changed anchors to prefix with `1.0` (for future-proofing)