### PR TITLE
Document support for Ruby 3.1

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -109,7 +109,8 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
 
 | Type  | Documentation              | Version | Support type                         | Gem version support |
 | ----- | -------------------------- | -----   | ------------------------------------ | ------------------- |
-| MRI   | https://www.ruby-lang.org/ | 3.0     | Full                                 | Latest              |
+| MRI   | https://www.ruby-lang.org/ | 3.1     | Full                                 | Latest              |
+|       |                            | 3.0     | Full                                 | Latest              |
 |       |                            | 2.7     | Full                                 | Latest              |
 |       |                            | 2.6     | Full                                 | Latest              |
 |       |                            | 2.5     | Full                                 | Latest              |


### PR DESCRIPTION
We've been running Ruby 3.1 in CI since November 2021 (see #1779 and #1915) but we had not yet updated our docs to state our support for it.