### PR TITLE
[PROF-4904] First implementation of new Stack collector based on `rb_profile_frames` API

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,3 +1,4 @@
 Component,Origin,License,Copyright
 lib/datadog/core/vendor/multipart-post,https://github.com/socketry/multipart-post,MIT,"Copyright (c) 2007-2013 Nick Sieger."
 lib/datadog/tracing/contrib/active_record/vendor,https://github.com/rails/rails/,MIT,"Copyright (c) 2005-2018 David Heinemeier Hansson"
+ext/ddtrace_profiling_native_extension/private_vm_api_access,https://github.com/ruby/ruby,BSD-2-Clause,"Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved."

--- a/ext/ddtrace_profiling_native_extension/clock_id_from_pthread.c
+++ b/ext/ddtrace_profiling_native_extension/clock_id_from_pthread.c
@@ -9,15 +9,7 @@
 #include <errno.h>
 
 #include <ruby.h>
-
-#ifdef RUBY_2_1_WORKAROUND
-#include <thread_native.h>
-#else
-#include <ruby/thread_native.h>
-#endif
-
 #include "private_vm_api_access.h"
-
 #include "clock_id.h"
 
 // Validate that our home-cooked pthread_id_for() matches pthread_self() for the current thread

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -1,0 +1,105 @@
+#include <ruby.h>
+#include <ruby/debug.h>
+#include "libddprof_helpers.h"
+#include "private_vm_api_access.h"
+#include "stack_recorder.h"
+
+static VALUE missing_string = Qnil;
+
+// Gathers stack traces from running threads, storing them in a StackRecorder instance
+// This file implements the native bits of the Datadog::Profiling::Collectors::Stack class
+
+static VALUE _native_sample(VALUE self, VALUE thread, VALUE recorder_instance, VALUE metric_values_hash, VALUE labels_array);
+
+void collectors_stack_init(VALUE profiling_module) {
+  VALUE collectors_module = rb_define_module_under(profiling_module, "Collectors");
+  VALUE collectors_stack_class = rb_define_class_under(collectors_module, "Stack", rb_cObject);
+
+  rb_define_singleton_method(collectors_stack_class, "_native_sample", _native_sample, 4);
+
+  missing_string = rb_str_new2("");
+  rb_global_variable(&missing_string);
+}
+
+void sample(VALUE thread, VALUE recorder_instance, ddprof_ffi_Slice_i64 metric_values, ddprof_ffi_Slice_label labels);
+
+// This method exists only to enable testing Collectors::Stack behavior using RSpec.
+// It SHOULD NOT be used for other purposes.
+static VALUE _native_sample(VALUE self, VALUE thread, VALUE recorder_instance, VALUE metric_values_hash, VALUE labels_array) {
+  Check_Type(metric_values_hash, T_HASH);
+  Check_Type(labels_array, T_ARRAY);
+
+  if (rb_hash_size_num(metric_values_hash) != ENABLED_VALUE_TYPES_COUNT) {
+    rb_raise(
+      rb_eArgError,
+      "Mismatched values for metrics; expected %lu values and got %lu instead",
+      ENABLED_VALUE_TYPES_COUNT,
+      rb_hash_size_num(metric_values_hash)
+    );
+  }
+
+  int64_t metric_values[ENABLED_VALUE_TYPES_COUNT];
+  for (int i = 0; i < ENABLED_VALUE_TYPES_COUNT; i++) {
+    VALUE metric_value = rb_hash_fetch(metric_values_hash, rb_str_new_cstr(enabled_value_types[i].type_.ptr));
+    metric_values[i] = NUM2LONG(metric_value);
+  }
+
+  int labels_count = RARRAY_LEN(labels_array);
+  ddprof_ffi_Label labels[labels_count];
+
+  for (int i = 0; i < labels_count; i++) {
+    VALUE key_str_pair = rb_ary_entry(labels_array, i);
+
+    labels[i] = (ddprof_ffi_Label) {
+      .key = char_slice_from_ruby_string(rb_ary_entry(key_str_pair, 0)),
+      .str = char_slice_from_ruby_string(rb_ary_entry(key_str_pair, 1))
+    };
+  }
+
+  sample(
+    thread,
+    recorder_instance,
+    (ddprof_ffi_Slice_i64) {.ptr = metric_values, .len = ENABLED_VALUE_TYPES_COUNT},
+    (ddprof_ffi_Slice_label) {.ptr = labels, .len = labels_count}
+  );
+
+  return Qtrue;
+}
+
+void sample(VALUE thread, VALUE recorder_instance, ddprof_ffi_Slice_i64 metric_values, ddprof_ffi_Slice_label labels) {
+  const int max_frames = 400; // FIXME: Should be configurable
+  VALUE stack_buffer[max_frames];
+  int lines_buffer[max_frames];
+
+  int captured_frames = ddtrace_rb_profile_frames(thread, 0 /* stack starting depth */, max_frames, stack_buffer, lines_buffer);
+
+  ddprof_ffi_Location locations[captured_frames];
+  ddprof_ffi_Line lines[captured_frames];
+
+  for (int i = 0; i < captured_frames; i++) {
+    VALUE name = rb_profile_frame_base_label(stack_buffer[i]);
+    VALUE filename = rb_profile_frame_path(stack_buffer[i]);
+
+    name = NIL_P(name) ? missing_string : name;
+    filename = NIL_P(filename) ? missing_string : filename;
+
+    lines[i] = (ddprof_ffi_Line) {
+      .function = (ddprof_ffi_Function) {
+        .name = char_slice_from_ruby_string(name),
+        .filename = char_slice_from_ruby_string(filename)
+      },
+      .line = lines_buffer[i],
+    };
+
+    locations[i] = (ddprof_ffi_Location) {.lines = (ddprof_ffi_Slice_line) {.ptr = &lines[i], .len = 1}};
+  }
+
+  record_sample(
+    recorder_instance,
+    (ddprof_ffi_Sample) {
+      .locations = (ddprof_ffi_Slice_location) {.ptr = locations, .len = captured_frames},
+      .values = metric_values,
+      .labels = labels,
+    }
+  );
+}

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -29,12 +29,12 @@ static VALUE _native_sample(VALUE self, VALUE thread, VALUE recorder_instance, V
   Check_Type(metric_values_hash, T_HASH);
   Check_Type(labels_array, T_ARRAY);
 
-  if (rb_hash_size_num(metric_values_hash) != ENABLED_VALUE_TYPES_COUNT) {
+  if (RHASH_SIZE(metric_values_hash) != ENABLED_VALUE_TYPES_COUNT) {
     rb_raise(
       rb_eArgError,
       "Mismatched values for metrics; expected %lu values and got %lu instead",
       ENABLED_VALUE_TYPES_COUNT,
-      rb_hash_size_num(metric_values_hash)
+      RHASH_SIZE(metric_values_hash)
     );
   }
 

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -92,6 +92,10 @@ if RUBY_PLATFORM.include?('linux')
   $defs << '-DHAVE_PTHREAD_GETCPUCLOCKID'
 end
 
+# This is temporary just to break up implementation into two PRs and will be reverted in
+# https://github.com/DataDog/dd-trace-rb/pull/2000
+$defs << '-DTEMPORARY_SKIP_OLDER_RUBIES' if RUBY_VERSION < '2.6'
+
 # For REALLY OLD Rubies...
 if RUBY_VERSION < '2.3'
   # ...there was no rb_time_timespec_new function

--- a/ext/ddtrace_profiling_native_extension/libddprof_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/libddprof_helpers.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <ddprof/ffi.h>
+
+inline static ddprof_ffi_CharSlice char_slice_from_ruby_string(VALUE string) {
+  Check_Type(string, T_STRING);
+  ddprof_ffi_CharSlice char_slice = {.ptr = StringValuePtr(string), .len = RSTRING_LEN(string)};
+  return char_slice;
+}

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -33,3 +33,140 @@ static inline rb_thread_t *thread_struct_from_object(VALUE thread) {
 rb_nativethread_id_t pthread_id_for(VALUE thread) {
   return thread_struct_from_object(thread)->thread_id;
 }
+
+// -----------------------------------------------------------------------------
+// The sources below are modified versions of code extracted from the Ruby project.
+// The Ruby project copyright and license follow:
+// -----------------------------------------------------------------------------
+// Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+// SUCH DAMAGE.
+
+// Taken from upstream vm_core.h at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
+// Copyright (C) 2004-2007 Koichi Sasada
+// Modifications: None
+#define ISEQ_BODY(iseq) ((iseq)->body)
+
+// Taken from upstream vm_bactrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
+// Copyright (C) 1993-2012 Yukihiro Matsumoto
+// Modifications: None
+inline static int
+calc_pos(const rb_iseq_t *iseq, const VALUE *pc, int *lineno, int *node_id)
+{
+    VM_ASSERT(iseq);
+    VM_ASSERT(ISEQ_BODY(iseq));
+    VM_ASSERT(ISEQ_BODY(iseq)->iseq_encoded);
+    VM_ASSERT(ISEQ_BODY(iseq)->iseq_size);
+    if (! pc) {
+        if (ISEQ_BODY(iseq)->type == ISEQ_TYPE_TOP) {
+            VM_ASSERT(! ISEQ_BODY(iseq)->local_table);
+            VM_ASSERT(! ISEQ_BODY(iseq)->local_table_size);
+            return 0;
+        }
+        if (lineno) *lineno = FIX2INT(ISEQ_BODY(iseq)->location.first_lineno);
+#ifdef USE_ISEQ_NODE_ID
+        if (node_id) *node_id = -1;
+#endif
+        return 1;
+    }
+    else {
+        ptrdiff_t n = pc - ISEQ_BODY(iseq)->iseq_encoded;
+        VM_ASSERT(n <= ISEQ_BODY(iseq)->iseq_size);
+        VM_ASSERT(n >= 0);
+        ASSUME(n >= 0);
+        size_t pos = n; /* no overflow */
+        if (LIKELY(pos)) {
+            /* use pos-1 because PC points next instruction at the beginning of instruction */
+            pos--;
+        }
+#if VMDEBUG && defined(HAVE_BUILTIN___BUILTIN_TRAP)
+        else {
+            /* SDR() is not possible; that causes infinite loop. */
+            rb_print_backtrace();
+            __builtin_trap();
+        }
+#endif
+        if (lineno) *lineno = rb_iseq_line_no(iseq, pos);
+#ifdef USE_ISEQ_NODE_ID
+        if (node_id) *node_id = rb_iseq_node_id(iseq, pos);
+#endif
+        return 1;
+    }
+}
+
+// Taken from upstream vm_bactrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
+// Copyright (C) 1993-2012 Yukihiro Matsumoto
+// Modifications: None
+inline static int
+calc_lineno(const rb_iseq_t *iseq, const VALUE *pc)
+{
+    int lineno;
+    if (calc_pos(iseq, pc, &lineno, NULL)) return lineno;
+    return 0;
+}
+
+// Taken from upstream vm_bactrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
+// Copyright (C) 1993-2012 Yukihiro Matsumoto
+// Modifications:
+// * Renamed rb_profile_frames => ddtrace_rb_profile_frames
+// * Add thread argument
+int
+ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines)
+{
+    int i;
+    const rb_execution_context_t *ec = thread_struct_from_object(thread)->ec;
+    const rb_control_frame_t *cfp = ec->cfp, *end_cfp = RUBY_VM_END_CONTROL_FRAME(ec);
+    const rb_callable_method_entry_t *cme;
+
+    for (i=0; i<limit && cfp != end_cfp;) {
+        if (VM_FRAME_RUBYFRAME_P(cfp)) {
+            if (start > 0) {
+                start--;
+                continue;
+            }
+
+            /* record frame info */
+            cme = rb_vm_frame_method_entry(cfp);
+            if (cme && cme->def->type == VM_METHOD_TYPE_ISEQ) {
+                buff[i] = (VALUE)cme;
+            }
+            else {
+                buff[i] = (VALUE)cfp->iseq;
+            }
+
+            if (lines) lines[i] = calc_lineno(cfp->iseq, cfp->pc);
+
+            i++;
+        }
+        else {
+            cme = rb_vm_frame_method_entry(cfp);
+            if (cme && cme->def->type == VM_METHOD_TYPE_CFUNC) {
+                buff[i] = (VALUE)cme;
+                if (lines) lines[i] = 0;
+                i++;
+            }
+        }
+        cfp = RUBY_VM_PREVIOUS_CONTROL_FRAME(cfp);
+    }
+
+    return i;
+}

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -23,11 +23,11 @@
 //
 // Note that beyond returning the rb_thread_struct*, rb_check_typeddata() raises an exception
 // if the argument passed in is not actually a `Thread` instance.
-static inline struct rb_thread_struct *thread_struct_from_object(VALUE thread) {
+static inline rb_thread_t *thread_struct_from_object(VALUE thread) {
   static const rb_data_type_t *thread_data_type = NULL;
   if (thread_data_type == NULL) thread_data_type = RTYPEDDATA_TYPE(rb_thread_current());
 
-  return (struct rb_thread_struct *) rb_check_typeddata(thread, thread_data_type);
+  return (rb_thread_t *) rb_check_typeddata(thread, thread_data_type);
 }
 
 rb_nativethread_id_t pthread_id_for(VALUE thread) {

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -34,6 +34,13 @@ rb_nativethread_id_t pthread_id_for(VALUE thread) {
   return thread_struct_from_object(thread)->thread_id;
 }
 
+// This is temporary just to break up implementation into two PRs and will be reverted in
+// https://github.com/DataDog/dd-trace-rb/pull/2000
+#ifdef TEMPORARY_SKIP_OLDER_RUBIES
+int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines) { return 0; }
+
+#else
+
 // -----------------------------------------------------------------------------
 // The sources below are modified versions of code extracted from the Ruby project.
 // The Ruby project copyright and license follow:
@@ -197,3 +204,5 @@ ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *
 
     return i;
 }
+
+#endif

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -43,6 +43,8 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, i
 
 // -----------------------------------------------------------------------------
 // The sources below are modified versions of code extracted from the Ruby project.
+// Each function is annotated with its origin, why we imported it, and the changes made.
+//
 // The Ruby project copyright and license follow:
 // -----------------------------------------------------------------------------
 // Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
@@ -167,6 +169,8 @@ int
 ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines)
 {
     int i;
+    // Modified from upstream: Instead of using `GET_EC` to collect info from the current thread,
+    // support sampling any thread (including the current) passed as an argument
     const rb_execution_context_t *ec = thread_struct_from_object(thread)->ec;
     const rb_control_frame_t *cfp = ec->cfp, *end_cfp = RUBY_VM_END_CONTROL_FRAME(ec);
     const rb_callable_method_entry_t *cme;

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -1,3 +1,9 @@
 #pragma once
 
+#ifdef RUBY_2_1_WORKAROUND
+#include <thread_native.h>
+#else
+#include <ruby/thread_native.h>
+#endif
+
 rb_nativethread_id_t pthread_id_for(VALUE thread);

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -7,3 +7,4 @@
 #endif
 
 rb_nativethread_id_t pthread_id_for(VALUE thread);
+int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines);

--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -3,6 +3,7 @@
 #include "clock_id.h"
 
 // Each class/module here is implemented in their separate file
+void collectors_stack_init(VALUE profiling_module);
 void stack_recorder_init(VALUE profiling_module);
 
 static VALUE native_working_p(VALUE self);
@@ -19,6 +20,7 @@ void DDTRACE_EXPORT Init_ddtrace_profiling_native_extension(void) {
 
   rb_define_singleton_method(native_extension_module, "clock_id_for", clock_id_for, 1); // from clock_id.h
 
+  collectors_stack_init(profiling_module);
   stack_recorder_init(profiling_module);
 }
 

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -1,6 +1,4 @@
 #include <ruby.h>
-#include <ruby/debug.h>
-#include <ddprof/ffi.h>
 #include "stack_recorder.h"
 
 // Used to wrap a ddprof_ffi_Profile in a Ruby object and expose Ruby-level serialization APIs

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -13,29 +13,6 @@ static ID ruby_time_from_id; // id of :ruby_time_from in Ruby
 
 static VALUE stack_recorder_class = Qnil;
 
-// Note: Please DO NOT use `VALUE_STRING` anywhere else, instead use `DDPROF_FFI_CHARSLICE_C`.
-// `VALUE_STRING` is only needed because older versions of gcc (4.9.2, used in our Ruby 2.1 and 2.2 CI test images)
-// tripped when compiling `enabled_value_types` using `-std=gnu99` due to the extra cast that is included in
-// `DDPROF_FFI_CHARSLICE_C` with the following error:
-//
-// ```
-// compiling ../../../../ext/ddtrace_profiling_native_extension/stack_recorder.c
-// ../../../../ext/ddtrace_profiling_native_extension/stack_recorder.c:23:1: error: initializer element is not constant
-// static const ddprof_ffi_ValueType enabled_value_types[] = {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE};
-// ^
-// ```
-#define VALUE_STRING(string) {.ptr = "" string, .len = sizeof(string) - 1}
-
-#define      CPU_TIME_VALUE {.type_ = VALUE_STRING("cpu-time"),      .unit = VALUE_STRING("nanoseconds")}
-#define   CPU_SAMPLES_VALUE {.type_ = VALUE_STRING("cpu-samples"),   .unit = VALUE_STRING("count")}
-#define     WALL_TIME_VALUE {.type_ = VALUE_STRING("wall-time"),     .unit = VALUE_STRING("nanoseconds")}
-#define ALLOC_SAMPLES_VALUE {.type_ = VALUE_STRING("alloc-samples"), .unit = VALUE_STRING("count")}
-#define   ALLOC_SPACE_VALUE {.type_ = VALUE_STRING("alloc-space"),   .unit = VALUE_STRING("bytes")}
-#define    HEAP_SPACE_VALUE {.type_ = VALUE_STRING("heap-space"),    .unit = VALUE_STRING("bytes")}
-
-const static ddprof_ffi_ValueType enabled_value_types[] = {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE};
-#define ENABLED_VALUE_TYPES_COUNT (sizeof(enabled_value_types) / sizeof(ddprof_ffi_ValueType))
-
 static VALUE _native_new(VALUE klass);
 static void stack_recorder_typed_data_free(void *data);
 static VALUE _native_serialize(VALUE self, VALUE recorder_instance);

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.h
@@ -1,3 +1,28 @@
 #pragma once
 
+#include <ddprof/ffi.h>
+
+// Note: Please DO NOT use `VALUE_STRING` anywhere else, instead use `DDPROF_FFI_CHARSLICE_C`.
+// `VALUE_STRING` is only needed because older versions of gcc (4.9.2, used in our Ruby 2.1 and 2.2 CI test images)
+// tripped when compiling `enabled_value_types` using `-std=gnu99` due to the extra cast that is included in
+// `DDPROF_FFI_CHARSLICE_C` with the following error:
+//
+// ```
+// compiling ../../../../ext/ddtrace_profiling_native_extension/stack_recorder.c
+// ../../../../ext/ddtrace_profiling_native_extension/stack_recorder.c:23:1: error: initializer element is not constant
+// static const ddprof_ffi_ValueType enabled_value_types[] = {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE};
+// ^
+// ```
+#define VALUE_STRING(string) {.ptr = "" string, .len = sizeof(string) - 1}
+
+#define      CPU_TIME_VALUE {.type_ = VALUE_STRING("cpu-time"),      .unit = VALUE_STRING("nanoseconds")}
+#define   CPU_SAMPLES_VALUE {.type_ = VALUE_STRING("cpu-samples"),   .unit = VALUE_STRING("count")}
+#define     WALL_TIME_VALUE {.type_ = VALUE_STRING("wall-time"),     .unit = VALUE_STRING("nanoseconds")}
+#define ALLOC_SAMPLES_VALUE {.type_ = VALUE_STRING("alloc-samples"), .unit = VALUE_STRING("count")}
+#define   ALLOC_SPACE_VALUE {.type_ = VALUE_STRING("alloc-space"),   .unit = VALUE_STRING("bytes")}
+#define    HEAP_SPACE_VALUE {.type_ = VALUE_STRING("heap-space"),    .unit = VALUE_STRING("bytes")}
+
+const static ddprof_ffi_ValueType enabled_value_types[] = {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE};
+#define ENABLED_VALUE_TYPES_COUNT (sizeof(enabled_value_types) / sizeof(ddprof_ffi_ValueType))
+
 void record_sample(VALUE recorder_instance, ddprof_ffi_Sample sample);

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -148,6 +148,8 @@ module Datadog
       require 'datadog/profiling/ext/forking'
       require 'datadog/profiling/collectors/code_provenance'
       require 'datadog/profiling/collectors/old_stack'
+      require 'datadog/profiling/collectors/stack'
+      require 'datadog/profiling/stack_recorder'
       require 'datadog/profiling/exporter'
       require 'datadog/profiling/recorder'
       require 'datadog/profiling/scheduler'

--- a/lib/datadog/profiling/collectors/stack.rb
+++ b/lib/datadog/profiling/collectors/stack.rb
@@ -1,0 +1,15 @@
+# typed: false
+
+module Datadog
+  module Profiling
+    module Collectors
+      # Used to gather a stack trace from a given Ruby thread
+      # Methods prefixed with _native_ are implemented in `collectors_stack.c`
+      class Stack
+        def sample(thread, recorder_instance, metric_values_hash, labels_array)
+          self.class._native_sample(thread, recorder_instance, metric_values_hash, labels_array)
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -1,0 +1,74 @@
+# typed: ignore
+
+require 'datadog/profiling/spec_helper'
+require 'datadog/profiling/collectors/stack'
+
+RSpec.describe Datadog::Profiling::Collectors::Stack do
+  before { skip_if_profiling_not_supported(self) }
+
+  subject(:collectors_stack) { described_class.new }
+
+  let(:recorder) { Datadog::Profiling::StackRecorder.new }
+  let(:metric_values) { {'cpu-time' => 123, 'cpu-samples' => 456, 'wall-time' => 789} }
+  let(:labels) { {'label_a' => 'value_a', 'label_b' => 'value_b'}.to_a }
+
+  let(:pprof_data) { recorder.serialize.last }
+  let(:decoded_profile) { ::Perftools::Profiles::Profile.decode(pprof_data) }
+
+  let(:raw_reference_stack) { stacks.fetch(:reference) }
+  let(:reference_stack) { raw_reference_stack.map { |location| {base_label: location.base_label, path: location.path, lineno: location.lineno} } }
+  let(:gathered_stack) { stacks.fetch(:gathered) }
+
+  context 'when sampling a sleeping thread' do
+    let(:ready_queue) { Queue.new }
+    let(:another_thread) do
+      Thread.new(ready_queue) do |ready_queue|
+        ready_queue << true
+        sleep
+      end
+    end
+
+    before do
+      another_thread
+      ready_queue.pop
+    end
+
+    after do
+      another_thread.kill
+      another_thread.join
+    end
+
+    let!(:stacks) { {reference: another_thread.backtrace_locations, gathered: sample_and_decode(another_thread)} }
+
+    it 'matches the Ruby backtrace API' do
+      pending 'Needs fixes in rb_profile_frames to fix sleep'
+
+      expect(gathered_stack).to eq reference_stack
+    end
+
+    it 'matches the Ruby backtrace API excluding the sleep frame' do
+      # FIXME: Temporary, until above test can be fixed
+
+      expect(gathered_stack[1..-1]).to eq reference_stack[1..-1]
+    end
+  end
+
+  def sample_and_decode(thread)
+    collectors_stack.sample(thread, recorder, metric_values, labels)
+
+    expect(decoded_profile.sample.size).to be 1
+    sample = decoded_profile.sample.first
+
+    sample.location_id.map { |location_id| decode_frame(decoded_profile, location_id) }
+  end
+
+  def decode_frame(decoded_profile, location_id)
+    strings = decoded_profile.string_table
+    location = decoded_profile.location.find { |location| location.id == location_id }
+    expect(location.line.size).to be 1
+    line_entry = location.line.first
+    function = decoded_profile.function.find { |function| function.id == line_entry.function_id }
+
+    {base_label: strings[function.name], path: strings[function.filename], lineno: line_entry.line}
+  end
+end

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -4,7 +4,15 @@ require 'datadog/profiling/spec_helper'
 require 'datadog/profiling/collectors/stack'
 
 RSpec.describe Datadog::Profiling::Collectors::Stack do
-  before { skip_if_profiling_not_supported(self) }
+  before do
+    skip_if_profiling_not_supported(self)
+    if RUBY_VERSION < '2.6'
+      skip(
+        'This is temporarily disabled just to break up implementation into two PRs and will be ' \
+        'reverted in https://github.com/DataDog/dd-trace-rb/pull/2000'
+      )
+    end
+  end
 
   subject(:collectors_stack) { described_class.new }
 

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
     context 'when profile has a sample' do
       let(:collectors_stack) { Datadog::Profiling::Collectors::Stack.new }
 
-      let(:metric_values) { {'cpu-time' => 123, 'cpu-samples' => 456, 'wall-time' => 789} }
-      let(:labels) { {'label_a' => 'value_a', 'label_b' => 'value_b'}.to_a }
+      let(:metric_values) { { 'cpu-time' => 123, 'cpu-samples' => 456, 'wall-time' => 789 } }
+      let(:labels) { { 'label_a' => 'value_a', 'label_b' => 'value_b' }.to_a }
 
       before do
         collectors_stack.sample(Thread.current, stack_recorder, metric_values, labels)

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -4,7 +4,15 @@ require 'datadog/profiling/spec_helper'
 require 'datadog/profiling/stack_recorder'
 
 RSpec.describe Datadog::Profiling::StackRecorder do
-  before { skip_if_profiling_not_supported(self) }
+  before do
+    skip_if_profiling_not_supported(self)
+    if RUBY_VERSION < '2.6'
+      skip(
+        'This is temporarily disabled just to break up implementation into two PRs and will be ' \
+        'reverted in https://github.com/DataDog/dd-trace-rb/pull/2000'
+      )
+    end
+  end
 
   subject(:stack_recorder) { described_class.new }
 


### PR DESCRIPTION
This PR adds the new `Stack` collector, which samples using the `rb_profile_frames` API.

Rather than using the `rb_profile_frames` API directly, it copy pastes it from the Ruby VM sources into the `private_vm_api_access.c` file. 

I claim license-wise this is OK since upstream Ruby allows the source code to be used under the terms of the BSD-2-Clause license, which I include in the file with the copied snippets as well as in the `LICENSE-3rdparty.csv` file as usual. I'll also run this through the internal opensource group, in case they have any notes/concerns.

Code-wise, here's a quick description of `rb_profile_frames` and why we need it:

#### What is rb_profile_frames?

`rb_profile_frames` is a Ruby VM debug API added for use by profilers for sampling the stack trace of a Ruby thread.
Its main other user is the stackprof profiler: https://github.com/tmm1/stackprof .

#### Why do we need a custom version of rb_profile_frames?
There are a few reasons:
1. To backport improved behavior to older Rubies. Prior to Ruby 3.0 (https://github.com/ruby/ruby/pull/3299), rb_profile_frames skipped CFUNC frames, aka frames that are implemented with native code, and thus the resulting stacks were quite incomplete as a big part of the Ruby standard library is implemented with native code.
2. To extend this function to work with any thread. The upstream rb_profile_frames function only targets the current
   thread, and to support wall-clock profiling we require sampling other threads. This is only safe because of the
   Global VM Lock. (We don't yet support sampling Ractors beyond the main one; we'll need to find a way to do it
   safely first.)
3. To get more information out of the Ruby VM. The Ruby VM has a lot more information than is exposed through
   rb_profile_frames, and by making our own copy of this function we can extract more of this information.
   See for backtracie gem (https://github.com/ivoanjo/backtracie) for an exploration of what can potentially be done.
4. Because we haven't yet submitted patches to upstream Ruby. As with any changes on the `private_vm_api_access.c`,
   our medium/long-term plan is to contribute upstream changes and make it so that we don't need any of this
   on modern Rubies.

This PR depends on #1960. It also isn't the full story -- I tried to limit the scope of this PR to avoid it growing too much, since "copy pasting code from the Ruby codebase" was already a quite important event by itself.