### PR TITLE
Add setting a tag at the trace-level

### DIFF
--- a/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
@@ -27,7 +27,6 @@ module Datadog
                   # TODO: factor out
                   if defined?(Datadog::Tracing) && Datadog::Tracing.respond_to?(:active_span)
                     active_trace = Datadog::Tracing.active_trace
-                    root_span = active_trace.send(:root_span) if active_trace
                     active_span = Datadog::Tracing.active_span
 
                     Datadog.logger.debug { "active span: #{active_span.span_id}" } if active_span
@@ -45,7 +44,6 @@ module Datadog
                       event = {
                         waf_result: result,
                         trace: active_trace,
-                        root_span: root_span,
                         span: active_span,
                         request: request,
                         action: action
@@ -77,7 +75,6 @@ module Datadog
                   # TODO: factor out
                   if defined?(Datadog::Tracing) && Datadog::Tracing.respond_to?(:active_span)
                     active_trace = Datadog::Tracing.active_trace
-                    root_span = active_trace.send(:root_span) if active_trace
                     active_span = Datadog::Tracing.active_span
 
                     Datadog.logger.debug { "active span: #{active_span.span_id}" } if active_span
@@ -95,7 +92,6 @@ module Datadog
                       event = {
                         waf_result: result,
                         trace: active_trace,
-                        root_span: root_span,
                         span: active_span,
                         response: response,
                         action: action

--- a/lib/datadog/appsec/event.rb
+++ b/lib/datadog/appsec/event.rb
@@ -93,10 +93,10 @@ module Datadog
 
           # complex types are unsupported, we need to serialize to a string
           triggers = trace_tags.delete('_dd.appsec.triggers')
-          trace.send(:set_tag, '_dd.appsec.json', JSON.dump({ triggers: triggers }))
+          trace.set_tag('_dd.appsec.json', JSON.dump({ triggers: triggers }))
 
           trace_tags.each do |key, value|
-            trace.send(:set_tag, key, value.is_a?(String) ? value.encode('UTF-8') : value)
+            trace.set_tag(key, value.is_a?(String) ? value.encode('UTF-8') : value)
           end
         end
       end

--- a/lib/datadog/appsec/event.rb
+++ b/lib/datadog/appsec/event.rb
@@ -96,7 +96,7 @@ module Datadog
           trace.set_tag('_dd.appsec.json', JSON.dump({ triggers: triggers }))
 
           trace_tags.each do |key, value|
-            trace.set_tag(key, value.is_a?(String) ? value.encode('UTF-8') : value)
+            trace.set_tag(key, value)
           end
         end
       end

--- a/lib/datadog/appsec/event.rb
+++ b/lib/datadog/appsec/event.rb
@@ -43,26 +43,20 @@ module Datadog
       end
 
       # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
       def self.record_via_span(*events)
-        events.group_by { |e| e[:root_span] }.each do |root_span, event_group|
-          unless root_span
-            Datadog.logger.debug { "{ error: 'no root span: cannot record', event_group: #{event_group.inspect}}" }
+        events.group_by { |e| e[:trace] }.each do |trace, event_group|
+          unless trace
+            Datadog.logger.debug { "{ error: 'no trace: cannot record', event_group: #{event_group.inspect}}" }
             next
           end
 
-          # TODO: this is a hack but there is no API to do that
-          root_span_tags = root_span.send(:meta).keys
+          trace.keep!
 
           # prepare and gather tags to apply
-          root_tags = event_group.each_with_object({}) do |event, tags|
+          trace_tags = event_group.each_with_object({}) do |event, tags|
             span = event[:span]
-            trace = event[:trace]
 
-            if span
-              span.set_tag('appsec.event', 'true')
-              trace.keep!
-            end
+            span.set_tag('appsec.event', 'true') if span
 
             request = event[:request]
             response = event[:response]
@@ -98,16 +92,15 @@ module Datadog
           # apply tags to root span
 
           # complex types are unsupported, we need to serialize to a string
-          triggers = root_tags.delete('_dd.appsec.triggers')
-          root_span.set_tag('_dd.appsec.json', JSON.dump({ triggers: triggers }))
+          triggers = trace_tags.delete('_dd.appsec.triggers')
+          trace.send(:set_tag, '_dd.appsec.json', JSON.dump({ triggers: triggers }))
 
-          root_tags.each do |key, value|
-            root_span.set_tag(key, value.is_a?(String) ? value.encode('UTf-8') : value) unless root_span_tags.include?(key)
+          trace_tags.each do |key, value|
+            trace.send(:set_tag, key, value.is_a?(String) ? value.encode('UTF-8') : value)
           end
         end
       end
       # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/datadog/core/utils/safe_dup.rb
+++ b/lib/datadog/core/utils/safe_dup.rb
@@ -1,0 +1,27 @@
+# typed: false
+
+module Datadog
+  module Core
+    module Utils
+      # Helper methods for safer dup
+      module SafeDup
+        if RUBY_VERSION < '2.2' # nil.dup only fails in Ruby 2.1
+          # Ensures #initialize can call nil.dup safely
+          module RefineNil
+            refine NilClass do
+              def dup
+                self
+              end
+            end
+          end
+
+          using RefineNil
+        end
+
+        def self.frozen_or_dup(v)
+          v.frozen? ? v : v.dup
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/tracing/metadata.rb
+++ b/lib/datadog/tracing/metadata.rb
@@ -2,6 +2,7 @@
 
 require 'datadog/tracing/metadata/analytics'
 require 'datadog/tracing/metadata/tagging'
+require 'datadog/tracing/metadata/errors'
 
 module Datadog
   module Tracing
@@ -9,6 +10,7 @@ module Datadog
     module Metadata
       def self.included(base)
         base.include(Metadata::Tagging)
+        base.include(Metadata::Errors)
 
         # Additional extensions
         base.prepend(Metadata::Analytics)

--- a/lib/datadog/tracing/metadata/errors.rb
+++ b/lib/datadog/tracing/metadata/errors.rb
@@ -1,0 +1,24 @@
+# typed: false
+
+require 'datadog/core/error'
+
+require 'datadog/tracing/metadata/ext'
+
+module Datadog
+  module Tracing
+    module Metadata
+      # Adds error tagging behavior
+      # @public_api
+      module Errors
+        # Mark the span with the given error.
+        def set_error(e)
+          e = Core::Error.build_from(e)
+
+          set_tag(Ext::Errors::TAG_TYPE, e.type) unless e.type.empty?
+          set_tag(Ext::Errors::TAG_MSG, e.message) unless e.message.empty?
+          set_tag(Ext::Errors::TAG_STACK, e.backtrace) unless e.backtrace.empty?
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/tracing/metadata/tagging.rb
+++ b/lib/datadog/tracing/metadata/tagging.rb
@@ -1,6 +1,5 @@
 # typed: false
 
-require 'datadog/core/error'
 require 'datadog/core/environment/ext'
 
 require 'datadog/tracing/metadata/ext'
@@ -94,15 +93,6 @@ module Datadog
         # This method removes a metric for the given key. It acts like {#clear_tag}.
         def clear_metric(key)
           metrics.delete(key)
-        end
-
-        # Mark the span with the given error.
-        def set_error(e)
-          e = Core::Error.build_from(e)
-
-          set_tag(Ext::Errors::TAG_TYPE, e.type) unless e.type.empty?
-          set_tag(Ext::Errors::TAG_MSG, e.message) unless e.message.empty?
-          set_tag(Ext::Errors::TAG_STACK, e.backtrace) unless e.backtrace.empty?
         end
 
         protected

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -327,6 +327,10 @@ module Datadog
         @tags ||= {}
       end
 
+      def get_tag(key)
+        tags[key]
+      end
+
       def set_tag(key, value = nil)
         tags[key] = value
       end

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -412,7 +412,8 @@ module Datadog
           name: @name,
           resource: @resource,
           service: @service,
-          tags: meta.merge(metrics),
+          tags: meta,
+          metrics: metrics,
           root_span_id: !partial ? @root_span && @root_span.id : nil
         )
       end

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -9,7 +9,7 @@ require 'datadog/tracing/event'
 require 'datadog/tracing/span_operation'
 require 'datadog/tracing/trace_segment'
 require 'datadog/tracing/trace_digest'
-require 'datadog/tracing/metadata'
+require 'datadog/tracing/metadata/tagging'
 
 module Datadog
   module Tracing
@@ -25,7 +25,7 @@ module Datadog
     # rubocop:disable Metrics/ClassLength
     # @public_api
     class TraceOperation
-      include Metadata
+      include Metadata::Tagging
 
       DEFAULT_MAX_LENGTH = 100_000
 

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -67,7 +67,8 @@ module Datadog
         sampled: nil,
         sampling_priority: nil,
         service: nil,
-        tags: nil
+        tags: nil,
+        metrics: nil
       )
         # Attributes
         @events = events || Events.new
@@ -90,6 +91,7 @@ module Datadog
 
         # Generic tags
         set_tags(tags) if tags
+        set_tags(metrics) if metrics
 
         # State
         @root_span = nil
@@ -269,7 +271,8 @@ module Datadog
           sampled: @sampled,
           sampling_priority: @sampling_priority,
           service: (@service && @service.dup),
-          tags: @tags.dup
+          tags: meta.dup,
+          metrics: metrics.dup
         )
       end
 

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -9,6 +9,7 @@ require 'datadog/tracing/event'
 require 'datadog/tracing/span_operation'
 require 'datadog/tracing/trace_segment'
 require 'datadog/tracing/trace_digest'
+require 'datadog/tracing/metadata'
 
 module Datadog
   module Tracing
@@ -24,6 +25,8 @@ module Datadog
     # rubocop:disable Metrics/ClassLength
     # @public_api
     class TraceOperation
