### PR TITLE
[PROF-4904] Add libddprof-based `StackRecorder`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -60,7 +60,7 @@ Lint/MissingSuper:
     - 'lib/datadog/opentracer/scope.rb'
     - 'lib/datadog/opentracer/span.rb'
     - 'lib/datadog/opentracer/span_context.rb'
-    - 'lib/datadog/profiling/collectors/stack.rb'
+    - 'lib/datadog/profiling/collectors/old_stack.rb'
     - 'lib/datadog/profiling/pprof/converter.rb'
     - 'lib/datadog/profiling/pprof/template.rb'
     - 'lib/datadog/profiling/old_recorder.rb'

--- a/docs/ProfilingDevelopment.md
+++ b/docs/ProfilingDevelopment.md
@@ -8,7 +8,7 @@ For a more practical view of getting started with development of `ddtrace`, see 
 
 Components below live inside <../lib/datadog/profiling>:
 
-* `Collectors::Stack`: Collects stack trace samples from Ruby threads for both CPU-time (if available) and wall-clock.
+* `Collectors::OldStack`: Collects stack trace samples from Ruby threads for both CPU-time (if available) and wall-clock.
   Runs on its own background thread.
 * `Collectors::CodeProvenance`: Collects library metadata to power grouping and categorization of stack traces (e.g. to help distinguish user code, from libraries, from the standard library, etc).
 * `Encoding::Profile::Protobuf`: Encodes gathered data into the pprof format.
@@ -24,7 +24,7 @@ Components below live inside <../lib/datadog/profiling>:
 * `Buffer`: Bounded buffer used to store profiling events.
 * `Flush`: Entity class used to represent the payload to be reported for a given profile.
 * `Profiler`: Profiling entry point, which coordinates collectors and a scheduler.
-* `OldRecorder`: Stores profiling events gathered by the `Collector::Stack`. (To be removed after migration to libddprof aggregation)
+* `OldRecorder`: Stores profiling events gathered by the `Collector::OldStack`. (To be removed after migration to libddprof aggregation)
 * `Exporter`: Gathers data from `OldRecorder` and `Collectors::CodeProvenance` to be reported as a profile.
 * `Scheduler`: Periodically (every 1 minute) takes data from the `Exporter` and pushes them to the configured transport.
   Runs on its own background thread.
@@ -51,9 +51,9 @@ flow:
     +---------+--+  +-+-------+-+
               |       |       |
               v       |       v
-        +-----+-+     |  +----+----------+
-        | Stack |     |  | HttpTransport |
-        +--+----+     |  +---------------+
+     +--------+-+     |  +----+----------+
+     | OldStack |     |  | HttpTransport |
+     +-----+----+     |  +---------------+
            |          |
            v          v
 +-------------+     +-+---------+
@@ -69,9 +69,9 @@ flow:
 
 ## Run-time execution
 
-During run-time, the `Scheduler` and the `Collectors::Stack` each execute on their own background thread.
+During run-time, the `Scheduler` and the `Collectors::OldStack` each execute on their own background thread.
 
-The `Collectors::Stack` samples stack traces of threads, capturing both CPU-time (if available) and wall-clock, storing
+The `Collectors::OldStack` samples stack traces of threads, capturing both CPU-time (if available) and wall-clock, storing
 them in the `OldRecorder`.
 
 The `Scheduler` wakes up every 1 minute to flush the results of the `Exporter` into the transport.
@@ -100,7 +100,7 @@ To further enable filtering of a profile to show only samples related to a given
 profiler is tagged with the `local root span id` and `span id` for the given trace/span.
 
 This is done using the `Datadog::Profiling::TraceIdentifiers::Helper` that retrieves a `root_span_id` and `span_id`, if
-available, from the supported tracers. This helper is called by the `Collectors::Stack` during sampling.
+available, from the supported tracers. This helper is called by the `Collectors::OldStack` during sampling.
 
 Note that if a given trace executes too fast, it's possible that the profiler will not contain any samples for that
 specific trace. Nevertheless, the linking still works and is useful, as it allows users to explore what was going on their

--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -4,6 +4,7 @@
 
 // Each class/module here is implemented in their separate file
 void http_transport_init(VALUE profiling_module);
+void stack_recorder_init(VALUE profiling_module);
 
 static VALUE native_working_p(VALUE self);
 
