### PR TITLE
Hide symbols/functions in profiling native extension

### DIFF
--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -109,6 +109,14 @@ add_compiler_flag '-Wno-declaration-after-statement'
 # cause a segfault later. Let's ensure that never happens.
 add_compiler_flag '-Werror-implicit-function-declaration'
 
+# The native extension is not intended to expose any symbols/functions for other native libraries to use;
+# the sole exception being `Init_ddtrace_profiling_native_extension` which needs to be visible for Ruby to call it when
+# it `dlopen`s the library.
+#
+# By setting this compiler flag, we tell it to assume that everything is private unless explicitly stated.
+# For more details see https://gcc.gnu.org/wiki/Visibility
+add_compiler_flag '-fvisibility=hidden'
+
 if RUBY_PLATFORM.include?('linux')
   # Supposedly, the correct way to do this is
   # ```

--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -4,7 +4,9 @@
 
 static VALUE native_working_p(VALUE self);
 
-void __attribute__ ((visibility ("default"))) Init_ddtrace_profiling_native_extension(void) {
+#define DDTRACE_EXPORT __attribute__ ((visibility ("default")))
+
+void DDTRACE_EXPORT Init_ddtrace_profiling_native_extension(void) {
   VALUE datadog_module = rb_define_module("Datadog");
   VALUE profiling_module = rb_define_module_under(datadog_module, "Profiling");
   VALUE native_extension_module = rb_define_module_under(profiling_module, "NativeExtension");

--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -4,7 +4,7 @@
 
 static VALUE native_working_p(VALUE self);
 
-void Init_ddtrace_profiling_native_extension(void) {
+void __attribute__ ((visibility ("default"))) Init_ddtrace_profiling_native_extension(void) {
   VALUE datadog_module = rb_define_module("Datadog");
   VALUE profiling_module = rb_define_module_under(datadog_module, "Profiling");
   VALUE native_extension_module = rb_define_module_under(profiling_module, "NativeExtension");


### PR DESCRIPTION
The native extension is not intended to expose any symbols/functions for other native libraries to use, so let's set the default visibility to hidden.

This avoids accidental symbol naming clashes with other extensions/libraries.

Test suite still green :)