### PR TITLE
Fix Grape raising error while tracing is disabled

### DIFF
--- a/lib/datadog/tracing/contrib/grape/endpoint.rb
+++ b/lib/datadog/tracing/contrib/grape/endpoint.rb
@@ -237,7 +237,8 @@ module Datadog
             end
 
             def enabled?
-              datadog_configuration[:enabled] == true
+              Datadog.configuration.tracing.enabled && \
+                datadog_configuration[:enabled] == true
             end
 
             def datadog_configuration

--- a/spec/datadog/tracing/contrib/grape/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/grape/tracer_spec.rb
@@ -589,6 +589,21 @@ RSpec.describe 'Grape instrumentation' do
         expect(trace.resource).to eq('TestingAPI GET /span_resource/span_resource')
       end
     end
+
+    context 'when tracing is disabled' do
+      subject(:response) { get '/base/success' }
+
+      before do
+        Datadog.configure { |c| c.tracing.enabled = false }
+        expect(Datadog.logger).to_not receive(:error)
+      end
+
+      it 'runs the endpoint request without tracing' do
+        is_expected.to be_ok
+        expect(response.body).to eq('OK')
+        expect(spans.length).to eq(0)
+      end
+    end
   end
 
   context 'with rack' do


### PR DESCRIPTION
Closes #1940 

When tracing is disabled, the `enabled?` function in Grape instrumentation was still evaluating to true, because it was only checking the Grape configuration setting. This would cause instrumentation to still run, but yield a `nil` trace and attempt to decorate it.

Updating `enabled?` to check for whether `tracing.enabled` is set fixes the issue.

It would be better in the future if setting `c.tracing.enabled` simply precluded all instrumentation blocks, but our API currently doesn't support this. Thus, instrumentation must check the state itself. Something to improve another time.