### PR TITLE
Bump `debase-ruby_core_source` maximum version to include latest version

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   #
   # Because we only use this for older Rubies, and we consider it "feature-complete" for those older Rubies,
   # we're pinning it at the latest available version and will manually bump the dependency as needed.
-  spec.add_dependency 'debase-ruby_core_source', '<= 0.10.14'
+  spec.add_dependency 'debase-ruby_core_source', '<= 0.10.15'
 
   # Used by appsec
   spec.add_dependency 'libddwaf', '~> 1.2.1.0.0.a'


### PR DESCRIPTION
Latest version changelog looks good:
<https://my.diffend.io/gems/debase-ruby_core_source/0.10.14/0.10.15>
so let's allow this version to be used as well.