### PR TITLE
Rename profiling `pid` tag to `process_id` to align with other products 

### DIFF
--- a/lib/datadog/profiling/ext.rb
+++ b/lib/datadog/profiling/ext.rb
@@ -30,7 +30,7 @@ module Datadog
           FORM_FIELD_TAG_ENV = 'env'.freeze
           FORM_FIELD_TAG_HOST = 'host'.freeze
           FORM_FIELD_TAG_LANGUAGE = 'language'.freeze
-          FORM_FIELD_TAG_PID = 'pid'.freeze
+          FORM_FIELD_TAG_PID = 'process_id'.freeze
           FORM_FIELD_TAG_PROFILER_VERSION = 'profiler_version'.freeze
           FORM_FIELD_TAG_RUNTIME = 'runtime'.freeze
           FORM_FIELD_TAG_RUNTIME_ENGINE = 'runtime_engine'.freeze

--- a/spec/datadog/profiling/transport/http/adapters/net_integration_spec.rb
+++ b/spec/datadog/profiling/transport/http/adapters/net_integration_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe 'Adapters::Net profiling integration tests' do
           /runtime_engine:#{Datadog::Core::Environment::Ext::LANG_ENGINE}/o,
           /runtime_platform:#{Datadog::Core::Environment::Ext::LANG_PLATFORM}/o,
           /runtime_version:#{Datadog::Core::Environment::Ext::LANG_VERSION}/o,
-          /pid:#{Process.pid}/o,
+          /process_id:#{Process.pid}/o,
           /profiler_version:#{Datadog::Core::Environment::Ext::TRACER_VERSION}/o,
           /language:ruby/o,
           'test_tag:test_value'

--- a/spec/datadog/profiling/transport/http/api/endpoint_spec.rb
+++ b/spec/datadog/profiling/transport/http/api/endpoint_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Datadog::Profiling::Transport::HTTP::API::Endpoint do
             "runtime_engine:#{flush.runtime_engine}",
             "runtime_platform:#{flush.runtime_platform}",
             "runtime_version:#{flush.runtime_version}",
-            "pid:#{Process.pid}",
+            "process_id:#{Process.pid}",
             "profiler_version:#{flush.profiler_version}",
             "language:#{flush.language}",
             "host:#{flush.host}"


### PR DESCRIPTION
In the UX, tracing is using `process_id` (automatically mapped) and the processes product will also work with `process_id`.