### PR TITLE
Upgrade to Rubocop 1.29.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.5 # Lowest version supported as of Rubocop 0.13.0
+  TargetRubyVersion: 2.6 # Lowest version supported as of Rubocop 1.29.0
   Include:
     - 'lib/**/*.rb'
     - 'ext/**/*.rb'
@@ -216,6 +216,10 @@ Style/RedundantBegin:
 
 # Requires Ruby 2.5
 Style/HashTransformKeys:
+  Enabled: false
+
+# Requires Ruby 2.6
+Style/SlicingWithRange:
   Enabled: false
 
 # Enforces negative/positive branching order,

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -85,10 +85,10 @@ module Datadog
           # rubocop:enable Metrics/MethodLength
         end
 
-        # rubocop:disable Metrics/LineLength
+        # rubocop:disable Layout/LineLength
         DEFAULT_OBFUSCATOR_KEY_REGEX = '(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?)key)|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization'.freeze
         DEFAULT_OBFUSCATOR_VALUE_REGEX = '(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}'.freeze
-        # rubocop:enable Metrics/LineLength
+        # rubocop:enable Layout/LineLength
 
         DEFAULTS = {
           enabled: false,


### PR DESCRIPTION
Rubocop has [dropped support for Ruby 2.5 analysis in 1.29.0](https://github.com/rubocop/rubocop/blob/2f2b2a7aa75b5222457966fdacc464f085c8c308/relnotes/v1.29.0.md#changes).

This PR upgrades our `.rubocop.yml` file to adapt to this change.

Another minor change is a fix to a warning about `rubocop:disable Metrics/LineLength` being moved to `rubocop:enable Layout/LineLength`.