### PR TITLE
Fetch parameters from route path

### DIFF
--- a/lib/datadog/appsec/contrib/rack/request.rb
+++ b/lib/datadog/appsec/contrib/rack/request.rb
@@ -48,9 +48,8 @@ module Datadog
 
           def self.form_hash(request)
             # usually Hash<String,String> but can be a more complex
-            # Hash<String,String||Array||Hash> when e.g coming from JSON or
-            # with Rails advanced param square bracket parsing
-            request.env['rack.request.form_hash'] || request.env['action_dispatch.request.request_parameters']
+            # Hash<String,String||Array||Hash> when e.g coming from JSON
+            request.env['rack.request.form_hash']
           end
         end
       end

--- a/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
@@ -1,0 +1,81 @@
+# typed: false
+
+require 'datadog/appsec/instrumentation/gateway'
+require 'datadog/appsec/reactive/operation'
+require 'datadog/appsec/contrib/rails/reactive/action'
+require 'datadog/appsec/event'
+
+module Datadog
+  module AppSec
+    module Contrib
+      module Rails
+        module Gateway
+          # Watcher for Rails gateway events
+          module Watcher
+            def self.watch
+              Instrumentation.gateway.watch('rails.request.action') do |stack, request|
+                block = false
+                event = nil
+                waf_context = request.env['datadog.waf.context']
+
+                AppSec::Reactive::Operation.new('rails.request.action') do |op|
+                  trace = active_trace
+                  span = active_span
+
+                  Rails::Reactive::Action.subscribe(op, waf_context) do |action, result, _block|
+                    record = [:block, :monitor].include?(action)
+                    if record
+                      # TODO: should this hash be an Event instance instead?
+                      event = {
+                        waf_result: result,
+                        trace: trace,
+                        span: span,
+                        request: request,
+                        action: action
+                      }
+
+                      waf_context.events << event
+                    end
+                  end
+
+                  _action, _result, block = Rails::Reactive::Action.publish(op, request)
+                end
+
+                next [nil, [[:block, event]]] if block
+
+                ret, res = stack.call(request)
+
+                if event
+                  res ||= []
+                  res << [:monitor, event]
+                end
+
+                [ret, res]
+              end
+            end
+
+            class << self
+              private
+
+              def active_trace
+                # TODO: factor out tracing availability detection
+
+                return unless defined?(Datadog::Tracing)
+
+                Datadog::Tracing.active_trace
+              end
+
+              def active_span
+                # TODO: factor out tracing availability detection
+
+                return unless defined?(Datadog::Tracing)
+
+                Datadog::Tracing.active_span
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/contrib/rails/patcher.rb
+++ b/lib/datadog/appsec/contrib/rails/patcher.rb
@@ -6,6 +6,7 @@ require 'datadog/appsec/contrib/patcher'
 require 'datadog/appsec/contrib/rails/framework'
 require 'datadog/appsec/contrib/rack/request_middleware'
 require 'datadog/appsec/contrib/rack/request_body_middleware'
+require 'datadog/appsec/contrib/rails/gateway/watcher'
 
 require 'datadog/tracing/contrib/rack/middlewares'
 
@@ -31,6 +32,7 @@ module Datadog
           end
 
           def patch
+            Gateway::Watcher.watch
             patch_before_intialize
             patch_after_intialize
 
@@ -74,7 +76,7 @@ module Datadog
 
               # TODO: handle exceptions, except for super
 
-              request_return, request_response = Instrumentation.gateway.push('rack.request.body', request) do
+              request_return, request_response = Instrumentation.gateway.push('rails.request.action', request) do
                 super
               end
 