+      include Metadata
+
       DEFAULT_MAX_LENGTH = 100_000
 
       attr_accessor \
@@ -86,7 +89,7 @@ module Datadog
         @service = service
 
         # Generic tags
-        @tags = set_tags(tags)
+        set_tags(tags) if tags
 
         # State
         @root_span = nil
@@ -323,22 +326,6 @@ module Datadog
         :events,
         :root_span
 
-      def tags
-        @tags ||= {}
-      end
-
-      def get_tag(key)
-        tags[key]
-      end
-
-      def set_tag(key, value = nil)
-        tags[key] = value
-      end
-
-      def set_tags(tags)
-        (tags || {}).each { |k, v| set_tag(k, v) }
-      end
-
       def activate_span!(span_op)
         parent = @active_span
 
@@ -425,7 +412,7 @@ module Datadog
           name: @name,
           resource: @resource,
           service: @service,
-          tags: !partial ? @tags : nil,
+          tags: !partial ? meta.merge(metrics) : nil,
           root_span_id: !partial ? @root_span && @root_span.id : nil
         )
       end

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -412,7 +412,7 @@ module Datadog
           name: @name,
           resource: @resource,
           service: @service,
-          tags: !partial ? meta.merge(metrics) : nil,
+          tags: meta.merge(metrics),
           root_span_id: !partial ? @root_span && @root_span.id : nil
         )
       end

--- a/lib/datadog/tracing/trace_segment.rb
+++ b/lib/datadog/tracing/trace_segment.rb
@@ -18,7 +18,21 @@ module Datadog
 
       attr_reader \
         :id,
-        :spans
+        :spans,
+        :agent_sample_rate,
+        :hostname,
+        :id,
+        :lang,
+        :name,
+        :origin,
+        :process_id,
+        :rate_limiter_rate,
+        :resource,
+        :rule_sample_rate,
+        :runtime_id,
+        :sample_rate,
+        :sampling_priority,
+        :service
 
       if RUBY_VERSION < '2.2' # nil.dup only fails in Ruby 2.1
         # Ensures #initialize can call nil.dup safely
@@ -63,19 +77,21 @@ module Datadog
         @metrics = metrics || {}
 
         # Set well-known tags, defaulting to getting the values from tags
-        self.agent_sample_rate = agent_sample_rate || self.agent_sample_rate
-        self.hostname = hostname || self.hostname
-        self.lang = lang || self.lang
-        self.name = (name || self.name).tap { |v| break (v.frozen? ? v : v.dup) }
-        self.origin = (origin || self.origin).tap { |v| break (v.frozen? ? v : v.dup) }
-        self.process_id = process_id || self.process_id
-        self.rate_limiter_rate = rate_limiter_rate || self.rate_limiter_rate
-        self.resource = (resource || self.resource).tap { |v| break (v.frozen? ? v : v.dup) }
-        self.rule_sample_rate = rule_sample_rate || self.rule_sample_rate
-        self.runtime_id = runtime_id || self.runtime_id
-        self.sample_rate = sample_rate || self.sample_rate
-        self.sampling_priority = sampling_priority || self.sampling_priority
-        self.service = (service || self.service).tap { |v| break (v.frozen? ? v : v.dup) }
+        @agent_sample_rate = agent_sample_rate || agent_sample_rate_tag
+        @hostname = hostname || hostname_tag
+        @lang = lang || lang_tag
+        @name = (name || name_tag).tap { |v| break (v.frozen? ? v : v.dup) }
+        @origin = (origin || origin_tag).tap { |v| break (v.frozen? ? v : v.dup) }
+        @process_id = process_id || process_id_tag
+        @rate_limiter_rate = rate_limiter_rate || rate_limiter_rate_tag
+        @resource = (resource || resource_tag).tap { |v| break (v.frozen? ? v : v.dup) }
+        @rule_sample_rate = rule_sample_rate_tag || rule_sample_rate
+        @runtime_id = runtime_id || runtime_id_tag
+        @sample_rate = sample_rate || sample_rate_tag
+        @sampling_priority = sampling_priority || sampling_priority_tag
+        @service = (service || service_tag).tap { |v| break (v.frozen? ? v : v.dup) }
+
+        clear_known_tags
       end
 
       def any?
@@ -96,175 +112,6 @@ module Datadog
 
       def size
         @spans.size
-      end
-
-      def agent_sample_rate
-        metrics[Metadata::Ext::Sampling::TAG_AGENT_RATE]
-      end
-
-      def agent_sample_rate=(value)
-        if value.nil?
-          metrics.delete(Metadata::Ext::Sampling::TAG_AGENT_RATE)
-          return
-        end
-
-        metrics[Metadata::Ext::Sampling::TAG_AGENT_RATE] = value
-      end
-
-      def hostname
-        meta[Metadata::Ext::NET::TAG_HOSTNAME]
-      end
-
-      def hostname=(value)
-        if value.nil?
-          meta.delete(Metadata::Ext::NET::TAG_HOSTNAME)
-          return
-        end
-
-        meta[Metadata::Ext::NET::TAG_HOSTNAME] = value
-      end
-
-      def lang
-        meta[Core::Runtime::Ext::TAG_LANG]
-      end
-
-      def lang=(value)
-        if value.nil?
-          meta.delete(Core::Runtime::Ext::TAG_LANG)
-          return
-        end
-
-        meta[Core::Runtime::Ext::TAG_LANG] = value
-      end
-
-      def name
-        meta[TAG_NAME]
-      end
-
-      def name=(value)
-        if value.nil?
-          meta.delete(TAG_NAME)
-          return
-        end
-
-        meta[TAG_NAME] = value
-      end
-
-      def origin
-        meta[Metadata::Ext::Distributed::TAG_ORIGIN]
-      end
-
-      def origin=(value)
-        if value.nil?
-          meta.delete(Metadata::Ext::Distributed::TAG_ORIGIN)
-          return
-        end
-
-        meta[Metadata::Ext::Distributed::TAG_ORIGIN] = value
-      end
-
-      def process_id
-        meta[Core::Runtime::Ext::TAG_PID]
-      end
-
-      def process_id=(value)
-        if value.nil?
-          meta.delete(Core::Runtime::Ext::TAG_PID)
-          return
-        end
-
-        meta[Core::Runtime::Ext::TAG_PID] = value
-      end
-
-      def rate_limiter_rate
-        metrics[Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE]
-      end
-
-      def rate_limiter_rate=(value)
-        if value.nil?
-          metrics.delete(Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE)
-          return
-        end
-
-        metrics[Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE] = value
-      end
-
-      def resource
-        meta[TAG_RESOURCE]
-      end
-
-      def resource=(value)
-        if value.nil?
-          meta.delete(TAG_RESOURCE)
-          return
-        end
-
-        meta[TAG_RESOURCE] = value
-      end
-
-      def rule_sample_rate
-        metrics[Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE]
-      end
-
-      def rule_sample_rate=(value)
-        if value.nil?
-          metrics.delete(Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE)
-          return
-        end
-
-        metrics[Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE] = value
-      end
-
-      def runtime_id
-        meta[Core::Runtime::Ext::TAG_ID]
-      end
-
-      def runtime_id=(value)
-        if value.nil?
-          meta.delete(Core::Runtime::Ext::TAG_ID)
-          return
-        end
-
-        meta[Core::Runtime::Ext::TAG_ID] = value
-      end
-
-      def sample_rate
-        metrics[Metadata::Ext::Sampling::TAG_SAMPLE_RATE]
-      end
-
-      def sample_rate=(value)
-        if value.nil?
-          metrics.delete(Metadata::Ext::Sampling::TAG_SAMPLE_RATE)
-          return
-        end
-
-        metrics[Metadata::Ext::Sampling::TAG_SAMPLE_RATE] = value
-      end
-
-      def sampling_priority
-        meta[Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY]
-      end
-
-      def sampling_priority=(value)
-        if value.nil?
-          meta.delete(Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY)
-          return
-        end
-
-        meta[Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY] = value
-      end
-
-      def service
-        meta[TAG_SERVICE]
-      end
-
-      def service=(value)
-        if value.nil?
-          meta.delete(TAG_SERVICE)
-          return
-        end
-
-        meta[TAG_SERVICE] = value
       end
 
       # If an active trace is present, forces it to be retained by the Datadog backend.
@@ -296,6 +143,92 @@ module Datadog
         :root_span_id,
         :meta,
         :metrics
+
+      private
+
+      attr_writer \
+        :agent_sample_rate,
+        :hostname,
+        :id,
+        :lang,
+        :name,
+        :origin,
+        :process_id,
+        :rate_limiter_rate,
+        :resource,
+        :rule_sample_rate,
+        :runtime_id,
+        :sample_rate,
+        :sampling_priority,
+        :service
+
+      def agent_sample_rate_tag
+        metrics[Metadata::Ext::Sampling::TAG_AGENT_RATE]
+      end
+
+      def hostname_tag
+        meta[Metadata::Ext::NET::TAG_HOSTNAME]
+      end
+
+      def lang_tag
+        meta[Core::Runtime::Ext::TAG_LANG]
+      end
+
+      def name_tag
+        meta[TAG_NAME]
+      end
+
+      def origin_tag
+        meta[Metadata::Ext::Distributed::TAG_ORIGIN]
+      end
+
+      def process_id_tag
+        meta[Core::Runtime::Ext::TAG_PID]
+      end
+
+      def rate_limiter_rate_tag
+        metrics[Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE]
+      end
+
+      def resource_tag
+        meta[TAG_RESOURCE]
+      end
+
+      def rule_sample_rate_tag
+        metrics[Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE]
+      end
+
+      def runtime_id_tag
+        meta[Core::Runtime::Ext::TAG_ID]
+      end
+
+      def sample_rate_tag
+        metrics[Metadata::Ext::Sampling::TAG_SAMPLE_RATE]
+      end
+
+      def sampling_priority_tag
+        meta[Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY]
+      end
+
+      def service_tag
+        meta[TAG_SERVICE]
+      end
+
+      def clear_known_tags
+        metrics.delete(Metadata::Ext::Sampling::TAG_AGENT_RATE)
+        meta.delete(Metadata::Ext::NET::TAG_HOSTNAME)
+        meta.delete(Core::Runtime::Ext::TAG_LANG)
+        meta.delete(TAG_NAME)
+        meta.delete(Metadata::Ext::Distributed::TAG_ORIGIN)
+        meta.delete(Core::Runtime::Ext::TAG_PID)
+        metrics.delete(Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE)
+        meta.delete(TAG_RESOURCE)
+        metrics.delete(Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE)
+        meta.delete(Core::Runtime::Ext::TAG_ID)
+        metrics.delete(Metadata::Ext::Sampling::TAG_SAMPLE_RATE)
+        meta.delete(Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY)
+        meta.delete(TAG_SERVICE)
+      end
     end
     # rubocop:enable Metrics/ClassLength
   end

