### PR TITLE
AppSec: resist missing ruleset file

### DIFF
--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -22,7 +22,7 @@ module Datadog
 
             # TODO: handle exceptions, except for @app.call
 
-            context = @processor.context
+            context = @processor.new_context
 
             env['datadog.waf.context'] = context
             request = ::Rack::Request.new(env)
@@ -49,20 +49,6 @@ module Datadog
             AppSec::Event.record(*both_response.map { |_action, event| event }) if both_response.any?
 
             request_return
-          end
-
-          def libddwaf_required?
-            defined?(Datadog::AppSec::WAF)
-          end
-
-          def waf?
-            !@waf.nil?
-          end
-
-          def require_libddwaf
-            require 'libddwaf'
-          rescue LoadError => e
-            Datadog.logger.warn { "LoadError: libddwaf failed to load: #{e.message}" }
           end
         end
       end

--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -12,13 +12,16 @@ module Datadog
         def rewind; end
 
         def self.===(other)
-          instance_methods.reduce(true) { |ok, meth| ok && other.respond_to?(meth) }
+          instance_methods.all? { |meth| other.respond_to?(meth) }
         end
       end
 
       def initialize
+        @ruleset = nil
+        @handle = nil
+
         unless load_libddwaf && load_ruleset && create_waf_handle
-          Datadog.logger.warn { 'appsec is disabled, cause: errors' }
+          Datadog.logger.warn { 'AppSec is disabled, see logged errors above' }
         end
       end
 
@@ -26,7 +29,7 @@ module Datadog
         !@ruleset.nil? && !@handle.nil?
       end
 
-      def context
+      def new_context
         Datadog::AppSec::WAF::Context.new(@handle)
       end
 
@@ -56,7 +59,7 @@ module Datadog
           true
         rescue StandardError => e
           Datadog.logger.error do
-            "libddwaf ruleset failed to load, ruleset: #{ruleset_setting.inspect} error:#{e.inspect}"
+            "libddwaf ruleset failed to load, ruleset: #{ruleset_setting.inspect} error: #{e.inspect}"
           end
 
           false

--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -1,0 +1,113 @@
+# typed: ignore
+
+require 'datadog/appsec/assets'
+
+module Datadog
+  module AppSec
+    # Processor integrates libddwaf into datadog/appsec
+    class Processor
+      # Interface object to check using case .. when
+      module IOLike
+        def read; end
+        def rewind; end
+
+        def self.===(other)
+          instance_methods.reduce(true) { |ok, meth| ok && other.respond_to?(meth) }
+        end
+      end
+
+      def initialize
+        unless load_libddwaf && load_ruleset && create_waf_handle
+          Datadog.logger.warn { 'appsec is disabled, cause: errors' }
+        end
+      end
+
+      def ready?
+        !@ruleset.nil? && !@handle.nil?
+      end
+
+      def context
+        Datadog::AppSec::WAF::Context.new(@handle)
+      end
+
+      private
+
+      def load_libddwaf
+        Processor.require_libddwaf && Processor.libddwaf_required?
+      end
+
+      def load_ruleset
+        ruleset_setting = Datadog::AppSec.settings.ruleset
+
+        begin
+          @ruleset = case ruleset_setting
+                     when :recommended, :risky, :strict
+                       JSON.parse(Datadog::AppSec::Assets.waf_rules(ruleset_setting))
+                     when String
+                       JSON.parse(File.read(ruleset_setting))
+                     when IOLike
+                       JSON.parse(ruleset_setting.read).tap { ruleset_setting.rewind }
+                     when Hash
+                       ruleset_setting
+                     else
+                       raise ArgumentError, "unsupported value for ruleset setting: #{ruleset_setting.inspect}"
+                     end
+
+          true
+        rescue StandardError => e
+          Datadog.logger.error do
+            "libddwaf ruleset failed to load, ruleset: #{ruleset_setting.inspect} error:#{e.inspect}"
+          end
+
+          false
+        end
+      end
+
+      def create_waf_handle
+        Datadog::AppSec::WAF.logger = Datadog.logger if Datadog.logger.debug? && Datadog::AppSec.settings.waf_debug
+        @handle = Datadog::AppSec::WAF::Handle.new(@ruleset)
+
+        true
+      rescue StandardError => e
+        Datadog.logger.error do
+          "libddwaf failed to initialize, error: #{e.inspect}"
+        end
+
+        false
+      end
+
+      class << self
+        def libddwaf_required?
+          defined?(Datadog::AppSec::WAF) ? true : false
+        end
+
+        def require_libddwaf
+          Datadog.logger.debug { "libddwaf platform: #{libddwaf_platform}" }
+
+          require 'libddwaf'
+
+          true
+        rescue LoadError => e
+          Datadog.logger.error do
+            'libddwaf failed to load,' \
+              "installed platform: #{libddwaf_platform} ruby platforms: #{ruby_platforms} error: #{e.inspect}"
+          end
+
+          false
+        end
+
+        def libddwaf_spec
+          Gem.loaded_specs['libddwaf']
+        end
+
+        def libddwaf_platform
+          libddwaf_spec ? libddwaf_spec.platform.to_s : 'unknown'
+        end
+
+        def ruby_platforms
+          Gem.platforms.map(&:to_s)
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/processor_spec.rb
+++ b/spec/datadog/appsec/processor_spec.rb
@@ -5,6 +5,9 @@ require 'datadog/appsec/processor'
 
 RSpec.describe Datadog::AppSec::Processor do
   before do
