### PR TITLE
Rename `code_provenance.json` reported by profiler to `code-provenance.json`

### DIFF
--- a/lib/datadog/profiling/ext.rb
+++ b/lib/datadog/profiling/ext.rb
@@ -47,8 +47,8 @@ module Datadog
           FORM_FIELD_PPROF_DATA = 'data[rubyprofile.pprof]'.freeze
           PPROF_DEFAULT_FILENAME = 'rubyprofile.pprof.gz'.freeze
 
-          FORM_FIELD_CODE_PROVENANCE_DATA = 'data[code_provenance.json]'.freeze
-          CODE_PROVENANCE_FILENAME = 'code_provenance.json.gz'.freeze
+          FORM_FIELD_CODE_PROVENANCE_DATA = 'data[code-provenance.json]'.freeze
+          CODE_PROVENANCE_FILENAME = 'code-provenance.json.gz'.freeze
         end
       end
     end

--- a/spec/datadog/profiling/transport/http/adapters/net_integration_spec.rb
+++ b/spec/datadog/profiling/transport/http/adapters/net_integration_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe 'Adapters::Net profiling integration tests' do
 
           code_provenance_data = JSON.parse(
             Datadog::Core::Utils::Compression.gunzip(
-              body.fetch('data[code_provenance.json]')
+              body.fetch('data[code-provenance.json]')
             )
           )
 

--- a/spec/datadog/profiling/transport/http/api/endpoint_spec.rb
+++ b/spec/datadog/profiling/transport/http/api/endpoint_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Datadog::Profiling::Transport::HTTP::API::Endpoint do
           call
 
           expect(env.form)
-            .to include('data[code_provenance.json]' => kind_of(Datadog::Core::Vendor::Multipart::Post::UploadIO))
+            .to include('data[code-provenance.json]' => kind_of(Datadog::Core::Vendor::Multipart::Post::UploadIO))
         end
       end
     end


### PR DESCRIPTION
The profiling team decided to rename this file for consistency.

The code provenance feature (#1813) is not yet exposed to customers, and the only release made with the old file name is 1.0.0.beta1 so this does not cause any regression.