### PR TITLE
Add note to remind us to keep compatibility requirements page in docs in sync

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -105,6 +105,12 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
 
 ## Compatibility
 
+<!--
+    Note: Please replicate any changes to this section also to
+    https://github.com/datadog/documentation/blob/master/content/en/tracing/setup_overview/compatibility_requirements/ruby.md
+    so that they remain in sync.
+-->
+
 **Supported Ruby interpreters**:
 
 | Type  | Documentation              | Version | Support type                         | Gem version support |
@@ -454,6 +460,12 @@ end
 `options` is a `Hash` of integration-specific configuration settings.
 
 For a list of available integrations, and their configuration options, please refer to the following:
+
+<!--
+    Note: Please replicate any changes to this section also to
+    https://github.com/datadog/documentation/blob/master/content/en/tracing/setup_overview/compatibility_requirements/ruby.md
+    so that they remain in sync.
+-->
 
 | Name                       | Key                        | Versions Supported: MRI  | Versions Supported: JRuby | How to configure                    | Gem source                                                                     |
 | -------------------------- | -------------------------- | ------------------------ | --------------------------| ----------------------------------- | ------------------------------------------------------------------------------ |


### PR DESCRIPTION
While reviewing https://github.com/datadog/documentation/pull/13871 I got to thinking how easy it is to forget to update the requirements page with any changes we do to `GettingStarted.md`, so I thought of at least adding a comment to hopefully remind us to keep them in sync.