### PR TITLE
Add JRuby 9.3 to compatibility matrix

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -121,7 +121,8 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
 |       |                            | 2.0     | EOL since June 7th, 2021             | < 0.50.0            |
 |       |                            | 1.9.3   | EOL since August 6th, 2020           | < 0.27.0            |
 |       |                            | 1.9.1   | EOL since August 6th, 2020           | < 0.27.0            |
-| JRuby | https://www.jruby.org      | 9.2     | Full                                 | Latest              |
+| JRuby | https://www.jruby.org      | 9.3     | Full                                 | Latest              |
+|       |                            | 9.2     | Full                                 | Latest              |
 
 **Supported web servers**:
 


### PR DESCRIPTION
We've been running JRuby 9.3 in CI for ~1 month now (see #1723) without issue, so let's flag it as supported in the compatibility matrix.