--- a/lib/datadog/appsec/contrib/rails/reactive/action.rb
+++ b/lib/datadog/appsec/contrib/rails/reactive/action.rb
@@ -1,0 +1,68 @@
+# typed: true
+
+require 'datadog/appsec/contrib/rails/request'
+
+module Datadog
+  module AppSec
+    module Contrib
+      module Rails
+        module Reactive
+          # Dispatch data from a Rails request to the WAF context
+          module Action
+            def self.publish(op, request)
+              catch(:block) do
+                # params have been parsed from the request body
+                op.publish('rails.request.body', Rails::Request.parsed_body(request))
+                op.publish('rails.request.route_params', Rails::Request.route_params(request))
+
+                nil
+              end
+            end
+
+            def self.subscribe(op, waf_context)
+              addresses = [
+                'rails.request.body',
+                'rails.request.route_params',
+              ]
+
+              op.subscribe(*addresses) do |*values|
+                Datadog.logger.debug { "reacted to #{addresses.inspect}: #{values.inspect}" }
+                body = values[0]
+                path_params = values[1]
+
+                waf_args = {
+                  'server.request.body' => body,
+                  'server.request.path_params' => path_params,
+                }
+
+                waf_timeout = Datadog::AppSec.settings.waf_timeout
+                action, result = waf_context.run(waf_args, waf_timeout)
+
+                Datadog.logger.debug { "WAF TIMEOUT: #{result.inspect}" } if result.timeout
+
+                # TODO: encapsulate return array in a type
+                case action
+                when :monitor
+                  Datadog.logger.debug { "WAF: #{result.inspect}" }
+                  yield [action, result, false]
+                when :block
+                  Datadog.logger.debug { "WAF: #{result.inspect}" }
+                  yield [action, result, true]
+                  throw(:block, [action, result, true])
+                when :good
+                  Datadog.logger.debug { "WAF OK: #{result.inspect}" }
+                when :invalid_call
+                  Datadog.logger.debug { "WAF CALL ERROR: #{result.inspect}" }
+                when :invalid_rule, :invalid_flow, :no_rule
+                  Datadog.logger.debug { "WAF RULE ERROR: #{result.inspect}" }
+                else
+                  Datadog.logger.debug { "WAF UNKNOWN: #{action.inspect} #{result.inspect}" }
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/contrib/rails/request.rb
+++ b/lib/datadog/appsec/contrib/rails/request.rb
@@ -1,0 +1,33 @@
+# typed: true
+
+module Datadog
+  module AppSec
+    module Contrib
+      module Rails
+        # Normalized extration of data from ActionDispatch::Request
+        module Request
+          def self.parsed_body(request)
+            # usually Hash<String,String> but can be a more complex
+            # Hash<String,String||Array||Hash> when e.g coming from JSON or
+            # with Rails advanced param square bracket parsing
+            body = request.env['action_dispatch.request.request_parameters']
+
+            return if body.nil?
+
+            body.reject do |k, _v|
+              request.env['action_dispatch.request.path_parameters'].key?(k)
+            end
+          end
+
+          def self.route_params(request)
+            excluded = [:controller, :action]
+
+            request.env['action_dispatch.request.path_parameters'].reject do |k, _v|
+              excluded.include?(k)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
@@ -1,0 +1,124 @@
+# typed: false
+
+require 'datadog/appsec/instrumentation/gateway'
+require 'datadog/appsec/reactive/operation'
+require 'datadog/appsec/contrib/rack/reactive/request_body'
+require 'datadog/appsec/contrib/sinatra/reactive/routed'
+require 'datadog/appsec/event'
+
+module Datadog
+  module AppSec
+    module Contrib
+      module Sinatra
+        module Gateway
+          # Watcher for Rails gateway events
+          module Watcher
+            # rubocop:disable Metrics/MethodLength
+            def self.watch
+              Instrumentation.gateway.watch('sinatra.request.dispatch') do |stack, request|
+                block = false
+                event = nil
+                waf_context = request.env['datadog.waf.context']
+
+                AppSec::Reactive::Operation.new('sinatra.request.dispatch') do |op|
+                  trace = active_trace
+                  span = active_span
+
+                  Rack::Reactive::RequestBody.subscribe(op, waf_context) do |action, result, _block|
+                    record = [:block, :monitor].include?(action)
+                    if record
+                      # TODO: should this hash be an Event instance instead?
+                      event = {
+                        waf_result: result,
+                        trace: trace,
+                        span: span,
+                        request: request,
+                        action: action
+                      }
+
+                      waf_context.events << event
+                    end
+                  end
+
+                  _action, _result, block = Rack::Reactive::RequestBody.publish(op, request)
+                end
+
+                next [nil, [[:block, event]]] if block
+
+                ret, res = stack.call(request)
+
+                if event
+                  res ||= []
+                  res << [:monitor, event]
+                end
+
+                [ret, res]
+              end
+
+              Instrumentation.gateway.watch('sinatra.request.routed') do |stack, (request, route_params)|
+                block = false
+                event = nil
+                waf_context = request.env['datadog.waf.context']
+
+                AppSec::Reactive::Operation.new('sinatra.request.routed') do |op|
+                  trace = active_trace
+                  span = active_span
+
+                  Sinatra::Reactive::Routed.subscribe(op, waf_context) do |action, result, _block|
+                    record = [:block, :monitor].include?(action)
+                    if record
+                      # TODO: should this hash be an Event instance instead?
+                      event = {
+                        waf_result: result,
+                        trace: trace,
+                        span: span,
+                        request: request,
+                        action: action
+                      }
+
+                      waf_context.events << event
+                    end
+                  end
+
+                  _action, _result, block = Sinatra::Reactive::Routed.publish(op, [request, route_params])
+                end
+
+                next [nil, [[:block, event]]] if block
+
+                ret, res = stack.call(request)
+
+                if event
+                  res ||= []
+                  res << [:monitor, event]
+                end
+
+                [ret, res]
+              end
+            end
+            # rubocop:enable Metrics/MethodLength
+
+            class << self
+              private
+
+              def active_trace
+                # TODO: factor out tracing availability detection
+
+                return unless defined?(Datadog::Tracing)
+
+                Datadog::Tracing.active_trace
+              end
+
+              def active_span
+                # TODO: factor out tracing availability detection
+
+                return unless defined?(Datadog::Tracing)
+
+                Datadog::Tracing.active_span
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/contrib/sinatra/patcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/patcher.rb
@@ -5,6 +5,7 @@ require 'datadog/tracing/contrib/rack/middlewares'
 require 'datadog/appsec/contrib/patcher'
 require 'datadog/appsec/contrib/rack/request_middleware'
 require 'datadog/appsec/contrib/sinatra/framework'
