### PR TITLE
Add libddwaf metrics

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'debase-ruby_core_source', '<= 0.10.15'
 
   # Used by appsec
-  spec.add_dependency 'libddwaf', '~> 1.3.0.1.0.a'
+  spec.add_dependency 'libddwaf', '~> 1.3.0.1.0'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb']
 end

--- a/gemfiles/jruby_9.2.18.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -1413,7 +1413,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -62,7 +62,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.18.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.18.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.18.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -1413,7 +1413,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -62,7 +62,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.8.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.8.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.8.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.4.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -1413,7 +1413,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.4.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.4.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -62,7 +62,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.4.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.4.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.3.4.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.3.4.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.3.4.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.4.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.1.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack (< 1.4)
 
 GEM
@@ -120,7 +120,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     makara (0.4.1)
       activerecord (>= 3.0.0)

--- a/gemfiles/ruby_2.1.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack (< 1.4)
 
 GEM
@@ -36,7 +36,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack (< 1.4)
 
 GEM
@@ -73,7 +73,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack (< 1.4)
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack (< 1.4)
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack (< 1.4)
 
 GEM
@@ -70,7 +70,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack (< 1.4)
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack (< 1.4)
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack (< 1.4)
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack (< 1.4)
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.2.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -1262,7 +1262,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -36,7 +36,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -73,7 +73,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -70,7 +70,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -78,7 +78,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -85,7 +85,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.3.8_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -1367,7 +1367,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -36,7 +36,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -54,7 +54,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -74,7 +74,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -73,7 +73,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -70,7 +70,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -78,7 +78,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -85,7 +85,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -36,7 +36,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -36,7 +36,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -1413,7 +1413,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -41,7 +41,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -56,7 +56,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -76,7 +76,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -1411,7 +1411,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -52,7 +52,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -66,7 +66,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -109,7 +109,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -109,7 +109,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -109,7 +109,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -109,7 +109,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -109,7 +109,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -1412,7 +1412,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -53,7 +53,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.6.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.6.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.6.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -1411,7 +1411,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -53,7 +53,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.7.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1)
+    libddwaf (1.3.0.1.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -1418,7 +1418,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.0.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -51,7 +51,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.0.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -1418,7 +1418,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.1.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -51,7 +51,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.1.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -1420,7 +1420,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.16.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -66,7 +66,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.16.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.1.0.a)
+      libddwaf (~> 1.3.0.1.0)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
@@ -97,13 +97,17 @@ module Datadog
               private
 
               def active_trace
-                return unless defined?(Datadog::Tracing) && Datadog::Tracing.respond_to?(:active_trace)
+                # TODO: factor out tracing availability detection
+
+                return unless defined?(Datadog::Tracing)
 
                 Datadog::Tracing.active_trace
               end
 
               def active_span
-                return unless defined?(Datadog::Tracing) && Datadog::Tracing.respond_to?(:active_span)
+                # TODO: factor out tracing availability detection
+
+                return unless defined?(Datadog::Tracing)
 
                 Datadog::Tracing.active_span
               end

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -14,6 +14,7 @@ module Datadog
           def initialize(app, opt = {})
             @app = app
 
+            @first_request = true
             @processor = Datadog::AppSec::Processor.new
           end
 
@@ -26,6 +27,8 @@ module Datadog
 
             env['datadog.waf.context'] = context
             request = ::Rack::Request.new(env)
+
+            add_appsec_tags
 
             request_return, request_response = Instrumentation.gateway.push('rack.request', request) do
               @app.call(env)
@@ -49,6 +52,49 @@ module Datadog
             AppSec::Event.record(*both_response.map { |_action, event| event }) if both_response.any?
 
             request_return