--- a/lib/datadog/tracing/trace_segment.rb
+++ b/lib/datadog/tracing/trace_segment.rb
@@ -12,8 +12,6 @@ module Datadog
     # @public_api
     # rubocop:disable Metrics/ClassLength
     class TraceSegment
-      include Metadata::Tagging
-
       TAG_NAME = 'name'.freeze
       TAG_RESOURCE = 'resource'.freeze
       TAG_SERVICE = 'service'.freeze
@@ -59,7 +57,10 @@ module Datadog
         @root_span_id = root_span_id
         @spans = spans || []
 
-        set_tags((tags || {}).merge(metrics || {}))
+        # Does not make an effort to move metrics out of tags
+        # The caller is expected to have done that
+        @meta = tags || {}
+        @metrics = metrics || {}
 
         # Set well-known tags
         self.agent_sample_rate = agent_sample_rate
@@ -98,172 +99,172 @@ module Datadog
       end
 
       def agent_sample_rate
-        get_metric(Metadata::Ext::Sampling::TAG_AGENT_RATE)
+        metrics[Metadata::Ext::Sampling::TAG_AGENT_RATE]
       end
 
       def agent_sample_rate=(value)
         if value.nil?
-          clear_metric(Metadata::Ext::Sampling::TAG_AGENT_RATE)
+          metrics.delete(Metadata::Ext::Sampling::TAG_AGENT_RATE)
           return
         end
 
-        set_metric(Metadata::Ext::Sampling::TAG_AGENT_RATE, value)
+        metrics[Metadata::Ext::Sampling::TAG_AGENT_RATE] = value
       end
 
       def hostname
-        get_tag(Metadata::Ext::NET::TAG_HOSTNAME)
+        meta[Metadata::Ext::NET::TAG_HOSTNAME]
       end
 
       def hostname=(value)
         if value.nil?
-          clear_tag(Metadata::Ext::NET::TAG_HOSTNAME)
+          meta.delete(Metadata::Ext::NET::TAG_HOSTNAME)
           return
         end
 
-        set_tag(Metadata::Ext::NET::TAG_HOSTNAME, value)
+        meta[Metadata::Ext::NET::TAG_HOSTNAME] = value
       end
 
       def lang
-        get_tag(Core::Runtime::Ext::TAG_LANG)
+        meta[Core::Runtime::Ext::TAG_LANG]
       end
 
       def lang=(value)
         if value.nil?
-          clear_tag(Core::Runtime::Ext::TAG_LANG)
+          meta.delete(Core::Runtime::Ext::TAG_LANG)
           return
         end
 
-        set_tag(Core::Runtime::Ext::TAG_LANG, value)
+        meta[Core::Runtime::Ext::TAG_LANG] = value
       end
 
       def name
-        get_tag(TAG_NAME)
+        meta[TAG_NAME]
       end
 
       def name=(value)
         if value.nil?
-          clear_tag(TAG_NAME)
+          meta.delete(TAG_NAME)
           return
         end
 
-        set_tag(TAG_NAME, value)
+        meta[TAG_NAME] = value
       end
 
       def origin
-        get_tag(Metadata::Ext::Distributed::TAG_ORIGIN)
+        meta[Metadata::Ext::Distributed::TAG_ORIGIN]
       end
 
       def origin=(value)
         if value.nil?
-          clear_tag(Metadata::Ext::Distributed::TAG_ORIGIN)
+          meta.delete(Metadata::Ext::Distributed::TAG_ORIGIN)
           return
         end
 
-        set_tag(Metadata::Ext::Distributed::TAG_ORIGIN, value)
+        meta[Metadata::Ext::Distributed::TAG_ORIGIN] = value
       end
 
       def process_id
-        get_tag(Core::Runtime::Ext::TAG_PID)
+        meta[Core::Runtime::Ext::TAG_PID]
       end
 
       def process_id=(value)
         if value.nil?
-          clear_tag(Core::Runtime::Ext::TAG_PID)
+          meta.delete(Core::Runtime::Ext::TAG_PID)
           return
         end
 
-        set_tag(Core::Runtime::Ext::TAG_PID, value)
+        meta[Core::Runtime::Ext::TAG_PID] = value
       end
 
       def rate_limiter_rate
-        get_metric(Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE)
+        metrics[Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE]
       end
 
       def rate_limiter_rate=(value)
         if value.nil?
-          clear_metric(Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE)
+          metrics.delete(Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE)
           return
         end
 
-        set_metric(Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE, value)
+        metrics[Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE] = value
       end
 
       def resource
-        get_tag(TAG_RESOURCE)
+        meta[TAG_RESOURCE]
       end
 
       def resource=(value)
         if value.nil?
-          clear_tag(TAG_RESOURCE)
+          meta.delete(TAG_RESOURCE)
           return
         end
 
-        set_tag(TAG_RESOURCE, value)
+        meta[TAG_RESOURCE] = value
       end
 
       def rule_sample_rate
-        get_metric(Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE)
+        metrics[Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE]
       end
 
       def rule_sample_rate=(value)
         if value.nil?
-          clear_metric(Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE)
+          metrics.delete(Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE)
           return
         end
 
-        set_metric(Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE, value)
+        metrics[Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE] = value
       end
 
       def runtime_id
-        get_tag(Core::Runtime::Ext::TAG_ID)
+        meta[Core::Runtime::Ext::TAG_ID]
       end
 
       def runtime_id=(value)
         if value.nil?
-          clear_tag(Core::Runtime::Ext::TAG_ID)
+          meta.delete(Core::Runtime::Ext::TAG_ID)
           return
         end
 
-        set_tag(Core::Runtime::Ext::TAG_ID, value)
+        meta[Core::Runtime::Ext::TAG_ID] = value
       end
 
       def sample_rate
-        get_metric(Metadata::Ext::Sampling::TAG_SAMPLE_RATE)
+        metrics[Metadata::Ext::Sampling::TAG_SAMPLE_RATE]
       end
 
       def sample_rate=(value)
         if value.nil?
-          clear_metric(Metadata::Ext::Sampling::TAG_SAMPLE_RATE)
+          metrics.delete(Metadata::Ext::Sampling::TAG_SAMPLE_RATE)
           return
         end
 
-        set_metric(Metadata::Ext::Sampling::TAG_SAMPLE_RATE, value)
+        metrics[Metadata::Ext::Sampling::TAG_SAMPLE_RATE] = value
       end
 
       def sampling_priority
-        get_tag(Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY)
+        meta[Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY]
       end
 
       def sampling_priority=(value)
         if value.nil?
-          clear_tag(Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY)
+          meta.delete(Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY)
           return
         end
 
-        set_tag(Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY, value)
+        meta[Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY] = value
       end
 
       def service
-        get_tag(TAG_SERVICE)
+        meta[TAG_SERVICE]
       end
 
       def service=(value)
         if value.nil?
-          clear_tag(TAG_SERVICE)
+          meta.delete(TAG_SERVICE)
           return
         end
 
-        set_tag(TAG_SERVICE, value)
+        meta[TAG_SERVICE] = value
       end
 
       # If an active trace is present, forces it to be retained by the Datadog backend.
@@ -292,7 +293,9 @@ module Datadog
       protected
 
       attr_reader \
-        :root_span_id
+        :root_span_id,
+        :meta,
+        :metrics
     end
     # rubocop:enable Metrics/ClassLength
   end

--- a/lib/datadog/tracing/trace_segment.rb
+++ b/lib/datadog/tracing/trace_segment.rb
@@ -18,20 +18,7 @@ module Datadog
 
       attr_reader \
         :id,
-        :spans,
-        :agent_sample_rate,
-        :hostname,
-        :lang,
-        :name,
-        :origin,
-        :process_id,
-        :rate_limiter_rate,
-        :resource,
-        :rule_sample_rate,
-        :runtime_id,
-        :sample_rate,
-        :sampling_priority,
-        :service
+        :spans
 
       if RUBY_VERSION < '2.2' # nil.dup only fails in Ruby 2.1
         # Ensures #initialize can call nil.dup safely
@@ -78,24 +65,74 @@ module Datadog
         @metrics = metrics || {}
 
         # Set well-known tags, defaulting to getting the values from tags