+require 'datadog/appsec/contrib/sinatra/gateway/watcher'
 require 'datadog/tracing/contrib/sinatra/framework'
 
 module Datadog
@@ -53,7 +54,7 @@ module Datadog
 
             # TODO: handle exceptions, except for super
 
-            request_return, request_response = Instrumentation.gateway.push('rack.request.body', request) do
+            request_return, request_response = Instrumentation.gateway.push('sinatra.request.dispatch', request) do
               super
             end
 
@@ -65,6 +66,30 @@ module Datadog
             end
 
             request_return
+          end
+        end
+
+        # Hook into Base#route_eval, which
+        # path params are returned by pattern.params in process_route, then
+        # merged with normal params, so we get both
+        module RoutePatch
+          def process_route(*)
+            # process_route is called repeatedly until a route is found.
+            # Until then, params has no route params.
+            # Capture normal params.
+            base_params = params
+
+            super do |*args|
+              # This block is called only once the route is found.
+              # At this point params has both route params and normal params.
+              route_params = params.each.with_object({}) { |(k, v), h| h[k] = v unless base_params.key?(k) }
+
+              Instrumentation.gateway.push('sinatra.request.routed', [request, route_params])
+
+              # TODO: handle block
+
+              yield(*args)
+            end
           end
         end
 
@@ -83,8 +108,10 @@ module Datadog
           end
 
           def patch
+            Gateway::Watcher.watch
             patch_default_middlewares
             patch_dispatch
+            patch_route
             setup_security
             Patcher.instance_variable_set(:@patched, true)
           end
@@ -99,6 +126,10 @@ module Datadog
 
           def patch_dispatch
             ::Sinatra::Base.prepend(DispatchPatch)
+          end
+
+          def patch_route
+            ::Sinatra::Base.prepend(RoutePatch)
           end
         end
       end

--- a/lib/datadog/appsec/contrib/sinatra/reactive/routed.rb
+++ b/lib/datadog/appsec/contrib/sinatra/reactive/routed.rb
@@ -1,0 +1,63 @@
+# typed: true
+
+module Datadog
+  module AppSec
+    module Contrib
+      module Sinatra
+        module Reactive
+          # Dispatch data from a Rack request to the WAF context
+          module Routed
+            def self.publish(op, data)
+              _request, route_params = data
+
+              catch(:block) do
+                op.publish('sinatra.request.route_params', route_params)
+
+                nil
+              end
+            end
+
+            def self.subscribe(op, waf_context)
+              addresses = [
+                'sinatra.request.route_params',
+              ]
+
+              op.subscribe(*addresses) do |*values|
+                Datadog.logger.debug { "reacted to #{addresses.inspect}: #{values.inspect}" }
+                path_params = values[0]
+
+                waf_args = {
+                  'server.request.path_params' => path_params,
+                }
+
+                waf_timeout = Datadog::AppSec.settings.waf_timeout
+                action, result = waf_context.run(waf_args, waf_timeout)
+
+                Datadog.logger.debug { "WAF TIMEOUT: #{result.inspect}" } if result.timeout
+
+                # TODO: encapsulate return array in a type
+                case action
+                when :monitor
+                  Datadog.logger.debug { "WAF: #{result.inspect}" }
+                  yield [action, result, false]
+                when :block
+                  Datadog.logger.debug { "WAF: #{result.inspect}" }
+                  yield [action, result, true]
+                  throw(:block, [action, result, true])
+                when :good
+                  Datadog.logger.debug { "WAF OK: #{result.inspect}" }
+                when :invalid_call
+                  Datadog.logger.debug { "WAF CALL ERROR: #{result.inspect}" }
+                when :invalid_rule, :invalid_flow, :no_rule
+                  Datadog.logger.debug { "WAF RULE ERROR: #{result.inspect}" }
+                else
+                  Datadog.logger.debug { "WAF UNKNOWN: #{action.inspect} #{result.inspect}" }
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since this needs a more varied per framework access pattern, it also splits Rails body params extraction out of Rack.

System test is:

```
runner           | XPASSED tests/appsec/waf/test_addresses.py::Test_PathParams::test_security_scanner - Expected to fail, but all is ok
```