### PR TITLE
Fix broken CI by disabling testing with Ruby head/nightly on macOS

### DIFF
--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        ruby: [2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, head] # ADD NEW RUBIES HERE
+        ruby: [2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1] # ADD NEW RUBIES HERE
     runs-on: ${{ matrix.os }}
     env:
       SKIP_SIMPLECOV: 1


### PR DESCRIPTION
For quite a while Ruby-head was stable enough that it did not affect our testing, but recently a few tests started failing consistently, e.g. <https://github.com/DataDog/dd-trace-rb/runs/5885670306?check_suite_focus=true>

At least one failure is related to a change to the `RubyVM.stat` output, which seems to be undergoing some development (see <https://github.com/ruby/ruby/pull/5766>).

At least one of the other failures (regarding initialization of `Datadog::Profiling::Recorder` seems to be a regression/new bug on upstream Ruby.

I don't think it's worth necessarily tracking Ruby-head breaking changes (for instance the `RubyVM` change had a bit of back and forth and we would've had to do more work if we were trying to keep up with it), so let's remove this for now.

As an alternative, Ruby 3.2.0-preview1 is out, so I suggest we look into adding it to our usual CircleCI setup, and then keep up with the other preview/rc releases so when December rolls around we're in good shape to support 3.2.0.