-        @agent_sample_rate = agent_sample_rate || agent_sample_rate_tag
-        @hostname = hostname || hostname_tag
-        @lang = lang || lang_tag
-        @name = (name || name_tag).tap { |v| break (v.frozen? ? v : v.dup) }
-        @origin = (origin || origin_tag).tap { |v| break (v.frozen? ? v : v.dup) }
-        @process_id = process_id || process_id_tag
-        @rate_limiter_rate = rate_limiter_rate || rate_limiter_rate_tag
-        @resource = (resource || resource_tag).tap { |v| break (v.frozen? ? v : v.dup) }
-        @rule_sample_rate = rule_sample_rate_tag || rule_sample_rate
-        @runtime_id = runtime_id || runtime_id_tag
-        @sample_rate = sample_rate || sample_rate_tag
-        @sampling_priority = sampling_priority || sampling_priority_tag
-        @service = (service || service_tag).tap { |v| break (v.frozen? ? v : v.dup) }
-
-        clear_known_tags
+        @agent_sample_rate = agent_sample_rate
+        @hostname = hostname
+        @lang = lang
+        @name = name.tap { |v| break (v.frozen? ? v : v.dup) }
+        @origin = origin.tap { |v| break (v.frozen? ? v : v.dup) }
+        @process_id = process_id
+        @rate_limiter_rate = rate_limiter_rate
+        @resource = resource.tap { |v| break (v.frozen? ? v : v.dup) }
+        @rule_sample_rate = rule_sample_rate
+        @runtime_id = runtime_id
+        @sample_rate = sample_rate
+        @sampling_priority = sampling_priority
+        @service = service.tap { |v| break (v.frozen? ? v : v.dup) }
       end
       # rubocop:enable Metrics/PerceivedComplexity
       # rubocop:enable Metrics/CyclomaticComplexity
+
+      def agent_sample_rate
+        @agent_sample_rate ||= agent_sample_rate_tag
+      end
+
+      def hostname
+        @hostname ||= hostname_tag
+      end
+
+      def lang
+        @lang ||= lang_tag
+      end
+
+      def name
+        @name ||= name_tag.tap { |v| break (v.frozen? ? v : v.dup) }
+      end
+
+      def origin
+        @origin ||= origin_tag.tap { |v| break (v.frozen? ? v : v.dup) }
+      end
+
+      def process_id
+        @process_id ||= process_id_tag
+      end
+
+      def rate_limiter_rate
+        @rate_limiter_rate ||= rate_limiter_rate_tag
+      end
+
+      def resource
+        @resource ||= resource_tag.tap { |v| break (v.frozen? ? v : v.dup) }
+      end
+
+      def rule_sample_rate
+        @rule_sample_rate ||= rule_sample_rate_tag
+      end
+
+      def runtime_id
+        @runtime_id ||= runtime_id_tag
+      end
+
+      def sample_rate
+        @sample_rate ||= sample_rate_tag
+      end
+
+      def sampling_priority
+        @sampling_priority ||= sampling_priority_tag
+      end
+
+      def service
+        @service ||= service_tag.tap { |v| break (v.frozen? ? v : v.dup) }
+      end
 
       def any?
         @spans.any?
@@ -152,7 +189,6 @@ module Datadog
       attr_writer \
         :agent_sample_rate,
         :hostname,
-        :id,
         :lang,
         :name,
         :origin,

--- a/lib/datadog/tracing/trace_segment.rb
+++ b/lib/datadog/tracing/trace_segment.rb
@@ -49,12 +49,13 @@ module Datadog
         runtime_id: nil,
         sample_rate: nil,
         sampling_priority: nil,
-        service: nil
+        service: nil,
+        tags: nil
       )
         @id = id
         @root_span_id = root_span_id
         @spans = spans || []
-        @tags = {}
+        @tags = tags || {}
 
         # Set well-known tags
         self.agent_sample_rate = agent_sample_rate

--- a/lib/datadog/tracing/trace_segment.rb
+++ b/lib/datadog/tracing/trace_segment.rb
@@ -79,8 +79,6 @@ module Datadog
         @sample_rate = sample_rate || sample_rate_tag
         @sampling_priority = sampling_priority || sampling_priority_tag
         @service = Core::Utils::SafeDup.frozen_or_dup(service || service_tag)
-
-        clear_known_tags
       end
       # rubocop:enable Metrics/PerceivedComplexity
       # rubocop:enable Metrics/CyclomaticComplexity
@@ -202,22 +200,6 @@ module Datadog
 
       def service_tag
         meta[TAG_SERVICE]
-      end
-
-      def clear_known_tags
-        metrics.delete(Metadata::Ext::Sampling::TAG_AGENT_RATE)
-        meta.delete(Metadata::Ext::NET::TAG_HOSTNAME)
-        meta.delete(Core::Runtime::Ext::TAG_LANG)
-        meta.delete(TAG_NAME)
-        meta.delete(Metadata::Ext::Distributed::TAG_ORIGIN)
-        meta.delete(Core::Runtime::Ext::TAG_PID)
-        metrics.delete(Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE)
-        meta.delete(TAG_RESOURCE)
-        metrics.delete(Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE)
-        meta.delete(Core::Runtime::Ext::TAG_ID)
-        metrics.delete(Metadata::Ext::Sampling::TAG_SAMPLE_RATE)
-        meta.delete(Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY)
-        meta.delete(TAG_SERVICE)
       end
     end
     # rubocop:enable Metrics/ClassLength

--- a/lib/datadog/tracing/trace_segment.rb
+++ b/lib/datadog/tracing/trace_segment.rb
@@ -62,20 +62,20 @@ module Datadog
         @meta = tags || {}
         @metrics = metrics || {}
 
-        # Set well-known tags
-        self.agent_sample_rate = agent_sample_rate
-        self.hostname = hostname
-        self.lang = lang
-        self.name = (name.frozen? ? name : name.dup)
-        self.origin = (origin.frozen? ? origin : origin.dup)
-        self.process_id = process_id
-        self.rate_limiter_rate = rate_limiter_rate
-        self.resource = (resource.frozen? ? resource : resource.dup)
-        self.rule_sample_rate = rule_sample_rate
-        self.runtime_id = runtime_id
-        self.sample_rate = sample_rate
-        self.sampling_priority = sampling_priority
-        self.service = (service.frozen? ? service : service.dup)
+        # Set well-known tags, defaulting to getting the values from tags
+        self.agent_sample_rate = agent_sample_rate || self.agent_sample_rate
+        self.hostname = hostname || self.hostname
+        self.lang = lang || self.lang
+        self.name = (name || self.name).tap { |v| break (v.frozen? ? v : v.dup) }
+        self.origin = (origin || self.origin).tap { |v| break (v.frozen? ? v : v.dup) }
+        self.process_id = process_id || self.process_id
+        self.rate_limiter_rate = rate_limiter_rate || self.rate_limiter_rate
+        self.resource = (resource || self.resource).tap { |v| break (v.frozen? ? v : v.dup) }
+        self.rule_sample_rate = rule_sample_rate || self.rule_sample_rate
+        self.runtime_id = runtime_id || self.runtime_id
+        self.sample_rate = sample_rate || self.sample_rate
+        self.sampling_priority = sampling_priority || self.sampling_priority
+        self.service = (service || self.service).tap { |v| break (v.frozen? ? v : v.dup) }
       end
 
       def any?

--- a/lib/datadog/tracing/trace_segment.rb
+++ b/lib/datadog/tracing/trace_segment.rb
@@ -21,7 +21,6 @@ module Datadog
         :spans,
         :agent_sample_rate,
         :hostname,
-        :id,
         :lang,
         :name,
         :origin,
@@ -47,6 +46,8 @@ module Datadog
         using RefineNil
       end
 
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/PerceivedComplexity
       def initialize(
         spans,
         agent_sample_rate: nil,
@@ -93,6 +94,8 @@ module Datadog
 
         clear_known_tags
       end
+      # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       def any?
         @spans.any?

--- a/lib/datadog/tracing/trace_segment.rb
+++ b/lib/datadog/tracing/trace_segment.rb
@@ -4,6 +4,7 @@ require 'datadog/core/runtime/ext'
 
 require 'datadog/tracing/sampling/ext'
 require 'datadog/tracing/metadata/ext'
+require 'datadog/tracing/metadata/tagging'
 
 module Datadog
   module Tracing
@@ -11,14 +12,15 @@ module Datadog
     # @public_api
     # rubocop:disable Metrics/ClassLength
     class TraceSegment
+      include Metadata::Tagging
+
       TAG_NAME = 'name'.freeze
       TAG_RESOURCE = 'resource'.freeze
       TAG_SERVICE = 'service'.freeze
 
       attr_reader \
         :id,
-        :spans,
-        :tags
+        :spans
 
       if RUBY_VERSION < '2.2' # nil.dup only fails in Ruby 2.1
         # Ensures #initialize can call nil.dup safely
@@ -50,12 +52,14 @@ module Datadog
         sample_rate: nil,
         sampling_priority: nil,
         service: nil,
-        tags: nil
+        tags: nil,
+        metrics: nil
       )
         @id = id
         @root_span_id = root_span_id
         @spans = spans || []
-        @tags = tags || {}
+
+        set_tags((tags || {}).merge(metrics || {}))
 
         # Set well-known tags
         self.agent_sample_rate = agent_sample_rate
@@ -94,172 +98,172 @@ module Datadog
       end
 
       def agent_sample_rate
-        tags[Metadata::Ext::Sampling::TAG_AGENT_RATE]
+        get_metric(Metadata::Ext::Sampling::TAG_AGENT_RATE)
       end
 
       def agent_sample_rate=(value)
         if value.nil?
-          tags.delete(Metadata::Ext::Sampling::TAG_AGENT_RATE)
+          clear_metric(Metadata::Ext::Sampling::TAG_AGENT_RATE)
           return
         end
 
-        tags[Metadata::Ext::Sampling::TAG_AGENT_RATE] = value
+        set_metric(Metadata::Ext::Sampling::TAG_AGENT_RATE, value)
       end
 
       def hostname
-        tags[Metadata::Ext::NET::TAG_HOSTNAME]
+        get_tag(Metadata::Ext::NET::TAG_HOSTNAME)
       end
 
       def hostname=(value)
         if value.nil?
