### PR TITLE
Fix resource not inherited from lazily annotated spans

### DIFF
--- a/lib/datadog/tracing/correlation.rb
+++ b/lib/datadog/tracing/correlation.rb
@@ -30,8 +30,6 @@ module Datadog
           :trace_service,
           :version
 
-        # rubocop:disable Metrics/CyclomaticComplexity
-        # rubocop:disable Metrics/PerceivedComplexity
         # @!visibility private
         def initialize(
           env: nil,
@@ -48,26 +46,19 @@ module Datadog
           version: nil
         )
           # Dup and freeze strings so they aren't modified by reference.
-          @env = env || Datadog.configuration.env
-          @service = service || Datadog.configuration.service
+          @env = Core::Utils::SafeDup.frozen_or_dup(env || Datadog.configuration.env).freeze
+          @service = Core::Utils::SafeDup.frozen_or_dup(service || Datadog.configuration.service).freeze
           @span_id = span_id || 0
-          @span_name = span_name && span_name.dup.freeze
-          @span_resource = span_resource && span_resource.dup.freeze
-          @span_service = span_service && span_service.dup.freeze
-          @span_type = span_type && span_type.dup.freeze
+          @span_name = Core::Utils::SafeDup.frozen_or_dup(span_name).freeze
+          @span_resource = Core::Utils::SafeDup.frozen_or_dup(span_resource).freeze
+          @span_service = Core::Utils::SafeDup.frozen_or_dup(span_service).freeze
+          @span_type = Core::Utils::SafeDup.frozen_or_dup(span_type).freeze
           @trace_id = trace_id || 0
-          @trace_name = trace_name && trace_name.dup.freeze
-          @trace_resource = trace_resource && trace_resource.dup.freeze
-          @trace_service = trace_service && trace_service.dup.freeze
-          @version = version || Datadog.configuration.version
-
-          # Finish freezing globals
-          @service = @service.dup.freeze unless @service.nil?
-          @env = @env.dup.freeze unless @env.nil?
-          @version = @version.dup.freeze unless @version.nil?
+          @trace_name = Core::Utils::SafeDup.frozen_or_dup(trace_name).freeze
+          @trace_resource = Core::Utils::SafeDup.frozen_or_dup(trace_resource).freeze
+          @trace_service = Core::Utils::SafeDup.frozen_or_dup(trace_service).freeze
+          @version = Core::Utils::SafeDup.frozen_or_dup(version || Datadog.configuration.version).freeze
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
-        # rubocop:enable Metrics/PerceivedComplexity
 
         def to_log_format
           @log_format ||= begin

--- a/lib/datadog/tracing/span.rb
+++ b/lib/datadog/tracing/span.rb
@@ -3,6 +3,7 @@
 # typed: true
 
 require 'datadog/core/utils'
+require 'datadog/core/utils/safe_dup'
 
 require 'datadog/tracing/metadata/ext'
 require 'datadog/tracing/metadata'
@@ -79,10 +80,10 @@ module Datadog
         type: span_type,
         trace_id: nil
       )
-        @name = name
-        @service = service
-        @resource = resource
-        @type = type
+        @name = Core::Utils::SafeDup.frozen_or_dup(name)
+        @service = Core::Utils::SafeDup.frozen_or_dup(service)
+        @resource = Core::Utils::SafeDup.frozen_or_dup(resource)
+        @type = Core::Utils::SafeDup.frozen_or_dup(type)
 
         @id = id || Core::Utils.next_id
         @parent_id = parent_id || 0

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -457,18 +457,18 @@ module Datadog
       # we don't want this SpanOperation to modify it further.
       def build_span
         Span.new(
-          @name.frozen? ? @name : @name.dup,
+          @name,
           duration: duration,
           end_time: @end_time,
           id: @id,
           meta: meta.dup,
           metrics: metrics.dup,
           parent_id: @parent_id,
-          resource: @resource.frozen? ? @resource : @resource.dup,
-          service: @service.frozen? ? @service : @service.dup,
+          resource: @resource,
+          service: @service,
           start_time: @start_time,
           status: @status,
-          type: @type.frozen? ? @type : @type.dup,
+          type: @type,
           trace_id: @trace_id
         )
       end

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -32,14 +32,11 @@ module Datadog
       attr_accessor \
         :agent_sample_rate,
         :hostname,
-        :name,
         :origin,
         :rate_limiter_rate,
-        :resource,
         :rule_sample_rate,
         :sample_rate,
-        :sampling_priority,
-        :service
+        :sampling_priority
 
       attr_reader \
         :active_span_count,
@@ -49,7 +46,10 @@ module Datadog
         :parent_span_id
 
       attr_writer \
