### PR TITLE
Remove AppSec circular require references

### DIFF
--- a/lib/datadog/appsec/contrib/rack/patcher.rb
+++ b/lib/datadog/appsec/contrib/rack/patcher.rb
@@ -1,7 +1,6 @@
 # typed: ignore
 
 require 'datadog/appsec/contrib/patcher'
-require 'datadog/appsec/contrib/rack/integration'
 require 'datadog/appsec/contrib/rack/gateway/watcher'
 
 module Datadog

--- a/lib/datadog/appsec/contrib/rails/patcher.rb
+++ b/lib/datadog/appsec/contrib/rails/patcher.rb
@@ -3,7 +3,6 @@
 require 'datadog/core/utils/only_once'
 
 require 'datadog/appsec/contrib/patcher'
-require 'datadog/appsec/contrib/rails/integration'
 require 'datadog/appsec/contrib/rails/framework'
 require 'datadog/appsec/contrib/rack/request_middleware'
 

--- a/lib/datadog/appsec/contrib/sinatra/patcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/patcher.rb
@@ -3,7 +3,6 @@
 require 'datadog/tracing/contrib/rack/middlewares'
 
 require 'datadog/appsec/contrib/patcher'
-require 'datadog/appsec/contrib/sinatra/integration'
 require 'datadog/appsec/contrib/rack/request_middleware'
 require 'datadog/appsec/contrib/sinatra/framework'
 require 'datadog/tracing/contrib/sinatra/framework'

--- a/lib/datadog/appsec/reactive/operation.rb
+++ b/lib/datadog/appsec/reactive/operation.rb
@@ -1,6 +1,5 @@
 # typed: true
 
-require 'datadog/appsec'
 require 'datadog/appsec/reactive/engine'
 
 module Datadog


### PR DESCRIPTION
There were a couple of circular `require` references in AppSec code that raised some warnings during specs.