### PR TITLE
Move ENVIRONMENT_AGENT_SETTINGS to class/specs that need it

### DIFF
--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -282,14 +282,6 @@ module Datadog
           end
         end
         private_constant :DetectedConfiguration
-
-        # NOTE: Due to... legacy reasons... Some classes like having an `AgentSettings` instance to fall back to.
-        # Because we generate this instance with an empty instance of `Settings`, the resulting `AgentSettings` below
-        # represents only settings specified via environment variables + the usual defaults.
-        #
-        # YOU DO NOT WANT TO USE THE BELOW INSTANCE ON ANY NEWLY WRITTEN CODE, as it ignores any settings specified
-        # by users via `Datadog.configure`.
-        ENVIRONMENT_AGENT_SETTINGS = call(Settings.new, logger: nil)
       end
       # rubocop:enable Metrics/ClassLength
     end

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -18,6 +18,16 @@ module Datadog
     module HTTP
       include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
 
+      # NOTE: Due to... legacy reasons... This class likes having a default `AgentSettings` instance to fall back to.
+      # Because we generate this instance with an empty instance of `Settings`, the resulting `AgentSettings` below
+      # represents only settings specified via environment variables + the usual defaults.
+      #
+      # DO NOT USE THIS IN NEW CODE, as it ignores any settings specified by users via `Datadog.configure`.
+      DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS = Datadog::Core::Configuration::AgentSettingsResolver.call(
+        Datadog::Core::Configuration::Settings.new,
+        logger: nil,
+      )
+
       module_function
 
       # Builds a new Transport::HTTP::Client
@@ -28,7 +38,7 @@ module Datadog
       # Builds a new Transport::HTTP::Client with default settings
       # Pass a block to override any settings.
       def default(
-        agent_settings: Datadog::Core::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS,
+        agent_settings: DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS,
         **options
       )
         new do |transport|
@@ -78,7 +88,7 @@ module Datadog
           'be removed on a future ddtrace release.'
         )
 
-        Datadog::Core::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS.hostname
+        DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS.hostname
       end
 
       def default_port(logger: Datadog.logger)
@@ -87,7 +97,7 @@ module Datadog
           'be removed on a future ddtrace release.'
         )
 
-        Datadog::Core::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS.port
+        DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS.port
       end
 
       def default_url(logger: Datadog.logger)

--- a/spec/datadog/profiling/transport/http/integration_spec.rb
+++ b/spec/datadog/profiling/transport/http/integration_spec.rb
@@ -44,7 +44,10 @@ RSpec.describe 'Datadog::Profiling::Transport::HTTP integration tests' do
       context 'agent' do
         let(:options) do
           {
-            agent_settings: Datadog::Core::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS
+            agent_settings: Datadog::Core::Configuration::AgentSettingsResolver.call(
+              Datadog::Core::Configuration::Settings.new,
+              logger: nil,
+            )
           }
         end
 

--- a/spec/ddtrace/transport/http_spec.rb
+++ b/spec/ddtrace/transport/http_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe Datadog::Transport::HTTP do
 
   describe '.default' do
     subject(:default) { described_class.default }
-    let(:env_agent_settings) { Datadog::Core::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS }
+    let(:env_agent_settings) { described_class::DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS }
 
     # This test changes based on the environment tests are running. We have other
     # tests around each specific environment scenario, while this one specifically
     # ensures that we are matching the default environment settings.
     #
-    # TODO: we should deprecate the use of Datadog::Core::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS
+    # TODO: we should deprecate the use of DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS
     # and thus remove this test scenario.
     it 'returns a transport with default configuration' do
       is_expected.to be_a_kind_of(Datadog::Transport::Traces::Transport)
@@ -206,12 +206,12 @@ RSpec.describe Datadog::Transport::HTTP do
 
     before do
       stub_const(
-        'Datadog::Core::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS',
+        'Datadog::Transport::HTTP::DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS',
         instance_double(Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings, hostname: 'example-hostname')
       )
     end
 
-    it 'returns the hostname from the ENVIRONMENT_AGENT_SETTINGS object' do
+    it 'returns the hostname from the DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS object' do
       expect(default_hostname).to eq 'example-hostname'
     end
 
@@ -229,12 +229,12 @@ RSpec.describe Datadog::Transport::HTTP do
 
     before do
       stub_const(
-        'Datadog::Core::Configuration::AgentSettingsResolver::ENVIRONMENT_AGENT_SETTINGS',
+        'Datadog::Transport::HTTP::DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS',
         instance_double(Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings, port: 12345)
       )
     end
 
-    it 'returns the port from the ENVIRONMENT_AGENT_SETTINGS object' do
+    it 'returns the port from the DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS object' do
       expect(default_port).to eq 12345
     end
 


### PR DESCRIPTION
The `ENVIRONMENT_AGENT_SETTINGS` constant was introduced to support a few classes/specs that needed an `agent_settings` object  to fall back to.

Since there are so little users of this constant (which is good), let's remove it from the `AgentSettingsResolver` class and instead move it to the class/specs that make use of it.

This way, the weight of legacy/weird behavior is on the classes that need it, rather than on the `AgentSettingsResolver` class.