### PR TITLE
Update rulesets to v1.3.1

### DIFF
--- a/lib/datadog/appsec/assets/waf_rules/recommended.json
+++ b/lib/datadog/appsec/assets/waf_rules/recommended.json
@@ -1,7 +1,7 @@
 {
   "version": "2.2",
   "metadata": {
-    "rules_version": "1.2.7"
+    "rules_version": "1.3.1"
   },
   "rules": [
     {
@@ -3040,7 +3040,9 @@
           "operator": "match_regex"
         }
       ],
-      "transformers": []
+      "transformers": [
+        "keys_only"
+      ]
     },
     {
       "id": "crs-942-360",
@@ -3439,6 +3441,33 @@
         }
       ],
       "transformers": []
+    },
+    {
+      "id": "dog-000-004",
+      "name": "Spring4Shell - Attempts to exploit the Spring4shell vulnerability",
+      "tags": {
+        "type": "exploit_detection",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "operator": "match_regex",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.body"
+              }
+            ],
+            "regex": "^class\\.module\\.classLoader\\.",
+            "options": {
+              "case_sensitive": false
+            }
+          }
+        }
+      ],
+      "transformers": [
+        "keys_only"
+      ]
     },
     {
       "id": "nfd-000-001",
@@ -4070,15 +4099,23 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.headers.no_cookies"
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
               }
             ],
-            "regex": "\\$(eq|ne|lte?|gte?|n?in)\\b"
+            "regex": "^\\$(eq|ne|(l|g)te?|n?in|not|(n|x|)or|and|regex|where|expr|exists)$"
           },
           "operator": "match_regex"
         }
       ],
-      "transformers": []
+      "transformers": [
+        "keys_only"
+      ]
     },
     {
       "id": "sqr-000-008",
@@ -4356,9 +4393,9 @@
     },
     {
       "id": "sqr-000-017",
-      "name": "JNDI: Attempt to exploit log4j CVE-2021-44228",
+      "name": "Log4shell: Attempt to exploit log4j CVE-2021-44228",
       "tags": {
-        "type": "java_code_injection",
+        "type": "exploit_detection",
         "category": "attack_attempt"
       },
       "conditions": [

--- a/lib/datadog/appsec/assets/waf_rules/risky.json
+++ b/lib/datadog/appsec/assets/waf_rules/risky.json
@@ -1,7 +1,7 @@
 {
   "version": "2.2",
   "metadata": {
-    "rules_version": "1.2.7"
+    "rules_version": "1.3.1"
   },
   "rules": [
     {

--- a/lib/datadog/appsec/assets/waf_rules/strict.json
+++ b/lib/datadog/appsec/assets/waf_rules/strict.json
@@ -1,7 +1,7 @@
 {
   "version": "2.2",
   "metadata": {
-    "rules_version": "1.2.7"
+    "rules_version": "1.3.1"
   },
   "rules": [
     {


### PR DESCRIPTION
This updates to a ruleset version supporting detection of spring4shell attacks, although detecting it requires the `server.request.body` address, which is not yet implemented.