### PR TITLE
Fix Rails log tagging in 1.0.0.beta2

### DIFF
--- a/lib/datadog/tracing/contrib/rails/patcher.rb
+++ b/lib/datadog/tracing/contrib/rails/patcher.rb
@@ -83,7 +83,7 @@ module Datadog
             # if so, add proc that injects trace identifiers for tagged logging.
             logger = app.config.logger || ::Rails.logger
 
-            if (logger) \
+            if logger \
                 && defined?(::ActiveSupport::TaggedLogging) \
                 && logger.is_a?(::ActiveSupport::TaggedLogging)
 
@@ -91,7 +91,9 @@ module Datadog
               should_warn = false
             end
 
-            Datadog.logger.warn("Unable to enable Datadog Trace context, Logger #{logger.class} is not supported") if should_warn
+            if should_warn
+              Datadog.logger.warn("Unable to enable Datadog Trace context, Logger #{logger.class} is not supported")
+            end
           end
 
           def patch_after_intialize

--- a/lib/datadog/tracing/contrib/rails/patcher.rb
+++ b/lib/datadog/tracing/contrib/rails/patcher.rb
@@ -89,7 +89,7 @@ module Datadog
               should_warn = false
             end
 
-            Datadog.logger.warn("Unable to enable Datadog Trace context, Logger #{logger} is not supported") if should_warn
+            Datadog.logger.warn("Unable to enable Datadog Trace context, Logger #{logger.class} is not supported") if should_warn
           end
 
           def patch_after_intialize

--- a/lib/datadog/tracing/contrib/rails/patcher.rb
+++ b/lib/datadog/tracing/contrib/rails/patcher.rb
@@ -81,7 +81,9 @@ module Datadog
 
             # if lograge isn't set, check if tagged logged is enabled.
             # if so, add proc that injects trace identifiers for tagged logging.
-            if (logger = app.config.logger) \
+            logger = app.config.logger || ::Rails.logger
+
+            if (logger) \
                 && defined?(::ActiveSupport::TaggedLogging) \
                 && logger.is_a?(::ActiveSupport::TaggedLogging)
 

--- a/spec/datadog/tracing/contrib/rails/support/base.rb
+++ b/spec/datadog/tracing/contrib/rails/support/base.rb
@@ -41,7 +41,7 @@ RSpec.shared_context 'Rails base application' do
     proc do
       if ENV['USE_TAGGED_LOGGING'] == true
         config.log_tags = ENV['LOG_TAGS'] || []
-        config.logger = ActiveSupport::TaggedLogging.new(logger)
+        Rails.logger = ActiveSupport::TaggedLogging.new(logger)
       end
 
       if ENV['USE_SEMANTIC_LOGGER'] == true


### PR DESCRIPTION
Fixes #1986.

I updated the specs to set up the mock Rails logger to be like [the default logger](https://github.com/rails/rails/blob/7-0-stable/railties/lib/rails/application/bootstrap.rb#L37-L53) that ships in a Rails application. I also tested this in a freshly-generated Rails 7.0 app, and our own production applications. No more warning, and the log tags work correctly.