### PR TITLE
Remove redundant events assignment

### DIFF
--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -71,7 +71,6 @@ module Datadog
         metrics: nil
       )
         # Attributes
-        @events = events || Events.new
         @id = id || Core::Utils.next_id
         @max_length = max_length || DEFAULT_MAX_LENGTH
         @parent_span_id = parent_span_id


### PR DESCRIPTION
Remove duplicated assignment. This should be a save change without behaviour change.

https://github.com/DataDog/dd-trace-rb/pull/2023/files#diff-cee994df96bef5c3cb8fb5c1b83ed6fa3e9d68abb5ba3207a031c1beb2d2e62dL100