### PR TITLE
Reduce test flakyness by relaxing expectation

### DIFF
--- a/spec/datadog/integration_spec.rb
+++ b/spec/datadog/integration_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Datadog integration' do
         end
       end
 
-      it 'closes tracer file descriptors' do
+      it 'closes tracer file descriptors (known flaky test)' do
         before_open_file_descriptors = open_file_descriptors
 
         start_tracer
@@ -66,7 +66,9 @@ RSpec.describe 'Datadog integration' do
 
         expect(after_open_file_descriptors.size)
           .to(
-            eq(before_open_file_descriptors.size),
+            # Below was changed from eq to <= to cause less flakyness. We still don't know why this test fails in CI
+            # from time to time.
+            (be <= (before_open_file_descriptors.size)),
             lambda {
               "Open fds before (#{before_open_file_descriptors.size}): #{before_open_file_descriptors}\n" \
               "Open fds after (#{after_open_file_descriptors.size}):  #{after_open_file_descriptors}"


### PR DESCRIPTION
This test is regularly flaky, e.g.:

<https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/6027/workflows/64536fbc-1101-4a81-8e85-c5321422aa32/jobs/223019/tests>

```
Failure/Error:
  expect(after_open_file_descriptors.size)
    .to(
      eq(before_open_file_descriptors.size),
      lambda {
        "Open fds before (#{before_open_file_descriptors.size}): #{before_open_file_descriptors}\n" \
        "Open fds after (#{after_open_file_descriptors.size}):  #{after_open_file_descriptors}"
      }
    )

  Open fds before (10): {"/dev/fd/0"=>"/dev/pts/1", "/dev/fd/1"=>"/dev/pts/1", "/dev/fd/2"=>"/dev/pts/1",
"/dev/fd/3"=>nil, "/dev/fd/4"=>nil, "/dev/fd/5"=>nil, "/dev/fd/6"=>nil,
"/dev/fd/7"=>"/tmp/rspec/---patternspec-**-*_spec.rb--exclude-patternspec-**-{contrib,benchmark,redis,opentracer,auto_instrument}-**-*_spec.rb,
spec-**-auto_instrument_spec.rb.xml", "/dev/fd/8"=>nil, "/dev/fd/13"=>nil}
  Open fds after (9):  {"/dev/fd/0"=>"/dev/pts/1", "/dev/fd/1"=>"/dev/pts/1", "/dev/fd/2"=>"/dev/pts/1",
"/dev/fd/3"=>nil, "/dev/fd/4"=>nil, "/dev/fd/5"=>nil, "/dev/fd/6"=>nil,
"/dev/fd/7"=>"/tmp/rspec/---patternspec-**-*_spec.rb--exclude-patternspec-**-{contrib,benchmark,redis,opentracer,auto_instrument}-**-*_spec.rb,
spec-**-auto_instrument_spec.rb.xml", "/dev/fd/8"=>nil}
./spec/datadog/integration_spec.rb:68:in `block (4 levels) in <top (required)>'
./spec/spec_helper.rb:216:in `block (2 levels) in <top (required)>'
./spec/spec_helper.rb:108:in `block (2 levels) in <top (required)>'
/usr/local/bundle/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

Under the assumption that we still want to keep this test, I've decided to relax the expectation to avoid failing in cases where the number of file descriptors at the end of the test IS LESS THAN the number at the beginning.