### PR TITLE
Enable extraction of http/unix adapter config from transport_options proc

### DIFF
--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -536,7 +536,10 @@ RSpec.describe 'Tracer integration tests' do
           double('on_build').tap do |double|
             expect(double).to receive(:call)
               .with(kind_of(Datadog::Transport::HTTP::Builder))
-              .at_least(1)
+              .at_least(1).time
+            expect(double).to receive(:call)
+              .with(kind_of(Datadog::Core::Configuration::AgentSettingsResolver::TransportOptionsResolver))
+              .at_least(1).time
           end
         end
 


### PR DESCRIPTION
As documented in the getting started guide (<https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#configuring-the-transport-layer>), one way of configuring ddtrace is to provide a proc as the `tracing.transport_options` configuration setting.

Up until now, the `AgentSettingsResolver` class effectively "gave up" when it saw one of these procs, and just included it the proc in its `AgentSettings` output.

This meant that:

a) If there were any invalid or conflicting settings, we could not detect or warn about them

b) We were in the dark on what settings actually were going to be used, since the proc could do anything it wanted. The `AgentSettings` object could be completely used or completely ignored.

c) It was hard to provide alternative transport implementations, because they may not be able to implement the full adapter configuration API expected by the user code. For instance, this is needed to implement unix domain socket support in the new profiler libddprof-based transport.

To fix this, I've implemented a very minimalistic approach: Inside the `AgentSettingsResolver` we try to execute the `transport_options` proc and see if all it does is configure an http or unix adapter. If so, success, we get its configuration and
no longer need to deal with the proc.

If the proc tries to do anything fancier (extra transport configuration or using a test or custom adapter), we just give up and retain the previous behavior.

Worst case, the previous behavior is retained exactly. Best case, we are able to parse the configuration correctly, and are able to do the usual validations and include it in the `AgentSettings` object.

Finally, yes, this does add more complexity to the `AgentSettingsResolver` but I claim that this complexity was already there, and now I've exposed it where it should be.

(P.s.: This relies on the refactoring in #1931)