### PR TITLE
Fix incorrect image used for testing Ruby 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -484,7 +484,7 @@ job_configuration:
   - &config-3_0
     <<: *filters_all_branches_and_tags
     ruby_version: '3.0'
-    image: ivoanjo/docker-library:ddtrace_rb_3_0_1
+    image: ivoanjo/docker-library:ddtrace_rb_3_0_3
   - &config-3_1
     <<: *filters_all_branches_and_tags
     ruby_version: '3.1'

--- a/gemfiles/ruby_3.0.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib.gemfile.lock
@@ -1284,7 +1284,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
-    ffi (1.15.4)
+    ffi (1.15.5)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake


### PR DESCRIPTION
In #1915 the Ruby 3.0 image was updated to 3.0.3 but I forgot to also update the image in `config.yml`.

I've double-checked, and I believe this was the only missing update.

This brings our CI back to beautiful green!