### PR TITLE
Configure libddwaf obfuscator

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'debase-ruby_core_source', '<= 0.10.15'
 
   # Used by appsec
-  spec.add_dependency 'libddwaf', '~> 1.3.0.0.0.a'
+  spec.add_dependency 'libddwaf', '~> 1.3.0.1.0.a'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb']
 end

--- a/gemfiles/jruby_9.2.18.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -1413,7 +1413,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -62,7 +62,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.18.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.18.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.18.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.18.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.18.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -1413,7 +1413,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -62,7 +62,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.8.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.8.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.2.8.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.2.8.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.2.8.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.4.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -1413,7 +1413,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.4.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.4.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -62,7 +62,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.4.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.4.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -83,7 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.3.4.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.3.4.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/jruby_9.3.4.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/jruby_9.3.4.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/jruby_9.3.4.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.1.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -120,7 +120,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     makara (0.4.1)
       activerecord (>= 3.0.0)

--- a/gemfiles/ruby_2.1.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -36,7 +36,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -73,7 +73,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -70,7 +70,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack (< 1.4)
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.2.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -1262,7 +1262,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -36,7 +36,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.12)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -73,7 +73,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -70,7 +70,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -78,7 +78,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -85,7 +85,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.3.8_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -1367,7 +1367,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -36,7 +36,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -54,7 +54,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -74,7 +74,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -73,7 +73,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -69,7 +69,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -70,7 +70,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)
       mime-types (~> 1.16)

--- a/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -78,7 +78,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -77,7 +77,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -85,7 +85,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -84,7 +84,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -36,7 +36,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -36,7 +36,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -1413,7 +1413,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -41,7 +41,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -56,7 +56,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -76,7 +76,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -38,7 +38,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -1411,7 +1411,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -52,7 +52,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -66,7 +66,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -96,7 +96,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -113,7 +113,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -109,7 +109,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -109,7 +109,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -109,7 +109,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -109,7 +109,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -109,7 +109,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -1412,7 +1412,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -53,7 +53,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.6.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.6.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.6.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.6.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.6.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -1411,7 +1411,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -53,7 +53,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_2.7.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_2.7.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -1418,7 +1418,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.0.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -51,7 +51,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.0.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.0.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.0.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -1418,7 +1418,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.1.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -51,7 +51,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -117,7 +117,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.1.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -116,7 +116,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.1.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.1.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -1420,7 +1420,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.16.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -66,7 +66,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -86,7 +86,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)
       actionpack (>= 4)

--- a/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.16.0)
       crass (~> 1.0.2)

--- a/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.0.0)
       debase-ruby_core_source (<= 0.10.15)
-      libddwaf (~> 1.3.0.0.0.a)
+      libddwaf (~> 1.3.0.1.0.a)
       msgpack
 
 GEM
@@ -48,7 +48,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddwaf (1.3.0.0.0.beta1-x86_64-linux)
+    libddwaf (1.3.0.1.0.beta1-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)

--- a/lib/datadog/appsec/configuration.rb
+++ b/lib/datadog/appsec/configuration.rb
@@ -47,6 +47,14 @@ module Datadog
           options[:trace_rate_limit] = value
         end
 
+        def obfuscator_key_regex=(value)
+          options[:obfuscator_key_regex] = value
+        end
+
+        def obfuscator_value_regex=(value)
+          options[:obfuscator_value_regex] = value
+        end
+
         def [](key)
           found = @instruments.find { |e| e.name == key }
 

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -5,6 +5,7 @@ module Datadog
     module Configuration
       # Configuration settings, acting as an integration registry
       # TODO: as with Configuration, this is a trivial implementation
+      # rubocop:disable Metrics/ClassLength
       class Settings
         class << self
           def boolean
@@ -84,12 +85,19 @@ module Datadog
           # rubocop:enable Metrics/MethodLength
         end
 
+        # rubocop:disable Metrics/LineLength
+        DEFAULT_OBFUSCATOR_KEY_REGEX = '(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?)key)|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization'.freeze
+        DEFAULT_OBFUSCATOR_VALUE_REGEX = '(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}'.freeze
+        # rubocop:enable Metrics/LineLength
+
         DEFAULTS = {
           enabled: false,
           ruleset: :recommended,
           waf_timeout: 5_000, # us
           waf_debug: false,
           trace_rate_limit: 100, # traces/s
+          obfuscator_key_regex: DEFAULT_OBFUSCATOR_KEY_REGEX,
+          obfuscator_value_regex: DEFAULT_OBFUSCATOR_VALUE_REGEX,
         }.freeze
 
         ENVS = {
@@ -98,6 +106,8 @@ module Datadog
           'DD_APPSEC_WAF_TIMEOUT' => [:waf_timeout, Settings.duration(:us)],
           'DD_APPSEC_WAF_DEBUG' => [:waf_debug, Settings.boolean],
           'DD_APPSEC_TRACE_RATE_LIMIT' => [:trace_rate_limit, Settings.integer],
+          'DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP' => [:obfuscator_key_regex, Settings.string],
+          'DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP' => [:obfuscator_value_regex, Settings.string],
         }.freeze
 
         Integration = Struct.new(:integration, :options)
