### PR TITLE
Run all system tests on test failure

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   system-tests:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - library: ruby


### PR DESCRIPTION
Bailing out on the first failure prevents other possible failures to be displayed, which makes addressing each one of them in turn a slow, iterative business.