### PR TITLE
Refactor to remove usage of forwardable

### DIFF
--- a/lib/datadog/core/configuration.rb
+++ b/lib/datadog/core/configuration.rb
@@ -1,6 +1,5 @@
 # typed: true
 
-require 'forwardable'
 require 'datadog/core/configuration/components'
 require 'datadog/core/configuration/settings'
 require 'datadog/core/logger'
@@ -11,7 +10,6 @@ module Datadog
     # Configuration provides a unique access point for configurations
     module Configuration # rubocop:disable Metrics/ModuleLength
       include Kernel # Ensure that kernel methods are always available (https://sorbet.org/docs/error-reference#7003)
-      extend Forwardable
 
       # Used to ensure that @components initialization/reconfiguration is performed one-at-a-time, by a single thread.
       #
@@ -154,9 +152,19 @@ module Datadog
         pin[option] if pin
       end
 
-      def_delegators \
-        :components,
-        :health_metrics
+      def health_metrics
+        HEALTH_METRICS_DEPRECATION_ONLY_ONCE.run do
+          Datadog.logger.warn(
+            'configuration#health_metrics access is deprecated.' \
+                      'Use `Datadog.health_metrics` instead.'
+          )
+        end
+
+        components.health_metrics
+      end
+
+      HEALTH_METRICS_DEPRECATION_ONLY_ONCE = Utils::OnlyOnce.new
+      private_constant :HEALTH_METRICS_DEPRECATION_ONLY_ONCE
 
       def logger
         # avoid initializing components if they didn't already exist

--- a/lib/datadog/core/configuration.rb
+++ b/lib/datadog/core/configuration.rb
@@ -152,19 +152,13 @@ module Datadog
         pin[option] if pin
       end
 
+      # Internal {Datadog::Statsd} metrics collection.
+      #
+      # The list of metrics collected can be found in {Datadog::Core::Diagnostics::Ext::Health::Metrics}.
+      # @public_api
       def health_metrics
-        HEALTH_METRICS_DEPRECATION_ONLY_ONCE.run do
-          Datadog.logger.warn(
-            'configuration#health_metrics access is deprecated.' \
-                      'Use `Datadog.health_metrics` instead.'
-          )
-        end
-
         components.health_metrics
       end
-
-      HEALTH_METRICS_DEPRECATION_ONLY_ONCE = Utils::OnlyOnce.new
-      private_constant :HEALTH_METRICS_DEPRECATION_ONLY_ONCE
 
       def logger
         # avoid initializing components if they didn't already exist

--- a/lib/datadog/tracing/sampling/priority_sampler.rb
+++ b/lib/datadog/tracing/sampling/priority_sampler.rb
@@ -1,7 +1,5 @@
 # typed: true
 
-require 'forwardable'
-
 require 'datadog/tracing/sampling/ext'
 require 'datadog/tracing/sampling/all_sampler'
 require 'datadog/tracing/sampling/rate_sampler'
@@ -13,8 +11,6 @@ module Datadog
       # {Datadog:::Tracing::Sampling::PrioritySampler}
       # @public_api
       class PrioritySampler
-        extend Forwardable
-
         # NOTE: We do not advise using a pre-sampler. It can save resources,
         # but pre-sampling at rates < 100% may result in partial traces, unless
         # the pre-sampler knows exactly how to drop a span without dropping its ancestors.
@@ -59,7 +55,10 @@ module Datadog
           trace.sampled?
         end
 
-        def_delegators :@priority_sampler, :update
+        # (see Datadog::Tracing::Sampling::RateByServiceSampler#update)
+        def update(rate_by_service)
+          @priority_sampler.update(rate_by_service)
+        end
 
         private
 

--- a/lib/datadog/tracing/sampling/rule.rb
+++ b/lib/datadog/tracing/sampling/rule.rb
@@ -1,7 +1,5 @@
 # typed: true
 
-require 'forwardable'
-
 require 'datadog/core'
 
 require 'datadog/tracing/sampling/matcher'
@@ -15,8 +13,6 @@ module Datadog
       # apply in case of a positive match.
       # @public_api
       class Rule
-        extend Forwardable
-
         attr_reader :matcher, :sampler
 
         # @param [Matcher] matcher A matcher to verify trace conformity against
@@ -40,7 +36,15 @@ module Datadog
           nil
         end
 
