### PR TITLE
[PROF-4904] New Stack collector is feature-complete

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,7 @@ AllCops:
     - 'integration/apps/*/bin/*'
     - 'integration/apps/*/Gemfile'
     - 'lib/datadog/profiling/pprof/pprof_pb.rb'
+    - 'spec/**/**/interesting_backtrace_helper.rb' # This file needs quite a few bizarre code patterns by design
   NewCops: disable # Don't allow new cops to be enabled implicitly.
 
 Layout/LineLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,8 +24,6 @@ AllCops:
     - 'lib/datadog/profiling/pprof/pprof_pb.rb'
   NewCops: disable # Don't allow new cops to be enabled implicitly.
 
-# 80 characters is a nice goal, but not worth currently changing in existing
-# code for the sake of changing it to conform to a length set in 1928 (IBM).
 Layout/LineLength:
   Max: 124
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem 'opentracing', '>= 0.4.1'
 #       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
 #       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
 if RUBY_PLATFORM != 'java'
-  if RUBY_VERSION >= '2.4.0' # Bundler 1.x fails to recognize that version >= 3.19.2 is not compatible with older rubies
+  if RUBY_VERSION >= '2.5.0' # Bundler 1.x fails to recognize that version >= 3.19.2 is not compatible with older rubies
     gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
   else
     gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -168,7 +168,7 @@ void sample(VALUE thread, sampling_buffer* buffer, VALUE recorder_instance, ddpr
 
   // If we filled up the buffer, some frames may have been omitted. In that case, we'll add a placeholder frame
   // with that info.
-  if (captured_frames == buffer->max_frames) maybe_add_placeholder_frames_omitted(thread, buffer);
+  if (captured_frames == (long) buffer->max_frames) maybe_add_placeholder_frames_omitted(thread, buffer);
 
   record_sample(
     recorder_instance,
@@ -181,7 +181,7 @@ void sample(VALUE thread, sampling_buffer* buffer, VALUE recorder_instance, ddpr
 }
 
 void maybe_add_placeholder_frames_omitted(VALUE thread, sampling_buffer* buffer) {
-  int frames_omitted = stack_depth_for(thread) - buffer->max_frames;
+  ptrdiff_t frames_omitted = stack_depth_for(thread) - buffer->max_frames;
 
   if (frames_omitted == 0) return; // Perfect fit!
 
@@ -191,7 +191,7 @@ void maybe_add_placeholder_frames_omitted(VALUE thread, sampling_buffer* buffer)
 
   const int message_size = sizeof(MAX_FRAMES_LIMIT_AS_STRING " frames omitted");
   char frames_omitted_message[message_size];
-  snprintf(frames_omitted_message, message_size, "%d frames omitted", frames_omitted);
+  snprintf(frames_omitted_message, message_size, "%td frames omitted", frames_omitted);
 
   buffer->lines[buffer->max_frames - 1] = (ddprof_ffi_Line) {
     .function = (ddprof_ffi_Function) {

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -9,14 +9,25 @@
 
 static VALUE missing_string = Qnil;
 
-static VALUE _native_sample(VALUE self, VALUE thread, VALUE recorder_instance, VALUE metric_values_hash, VALUE labels_array);
-void sample(VALUE thread, VALUE recorder_instance, ddprof_ffi_Slice_i64 metric_values, ddprof_ffi_Slice_label labels);
+// Used as scratch space during sampling
+typedef struct sampling_buffer {
+  int max_frames;
+  VALUE *stack_buffer;
+  int *lines_buffer;
+  ddprof_ffi_Location *locations;
+  ddprof_ffi_Line *lines;
+} sampling_buffer;
+
+static VALUE _native_sample(VALUE self, VALUE thread, VALUE recorder_instance, VALUE metric_values_hash, VALUE labels_array, VALUE max_frames);
+void sample(VALUE thread, sampling_buffer* buffer, VALUE recorder_instance, ddprof_ffi_Slice_i64 metric_values, ddprof_ffi_Slice_label labels);
+sampling_buffer *sampling_buffer_new(int max_frames);
+void sampling_buffer_free(sampling_buffer *buffer);
 
 void collectors_stack_init(VALUE profiling_module) {
   VALUE collectors_module = rb_define_module_under(profiling_module, "Collectors");
   VALUE collectors_stack_class = rb_define_class_under(collectors_module, "Stack", rb_cObject);
 
-  rb_define_singleton_method(collectors_stack_class, "_native_sample", _native_sample, 4);
+  rb_define_singleton_method(collectors_stack_class, "_native_sample", _native_sample, 5);
 
   missing_string = rb_str_new2("");
   rb_global_variable(&missing_string);
@@ -24,7 +35,7 @@ void collectors_stack_init(VALUE profiling_module) {
 
 // This method exists only to enable testing Collectors::Stack behavior using RSpec.
 // It SHOULD NOT be used for other purposes.
-static VALUE _native_sample(VALUE self, VALUE thread, VALUE recorder_instance, VALUE metric_values_hash, VALUE labels_array) {
+static VALUE _native_sample(VALUE self, VALUE thread, VALUE recorder_instance, VALUE metric_values_hash, VALUE labels_array, VALUE max_frames) {
   Check_Type(metric_values_hash, T_HASH);
   Check_Type(labels_array, T_ARRAY);
 
@@ -55,50 +66,85 @@ static VALUE _native_sample(VALUE self, VALUE thread, VALUE recorder_instance, V
     };
   }
 
+  sampling_buffer *buffer = sampling_buffer_new(NUM2INT(max_frames));
+
   sample(
     thread,
+    buffer,
     recorder_instance,
     (ddprof_ffi_Slice_i64) {.ptr = metric_values, .len = ENABLED_VALUE_TYPES_COUNT},
     (ddprof_ffi_Slice_label) {.ptr = labels, .len = labels_count}
   );
 
+  sampling_buffer_free(buffer);
+
   return Qtrue;
 }
 
-void sample(VALUE thread, VALUE recorder_instance, ddprof_ffi_Slice_i64 metric_values, ddprof_ffi_Slice_label labels) {
-  const int max_frames = 400; // FIXME: Should be configurable
-  VALUE stack_buffer[max_frames];
-  int lines_buffer[max_frames];
-
-  int captured_frames = ddtrace_rb_profile_frames(thread, 0 /* stack starting depth */, max_frames, stack_buffer, lines_buffer);
-
-  ddprof_ffi_Location locations[captured_frames];
-  ddprof_ffi_Line lines[captured_frames];
+void sample(VALUE thread, sampling_buffer* buffer, VALUE recorder_instance, ddprof_ffi_Slice_i64 metric_values, ddprof_ffi_Slice_label labels) {
+  int captured_frames = ddtrace_rb_profile_frames(thread, 0 /* stack starting depth */, buffer->max_frames, buffer->stack_buffer, buffer->lines_buffer);
 
   for (int i = 0; i < captured_frames; i++) {
-    VALUE name = rb_profile_frame_base_label(stack_buffer[i]);
-    VALUE filename = rb_profile_frame_path(stack_buffer[i]);
+    VALUE name = rb_profile_frame_base_label(buffer->stack_buffer[i]);
+    VALUE filename = rb_profile_frame_path(buffer->stack_buffer[i]);
 
     name = NIL_P(name) ? missing_string : name;
     filename = NIL_P(filename) ? missing_string : filename;
 
-    lines[i] = (ddprof_ffi_Line) {
+    buffer->lines[i] = (ddprof_ffi_Line) {
       .function = (ddprof_ffi_Function) {
         .name = char_slice_from_ruby_string(name),
         .filename = char_slice_from_ruby_string(filename)
       },
-      .line = lines_buffer[i],
+      .line = buffer->lines_buffer[i],
     };
 
-    locations[i] = (ddprof_ffi_Location) {.lines = (ddprof_ffi_Slice_line) {.ptr = &lines[i], .len = 1}};
+    buffer->locations[i] = (ddprof_ffi_Location) {.lines = (ddprof_ffi_Slice_line) {.ptr = &buffer->lines[i], .len = 1}};
   }
 
   record_sample(
     recorder_instance,
     (ddprof_ffi_Sample) {
-      .locations = (ddprof_ffi_Slice_location) {.ptr = locations, .len = captured_frames},
+      .locations = (ddprof_ffi_Slice_location) {.ptr = buffer->locations, .len = captured_frames},
       .values = metric_values,
       .labels = labels,
     }
   );
+}
+
+sampling_buffer *sampling_buffer_new(int max_frames) {
+  sampling_buffer* buffer = xcalloc(1, sizeof(sampling_buffer));
+  if (buffer == NULL) rb_raise(rb_eNoMemError, "Failed to allocate memory for sampling buffer");
+
+  buffer->max_frames = max_frames;
+
+  buffer->stack_buffer = xcalloc(max_frames, sizeof(VALUE));
+  buffer->lines_buffer = xcalloc(max_frames, sizeof(int));
+  buffer->locations    = xcalloc(max_frames, sizeof(ddprof_ffi_Location));
+  buffer->lines        = xcalloc(max_frames, sizeof(ddprof_ffi_Line));
+
+  if (
+    buffer->stack_buffer == NULL ||
+    buffer->lines_buffer == NULL ||
+    buffer->locations    == NULL ||
+    buffer->lines        == NULL
+  ) {
+    sampling_buffer_free(buffer);
+    rb_raise(rb_eNoMemError, "Failed to allocate memory for components of sampling buffer");
+  }
+
+  return buffer;
+}
+
+void sampling_buffer_free(sampling_buffer *buffer) {
+  // The only case where any of the underlying arrays are NULL is when initial allocation failed; otherwise they
+  // can be assumed to be not-null.
+  // Having these if tests here enables us to use this function also in sampling_buffer_new; otherwise we could do
+  // without them.
+  if (buffer->stack_buffer != NULL) xfree(buffer->stack_buffer);
+  if (buffer->lines_buffer != NULL) xfree(buffer->lines_buffer);
+  if (buffer->locations    != NULL) xfree(buffer->locations);
+  if (buffer->lines        != NULL) xfree(buffer->lines);
+
+  xfree(buffer);
 }

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -244,10 +244,11 @@ void record_placeholder_stack_in_native_code(VALUE recorder_instance, ddprof_ffi
 }
 
 sampling_buffer *sampling_buffer_new(unsigned int max_frames) {
-  sampling_buffer* buffer = xcalloc(1, sizeof(sampling_buffer));
-  if (buffer == NULL) rb_raise(rb_eNoMemError, "Failed to allocate memory for sampling buffer");
   if (max_frames < 5) rb_raise(rb_eArgError, "Invalid max_frames: value must be >= 5");
   if (max_frames > MAX_FRAMES_LIMIT) rb_raise(rb_eArgError, "Invalid max_frames: value must be <= " MAX_FRAMES_LIMIT_AS_STRING);
+
+  sampling_buffer* buffer = xcalloc(1, sizeof(sampling_buffer));
+  if (buffer == NULL) rb_raise(rb_eNoMemError, "Failed to allocate memory for sampling buffer");
 
   buffer->max_frames = max_frames;
 

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -40,22 +40,22 @@ static VALUE _native_sample(VALUE self, VALUE thread, VALUE recorder_instance, V
   Check_Type(metric_values_hash, T_HASH);
   Check_Type(labels_array, T_ARRAY);
 
-  if (rb_hash_size_num(metric_values_hash) != ENABLED_VALUE_TYPES_COUNT) {
+  if (RHASH_SIZE(metric_values_hash) != ENABLED_VALUE_TYPES_COUNT) {
     rb_raise(
       rb_eArgError,
       "Mismatched values for metrics; expected %lu values and got %lu instead",
       ENABLED_VALUE_TYPES_COUNT,
-      rb_hash_size_num(metric_values_hash)
+      RHASH_SIZE(metric_values_hash)
     );
   }
 
   int64_t metric_values[ENABLED_VALUE_TYPES_COUNT];
-  for (int i = 0; i < ENABLED_VALUE_TYPES_COUNT; i++) {
+  for (unsigned int i = 0; i < ENABLED_VALUE_TYPES_COUNT; i++) {
     VALUE metric_value = rb_hash_fetch(metric_values_hash, rb_str_new_cstr(enabled_value_types[i].type_.ptr));
     metric_values[i] = NUM2LONG(metric_value);
   }
 
-  int labels_count = RARRAY_LEN(labels_array);
+  long labels_count = RARRAY_LEN(labels_array);
   ddprof_ffi_Label labels[labels_count];
 
   for (int i = 0; i < labels_count; i++) {

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -112,7 +112,7 @@ void sample(VALUE thread, sampling_buffer* buffer, VALUE recorder_instance, ddpr
       filename = rb_profile_frame_path(buffer->stack_buffer[i]);
       line = buffer->lines_buffer[i];
     } else {
-      name = rb_profile_frame_method_name(buffer->stack_buffer[i]);
+      name = ddtrace_rb_profile_frame_method_name(buffer->stack_buffer[i]);
       filename = NIL_P(last_ruby_frame) ? Qnil : rb_profile_frame_path(last_ruby_frame);
       line = last_ruby_line;
     }

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -8,6 +8,9 @@
 // Gathers stack traces from running threads, storing them in a StackRecorder instance
 // This file implements the native bits of the Datadog::Profiling::Collectors::Stack class
 
+#define MAX_FRAMES_LIMIT            10000
+#define MAX_FRAMES_LIMIT_AS_STRING "10000"
+
 static VALUE missing_string = Qnil;
 
 // Used as scratch space during sampling
@@ -217,7 +220,7 @@ sampling_buffer *sampling_buffer_new(unsigned int max_frames) {
   sampling_buffer* buffer = xcalloc(1, sizeof(sampling_buffer));
   if (buffer == NULL) rb_raise(rb_eNoMemError, "Failed to allocate memory for sampling buffer");
   if (max_frames < 5) rb_raise(rb_eArgError, "Invalid max_frames: value must be >= 5");
-  if (max_frames > 10000) rb_raise(rb_eArgError, "Invalid max_frames: value must be <= 10_000");
+  if (max_frames > MAX_FRAMES_LIMIT) rb_raise(rb_eArgError, "Invalid max_frames: value must be <= " MAX_FRAMES_LIMIT_AS_STRING);
 
   buffer->max_frames = max_frames;
 

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -4,12 +4,13 @@
 #include "private_vm_api_access.h"
 #include "stack_recorder.h"
 
-static VALUE missing_string = Qnil;
-
 // Gathers stack traces from running threads, storing them in a StackRecorder instance
 // This file implements the native bits of the Datadog::Profiling::Collectors::Stack class
 
+static VALUE missing_string = Qnil;
+
 static VALUE _native_sample(VALUE self, VALUE thread, VALUE recorder_instance, VALUE metric_values_hash, VALUE labels_array);
+void sample(VALUE thread, VALUE recorder_instance, ddprof_ffi_Slice_i64 metric_values, ddprof_ffi_Slice_label labels);
 
 void collectors_stack_init(VALUE profiling_module) {
   VALUE collectors_module = rb_define_module_under(profiling_module, "Collectors");
@@ -20,8 +21,6 @@ void collectors_stack_init(VALUE profiling_module) {
   missing_string = rb_str_new2("");
   rb_global_variable(&missing_string);
 }
-
-void sample(VALUE thread, VALUE recorder_instance, ddprof_ffi_Slice_i64 metric_values, ddprof_ffi_Slice_label labels);
 
 // This method exists only to enable testing Collectors::Stack behavior using RSpec.
 // It SHOULD NOT be used for other purposes.

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -93,6 +93,16 @@ void sample(VALUE thread, sampling_buffer* buffer, VALUE recorder_instance, ddpr
     buffer->is_ruby_frame
   );
 
+  // Idea: Should we release the global vm lock (GVL) after we get the data from `rb_profile_frames`? That way other Ruby threads
+  // could continue making progress while the sample was ingested into the profile.
+  //
+  // Other things to take into consideration if we go in that direction:
+  // * Is it safe to call `rb_profile_frame_...` methods on things from the `stack_buffer` without the GVL acquired?
+  // * We need to make `VALUE` references in the `stack_buffer` visible to the Ruby GC
+  // * Should we move this into a different thread entirely?
+  // * If we don't move it into a different thread, does releasing the GVL on a Ruby thread mean that we're introducing
+  //   a new thread switch point where there previously was none?
+
   // Ruby does not give us path and line number for methods implemented using native code.
   // The convention in Kernel#caller_locations is to instead use the path and line number of the first Ruby frame
   // on the stack that is below (e.g. directly or indirectly has called) the native method.

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -248,7 +248,7 @@ sampling_buffer *sampling_buffer_new(unsigned int max_frames) {
   if (max_frames > MAX_FRAMES_LIMIT) rb_raise(rb_eArgError, "Invalid max_frames: value must be <= " MAX_FRAMES_LIMIT_AS_STRING);
 
   sampling_buffer* buffer = xcalloc(1, sizeof(sampling_buffer));
-  if (buffer == NULL) rb_raise(rb_eNoMemError, "Failed to allocate memory for sampling buffer");
+  if (buffer == NULL) rb_memerror();
 
   buffer->max_frames = max_frames;
 
@@ -266,7 +266,7 @@ sampling_buffer *sampling_buffer_new(unsigned int max_frames) {
     buffer->lines         == NULL
   ) {
     sampling_buffer_free(buffer);
-    rb_raise(rb_eNoMemError, "Failed to allocate memory for components of sampling buffer");
+    rb_memerror();
   }
 
   return buffer;

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -29,12 +29,12 @@ static VALUE _native_sample(VALUE self, VALUE thread, VALUE recorder_instance, V
   Check_Type(metric_values_hash, T_HASH);
   Check_Type(labels_array, T_ARRAY);
 
-  if (RHASH_SIZE(metric_values_hash) != ENABLED_VALUE_TYPES_COUNT) {
+  if (rb_hash_size_num(metric_values_hash) != ENABLED_VALUE_TYPES_COUNT) {
     rb_raise(
       rb_eArgError,
       "Mismatched values for metrics; expected %lu values and got %lu instead",
       ENABLED_VALUE_TYPES_COUNT,
-      RHASH_SIZE(metric_values_hash)
+      rb_hash_size_num(metric_values_hash)
     );
   }
 

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -102,9 +102,12 @@ if RUBY_VERSION < '2.5'
   $defs << '-DUSE_THREAD_INSTEAD_OF_EXECUTION_CONTEXT'
 end
 
-# On older Rubies, we need to use RUBY_VM_NORMAL_ISEQ_P instead of VM_FRAME_RUBYFRAME_P
+# On older Rubies...
 if RUBY_VERSION < '2.4'
+  # ...we need to use RUBY_VM_NORMAL_ISEQ_P instead of VM_FRAME_RUBYFRAME_P
   $defs << '-DUSE_ISEQ_P_INSTEAD_OF_RUBYFRAME_P'
+  # ...we use a legacy copy of rb_vm_frame_method_entry
+  $defs << '-DUSE_LEGACY_RB_VM_FRAME_METHOD_ENTRY'
 end
 
 # For REALLY OLD Rubies...

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -114,6 +114,8 @@ end
 if RUBY_VERSION < '2.3'
   # ...there was no rb_time_timespec_new function
   $defs << '-DNO_RB_TIME_TIMESPEC_NEW'
+  # ...the VM changed enough that we need an alternative legacy rb_profile_frames
+  $defs << '-DUSE_LEGACY_RB_PROFILE_FRAMES'
 end
 
 # If we got here, libddprof is available and loaded

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -97,6 +97,11 @@ if RUBY_VERSION < '3'
   $defs << '-DUSE_BACKPORTED_RB_PROFILE_FRAME_METHOD_NAME'
 end
 
+# On older Rubies, we need to use rb_thread_t instead of rb_execution_context_t
+if RUBY_VERSION < '2.5'
+  $defs << '-DUSE_THREAD_INSTEAD_OF_EXECUTION_CONTEXT'
+end
+
 # For REALLY OLD Rubies...
 if RUBY_VERSION < '2.3'
   # ...there was no rb_time_timespec_new function

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -92,10 +92,6 @@ if RUBY_PLATFORM.include?('linux')
   $defs << '-DHAVE_PTHREAD_GETCPUCLOCKID'
 end
 
-# This is temporary just to break up implementation into two PRs and will be reverted in
-# https://github.com/DataDog/dd-trace-rb/pull/2000
-$defs << '-DTEMPORARY_SKIP_OLDER_RUBIES' if RUBY_VERSION < '2.6'
-
 # For REALLY OLD Rubies...
 if RUBY_VERSION < '2.3'
   # ...there was no rb_time_timespec_new function

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -93,14 +93,10 @@ if RUBY_PLATFORM.include?('linux')
 end
 
 # On older Rubies, we need to use a backported version of this function. See private_vm_api_access.h for details.
-if RUBY_VERSION < '3'
-  $defs << '-DUSE_BACKPORTED_RB_PROFILE_FRAME_METHOD_NAME'
-end
+$defs << '-DUSE_BACKPORTED_RB_PROFILE_FRAME_METHOD_NAME' if RUBY_VERSION < '3'
 
 # On older Rubies, we need to use rb_thread_t instead of rb_execution_context_t
-if RUBY_VERSION < '2.5'
-  $defs << '-DUSE_THREAD_INSTEAD_OF_EXECUTION_CONTEXT'
-end
+$defs << '-DUSE_THREAD_INSTEAD_OF_EXECUTION_CONTEXT' if RUBY_VERSION < '2.5'
 
 # On older Rubies...
 if RUBY_VERSION < '2.4'

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -131,24 +131,10 @@ if Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER
   end
   MakeMakefile::COMMON_HEADERS = original_common_headers
 
-  $defs << '-DUSE_MJIT_HEADER'
+  $defs << "-DRUBY_MJIT_HEADER='\"#{mjit_header_file_name}\"'"
 
   # NOTE: This needs to come after all changes to $defs
   create_header
-
-  # The MJIT header is always (afaik?) suffixed with the exact Ruby VM version,
-  # including patch (e.g. 2.7.2). Thus, we add to the header file a definition
-  # containing the exact file, so that it can be used in a #include in the C code.
-  header_contents =
-    File.read($extconf_h)
-        .sub('#endif',
-             <<-EXTCONF_H.strip
-#define RUBY_MJIT_HEADER "#{mjit_header_file_name}"
-
-#endif
-             EXTCONF_H
-            )
-  File.open($extconf_h, 'w') { |file| file.puts(header_contents) }
 
   create_makefile EXTENSION_NAME
 else

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -102,6 +102,11 @@ if RUBY_VERSION < '2.5'
   $defs << '-DUSE_THREAD_INSTEAD_OF_EXECUTION_CONTEXT'
 end
 
+# On older Rubies, we need to use RUBY_VM_NORMAL_ISEQ_P instead of VM_FRAME_RUBYFRAME_P
+if RUBY_VERSION < '2.4'
+  $defs << '-DUSE_ISEQ_P_INSTEAD_OF_RUBYFRAME_P'
+end
+
 # For REALLY OLD Rubies...
 if RUBY_VERSION < '2.3'
   # ...there was no rb_time_timespec_new function

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -155,7 +155,10 @@ else
   dir_config('ruby') # allow user to pass in non-standard core include directory
 
   Debase::RubyCoreSource
-    .create_makefile_with_core(proc { have_header('vm_core.h') && thread_native_for_ruby_2_1.call }, EXTENSION_NAME)
+    .create_makefile_with_core(
+      proc { have_header('vm_core.h') && have_header('iseq.h') && thread_native_for_ruby_2_1.call },
+      EXTENSION_NAME,
+    )
 end
 
 # rubocop:enable Style/GlobalVars

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -92,6 +92,11 @@ if RUBY_PLATFORM.include?('linux')
   $defs << '-DHAVE_PTHREAD_GETCPUCLOCKID'
 end
 
+# On older Rubies, we need to use a backported version of this function. See private_vm_api_access.h for details.
+if RUBY_VERSION < '3'
+  $defs << '-DUSE_BACKPORTED_RB_PROFILE_FRAME_METHOD_NAME'
+end
+
 # For REALLY OLD Rubies...
 if RUBY_VERSION < '2.3'
   # ...there was no rb_time_timespec_new function

--- a/ext/ddtrace_profiling_native_extension/libddprof_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/libddprof_helpers.h
@@ -7,3 +7,7 @@ inline static ddprof_ffi_CharSlice char_slice_from_ruby_string(VALUE string) {
   ddprof_ffi_CharSlice char_slice = {.ptr = StringValuePtr(string), .len = RSTRING_LEN(string)};
   return char_slice;
 }
+
+inline static VALUE ruby_string_from_vec_u8(ddprof_ffi_Vec_u8 string) {
+  return rb_str_new((char *) string.ptr, string.len);
+}

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -8,7 +8,7 @@
 //
 // In the meanwhile, be very careful when changing things here :)
 
-#ifdef USE_MJIT_HEADER
+#ifdef RUBY_MJIT_HEADER
 // Pick up internal structures from the private Ruby MJIT header file
 #include RUBY_MJIT_HEADER
 #else

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -9,12 +9,15 @@
 // In the meanwhile, be very careful when changing things here :)
 
 #ifdef RUBY_MJIT_HEADER
-// Pick up internal structures from the private Ruby MJIT header file
-#include RUBY_MJIT_HEADER
+  // Pick up internal structures from the private Ruby MJIT header file
+  #include RUBY_MJIT_HEADER
 #else
-// On older Rubies, use a copy of the VM internal headers shipped in the debase-ruby_core_source gem
-#include <vm_core.h>
+  // On older Rubies, use a copy of the VM internal headers shipped in the debase-ruby_core_source gem
+  #include <vm_core.h>
 #endif
+
+#define PRIVATE_VM_API_ACCESS_SKIP_RUBY_INCLUDES
+#include "private_vm_api_access.h"
 
 // MRI has a similar rb_thread_ptr() function which we can't call it directly
 // because Ruby does not expose the thread_data_type publicly.

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -448,14 +448,14 @@ calc_lineno(const rb_iseq_t *iseq, const VALUE *pc)
 //   `vm_backtrace.c`. Note that unlike the `rb_profile_frames` for modern Rubies, this version actually returns the
 //   method name as as `VALUE` containing a Ruby string in the `buff`.
 //
-// **IMPORTANT: THIS IS A CUSTOM RB_PROFILE_FRAMES JUST FOR RUBY 2.2 AND BELOW; SEE ABOVE FOR THE FUNCTION THAT GETS
-// USED FOR MODERN RUBIES**
-//
 // The `rb_profile_frames` function changed quite a bit between Ruby 2.2 and 2.3. Since the change was quite complex
 // I opted not to try to extend support to Ruby 2.2 and below using the same custom function, and instead I started
 // anew from the Ruby 2.2 version of the function, applying some of the same fixes that we have for the modern version.
 int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines, bool* is_ruby_frame)
 {
+    // **IMPORTANT: THIS IS A CUSTOM RB_PROFILE_FRAMES JUST FOR RUBY 2.2 AND BELOW;
+    // SEE ABOVE FOR THE FUNCTION THAT GETS USED FOR MODERN RUBIES**
+
     int i;
     rb_thread_t *th = thread_struct_from_object(thread);
     rb_control_frame_t *cfp = th->cfp, *end_cfp = RUBY_VM_END_CONTROL_FRAME(th);

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -73,7 +73,7 @@ rb_nativethread_id_t pthread_id_for(VALUE thread) {
 // Modifications: None
 #define ISEQ_BODY(iseq) ((iseq)->body)
 
-// Taken from upstream vm_bactrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
+// Taken from upstream vm_backtrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
 // Copyright (C) 1993-2012 Yukihiro Matsumoto
 // to support our custom rb_profile_frames (see below)
 // Modifications: None
@@ -121,7 +121,7 @@ calc_pos(const rb_iseq_t *iseq, const VALUE *pc, int *lineno, int *node_id)
     }
 }
 
-// Taken from upstream vm_bactrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
+// Taken from upstream vm_backtrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
 // Copyright (C) 1993-2012 Yukihiro Matsumoto
 // to support our custom rb_profile_frames (see below)
 // Modifications: None
@@ -133,7 +133,7 @@ calc_lineno(const rb_iseq_t *iseq, const VALUE *pc)
     return 0;
 }
 
-// Taken from upstream vm_bactrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
+// Taken from upstream vm_backtrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
 // Copyright (C) 1993-2012 Yukihiro Matsumoto
 // Modifications:
 // * Renamed rb_profile_frames => ddtrace_rb_profile_frames
@@ -225,7 +225,7 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, i
 
 #ifdef USE_BACKPORTED_RB_PROFILE_FRAME_METHOD_NAME
 
-// Taken from upstream vm_bactrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
+// Taken from upstream vm_backtrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
 // Copyright (C) 1993-2012 Yukihiro Matsumoto
 // to support our custom rb_profile_frame_method_name (see below)
 // Modifications: None
@@ -238,7 +238,7 @@ id2str(ID id)
 }
 #define rb_id2str(id) id2str(id)
 
-// Taken from upstream vm_bactrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
+// Taken from upstream vm_backtrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
 // Copyright (C) 1993-2012 Yukihiro Matsumoto
 // to support our custom rb_profile_frame_method_name (see below)
 // Modifications: None
@@ -268,7 +268,7 @@ frame2iseq(VALUE frame)
     rb_bug("frame2iseq: unreachable");
 }
 
-// Taken from upstream vm_bactrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
+// Taken from upstream vm_backtrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
 // Copyright (C) 1993-2012 Yukihiro Matsumoto
 // to support our custom rb_profile_frame_method_name (see below)
 // Modifications: None
@@ -297,7 +297,7 @@ cframe(VALUE frame)
     return NULL;
 }
 
-// Taken from upstream vm_bactrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
+// Taken from upstream vm_backtrace.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
 // Copyright (C) 1993-2012 Yukihiro Matsumoto
 //
 // Ruby 3.0 finally added support for showing CFUNC frames (frames for methods written using native code)
@@ -328,7 +328,7 @@ ddtrace_rb_profile_frame_method_name(VALUE frame)
 
 // Taken from upstream include/ruby/backward/2/bool.h at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
 // Copyright (C) Ruby developers <ruby-core@ruby-lang.org>
-// to support our custom rb_profile_frames (see above).
+// to support our custom rb_profile_frames (see above)
 // Modifications: None
 #ifndef FALSE
 # define FALSE false
@@ -344,7 +344,7 @@ ddtrace_rb_profile_frame_method_name(VALUE frame)
 
 // Taken from upstream vm_insnhelper.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
 // Copyright (C) 2007 Koichi Sasada
-// to support our custom rb_profile_frames (see above).
+// to support our custom rb_profile_frames (see above)
 // Modifications: None
 static rb_callable_method_entry_t *
 check_method_entry(VALUE obj, int can_be_svar)
@@ -375,7 +375,7 @@ check_method_entry(VALUE obj, int can_be_svar)
 #ifndef USE_LEGACY_RB_VM_FRAME_METHOD_ENTRY
   // Taken from upstream vm_insnhelper.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
   // Copyright (C) 2007 Koichi Sasada
-  // to support our custom rb_profile_frames (see above).
+  // to support our custom rb_profile_frames (see above)
   //
   // While older Rubies may have this function, the symbol is not exported which leads to dynamic loader issues, e.g.
   // `dyld: lazy symbol binding failed: Symbol not found: _rb_vm_frame_method_entry`.
@@ -397,7 +397,7 @@ check_method_entry(VALUE obj, int can_be_svar)
 #else
   // Taken from upstream vm_insnhelper.c at commit 556e9f726e2b80f6088982c6b43abfe68bfad591 (October 2018, ruby_2_3 branch)
   // Copyright (C) 2007 Koichi Sasada
-  // to support our custom rb_profile_frames (see above).
+  // to support our custom rb_profile_frames (see above)
   //
   // Quite a few macros in this function changed after Ruby 2.3. Rather than trying to fix the Ruby 3.2 version to work
   // with 2.3 constants, I decided to import the Ruby 2.3 version.

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -140,6 +140,8 @@ calc_lineno(const rb_iseq_t *iseq, const VALUE *pc)
 // * Add thread argument
 // * Add is_ruby_frame argument
 // * Removed `if (lines)` tests -- require/assume that like `buff`, `lines` is always specified
+// * Support Ruby < 2.5 by using rb_thread_t instead of rb_execution_context_t (which did not exist and was just
+//   part of rb_thread_t)
 //
 // What is rb_profile_frames?
 // `rb_profile_frames` is a Ruby VM debug API added for use by profilers for sampling the stack trace of a Ruby thread.
@@ -169,7 +171,11 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, i
     int i;
     // Modified from upstream: Instead of using `GET_EC` to collect info from the current thread,
     // support sampling any thread (including the current) passed as an argument
+#ifndef USE_THREAD_INSTEAD_OF_EXECUTION_CONTEXT // Modern Rubies
     const rb_execution_context_t *ec = thread_struct_from_object(thread)->ec;
+#else // Ruby < 2.5
+    const rb_thread_t *ec = thread_struct_from_object(thread);
+#endif
     const rb_control_frame_t *cfp = ec->cfp, *end_cfp = RUBY_VM_END_CONTROL_FRAME(ec);
     const rb_callable_method_entry_t *cme;
 

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -34,13 +34,6 @@ rb_nativethread_id_t pthread_id_for(VALUE thread) {
   return thread_struct_from_object(thread)->thread_id;
 }
 
-// This is temporary just to break up implementation into two PRs and will be reverted in
-// https://github.com/DataDog/dd-trace-rb/pull/2000
-#ifdef TEMPORARY_SKIP_OLDER_RUBIES
-int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines) { return 0; }
-
-#else
-
 // -----------------------------------------------------------------------------
 // The sources below are modified versions of code extracted from the Ruby project.
 // Each function is annotated with its origin, why we imported it, and the changes made.
@@ -208,5 +201,3 @@ ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *
 
     return i;
 }
-
-#endif

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -138,6 +138,7 @@ calc_lineno(const rb_iseq_t *iseq, const VALUE *pc)
 // * Renamed rb_profile_frames => ddtrace_rb_profile_frames
 // * Add thread argument
 // * Add is_ruby_frame argument
+// * Removed `if (lines)` tests -- require/assume that like `buff`, `lines` is always specified
 //
 // What is rb_profile_frames?
 // `rb_profile_frames` is a Ruby VM debug API added for use by profilers for sampling the stack trace of a Ruby thread.
@@ -187,7 +188,7 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, i
                 buff[i] = (VALUE)cfp->iseq;
             }
 
-            if (lines) lines[i] = calc_lineno(cfp->iseq, cfp->pc);
+            lines[i] = calc_lineno(cfp->iseq, cfp->pc);
             is_ruby_frame[i] = true;
             i++;
         }
@@ -195,7 +196,7 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, i
             cme = rb_vm_frame_method_entry(cfp);
             if (cme && cme->def->type == VM_METHOD_TYPE_CFUNC) {
                 buff[i] = (VALUE)cme;
-                if (lines) lines[i] = 0;
+                lines[i] = 0;
                 is_ruby_frame[i] = false;
                 i++;
             }

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -193,6 +193,7 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, i
     const rb_control_frame_t *cfp = ec->cfp, *end_cfp = RUBY_VM_END_CONTROL_FRAME(ec);
     const rb_callable_method_entry_t *cme;
 
+    // Without this check, we get a VM crash if we try to sample a dead thread
     if (end_cfp == NULL) return 0;
 
     // Fix: Skip dummy frame that shows up in main thread.
@@ -485,6 +486,7 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, i
     rb_thread_t *th = thread_struct_from_object(thread);
     rb_control_frame_t *cfp = th->cfp, *end_cfp = RUBY_VM_END_CONTROL_FRAME(th);
 
+    // Without this check, we get a VM crash if we try to sample a dead thread
     if (end_cfp == NULL) return 0;
 
     // Fix: Skip dummy frame that shows up in main thread.

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -1,9 +1,14 @@
 #pragma once
 
-#ifdef RUBY_2_1_WORKAROUND
-#include <thread_native.h>
-#else
-#include <ruby/thread_native.h>
+// The private_vm_api_access.c includes the RUBY_MJIT_HEADER which replaces and conflicts with any other Ruby headers;
+// so we use PRIVATE_VM_API_ACCESS_SKIP_RUBY_INCLUDES to be able to include private_vm_api_access.h on that file
+// without also dragging the incompatible includes
+#ifndef PRIVATE_VM_API_ACCESS_SKIP_RUBY_INCLUDES
+  #ifdef RUBY_2_1_WORKAROUND
+    #include <thread_native.h>
+  #else
+    #include <ruby/thread_native.h>
+  #endif
 #endif
 
 #include "extconf.h"

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -16,6 +16,7 @@
 #include "extconf.h"
 
 rb_nativethread_id_t pthread_id_for(VALUE thread);
+ptrdiff_t stack_depth_for(VALUE thread);
 int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines, bool* is_ruby_frame);
 
 // Ruby 3.0 finally added support for showing CFUNC frames (frames for methods written using native code)

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdbool.h>
+
 // The private_vm_api_access.c includes the RUBY_MJIT_HEADER which replaces and conflicts with any other Ruby headers;
 // so we use PRIVATE_VM_API_ACCESS_SKIP_RUBY_INCLUDES to be able to include private_vm_api_access.h on that file
 // without also dragging the incompatible includes

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -27,3 +27,6 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, i
 #else // Ruby > 3.0, just use the stock functionality
   #define ddtrace_rb_profile_frame_method_name rb_profile_frame_method_name
 #endif
+
+// See comment on `record_placeholder_stack_in_native_code` for a full explanation of what this means (and why we don't just return 0)
+#define PLACEHOLDER_STACK_IN_NATIVE_CODE -1

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -6,5 +6,17 @@
 #include <ruby/thread_native.h>
 #endif
 
+#include "extconf.h"
+
 rb_nativethread_id_t pthread_id_for(VALUE thread);
 int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines, bool* is_ruby_frame);
+
+// Ruby 3.0 finally added support for showing CFUNC frames (frames for methods written using native code)
+// in stack traces gathered via `rb_profile_frames` (https://github.com/ruby/ruby/pull/3299).
+// To access this information on older Rubies, beyond using our custom `ddtrace_rb_profile_frames` above, we also need
+// to backport the Ruby 3.0+ version of `rb_profile_frame_method_name`.
+#ifdef USE_BACKPORTED_RB_PROFILE_FRAME_METHOD_NAME
+  VALUE ddtrace_rb_profile_frame_method_name(VALUE frame);
+#else // Ruby > 3.0, just use the stock functionality
+  #define ddtrace_rb_profile_frame_method_name rb_profile_frame_method_name
+#endif

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -7,4 +7,4 @@
 #endif
 
 rb_nativethread_id_t pthread_id_for(VALUE thread);
-int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines);
+int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines, bool* is_ruby_frame);

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -62,8 +62,6 @@ static void stack_recorder_typed_data_free(void *data) {
 }
 
 static VALUE _native_serialize(VALUE self, VALUE recorder_instance) {
-  Check_TypedStruct(recorder_instance, &stack_recorder_typed_data);
-
   ddprof_ffi_Profile *profile;
   TypedData_Get_Struct(recorder_instance, ddprof_ffi_Profile, &stack_recorder_typed_data, profile);
 
@@ -96,8 +94,8 @@ static VALUE ruby_time_from(ddprof_ffi_Timespec ddprof_time) {
 }
 
 void record_sample(VALUE recorder_instance, ddprof_ffi_Sample sample) {
-  Check_TypedStruct(recorder_instance, &stack_recorder_typed_data);
   ddprof_ffi_Profile *profile;
   TypedData_Get_Struct(recorder_instance, ddprof_ffi_Profile, &stack_recorder_typed_data, profile);
+
   ddprof_ffi_Profile_add(profile, sample);
 }

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -1,5 +1,6 @@
 #include <ruby.h>
 #include "stack_recorder.h"
+#include "libddprof_helpers.h"
 
 // Used to wrap a ddprof_ffi_Profile in a Ruby object and expose Ruby-level serialization APIs
 // This file implements the native bits of the Datadog::Profiling::StackRecorder class
@@ -69,12 +70,12 @@ static VALUE _native_serialize(VALUE self, VALUE recorder_instance) {
   ddprof_ffi_SerializeResult serialized_profile = ddprof_ffi_Profile_serialize(profile);
 
   if (serialized_profile.tag == DDPROF_FFI_SERIALIZE_RESULT_ERR) {
-    VALUE err_details = rb_str_new((char *) serialized_profile.err.ptr, serialized_profile.err.len);
+    VALUE err_details = ruby_string_from_vec_u8(serialized_profile.err);
     ddprof_ffi_SerializeResult_drop(serialized_profile);
     return rb_ary_new_from_args(2, error_symbol, err_details);
   }
 
-  VALUE encoded_pprof = rb_str_new((char *) serialized_profile.ok.buffer.ptr, serialized_profile.ok.buffer.len);
+  VALUE encoded_pprof = ruby_string_from_vec_u8(serialized_profile.ok.buffer);
   VALUE start = ruby_time_from(serialized_profile.ok.start);
   VALUE finish = ruby_time_from(serialized_profile.ok.end);
 

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.h
@@ -22,7 +22,7 @@
 #define   ALLOC_SPACE_VALUE {.type_ = VALUE_STRING("alloc-space"),   .unit = VALUE_STRING("bytes")}
 #define    HEAP_SPACE_VALUE {.type_ = VALUE_STRING("heap-space"),    .unit = VALUE_STRING("bytes")}
 
-const static ddprof_ffi_ValueType enabled_value_types[] = {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE};
+static const ddprof_ffi_ValueType enabled_value_types[] = {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE};
 #define ENABLED_VALUE_TYPES_COUNT (sizeof(enabled_value_types) / sizeof(ddprof_ffi_ValueType))
 
 void record_sample(VALUE recorder_instance, ddprof_ffi_Sample sample);

--- a/lib/datadog/profiling/collectors/stack.rb
+++ b/lib/datadog/profiling/collectors/stack.rb
@@ -3,7 +3,8 @@
 module Datadog
   module Profiling
     module Collectors
-      # Used to gather a stack trace from a given Ruby thread
+      # Used to gather a stack trace from a given Ruby thread. Almost all of this class is implemented as native code.
+      #
       # Methods prefixed with _native_ are implemented in `collectors_stack.c`
       class Stack
         def sample(thread, recorder_instance, metric_values_hash, labels_array, max_frames: 400)

--- a/lib/datadog/profiling/collectors/stack.rb
+++ b/lib/datadog/profiling/collectors/stack.rb
@@ -6,8 +6,8 @@ module Datadog
       # Used to gather a stack trace from a given Ruby thread
       # Methods prefixed with _native_ are implemented in `collectors_stack.c`
       class Stack
-        def sample(thread, recorder_instance, metric_values_hash, labels_array)
-          self.class._native_sample(thread, recorder_instance, metric_values_hash, labels_array)
+        def sample(thread, recorder_instance, metric_values_hash, labels_array, max_frames: 400)
+          self.class._native_sample(thread, recorder_instance, metric_values_hash, labels_array, max_frames)
         end
       end
     end

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -11,6 +11,8 @@ module Datadog
         if status == :ok
           start, finish, encoded_pprof = result
 
+          Datadog.logger.debug { "Encoded profile covering #{start.iso8601} to #{finish.iso8601}" }
+
           [start, finish, encoded_pprof]
         else
           error_message = result

--- a/spec/datadog/profiling/collectors/interesting_backtrace_helper.rb
+++ b/spec/datadog/profiling/collectors/interesting_backtrace_helper.rb
@@ -1,0 +1,185 @@
+# typed: ignore
+
+# This (very bizarre file) gets used from `stack_spec.rb`. It tries to reproduce the most interesting (contrived?) call
+# stack I can think of, with as many weird variants as possible.
+# The objective is to thoroughly test our stack trace sampling abilities.
+# Control flow goes from bottom of file to top (e.g. ClassA will be the top of the stack)
+
+# ----
+
+class IbhClassA
+  def hello
+    $ibh_ready_queue << true
+    sleep
+  end
+end
+
+module IbhModuleB
+  class IbhClassB < IbhClassA
+    def hello
+      super
+    end
+  end
+end
+
+module IbhModuleC
+  def self.hello
+    IbhModuleB::IbhClassB.new.hello
+  end
+end
+
+class IbhClassWithStaticMethod
+  def self.hello
+    IbhModuleC.hello
+  end
+end
+
+module IbhModuleD
+  def hello
+    IbhClassWithStaticMethod.hello
+  end
+end
+
+class IbhClassC
+  include IbhModuleD
+end
+
+$ibh_a_proc = proc { IbhClassC.new.hello }
+
+$ibh_a_lambda = lambda { $ibh_a_proc.call }
+
+class IbhClassD; end
+
+$ibh_class_d_object = IbhClassD.new
+
+def $ibh_class_d_object.hello
+  $ibh_a_lambda.call
+end
+
+class IbhClassE
+  def hello
+    $ibh_class_d_object.hello
+  end
+end
+
+class IbhClassG
+  def hello
+    raise "This should not be called"
+  end
+end
+
+module IbhContainsRefinement
+  module RefinesIbhClassG
+    refine IbhClassG do
+      def hello
+        if RUBY_VERSION >= "2.7.0"
+          IbhClassE.instance_method(:hello).bind_call(IbhClassF.new)
+        else
+          IbhClassE.instance_method(:hello).bind(IbhClassF.new).call
+        end
+      end
+    end
+  end
+end
+
+module IbhModuleE
+  using IbhContainsRefinement::RefinesIbhClassG
+
+  def self.hello
+    IbhClassG.new.hello
+  end
+end
+
+class IbhClassH
+  def method_missing(name, *_)
+    super unless name == :hello
+
+    IbhModuleE.hello
+  end
+end
+
+class IbhClassF < IbhClassE
+  def hello(arg1, arg2, test1, test2)
+    1.times {
+      IbhClassH.new.hello
+    }
+  end
+end
+
+IbhClassI = Class.new do
+  define_method(:hello) do
+    IbhClassF.new.hello(0, 1, 2, 3)
+  end
+end
+
+$ibh_singleton_class = Object.new.singleton_class
+
+def $ibh_singleton_class.hello
+  IbhClassI.new.hello
+end
+
+$ibh_anonymous_instance = Class.new do
+  def hello
+    $ibh_singleton_class.hello
+  end
+end.new
+
+$ibh_anonymous_module = Module.new do
+  def self.hello
+    $ibh_anonymous_instance.hello
+  end
+end
+
+def ibh_method_with_complex_parameters(a, b = nil, *c, (d), f:, g: nil, **h, &i)
+  $ibh_anonymous_module.hello
+end
+
+class IbhClassJ
+  def hello_helper
+    yield
+  end
+
+  def hello
+    hello_helper do
+      hello_helper do
+        ibh_method_with_complex_parameters(0, 1, 2, [3, 4], f: 5, g: 6, h: 7, &proc {})
+      end
+    end
+  end
+end
+
+class IbhClassK
+  def hello
+    eval("IbhClassJ.new.hello", binding, __FILE__, __LINE__)
+  end
+end
+
+class IbhClassL
+  def hello
+    IbhClassK.new.send(:instance_eval, "hello")
+  end
+end
+
+class IbhClassM
+  def hello
+    IbhClassL.new.send(:eval, "hello")
+  end
+end
+
+IbhClassN = Class.new do
+  define_method(:hello) do
+    1.times {
+      IbhClassM.new.hello
+    }
+  end
+end
+
+def ibh_top_level_hello
+  IbhClassN.new.hello
+end
+
+1.times {
+  1.times {
+    eval("ibh_top_level_hello()")
+  }
+}

--- a/spec/datadog/profiling/collectors/interesting_backtrace_helper.rb
+++ b/spec/datadog/profiling/collectors/interesting_backtrace_helper.rb
@@ -174,8 +174,27 @@ IbhClassN = Class.new do
   end
 end
 
+def ibh_subclass_of_anonymous_class
+  c1 = Class.new(Array)
+  c2 = Class.new(c1) do
+    def hello
+      [nil].map { IbhClassN.new.hello }.first
+    end
+  end
+
+  c2.new.hello
+end
+
+module IbhModuleO
+  module_function
+
+  def hello
+    ibh_subclass_of_anonymous_class
+  end
+end
+
 def ibh_top_level_hello
-  IbhClassN.new.hello
+  IbhModuleO.hello
 end
 
 1.times {

--- a/spec/datadog/profiling/collectors/interesting_backtrace_helper.rb
+++ b/spec/datadog/profiling/collectors/interesting_backtrace_helper.rb
@@ -44,16 +44,18 @@ class IbhClassC
   include IbhModuleD
 end
 
-$ibh_a_proc = proc { IbhClassC.new.hello }
-
-$ibh_a_lambda = lambda { $ibh_a_proc.call }
-
 class IbhClassD; end
 
-$ibh_class_d_object = IbhClassD.new
+module IbhGlobals
+  $ibh_a_proc = proc { IbhClassC.new.hello }
 
-def $ibh_class_d_object.hello
-  $ibh_a_lambda.call
+  $ibh_a_lambda = lambda { $ibh_a_proc.call }
+
+  $ibh_class_d_object = IbhClassD.new
+
+  def $ibh_class_d_object.hello
+    $ibh_a_lambda.call
+  end
 end
 
 class IbhClassE
@@ -112,21 +114,23 @@ IbhClassI = Class.new do
   end
 end
 
-$ibh_singleton_class = Object.new.singleton_class
+module IbhMoreGlobals
+  $ibh_singleton_class = Object.new.singleton_class
 
-def $ibh_singleton_class.hello
-  IbhClassI.new.hello
-end
-
-$ibh_anonymous_instance = Class.new do
-  def hello
-    $ibh_singleton_class.hello
+  def $ibh_singleton_class.hello
+    IbhClassI.new.hello
   end
-end.new
 
-$ibh_anonymous_module = Module.new do
-  def self.hello
-    $ibh_anonymous_instance.hello
+  $ibh_anonymous_instance = Class.new do
+    def hello
+      $ibh_singleton_class.hello
+    end
+  end.new
+
+  $ibh_anonymous_module = Module.new do
+    def self.hello
+      $ibh_anonymous_instance.hello
+    end
   end
 end
 

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -138,8 +138,6 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       let(:target_stack_depth) { 5 }
 
       it 'matches the Ruby backtrace API' do
-        pending 'Broken due to unexpected extra frame showing up on stack trace'
-
         expect(gathered_stack).to eq reference_stack
       end
     end

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -171,6 +171,29 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       end
     end
     # rubocop:enable Style/EvalWithLocation
+
+    context 'when sampling the interesting backtrace helper' do
+      # rubocop:disable Style/GlobalVars
+      let(:do_in_background_thread) do
+        proc do |ready_queue|
+          $ibh_ready_queue = ready_queue
+          load("#{__dir__}/interesting_backtrace_helper.rb")
+        end
+      end
+
+      after do
+        $ibh_ready_queue = nil
+      end
+      # rubocop:enable Style/GlobalVars
+
+      it 'matches the Ruby backtrace API' do
+        expect(gathered_stack).to eq reference_stack
+      end
+
+      it 'has a sleeping frame at the top of the stack' do
+        expect(reference_stack.first).to match(hash_including(base_label: 'sleep'))
+      end
+    end
   end
 
   context 'when sampling a thread with a stack that is deeper than the configured max_frames' do

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -89,9 +89,10 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       end
     end
 
+    # rubocop:disable Style/EvalWithLocation
     context 'when sampling a top-level eval' do
       let(:do_in_background_thread) do
-        proc do |ready_queue|
+        proc do
           eval(%(
             ready_queue << true
             sleep
@@ -117,11 +118,11 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       let(:eval_test_class) do
         Class.new do
           def call_eval
-            eval("call_instance_eval")
+            eval('call_instance_eval')
           end
 
           def call_instance_eval
-            instance_eval("call_sleep")
+            instance_eval('call_sleep')
           end
 
           def call_sleep
@@ -150,6 +151,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
         )
       end
     end
+    # rubocop:enable Style/EvalWithLocation
   end
 
   context 'when sampling a thread with a stack that is deeper than the configured max_frames' do

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -186,11 +186,9 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       end
       # rubocop:enable Style/GlobalVars
 
-      it 'matches the Ruby backtrace API' do
+      # I opted to join these two expects to avoid running the `load` above more than once
+      it 'matches the Ruby backtrace API has has a sleeping frame at the top of the stack' do
         expect(gathered_stack).to eq reference_stack
-      end
-
-      it 'has a sleeping frame at the top of the stack' do
         expect(reference_stack.first).to match(hash_including(base_label: 'sleep'))
       end
     end

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -151,6 +151,25 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
         )
       end
     end
+
+    context 'when sampling an eval with a custom file and line provided' do
+      let(:do_in_background_thread) do
+        proc do |ready_queue|
+          ready_queue << true
+          eval('sleep', binding, '/this/is/a/fake_file_.rb', -123456789)
+        end
+      end
+
+      it 'matches the Ruby backtrace API' do
+        expect(gathered_stack).to eq reference_stack
+      end
+
+      it 'has a frame with the custom file and line provided on the stack' do
+        expect(reference_stack).to include(
+          hash_including(path: '/this/is/a/fake_file_.rb', lineno: -123456789),
+        )
+      end
+    end
     # rubocop:enable Style/EvalWithLocation
   end
 

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -208,6 +208,18 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     end
   end
 
+  context 'when max_frames is too small' do
+    it 'raises an ArgumentError' do
+      expect { collectors_stack.sample(Thread.current, recorder, metric_values, labels, max_frames: 4) }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'when max_frames is too large' do
+    it 'raises an ArgumentError' do
+      expect { collectors_stack.sample(Thread.current, recorder, metric_values, labels, max_frames: 10_001) }.to raise_error(ArgumentError)
+    end
+  end
+
   def sample_and_decode(thread, max_frames: 400)
     collectors_stack.sample(thread, recorder, metric_values, labels, max_frames: max_frames)
 

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -44,8 +44,6 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     end
 
     it 'matches the Ruby backtrace API' do
-      pending 'Missing more backported rb_profile_frames functionality' if RUBY_VERSION < '3'
-
       expect(gathered_stack).to eq reference_stack
     end
   end

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       # rubocop:enable Style/GlobalVars
 
       # I opted to join these two expects to avoid running the `load` above more than once
-      it 'matches the Ruby backtrace API has has a sleeping frame at the top of the stack' do
+      it 'matches the Ruby backtrace API AND has a sleeping frame at the top of the stack' do
         expect(gathered_stack).to eq reference_stack
         expect(reference_stack.first).to match(hash_including(base_label: 'sleep'))
       end

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -3,6 +3,10 @@
 require 'datadog/profiling/spec_helper'
 require 'datadog/profiling/collectors/stack'
 
+# This file has a few lines that cannot be broken because we want some things to have the same line number when looking
+# at their stack traces. Hence, we disable Rubocop's complaints here.
+#
+# rubocop:disable Layout/LineLength
 RSpec.describe Datadog::Profiling::Collectors::Stack do
   before { skip_if_profiling_not_supported(self) }
 
@@ -59,7 +63,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   # main thread than the reference Ruby API. This is almost-surely a bug in rb_profile_frames, since the same frame
   # gets excluded from the reference Ruby API.
   context 'when sampling the main thread' do
-    let!(:stacks) { {reference: Thread.current.backtrace_locations, gathered: sample_and_decode(Thread.current)} }
+    let(:stacks) { { reference: Thread.current.backtrace_locations, gathered: sample_and_decode(Thread.current) } }
 
     let(:reference_stack) do
       # To make the stacks comparable we slice off the actual Ruby `Thread#backtrace_locations` frame since that part
@@ -95,7 +99,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     let(:target_stack_depth) { 100 }
     let(:thread_with_deep_stack) { thread_with_stack_depth(target_stack_depth) }
 
-    let!(:stacks) { {reference: thread_with_deep_stack.backtrace_locations, gathered: sample_and_decode(thread_with_deep_stack, max_frames: max_frames)} }
+    let(:stacks) { { reference: thread_with_deep_stack.backtrace_locations, gathered: sample_and_decode(thread_with_deep_stack, max_frames: max_frames) } }
 
     after do
       thread_with_deep_stack.kill
@@ -116,7 +120,8 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       placeholder = 1
       omitted_frames = target_stack_depth - max_frames - placeholder
 
-      expect(gathered_stack.last).to match(hash_including({base_label: '', path: "#{omitted_frames} frames omitted", lineno: 0}))
+      expect(gathered_stack.last)
+        .to match(hash_including({ base_label: '', path: "#{omitted_frames} frames omitted", lineno: 0 }))
     end
 
     def thread_with_stack_depth(depth)
@@ -140,9 +145,9 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   end
 
   context 'when sampling a dead thread' do
-    let(:dead_thread) { Thread.new { }.tap(&:join) }
+    let(:dead_thread) { Thread.new {}.tap(&:join) }
 
-    let!(:stacks) { {reference: dead_thread.backtrace_locations, gathered: sample_and_decode(dead_thread)} }
+    let(:stacks) { { reference: dead_thread.backtrace_locations, gathered: sample_and_decode(dead_thread) } }
 
     it 'gathers an empty stack' do
       expect(gathered_stack).to be_empty
@@ -151,6 +156,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
 
   context 'when sampling a thread with empty locations' do
     let(:ready_pipe) { IO.pipe }
+    let(:stacks) { { reference: thread_with_empty_locations.backtrace_locations, gathered: sample_and_decode(thread_with_empty_locations) } }
     let(:finish_pipe) { IO.pipe }
 
     let(:thread_with_empty_locations) do
@@ -191,10 +197,8 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       thread_with_empty_locations.join
     end
 
-    let!(:stacks) { {reference: thread_with_empty_locations.backtrace_locations, gathered: sample_and_decode(thread_with_empty_locations)} }
-
     it 'gathers a one-element stack with a "In native code" placeholder' do
-      expect(gathered_stack).to contain_exactly({base_label: '', path: 'In native code', lineno: 0})
+      expect(gathered_stack).to contain_exactly({ base_label: '', path: 'In native code', lineno: 0 })
     end
   end
 
@@ -223,3 +227,4 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     { base_label: strings[function.name], path: strings[function.filename], lineno: line_entry.line }
   end
 end
+# rubocop:enable Layout/LineLength

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -43,8 +43,12 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       another_thread.join
     end
 
-    it 'matches the Ruby backtrace API' do
+    it 'matches the Ruby backtrace API', if: RUBY_VERSION >= '2.3' do
       expect(gathered_stack).to eq reference_stack
+    end
+
+    it 'matches the Ruby backtrace API, minus the native sleep and call methods', if: RUBY_VERSION < '2.3' do
+      expect(gathered_stack).to eq reference_stack.reject { |frame| ['sleep', 'call'].include?(frame.fetch(:base_label)) }
     end
   end
 

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   # do correctly overcome this.
   context 'when sampling a sleeping thread' do
     let(:ready_queue) { Queue.new }
-    let(:stacks) { { reference: another_thread.backtrace_locations, gathered: sample_and_decode(another_thread) } }
-    let(:another_thread) do
+    let(:stacks) { { reference: sleeping_thread.backtrace_locations, gathered: sample_and_decode(sleeping_thread) } }
+    let(:sleeping_thread) do
       Thread.new(ready_queue) do |ready_queue|
         ready_queue << true
         sleep
@@ -37,13 +37,13 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     end
 
     before do
-      another_thread
+      sleeping_thread
       ready_queue.pop
     end
 
     after do
-      another_thread.kill
-      another_thread.join
+      sleeping_thread.kill
+      sleeping_thread.join
     end
 
     it 'matches the Ruby backtrace API' do
@@ -99,7 +99,6 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       expect(gathered_stack).to be_empty
     end
   end
-
 
   context 'when sampling a thread with empty locations' do
     let(:ready_pipe) { IO.pipe }

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -43,12 +43,8 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       another_thread.join
     end
 
-    it 'matches the Ruby backtrace API', if: RUBY_VERSION >= '2.3' do
+    it 'matches the Ruby backtrace API' do
       expect(gathered_stack).to eq reference_stack
-    end
-
-    it 'matches the Ruby backtrace API, minus the native sleep and call methods', if: RUBY_VERSION < '2.3' do
-      expect(gathered_stack).to eq reference_stack.reject { |frame| ['sleep', 'call'].include?(frame.fetch(:base_label)) }
     end
   end
 

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -90,6 +90,16 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     end
   end
 
+  context 'when sampling a dead thread' do
+    let(:dead_thread) { Thread.new { }.tap(&:join) }
+
+    let!(:stacks) { {reference: dead_thread.backtrace_locations, gathered: sample_and_decode(dead_thread)} }
+
+    it 'gathers an empty stack' do
+      expect(gathered_stack).to be_empty
+    end
+  end
+
   def sample_and_decode(thread)
     collectors_stack.sample(thread, recorder, metric_values, labels)
 

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -44,15 +44,9 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     end
 
     it 'matches the Ruby backtrace API' do
-      pending 'Needs fixes in rb_profile_frames to fix sleep'
+      pending 'Missing more backported rb_profile_frames functionality' if RUBY_VERSION < '3'
 
       expect(gathered_stack).to eq reference_stack
-    end
-
-    it 'matches the Ruby backtrace API excluding the sleep frame' do
-      # FIXME: Temporary, until above test can be fixed
-
-      expect(gathered_stack[1..-1]).to eq reference_stack[1..-1]
     end
   end
 

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -4,15 +4,7 @@ require 'datadog/profiling/spec_helper'
 require 'datadog/profiling/collectors/stack'
 
 RSpec.describe Datadog::Profiling::Collectors::Stack do
-  before do
-    skip_if_profiling_not_supported(self)
-    if RUBY_VERSION < '2.6'
-      skip(
-        'This is temporarily disabled just to break up implementation into two PRs and will be ' \
-        'reverted in https://github.com/DataDog/dd-trace-rb/pull/2000'
-      )
-    end
-  end
+  before { skip_if_profiling_not_supported(self) }
 
   subject(:collectors_stack) { described_class.new }
 

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -150,6 +150,12 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     end
   end
 
+  context 'when trying to sample something which is not a thread' do
+    it 'raises a TypeError' do
+      expect { collectors_stack.sample(:not_a_thread, recorder, metric_values, labels) }.to raise_error(TypeError)
+    end
+  end
+
   def sample_and_decode(thread)
     collectors_stack.sample(thread, recorder, metric_values, labels)
 

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -20,6 +20,19 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
     let(:decoded_profile) { ::Perftools::Profiles::Profile.decode(encoded_pprof) }
 
+    it 'debug logs profile information' do
+      message = nil
+
+      expect(Datadog.logger).to receive(:debug) do |&message_block|
+        message = message_block.call
+      end
+
+      serialize
+
+      expect(message).to include start.iso8601
+      expect(message).to include finish.iso8601
+    end
+
     context 'when the profile is empty' do
       it 'uses the current time as the start and finish time' do
         before_serialize = Time.now

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -4,15 +4,7 @@ require 'datadog/profiling/spec_helper'
 require 'datadog/profiling/stack_recorder'
 
 RSpec.describe Datadog::Profiling::StackRecorder do
-  before do
-    skip_if_profiling_not_supported(self)
-    if RUBY_VERSION < '2.6'
-      skip(
-        'This is temporarily disabled just to break up implementation into two PRs and will be ' \
-        'reverted in https://github.com/DataDog/dd-trace-rb/pull/2000'
-      )
-    end
-  end
+  before { skip_if_profiling_not_supported(self) }
 
   subject(:stack_recorder) { described_class.new }
 

--- a/spec/datadog/profiling/tasks/exec_spec.rb
+++ b/spec/datadog/profiling/tasks/exec_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Datadog::Profiling::Tasks::Exec do
       ENV['RUBYOPT'] = original_opts
     end
 
-    context 'when RUBOPT is not defined' do
+    context 'when RUBYOPT is not defined' do
       before do
         # Must stub the call out or test will prematurely terminate.
         expect(Kernel).to receive(:exec)


### PR DESCRIPTION
The new stack collector introduced in #1966 gets feature-complete in this PR.

By feature-complete I mean:

* There is extensive test coverage with many corner cases being checked
* Our custom `rb_profile_frames` got quite a lot of fixes to exactly match the Ruby reference stack trace api (`Thread#backtrace_locations`)
* It works for all supported Rubies, including 2.1 and 2.2 which were a though nut to crack
* It matches the behavior of the old profiling codepaths, e.g. it has placeholders for threads with empty stacks that are running in native code and for threads with too deep stacks
* etc...

I don't quite like how long and how complex this PR got. Thanks for putting up with it 😅 , and feel free to challenge me if this should be further broken down. Reviewing it commit-by-commit may make more sense, helping to show what bits were added why.

Note: This PR builds on top of #1966.
Note 2: I'm aware that specs for "Datadog::Profiling::Collectors::Stack when sampling a thread with a stack that is deeper than the configured max_frames" are failing. I missed this previously as it did not happen on macOS (works fine on macOS). I'll push a fix for it ASAP, but otherwise this is ready for reviewing.