### PR TITLE
Prevent `action_controller` tracing when disabled

### DIFF
--- a/lib/datadog/tracing/contrib/action_pack/action_controller/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/action_pack/action_controller/instrumentation.rb
@@ -18,6 +18,8 @@ module Datadog
             module_function
 
             def start_processing(payload)
+              return unless Tracing.enabled?
+
               # trace the execution
               service = Datadog.configuration.tracing[:action_pack][:service_name]
               type = Tracing::Metadata::Ext::HTTP::TYPE_INBOUND
@@ -44,6 +46,8 @@ module Datadog
             end
 
             def finish_processing(payload)
+              return unless Tracing.enabled?
+
               # retrieve the tracing context and the latest active span
               tracing_context = payload.fetch(:tracing_context)
               trace = tracing_context[:dd_request_trace]

--- a/spec/datadog/tracing/contrib/rails/action_controller_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/action_controller_spec.rb
@@ -43,6 +43,19 @@ RSpec.describe 'Rails ActionController' do
           expect(spans.first.name).to eq('rails.action_controller')
         end
 
+        context 'with tracing disabled' do
+          before do
+            Datadog.configure { |c| c.tracing.enabled = false }
+            expect(Datadog.logger).to_not receive(:error)
+            expect(Datadog::Tracing).to_not receive(:trace)
+          end
+
+          it 'runs the action without tracing' do
+            expect { result }.to_not raise_error
+            expect(spans).to have(0).items
+          end
+        end
+
         context 'when response is overridden' do
           context 'with an Array' do
             let(:headers) { double('headers') }


### PR DESCRIPTION
In environments where tracing is disabled, Datadog spits out a lot of
unnecessary error logs here, due to the instrumentation assuming that
there's an active trace to maintain.

This fix is in the same vein as #1943 and #1945.

```
E, [2022-05-17T22:15:02.337370 #2639] ERROR -- ddtrace: [ddtrace] (/home/circleci/tmp/vendor/bundle/ruby/3.1.0/gems/ddtrace-1.0.0/lib/datadog/tracing/contrib/action_pack/action_controller/instrumentation.rb:43:in `rescue in start_processing') undefined method `resource=' for nil:NilClass

              trace.resource = span.resource
                   ^^^^^^^^^^^
E, [2022-05-17T22:15:02.340414 #2639] ERROR -- ddtrace: [ddtrace] (/home/circleci/tmp/vendor/bundle/ruby/3.1.0/gems/ddtrace-1.0.0/lib/datadog/tracing/contrib/action_pack/action_controller/instrumentation.rb:79:in `rescue in finish_processing') undefined method `resource=' for nil:NilClass

                trace.resource = span.resource
                     ^^^^^^^^^^^
```