### PR TITLE
Align env var with RFC

### DIFF
--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -94,7 +94,7 @@ module Datadog
 
         ENVS = {
           'DD_APPSEC_ENABLED' => [:enabled, Settings.boolean],
-          'DD_APPSEC_RULESET' => [:ruleset, Settings.string],
+          'DD_APPSEC_RULES' => [:ruleset, Settings.string],
           'DD_APPSEC_WAF_TIMEOUT' => [:waf_timeout, Settings.duration(:us)],
           'DD_APPSEC_WAF_DEBUG' => [:waf_debug, Settings.boolean],
           'DD_APPSEC_TRACE_RATE_LIMIT' => [:trace_rate_limit, Settings.integer],

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -1,0 +1,192 @@
+# typed: false
+
+require 'datadog/appsec/spec_helper'
+
+RSpec.describe Datadog::AppSec::Configuration::Settings do
+  shared_context 'registry with integration' do
+    let(:registry) { {} }
+    let(:integration_name) { :example }
+    let(:integration_options) { double('integration integration_options') }
+    let(:integration_class) { double('integration class', loaded?: false) }
+    let(:integration) do
+      instance_double(
+        Datadog::AppSec::Contrib::Integration::RegisteredIntegration,
+        klass: integration_class,
+        options: integration_options
+      )
+    end
+
+    before do
+      registry[integration_name] = integration
+
+      allow(Datadog::AppSec::Contrib::Integration).to receive(:registry).and_return(registry)
+    end
+  end
+
+  describe Datadog::AppSec::Configuration::Settings do
+    include_context 'registry with integration'
+
+    subject(:settings) { described_class.new }
+
+    let(:dsl) { Datadog::AppSec::Configuration::DSL.new }
+
+    after { settings.send(:reset!) }
+
+    describe '#enabled' do
+      subject(:enabled) { settings.enabled }
+      it { is_expected.to eq(true) }
+    end
+
+    describe '#enabled=' do
+      subject(:enabled_) { settings.merge(dsl.tap { |c| c.enabled = false }) }
+      it { expect { enabled_ }.to change { settings.enabled }.from(true).to(false) }
+    end
+
+    describe '#ruleset' do
+      subject(:ruleset) { settings.ruleset }
+      it { is_expected.to eq(:recommended) }
+    end
+
+    describe '#ruleset=' do
+      subject(:ruleset_) { settings.merge(dsl.tap { |c| c.ruleset = :risky }) }
+      it { expect { ruleset_ }.to change { settings.ruleset }.from(:recommended).to(:risky) }
+    end
+
+    describe '#waf_timeout' do
+      subject(:waf_timeout) { settings.waf_timeout }
+      it { is_expected.to eq(5000) }
+    end
+
+    describe '#waf_timeout=' do
+      subject(:waf_timeout_) { settings.merge(dsl.tap { |c| c.waf_timeout = 3 }) }
+      it { expect { waf_timeout_ }.to change { settings.waf_timeout }.from(5000).to(3) }
+    end
+
+    describe '#waf_debug' do
+      subject(:waf_debug) { settings.waf_debug }
+      it { is_expected.to eq(false) }
+    end
+
+    describe '#waf_debug=' do
+      subject(:waf_debug_) { settings.merge(dsl.tap { |c| c.waf_debug = true }) }
+      it { expect { waf_debug_ }.to change { settings.waf_debug }.from(false).to(true) }
+    end
+
+    describe '#trace_rate_limit' do
+      subject(:trace_rate_limit) { settings.trace_rate_limit }
+      it { is_expected.to eq(100) }
+    end
+
+    describe '#trace_rate_limit=' do
+      subject(:trace_rate_limit_) { settings.merge(dsl.tap { |c| c.trace_rate_limit = 2 }) }
+      it { expect { trace_rate_limit_ }.to change { settings.trace_rate_limit }.from(100).to(2) }
+    end
+
+    describe '#[]' do
+      describe 'when the integration exists' do
+        subject(:get) { settings[integration_name] }
+
+        let(:integration_options) { { foo: :bar } }
+
+        before { settings.merge(dsl.tap { |c| c.instrument(integration_name, integration_options) }) }
+
+        it 'retrieves the described configuration' do
+          is_expected.to eq(integration_options)
+        end
+      end
+
+      context 'when the integration doesn\'t exist' do
+        it do
+          expect { settings[:foobar] }.to raise_error(ArgumentError, /foobar/)
+        end
+      end
+    end
+
+    context 'with env vars' do
+      before do
+        stub_const('ENV', {})
+        allow(ENV).to receive(:[]).and_call_original
+      end
+
+      describe 'DD_APPSEC_ENABLED' do
+        before do
+          allow(ENV).to receive(:[]).with('DD_APPSEC_ENABLED').and_return('1')
+        end
+
+        describe '#enabled' do
+          subject(:enabled) { settings.enabled }
+          it { is_expected.to eq(true) }
+        end
+
+        describe '#enabled=' do
+          subject(:enabled_) { settings.merge(dsl.tap { |c| c.enabled = false }) }
+          it { expect { enabled_ }.to change { settings.enabled }.from(true).to(false) }
+        end
+      end
+
+      describe 'DD_APPSEC_RULES' do
+        before do
+          allow(ENV).to receive(:[]).with('DD_APPSEC_RULES').and_return('/some/path')
+        end
+
+        describe '#ruleset' do
+          subject(:ruleset) { settings.ruleset }
+          it { is_expected.to eq('/some/path') }
+        end
+
+        describe '#ruleset=' do
+          subject(:ruleset_) { settings.merge(dsl.tap { |c| c.ruleset = :risky }) }
+          it { expect { ruleset_ }.to change { settings.ruleset }.from('/some/path').to(:risky) }
+        end
+      end
+
+      describe 'DD_APPSEC_WAF_TIMEOUT' do
+        before do
+          allow(ENV).to receive(:[]).with('DD_APPSEC_WAF_TIMEOUT').and_return('42')
+        end
+
+        describe '#waf_timeout' do
+          subject(:waf_timeout) { settings.waf_timeout }
+          it { is_expected.to eq(42) }
+        end
+
+        describe '#waf_timeout=' do
+          subject(:waf_timeout_) { settings.merge(dsl.tap { |c| c.waf_timeout = 3 }) }
+          it { expect { waf_timeout_ }.to change { settings.waf_timeout }.from(42).to(3) }
+        end
+      end
+
+      describe 'DD_APPSEC_WAF_DEBUG' do
+        before do
+          allow(ENV).to receive(:[]).with('DD_APPSEC_WAF_DEBUG').and_return('1')
+        end
+
+        describe '#waf_debug' do
+          subject(:waf_debug) { settings.waf_debug }
+          it { is_expected.to eq(true) }
+        end
+
+        describe '#waf_debug=' do
+          subject(:waf_debug_) { settings.merge(dsl.tap { |c| c.waf_debug = false }) }
+          it { expect { waf_debug_ }.to change { settings.waf_debug }.from(true).to(false) }
+        end
+      end
+
+      describe 'DD_APPSEC_TRACE_RATE_LIMIT' do
+        before do
+          allow(ENV).to receive(:[]).with('DD_APPSEC_TRACE_RATE_LIMIT').and_return('1024')
+        end
+
+        describe '#trace_rate_limit' do
+          subject(:trace_rate_limit) { settings.trace_rate_limit }
+          it { is_expected.to eq(1024) }
+        end
+
+        describe '#trace_rate_limit=' do
+          subject(:trace_rate_limit_) { settings.merge(dsl.tap { |c| c.trace_rate_limit = 2 }) }
+          it { expect { trace_rate_limit_ }.to change { settings.trace_rate_limit }.from(1024).to(2) }
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/extensions_spec.rb
+++ b/spec/datadog/appsec/extensions_spec.rb
@@ -60,9 +60,7 @@ RSpec.describe Datadog::AppSec::Extensions do
 
       describe '#enabled=' do
         subject(:enabled_) { settings.enabled = false }
-        it do
-          expect { enabled_ }.to change { settings.enabled }.from(true).to(false)
-        end
+        it { expect { enabled_ }.to change { settings.enabled }.from(true).to(false) }
       end
 
       describe '#ruleset' do
@@ -71,8 +69,8 @@ RSpec.describe Datadog::AppSec::Extensions do
       end
 
       describe '#ruleset=' do
-        subject(:ruleset_) { settings.ruleset = :expert }
-        it { expect { ruleset_ }.to change { settings.ruleset }.from(:recommended).to(:expert) }
+        subject(:ruleset_) { settings.ruleset = :risky }
+        it { expect { ruleset_ }.to change { settings.ruleset }.from(:recommended).to(:risky) }
       end
 
       describe '#waf_timeout' do


### PR DESCRIPTION
Current RFC-defined env vars are:
-  `DD_APPSEC_ENABLED`
-  `DD_APPSEC_RULES` # This one is currently not compliant, which this PR addresses
-  `DD_APPSEC_WAF_TIMEOUT`