-          tags.delete(Metadata::Ext::NET::TAG_HOSTNAME)
+          clear_tag(Metadata::Ext::NET::TAG_HOSTNAME)
           return
         end
 
-        tags[Metadata::Ext::NET::TAG_HOSTNAME] = value
+        set_tag(Metadata::Ext::NET::TAG_HOSTNAME, value)
       end
 
       def lang
-        tags[Core::Runtime::Ext::TAG_LANG]
+        get_tag(Core::Runtime::Ext::TAG_LANG)
       end
 
       def lang=(value)
         if value.nil?
-          tags.delete(Core::Runtime::Ext::TAG_LANG)
+          clear_tag(Core::Runtime::Ext::TAG_LANG)
           return
         end
 
-        tags[Core::Runtime::Ext::TAG_LANG] = value
+        set_tag(Core::Runtime::Ext::TAG_LANG, value)
       end
 
       def name
-        tags[TAG_NAME]
+        get_tag(TAG_NAME)
       end
 
       def name=(value)
         if value.nil?
-          tags.delete(TAG_NAME)
+          clear_tag(TAG_NAME)
           return
         end
 
-        tags[TAG_NAME] = value
+        set_tag(TAG_NAME, value)
       end
 
       def origin
-        tags[Metadata::Ext::Distributed::TAG_ORIGIN]
+        get_tag(Metadata::Ext::Distributed::TAG_ORIGIN)
       end
 
       def origin=(value)
         if value.nil?
-          tags.delete(Metadata::Ext::Distributed::TAG_ORIGIN)
+          clear_tag(Metadata::Ext::Distributed::TAG_ORIGIN)
           return
         end
 
-        tags[Metadata::Ext::Distributed::TAG_ORIGIN] = value
+        set_tag(Metadata::Ext::Distributed::TAG_ORIGIN, value)
       end
 
       def process_id
-        tags[Core::Runtime::Ext::TAG_PID]
+        get_tag(Core::Runtime::Ext::TAG_PID)
       end
 
       def process_id=(value)
         if value.nil?
-          tags.delete(Core::Runtime::Ext::TAG_PID)
+          clear_tag(Core::Runtime::Ext::TAG_PID)
           return
         end
 
-        tags[Core::Runtime::Ext::TAG_PID] = value
+        set_tag(Core::Runtime::Ext::TAG_PID, value)
       end
 
       def rate_limiter_rate
-        tags[Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE]
+        get_metric(Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE)
       end
 
       def rate_limiter_rate=(value)
         if value.nil?
-          tags.delete(Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE)
+          clear_metric(Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE)
           return
         end
 
-        tags[Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE] = value
+        set_metric(Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE, value)
       end
 
       def resource
-        tags[TAG_RESOURCE]
+        get_tag(TAG_RESOURCE)
       end
 
       def resource=(value)
         if value.nil?
-          tags.delete(TAG_RESOURCE)
+          clear_tag(TAG_RESOURCE)
           return
         end
 
-        tags[TAG_RESOURCE] = value
+        set_tag(TAG_RESOURCE, value)
       end
 
       def rule_sample_rate
-        tags[Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE]
+        get_metric(Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE)
       end
 
       def rule_sample_rate=(value)
         if value.nil?
-          tags.delete(Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE)
+          clear_metric(Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE)
           return
         end
 
-        tags[Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE] = value
+        set_metric(Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE, value)
       end
 
       def runtime_id
-        tags[Core::Runtime::Ext::TAG_ID]
+        get_tag(Core::Runtime::Ext::TAG_ID)
       end
 
       def runtime_id=(value)
         if value.nil?
-          tags.delete(Core::Runtime::Ext::TAG_ID)
+          clear_tag(Core::Runtime::Ext::TAG_ID)
           return
         end
 
-        tags[Core::Runtime::Ext::TAG_ID] = value
+        set_tag(Core::Runtime::Ext::TAG_ID, value)
       end
 
       def sample_rate
-        tags[Metadata::Ext::Sampling::TAG_SAMPLE_RATE]
+        get_metric(Metadata::Ext::Sampling::TAG_SAMPLE_RATE)
       end
 
       def sample_rate=(value)
         if value.nil?
-          tags.delete(Metadata::Ext::Sampling::TAG_SAMPLE_RATE)
+          clear_metric(Metadata::Ext::Sampling::TAG_SAMPLE_RATE)
           return
         end
 
-        tags[Metadata::Ext::Sampling::TAG_SAMPLE_RATE] = value
+        set_metric(Metadata::Ext::Sampling::TAG_SAMPLE_RATE, value)
       end
 
       def sampling_priority
-        tags[Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY]
+        get_tag(Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY)
       end
 
       def sampling_priority=(value)
         if value.nil?
-          tags.delete(Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY)
+          clear_tag(Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY)
           return
         end
 
-        tags[Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY] = value
+        set_tag(Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY, value)
       end
 
       def service
-        tags[TAG_SERVICE]
+        get_tag(TAG_SERVICE)
       end
 
       def service=(value)
         if value.nil?
-          tags.delete(TAG_SERVICE)
+          clear_tag(TAG_SERVICE)
           return
         end
 
-        tags[TAG_SERVICE] = value
+        set_tag(TAG_SERVICE, value)
       end
 
       # If an active trace is present, forces it to be retained by the Datadog backend.

--- a/lib/ddtrace/transport/trace_formatter.rb
+++ b/lib/ddtrace/transport/trace_formatter.rb
@@ -32,6 +32,11 @@ module Datadog
         # trace metadata, we must put our trace
         # metadata on the root span. This "root span"
         # is needed by the agent/API to ingest the trace.
+
+        # Apply generic trace tags. Any more specific value will be overridden
+        # by the subsequent calls below.
+        set_trace_tags!
+
         set_resource!
 
         tag_agent_sample_rate!
@@ -57,6 +62,10 @@ module Datadog
         return if trace.resource.nil? || !@found_root_span
 
         root_span.resource = trace.resource
+      end
+
+      def set_trace_tags!
+        root_span.set_tags(trace.tags)
       end
 
       def tag_agent_sample_rate!

--- a/lib/ddtrace/transport/trace_formatter.rb
+++ b/lib/ddtrace/transport/trace_formatter.rb
@@ -70,7 +70,7 @@ module Datadog
         # trace.
         return if !@found_root_span
 
-        root_span.set_tags(trace.tags)
+        root_span.set_tags(trace.send(:meta).merge(trace.send(:metrics)))
       end
 
       def tag_agent_sample_rate!

--- a/lib/ddtrace/transport/trace_formatter.rb
+++ b/lib/ddtrace/transport/trace_formatter.rb
@@ -59,7 +59,7 @@ module Datadog
         # If the trace resource is undefined, or the root span wasn't
         # specified, don't set this. We don't want to overwrite the
         # resource of a span that is in the middle of the trace.
-        return if trace.resource.nil? || !@found_root_span
+        return if trace.resource.nil? || partial?
 
         root_span.resource = trace.resource
       end
@@ -68,7 +68,7 @@ module Datadog
         # If the root span wasn't specified, don't set this. We don't want to
         # misset or overwrite the tags of a span that is in the middle of the
         # trace.
-        return if !@found_root_span
+        return if partial?
 
         root_span.set_tags(trace.send(:meta).merge(trace.send(:metrics)))
       end
@@ -164,6 +164,10 @@ module Datadog
       end
 
       private
+
+      def partial?
+        !@found_root_span
+      end
 
       def find_root_span(trace)
         # TODO: Should we memoize this?

--- a/lib/ddtrace/transport/trace_formatter.rb
+++ b/lib/ddtrace/transport/trace_formatter.rb
@@ -70,7 +70,8 @@ module Datadog
         # trace.
         return if partial?
 
-        root_span.set_tags(trace.send(:meta).merge(trace.send(:metrics)))
+        root_span.set_tags(trace.send(:meta))
+        root_span.set_tags(trace.send(:metrics))
       end
 
       def tag_agent_sample_rate!

--- a/lib/ddtrace/transport/trace_formatter.rb
+++ b/lib/ddtrace/transport/trace_formatter.rb
@@ -65,6 +65,11 @@ module Datadog
       end
 
       def set_trace_tags!
+        # If the root span wasn't specified, don't set this. We don't want to
+        # misset or overwrite the tags of a span that is in the middle of the
+        # trace.
+        return if !@found_root_span
+
         root_span.set_tags(trace.tags)
       end
 
@@ -168,6 +173,8 @@ module Datadog
         root_span_id = trace.send(:root_span_id)
         root_span = trace.spans.find { |s| s.id == root_span_id } if root_span_id
         @found_root_span = !root_span.nil?
+
+        # when root span is not found, fall back to last span (partial flush)
         root_span || trace.spans.last
       end
     end

--- a/spec/datadog/tracing/metadata/errors_spec.rb
+++ b/spec/datadog/tracing/metadata/errors_spec.rb
@@ -1,0 +1,35 @@
+# typed: ignore
+
+require 'spec_helper'
+
+require 'datadog/tracing/metadata/tagging'
+require 'datadog/tracing/metadata/errors'
+
+RSpec.describe Datadog::Tracing::Metadata::Errors do
+  subject(:test_object) { test_class.new }
+  let(:test_class) do
+    Class.new do
+      include Datadog::Tracing::Metadata::Tagging
+      include Datadog::Tracing::Metadata::Errors
+    end
+  end
+
+  describe '#set_error' do
+    subject(:set_error) { test_object.set_error(error) }
+
+    let(:error) { RuntimeError.new('oops') }
+    let(:backtrace) { %w[method1 method2 method3] }
+
+    before { error.set_backtrace(backtrace) }
+
+    it do
+      set_error
+
+      expect(test_object).to have_error_message('oops')
+      expect(test_object).to have_error_type('RuntimeError')
+      backtrace.each do |method|
+        expect(test_object).to have_error_stack(include(method))
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/metadata/tagging_spec.rb
+++ b/spec/datadog/tracing/metadata/tagging_spec.rb
@@ -352,23 +352,4 @@ RSpec.describe Datadog::Tracing::Metadata::Tagging do
       expect(test_object.send(:metrics)).to_not have_key(key)
     end
   end
