### PR TITLE
remove ruby patch level from apprasails filename [ci skip]

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1528,7 +1528,7 @@ ruby_runtime = if defined?(RUBY_ENGINE_VERSION)
                  "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}"
                else
                  "#{RUBY_ENGINE}-#{RUBY_VERSION}" # For Ruby < 2.3
-               end
+               end.split('.')[0..1].join('.') # Remove patchlevel
 
 appraisals.each do |appraisal|
   appraisal.name.prepend("#{ruby_runtime}-")


### PR DESCRIPTION
Since gemfiles are per ruby version. Removing the patch level will prevent creation of new one if a different version is used.

instead of 
```
ruby_3.1.1_resque2_redis4.gemfile.lock
ruby_3.2.0_contrib.gemfile
```
we have now
```
ruby_3.1_resque2_redis4.gemfile.lock
ruby_3.2_contrib.gemfile
```

Note: I didn't regenerate the gems files as it will make the PR super big to review. Once approved, i can fix the build if required.