-        def_delegators :@sampler, :sample?, :sample_rate
+        # (see Datadog::Tracing::Sampling::Sampler#sample?)
+        def sample?(trace)
+          @sampler.sample?(trace)
+        end
+
+        # (see Datadog::Tracing::Sampling::Sampler#sample_rate)
+        def sample_rate(trace)
+          @sampler.sample_rate(trace)
+        end
       end
 
       # A {Datadog::Tracing::Sampling::Rule} that matches a trace based on

--- a/lib/ddtrace/transport/http/response.rb
+++ b/lib/ddtrace/transport/http/response.rb
@@ -1,6 +1,5 @@
 # typed: false
 
-require 'forwardable'
 require 'ddtrace/transport/response'
 
 module Datadog
@@ -11,13 +10,49 @@ module Datadog
       # Used by endpoints to wrap responses from adapters with
       # fields or behavior that's specific to that endpoint.
       module Response
-        extend ::Forwardable
-
         def initialize(http_response)
           @http_response = http_response
         end
 
-        def_delegators :@http_response, *Datadog::Transport::Response.instance_methods
+        # (see Datadog::Transport::Response#payload)
+        def payload
+          @http_response.payload
+        end
+
+        # (see Datadog::Transport::Response#internal_error?)
+        def internal_error?
+          @http_response.internal_error?
+        end
+
+        # (see Datadog::Transport::Response#unsupported?)
+        def unsupported?
+          @http_response.unsupported?
+        end
+
+        # (see Datadog::Transport::Response#ok?)
+        def ok?
+          @http_response.ok?
+        end
+
+        # (see Datadog::Transport::Response#not_found?)
+        def not_found?
+          @http_response.not_found?
+        end
+
+        # (see Datadog::Transport::Response#client_error?)
+        def client_error?
+          @http_response.client_error?
+        end
+
+        # (see Datadog::Transport::Response#inspect)
+        def inspect
+          @http_response.inspect
+        end
+
+        # (see Datadog::Transport::Response#server_error?)
+        def server_error?
+          @http_response.server_error?
+        end
 
         def code
           @http_response.respond_to?(:code) ? @http_response.code : nil

--- a/lib/ddtrace/transport/http/response.rb
+++ b/lib/ddtrace/transport/http/response.rb
@@ -44,11 +44,6 @@ module Datadog
           @http_response.client_error?
         end
 
-        # (see Datadog::Transport::Response#inspect)
-        def inspect
-          @http_response.inspect
-        end
-
         # (see Datadog::Transport::Response#server_error?)
         def server_error?
           @http_response.server_error?

--- a/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -4837,24 +4837,6 @@ class Datadog::Transport::HTTP::Client
   include ::Datadog::Transport::HTTP::Traces::Client
 end
 
-module Datadog::Transport::HTTP::Response
-  def client_error?(*args, &block); end
-
-  def inspect(*args, &block); end
-
-  def internal_error?(*args, &block); end
-
-  def not_found?(*args, &block); end
-
-  def ok?(*args, &block); end
-
-  def payload(*args, &block); end
-
-  def server_error?(*args, &block); end
-
-  def unsupported?(*args, &block); end
-end
-
 class Datadog::Transport::IO::Client
   include ::Datadog::Transport::IO::Traces::Client
 end

--- a/spec/datadog/profiling/transport/http/response_spec.rb
+++ b/spec/datadog/profiling/transport/http/response_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Datadog::Profiling::Transport::HTTP::Response do
 
   describe 'Datadog::Transport::Response methods' do
     it 'are forwarded to the HTTP response' do
-      Datadog::Transport::Response.instance_methods.each do |method|
+      (Datadog::Transport::Response.instance_methods - [:inspect]).each do |method|
         expect(http_response).to receive(method)
         response.send(method)
       end

--- a/spec/ddtrace/transport/http/response_spec.rb
+++ b/spec/ddtrace/transport/http/response_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Datadog::Transport::HTTP::Response do
 
     describe 'Datadog::Transport::Response methods' do
       it 'are forwarded to the HTTP response' do
-        Datadog::Transport::Response.instance_methods.each do |method|
+        (Datadog::Transport::Response.instance_methods - [:inspect]).each do |method|
           expect(http_response).to receive(method)
           response.send(method)
         end


### PR DESCRIPTION
Following up on the work of #2025, this PR performs the refactoring necessary to remove the remaining usage of `Forwardable`.

No functional changes take place in this PR, it should be a strict refactor.