-
-  describe '#set_error' do
-    subject(:set_error) { test_object.set_error(error) }
-
-    let(:error) { RuntimeError.new('oops') }
-    let(:backtrace) { %w[method1 method2 method3] }
-
-    before { error.set_backtrace(backtrace) }
-
-    it do
-      set_error
-
-      expect(test_object).to have_error_message('oops')
-      expect(test_object).to have_error_type('RuntimeError')
-      backtrace.each do |method|
-        expect(test_object).to have_error_stack(include(method))
-      end
-    end
-  end
 end

--- a/spec/datadog/tracing/metadata_spec.rb
+++ b/spec/datadog/tracing/metadata_spec.rb
@@ -3,8 +3,6 @@
 require 'spec_helper'
 
 require 'datadog/tracing/metadata'
-require 'datadog/tracing/metadata/analytics'
-require 'datadog/tracing/metadata/tagging'
 
 RSpec.describe Datadog::Tracing::Metadata do
   context 'when included' do
@@ -16,7 +14,8 @@ RSpec.describe Datadog::Tracing::Metadata do
       it 'has all of the tagging behavior in correct order' do
         expect(ancestors.first(5)).to include(
           described_class::Analytics,
-          described_class::Tagging
+          described_class::Tagging,
+          described_class::Errors
         )
       end
     end

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -789,6 +789,28 @@ RSpec.describe Datadog::Tracing::TraceOperation do
     end
   end
 
+  describe '#set_metric' do
+    it 'sets metrics' do
+      trace_op.send(:set_metric, 'foo', 42)
+      trace_op.measure('top') {}
+
+      trace = trace_op.flush!
+
+      expect(trace.tags).to include('foo' => 42)
+    end
+  end
+
+  describe '#set_error' do
+    it 'sets errors' do
+      trace_op.send(:set_error, Exception.new('foo'))
+      trace_op.measure('top') {}
+
+      trace = trace_op.flush!
+
+      expect(trace.tags).to include('error.msg' => 'foo', 'error.type' => 'Exception')
+    end
+  end
+
   describe '#set_tag' do
     it 'sets tag on trace before a measurement' do
       trace_op.send(:set_tag, 'foo', 'bar')
@@ -830,6 +852,33 @@ RSpec.describe Datadog::Tracing::TraceOperation do
       expect(trace.spans).to have(2).items
       expect(trace.spans.map(&:name)).to include('parent')
       expect(trace.tags).to include('foo' => 'bar')
+    end
+
+    it 'sets metrics' do
+      trace_op.send(:set_tag, 'foo', 42)
+      trace_op.measure('top') {}
+
+      trace = trace_op.flush!
+
+      expect(trace.tags).to include('foo' => 42)
+    end
+
+    it 'sets analytics enabled' do
+      trace_op.send(:set_tag, Datadog::Tracing::Metadata::Ext::Analytics::TAG_ENABLED, true)
+      trace_op.measure('top') {}
+
+      trace = trace_op.flush!
+
+      expect(trace.tags).to include(Datadog::Tracing::Metadata::Ext::Analytics::TAG_SAMPLE_RATE => 1.0)
+    end
+
+    it 'sets analytics sample rate' do
+      trace_op.send(:set_tag, Datadog::Tracing::Metadata::Ext::Analytics::TAG_SAMPLE_RATE, 42)
+      trace_op.measure('top') {}
+
+      trace = trace_op.flush!
+
+      expect(trace.tags).to include(Datadog::Tracing::Metadata::Ext::Analytics::TAG_SAMPLE_RATE => 42.0)
     end
 
     context 'with partial flushing' do

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -781,11 +781,11 @@ RSpec.describe Datadog::Tracing::TraceOperation do
     end
 
     it 'gets tag set on trace' do
-      expect(trace_op.send(:get_tag, 'foo')).to eq('bar')
+      expect(trace_op.get_tag('foo')).to eq('bar')
     end
 
     it 'gets unset tag as nil' do
-      expect(trace_op.send(:get_tag, 'unset')).to be_nil
+      expect(trace_op.get_tag('unset')).to be_nil
     end
   end
 
@@ -796,7 +796,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
       trace = trace_op.flush!
 
-      expect(trace.tags).to include('foo' => 42)
+      expect(trace.get_metric('foo')).to eq(42)
     end
   end
 
@@ -807,7 +807,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
       trace = trace_op.flush!
 
-      expect(trace.tags).to include('foo' => 'bar')
+      expect(trace.get_tag('foo')).to eq('bar')
     end
 
     it 'sets tag on trace after a measurement' do
@@ -816,7 +816,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
       trace = trace_op.flush!
 
-      expect(trace.tags).to include('foo' => 'bar')
+      expect(trace.get_tag('foo')).to eq('bar')
     end
 
     it 'sets tag on trace from a measurement' do
@@ -826,7 +826,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
       trace = trace_op.flush!
 
-      expect(trace.tags).to include('foo' => 'bar')
+      expect(trace.get_tag('foo')).to eq('bar')
     end
 
     it 'sets tag on trace from a nested measurement' do
@@ -840,7 +840,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
       expect(trace.spans).to have(2).items
       expect(trace.spans.map(&:name)).to include('parent')
-      expect(trace.tags).to include('foo' => 'bar')
+      expect(trace.get_tag('foo')).to eq('bar')
     end
 
     it 'sets metrics' do
@@ -849,7 +849,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
       trace = trace_op.flush!
 
-      expect(trace.tags).to include('foo' => 42)
+      expect(trace.get_metric('foo')).to eq(42)
     end
 
     context 'with partial flushing' do
@@ -866,12 +866,12 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
         expect(trace.spans).to have(1).items
         expect(trace.spans.map(&:name)).to include('parent')
-        expect(trace.tags).to include('foo' => 'bar')
+        expect(trace.get_tag('foo')).to eq('bar')
 
         final_flush = trace_op.flush!
         expect(final_flush.spans).to have(1).items
         expect(final_flush.spans.map(&:name)).to include('grandparent')
-        expect(final_flush.tags).to include('foo' => 'bar')
+        expect(final_flush.get_tag('foo')).to eq('bar')
       end
     end
   end

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -777,7 +777,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
   describe '#get_tag' do
     before do
-      trace_op.send(:set_tag, 'foo', 'bar')
+      trace_op.set_tag('foo', 'bar')
     end
 
     it 'gets tag set on trace' do
@@ -791,7 +791,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
   describe '#set_metric' do
     it 'sets metrics' do
-      trace_op.send(:set_metric, 'foo', 42)
+      trace_op.set_metric('foo', 42)
       trace_op.measure('top') {}
 
       trace = trace_op.flush!
@@ -802,7 +802,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
   describe '#set_tag' do
     it 'sets tag on trace before a measurement' do
-      trace_op.send(:set_tag, 'foo', 'bar')
+      trace_op.set_tag('foo', 'bar')
       trace_op.measure('top') {}
 
       trace = trace_op.flush!
@@ -812,7 +812,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
     it 'sets tag on trace after a measurement' do
       trace_op.measure('top') {}
-      trace_op.send(:set_tag, 'foo', 'bar')
+      trace_op.set_tag('foo', 'bar')
 
       trace = trace_op.flush!
 
@@ -821,7 +821,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
     it 'sets tag on trace from a measurement' do
       trace_op.measure('top') do
-        trace_op.send(:set_tag, 'foo', 'bar')
+        trace_op.set_tag('foo', 'bar')
       end
 
       trace = trace_op.flush!
@@ -832,7 +832,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
     it 'sets tag on trace from a nested measurement' do
       trace_op.measure('grandparent') do
         trace_op.measure('parent') do
-          trace_op.send(:set_tag, 'foo', 'bar')
+          trace_op.set_tag('foo', 'bar')
         end
       end
 
@@ -844,7 +844,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
     end
 
     it 'sets metrics' do
-      trace_op.send(:set_tag, 'foo', 42)
+      trace_op.set_tag('foo', 42)
       trace_op.measure('top') {}
 
       trace = trace_op.flush!
@@ -859,7 +859,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
       it 'sets tag on trace from a nested measurement' do
         trace_op.measure('grandparent') do
           trace_op.measure('parent') do
-            trace_op.send(:set_tag, 'foo', 'bar')
+            trace_op.set_tag('foo', 'bar')
           end
           flush!
         end

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -800,17 +800,6 @@ RSpec.describe Datadog::Tracing::TraceOperation do
     end
   end
 
-  describe '#set_error' do
-    it 'sets errors' do
-      trace_op.send(:set_error, Exception.new('foo'))
-      trace_op.measure('top') {}
-
-      trace = trace_op.flush!
-
-      expect(trace.tags).to include('error.msg' => 'foo', 'error.type' => 'Exception')
-    end
-  end
-
   describe '#set_tag' do
     it 'sets tag on trace before a measurement' do
       trace_op.send(:set_tag, 'foo', 'bar')
@@ -861,24 +850,6 @@ RSpec.describe Datadog::Tracing::TraceOperation do
       trace = trace_op.flush!
 
       expect(trace.tags).to include('foo' => 42)
