### PR TITLE
Improve exception logging

### DIFF
--- a/integration/apps/rack/app/acme.rb
+++ b/integration/apps/rack/app/acme.rb
@@ -58,7 +58,7 @@ module Acme
     end
 
     def application_error(request, error)
-      [500, { 'Content-Type' => 'text/plain' }, ["500 Application Error: #{error.message} Location: #{error.backtrace.first(3)}"]]
+      [500, { 'Content-Type' => 'text/plain' }, ["500 Application Error: #{error.class.name} #{error.message} Location: #{error.backtrace.first(3)}"]]
     end
   end
 

--- a/lib/datadog/appsec/autoload.rb
+++ b/lib/datadog/appsec/autoload.rb
@@ -4,13 +4,13 @@ if %w[1 true].include?((ENV['DD_APPSEC_ENABLED'] || '').downcase)
   begin
     require 'datadog/appsec'
   rescue StandardError => e
-    puts "AppSec failed to load. No security check will be performed. error: #{e.message}"
+    puts "AppSec failed to load. No security check will be performed. error: #{e.class.name} #{e.message}"
   end
 
   begin
     require 'datadog/appsec/contrib/auto_instrument'
     Datadog::AppSec::Contrib::AutoInstrument.patch_all
   rescue StandardError => e
-    puts "AppSec failed to instrument. No security check will be performed. error: #{e.message}"
+    puts "AppSec failed to instrument. No security check will be performed. error: #{e.class.name} #{e.message}"
   end
 end

--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -379,49 +379,63 @@ module Datadog
             committer_date: Time.at(fields[5].to_i).utc.to_datetime.iso8601
           }
         rescue => e
-          Datadog.logger.debug("Unable to read git commit users: #{e.message} at #{Array(e.backtrace).first}")
+          Datadog.logger.debug(
+            "Unable to read git commit users: #{e.class.name} #{e.message} at #{Array(e.backtrace).first}"
+          )
           nil
         end
 
         def git_repository_url
           exec_git_command('git ls-remote --get-url')
         rescue => e
-          Datadog.logger.debug("Unable to read git repository url: #{e.message} at #{Array(e.backtrace).first}")
+          Datadog.logger.debug(
+            "Unable to read git repository url: #{e.class.name} #{e.message} at #{Array(e.backtrace).first}"
+          )
           nil
         end
 
         def git_commit_message
           exec_git_command('git show -s --format=%s')
         rescue => e
-          Datadog.logger.debug("Unable to read git commit message: #{e.message} at #{Array(e.backtrace).first}")
+          Datadog.logger.debug(
+            "Unable to read git commit message: #{e.class.name} #{e.message} at #{Array(e.backtrace).first}"
+          )
           nil
         end
 
         def git_branch
           exec_git_command('git rev-parse --abbrev-ref HEAD')
         rescue => e
-          Datadog.logger.debug("Unable to read git branch: #{e.message} at #{Array(e.backtrace).first}")
+          Datadog.logger.debug(
+            "Unable to read git branch: #{e.class.name} #{e.message} at #{Array(e.backtrace).first}"
+          )
           nil
         end
 
         def git_commit_sha
           exec_git_command('git rev-parse HEAD')
         rescue => e
-          Datadog.logger.debug("Unable to read git commit SHA: #{e.message} at #{Array(e.backtrace).first}")
+          Datadog.logger.debug(
+            "Unable to read git commit SHA: #{e.class.name} #{e.message} at #{Array(e.backtrace).first}"
+          )
           nil
         end
 
         def git_tag
           exec_git_command('git tag --points-at HEAD')
         rescue => e
-          Datadog.logger.debug("Unable to read git tag: #{e.message} at #{Array(e.backtrace).first}")
+          Datadog.logger.debug(
+            "Unable to read git tag: #{e.class.name} #{e.message} at #{Array(e.backtrace).first}"
+          )
           nil
         end
 
         def git_base_directory
           exec_git_command('git rev-parse --show-toplevel')
         rescue => e
-          Datadog.logger.debug("Unable to read git base directory: #{e.message} at #{Array(e.backtrace).first}")
+          Datadog.logger.debug(
+            "Unable to read git base directory: #{e.class.name} #{e.message} at #{Array(e.backtrace).first}"
+          )
           nil
         end
 

--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -303,7 +303,7 @@ module Datadog
               if logger
                 logger.debug do
                   'Could not extract configuration from transport_options proc. ' \
-                  "Cause: #{e.message} Source: #{Array(e.backtrace).first}"
+                  "Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
                 end
               end
 

