### PR TITLE
[PROF-4780] Add `HttpTransport` class to report profiles through libddprof

### DIFF
--- a/ext/ddtrace_profiling_native_extension/http_transport.c
+++ b/ext/ddtrace_profiling_native_extension/http_transport.c
@@ -1,0 +1,285 @@
+#include <ruby.h>
+#include <ruby/thread.h>
+#include <ddprof/ffi.h>
+
+// Used to report profiling data to Datadog.
+// This file implements the native bits of the Datadog::Profiling::HttpTransport class
+
+// Datadog::Profiling::HttpTransport::Exporter
+// This is used to wrap a native pointer to a libddprof exporter as a Ruby object of this class;
+// see exporter_as_ruby_object below for more details
+static VALUE exporter_class = Qnil;
+
+static VALUE ok_symbol = Qnil; // :ok in Ruby
+static VALUE error_symbol = Qnil; // :error in Ruby
+
+#define byte_slice_from_literal(string) ((ddprof_ffi_ByteSlice) {.ptr = (uint8_t *) "" string, .len = sizeof("" string) - 1})
+
+struct call_exporter_without_gvl_arguments {
+  ddprof_ffi_ProfileExporterV3 *exporter;
+  ddprof_ffi_Request *request;
+  ddprof_ffi_SendResult result;
+};
+
+inline static ddprof_ffi_ByteSlice byte_slice_from_ruby_string(VALUE string);
+static VALUE _native_create_agentless_exporter(VALUE self, VALUE site, VALUE api_key, VALUE tags_as_array);
+static VALUE _native_create_agent_exporter(VALUE self, VALUE base_url, VALUE tags_as_array);
+static VALUE create_exporter(struct ddprof_ffi_EndpointV3 endpoint, VALUE tags_as_array);
+static void convert_tags(ddprof_ffi_Tag *converted_tags, long tags_count, VALUE tags_as_array);
+static void exporter_as_ruby_object_free(void *data);
+static VALUE exporter_to_ruby_object(ddprof_ffi_ProfileExporterV3* exporter);
+static VALUE _native_do_export(
+  VALUE self,
+  VALUE libddprof_exporter,
+  VALUE upload_timeout_milliseconds,
+  VALUE start_timespec_seconds,
+  VALUE start_timespec_nanoseconds,
+  VALUE finish_timespec_seconds,
+  VALUE finish_timespec_nanoseconds,
+  VALUE pprof_file_name,
+  VALUE pprof_data,
+  VALUE code_provenance_file_name,
+  VALUE code_provenance_data
+);
+static ddprof_ffi_Request *build_request(
+  ddprof_ffi_ProfileExporterV3 *exporter,
+  VALUE upload_timeout_milliseconds,
+  VALUE start_timespec_seconds,
+  VALUE start_timespec_nanoseconds,
+  VALUE finish_timespec_seconds,
+  VALUE finish_timespec_nanoseconds,
+  VALUE pprof_file_name,
+  VALUE pprof_data,
+  VALUE code_provenance_file_name,
+  VALUE code_provenance_data
+);
+static void *call_exporter_without_gvl(void *exporter_and_request);
+
+void http_transport_init(VALUE profiling_module) {
+  VALUE http_transport_class = rb_define_class_under(profiling_module, "HttpTransport", rb_cObject);
+
+  rb_define_singleton_method(
+    http_transport_class, "_native_create_agentless_exporter",  _native_create_agentless_exporter, 3
+  );
+  rb_define_singleton_method(
+    http_transport_class, "_native_create_agent_exporter",  _native_create_agent_exporter, 2
+  );
+  rb_define_singleton_method(
+    http_transport_class, "_native_do_export",  _native_do_export, 10
+  );
+
+  exporter_class = rb_define_class_under(http_transport_class, "Exporter", rb_cObject);
+  // This prevents creation of the exporter class outside of our extension, see https://bugs.ruby-lang.org/issues/18007
+  rb_undef_alloc_func(exporter_class);
+
+  ok_symbol = ID2SYM(rb_intern("ok"));
+  error_symbol = ID2SYM(rb_intern("error"));
+}
+
+inline static ddprof_ffi_ByteSlice byte_slice_from_ruby_string(VALUE string) {
+  Check_Type(string, T_STRING);
+  ddprof_ffi_ByteSlice byte_slice = {.ptr = (uint8_t *) StringValuePtr(string), .len = RSTRING_LEN(string)};
+  return byte_slice;
+}
+
+static VALUE _native_create_agentless_exporter(VALUE self, VALUE site, VALUE api_key, VALUE tags_as_array) {
+  Check_Type(site, T_STRING);
+  Check_Type(api_key, T_STRING);
+  Check_Type(tags_as_array, T_ARRAY);
+
+  return create_exporter(
+    ddprof_ffi_EndpointV3_agentless(
+      byte_slice_from_ruby_string(site),
+      byte_slice_from_ruby_string(api_key)
+    ),
+    tags_as_array
+  );
+}
+
+static VALUE _native_create_agent_exporter(VALUE self, VALUE base_url, VALUE tags_as_array) {
+  Check_Type(base_url, T_STRING);
+  Check_Type(tags_as_array, T_ARRAY);
+
+  return create_exporter(
+    ddprof_ffi_EndpointV3_agent(byte_slice_from_ruby_string(base_url)),
+    tags_as_array
+  );
+}
+
+static VALUE create_exporter(struct ddprof_ffi_EndpointV3 endpoint, VALUE tags_as_array) {
+  long tags_count = rb_array_len(tags_as_array);
+  ddprof_ffi_Tag converted_tags[tags_count];
+
+  convert_tags(converted_tags, tags_count, tags_as_array);
+
+  struct ddprof_ffi_NewProfileExporterV3Result exporter_result =
+    ddprof_ffi_ProfileExporterV3_new(
+      byte_slice_from_literal("ruby"),
+      (ddprof_ffi_Slice_tag) {.ptr = converted_tags, .len = tags_count},
+      endpoint
+    );
+
+  if (exporter_result.tag != DDPROF_FFI_NEW_PROFILE_EXPORTER_V3_RESULT_OK) {
+    VALUE failure_details = rb_str_new((char *) exporter_result.err.ptr, exporter_result.err.len);
+    ddprof_ffi_NewProfileExporterV3Result_dtor(exporter_result); // Clean up result
+    return rb_ary_new_from_args(2, error_symbol, failure_details);
+  }
+
+  VALUE exporter = exporter_to_ruby_object(exporter_result.ok);
+  // No need to call the result dtor, since the only heap-allocated part is the exporter and we like that part
+
+  return rb_ary_new_from_args(2, ok_symbol, exporter);
+}
+
+static void convert_tags(ddprof_ffi_Tag *converted_tags, long tags_count, VALUE tags_as_array) {
+  Check_Type(tags_as_array, T_ARRAY);
+
+  for (long i = 0; i < tags_count; i++) {
+    VALUE name_value_pair = rb_ary_entry(tags_as_array, i);
+    Check_Type(name_value_pair, T_ARRAY);
+
+    // Note: We can index the array without checking its size first because rb_ary_entry returns Qnil if out of bounds
+    VALUE tag_name = rb_ary_entry(name_value_pair, 0);
+    VALUE tag_value = rb_ary_entry(name_value_pair, 1);
+    Check_Type(tag_name, T_STRING);
+    Check_Type(tag_value, T_STRING);
+
+    converted_tags[i] = (ddprof_ffi_Tag) {
+      .name = byte_slice_from_ruby_string(tag_name),
+      .value = byte_slice_from_ruby_string(tag_value)
+    };
+  }
+}
+
+// This structure is used to define a Ruby object that stores a pointer to a ddprof_ffi_ProfileExporterV3 instance
+// See also https://github.com/ruby/ruby/blob/master/doc/extension.rdoc for how this works
+static const rb_data_type_t exporter_as_ruby_object = {
+  .wrap_struct_name = "Datadog::Profiling::HttpTransport::Exporter",
+  .function = {
+    .dfree = exporter_as_ruby_object_free,
+    .dsize = NULL, // We don't track exporter memory usage
+    // No need to provide dmark nor dcompact because we don't reference Ruby VALUEs from inside this object
+  },
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+static void exporter_as_ruby_object_free(void *data) {
+  ddprof_ffi_ProfileExporterV3_delete((ddprof_ffi_ProfileExporterV3 *) data);
+}
+
+static VALUE exporter_to_ruby_object(ddprof_ffi_ProfileExporterV3* exporter) {
+  return TypedData_Wrap_Struct(exporter_class, &exporter_as_ruby_object, exporter);
+}
+
+static VALUE _native_do_export(
+  VALUE self,
+  VALUE libddprof_exporter,
+  VALUE upload_timeout_milliseconds,
+  VALUE start_timespec_seconds,
+  VALUE start_timespec_nanoseconds,
+  VALUE finish_timespec_seconds,
+  VALUE finish_timespec_nanoseconds,
+  VALUE pprof_file_name,
+  VALUE pprof_data,
+  VALUE code_provenance_file_name,
+  VALUE code_provenance_data
+) {
+  Check_TypedStruct(libddprof_exporter, &exporter_as_ruby_object);
+
+  ddprof_ffi_ProfileExporterV3 *exporter;
+  TypedData_Get_Struct(libddprof_exporter, ddprof_ffi_ProfileExporterV3, &exporter_as_ruby_object, exporter);
+
+  ddprof_ffi_Request *request =
+    build_request(
+      exporter,
+      upload_timeout_milliseconds,
+      start_timespec_seconds,
+      start_timespec_nanoseconds,
+      finish_timespec_seconds,
+      finish_timespec_nanoseconds,
+      pprof_file_name,
+      pprof_data,
+      code_provenance_file_name,
+      code_provenance_data
+    );
+
+  // We'll release the Global VM Lock while we're calling send, so that the Ruby VM can continue to work while this
+  // is pending
+  struct call_exporter_without_gvl_arguments args = {.exporter = exporter, .request = request};
+  // TODO: We don't provide a function to interrupt reporting, which means this thread will be blocked until
+  // call_exporter_without_gvl returns.
+  rb_thread_call_without_gvl(call_exporter_without_gvl, &args, NULL, NULL);
+  ddprof_ffi_SendResult result = args.result;
+
+  // The request does not need to be freed as libddprof takes care of it.
+
+  if (result.tag != DDPROF_FFI_SEND_RESULT_HTTP_RESPONSE) {
+    VALUE failure_details = rb_str_new((char *) result.failure.ptr, result.failure.len);
+    ddprof_ffi_Buffer_reset(&result.failure); // Clean up result
+    return rb_ary_new_from_args(2, error_symbol, failure_details);
+  }
+
+  return rb_ary_new_from_args(2, ok_symbol, UINT2NUM(result.http_response.code));
+}
+
+static ddprof_ffi_Request *build_request(
+  ddprof_ffi_ProfileExporterV3 *exporter,
+  VALUE upload_timeout_milliseconds,
+  VALUE start_timespec_seconds,
+  VALUE start_timespec_nanoseconds,
+  VALUE finish_timespec_seconds,
+  VALUE finish_timespec_nanoseconds,
+  VALUE pprof_file_name,
+  VALUE pprof_data,
+  VALUE code_provenance_file_name,
+  VALUE code_provenance_data
+) {
+  Check_Type(upload_timeout_milliseconds, T_FIXNUM);
+  Check_Type(start_timespec_seconds, T_FIXNUM);
+  Check_Type(start_timespec_nanoseconds, T_FIXNUM);
+  Check_Type(finish_timespec_seconds, T_FIXNUM);
+  Check_Type(finish_timespec_nanoseconds, T_FIXNUM);
+  Check_Type(pprof_file_name, T_STRING);
+  Check_Type(pprof_data, T_STRING);
+  Check_Type(code_provenance_file_name, T_STRING);
+  Check_Type(code_provenance_data, T_STRING);
+
+  uint64_t timeout_milliseconds = NUM2ULONG(upload_timeout_milliseconds);
+
+  ddprof_ffi_Timespec start =
+    {.seconds = NUM2LONG(start_timespec_seconds), .nanoseconds = NUM2UINT(start_timespec_nanoseconds)};
+  ddprof_ffi_Timespec finish =
+    {.seconds = NUM2LONG(finish_timespec_seconds), .nanoseconds = NUM2UINT(finish_timespec_nanoseconds)};
+
+  ddprof_ffi_Buffer *pprof_buffer =
+    ddprof_ffi_Buffer_from_byte_slice((ddprof_ffi_ByteSlice) {
+      .ptr = (uint8_t *) StringValuePtr(pprof_data),
+      .len = RSTRING_LEN(pprof_data)
+    });
+  ddprof_ffi_Buffer *code_provenance_buffer =
+    ddprof_ffi_Buffer_from_byte_slice((ddprof_ffi_ByteSlice) {
+      .ptr = (uint8_t *) StringValuePtr(code_provenance_data),
+      .len = RSTRING_LEN(code_provenance_data)
+    });
+
+  const ddprof_ffi_File files[] = {
+    {.name = byte_slice_from_ruby_string(pprof_file_name), .file = pprof_buffer},
+    {.name = byte_slice_from_ruby_string(code_provenance_file_name), .file = code_provenance_buffer}
+  };
+  ddprof_ffi_Slice_file slice_files = {.ptr = files, .len = (sizeof(files) / sizeof(ddprof_ffi_File))};
+
+  ddprof_ffi_Request *request =
+    ddprof_ffi_ProfileExporterV3_build(exporter, start, finish, slice_files, timeout_milliseconds);
+
+  // We don't need to free pprof_buffer nor code_provenance_buffer because libddprof takes care of it.
+
+  return request;
+}
+
+static void *call_exporter_without_gvl(void *exporter_and_request) {
+  struct call_exporter_without_gvl_arguments *args = (struct call_exporter_without_gvl_arguments*) exporter_and_request;
+
+  args->result = ddprof_ffi_ProfileExporterV3_send(args->exporter, args->request);
+
+  return NULL; // Unused
+}

--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -2,6 +2,9 @@
 
 #include "clock_id.h"
 
+// Each class/module here is implemented in their separate file
+void http_transport_init(VALUE profiling_module);
+
 static VALUE native_working_p(VALUE self);
 
 void Init_ddtrace_profiling_native_extension(void) {
@@ -13,6 +16,8 @@ void Init_ddtrace_profiling_native_extension(void) {
   rb_funcall(native_extension_module, rb_intern("private_class_method"), 1, ID2SYM(rb_intern("native_working?")));
 
   rb_define_singleton_method(native_extension_module, "clock_id_for", clock_id_for, 1); // from clock_id.h
+
+  http_transport_init(profiling_module);
 }
 
 static VALUE native_working_p(VALUE self) {

--- a/lib/datadog/profiling/flush.rb
+++ b/lib/datadog/profiling/flush.rb
@@ -5,7 +5,7 @@ require 'datadog/core/environment/socket'
 module Datadog
   module Profiling
     # Entity class used to represent metadata for a given profile
-    Flush = Struct.new(
+    OldFlush = Struct.new(
       :start,
       :finish,
       :event_groups,

--- a/lib/datadog/profiling/flush.rb
+++ b/lib/datadog/profiling/flush.rb
@@ -64,5 +64,32 @@ module Datadog
 
     # Represents a collection of events of a specific type being flushed.
     EventGroup = Struct.new(:event_class, :events).freeze
+
+    # Entity class used to represent metadata for a given profile
+    class Flush
+      attr_reader \
+        :start,
+        :finish,
+        :pprof_file_name,
+        :pprof_data, # gzipped pprof bytes
+        :code_provenance_file_name,
+        :code_provenance_data # gzipped json bytes
+
+      def initialize(
+        start:,
+        finish:,
+        pprof_file_name:,
+        pprof_data:,
+        code_provenance_file_name:,
+        code_provenance_data:
+      )
+        @start = start
+        @finish = finish
+        @pprof_file_name = pprof_file_name
+        @pprof_data = pprof_data
+        @code_provenance_file_name = code_provenance_file_name
+        @code_provenance_data = code_provenance_data
+      end
+    end
   end
 end

--- a/lib/datadog/profiling/http_transport.rb
+++ b/lib/datadog/profiling/http_transport.rb
@@ -1,0 +1,131 @@
+# typed: false
+
+module Datadog
+  module Profiling
+    # Used to report profiling data to Datadog.
+    # Methods prefixed with _native_ are implemented in `http_transport.c`
+    class HttpTransport
+      def initialize(agent_settings:, site:, api_key:, tags:, upload_timeout_seconds:)
+        @upload_timeout_milliseconds = (upload_timeout_seconds * 1_000).to_i
+
+        validate_agent_settings(agent_settings)
+
+        tags_as_array = tags.to_a
+
+        status, result =
+          if site && api_key && agentless_allowed?
+            create_agentless_exporter(site, api_key, tags_as_array)
+          else
+            create_agent_exporter(base_url_from(agent_settings), tags_as_array)
+          end
+
+        if status == :ok
+          @libddprof_exporter = result
+        else # :error
+          raise(ArgumentError, "Failed to initialize transport: #{result}")
+        end
+      end
+
+      def export(flush)
+        status, result = do_export(
+          libddprof_exporter: @libddprof_exporter,
+          upload_timeout_milliseconds: @upload_timeout_milliseconds,
+
+          # why "timespec"?
+          # libddprof represents time using POSIX's struct timespec, see
+          # https://www.gnu.org/software/libc/manual/html_node/Time-Types.html
+          # aka it represents the seconds part separate from the nanoseconds part
+          start_timespec_seconds: flush.start.tv_sec,
+          start_timespec_nanoseconds: flush.start.tv_nsec,
+          finish_timespec_seconds: flush.finish.tv_sec,
+          finish_timespec_nanoseconds: flush.finish.tv_nsec,
+
+          pprof_file_name: flush.pprof_file_name,
+          pprof_data: flush.pprof_data,
+          code_provenance_file_name: flush.code_provenance_file_name,
+          code_provenance_data: flush.code_provenance_data,
+        )
+
+        if status == :ok
+          if (200..299).cover?(result)
+            Datadog.logger.debug('Successfully reported profiling data')
+            true
+          else
+            Datadog.logger.error("Failed to report profiling data: server returned unexpected HTTP #{result} status code")
+            false
+          end
+        else
+          Datadog.logger.error("Failed to report profiling data: #{result}")
+          false
+        end
+      end
+
+      private
+
+      def base_url_from(agent_settings)
+        case agent_settings.adapter
+        when Datadog::Transport::Ext::HTTP::ADAPTER
+          "#{agent_settings.ssl ? 'https' : 'http'}://#{agent_settings.hostname}:#{agent_settings.port}/"
+        when Datadog::Transport::Ext::UnixSocket::ADAPTER
+          "unix://#{agent_settings.uds_path}"
+        else
+          raise ArgumentError, "Unexpected adapter: #{agent_settings.adapter}"
+        end
+      end
+
+      def validate_agent_settings(agent_settings)
+        supported_adapters = [Datadog::Transport::Ext::HTTP::ADAPTER, Datadog::Transport::Ext::UnixSocket::ADAPTER]
+        unless supported_adapters.include?(agent_settings.adapter)
+          raise ArgumentError, "Unsupported transport configuration for profiling: Adapter #{agent_settings.adapter} " \
+            ' is not supported'
+        end
+
+        # FIXME: Currently the transport_configuration_proc is the only public API available for enable reporting
+        # via unix domain sockets. Not supporting it means not supporting Unix Domain Sockets in practice.
+        # This will need to be fixed before we make HttpTransport the default option for reporting profiles.
+        if agent_settings.deprecated_for_removal_transport_configuration_proc
+          raise ArgumentError,
+                'Unsupported agent configuration for profiling: custom c.tracer.transport_options is currently unsupported.'
+        end
+      end
+
+      def agentless_allowed?
+        Core::Environment::VariableHelpers.env_to_bool(Profiling::Ext::ENV_AGENTLESS, false)
+      end
+
+      def create_agentless_exporter(site, api_key, tags_as_array)
+        self.class._native_create_agentless_exporter(site, api_key, tags_as_array)
+      end
+
+      def create_agent_exporter(base_url, tags_as_array)
+        self.class._native_create_agent_exporter(base_url, tags_as_array)
+      end
+
+      def do_export(
+        libddprof_exporter:,
+        upload_timeout_milliseconds:,
+        start_timespec_seconds:,
+        start_timespec_nanoseconds:,
+        finish_timespec_seconds:,
+        finish_timespec_nanoseconds:,
+        pprof_file_name:,
+        pprof_data:,
+        code_provenance_file_name:,
+        code_provenance_data:
+      )
+        self.class._native_do_export(
+          libddprof_exporter,
+          upload_timeout_milliseconds,
+          start_timespec_seconds,
+          start_timespec_nanoseconds,
+          finish_timespec_seconds,
+          finish_timespec_nanoseconds,
+          pprof_file_name,
+          pprof_data,
+          code_provenance_file_name,
+          code_provenance_data,
+        )
+      end
+    end
+  end
+end

--- a/lib/datadog/profiling/recorder.rb
+++ b/lib/datadog/profiling/recorder.rb
@@ -74,7 +74,7 @@ module Datadog
 
         code_provenance = @code_provenance_collector.refresh.generate_json if @code_provenance_collector
 
-        Flush.new(
+        OldFlush.new(
           start: start,
           finish: finish,
           event_groups: event_groups,

--- a/lib/datadog/profiling/scheduler.rb
+++ b/lib/datadog/profiling/scheduler.rb
@@ -113,7 +113,7 @@ module Datadog
         # Sleep for a bit to cause misalignment between profilers in multi-process applications
         #
         # When not being run in a loop, it means the scheduler has not been started or was stopped, and thus
-        # a) it's being shutting down (and is trying to report the last profile)
+        # a) it's being shut down (and is trying to report the last profile)
         # b) it's being run as a one-shot, usually in a test
         # ...so in those cases we don't sleep
         #

--- a/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -3682,7 +3682,7 @@ class Datadog::Profiling::Collectors::Stack
   include ::Datadog::Core::Workers::Polling::PrependedMethods
 end
 
-class Datadog::Profiling::Flush
+class Datadog::Profiling::OldFlush
   def self.[](*arg); end
 
   def self.members(); end

--- a/spec/datadog/profiling/encoding/profile_spec.rb
+++ b/spec/datadog/profiling/encoding/profile_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Datadog::Profiling::Encoding::Profile::Protobuf do
     subject(:encode) { described_class.encode(flush) }
 
     let(:flush) do
-      instance_double(Datadog::Profiling::Flush, event_groups: event_groups, start: start_time, finish: finish_time)
+      instance_double(Datadog::Profiling::OldFlush, event_groups: event_groups, start: start_time, finish: finish_time)
     end
     let(:event_groups) { [event_group] }
     let(:event_group) { instance_double(Datadog::Profiling::EventGroup, event_class: event_class, events: events) }

--- a/spec/datadog/profiling/exporter_spec.rb
+++ b/spec/datadog/profiling/exporter_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Datadog::Profiling::Exporter do
   describe '#export' do
     subject(:export) { exporter.export(flush) }
 
-    let(:flush) { instance_double(Datadog::Profiling::Flush) }
+    let(:flush) { instance_double(Datadog::Profiling::OldFlush) }
     let(:result) { double('result') }
 
     before do

--- a/spec/datadog/profiling/flush_spec.rb
+++ b/spec/datadog/profiling/flush_spec.rb
@@ -1,6 +1,6 @@
 # typed: false
 
-RSpec.describe Datadog::Profiling::Flush do
+RSpec.describe Datadog::Profiling::OldFlush do
   describe '#new' do
     let(:start) { double('start') }
     let(:finish) { double('finish') }

--- a/spec/datadog/profiling/flush_spec.rb
+++ b/spec/datadog/profiling/flush_spec.rb
@@ -98,3 +98,36 @@ RSpec.describe Datadog::Profiling::OldFlush do
     end
   end
 end
+
+RSpec.describe Datadog::Profiling::Flush do
+  describe '.new' do
+    let(:start) { instance_double(Time, 'start time') }
+    let(:finish) { instance_double(Time, 'finish time') }
+    let(:pprof_file_name) { 'the_pprof_file_name.pprof' }
+    let(:pprof_data) { 'the_pprof_data' }
+    let(:code_provenance_file_name) { 'the_code_provenance_file_name.json' }
+    let(:code_provenance_data) { 'the_code_provenance_data' }
+
+    subject(:flush) do
+      described_class.new(
+        start: start,
+        finish: finish,
+        pprof_file_name: pprof_file_name,
+        pprof_data: pprof_data,
+        code_provenance_file_name: code_provenance_file_name,
+        code_provenance_data: code_provenance_data,
+      )
+    end
+
+    it do
+      expect(flush).to have_attributes(
+        start: start,
+        finish: finish,
+        pprof_file_name: pprof_file_name,
+        pprof_data: pprof_data,
+        code_provenance_file_name: code_provenance_file_name,
+        code_provenance_data: code_provenance_data,
+      )
+    end
+  end
+end

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -1,0 +1,384 @@
+# typed: ignore
+
+require 'datadog/profiling/spec_helper'
+
+require 'datadog/profiling/http_transport'
+require 'datadog/profiling'
+
+require 'webrick'
+require 'socket'
+
+# Design note for this class's specs: from the Ruby code side, we're treating the `_native_` methods as an API
+# between the Ruby code and the native methods, and thus in this class we have a bunch of tests to make sure the
+# native methods are invoked correctly.
+#
+# We also have "integration" specs, where we exercise the Ruby code together with the C code and libddprof to ensure
+# that things come out of libddprof as we expected.
+RSpec.describe Datadog::Profiling::HttpTransport do
+  before { skip_if_profiling_not_supported(self) }
+
+  subject(:http_transport) do
+    described_class.new(
+      agent_settings: agent_settings,
+      site: site,
+      api_key: api_key,
+      tags: tags,
+      upload_timeout_seconds: upload_timeout_seconds,
+    )
+  end
+
+  let(:agent_settings) do
+    Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings.new(
+      adapter: adapter,
+      uds_path: uds_path,
+      ssl: ssl,
+      hostname: hostname,
+      port: port,
+      deprecated_for_removal_transport_configuration_proc: deprecated_for_removal_transport_configuration_proc,
+      timeout_seconds: nil,
+    )
+  end
+  let(:adapter) { Datadog::Transport::Ext::HTTP::ADAPTER }
+  let(:uds_path) { nil }
+  let(:ssl) { false }
+  let(:hostname) { '192.168.0.1' }
+  let(:port) { '12345' }
+  let(:deprecated_for_removal_transport_configuration_proc) { nil }
+  let(:site) { nil }
+  let(:api_key) { nil }
+  let(:tags) { { 'tag_a' => 'value_a', 'tag_b' => 'value_b' } }
+  let(:upload_timeout_seconds) { 123 }
+
+  let(:flush) do
+    Datadog::Profiling::Flush.new(
+      start: start,
+      finish: finish,
+      pprof_file_name: pprof_file_name,
+      pprof_data: pprof_data,
+      code_provenance_file_name: code_provenance_file_name,
+      code_provenance_data: code_provenance_data,
+    )
+  end
+  let(:start_timestamp) { '2022-02-07T15:59:53.987654321Z' }
+  let(:end_timestamp) { '2023-11-11T16:00:00.123456789Z' }
+  let(:start)  { Time.iso8601(start_timestamp) }
+  let(:finish) { Time.iso8601(end_timestamp) }
+  let(:pprof_file_name) { 'the_pprof_file_name.pprof' }
+  let(:pprof_data) { 'the_pprof_data' }
+  let(:code_provenance_file_name) { 'the_code_provenance_file_name.json' }
+  let(:code_provenance_data) { 'the_code_provenance_data' }
+
+  describe '#initialize' do
+    let(:tags_as_array) { [%w[tag_a value_a], %w[tag_b value_b]] }
+
+    context 'when agent_settings are provided' do
+      it 'creates an agent exporter with the given settings' do
+        expect(described_class)
+          .to receive(:_native_create_agent_exporter)
+          .with('http://192.168.0.1:12345/', tags_as_array)
+          .and_return([:ok, :dummy_exporter])
+
+        http_transport
+      end
+
+      context 'when ssl is enabled' do
+        let(:ssl) { true }
+
+        it 'creates an agent exporter that reports over https' do
+          expect(described_class)
+            .to receive(:_native_create_agent_exporter)
+            .with('https://192.168.0.1:12345/', tags_as_array)
+            .and_return([:ok, :dummy_exporter])
+
+          http_transport
+        end
+      end
+
+      context 'when agent_settings requests a unix domain socket' do
+        let(:adapter) { Datadog::Transport::Ext::UnixSocket::ADAPTER }
+        let(:uds_path) { '/var/run/datadog/apm.socket' }
+
+        it 'creates an agent exporter that reports over a unix domain socket' do
+          expect(described_class)
+            .to receive(:_native_create_agent_exporter)
+            .with('unix:///var/run/datadog/apm.socket', tags_as_array)
+            .and_return([:ok, :dummy_exporter])
+
+          http_transport
+        end
+      end
+
+      context 'when agent_settings includes a deprecated_for_removal_transport_configuration_proc' do
+        let(:deprecated_for_removal_transport_configuration_proc) { instance_double(Proc, 'Configuration proc') }
+
+        it do
+          expect { http_transport }.to raise_error(ArgumentError, /c.tracer.transport_options is currently unsupported/)
+        end
+      end
+
+      context 'when agent_settings requests an unsupported transport' do
+        let(:adapter) { :test }
+
+        it do
+          expect { http_transport }.to raise_error(ArgumentError, /Unsupported transport/)
+        end
+      end
+    end
+
+    context 'when additionally site and api_key are provided' do
+      let(:site) { 'test.datadoghq.com' }
+      let(:api_key) { SecureRandom.uuid }
+
+      it 'ignores them and creates an agent exporter using the agent_settings' do
+        expect(described_class)
+          .to receive(:_native_create_agent_exporter)
+          .with('http://192.168.0.1:12345/', tags_as_array)
+          .and_return([:ok, :dummy_exporter])
+
+        http_transport
+      end
+
+      context 'when agentless mode is allowed' do
+        around do |example|
+          ClimateControl.modify('DD_PROFILING_AGENTLESS' => 'true') do
+            example.run
+          end
+        end
+
+        it 'creates an agentless exporter with the given site and api key' do
+          expect(described_class)
+            .to receive(:_native_create_agentless_exporter)
+            .with(site, api_key, tags_as_array)
+            .and_return([:ok, :dummy_exporter])
+
+          http_transport
+        end
+      end
+    end
+
+    context 'when an invalid configuration is provided' do
+      let(:port) { 1_000_000_000.to_s }
+
+      it do
+        expect { http_transport }.to raise_error(ArgumentError, /Failed to initialize transport/)
+      end
+    end
+  end
+
+  describe '#export' do
+    subject(:export) { http_transport.export(flush) }
+
+    it 'calls the native export method with the data from the flush' do
+      # Manually converted from the lets above :)
+      upload_timeout_milliseconds = 123_000
+      start_timespec_seconds = 1644249593
+      start_timespec_nanoseconds = 987654321
+      finish_timespec_seconds = 1699718400
+      finish_timespec_nanoseconds = 123456789
+
+      expect(described_class).to receive(:_native_do_export).with(
+        kind_of(Datadog::Profiling::HttpTransport::Exporter),
+        upload_timeout_milliseconds,
+        start_timespec_seconds,
+        start_timespec_nanoseconds,
+        finish_timespec_seconds,
+        finish_timespec_nanoseconds,
+        pprof_file_name,
+        pprof_data,
+        code_provenance_file_name,
+        code_provenance_data
+      ).and_return([:ok, 200])
+
+      export
+    end
+
+    context 'when export was successful' do
+      before do
+        expect(described_class).to receive(:_native_do_export).and_return([:ok, 200])
+      end
+
+      it 'logs a debug message' do
+        expect(Datadog.logger).to receive(:debug).with('Successfully reported profiling data')
+
+        export
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when failed' do
+      before do
+        expect(described_class).to receive(:_native_do_export).and_return([:ok, 500])
+        allow(Datadog.logger).to receive(:error)
+      end
+
+      it 'logs an error message' do
+        expect(Datadog.logger).to receive(:error)
+
+        export
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
+  context 'integration testing' do
+    shared_context 'HTTP server' do
+      let(:server) do
+        WEBrick::HTTPServer.new(
+          Port: port,
+          Logger: log,
+          AccessLog: access_log,
+          StartCallback: -> { init_signal.push(1) }
+        )
+      end
+      let(:hostname) { '127.0.0.1' }
+      let(:port) { 6006 }
+      let(:log) { WEBrick::Log.new(log_buffer) }
+      let(:log_buffer) { StringIO.new }
+      let(:access_log) { [[log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]] }
+      let(:server_proc) do
+        proc do |req, res|
+          messages << req.tap { req.body } # Read body, store message before socket closes.
+          res.body = '{}'
+        end
+      end
+      let(:init_signal) { Queue.new }
+
+      let(:messages) { [] }
+
+      before do
+        server.mount_proc('/', &server_proc)
+        @server_thread = Thread.new { server.start }
+        init_signal.pop
+      end
+
+      after do
+        unless RSpec.current_example.skipped?
+          # When the test is skipped, server has not been initialized and @server_thread would be nil; thus we only
+          # want to touch them when the test actually run, otherwise we would cause the server to start (incorrectly)
+          # and join to be called on a nil @server_thread
+          server.shutdown
+          @server_thread.join
+        end
+      end
+    end
+
+    include_context 'HTTP server'
+
+    let(:request) { messages.first }
+
+    let(:hostname) { '127.0.0.1' }
+    let(:port) { '6006' }
+
+    shared_examples 'correctly reports profiling data' do
+      it 'correctly reports profiling data' do
+        success = http_transport.export(flush)
+
+        expect(success).to be true
+
+        expect(request.header).to include(
+          'content-type' => [%r{^multipart/form-data; boundary=(.+)}],
+        )
+
+        # check body
+        boundary = request['content-type'][%r{^multipart/form-data; boundary=(.+)}, 1]
+        body = WEBrick::HTTPUtils.parse_form_data(StringIO.new(request.body), boundary)
+
+        expect(body).to include(
+          'version' => '3',
+          'family' => 'ruby',
+          'start' => start_timestamp,
+          'end' => end_timestamp,
+          "data[#{pprof_file_name}]" => pprof_data,
+          "data[#{code_provenance_file_name}]" => code_provenance_data,
+        )
+
+        tags = body['tags[]'].list
+        expect(tags).to include('tag_a:value_a', 'tag_b:value_b')
+      end
+    end
+
+    include_examples 'correctly reports profiling data'
+
+    it 'exports data via http to the agent url' do
+      http_transport.export(flush)
+
+      expect(request.request_uri.to_s).to eq 'http://127.0.0.1:6006/profiling/v1/input'
+    end
+
+    context 'via unix domain socket' do
+      before { pending 'Support for reporting via unix domain socket in libddprof is still work in progress' }
+
+      let(:temporary_directory) { Dir.mktmpdir }
+      let(:socket_path) { "#{temporary_directory}/rspec_unix_domain_socket" }
+      let(:unix_domain_socket) { UNIXServer.new(socket_path) } # Closing the socket is handled by webrick
+      let(:server) do
+        server = WEBrick::HTTPServer.new(
+          DoNotListen: true,
+          Logger: log,
+          AccessLog: access_log,
+          StartCallback: -> { init_signal.push(1) }
+        )
+        server.listeners << unix_domain_socket
+        server
+      end
+      let(:adapter) { Datadog::Transport::Ext::UnixSocket::ADAPTER }
+      let(:uds_path) { socket_path }
+
+      after do
+        begin
+          FileUtils.remove_entry(temporary_directory)
+        rescue Errno::ENOENT => _e
+          # Do nothing, it's ok
+        end
+      end
+
+      include_examples 'correctly reports profiling data'
+    end
+
+    context 'when agent is down' do
+      before do
+        server.shutdown
+        @server_thread.join
+      end
+
+      it 'logs an error' do
+        expect(Datadog.logger).to receive(:error).with(/error trying to connect/)
+
+        http_transport.export(flush)
+      end
+    end
+
+    context 'when request times out' do
+      let(:upload_timeout_seconds) { 0.001 }
+      let(:server_proc) { proc { sleep 0.05 } }
+
+      it 'logs an error' do
+        expect(Datadog.logger).to receive(:error).with(/timed out/)
+
+        http_transport.export(flush)
+      end
+    end
+
+    context 'when server returns a 4xx failure' do
+      let(:server_proc) { proc { |_req, res| res.status = 418 } }
+
+      it 'logs an error' do
+        expect(Datadog.logger).to receive(:error).with(/unexpected HTTP 418/)
+
+        http_transport.export(flush)
+      end
+    end
+
+    context 'when server returns a 5xx failure' do
+      let(:server_proc) { proc { |_req, res| res.status = 503 } }
+
+      it 'logs an error' do
+        expect(Datadog.logger).to receive(:error).with(/unexpected HTTP 503/)
+
+        http_transport.export(flush)
+      end
+    end
+  end
+end

--- a/spec/datadog/profiling/recorder_spec.rb
+++ b/spec/datadog/profiling/recorder_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Datadog::Profiling::Recorder do
       context 'whose buffer returns events' do
         let(:events) { [event_class.new, event_class.new] }
 
-        it { is_expected.to be_a_kind_of(Datadog::Profiling::Flush) }
+        it { is_expected.to be_a_kind_of(Datadog::Profiling::OldFlush) }
 
         it do
           is_expected.to have_attributes(
@@ -152,7 +152,7 @@ RSpec.describe Datadog::Profiling::Recorder do
       end
 
       context 'whose buffer returns no events' do
-        it { is_expected.to be_a_kind_of(Datadog::Profiling::Flush) }
+        it { is_expected.to be_a_kind_of(Datadog::Profiling::OldFlush) }
         it { expect(flush.event_groups).to be_empty }
       end
 

--- a/spec/datadog/profiling/scheduler_spec.rb
+++ b/spec/datadog/profiling/scheduler_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Datadog::Profiling::Scheduler do
     let(:flush_start) { Time.now }
     let(:flush_finish) { flush_start + 1 }
     let(:flush) do
-      instance_double(Datadog::Profiling::Flush, event_count: event_count, start: flush_start, finish: flush_finish)
+      instance_double(Datadog::Profiling::OldFlush, event_count: event_count, start: flush_start, finish: flush_finish)
     end
 
     before { expect(recorder).to receive(:flush).and_return(flush) }

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -30,7 +30,7 @@ module ProfileHelpers
     finish = start + 10
     event_groups = [Datadog::Profiling::EventGroup.new(Datadog::Profiling::Events::StackSample, stack_samples)]
 
-    Datadog::Profiling::Flush.new(
+    Datadog::Profiling::OldFlush.new(
       start: start,
       finish: finish,
       event_groups: event_groups,

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -68,7 +68,21 @@ module ProfileHelpers
   def skip_if_profiling_not_supported(testcase)
     testcase.skip('Profiling is not supported on JRuby') if PlatformHelpers.jruby?
     testcase.skip('Profiling is not supported on TruffleRuby') if PlatformHelpers.truffleruby?
-    testcase.skip('Profiling is not supported on macOS') if PlatformHelpers.mac?
+
+    # Profiling is not officially supported on macOS due to missing libddprof binaries,
+    # but it's still useful to allow it to be enabled for development.
+    if PlatformHelpers.mac? && ENV['DD_PROFILING_MACOS_TESTING'] != 'true'
+      testcase.skip(
+        'Profiling is not supported on macOS. If you still want to run these specs, you can use ' \
+        'DD_PROFILING_MACOS_TESTING=true to override this check.'
+      )
+    end
+
+    return if Datadog::Profiling.supported?
+
+    # Ensure profiling was loaded correctly
+    raise "Profiling does not seem to be available: #{Datadog::Profiling.unsupported_reason}. " \
+      'Try running `bundle exec rake compile` before running this test.'
   end
 end
 

--- a/spec/datadog/profiling/transport/client_spec.rb
+++ b/spec/datadog/profiling/transport/client_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Datadog::Profiling::Transport::Client do
     describe '#send_profiling_flush' do
       subject(:send_profiling_flush) { client.send_profiling_flush(flush) }
 
-      let(:flush) { instance_double(Datadog::Profiling::Flush) }
+      let(:flush) { instance_double(Datadog::Profiling::OldFlush) }
 
       it { expect { send_profiling_flush }.to raise_error(NotImplementedError) }
     end

--- a/spec/datadog/profiling/transport/http/client_spec.rb
+++ b/spec/datadog/profiling/transport/http/client_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Datadog::Profiling::Transport::HTTP::Client do
 
     subject(:send_profiling_flush) { client.send_profiling_flush(flush) }
 
-    let(:flush) { instance_double(Datadog::Profiling::Flush) }
+    let(:flush) { instance_double(Datadog::Profiling::OldFlush) }
 
     context 'when request was successful' do
       before do

--- a/spec/datadog/profiling/transport/io/client_spec.rb
+++ b/spec/datadog/profiling/transport/io/client_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Datadog::Profiling::Transport::IO::Client do
   describe '#send_profiling_flush' do
     subject(:send_profiling_flush) { client.send_profiling_flush(flush) }
 
-    let(:flush) { instance_double(Datadog::Profiling::Flush) }
+    let(:flush) { instance_double(Datadog::Profiling::OldFlush) }
     let(:encoded_events) { double('encoded events') }
     let(:result) { double('IO result') }
 

--- a/spec/datadog/profiling/transport/request_spec.rb
+++ b/spec/datadog/profiling/transport/request_spec.rb
@@ -7,7 +7,7 @@ require 'datadog/profiling/transport/request'
 RSpec.describe Datadog::Profiling::Transport::Request do
   subject(:request) { described_class.new(flush) }
 
-  let(:flush) { instance_double(Datadog::Profiling::Flush) }
+  let(:flush) { instance_double(Datadog::Profiling::OldFlush) }
 
   it { is_expected.to be_a_kind_of(Datadog::Transport::Request) }
 


### PR DESCRIPTION
One of the features provided by `libddprof` is reporting profiles.

The `HttpTransport` class exposes this functionality to Ruby code, and will in the future replace most of the code in `lib/datadog/profiling/transport/.

This PR only adds the `HttpTransport` without wiring it up; that will come in a separate PR.

A lot of the commit "noise" below stems from the new `HttpTransport` using a new shape for the `Flush` class for input. Because we haven't yet deleted the old code, I renamed the existing `Flush` class to `OldFlush`, and that's why that change shows up in a bunch of files.

I'm opening this as a draft because:
* [ ] This PR depends on #1885 being merged first
* [ ] This PR depends on a few unreleased changes in [libddprof](https://github.com/DataDog/libddprof)
* [ ] (CI is broken for the reasons above)

But otherwise this is expected to be code-complete and the tests are passing on my local machine.