+    # libddwaf is not available yet for JRuby
+    # These specs could be made to pass still via mocking and stubbing, but
+    # they'd require extensive mocking for little benefit
     skip 'disabled for Java' if RUBY_PLATFORM.include?('java')
 
     logger = double(Datadog::Core::Logger)
@@ -21,13 +24,13 @@ RSpec.describe Datadog::AppSec::Processor do
     it 'detects if the WAF is unavailable' do
       hide_const('Datadog::AppSec::WAF')
 
-      expect(described_class.libddwaf_required?).to be false
+      expect(described_class.libddwaf_provides_waf?).to be false
     end
 
     it 'detects if the WAF is available' do
       stub_const('Datadog::AppSec::WAF', Module.new)
 
-      expect(described_class.libddwaf_required?).to be true
+      expect(described_class.libddwaf_provides_waf?).to be true
     end
 
     it 'reports via return of libddwaf loading failure' do
@@ -186,7 +189,7 @@ RSpec.describe Datadog::AppSec::Processor do
     context 'when libddwaf fails to provide WAF' do
       before do
         expect(described_class).to receive(:require_libddwaf).and_return(true)
-        expect(described_class).to receive(:libddwaf_required?).and_return(false)
+        expect(described_class).to receive(:libddwaf_provides_waf?).and_return(false)
 
         expect(Datadog.logger).to receive(:warn)
       end