--- a/lib/datadog/core/environment/cgroup.rb
+++ b/lib/datadog/core/environment/cgroup.rb
@@ -35,7 +35,9 @@ module Datadog
                 end
               end
             rescue StandardError => e
-              Datadog.logger.error("Error while parsing cgroup. Cause: #{e.message} Location: #{Array(e.backtrace).first}")
+              Datadog.logger.error(
+                "Error while parsing cgroup. Cause: #{e.class.name} #{e.message} Location: #{Array(e.backtrace).first}"
+              )
             end
           end
         end

--- a/lib/datadog/core/environment/container.rb
+++ b/lib/datadog/core/environment/container.rb
@@ -81,7 +81,8 @@ module Datadog
               end
             rescue StandardError => e
               Datadog.logger.error(
-                "Error while parsing container info. Cause: #{e.message} Location: #{Array(e.backtrace).first}"
+                "Error while parsing container info. Cause: #{e.class.name} #{e.message} " \
+                "Location: #{Array(e.backtrace).first}"
               )
             end
           end

--- a/lib/datadog/core/metrics/client.rb
+++ b/lib/datadog/core/metrics/client.rb
@@ -96,7 +96,9 @@ module Datadog
 
           statsd.count(stat, value, metric_options(options))
         rescue StandardError => e