@@ -129,6 +139,14 @@ module Datadog
 
         def trace_rate_limit
           @options[:trace_rate_limit]
+        end
+
+        def obfuscator_key_regex
+          @options[:obfuscator_key_regex]
+        end
+
+        def obfuscator_value_regex
+          @options[:obfuscator_value_regex]
         end
 
         def [](integration_name)
@@ -170,6 +188,7 @@ module Datadog
           initialize
         end
       end
+      # rubocop:enable Metrics/ClassLength
     end
   end
 end

--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -70,7 +70,11 @@ module Datadog
         # TODO: this may need to be reset if the main Datadog logging level changes after initialization
         Datadog::AppSec::WAF.logger = Datadog.logger if Datadog.logger.debug? && Datadog::AppSec.settings.waf_debug
 
-        @handle = Datadog::AppSec::WAF::Handle.new(@ruleset)
+        obfuscator_config = {
+          key_regex: Datadog::AppSec.settings.obfuscator_key_regex,
+          value_regex: Datadog::AppSec.settings.obfuscator_value_regex,
+        }
+        @handle = Datadog::AppSec::WAF::Handle.new(@ruleset, obfuscator: obfuscator_config)
 
         true
       rescue StandardError => e

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -82,6 +82,28 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
       it { expect { trace_rate_limit_ }.to change { settings.trace_rate_limit }.from(100).to(2) }
     end
 
+    describe '#obfuscator_key_regex' do
+      subject(:obfuscator_key_regex) { settings.obfuscator_key_regex }
+      it { is_expected.to include('token') }
+    end
+
+    describe '#obfuscator_key_regex=' do
+      subject(:obfuscator_key_regex_) { settings.merge(dsl.tap { |c| c.obfuscator_key_regex = 'bar' }) }
+      let(:default) { described_class::DEFAULT_OBFUSCATOR_KEY_REGEX }
+      it { expect { obfuscator_key_regex_ }.to change { settings.obfuscator_key_regex }.from(default).to('bar') }
+    end
+
+    describe '#obfuscator_value_regex' do
+      subject(:obfuscator_value_regex) { settings.obfuscator_value_regex }
+      it { is_expected.to include('token') }
+    end
+
+    describe '#obfuscator_value_regex=' do
+      subject(:obfuscator_value_regex_) { settings.merge(dsl.tap { |c| c.obfuscator_value_regex = 'bar' }) }
+      let(:default) { described_class::DEFAULT_OBFUSCATOR_VALUE_REGEX }
+      it { expect { obfuscator_value_regex_ }.to change { settings.obfuscator_value_regex }.from(default).to('bar') }
+    end
+
     describe '#[]' do
       describe 'when the integration exists' do
         subject(:get) { settings[integration_name] }
@@ -185,6 +207,38 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
         describe '#trace_rate_limit=' do
           subject(:trace_rate_limit_) { settings.merge(dsl.tap { |c| c.trace_rate_limit = 2 }) }
           it { expect { trace_rate_limit_ }.to change { settings.trace_rate_limit }.from(1024).to(2) }
+        end
+      end
+
+      describe 'DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP' do
+        before do
+          allow(ENV).to receive(:[]).with('DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP').and_return('bar')
+        end
+
+        describe '#obfuscator_key_regex' do
+          subject(:obfuscator_key_regex) { settings.obfuscator_key_regex }
+          it { is_expected.to eq('bar') }
+        end
+
+        describe '#obfuscator_key_regex=' do
+          subject(:obfuscator_key_regex_) { settings.merge(dsl.tap { |c| c.obfuscator_key_regex = 'baz' }) }
+          it { expect { obfuscator_key_regex_ }.to change { settings.obfuscator_key_regex }.from('bar').to('baz') }
+        end
+      end
+
+      describe 'DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP' do
+        before do
+          allow(ENV).to receive(:[]).with('DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP').and_return('bar')
+        end
+
+        describe '#obfuscator_value_regex' do
+          subject(:obfuscator_value_regex) { settings.obfuscator_value_regex }
+          it { is_expected.to eq('bar') }
+        end
+
+        describe '#obfuscator_value_regex=' do
+          subject(:obfuscator_value_regex_) { settings.merge(dsl.tap { |c| c.obfuscator_value_regex = 'baz' }) }
+          it { expect { obfuscator_value_regex_ }.to change { settings.obfuscator_value_regex }.from('bar').to('baz') }
         end
       end
     end


### PR DESCRIPTION
The obfuscator introduced in libddwaf 1.3.0 has default scrubbing settings embedded, but:
- they're configurable for users to tune to their specifics
- they've been improved with new defaults

The improved defaults are stored in ddtrace as default values for these settings.

Specs for settings have been added, feature validation is covered by system tests:

```
runner           | XPASSED tests/appsec/test_traces.py::Test_AppSecObfuscator::test_appsec_obfuscator_key - Expected to fail, but all is ok
runner           | XPASSED tests/appsec/test_traces.py::Test_AppSecObfuscator::test_appsec_obfuscator_value - Expected to fail, but all is ok
```