### PR TITLE
Provide metrics for AWS spans...

### DIFF
--- a/lib/ddtrace/contrib/aws/instrumentation.rb
+++ b/lib/ddtrace/contrib/aws/instrumentation.rb
@@ -37,9 +37,9 @@ module Datadog
 
           # Set analytics sample rate
           if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
-            Contrib::Analytics.set_measured(span)
             Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])
           end
+          Contrib::Analytics.set_measured(span)
 
           span.set_tag(Ext::TAG_AGENT, Ext::TAG_DEFAULT_AGENT)
           span.set_tag(Ext::TAG_OPERATION, context.safely(:operation))

--- a/lib/ddtrace/contrib/aws/instrumentation.rb
+++ b/lib/ddtrace/contrib/aws/instrumentation.rb
@@ -37,6 +37,7 @@ module Datadog
 
           # Set analytics sample rate
           if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
+            Contrib::Analytics.set_measured(span)
             Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])
           end
 

--- a/spec/ddtrace/contrib/aws/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/aws/instrumentation_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'AWS instrumentation' do
         let(:analytics_sample_rate_var) { Datadog::Contrib::Aws::Ext::ENV_ANALYTICS_SAMPLE_RATE }
       end
 
-      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'measured span for integration'
       it_behaves_like 'a peer service span'
 
       it 'generates a span' do
@@ -54,7 +54,6 @@ RSpec.describe 'AWS instrumentation' do
         expect(span.get_tag('host')).to eq('sts.us-stubbed-1.amazonaws.com')
         expect(span.get_tag('http.method')).to eq('POST')
         expect(span.get_tag('http.status_code')).to eq('200')
-        expect(span.get_metric('_dd.measured')).to eq(1.0)
       end
 
       it 'returns an unmodified response' do
@@ -78,7 +77,7 @@ RSpec.describe 'AWS instrumentation' do
         let(:analytics_sample_rate_var) { Datadog::Contrib::Aws::Ext::ENV_ANALYTICS_SAMPLE_RATE }
       end
 
-      it_behaves_like 'measured span for integration', false
+      it_behaves_like 'measured span for integration'
 
       it 'generates a span' do
         expect(span.name).to eq('aws.command')
@@ -93,7 +92,6 @@ RSpec.describe 'AWS instrumentation' do
         expect(span.get_tag('host')).to eq('s3.us-stubbed-1.amazonaws.com')
         expect(span.get_tag('http.method')).to eq('GET')
         expect(span.get_tag('http.status_code')).to eq('200')
-        expect(span.get_metric('_dd.measured')).to eq(1.0)
       end
 
       it_behaves_like 'a peer service span'

--- a/spec/ddtrace/contrib/aws/instrumentation_spec.rb
+++ b/spec/ddtrace/contrib/aws/instrumentation_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe 'AWS instrumentation' do
         expect(span.get_tag('host')).to eq('sts.us-stubbed-1.amazonaws.com')
         expect(span.get_tag('http.method')).to eq('POST')
         expect(span.get_tag('http.status_code')).to eq('200')
+        expect(span.get_metric('_dd.measured')).to eq(1.0)
       end
 
       it 'returns an unmodified response' do
@@ -92,6 +93,7 @@ RSpec.describe 'AWS instrumentation' do
         expect(span.get_tag('host')).to eq('s3.us-stubbed-1.amazonaws.com')
         expect(span.get_tag('http.method')).to eq('GET')
         expect(span.get_tag('http.status_code')).to eq('200')
+        expect(span.get_metric('_dd.measured')).to eq(1.0)
       end
 
       it_behaves_like 'a peer service span'


### PR DESCRIPTION
...when analytics is enabled.

We tuck our `aws.command` operation into the calling service. We have analytics enabled, but we still don't see resources for all the calls through the aws sdk. *Service Entry Spans* show up, but not spans in the middle of a trace. This change should fix that... unless you left it out on purpose due to the shear number of metrics that would be generated 😑 .