-          Datadog.logger.error("Failed to send count stat. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
+          Datadog.logger.error(
+            "Failed to send count stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
+          )
         end
 
         def distribution(stat, value = nil, options = nil, &block)
@@ -107,7 +109,9 @@ module Datadog
 
           statsd.distribution(stat, value, metric_options(options))
         rescue StandardError => e
-          Datadog.logger.error("Failed to send distribution stat. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
+          Datadog.logger.error(
+            "Failed to send distribution stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
+          )
         end
 
         def increment(stat, options = nil)
@@ -117,7 +121,9 @@ module Datadog
 
           statsd.increment(stat, metric_options(options))
         rescue StandardError => e
-          Datadog.logger.error("Failed to send increment stat. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
+          Datadog.logger.error(
+            "Failed to send increment stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
+          )
         end
 
         def gauge(stat, value = nil, options = nil, &block)
@@ -128,7 +134,9 @@ module Datadog
 
           statsd.gauge(stat, value, metric_options(options))
         rescue StandardError => e
-          Datadog.logger.error("Failed to send gauge stat. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
+          Datadog.logger.error(
+            "Failed to send gauge stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
+          )
         end
 
         def time(stat, options = nil)
@@ -144,7 +152,9 @@ module Datadog
               distribution(stat, ((finished - start) * 1000), options)
             end
           rescue StandardError => e
-            Datadog.logger.error("Failed to send time stat. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
+            Datadog.logger.error(
+              "Failed to send time stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
+            )
           end
         end
 

--- a/lib/datadog/core/runtime/metrics.rb
+++ b/lib/datadog/core/runtime/metrics.rb
@@ -79,7 +79,7 @@ module Datadog
         def try_flush
           yield
         rescue StandardError => e
-          Datadog.logger.error("Error while sending runtime metric. Cause: #{e.message}")
+          Datadog.logger.error("Error while sending runtime metric. Cause: #{e.class.name} #{e.message}")
         end
 
         def default_metric_options

--- a/lib/datadog/core/workers/async.rb
+++ b/lib/datadog/core/workers/async.rb
@@ -138,7 +138,9 @@ module Datadog
               # rubocop:disable Lint/RescueException
               rescue Exception => e
                 @error = e
-                Datadog.logger.debug("Worker thread error. Cause #{e.message} Location: #{Array(e.backtrace).first}")
+                Datadog.logger.debug(
+                  "Worker thread error. Cause: #{e.class.name} #{e.message} Location: #{Array(e.backtrace).first}"
+                )
                 raise
               end
               # rubocop:enable Lint/RescueException

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -93,7 +93,7 @@ module Datadog
         # In the future it'd be nice to shuffle the logger startup to happen first to avoid this special case.
         Kernel.warn(
           '[DDTRACE] Error while loading google-protobuf gem. ' \
-          "Cause: '#{e.message}' Location: '#{Array(e.backtrace).first}'. " \
+          "Cause: '#{e.class.name} #{e.message}' Location: '#{Array(e.backtrace).first}'. " \
           'This can happen when google-protobuf is missing its native components. ' \
           'To fix this, try removing and reinstalling the gem, forcing it to recompile the components: ' \
           '`gem uninstall google-protobuf -a; BUNDLE_FORCE_RUBY_PLATFORM=true bundle install`. ' \
@@ -110,7 +110,7 @@ module Datadog
       unless success
         if exception
           'There was an error loading the profiling native extension due to ' \
-          "'#{exception.message}' at '#{exception.backtrace.first}'"
+          "'#{exception.class.name} #{exception.message}' at '#{exception.backtrace.first}'"
         else
           'The profiling native extension did not load correctly. ' \
           'If the error persists, please contact support via <https://docs.datadoghq.com/help/> or ' \

--- a/lib/datadog/profiling/tasks/exec.rb
+++ b/lib/datadog/profiling/tasks/exec.rb
@@ -38,10 +38,10 @@ module Datadog
         def exec_with_error_handling(args)
           Kernel.exec(*args)
         rescue Errno::ENOENT => e
-          Kernel.warn "ddtracerb exec failed: #{e.message} (command was '#{args.join(' ')}')"
+          Kernel.warn "ddtracerb exec failed: #{e.class.name} #{e.message} (command was '#{args.join(' ')}')"
           Kernel.exit 127
         rescue Errno::EACCES, Errno::ENOEXEC => e
-          Kernel.warn "ddtracerb exec failed: #{e.message} (command was '#{args.join(' ')}')"
+          Kernel.warn "ddtracerb exec failed: #{e.class.name} #{e.message} (command was '#{args.join(' ')}')"
           Kernel.exit 126
         end
       end

--- a/lib/datadog/profiling/tasks/setup.rb
+++ b/lib/datadog/profiling/tasks/setup.rb
@@ -19,7 +19,8 @@ module Datadog
               setup_at_fork_hooks
             rescue StandardError, ScriptError => e
               Datadog.logger.warn do
-                "Profiler extensions unavailable. Cause: #{e.message} Location: #{Array(e.backtrace).first}"
+                "Profiler extensions unavailable. Cause: #{e.class.name} #{e.message} " \
+                "Location: #{Array(e.backtrace).first}"
               end
             end
           end
@@ -35,7 +36,8 @@ module Datadog
           end
         rescue StandardError, ScriptError => e
           Datadog.logger.warn do
-            "Profiler forking extensions unavailable. Cause: #{e.message} Location: #{Array(e.backtrace).first}"
+            "Profiler forking extensions unavailable. Cause: #{e.class.name} #{e.message} " \
+            "Location: #{Array(e.backtrace).first}"
           end
         end
 
@@ -65,7 +67,8 @@ module Datadog
                 Profiling.start_if_enabled
               rescue StandardError => e
                 Datadog.logger.warn do
-                  "Error during post-fork hooks. Cause: #{e.message} Location: #{Array(e.backtrace).first}"
+                  "Error during post-fork hooks. Cause: #{e.class.name} #{e.message} " \
+                  "Location: #{Array(e.backtrace).first}"
                 end
               end
             end

--- a/lib/datadog/tracing/buffer.rb
+++ b/lib/datadog/tracing/buffer.rb
@@ -58,7 +58,9 @@ module Datadog
 
         @buffer_spans += trace.length
       rescue StandardError => e
-        Datadog.logger.debug("Failed to measure queue accept. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
+        Datadog.logger.debug(
+          "Failed to measure queue accept. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
+        )
       end
 
       def measure_drop(trace)
@@ -66,7 +68,9 @@ module Datadog
 
         @buffer_spans -= trace.length
       rescue StandardError => e
-        Datadog.logger.debug("Failed to measure queue drop. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
+        Datadog.logger.debug(
+          "Failed to measure queue drop. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
+        )
       end
 
       def measure_pop(traces)
@@ -89,7 +93,9 @@ module Datadog
         @buffer_dropped = 0
         @buffer_spans = 0
       rescue StandardError => e
-        Datadog.logger.debug("Failed to measure queue. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
+        Datadog.logger.debug(
+          "Failed to measure queue. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
+        )
       end
     end
 

--- a/lib/datadog/tracing/contrib/active_record/configuration/resolver.rb
+++ b/lib/datadog/tracing/contrib/active_record/configuration/resolver.rb
@@ -69,7 +69,7 @@ module Datadog
             rescue => e
               Datadog.logger.error(
                 "Failed to resolve ActiveRecord configuration key #{db_config.inspect}. " \
-                "Cause: #{e.message} Source: #{Array(e.backtrace).first}"
+                "Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
               )
 
               nil
@@ -88,7 +88,7 @@ module Datadog
             rescue => e
               Datadog.logger.error(
                 "Failed to resolve ActiveRecord configuration key #{matcher.inspect}. " \
-                "Cause: #{e.message} Source: #{Array(e.backtrace).first}"
+                "Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
               )
             end
 

--- a/lib/datadog/tracing/contrib/active_record/utils.rb
+++ b/lib/datadog/tracing/contrib/active_record/utils.rb
@@ -77,7 +77,7 @@ module Datadog
               # in case.
               Datadog.logger.debug(
                 "connection_id #{connection_id} does not represent a valid object. " \
-                        "Cause: #{e.message} Source: #{Array(e.backtrace).first}"
+                        "Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
               )
             end
           else

--- a/lib/datadog/tracing/contrib/active_record/vendor/connection_specification.rb
+++ b/lib/datadog/tracing/contrib/active_record/vendor/connection_specification.rb
@@ -216,7 +216,7 @@ module Datadog
                     # Bubbled up from the adapter require. Prefix the exception message
                     # with some guidance about how to address it and reraise.
                     else
-                      raise e.class, "Error loading the '#{spec[:adapter]}' Active Record adapter. Missing a gem it depends on? #{e.message}", e.backtrace
+                      raise e.class, "Error loading the '#{spec[:adapter]}' Active Record adapter. Missing a gem it depends on? #{e.class.name} #{e.message}", e.backtrace
                     end
                   end
 

--- a/lib/datadog/tracing/contrib/active_support/notifications/subscription.rb
+++ b/lib/datadog/tracing/contrib/active_support/notifications/subscription.rb
@@ -116,7 +116,9 @@ module Datadog
               def run(span, name, id, payload)
                 run!(span, name, id, payload)
               rescue StandardError => e
-                Datadog.logger.debug("ActiveSupport::Notifications handler for '#{name}' failed: #{e.message}")
+                Datadog.logger.debug(
+                  "ActiveSupport::Notifications handler for '#{name}' failed: #{e.class.name} #{e.message}"
+                )
               end
 
               def run!(*args)
@@ -142,7 +144,7 @@ module Datadog
                     callback.call(event, key, *args)
                   rescue StandardError => e
                     Datadog.logger.debug(
-                      "ActiveSupport::Notifications '#{key}' callback for '#{event}' failed: #{e.message}"
+                      "ActiveSupport::Notifications '#{key}' callback for '#{event}' failed: #{e.class.name} #{e.message}"
                     )
                   end
                 end

--- a/lib/datadog/tracing/contrib/rails/log_injection.rb
+++ b/lib/datadog/tracing/contrib/rails/log_injection.rb
@@ -22,7 +22,9 @@ module Datadog
             end
           rescue StandardError => e
             # TODO: can we use Datadog.logger at this point?
-            Datadog.logger.warn("Unable to add Datadog Trace context to ActiveSupport::TaggedLogging: #{e.message}")
+            Datadog.logger.warn(
+              "Unable to add Datadog Trace context to ActiveSupport::TaggedLogging: #{e.class.name} #{e.message}"
+            )
             false
           end
 

--- a/lib/datadog/tracing/contrib/rake/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/rake/instrumentation.rb
@@ -61,7 +61,7 @@ module Datadog
               span.set_tag(Ext::TAG_TASK_ARG_NAMES, arg_names)
               span.set_tag(Ext::TAG_INVOKE_ARGS, quantize_args(args)) unless args.nil?
             rescue StandardError => e
-              Datadog.logger.debug("Error while tracing Rake invoke: #{e.message}")
+              Datadog.logger.debug("Error while tracing Rake invoke: #{e.class.name} #{e.message}")
             end
 
             def annotate_execute!(span, args)
@@ -70,7 +70,7 @@ module Datadog
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_EXECUTE)
               span.set_tag(Ext::TAG_EXECUTE_ARGS, quantize_args(args.to_hash)) unless args.nil?
             rescue StandardError => e
-              Datadog.logger.debug("Error while tracing Rake execute: #{e.message}")
+              Datadog.logger.debug("Error while tracing Rake execute: #{e.class.name} #{e.message}")
             end
 
             def quantize_args(args)

--- a/lib/datadog/tracing/event.rb
+++ b/lib/datadog/tracing/event.rb
@@ -65,7 +65,8 @@ module Datadog
             block.call(*args)
           rescue StandardError => e
             Datadog.logger.debug do
-              "Error while handling '#{name}' event with '#{block}': #{e.message} at #{Array(e.backtrace).first}"
+              "Error while handling '#{name}' event with '#{block}': #{e.class.name} #{e.message} " \
+              "at #{Array(e.backtrace).first}"
             end
           end
         end

--- a/lib/datadog/tracing/sampling/rule.rb
+++ b/lib/datadog/tracing/sampling/rule.rb
@@ -34,7 +34,9 @@ module Datadog
         def match?(trace)
           @matcher.match?(trace)
         rescue => e
-          Datadog.logger.error("Matcher failed. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
+          Datadog.logger.error(
+            "Matcher failed. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
+          )
           nil
         end
 

--- a/lib/datadog/tracing/sampling/rule_sampler.rb
+++ b/lib/datadog/tracing/sampling/rule_sampler.rb
@@ -106,7 +106,9 @@ module Datadog
             set_limiter_metrics(trace, rate_limiter.effective_rate)
           end
         rescue StandardError => e
-          Datadog.logger.error("Rule sampling failed. Cause: #{e.message} Source: #{Array(e.backtrace).first}")
+          Datadog.logger.error(
+            "Rule sampling failed. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
+          )
           yield(trace)
         end
 

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -399,7 +399,7 @@ module Datadog
               rescue StandardError => e
                 Datadog.logger.debug do
                   "Custom on_error handler #{@handler} failed, using fallback behavior. \
-                  Error: #{e.message} Location: #{Array(e.backtrace).first}"
+                  Cause: #{e.class.name} #{e.message} Location: #{Array(e.backtrace).first}"
                 end
 
                 original.call(op, error) if original
@@ -412,7 +412,7 @@ module Datadog
               @handler.call(*args)
             rescue StandardError => e
               Datadog.logger.debug do
-                "Error in on_error handler '#{@default}': #{e.message} at #{Array(e.backtrace).first}"
+                "Error in on_error handler '#{@default}': #{e.class.name} #{e.message} at #{Array(e.backtrace).first}"
               end
             end
 

--- a/lib/ddtrace/transport/http/client.rb
+++ b/lib/ddtrace/transport/http/client.rb
@@ -29,7 +29,8 @@ module Datadog
           response
         rescue StandardError => e
           message =
-            "Internal error during #{self.class.name} request. Cause: #{e.message} Location: #{Array(e.backtrace).first}"
+            "Internal error during #{self.class.name} request. Cause: #{e.class.name} #{e.message} " \
+            "Location: #{Array(e.backtrace).first}"
 
           # Log error
           if stats.consecutive_errors > 0

--- a/lib/ddtrace/transport/http/client.rb
+++ b/lib/ddtrace/transport/http/client.rb
@@ -29,7 +29,7 @@ module Datadog
           response
         rescue StandardError => e
           message =
-            "Internal error during HTTP transport request. Cause: #{e.message} Location: #{Array(e.backtrace).first}"
+            "Internal error during #{self.class.name} request. Cause: #{e.message} Location: #{Array(e.backtrace).first}"
 
           # Log error
           if stats.consecutive_errors > 0

--- a/lib/ddtrace/transport/io/client.rb
+++ b/lib/ddtrace/transport/io/client.rb
@@ -40,7 +40,9 @@ module Datadog
           # Return response
           response
         rescue StandardError => e
-          message = "Internal error during IO transport request. Cause: #{e.message} Location: #{Array(e.backtrace).first}"
+          message =
+            "Internal error during IO transport request. Cause: #{e.class.name} #{e.message} " \
+            "Location: #{Array(e.backtrace).first}"
 
           # Log error
           if stats.consecutive_errors > 0


### PR DESCRIPTION
Ruby exceptions can have really confusing, vague, or even empty messages.

To help us out during debugging, I've added the exception class in exception-related logs to give us more context while debugging issues.

This is quite low-hanging fruit, but I think in general we have a long way to go in improving exception logging in dd-trace-rb.

In particular, we should probably look into centralizing exception logging in a method to solve the following:

* Eliminate duplication. Can you spot how often I had to copy paste `e.class.name` in this PR?

* There's a few cases where we just log the message, without any context. (I did not touch those)

* The formatting of our error messages is quite inconsistent. Sometimes we include the backtrace, sometimes not. Sometimes we call the backtrace location, sometimes source, etc.

* Sometimes we call the logger with a block (so that the string does not need to be generated if logging is disabled at that level), sometimes we just pass in a string.

* There is no way to get the full stack trace, if we need to know more about where an error came from.

But... for now here's a smaller improvement.