-        :sampled
+        :name,
+        :resource,
+        :sampled,
+        :service
 
       def initialize(
         agent_sample_rate: nil,
@@ -126,6 +126,18 @@ module Datadog
       def reject!
         self.sampled = false
         self.sampling_priority = Sampling::Ext::Priority::USER_REJECT
+      end
+
+      def name
+        @name || (root_span && root_span.name)
+      end
+
+      def resource
+        @resource || (root_span && root_span.resource)
+      end
+
+      def service
+        @service || (root_span && root_span.service)
       end
 
       def measure(
@@ -242,13 +254,13 @@ module Datadog
           span_type: (@active_span && @active_span.type),
           trace_hostname: @hostname,
           trace_id: @id,
-          trace_name: @name,
+          trace_name: name,
           trace_origin: @origin,
           trace_process_id: Core::Environment::Identity.pid,
-          trace_resource: @resource,
+          trace_resource: resource,
           trace_runtime_id: Core::Environment::Identity.id,
           trace_sampling_priority: @sampling_priority,
-          trace_service: @service,
+          trace_service: service,
         ).freeze
       end
 
@@ -261,16 +273,16 @@ module Datadog
           hostname: (@hostname && @hostname.dup),
           id: @id,
           max_length: @max_length,
-          name: (@name && @name.dup),
+          name: (name && name.dup),
           origin: (@origin && @origin.dup),
           parent_span_id: (@active_span && @active_span.id) || @parent_span_id,
           rate_limiter_rate: @rate_limiter_rate,
-          resource: (@resource && @resource.dup),
+          resource: (resource && resource.dup),
           rule_sample_rate: @rule_sample_rate,
           sample_rate: @sample_rate,
           sampled: @sampled,
           sampling_priority: @sampling_priority,
-          service: (@service && @service.dup),
+          service: (service && service.dup),
           tags: meta.dup,
           metrics: metrics.dup
         )
@@ -390,12 +402,6 @@ module Datadog
         return if span.nil? || root_span
 
         @root_span = span
-
-        # Auto populate these attributes if
-        # they haven't been set yet.
-        @name ||= span.name
-        @resource ||= span.resource
-        @service ||= span.service
       end
 
       def build_trace(spans, partial = false)
@@ -412,9 +418,9 @@ module Datadog
           runtime_id: Core::Environment::Identity.id,
           sample_rate: @sample_rate,
           sampling_priority: @sampling_priority,
-          name: @name,
-          resource: @resource,
-          service: @service,
+          name: name,
+          resource: resource,
+          service: service,
           tags: meta,
           metrics: metrics,
           root_span_id: !partial ? root_span && root_span.id : nil

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -370,7 +370,7 @@ module Datadog
           deactivate_span!(span_op)
 
           # Set finished, to signal root span has completed.
-          @finished = true if span_op == @root_span
+          @finished = true if span_op == root_span
 
           # Update active span count
           @active_span_count -= 1
@@ -417,7 +417,7 @@ module Datadog
           service: @service,
           tags: meta,
           metrics: metrics,
-          root_span_id: !partial ? @root_span && @root_span.id : nil
+          root_span_id: !partial ? root_span && root_span.id : nil
         )
       end
     end

--- a/lib/datadog/tracing/trace_segment.rb
+++ b/lib/datadog/tracing/trace_segment.rb
@@ -62,8 +62,8 @@ module Datadog
 
         # Does not make an effort to move metrics out of tags
         # The caller is expected to have done that
-        @meta = tags || {}
-        @metrics = metrics || {}
+        @meta = (tags && tags.dup) || {}
+        @metrics = (metrics && metrics.dup) || {}
 
         # Set well-known tags, defaulting to getting the values from tags
         @agent_sample_rate = agent_sample_rate || agent_sample_rate_tag


### PR DESCRIPTION
## Issue

`TraceOperation#resource` describes the "best" resource name for the trace. When no value is explicitly set, this value would be inherited (at span creation) from the first span in the trace. e.g. `trace.resource ||= root_span.resource`.

This kind of eager initialization doesn't work well with existing instrumentation: it's common practice for instrumentation to change the resource name from within the trace block itself, after the span was created. e.g.

```ruby
def execute
  Datadog::Tracing.trace('job.execute') do |span|
    span.resource = job_name
    super
  end
end
```

Because no resource name is provided when the span is created, the span's resource name defaults to the span's name, then the trace resource name defaults to the spans resource name. Thus the trace resource would be set as `'job.execute'`. We would actually expect the trace to reflect `job_name`, but this value is never used because the trace thinks it received a good value.

## Solution

`TraceOperation#name`, `TraceOperation#resource`, and `TraceOperation#service` are all attributes that are intended to be derived from the root span, if no explicit value is provided.

This pull request eliminates eager initialization, and makes these attributes into functions that return any explicitly defined value first if provided, then the root span's value if none set. Therefore, it should always reflect the root span's value as expected.