+          ensure
+            add_waf_runtime_tags(context)
+            request!
+          end
+
+          private
+
+          def first_request?
+            @first_request
+          end
+
+          def request!
+            @first_request = false
+          end
+
+          def active_trace
+            return unless defined?(Datadog::Tracing) && Datadog::Tracing.respond_to?(:active_span)
+
+            Datadog::Tracing.active_trace
+          end
+
+          def add_appsec_tags
+            return unless active_trace
+
+            active_trace.set_tag('_dd.appsec.enabled', 1)
+            active_trace.set_tag('_dd.runtime_family', 'ruby')
+            active_trace.set_tag('_dd.appsec.waf.version', Datadog::AppSec::WAF::VERSION::BASE_STRING)
+
+            if @processor.ruleset_info
+              active_trace.set_tag('_dd.appsec.event_rules.version', @processor.ruleset_info[:version])
+              if first_request?
+                active_trace.set_tag('_dd.appsec.event_rules.loaded', @processor.ruleset_info[:loaded].to_f)
+                active_trace.set_tag('_dd.appsec.event_rules.error_count', @processor.ruleset_info[:failed].to_f)
+                active_trace.set_tag('_dd.appsec.event_rules.errors', JSON.dump(@processor.ruleset_info[:errors]))
+                active_trace.keep!
+              end
+            end
+          end
+
+          def add_waf_runtime_tags(context)
+            active_trace.set_tag('_dd.appsec.waf.timeouts', context.timeouts)
+            active_trace.set_tag('_dd.appsec.waf.duration', context.time / 1000.0)
+            active_trace.set_tag('_dd.appsec.waf.duration_ext', context.time_ext / 1000.0)
           end
         end
       end

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -86,6 +86,7 @@ module Datadog
                 active_trace.set_tag('_dd.appsec.event_rules.loaded', @processor.ruleset_info[:loaded].to_f)
                 active_trace.set_tag('_dd.appsec.event_rules.error_count', @processor.ruleset_info[:failed].to_f)
                 active_trace.set_tag('_dd.appsec.event_rules.errors', JSON.dump(@processor.ruleset_info[:errors]))
+                active_trace.set_tag('_dd.appsec.event_rules.addresses', JSON.dump(@processor.addresses))
                 active_trace.keep!
               end
             end

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -1,5 +1,7 @@
 # typed: ignore
 
+require 'json'
+
 require 'datadog/appsec/instrumentation/gateway'
 require 'datadog/appsec/processor'
 require 'datadog/appsec/assets'

--- a/lib/datadog/appsec/event.rb
+++ b/lib/datadog/appsec/event.rb
@@ -1,5 +1,7 @@
 # typed: false
 
+require 'json'
+
 require 'datadog/appsec/contrib/rack/request'
 require 'datadog/appsec/contrib/rack/response'
 require 'datadog/appsec/rate_limiter'

--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -42,7 +42,7 @@ module Datadog
         end
       end
 
-      attr_reader :ruleset_info
+      attr_reader :ruleset_info, :addresses
 
       def initialize
         @ruleset = nil
@@ -109,6 +109,7 @@ module Datadog
         }
         @handle = Datadog::AppSec::WAF::Handle.new(@ruleset, obfuscator: obfuscator_config)
         @ruleset_info = @handle.ruleset_info
+        @addresses = @handle.required_addresses
 
         true
       rescue StandardError => e

--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -16,9 +16,38 @@ module Datadog
         end
       end
 
+      # Context wraps libddwaf's context
+      class Context
+        attr_reader :time, :time_ext, :timeouts
+
+        def initialize(processor)
+          @context = Datadog::AppSec::WAF::Context.new(processor.send(:handle))
+          @time = 0.0
+          @time_ext = 0.0
+          @timeouts = 0
+        end
+
+        def run(*args)
+          start = Core::Utils::Time.get_time
+
+          ret, res = @context.run(*args)
+
+          stop = Core::Utils::Time.get_time
+
+          @time += res.total_runtime
+          @time_ext += (stop - start) * 1_000_000_000
+          @timeouts += 1 if res.timeout
+
+          [ret, res]
+        end
+      end
+
+      attr_reader :ruleset_info
+
       def initialize
         @ruleset = nil
         @handle = nil
+        @ruleset_info = nil
 
         unless load_libddwaf && load_ruleset && create_waf_handle
           Datadog.logger.warn { 'AppSec is disabled, see logged errors above' }
@@ -30,8 +59,12 @@ module Datadog
       end
 
       def new_context
-        Datadog::AppSec::WAF::Context.new(@handle)
+        Context.new(self)
       end
+
+      protected
+
+      attr_reader :handle
 
       private
 
@@ -75,12 +108,15 @@ module Datadog
           value_regex: Datadog::AppSec.settings.obfuscator_value_regex,
         }
         @handle = Datadog::AppSec::WAF::Handle.new(@ruleset, obfuscator: obfuscator_config)