--- a/spec/datadog/appsec/processor_spec.rb
+++ b/spec/datadog/appsec/processor_spec.rb
@@ -1,0 +1,227 @@
+# typed: ignore
+
+require 'datadog/appsec/spec_helper'
+require 'datadog/appsec/processor'
+
+RSpec.describe Datadog::AppSec::Processor do
+  before do
+    skip 'disabled for Java' if RUBY_PLATFORM.include?('java')
+
+    logger = double(Datadog::Core::Logger)
+    allow(logger).to receive(:debug?).and_return true
+    allow(logger).to receive(:debug)
+    allow(logger).to receive(:info)
+    allow(logger).to receive(:warn)
+    allow(logger).to receive(:error)
+
+    allow(Datadog).to receive(:logger).and_return(logger)
+  end
+
+  context 'self' do
+    it 'detects if the WAF is unavailable' do
+      hide_const('Datadog::AppSec::WAF')
+
+      expect(described_class.libddwaf_required?).to be false
+    end
+
+    it 'detects if the WAF is available' do
+      stub_const('Datadog::AppSec::WAF', Module.new)
+
+      expect(described_class.libddwaf_required?).to be true
+    end
+
+    it 'reports via return of libddwaf loading failure' do
+      allow(Object).to receive(:require).with('libddwaf').and_raise(LoadError)
+
+      expect(described_class.require_libddwaf).to be false
+    end
+
+    it 'reports via return of libddwaf loading success (first require)' do
+      allow(Object).to receive(:require).with('libddwaf').and_return(true)
+
+      expect(described_class.require_libddwaf).to be true
+    end
+
+    it 'reports via return of libddwaf loading success (second require)' do
+      allow(Object).to receive(:require).with('libddwaf').and_return(false)
+
+      expect(described_class.require_libddwaf).to be true
+    end
+  end
+
+  describe '#load_libddwaf' do
+    context 'when LoadError is raised' do
+      before do
+        allow(Object).to receive(:require).with('libddwaf').and_raise(LoadError)
+      end
+
+      it { expect(described_class.new.send(:load_libddwaf)).to be false }
+    end
+
+    context 'when loaded but missing mandatory const' do
+      before do
+        allow(Object).to receive(:require).with('libddwaf').and_return(true)
+        hide_const('Datadog::AppSec::WAF')
+      end
+
+      it { expect(described_class.new.send(:load_libddwaf)).to be false }
+    end
+
+    context 'when loaded successfully' do
+      before do
+        allow(Object).to receive(:require).with('libddwaf').and_return(true)
+        stub_const('Datadog::AppSec::WAF', Module.new)
+      end
+
+      it { expect(described_class.new.send(:load_libddwaf)).to be true }
+    end
+  end
+
+  describe '#load_ruleset' do
+    before do
+      allow(Datadog::AppSec.settings).to receive(:ruleset).and_return(ruleset)
+    end
+
+    let(:basic_ruleset) do
+      {
+        'version' => '1.0',
+        'events' => [
+          {
+            'id' => 1,
+            'name' => 'Rule 1',
+            'tags' => { 'type' => 'flow1' },
+            'conditions' => [
+              { 'operation' => 'match_regex', 'parameters' => { 'inputs' => ['value2'], 'regex' => 'rule1' } },
+            ],
+            'action' => 'record',
+          }
+        ]
+      }
+    end
+
+    context 'when ruleset is default' do
+      let(:ruleset) { :recommended }
+
+      it { expect(described_class.new.send(:load_ruleset)).to be true }
+    end
+
+    context 'when ruleset is an existing path' do
+      let(:ruleset) { "#{__dir__}/../../../lib/datadog/appsec/assets/waf_rules/recommended.json" }
+
+      it { expect(described_class.new.send(:load_ruleset)).to be true }
+    end
+
+    context 'when ruleset is a non existing path' do
+      let(:ruleset) { '/does/not/exist' }
+
+      it { expect(described_class.new.send(:load_ruleset)).to be false }
+    end
+
+    context 'when ruleset is IO-like' do
+      let(:ruleset) { StringIO.new(JSON.dump(basic_ruleset)) }
+
+      it { expect(described_class.new.send(:load_ruleset)).to be true }
+    end
+
+    context 'when ruleset is Ruby' do
+      let(:ruleset) { basic_ruleset }
+
+      it { expect(described_class.new.send(:load_ruleset)).to be true }
+    end
+
+    context 'when ruleset is not parseable' do
+      let(:ruleset) { StringIO.new('this is not json') }
+
+      it { expect(described_class.new.send(:load_ruleset)).to be false }
+    end
+  end
+
+  describe '#create_waf_handle' do
+    let(:ruleset) { :recommended }
+
+    before do
+      allow(Datadog::AppSec.settings).to receive(:ruleset).and_return(ruleset)
+    end
+
+    context 'when ruleset is default' do
+      let(:ruleset) { :recommended }
+
+      it { expect(described_class.new.send(:create_waf_handle)).to be true }
+    end
+
+    context 'when ruleset is invalid' do
+      let(:ruleset) { { 'not' => 'valid' } }
+
+      it { expect(described_class.new.send(:create_waf_handle)).to be false }
+    end
+  end
+
+  describe '#initialize' do
+    let(:ruleset) { :recommended }
+
+    subject(:processor) { described_class.new }
+
+    before do
+      allow(Datadog::AppSec.settings).to receive(:ruleset).and_return(ruleset)
+    end
+
+    context 'when libddwaf fails to load' do
+      before do
+        expect(described_class).to receive(:require_libddwaf).and_return(false)
+
+        expect(Datadog.logger).to receive(:warn)
+      end
+
+      it { is_expected.to_not be_ready }
+    end
+
+    context 'when libddwaf fails to provide WAF' do
+      before do
+        expect(described_class).to receive(:require_libddwaf).and_return(true)
+        expect(described_class).to receive(:libddwaf_required?).and_return(false)
+
+        expect(Datadog.logger).to receive(:warn)
+      end
+
+      it { is_expected.to_not be_ready }
+    end
+
+    context 'when ruleset is a non existing path' do
+      let(:ruleset) { '/does/not/exist' }
+
+      before do
+        expect(Datadog.logger).to receive(:warn)
+      end
+
+      it { is_expected.to_not be_ready }
+    end
+
+    context 'when ruleset is not parseable' do
+      let(:ruleset) { StringIO.new('this is not json') }
+
+      before do
+        expect(Datadog.logger).to receive(:warn)
+      end
+
+      it { is_expected.to_not be_ready }
+    end
+
+    context 'when ruleset is invalid' do
+      let(:ruleset) { { 'not' => 'valid' } }
+
+      before do
+        expect(Datadog.logger).to receive(:warn)
+      end
+
+      it { is_expected.to_not be_ready }
+    end
+
+    context 'when things are OK' do
+      before do
+        expect(Datadog.logger).to_not receive(:warn)
+      end
+
+      it { is_expected.to be_ready }
+    end
+  end
+end