-    end
-
-    it 'sets analytics enabled' do
-      trace_op.send(:set_tag, Datadog::Tracing::Metadata::Ext::Analytics::TAG_ENABLED, true)
-      trace_op.measure('top') {}
-
-      trace = trace_op.flush!
-
-      expect(trace.tags).to include(Datadog::Tracing::Metadata::Ext::Analytics::TAG_SAMPLE_RATE => 1.0)
-    end
-
-    it 'sets analytics sample rate' do
-      trace_op.send(:set_tag, Datadog::Tracing::Metadata::Ext::Analytics::TAG_SAMPLE_RATE, 42)
-      trace_op.measure('top') {}
-
-      trace = trace_op.flush!
-
-      expect(trace.tags).to include(Datadog::Tracing::Metadata::Ext::Analytics::TAG_SAMPLE_RATE => 42.0)
     end
 
     context 'with partial flushing' do

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -796,7 +796,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
       trace = trace_op.flush!
 
-      expect(trace.get_metric('foo')).to eq(42)
+      expect(trace.send(:metrics)['foo']).to eq(42)
     end
   end
 
@@ -807,7 +807,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
       trace = trace_op.flush!
 
-      expect(trace.get_tag('foo')).to eq('bar')
+      expect(trace.send(:meta)['foo']).to eq('bar')
     end
 
     it 'sets tag on trace after a measurement' do
@@ -816,7 +816,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
       trace = trace_op.flush!
 
-      expect(trace.get_tag('foo')).to eq('bar')
+      expect(trace.send(:meta)['foo']).to eq('bar')
     end
 
     it 'sets tag on trace from a measurement' do
@@ -826,7 +826,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
       trace = trace_op.flush!
 
-      expect(trace.get_tag('foo')).to eq('bar')
+      expect(trace.send(:meta)['foo']).to eq('bar')
     end
 
     it 'sets tag on trace from a nested measurement' do
@@ -840,7 +840,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
       expect(trace.spans).to have(2).items
       expect(trace.spans.map(&:name)).to include('parent')
-      expect(trace.get_tag('foo')).to eq('bar')
+      expect(trace.send(:meta)['foo']).to eq('bar')
     end
 
     it 'sets metrics' do
@@ -849,7 +849,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
       trace = trace_op.flush!
 
-      expect(trace.get_metric('foo')).to eq(42)
+      expect(trace.send(:metrics)['foo']).to eq(42)
     end
 
     context 'with partial flushing' do
@@ -866,12 +866,12 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
         expect(trace.spans).to have(1).items
         expect(trace.spans.map(&:name)).to include('parent')
-        expect(trace.get_tag('foo')).to eq('bar')
+        expect(trace.send(:meta)['foo']).to eq('bar')
 
         final_flush = trace_op.flush!
         expect(final_flush.spans).to have(1).items
         expect(final_flush.spans.map(&:name)).to include('grandparent')
-        expect(final_flush.get_tag('foo')).to eq('bar')
+        expect(final_flush.send(:meta)['foo']).to eq('bar')
       end
     end
   end

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe Datadog::Tracing::TraceOperation do
         sample_rate: sample_rate,
         sampled: sampled,
         sampling_priority: sampling_priority,
-        service: service
+        service: service,
+        tags: tags,
+        metrics: metrics
       }
     end
 
@@ -46,6 +48,8 @@ RSpec.describe Datadog::Tracing::TraceOperation do
     let(:sampled) { true }
     let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP }
     let(:service) { 'billing-api' }
+    let(:tags) { { 'foo' => 'bar' } }
+    let(:metrics) { { 'baz' => 42.0 } }
   end
 
   shared_examples 'a span with default events' do
@@ -72,6 +76,14 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           sampling_priority: nil,
           service: nil
         )
+      end
+
+      it do
+        expect(trace_op.send(:meta)).to eq({})
+      end
+
+      it do
+        expect(trace_op.send(:metrics)).to eq({})
       end
     end
 
@@ -172,6 +184,20 @@ RSpec.describe Datadog::Tracing::TraceOperation do
         let(:service) { 'billing-worker' }
 
         it { expect(trace_op.service).to eq(service) }
+      end
+
+      context ':tags' do
+        subject(:options) { { tags: tags } }
+        let(:tags) { { 'foo' => 'bar' } }
+
+        it { expect(trace_op.send(:meta)).to eq({ 'foo' => 'bar' }) }
+      end
+
+      context ':metrics' do
+        subject(:options) { { metrics: metrics } }
+        let(:metrics) { { 'baz' => 42.0 } }
+
+        it { expect(trace_op.send(:metrics)).to eq({ 'baz' => 42.0 }) }
       end
     end
   end
@@ -1770,6 +1796,14 @@ RSpec.describe Datadog::Tracing::TraceOperation do
             )
           end
 
+          it 'maintains the same tags' do
+            expect(new_trace_op.send(:meta)).to eq({ 'foo' => 'bar' })
+          end
+
+          it 'maintains the same metrics' do
+            expect(new_trace_op.send(:metrics)).to eq({ 'baz' => 42.0 })
+          end
+
           it 'maintains the same events' do
             old_events = trace_op.send(:events)
             new_events = new_trace_op.send(:events)
@@ -1832,6 +1866,14 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           )
         end
 
+        it 'maintains the same tags' do
+          expect(new_trace_op.send(:meta)).to eq({ 'foo' => 'bar' })
+        end
+
+        it 'maintains the same metrics' do
+          expect(new_trace_op.send(:metrics)).to eq({ 'baz' => 42.0 })
+        end
+
         context 'and :parent_span_id has been defined' do
           let(:options) { { parent_span_id: parent_span_id } }
           let(:parent_span_id) { Datadog::Core::Utils.next_id }
@@ -1872,6 +1914,14 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               service: be_a_copy_of(service)
             )
           end
+
+          it 'maintains the same tags' do
+            expect(new_trace_op.send(:meta)).to eq({ 'foo' => 'bar' })
+          end
+
+          it 'maintains the same metrics' do
+            expect(new_trace_op.send(:metrics)).to eq({ 'baz' => 42.0 })
+          end
         end
 
         context 'that has started' do
@@ -1903,6 +1953,14 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               service: be_a_copy_of(service)
             )
           end
+
+          it 'maintains the same tags' do
+            expect(new_trace_op.send(:meta)).to eq({ 'foo' => 'bar' })
+          end
+
+          it 'maintains the same metrics' do
+            expect(new_trace_op.send(:metrics)).to eq({ 'baz' => 42.0 })
+          end
         end
 
         context 'that has finished' do
@@ -1933,6 +1991,14 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               sampling_priority: sampling_priority,
               service: be_a_copy_of(service)
             )
+          end
+
+          it 'maintains the same tags' do
+            expect(new_trace_op.send(:meta)).to eq({ 'foo' => 'bar' })
+          end
+
+          it 'maintains the same metrics' do
+            expect(new_trace_op.send(:metrics)).to eq({ 'baz' => 42.0 })
           end
         end
       end
@@ -1974,6 +2040,14 @@ RSpec.describe Datadog::Tracing::TraceOperation do
             sampling_priority: sampling_priority,
             service: be_a_copy_of(service)
           )
+        end
+
+        it 'maintains the same tags' do
+          expect(new_trace_op.send(:meta)).to eq({ 'foo' => 'bar' })
+        end
+
+        it 'maintains the same metrics' do
+          expect(new_trace_op.send(:metrics)).to eq({ 'baz' => 42.0 })
         end
 
         context 'and :parent_span_id has been defined' do

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -776,6 +776,24 @@ RSpec.describe Datadog::Tracing::TraceOperation do
   end
 
   describe '#set_tag' do
+    it 'sets tag on trace before a measurement' do
+      trace_op.send(:set_tag, 'foo', 'bar')
+      trace_op.measure('top') {}
+
+      trace = trace_op.flush!
+
+      expect(trace.tags).to include('foo' => 'bar')
+    end
+
+    it 'sets tag on trace after a measurement' do
+      trace_op.measure('top') {}
+      trace_op.send(:set_tag, 'foo', 'bar')
+
+      trace = trace_op.flush!
+
+      expect(trace.tags).to include('foo' => 'bar')
+    end
+
     it 'sets tag on trace from a measurement' do
       trace_op.measure('top') do
         trace_op.send(:set_tag, 'foo', 'bar')

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -895,7 +895,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
         expect(trace.spans).to have(1).items
         expect(trace.spans.map(&:name)).to include('parent')
-        expect(trace.tags).to_not include('foo' => 'bar')
+        expect(trace.tags).to include('foo' => 'bar')
 
         final_flush = trace_op.flush!
         expect(final_flush.spans).to have(1).items

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -775,6 +775,20 @@ RSpec.describe Datadog::Tracing::TraceOperation do
     end
   end
 
+  describe '#get_tag' do
+    before do
+      trace_op.send(:set_tag, 'foo', 'bar')
+    end
+
+    it 'gets tag set on trace' do
+      expect(trace_op.send(:get_tag, 'foo')).to eq('bar')
+    end
+
+    it 'gets unset tag as nil' do
+      expect(trace_op.send(:get_tag, 'unset')).to be_nil
+    end
+  end
+
   describe '#set_tag' do
     it 'sets tag on trace before a measurement' do
       trace_op.send(:set_tag, 'foo', 'bar')

--- a/spec/datadog/tracing/trace_segment_spec.rb
+++ b/spec/datadog/tracing/trace_segment_spec.rb
@@ -291,31 +291,33 @@ RSpec.describe Datadog::Tracing::TraceSegment do
 
   describe '#sampled?' do
     subject(:sampled?) { trace_segment.sampled? }
+    let(:options) { { sampling_priority: sampling_priority } }
+    let(:sampling_priority) { nil }
 
     context 'when sampling priority is not set' do
       it { is_expected.to be false }
     end
 
     context 'when sampling priority is set to AUTO_KEEP' do
