### PR TITLE
Skip building profiling loader extension on JRuby/TruffleRuby

### DIFF
--- a/ext/ddtrace_profiling_loader/extconf.rb
+++ b/ext/ddtrace_profiling_loader/extconf.rb
@@ -2,9 +2,9 @@
 # rubocop:disable Style/StderrPuts
 # rubocop:disable Style/GlobalVars
 
-if Gem.win_platform?
+if RUBY_ENGINE != 'ruby' || Gem.win_platform?
   $stderr.puts(
-    'WARN: Skipping build of ddtrace profiling loader on Windows. See ddtrace profiling native extension note for details.'
+    'WARN: Skipping build of ddtrace profiling loader. See ddtrace profiling native extension note for details.'
   )
 
   File.write('Makefile', 'all install clean: # dummy makefile that does nothing')


### PR DESCRIPTION
Trying to build for JRuby fails. Even if it did work, we wouldn't use it anyway (we don't support profiling for non-MRI rubies), so let's just skip it.