### PR TITLE
Update libddwaf to 1.2.1

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'debase-ruby_core_source', '<= 0.10.14'
 
   # Used by appsec
-  spec.add_dependency 'libddwaf', '~> 1.0.14.2.0.a'
+  spec.add_dependency 'libddwaf', '~> 1.2.1.0.0.a'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb']
 end

--- a/gemfiles/jruby_9.2.18.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -1401,7 +1401,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -62,7 +62,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     loofah (2.13.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.18.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     loofah (2.13.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.18.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     loofah (2.13.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.18.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -1401,7 +1401,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -62,7 +62,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     loofah (2.13.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.8.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     loofah (2.13.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.8.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.14)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     loofah (2.13.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.8.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.1.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -120,7 +120,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     makara (0.4.1)
       activerecord (>= 3.0.0)

--- a/gemfiles/ruby_2.1.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -36,7 +36,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -73,7 +73,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -70,7 +70,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.2.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -1262,7 +1262,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -36,7 +36,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -73,7 +73,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -70,7 +70,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -85,7 +85,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.3.8_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -1271,7 +1271,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.3.8_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -36,7 +36,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -54,7 +54,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -74,7 +74,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -73,7 +73,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -70,7 +70,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -85,7 +85,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -36,7 +36,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -36,7 +36,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.4.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -1315,7 +1315,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -40,7 +40,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.4.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -56,7 +56,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -76,7 +76,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.5.9_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -1316,7 +1316,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -51,7 +51,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.5.9_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -66,7 +66,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -109,7 +109,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -109,7 +109,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -109,7 +109,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -109,7 +109,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -109,7 +109,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)

--- a/gemfiles/ruby_2.6.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -1317,7 +1317,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -52,7 +52,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.6.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.6.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.6.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -1317,7 +1317,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -52,7 +52,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1)
+    libddwaf (1.2.1.0.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.7.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -1324,7 +1324,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.0.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.0.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -1372,7 +1372,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.1.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.1.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0.beta1)
       debase-ruby_core_source (<= 0.10.14)
-      libddwaf (~> 1.0.14.2.0.a)
+      libddwaf (~> 1.2.1.0.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.0.14.2.0.beta1-x86_64-linux)
+    libddwaf (1.2.1.0.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/lib/datadog/appsec/contrib/rack/reactive/request.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/request.rb
@@ -56,6 +56,8 @@ module Datadog
                 waf_timeout = Datadog::AppSec.settings.waf_timeout
                 action, result = waf_context.run(waf_args, waf_timeout)
 
+                Datadog.logger.debug { "WAF TIMEOUT: #{result.inspect}" } if result.timeout
+
                 # TODO: encapsulate return array in a type
                 case action
                 when :monitor
@@ -67,8 +69,6 @@ module Datadog
                   throw(:block, [action, result, true])
                 when :good
                   Datadog.logger.debug { "WAF OK: #{result.inspect}" }
-                when :timeout
-                  Datadog.logger.debug { "WAF TIMEOUT: #{result.inspect}" }
                 when :invalid_call
                   Datadog.logger.debug { "WAF CALL ERROR: #{result.inspect}" }
                 when :invalid_rule, :invalid_flow, :no_rule

--- a/lib/datadog/appsec/contrib/rack/reactive/response.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/response.rb
@@ -34,6 +34,8 @@ module Datadog
                 waf_timeout = Datadog::AppSec.settings.waf_timeout
                 action, result = waf_context.run(waf_args, waf_timeout)
 
+                Datadog.logger.debug { "WAF TIMEOUT: #{result.inspect}" } if result.timeout
+
                 # TODO: encapsulate return array in a type
                 case action
                 when :monitor
@@ -45,8 +47,6 @@ module Datadog
                   throw(:block, [action, result, true])
                 when :good
                   Datadog.logger.debug { "WAF OK: #{result.inspect}" }
-                when :timeout
-                  Datadog.logger.debug { "WAF TIMEOUT: #{result.inspect}" }
                 when :invalid_call
                   Datadog.logger.debug { "WAF CALL ERROR: #{result.inspect}" }
                 when :invalid_rule, :invalid_flow, :no_rule


### PR DESCRIPTION
Also adjusts for an API change regarding timeout reporting

libddwaf 1.2.1 adds more features, support for these extra features will be added in a subsequent PR.