-      before { trace_segment.sampling_priority = Datadog::Tracing::Sampling::Ext::Priority::AUTO_KEEP }
+      let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::AUTO_KEEP }
 
       it { is_expected.to be true }
     end
 
     context 'when sampling priority is set to USER_KEEP' do
-      before { trace_segment.sampling_priority = Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP }
+      let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP }
 
       it { is_expected.to be true }
     end
 
     context 'when sampling priority is set to AUTO_REJECT' do
-      before { trace_segment.sampling_priority = Datadog::Tracing::Sampling::Ext::Priority::AUTO_REJECT }
+      let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::AUTO_REJECT }
 
       it { is_expected.to be false }
     end
 
     context 'when sampling priority is set to USER_REJECT' do
-      before { trace_segment.sampling_priority = Datadog::Tracing::Sampling::Ext::Priority::USER_REJECT }
+      let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::USER_REJECT }
 
       it { is_expected.to be false }
     end

--- a/spec/datadog/tracing/trace_segment_spec.rb
+++ b/spec/datadog/tracing/trace_segment_spec.rb
@@ -49,15 +49,15 @@ RSpec.describe Datadog::Tracing::TraceSegment do
       end
 
       it do
-        expect(subject.send(:meta)).to eq({})
+        expect(trace_segment.send(:meta)).to eq({})
       end
 
       it do
-        expect(subject.send(:metrics)).to eq({})
+        expect(trace_segment.send(:metrics)).to eq({})
       end
     end
 
-    context 'given' do
+    context 'given arguments' do
       context ':agent_sample_rate' do
         let(:options) { { agent_sample_rate: agent_sample_rate } }
         let(:agent_sample_rate) { rand }
@@ -144,6 +144,105 @@ RSpec.describe Datadog::Tracing::TraceSegment do
 
       context ':service' do
         let(:options) { { service: service } }
+        let(:service) { 'job-worker' }
+
+        it { is_expected.to have_attributes(service: be_a_copy_of(service)) }
+      end
+    end
+
+    context 'given tags' do
+      context ':agent_sample_rate' do
+        let(:options) { { metrics: { Datadog::Tracing::Metadata::Ext::Sampling::TAG_AGENT_RATE => agent_sample_rate } } }
+        let(:agent_sample_rate) { rand }
+
+        it { is_expected.to have_attributes(agent_sample_rate: agent_sample_rate) }
+      end
+
+      context ':hostname' do
+        let(:options) { { tags: { Datadog::Tracing::Metadata::Ext::NET::TAG_HOSTNAME => hostname } } }
+        let(:hostname) { 'my.host' }
+
+        it { is_expected.to have_attributes(hostname: be(hostname)) }
+      end
+
+      context ':lang' do
+        let(:options) { { tags: { Datadog::Core::Runtime::Ext::TAG_LANG => lang } } }
+        let(:lang) { 'ruby' }
+
+        it { is_expected.to have_attributes(lang: be(lang)) }
+      end
+
+      context ':name' do
+        let(:options) { { tags: { Datadog::Tracing::TraceSegment::TAG_NAME => name } } }
+        let(:name) { 'job.work' }
+
+        it { is_expected.to have_attributes(name: be_a_copy_of(name)) }
+      end
+
+      context ':origin' do
+        let(:options) { { tags: { Datadog::Tracing::Metadata::Ext::Distributed::TAG_ORIGIN => origin } } }
+        let(:origin) { 'synthetics' }
+
+        it { is_expected.to have_attributes(origin: be_a_copy_of(origin)) }
+      end
+
+      context ':process_id' do
+        let(:options) { { tags: { Datadog::Core::Runtime::Ext::TAG_PID => process_id } } }
+        let(:process_id) { Datadog::Core::Environment::Identity.pid }
+
+        it { is_expected.to have_attributes(process_id: process_id) }
+      end
+
+      context ':rate_limiter_rate' do
+        let(:options) do
+          { metrics: { Datadog::Tracing::Metadata::Ext::Sampling::TAG_RATE_LIMITER_RATE => rate_limiter_rate } }
+        end
+        let(:rate_limiter_rate) { rand }
+
+        it { is_expected.to have_attributes(rate_limiter_rate: rate_limiter_rate) }
+      end
+
+      context ':resource' do
+        let(:options) { { tags: { Datadog::Tracing::TraceSegment::TAG_RESOURCE => resource } } }
+        let(:resource) { 'generate_report' }
+
+        it { is_expected.to have_attributes(resource: be_a_copy_of(resource)) }
+      end
+
+      context ':rule_sample_rate' do
+        let(:options) do
+          { metrics: { Datadog::Tracing::Metadata::Ext::Sampling::TAG_RULE_SAMPLE_RATE => rule_sample_rate } }
+        end
+        let(:rule_sample_rate) { rand }
+
+        it { is_expected.to have_attributes(rule_sample_rate: rule_sample_rate) }
+      end
+
+      context ':runtime_id' do
+        let(:options) { { tags: { Datadog::Core::Runtime::Ext::TAG_ID => runtime_id } } }
+        let(:runtime_id) { Datadog::Core::Environment::Identity.id }
+
+        it { is_expected.to have_attributes(runtime_id: runtime_id) }
+      end
+
+      context ':sample_rate' do
+        let(:options) { { metrics: { Datadog::Tracing::Metadata::Ext::Sampling::TAG_SAMPLE_RATE => sample_rate } } }
+        let(:sample_rate) { rand }
+
+        it { is_expected.to have_attributes(sample_rate: sample_rate) }
+      end
+
+      context ':sampling_priority' do
+        let(:options) do
+          { tags: { Datadog::Tracing::Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY => sampling_priority } }
+        end
+        let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP }
+
+        it { is_expected.to have_attributes(sampling_priority: sampling_priority) }
+      end
+
+      context ':service' do
+        let(:options) { { tags: { Datadog::Tracing::TraceSegment::TAG_SERVICE => service } } }
         let(:service) { 'job-worker' }
 
         it { is_expected.to have_attributes(service: be_a_copy_of(service)) }

--- a/spec/datadog/tracing/trace_segment_spec.rb
+++ b/spec/datadog/tracing/trace_segment_spec.rb
@@ -148,6 +148,20 @@ RSpec.describe Datadog::Tracing::TraceSegment do
 
         it { is_expected.to have_attributes(service: be_a_copy_of(service)) }
       end
+
+      context ':tags' do
+        let(:options) { { tags: tags } }
+        let(:tags) { { 'foo' => 'bar' } }
+
+        it { expect(trace_segment.send(:meta)).to eq({ 'foo' => 'bar' }) }
+      end
+
+      context ':metrics' do
+        let(:options) { { metrics: metrics } }
+        let(:metrics) { { 'foo' => 42.0 } }
+
+        it { expect(trace_segment.send(:metrics)).to eq({ 'foo' => 42.0 }) }
+      end
     end
 
     context 'given tags' do

--- a/spec/datadog/tracing/trace_segment_spec.rb
+++ b/spec/datadog/tracing/trace_segment_spec.rb
@@ -45,8 +45,15 @@ RSpec.describe Datadog::Tracing::TraceSegment do
           sampling_priority: nil,
           service: nil,
           spans: spans,
-          tags: {}
         )
+      end
+
+      it do
+        expect(subject.send(:meta)).to eq({})
+      end
+
+      it do
+        expect(subject.send(:metrics)).to eq({})
       end
     end
 
@@ -118,7 +125,7 @@ RSpec.describe Datadog::Tracing::TraceSegment do
         let(:options) { { runtime_id: runtime_id } }
         let(:runtime_id) { Datadog::Core::Environment::Identity.id }
 
-        it { is_expected.to have_attributes(runtime_id: be(runtime_id)) }
+        it { is_expected.to have_attributes(runtime_id: runtime_id) }
       end
 
       context ':sample_rate' do

--- a/spec/ddtrace/transport/trace_formatter_spec.rb
+++ b/spec/ddtrace/transport/trace_formatter_spec.rb
@@ -165,6 +165,16 @@ RSpec.describe Datadog::Transport::TraceFormatter do
         end
       end
 
+      shared_examples 'root span without generic tags' do
+        context 'metrics' do
+          it { expect(root_span.metrics).to_not include({ 'baz' => 42 }) }
+        end
+
+        context 'meta' do
+          it { expect(root_span.meta).to_not include({ 'foo' => 'bar' }) }
+        end
+      end
+
       context 'with no root span' do
         include_context 'no root span'
 
@@ -193,7 +203,7 @@ RSpec.describe Datadog::Transport::TraceFormatter do
           it { expect(root_span.resource).to eq('my.job') }
 
           it_behaves_like 'root span with tags'
-          it_behaves_like 'root span with generic tags'
+          it_behaves_like 'root span without generic tags'
         end
       end
 
@@ -225,7 +235,7 @@ RSpec.describe Datadog::Transport::TraceFormatter do
           it { expect(root_span.resource).to eq('my.job') }
 
           it_behaves_like 'root span with tags'
-          it_behaves_like 'root span with generic tags'
+          it_behaves_like 'root span without generic tags'
         end
       end
 
@@ -248,6 +258,16 @@ RSpec.describe Datadog::Transport::TraceFormatter do
           it { expect(root_span.resource).to eq(resource) }
 
           it_behaves_like 'root span with tags'
+        end
+
+        context 'when trace has metadata set with generic tags' do
+          include_context 'trace metadata with tags'
+
+          it { is_expected.to be(trace) }
+          it { expect(root_span.resource).to eq(resource) }
+
+          it_behaves_like 'root span with tags'
+          it_behaves_like 'root span with generic tags'
         end
       end
     end


### PR DESCRIPTION
Since trace transport does not have a concept of trace, tags are set on the topmost span.

When partial flushing is involved, the topmost span will be sent upon last flush, therefore tags will only appear in the UI when that final segment is processed.