### PR TITLE
Support spaces in environment variable lists

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -412,7 +412,7 @@ module Datadog
                     Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG,
                     Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3,
                     Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_SINGLE_HEADER
-                  ]
+                  ], comma_separated_only: true
                 )
               end
 
@@ -430,7 +430,7 @@ module Datadog
               o.default do
                 env_to_list(
                   Tracing::Configuration::Ext::Distributed::ENV_PROPAGATION_STYLE_INJECT,
-                  [Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG] # Only inject Datadog headers by default
+                  [Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG], comma_separated_only: true # Only inject Datadog headers by default
                 )
               end
 

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -305,7 +305,7 @@ module Datadog
             tags = {}
 
             # Parse tags from environment
-            env_to_list(Core::Environment::Ext::ENV_TAGS).each do |tag|
+            env_to_list(Core::Environment::Ext::ENV_TAGS, comma_separated_only: false).each do |tag|
               pair = tag.split(':')
               tags[pair.first] = pair.last if pair.length == 2
             end

--- a/lib/datadog/core/environment/variable_helpers.rb
+++ b/lib/datadog/core/environment/variable_helpers.rb
@@ -33,7 +33,7 @@ module Datadog
         # either trailing or leading are trimmed.
         #
         # Empty entries, after trimmed, are also removed from the result.
-        def env_to_list(var, default = [], comma_separated_only: false)
+        def env_to_list(var, default = [], comma_separated_only:)
           var = decode_array(var)
           if var && ENV.key?(var)
             value = ENV[var]
@@ -41,7 +41,7 @@ module Datadog
             values = if value.include?(',') || comma_separated_only
                        value.split(',')
                      else
-                       value.split # space splitting is the default
+                       value.split(' ') # rubocop:disable Style/RedundantArgument
                      end
 
             values.map! do |v|

--- a/spec/datadog/core/environment/variable_helpers_spec.rb
+++ b/spec/datadog/core/environment/variable_helpers_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Datadog::Core::Environment::VariableHelpers do
       end
     end
 
-    context 'when env var is set as' do
+    context 'when env var is set' do
       include_context 'env var'
 
       context '\'\'' do
@@ -201,10 +201,44 @@ RSpec.describe Datadog::Core::Environment::VariableHelpers do
         it { is_expected.to eq(%w[1 2]) }
       end
 
-      context ' 1 , 2 , 3 ' do
-        let(:env_value) { ' 1 , 2 , 3 ' }
+      context ' 1 , 2 ,  3 ' do
+        let(:env_value) { ' 1 , 2 ,  3 ' }
 
         it { is_expected.to eq(%w[1 2 3]) }
+      end
+
+      context '1 2 3' do
+        let(:env_value) { '1 2 3' }
+
+        it { is_expected.to eq(%w[1 2 3]) }
+      end
+
+      context '1,2 3' do
+        let(:env_value) { '1,2 3' }
+
+        it { is_expected.to eq(['1', '2 3']) }
+      end
+
+      context ' 1  2   3 ' do
+        let(:env_value) { ' 1  2   3 ' }
+
+        it { is_expected.to eq(%w[1 2 3]) }
+      end
+
+      context '1,, ,2,3,' do
+        let(:env_value) { '1,, ,2,3,' }
+
+        it { is_expected.to eq(%w[1 2 3]) }
+      end
+
+      context 'and comma_separated_only is set' do
+        subject(:env_to_list) { variable_helpers.env_to_list(var, comma_separated_only: true) }
+
+        context 'B3 single header ' do
+          let(:env_value) { 'B3 single header ' }
+
+          it { is_expected.to eq(['B3 single header']) }
+        end
       end
     end
   end

--- a/spec/datadog/core/environment/variable_helpers_spec.rb
+++ b/spec/datadog/core/environment/variable_helpers_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Datadog::Core::Environment::VariableHelpers do
   end
 
   describe '::env_to_list' do
-    subject(:env_to_list) { variable_helpers.env_to_list(var) }
+    subject(:env_to_list) { variable_helpers.env_to_list(var, comma_separated_only: false) }
 
     context 'when env var is not defined' do
       context 'and default is not defined' do
@@ -166,7 +166,7 @@ RSpec.describe Datadog::Core::Environment::VariableHelpers do
       end
 
       context 'and default is defined' do
-        subject(:env_to_list) { variable_helpers.env_to_list(var, default) }
+        subject(:env_to_list) { variable_helpers.env_to_list(var, default, comma_separated_only: false) }
 
         let(:default) { double }
 


### PR DESCRIPTION
Fixes #1953

This PR adds space-separated list support, in addition to the existing comma-separated list, to environment variable list options.

This brings us up to parity with [other traces](https://github.com/DataDog/dd-trace-py/pull/2196).

The only application option currently is `DD_TAGS`.

Initially, I implemented this change to all users of `Datadog::Core::Environment::VariableHelpers#env_to_list`, but the other use case, `DD_PROPAGATION_STYLE_*`, has a space in one of its supported values.
```
Datadog
B3
B3 single header
```

It wouldn't be possible to configure `DD_PROPAGATION_STYLE_INJECT=B3 single header` correctly, so I left `DD_PROPAGATION_STYLE_*` as comma-separated only in this PR.