### PR TITLE
Fix Rake instrumenting while disabled

### DIFF
--- a/lib/datadog/tracing/contrib/rake/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/rake/instrumentation.rb
@@ -79,7 +79,8 @@ module Datadog
             end
 
             def enabled?
-              configuration[:enabled] == true
+              Datadog.configuration.tracing.enabled && \
+                configuration[:enabled] == true
             end
 
             def span_options

--- a/spec/datadog/tracing/contrib/rake/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/rake/instrumentation_spec.rb
@@ -385,6 +385,20 @@ RSpec.describe Datadog::Tracing::Contrib::Rake::Instrumentation do
         it_behaves_like 'a successful single task execution'
         it_behaves_like 'a failed single task execution'
       end
+
+      context 'when tracing is disabled' do
+        before do
+          Datadog.configure { |c| c.tracing.enabled = false }
+          expect(Datadog.logger).to_not receive(:error)
+          expect(Datadog::Tracing).to_not receive(:trace)
+          expect(spy).to receive(:call)
+        end
+
+        it 'runs the task without tracing' do
+          expect { invoke }.to_not raise_error
+          expect(spans.length).to eq(0)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Addresses #1940 

This pull request adds an additional safeguard to prevent Rake from instrumenting when tracing is disabled.

We will want to adjust the internals and API of the tracer to do this automatically later, but this will help in the interim.