### PR TITLE
[PROF-5343] Isolate profiling native extension native symbols

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -383,9 +383,5 @@ Style/TrailingCommaInBlockArgs:
 Style/TrailingCommaInHashLiteral:
   Enabled: false
 
-Style/GlobalVars:
-  Exclude:
-    - 'ext/ddtrace_profiling_native_extension/extconf.rb'
-
 Naming/VariableNumber:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -397,6 +397,10 @@ Rake::ExtensionTask.new("ddtrace_profiling_native_extension.#{RUBY_VERSION}_#{RU
   ext.ext_dir = 'ext/ddtrace_profiling_native_extension'
 end
 
+Rake::ExtensionTask.new("ddtrace_profiling_loader.#{RUBY_VERSION}_#{RUBY_PLATFORM}") do |ext|
+  ext.ext_dir = 'ext/ddtrace_profiling_loader'
+end
+
 desc 'Runs the sorbet type checker on the codebase'
 task :typecheck do
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -55,5 +55,5 @@ Gem::Specification.new do |spec|
   # Used by appsec
   spec.add_dependency 'libddwaf', '~> 1.3.0.1.0'
 
-  spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb']
+  spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb', 'ext/ddtrace_profiling_loader/extconf.rb']
 end

--- a/ext/ddtrace_profiling_loader/ddtrace_profiling_loader.c
+++ b/ext/ddtrace_profiling_loader/ddtrace_profiling_loader.c
@@ -1,0 +1,118 @@
+#include <stdbool.h>
+#include <dlfcn.h>
+#include <ruby.h>
+
+// Why this exists:
+//
+// The Datadog::Profiling::Loader exists because when Ruby loads a native extension (using `require`), it uses
+// `dlopen(..., RTLD_LAZY | RTLD_GLOBAL)` (https://github.com/ruby/ruby/blob/67950a4c0a884bdb78d9beb4405ebf7459229b21/dln.c#L362).
+// This means that every symbol exposed directly or indirectly by that native extension becomes visible to every other
+// extension in the Ruby process. This can cause issues, see https://github.com/rubyjs/mini_racer/pull/179.
+//
+// Instead of `RTLD_LAZY | RTLD_GLOBAL`, we want to call `dlopen` with `RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND` when
+// loading the profiling native extension, to avoid leaking any unintended symbols (`RTLD_LOCAL`) and avoid picking
+// up other's symbols (`RTLD_DEEPBIND`).
+//
+// But Ruby's extension loading mechanism is not configurable -- there's no way to tell it to use different flags when
+// calling `dlopen`. To get around this, this file (ddtrace_profiling_loader.c) introduces another extension
+// (profiling loader) which has only a single responsibility: mimic Ruby's extension loading mechanism, but when calling
+// `dlopen` use a different set of flags.
+// This idea was shamelessly stolen from @lloeki's work in https://github.com/rubyjs/mini_racer/pull/179, big thanks!
+//
+// Extra note: Currently (May 2022), that we know of, the profiling native extension only exposes one potentially
+// problematic symbol: `rust_eh_personality` (coming from libddprof/libdatadog).
+// Future versions of Rust have been patched not to expose this
+// (see https://github.com/rust-lang/rust/pull/95604#issuecomment-1108563434) so we may want to revisit the need
+// for this loader in the future, and perhaps delete it if we no longer require its services :)
+
+#ifndef RTLD_DEEPBIND
+  #define RTLD_DEEPBIND 0
+#endif
+
+static VALUE ok_symbol = Qnil; // :ok in Ruby
+static VALUE error_symbol = Qnil; // :error in Ruby
+
+static VALUE _native_load(VALUE self, VALUE ruby_path, VALUE ruby_init_name);
+static bool failed_to_load(void *handle, VALUE *failure_details);
+static bool incompatible_library(void *handle, VALUE *failure_details);
+static bool failed_to_initialize(void *handle, char *init_name, VALUE *failure_details);
+static void set_failure_from_dlerror(VALUE *failure_details);
+static void unload_failed_library(void *handle);
+
+#define DDTRACE_EXPORT __attribute__ ((visibility ("default")))
+
+void DDTRACE_EXPORT Init_ddtrace_profiling_loader() {
+  VALUE datadog_module = rb_define_module("Datadog");
+  VALUE profiling_module = rb_define_module_under(datadog_module, "Profiling");
+  VALUE loader_module = rb_define_module_under(profiling_module, "Loader");
+  rb_define_singleton_method(loader_module, "_native_load", _native_load, 2);
+
+  ok_symbol = ID2SYM(rb_intern_const("ok"));
+  error_symbol = ID2SYM(rb_intern_const("error"));
+}
+
+static VALUE _native_load(VALUE self, VALUE ruby_path, VALUE ruby_init_name) {
+  Check_Type(ruby_path, T_STRING);
+  Check_Type(ruby_init_name, T_STRING);
+
+  char *path = StringValueCStr(ruby_path);
+  char *init_name = StringValueCStr(ruby_init_name);
+
+  void *handle = dlopen(path, RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+
+  VALUE failure_details = Qnil;
+
+  if (
+    failed_to_load(handle, &failure_details) ||
+    incompatible_library(handle, &failure_details) ||
+    failed_to_initialize(handle, init_name, &failure_details)
+  ) {
+    return rb_ary_new_from_args(2, error_symbol, failure_details);
+  }
+
+  return rb_ary_new_from_args(2, ok_symbol, Qnil);
+}
+
+static bool failed_to_load(void *handle, VALUE *failure_details) {
+  if (handle == NULL) {
+    set_failure_from_dlerror(failure_details);
+    return true;
+  } else {
+    return false;
+  }
+}
+
+static bool incompatible_library(void *handle, VALUE *failure_details) {
+  // The library being loaded may be linked to a different libruby than the current executing Ruby.
+  // We check if this is the case by checking if a well-known symbol resolves to a common address.
+  if (dlsym(handle, "ruby_xmalloc") != &ruby_xmalloc) {
+    *failure_details = rb_str_new_cstr("library was compiled and linked to a different Ruby version");
+    unload_failed_library(handle);
+    return true;
+  } else {
+    return false;
+  }
+}
+
+static bool failed_to_initialize(void *handle, char *init_name, VALUE *failure_details) {
+  void (*initialization_function)(void) = dlsym(handle, init_name);
+
+  if (initialization_function == NULL) {
+    set_failure_from_dlerror(failure_details);
+    unload_failed_library(handle);
+    return true;
+  } else {
+    (*initialization_function)();
+    return false;
+  }
+}
+
+static void set_failure_from_dlerror(VALUE *failure_details) {
+  char *failure = dlerror();
+  *failure_details = failure == NULL ? Qnil : rb_str_new_cstr(failure);
+}
+
+static void unload_failed_library(void *handle) {
+  // Note: According to the Ruby VM sources, this may fail with a segfault on really old versions of macOS (< 10.11)
+  dlclose(handle);
+}

--- a/ext/ddtrace_profiling_loader/extconf.rb
+++ b/ext/ddtrace_profiling_loader/extconf.rb
@@ -1,0 +1,53 @@
+# typed: ignore
+# rubocop:disable Style/StderrPuts
+# rubocop:disable Style/GlobalVars
+
+if Gem.win_platform?
+  $stderr.puts(
+    'WARN: Skipping build of ddtrace profiling loader on Windows. See ddtrace profiling native extension note for details.'
+  )
+
+  File.write('Makefile', 'all install clean: # dummy makefile that does nothing')
+  exit
+end
+
+require 'mkmf'
+
+# mkmf on modern Rubies actually has an append_cflags that does something similar
+# (see https://github.com/ruby/ruby/pull/5760), but as usual we need a bit more boilerplate to deal with legacy Rubies
+def add_compiler_flag(flag)
+  if try_cflags(flag)
+    $CFLAGS << ' ' << flag
+  else
+    $stderr.puts("WARNING: '#{flag}' not accepted by compiler, skipping it")
+  end
+end
+
+# Gets really noisy when we include the MJIT header, let's omit it
+add_compiler_flag '-Wno-unused-function'
+
+# Allow defining variables at any point in a function
+add_compiler_flag '-Wno-declaration-after-statement'
+
+# If we forget to include a Ruby header, the function call may still appear to work, but then
+# cause a segfault later. Let's ensure that never happens.
+add_compiler_flag '-Werror-implicit-function-declaration'
+
+# The native extension is not intended to expose any symbols/functions for other native libraries to use;
+# the sole exception being `Init_ddtrace_profiling_loader` which needs to be visible for Ruby to call it when
+# it `dlopen`s the library.
+#
+# By setting this compiler flag, we tell it to assume that everything is private unless explicitly stated.
+# For more details see https://gcc.gnu.org/wiki/Visibility
+add_compiler_flag '-fvisibility=hidden'
+
+# Tag the native extension library with the Ruby version and Ruby platform.
+# This makes it easier for development (avoids "oops I forgot to rebuild when I switched my Ruby") and ensures that
+# the wrong library is never loaded.
+# When requiring, we need to use the exact same string, including the version and the platform.
+EXTENSION_NAME = "ddtrace_profiling_loader.#{RUBY_VERSION}_#{RUBY_PLATFORM}".freeze
+
+create_makefile(EXTENSION_NAME)
+
+# rubocop:enable Style/GlobalVars
+# rubocop:enable Style/StderrPuts

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -1,6 +1,7 @@
 # typed: ignore
 
 # rubocop:disable Style/StderrPuts
+# rubocop:disable Style/GlobalVars
 
 # Older Rubies don't have the MJIT header, used by the JIT compiler, so we need to use a different approach
 CAN_USE_MJIT_HEADER = RUBY_VERSION >= '2.6'
@@ -203,4 +204,6 @@ else
   Debase::RubyCoreSource
     .create_makefile_with_core(proc { have_header('vm_core.h') && thread_native_for_ruby_2_1.call }, EXTENSION_NAME)
 end
+
+# rubocop:enable Style/GlobalVars
 # rubocop:enable Style/StderrPuts

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -134,7 +134,8 @@ module Datadog
       end
 
       begin
-        require "ddtrace_profiling_native_extension.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
+        require 'datadog/profiling/load_native_extension'
+
         success =
           defined?(Profiling::NativeExtension) && Profiling::NativeExtension.send(:native_working?)
         [success, nil]

--- a/lib/datadog/profiling/load_native_extension.rb
+++ b/lib/datadog/profiling/load_native_extension.rb
@@ -1,0 +1,22 @@
+# typed: ignore
+
+# This file is used to load the profiling native extension. It works in two steps:
+#
+# 1. Load the ddtrace_profiling_loader extension. This extension will be used to load the actual extension, but in
+#    a special way that avoids exposing native-level code symbols. See `ddtrace_profiling_loader.c` for more details.
+#
+# 2. Use the Datadog::Profiling::Loader exposed by the ddtrace_profiling_loader extension to load the actual
+#    profiling native extension.
+#
+# All code on this file is on-purpose at the top-level; this makes it so this file is executed only once,
+# the first time it gets required, to avoid any issues with the native extension being initialized more than once.
+
+require "ddtrace_profiling_loader.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
+
+extension_name = "ddtrace_profiling_native_extension.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
+full_file_path = "#{__dir__}/../../#{extension_name}.#{RbConfig::CONFIG['DLEXT']}"
+init_function_name = "Init_#{extension_name.split('.').first}"
+
+status, result = Datadog::Profiling::Loader._native_load(full_file_path, init_function_name)
+
+raise "Failure to load #{extension_name} due to #{result}" if status == :error

--- a/spec/datadog/profiling_spec.rb
+++ b/spec/datadog/profiling_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Datadog::Profiling do
   describe '::try_loading_native_library' do
     subject(:try_loading_native_library) { described_class.send(:try_loading_native_library) }
 
-    let(:native_extension_require) { "ddtrace_profiling_native_extension.#{RUBY_VERSION}_#{RUBY_PLATFORM}" }
+    let(:native_extension_require) { 'datadog/profiling/load_native_extension' }
 
     around { |example| ClimateControl.modify('DD_PROFILING_NO_EXTENSION' => nil) { example.run } }
 


### PR DESCRIPTION
When Ruby loads a native extension (using `require`), it uses `dlopen(..., RTLD_LAZY | RTLD_GLOBAL)` (https://github.com/ruby/ruby/blob/67950a4c0a884bdb78d9beb4405ebf7459229b21/dln.c#L362).

This means that every symbol exposed directly or indirectly by that native extension becomes visible to every other extension in the Ruby process. This can cause issues, see https://github.com/rubyjs/mini_racer/pull/179.

Ruby's extension loading mechanism is not configurable -- there's no way to tell it to use different flags when calling `dlopen`. To get around this, this commit introduces introduces another extension (profiling loader) which has only a single responsibility: mimic Ruby's extension loading mechanism, but when calling  `dlopen` use a different set of flags.

This idea was shamelessly stolen from @lloeki's work in https://github.com/rubyjs/mini_racer/pull/179, big thanks!

Note that, that we know of, the profiling native extension only exposes one potentially problematic symbol: `rust_eh_personality` (coming from libddprof/libdatadog).

Future versions of Rust have been patched not to expose this (see https://github.com/rust-lang/rust/pull/95604#issuecomment-1108563434) so we may want to revisit the need for this loader in the future, and perhaps delete it if we no longer require its services :)

Testing the `ddtrace_profiling_loader.c`'s failure handling paths is a bit non-trivial, so here's how I did it manually (some logs abridged):

```bash
 # 1️⃣  Validate everything's working fine:

 $ ruby -v
 ruby 2.7.6p219 (2022-04-12 revision c9c2245c0a) [x86_64-darwin20]
 $ bundle rake clean compile
 ...
 $ DD_TRACE_DEBUG=true DD_PROFILING_ENABLED=true bundle exec ddtracerb exec ruby -e 'nil'
 D, [2022-05-06T12:17:41.554770 #19686] DEBUG -- ddtrace: [ddtrace]
 (/Users/ivo.anjo/datadog/dd-trace-rb/lib/datadog/core/configuration/components.rb:340:in `startup!') Profiling started'

 # 2️⃣  Force library load failure:

 # (Delete the library version for the Ruby I'm using)
 $ rm lib/ddtrace_profiling_native_extension.2.7.6_x86_64-darwin20.bundle
 $ DD_TRACE_DEBUG=true DD_PROFILING_ENABLED=true bundle exec ddtracerb exec ruby -e 'nil'
 W, [2022-05-06T12:19:23.891711 #21159]  WARN -- ddtrace: [ddtrace]
 (/Users/ivo.anjo/datadog/dd-trace-rb/lib/datadog/core/configuration/components.rb:345:in `startup!')
 Profiling was requested but is not supported, profiling disabled: There was an error loading the profiling native extension due to
 'Failure to load ddtrace_profiling_native_extension.2.7.6_x86_64-darwin20 due to
 dlopen(/Users/ivo.anjo/datadog/dd-trace-rb/lib/datadog/profiling/../../ddtrace_profiling_native_extension.2.7.6_x86_64-darwin20.bundle, 5):
 image not found' at '/Users/ivo.anjo/datadog/dd-trace-rb/lib/datadog/profiling/load_native_extension.rb:22:in `<top (required)>''

 # 3️⃣  Force a library incompatibility:

 # (Copy library compiled with a different Ruby version)
 $ cp lib/ddtrace_profiling_native_extension.3.2.0_x86_64-darwin20.bundle lib/ddtrace_profiling_native_extension.2.7.6_x86_64-darwin20.bundle
 $ DD_TRACE_DEBUG=true DD_PROFILING_ENABLED=true bundle exec ddtracerb exec ruby -e 'nil'
 W, [2022-05-06T12:22:24.036956 #21773]  WARN -- ddtrace: [ddtrace]
 (/Users/ivo.anjo/datadog/dd-trace-rb/lib/datadog/core/configuration/components.rb:345:in `startup!')
 Profiling was requested but is not supported, profiling disabled: There was an error loading the profiling native extension due to
 Failure to load ddtrace_profiling_native_extension.2.7.6_x86_64-darwin20 due to library was compiled and linked to a different Ruby version'
 at '/Users/ivo.anjo/datadog/dd-trace-rb/lib/datadog/profiling/load_native_extension.rb:22:in `<top (required)>'

 # 4️⃣  Force an initialization failure:

 # (Restore library clobbered in previous steps)
 $ bundle rake clean compile
 ...
 # (Rename expected initialization function)
 $ git diff -U0 lib/datadog/profiling/load_native_extension.rb
 diff --git a/lib/datadog/profiling/load_native_extension.rb b/lib/datadog/profiling/load_native_extension.rb
 index 5ea4bb32c..af964bade 100644
 --- a/lib/datadog/profiling/load_native_extension.rb
 +++ b/lib/datadog/profiling/load_native_extension.rb
 @@ -18 +18 @@ full_file_path = "#{__dir__}/../../#{extension_name}.#{RbConfig::CONFIG['DLEXT']
 -init_function_name = "Init_#{extension_name.split('.').first}"
 +init_function_name = "Init_#{extension_name.split('.').first}_kaboom
 $ DD_TRACE_DEBUG=true DD_PROFILING_ENABLED=true bundle exec ddtracerb exec ruby -e 'nil'
 W, [2022-05-06T12:27:55.706221 #23036]  WARN -- ddtrace: [ddtrace]
 (/Users/ivo.anjo/datadog/dd-trace-rb/lib/datadog/core/configuration/components.rb:345:in `startup!')
 Profiling was requested but is not supported, profiling disabled: There was an error loading the profiling native extension due to
 'Failure to load ddtrace_profiling_native_extension.2.7.6_x86_64-darwin20 due to dlsym(0x7fe144151630,
   Init_ddtrace_profiling_native_extension_kaboom): symbol not found' at
 '/Users/ivo.anjo/datadog/dd-trace-rb/lib/datadog/profiling/load_native_extension.rb:22:in `<top (required)>''
```