### PR TITLE
Rename thread-local to fiber-local in concurrent context

### DIFF
--- a/lib/datadog/tracing/context_provider.rb
+++ b/lib/datadog/tracing/context_provider.rb
@@ -38,17 +38,12 @@ module Datadog
     end
 
     # FiberLocalContext can be used as a tracer global reference to create
-    # a different {Datadog::Tracing::Context} for each fiber. In synchronous tracer, this
-    # is required to prevent multiple fibers sharing the same {Datadog::Tracing::Context}
-    # in different executions.
+    # a different {Datadog::Tracing::Context} for each fiber. This allows for the tracer
+    # to create a serial execution graph regardless of any concurrent execution: each
+    # concurrent execution path creates a new trace graph.
     #
     # @see https://ruby-doc.org/core-3.1.2/Thread.html#method-i-5B-5D Thread attributes are fiber-local
     class FiberLocalContext
-      # FiberLocalContext can be used as a tracer global reference to create
-      # a different {Datadog::Tracing::Context} for each fiber. In synchronous tracer, this
-      # is required to prevent multiple fivers sharing the same {Datadog::Tracing::Context}
-      # in different executions.
-      #
       # To support multiple tracers simultaneously, each {Datadog::Tracing::FiberLocalContext}
       # instance has its own fiber-local variable.
       def initialize

--- a/lib/datadog/tracing/context_provider.rb
+++ b/lib/datadog/tracing/context_provider.rb
@@ -5,12 +5,14 @@ require 'datadog/tracing/context'
 module Datadog
   module Tracing
     # DefaultContextProvider is a default context provider that retrieves
-    # all contexts from the current thread-local storage. It is suitable for
+    # all contexts from the current fiber-local storage. It is suitable for
     # synchronous programming.
+    #
+    # @see https://ruby-doc.org/core-3.1.2/Thread.html#method-i-5B-5D Thread attributes are fiber-local
     class DefaultContextProvider
-      # Initializes the default context provider with a thread-bound context.
+      # Initializes the default context provider with a fiber-bound context.
       def initialize
-        @context = ThreadLocalContext.new
+        @context = FiberLocalContext.new
       end
 
       # Sets the current context.
@@ -35,32 +37,34 @@ module Datadog
       end
     end
 
-    # ThreadLocalContext can be used as a tracer global reference to create
-    # a different {Datadog::Tracing::Context} for each thread. In synchronous tracer, this
-    # is required to prevent multiple threads sharing the same {Datadog::Tracing::Context}
+    # FiberLocalContext can be used as a tracer global reference to create
+    # a different {Datadog::Tracing::Context} for each fiber. In synchronous tracer, this
+    # is required to prevent multiple fibers sharing the same {Datadog::Tracing::Context}
     # in different executions.
-    class ThreadLocalContext
-      # ThreadLocalContext can be used as a tracer global reference to create
-      # a different {Datadog::Tracing::Context} for each thread. In synchronous tracer, this
-      # is required to prevent multiple threads sharing the same {Datadog::Tracing::Context}
+    #
+    # @see https://ruby-doc.org/core-3.1.2/Thread.html#method-i-5B-5D Thread attributes are fiber-local
+    class FiberLocalContext
+      # FiberLocalContext can be used as a tracer global reference to create
+      # a different {Datadog::Tracing::Context} for each fiber. In synchronous tracer, this
+      # is required to prevent multiple fivers sharing the same {Datadog::Tracing::Context}
       # in different executions.
       #
-      # To support multiple tracers simultaneously, each {Datadog::Tracing::ThreadLocalContext}
-      # instance has its own thread-local variable.
+      # To support multiple tracers simultaneously, each {Datadog::Tracing::FiberLocalContext}
+      # instance has its own fiber-local variable.
       def initialize
         @key = "datadog_context_#{object_id}".to_sym
 
         self.local = Context.new
       end
 
-      # Override the thread-local context with a new context.
+      # Override the fiber-local context with a new context.
       def local=(ctx)
         Thread.current[@key] = ctx
       end
 
-      # Return the thread-local context.
-      def local(thread = Thread.current)
-        thread[@key] ||= Context.new
+      # Return the fiber-local context.
+      def local(storage = Thread.current)
+        storage[@key] ||= Context.new
       end
     end
   end

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -199,7 +199,7 @@ module Datadog
 
       # The active, unfinished trace, representing the current instrumentation context.
       #
-      # The active trace is thread-local.
+      # The active trace is fiber-local.
       #
       # @param [Thread] key Thread to retrieve trace from. Defaults to current thread. For internal use only.
       # @return [Datadog::Tracing::TraceSegment] the active trace

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -556,7 +556,7 @@ RSpec.describe 'Tracer integration tests' do
     end
   end
 
-  describe 'thread-local context' do
+  describe 'fiber-local context' do
     subject(:tracer) { new_tracer }
 
     it 'clears context after tracer finishes' do
@@ -596,7 +596,7 @@ RSpec.describe 'Tracer integration tests' do
 
       after { tracer2.shutdown! }
 
-      it 'create one thread-local context per tracer' do
+      it 'create one fiber-local context per tracer' do
         span = tracer.trace('test')
         context = tracer.send(:call_context)
 
@@ -613,7 +613,7 @@ RSpec.describe 'Tracer integration tests' do
       end
 
       context 'with another thread' do
-        it 'create one thread-local context per tracer per thread' do
+        it 'create one fiber-local context per tracer per thread' do
           span = tracer.trace('test')
           context = tracer.send(:call_context)
 
@@ -622,10 +622,10 @@ RSpec.describe 'Tracer integration tests' do
 
           Thread.new do
             thread_span = tracer.trace('thread_test')
-            @thread_context = tracer.send(:call_context)
+            @fiber_context = tracer.send(:call_context)
 
             thread_span2 = tracer2.trace('thread_test2')
-            @thread_context2 = tracer2.send(:call_context)
+            @fiber_context2 = tracer2.send(:call_context)
 
             thread_span.finish
             thread_span2.finish
@@ -634,7 +634,7 @@ RSpec.describe 'Tracer integration tests' do
           span2.finish
           span.finish
 
-          expect([context, context2, @thread_context, @thread_context2].uniq)
+          expect([context, context2, @fiber_context, @fiber_context2].uniq)
             .to have(4).items
 
           spans = tracer.writer.spans


### PR DESCRIPTION
Fixes https://github.com/DataDog/dd-trace-rb/issues/1979

`Thread[]` and `Thread[]=` are fiber-local attributes[¹](https://bugs.ruby-lang.org/issues/8215#note-1), not thread-local as we have described them in `ddtrace`.
But they are also thread-safe, given these attributes are retrieved from the ["current thread's root fiber if not explicitly inside a Fiber"](https://ruby-doc.org/core-3.1.2/Thread.html#method-i-5B-5D). Effectively, `Thread[]` and `Thread[]=` are both thread-safe and fiber-safe, but fiber-safe is the most accurate way to describe them.

This PR does not change any behavior, only clarifies nomenclature around fiber- vs thread-local storage.

Also, this PR adds one test to ensure the fiber-local behavior explicitly, given all tests are centered around threads today.

One alternative to this PR is to move from using `Thread[]` to [`Thread#thread_variable_get`](https://ruby-doc.org/core-3.1.2/Thread.html#method-i-thread_variable_get), making the execution context thread-safe but not fiber-safe. I believe this is not in our best interest, given in a context where Fibers are utilized concurrent spans could be created and interwoven, creating unexpected span child-parent relationships. Keeping our contexts fiber-local avoids this issue but creating distinct execution contexts for each fiber.