+        @ruleset_info = @handle.ruleset_info
 
         true
       rescue StandardError => e
         Datadog.logger.error do
           "libddwaf failed to initialize, error: #{e.inspect}"
         end
+
+        @ruleset_info = e.ruleset_info if e.respond_to?(:ruleset_info)
 
         false
       end

--- a/spec/datadog/appsec/processor_spec.rb
+++ b/spec/datadog/appsec/processor_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe Datadog::AppSec::Processor do
       it { expect(context.time).to be > 0 }
       it { expect(context.time_ext).to be > 0 }
       it { expect(context.time_ext).to be > context.time }
-      it { expect(context.time).to eq(runs.sum(&:total_runtime)) }
+      it { expect(context.time).to eq(runs.reduce(0) { |a, e| a + e.total_runtime }) }
       it { expect(context.timeouts).to eq 0 }
 
       context 'with timeout' do
@@ -273,7 +273,7 @@ RSpec.describe Datadog::AppSec::Processor do
       context 'with multiple runs' do
         let(:run_count) { 10 }
 
-        it { expect(context.time).to eq(runs.sum(&:total_runtime)) }
+        it { expect(context.time).to eq(runs.reduce(0) { |a, e| a + e.total_runtime }) }
 
         context 'with timeout' do
           let(:timeout) { 0 }

--- a/spec/datadog/appsec/processor_spec.rb
+++ b/spec/datadog/appsec/processor_spec.rb
@@ -255,32 +255,32 @@ RSpec.describe Datadog::AppSec::Processor do
       end
 
       it { expect(runs.first.action).to eq :monitor }
-      it { expect(context.time).to be > 0 }
-      it { expect(context.time_ext).to be > 0 }
-      it { expect(context.time_ext).to be > context.time }
-      it { expect(context.time).to eq(runs.reduce(0) { |a, e| a + e.total_runtime }) }
+      it { expect(context.time_ns).to be > 0 }
+      it { expect(context.time_ext_ns).to be > 0 }
+      it { expect(context.time_ext_ns).to be > context.time_ns }
+      it { expect(context.time_ns).to eq(runs.reduce(0) { |a, e| a + e.total_runtime }) }
       it { expect(context.timeouts).to eq 0 }
 
       context 'with timeout' do
         let(:timeout) { 0 }
 
         it { expect(runs.first.action).to eq :good }
-        it { expect(context.time).to eq 0 }
-        it { expect(context.time_ext).to be > 0 }
+        it { expect(context.time_ns).to eq 0 }
+        it { expect(context.time_ext_ns).to be > 0 }
         it { expect(context.timeouts).to eq run_count }
       end
 
       context 'with multiple runs' do
         let(:run_count) { 10 }
 
-        it { expect(context.time).to eq(runs.reduce(0) { |a, e| a + e.total_runtime }) }
+        it { expect(context.time_ns).to eq(runs.reduce(0) { |a, e| a + e.total_runtime }) }
 
         context 'with timeout' do
           let(:timeout) { 0 }
 
           it { expect(runs.first.action).to eq :good }
-          it { expect(context.time).to eq 0 }
-          it { expect(context.time_ext).to be > 0 }
+          it { expect(context.time_ns).to eq 0 }
+          it { expect(context.time_ext_ns).to be > 0 }
           it { expect(context.timeouts).to eq run_count }
         end
       end


### PR DESCRIPTION
Add libddwaf telemetry metrics and metadata as described by the corresponding AppSec RFC.

- Ruleset version must be sent with each trace to correlate with libddwaf runs (whether they trigger security events or not)
- As much as possible is sent only on the first trace. This 
- A wrapping class around `Datadog::AppSec::WAF::Context` is introduced, to track and report execution time (overall + internal) and timeout occurence

Spec for `Processor` has been updated, while `Rack::RequestMiddleware` and `Watcher` paths are exercised via System Tests (I wish these could report code coverage and fold it into Codecov):

```
runner           | XPASSED tests/appsec/waf/test_reports.py::Test_Monitoring::test_waf_monitoring - Expected to fail, but all is ok
runner           | XPASSED tests/appsec/waf/test_reports.py::Test_Monitoring::test_waf_monitoring_once - Expected to fail, but all is ok
```