--- a/spec/datadog/appsec/processor_spec.rb
+++ b/spec/datadog/appsec/processor_spec.rb
@@ -31,19 +31,19 @@ RSpec.describe Datadog::AppSec::Processor do
     end
 
     it 'reports via return of libddwaf loading failure' do
-      allow(Object).to receive(:require).with('libddwaf').and_raise(LoadError)
+      allow(described_class).to receive(:require).with('libddwaf').and_raise(LoadError)
 
       expect(described_class.require_libddwaf).to be false
     end
 
     it 'reports via return of libddwaf loading success (first require)' do
-      allow(Object).to receive(:require).with('libddwaf').and_return(true)
+      allow(described_class).to receive(:require).with('libddwaf').and_return(true)
 
       expect(described_class.require_libddwaf).to be true
     end
 
     it 'reports via return of libddwaf loading success (second require)' do
-      allow(Object).to receive(:require).with('libddwaf').and_return(false)
+      allow(described_class).to receive(:require).with('libddwaf').and_return(false)
 
       expect(described_class.require_libddwaf).to be true
     end
@@ -102,6 +102,10 @@ RSpec.describe Datadog::AppSec::Processor do
     context 'when ruleset is default' do
       let(:ruleset) { :recommended }
 
+      before do
+        expect(Datadog::AppSec::Assets).to receive(:waf_rules).with(:recommended).and_call_original.twice
+      end
+
       it { expect(described_class.new.send(:load_ruleset)).to be true }
     end
 
@@ -145,6 +149,10 @@ RSpec.describe Datadog::AppSec::Processor do
 
     context 'when ruleset is default' do
       let(:ruleset) { :recommended }
+
+      before do
+        expect(Datadog::AppSec::Assets).to receive(:waf_rules).with(:recommended).and_call_original
+      end
 
       it { expect(described_class.new.send(:create_waf_handle)).to be true }
     end
@@ -218,6 +226,7 @@ RSpec.describe Datadog::AppSec::Processor do
 
     context 'when things are OK' do
       before do
+        expect(Datadog::AppSec::Assets).to receive(:waf_rules).with(:recommended).and_call_original
         expect(Datadog.logger).to_not receive(:warn)
       end
 


### PR DESCRIPTION
Adjusts the behaviour from raising an exception to outputting an error and allow the app to continue running. This also generalises the error management beyond a ruleset file being missing and also takes into account various invalid ruleset cases or libddwaf unavailability.

In these cases, in addition to the error, a warning is produced that alerts the user that AppSec is subsequently disabled.