@@ -18,6 +19,7 @@ void Init_ddtrace_profiling_native_extension(void) {
   rb_define_singleton_method(native_extension_module, "clock_id_for", clock_id_for, 1); // from clock_id.h
 
   http_transport_init(profiling_module);
+  stack_recorder_init(profiling_module);
 }
 
 static VALUE native_working_p(VALUE self) {

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -1,0 +1,104 @@
+#include <ruby.h>
+#include <ruby/debug.h>
+#include <ddprof/ffi.h>
+#include "stack_recorder.h"
+
+// Used to wrap a ddprof_ffi_Profile in a Ruby object and expose Ruby-level serialization APIs
+// This file implements the native bits of the Datadog::Profiling::StackRecorder class
+
+static VALUE ok_symbol = Qnil; // :ok in Ruby
+static VALUE error_symbol = Qnil; // :error in Ruby
+
+static VALUE stack_recorder_class = Qnil;
+
+#define      CPU_TIME_VALUE {.type_ = DDPROF_FFI_CHARSLICE_C("cpu-time"),      .unit = DDPROF_FFI_CHARSLICE_C("nanoseconds")}
+#define   CPU_SAMPLES_VALUE {.type_ = DDPROF_FFI_CHARSLICE_C("cpu-samples"),   .unit = DDPROF_FFI_CHARSLICE_C("count")}
+#define     WALL_TIME_VALUE {.type_ = DDPROF_FFI_CHARSLICE_C("wall-time"),     .unit = DDPROF_FFI_CHARSLICE_C("nanoseconds")}
+#define ALLOC_SAMPLES_VALUE {.type_ = DDPROF_FFI_CHARSLICE_C("alloc-samples"), .unit = DDPROF_FFI_CHARSLICE_C("count")}
+#define   ALLOC_SPACE_VALUE {.type_ = DDPROF_FFI_CHARSLICE_C("alloc-space"),   .unit = DDPROF_FFI_CHARSLICE_C("bytes")}
+#define    HEAP_SPACE_VALUE {.type_ = DDPROF_FFI_CHARSLICE_C("heap-space"),    .unit = DDPROF_FFI_CHARSLICE_C("bytes")}
+
+const static ddprof_ffi_ValueType enabled_value_types[] = {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE};
+#define ENABLED_VALUE_TYPES_COUNT (sizeof(enabled_value_types) / sizeof(ddprof_ffi_ValueType))
+
+static VALUE _native_new(VALUE klass);
+static void stack_recorder_typed_data_free(void *data);
+static VALUE _native_serialize(VALUE self, VALUE recorder_instance);
+static VALUE ruby_time_from(ddprof_ffi_Timespec ddprof_time);
+
+void stack_recorder_init(VALUE profiling_module) {
+  stack_recorder_class = rb_define_class_under(profiling_module, "StackRecorder", rb_cObject);
+
+  // Instances of the StackRecorder class are going to be "TypedData" objects.
+  // "TypedData" objects are special objects in the Ruby VM that can wrap C structs.
+  // In our case, we're going to keep a libddprof profile reference inside our object.
+  //
+  // Because Ruby doesn't know how to initialize libddprof profiles, we MUST override the allocation function for objects
+  // of this class so that we can manage this part. Not overriding or disabling the allocation function is a common
+  // gotcha for "TypedData" objects that can very easily lead to VM crashes, see for instance
+  // https://bugs.ruby-lang.org/issues/18007 for a discussion around this.
+  rb_define_alloc_func(stack_recorder_class, _native_new);
+
+  rb_define_singleton_method(stack_recorder_class, "_native_serialize",  _native_serialize, 1);
+
+  ok_symbol = ID2SYM(rb_intern_const("ok"));
+  error_symbol = ID2SYM(rb_intern_const("error"));
+
+}
+
+// This structure is used to define a Ruby object that stores a pointer to a ddprof_ffi_Profile instance
+// See also https://github.com/ruby/ruby/blob/master/doc/extension.rdoc for how this works
+static const rb_data_type_t stack_recorder_typed_data = {
+  .wrap_struct_name = "Datadog::Profiling::StackRecorder",
+  .function = {
+    .dfree = stack_recorder_typed_data_free,
+    .dsize = NULL, // We don't track profile memory usage (although it'd be cool if we did!)
+    // No need to provide dmark nor dcompact because we don't directly reference Ruby VALUEs from inside this object
+  },
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+static VALUE _native_new(VALUE klass) {
+  ddprof_ffi_Slice_value_type sample_types = {.ptr = enabled_value_types, .len = ENABLED_VALUE_TYPES_COUNT};
+
+  ddprof_ffi_Profile *profile = ddprof_ffi_Profile_new(sample_types, NULL /* Period is optional */);
+
+  return TypedData_Wrap_Struct(stack_recorder_class, &stack_recorder_typed_data, profile);
+}
+
+static void stack_recorder_typed_data_free(void *data) {
+  ddprof_ffi_Profile_free((ddprof_ffi_Profile *) data);
+}
+
+static VALUE _native_serialize(VALUE self, VALUE recorder_instance) {
+  Check_TypedStruct(recorder_instance, &stack_recorder_typed_data);
+
+  ddprof_ffi_Profile *profile;
+  TypedData_Get_Struct(recorder_instance, ddprof_ffi_Profile, &stack_recorder_typed_data, profile);
+
+  // TODO: Update this after https://github.com/DataDog/libddprof/pull/42 gets merged
+  ddprof_ffi_EncodedProfile *serialized_profile = ddprof_ffi_Profile_serialize(profile);
+  if (serialized_profile == NULL) return rb_ary_new_from_args(2, error_symbol, rb_str_new_cstr("Failed to serialize profile"));
+
+  VALUE encoded_pprof = rb_str_new((char *) serialized_profile->buffer.ptr, serialized_profile->buffer.len);
+  VALUE start = ruby_time_from(serialized_profile->start);
+  VALUE finish = ruby_time_from(serialized_profile->end);
+
+  ddprof_ffi_EncodedProfile_delete(serialized_profile);
+  if (!ddprof_ffi_Profile_reset(profile)) return rb_ary_new_from_args(2, error_symbol, rb_str_new_cstr("Failed to reset profile"));
+
+  return rb_ary_new_from_args(2, ok_symbol, rb_ary_new_from_args(3, start, finish, encoded_pprof));
+}
+
+static VALUE ruby_time_from(ddprof_ffi_Timespec ddprof_time) {
+  const int utc = INT_MAX - 1; // From Ruby sources
+  struct timespec time = {.tv_sec = ddprof_time.seconds, .tv_nsec = ddprof_time.nanoseconds};
+  return rb_time_timespec_new(&time, utc);
+}
+
+void record_sample(VALUE recorder_instance, ddprof_ffi_Sample sample) {
+  Check_TypedStruct(recorder_instance, &stack_recorder_typed_data);
+  ddprof_ffi_Profile *profile;
+  TypedData_Get_Struct(recorder_instance, ddprof_ffi_Profile, &stack_recorder_typed_data, profile);
+  ddprof_ffi_Profile_add(profile, sample);
+}

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void record_sample(VALUE recorder_instance, ddprof_ffi_Sample sample);

--- a/integration/apps/rack/spec/integration/basic_spec.rb
+++ b/integration/apps/rack/spec/integration/basic_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Basic scenarios' do
 
   let(:expected_profiler_threads) do
     # NOTE: Threads can't be named on Ruby 2.1 and 2.2
-    contain_exactly('Datadog::Profiling::Collectors::Stack', 'Datadog::Profiling::Scheduler') unless RUBY_VERSION < '2.3'
+    contain_exactly('Datadog::Profiling::Collectors::OldStack', 'Datadog::Profiling::Scheduler') unless RUBY_VERSION < '2.3'
   end
 
   context 'component checks' do

--- a/integration/apps/rails-five/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-five/spec/integration/basic_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Basic scenarios' do
     it 'should be profiling' do
       expect(json_result).to include(
         profiler_available: true,
-        profiler_threads: contain_exactly('Datadog::Profiling::Collectors::Stack', 'Datadog::Profiling::Scheduler')
+        profiler_threads: contain_exactly('Datadog::Profiling::Collectors::OldStack', 'Datadog::Profiling::Scheduler')
       )
     end
 

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -282,7 +282,7 @@ module Datadog
 
           def build_profiler_collectors(settings, old_recorder, trace_identifiers_helper)
             [
-              Profiling::Collectors::Stack.new(
+              Profiling::Collectors::OldStack.new(
                 old_recorder,
                 trace_identifiers_helper: trace_identifiers_helper,
                 max_frames: settings.profiling.advanced.max_frames

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -145,7 +145,7 @@ module Datadog
 
       require 'datadog/profiling/ext/forking'
       require 'datadog/profiling/collectors/code_provenance'
-      require 'datadog/profiling/collectors/stack'
+      require 'datadog/profiling/collectors/old_stack'
       require 'datadog/profiling/old_recorder'
       require 'datadog/profiling/exporter'
       require 'datadog/profiling/scheduler'

--- a/lib/datadog/profiling/collectors/old_stack.rb
+++ b/lib/datadog/profiling/collectors/old_stack.rb
@@ -14,7 +14,8 @@ module Datadog
       # Collects stack trace samples from Ruby threads for both CPU-time (if available) and wall-clock.
       # Runs on its own background thread.
       #
-      class Stack < Core::Worker # rubocop:disable Metrics/ClassLength
+      # This class has the prefix "Old" because it will be deprecated by the new native CPU Profiler
+      class OldStack < Core::Worker # rubocop:disable Metrics/ClassLength
         include Core::Workers::Polling
 
         DEFAULT_MAX_TIME_USAGE_PCT = 2.0

--- a/lib/datadog/profiling/old_recorder.rb
+++ b/lib/datadog/profiling/old_recorder.rb
@@ -5,7 +5,9 @@ require 'datadog/profiling/encoding/profile'
 
 module Datadog
   module Profiling
-    # Stores profiling events gathered by the `Stack` collector
+    # Stores profiling events gathered by the `OldStack` collector
+    #
+    # This class has the prefix "Old" because it will be deprecated by the new native CPU Profiler
     class OldRecorder
       attr_reader :max_size
 

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -1,0 +1,25 @@
+# typed: false
+
+module Datadog
+  module Profiling
+    # Used to wrap a ddprof_ffi_Profile in a Ruby object and expose Ruby-level serialization APIs
+    # Methods prefixed with _native_ are implemented in `stack_recorder.c`
+    class StackRecorder
+      def serialize
+        status, result = self.class._native_serialize(self)
+
+        if status == :ok
+          start, finish, encoded_pprof = result
+
+          [start, finish, encoded_pprof]
+        else
+          error_message = result
+
+          Datadog.logger.error("Failed to serialize profiling data: #{error_message}")
+
+          nil
+        end
+      end
+    end
+  end
+end

--- a/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -3674,7 +3674,7 @@ class Datadog::Profiling::Collectors::CodeProvenance::Library
   def self.members(); end
 end
 
-class Datadog::Profiling::Collectors::Stack
+class Datadog::Profiling::Collectors::OldStack
   include ::Datadog::Core::Workers::IntervalLoop
   include ::Datadog::Core::Workers::Async::Thread
   include ::Datadog::Core::Workers::IntervalLoop::PrependedMethods

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -900,9 +900,9 @@ RSpec.describe Datadog::Core::Configuration::Components do
       shared_examples_for 'profiler with default collectors' do
         subject(:stack_collector) { profiler.collectors.first }
 
-        it 'has a Stack collector' do
+        it 'has a OldStack collector' do
           expect(profiler.collectors).to have(1).item
-          expect(profiler.collectors).to include(kind_of(Datadog::Profiling::Collectors::Stack))
+          expect(profiler.collectors).to include(kind_of(Datadog::Profiling::Collectors::OldStack))
           is_expected.to have_attributes(
             enabled?: true,
             started?: false,

--- a/spec/datadog/profiling/collectors/old_stack_spec.rb
+++ b/spec/datadog/profiling/collectors/old_stack_spec.rb
@@ -2,13 +2,13 @@
 require 'spec_helper'
 require 'datadog/profiling/spec_helper'
 
-require 'datadog/profiling/collectors/stack'
+require 'datadog/profiling/collectors/old_stack'
 require 'datadog/profiling/trace_identifiers/helper'
 require 'datadog/profiling/old_recorder'
 require 'set'
 require 'timeout'
 
-RSpec.describe Datadog::Profiling::Collectors::Stack do
+RSpec.describe Datadog::Profiling::Collectors::OldStack do
   subject(:collector) { described_class.new(recorder, **options) }
 
   let(:recorder) { instance_double(Datadog::Profiling::OldRecorder) }

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -1,9 +1,7 @@
 # typed: ignore
 
 require 'datadog/profiling/spec_helper'
-
 require 'datadog/profiling/http_transport'
-require 'datadog/profiling'
 
 require 'webrick'
 require 'socket'

--- a/spec/datadog/profiling/integration_spec.rb
+++ b/spec/datadog/profiling/integration_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'profiling integration test' do
     end
     let(:exporter) { Datadog::Profiling::Exporter.new(pprof_recorder: old_recorder, code_provenance_collector: nil) }
     let(:collector) do
-      Datadog::Profiling::Collectors::Stack.new(
+      Datadog::Profiling::Collectors::OldStack.new(
         old_recorder,
         trace_identifiers_helper:
           Datadog::Profiling::TraceIdentifiers::Helper.new(

--- a/spec/datadog/profiling/profiler_spec.rb
+++ b/spec/datadog/profiling/profiler_spec.rb
@@ -7,7 +7,7 @@ require 'datadog/profiling/profiler'
 RSpec.describe Datadog::Profiling::Profiler do
   subject(:profiler) { described_class.new(collectors, scheduler) }
 
-  let(:collectors) { Array.new(2) { instance_double(Datadog::Profiling::Collectors::Stack) } }
+  let(:collectors) { Array.new(2) { instance_double(Datadog::Profiling::Collectors::OldStack) } }
   let(:scheduler) { instance_double(Datadog::Profiling::Scheduler) }
 
   describe '::new' do

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -1,0 +1,78 @@
+# typed: ignore
+
+require 'datadog/profiling/spec_helper'
+require 'datadog/profiling/stack_recorder'
+
+RSpec.describe Datadog::Profiling::StackRecorder do
+  before { skip_if_profiling_not_supported(self) }
+
+  subject(:stack_recorder) { described_class.new }
+
+  # NOTE: A lot of libddprof integration behaviors are tested in the Collectors::Stack specs, since we need actual
+  # samples in order to observe what comes out of libddprof
+
+  describe '#serialize' do
+    subject(:serialize) { stack_recorder.serialize }
+
+    let(:start) { serialize[0] }
+    let(:finish) { serialize[1] }
+    let(:encoded_pprof) { serialize[2] }
+
+    let(:decoded_profile) { ::Perftools::Profiles::Profile.decode(encoded_pprof) }
+
+    context 'when the profile is empty' do
+      it 'uses the current time as the start and finish time' do
+        before_serialize = Time.now
+        serialize
+        after_serialize = Time.now
+
+        expect(start).to be_between(before_serialize, after_serialize)
+        expect(finish).to be_between(before_serialize, after_serialize)
+        expect(start).to be <= finish
+      end
+
+      it 'returns an empty pprof profile' do
+        expect(sample_types_from(decoded_profile)).to eq(
+          'cpu-time' => 'nanoseconds',
+          'cpu-samples' => 'count',
+          'wall-time' => 'nanoseconds',
+        )
+
+        expect(decoded_profile).to have_attributes(
+          sample: [],
+          mapping: [],
+          location: [],
+          function: [],
+          drop_frames: 0,
+          keep_frames: 0,
+          time_nanos: Datadog::Core::Utils::Time.as_utc_epoch_ns(start),
+          period_type: nil,
+          period: 0,
+          comment: [],
+        )
+      end
+
+      def sample_types_from(decoded_profile)
+        strings = decoded_profile.string_table
+        decoded_profile.sample_type.map { |sample_type| [strings[sample_type.type], strings[sample_type.unit]] }.to_h
+      end
+    end
+
+    context 'when there is a failure during serialization' do
+      before do
+        allow(Datadog.logger).to receive(:error)
+
+        # Real failures in serialization are hard to trigger, so we're using a mock failure instead
+        expect(described_class).to receive(:_native_serialize).and_return([:error, 'test error message'])
+      end
+
+      it { is_expected.to be nil }
+
+      it 'logs an error message' do
+        expect(Datadog.logger).to receive(:error).with(/test error message/)
+
+        serialize
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new `StackRecorder`, which has similar responsibilities to the `OldRecorder`, but is implemented in native code using libddprof.

It also renames the existing `Stack` collector to `OldStack`, to make space for a new native code implementation of a stack collector.

(This PR is a draft because it depends on #1929. I'm keeping track of it and will rebase/update the PRs as needed, but I like keeping the PRs open for my own tracking.)