### PR TITLE
[PROF-4780] Add libddprof dependency to power the new Ruby profiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,25 +14,10 @@
 /tmp/
 /log/
 TODO
+ext/**/skipped_reason.txt
 
 # Used by dotenv library to load environment variables.
 # .env
-
-## Specific to RubyMotion:
-.dat*
-.repl_history
-build/
-*.bridgesupport
-build-iPhoneOS/
-build-iPhoneSimulator/
-
-## Specific to RubyMotion (use of CocoaPods):
-#
-# We recommend against adding the Pods directory to your .gitignore. However
-# you should judge for yourself, the pros and cons are mentioned at:
-# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
-#
-# vendor/Pods/
 
 ## Documentation cache and generated files:
 /.yardoc/

--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,6 @@ if RUBY_PLATFORM != 'java'
     gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
   end
 end
-gem 'libddprof', '= 0.4.0.1.0.beta1'
 
 # For type checking
 # Sorbet releases almost daily, with new checks introduced that can make a

--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ if RUBY_PLATFORM != 'java'
     gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1', '< 3.19.2']
   end
 end
-gem 'libddprof', '~> 0.3.0.1.0'
+gem 'libddprof', '= 0.4.0.1.0.beta1'
 
 # For type checking
 # Sorbet releases almost daily, with new checks introduced that can make a

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -55,5 +55,8 @@ Gem::Specification.new do |spec|
   # Used by appsec
   spec.add_dependency 'libddwaf', '~> 1.3.0.1.0'
 
+  # Used by profiling
+  spec.add_dependency 'libddprof', '= 0.4.0.1.0.beta1'
+
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb', 'ext/ddtrace_profiling_loader/extconf.rb']
 end

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'libddwaf', '~> 1.3.0.1.0'
 
   # Used by profiling
-  spec.add_dependency 'libddprof', '~> 0.5.0.1.0'
+  spec.add_dependency 'libddprof', '~> 0.6.0.1.0'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb', 'ext/ddtrace_profiling_loader/extconf.rb']
 end

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'libddwaf', '~> 1.3.0.1.0'
 
   # Used by profiling
-  spec.add_dependency 'libddprof', '= 0.4.0.1.0.beta1'
+  spec.add_dependency 'libddprof', '~> 0.5.0.1.0'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb', 'ext/ddtrace_profiling_loader/extconf.rb']
 end

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -78,24 +78,22 @@ if RUBY_PLATFORM.include?('linux')
 end
 
 # If we got here, libddprof is available and loaded
-
-# TODO: Temporarily disabled for PR https://github.com/DataDog/dd-trace-rb/pull/1885; will be re-enabled in a follow-up PR
-# ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libddprof.pkgconfig_folder}"
-# unless pkg_config('ddprof_ffi')
-#   $stderr.puts(%(
-# +------------------------------------------------------------------------------+
-# | Skipping build of profiling native extension:                                |
-# | failed to configure `libddprof` for compilation.                             |
-# |                                                                              |
-# | The Datadog Continuous Profiler will not be available,                       |
-# | but all other ddtrace features will work fine!                               |
-# |                                                                              |
-# | For help solving this issue, please contact Datadog support at               |
-# | <https://docs.datadoghq.com/help/>.                                          |
-# +------------------------------------------------------------------------------+
-# ))
-#   skip_building_extension!
-# end
+ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libddprof.pkgconfig_folder}"
+unless pkg_config('ddprof_ffi')
+  $stderr.puts(%(
++------------------------------------------------------------------------------+
+| Skipping build of profiling native extension:                                |
+| failed to configure `libddprof` for compilation.                             |
+|                                                                              |
+| The Datadog Continuous Profiler will not be available,                       |
+| but all other ddtrace features will work fine!                               |
+|                                                                              |
+| For help solving this issue, please contact Datadog support at               |
+| <https://docs.datadoghq.com/help/>.                                          |
++------------------------------------------------------------------------------+
+))
+  skip_building_extension!
+end
 
 # Tag the native extension library with the Ruby version and Ruby platform.
 # This makes it easier for development (avoids "oops I forgot to rebuild when I switched my Ruby") and ensures that

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -6,7 +6,8 @@
 require_relative 'native_extension_helpers'
 
 def skip_building_extension!(reason)
-  $stderr.puts(reason)
+  $stderr.puts(Datadog::Profiling::NativeExtensionHelpers::Supported.failure_banner_for(**reason))
+
   File.write('Makefile', 'all install clean: # dummy makefile that does nothing')
   exit
 end
@@ -80,18 +81,7 @@ end
 # If we got here, libddprof is available and loaded
 ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libddprof.pkgconfig_folder}"
 unless pkg_config('ddprof_ffi_with_rpath')
-  skip_building_extension!(%(
-+------------------------------------------------------------------------------+
-| Skipping build of profiling native extension:                                |
-| failed to configure `libddprof` for compilation.                             |
-|                                                                              |
-| The Datadog Continuous Profiler will not be available,                       |
-| but all other ddtrace features will work fine!                               |
-|                                                                              |
-| For help solving this issue, please contact Datadog support at               |
-| <https://docs.datadoghq.com/help/>.                                          |
-+------------------------------------------------------------------------------+
-))
+  skip_building_extension!(Datadog::Profiling::NativeExtensionHelpers::Supported::FAILED_TO_CONFIGURE_LIBDDPROF)
 end
 
 # Tag the native extension library with the Ruby version and Ruby platform.
@@ -112,19 +102,7 @@ if Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER
   original_common_headers = MakeMakefile::COMMON_HEADERS
   MakeMakefile::COMMON_HEADERS = ''.freeze
   unless have_macro('RUBY_MJIT_H', mjit_header_file_name)
-    skip_building_extension!(%(
-+------------------------------------------------------------------------------+
-| WARNING: Unable to compile a needed component for ddtrace native extension.  |
-| Your C compiler or Ruby VM just-in-time compiler seems to be broken.         |
-|                                                                              |
-| The Datadog Continuous Profiler will not be available,                       |
-| but all other ddtrace features will work fine!                               |
-|                                                                              |
-| For help solving this issue, please contact Datadog support at               |
-| <https://docs.datadoghq.com/help/>.                                          |
-+------------------------------------------------------------------------------+
-
-))
+    skip_building_extension!(Datadog::Profiling::NativeExtensionHelpers::Supported::COMPILATION_BROKEN)
   end
   MakeMakefile::COMMON_HEADERS = original_common_headers
 

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -5,8 +5,19 @@
 
 require_relative 'native_extension_helpers'
 
+SKIPPED_REASON_FILE = "#{__dir__}/skipped_reason.txt".freeze
+begin
+  File.delete(SKIPPED_REASON_FILE)
+rescue StandardError => _e
+  # Not a problem if the file doesn't exist or we can't delete it
+end
+
 def skip_building_extension!(reason)
   $stderr.puts(Datadog::Profiling::NativeExtensionHelpers::Supported.failure_banner_for(**reason))
+  File.write(
+    SKIPPED_REASON_FILE,
+    Datadog::Profiling::NativeExtensionHelpers::Supported.render_skipped_reason_file(**reason),
+  )
 
   File.write('Makefile', 'all install clean: # dummy makefile that does nothing')
   exit

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -6,11 +6,8 @@
 require_relative 'native_extension_helpers'
 
 SKIPPED_REASON_FILE = "#{__dir__}/skipped_reason.txt".freeze
-begin
-  File.delete(SKIPPED_REASON_FILE)
-rescue StandardError => _e
-  # Not a problem if the file doesn't exist or we can't delete it
-end
+# Not a problem if the file doesn't exist or we can't delete it
+File.delete(SKIPPED_REASON_FILE) rescue nil
 
 def skip_building_extension!(reason)
   $stderr.puts(Datadog::Profiling::NativeExtensionHelpers::Supported.failure_banner_for(**reason))

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -79,7 +79,7 @@ end
 
 # If we got here, libddprof is available and loaded
 ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libddprof.pkgconfig_folder}"
-unless pkg_config('ddprof_ffi')
+unless pkg_config('ddprof_ffi_with_rpath')
   $stderr.puts(%(
 +------------------------------------------------------------------------------+
 | Skipping build of profiling native extension:                                |

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -5,14 +5,14 @@
 
 require_relative 'native_extension_helpers'
 
-def skip_building_extension!
+def skip_building_extension!(reason)
+  $stderr.puts(reason)
   File.write('Makefile', 'all install clean: # dummy makefile that does nothing')
   exit
 end
 
 unless Datadog::Profiling::NativeExtensionHelpers::Supported.supported?
-  $stderr.puts(Datadog::Profiling::NativeExtensionHelpers::Supported.unsupported_reason)
-  skip_building_extension!
+  skip_building_extension!(Datadog::Profiling::NativeExtensionHelpers::Supported.unsupported_reason)
 end
 
 $stderr.puts(%(
@@ -80,7 +80,7 @@ end
 # If we got here, libddprof is available and loaded
 ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libddprof.pkgconfig_folder}"
 unless pkg_config('ddprof_ffi_with_rpath')
-  $stderr.puts(%(
+  skip_building_extension!(%(
 +------------------------------------------------------------------------------+
 | Skipping build of profiling native extension:                                |
 | failed to configure `libddprof` for compilation.                             |
@@ -92,7 +92,6 @@ unless pkg_config('ddprof_ffi_with_rpath')
 | <https://docs.datadoghq.com/help/>.                                          |
 +------------------------------------------------------------------------------+
 ))
-  skip_building_extension!
 end
 
 # Tag the native extension library with the Ruby version and Ruby platform.
@@ -113,7 +112,7 @@ if Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER
   original_common_headers = MakeMakefile::COMMON_HEADERS
   MakeMakefile::COMMON_HEADERS = ''.freeze
   unless have_macro('RUBY_MJIT_H', mjit_header_file_name)
-    $stderr.puts(%(
+    skip_building_extension!(%(
 +------------------------------------------------------------------------------+
 | WARNING: Unable to compile a needed component for ddtrace native extension.  |
 | Your C compiler or Ruby VM just-in-time compiler seems to be broken.         |
@@ -126,7 +125,6 @@ if Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER
 +------------------------------------------------------------------------------+
 
 ))
-    skip_building_extension!
   end
   MakeMakefile::COMMON_HEADERS = original_common_headers
 

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -60,6 +60,12 @@ def add_compiler_flag(flag)
   end
 end
 
+# Older gcc releases may not default to C99 and we need to ask for this. This is also used:
+# * by upstream Ruby -- search for gnu99 in the codebase
+# * by msgpack, another ddtrace dependency
+#   (https://github.com/msgpack/msgpack-ruby/blob/18ce08f6d612fe973843c366ac9a0b74c4e50599/ext/msgpack/extconf.rb#L8)
+add_compiler_flag '-std=gnu99'
+
 # Gets really noisy when we include the MJIT header, let's omit it
 add_compiler_flag '-Wno-unused-function'
 

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -29,6 +29,7 @@ module Datadog
             on_jruby? ||
             on_truffleruby? ||
             on_windows? ||
+            on_macos? ||
             on_unknown_os? ||
             not_on_amd64_or_arm64? ||
             expected_to_use_mjit_but_mjit_is_disabled? ||
@@ -122,6 +123,17 @@ module Datadog
           )
 
           windows_not_supported if Gem.win_platform?
+        end
+
+        private_class_method def self.on_macos?
+          macos_not_supported = explain_issue(
+            'macOS is currently not supported by the Datadog Continuous Profiler.',
+            suggested: GET_IN_TOUCH,
+          )
+          # For development only; not supported otherwise
+          macos_testing_override = ENV['DD_PROFILING_MACOS_TESTING'] == 'true'
+
+          macos_not_supported if RUBY_PLATFORM.include?('darwin') && !macos_testing_override
         end
 
         private_class_method def self.on_unknown_os?

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -22,7 +22,7 @@ module Datadog
             on_truffleruby? ||
             on_windows? ||
             on_unknown_os? ||
-            not_on_x86_64? ||
+            not_on_amd64_or_arm64? ||
             expected_to_use_mjit_but_mjit_is_disabled? ||
             libddprof_not_usable?
         end
@@ -51,8 +51,8 @@ module Datadog
           UNKNOWN_OS_NOT_SUPPORTED unless RUBY_PLATFORM.include?('darwin') || RUBY_PLATFORM.include?('linux')
         end
 
-        private_class_method def self.not_on_x86_64?
-          ARCHITECTURE_NOT_SUPPORTED unless RUBY_PLATFORM.start_with?('x86_64')
+        private_class_method def self.not_on_amd64_or_arm64?
+          ARCHITECTURE_NOT_SUPPORTED unless (RUBY_PLATFORM.start_with?('x86_64') || RUBY_PLATFORM.start_with?('aarch64'))
         end
 
         # On some Rubies, we require the mjit header to be present. If Ruby was installed without MJIT support, we also skip

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -1,5 +1,7 @@
 # typed: ignore
 
+require 'libddprof'
+
 module Datadog
   module Profiling
     module NativeExtensionHelpers
@@ -62,12 +64,6 @@ module Datadog
         end
 
         private_class_method def self.libddprof_not_usable?
-          begin
-            require 'libddprof'
-          rescue LoadError
-            return LIBDDPROF_NOT_AVAILABLE
-          end
-
           return LIBDDPROF_NO_BINARIES unless Libddprof.binaries?
 
           unless Libddprof.pkgconfig_folder
@@ -154,16 +150,6 @@ module Datadog
 | Your Ruby has been compiled without JIT support (--disable-jit-support).     |
 | The profiling native extension requires a Ruby compiled with JIT support,    |
 | even if the JIT is not in use by the application itself.                     |
-|                                                                              |
-| The Datadog Continuous Profiler will not be available,                       |
-| but all other ddtrace features will work fine!                               |
-+------------------------------------------------------------------------------+
-).freeze
-
-        LIBDDPROF_NOT_AVAILABLE = %(
-+------------------------------------------------------------------------------+
-| Skipping build of profiling native extension:                                |
-| `libddprof` gem is not available.                                            |
 |                                                                              |
 | The Datadog Continuous Profiler will not be available,                       |
 | but all other ddtrace features will work fine!                               |

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # typed: ignore
 
 require 'libddprof'
@@ -5,7 +7,7 @@ require 'libddprof'
 module Datadog
   module Profiling
     module NativeExtensionHelpers
-      ENV_NO_EXTENSION = 'DD_PROFILING_NO_EXTENSION'.freeze
+      ENV_NO_EXTENSION = 'DD_PROFILING_NO_EXTENSION'
 
       # Older Rubies don't have the MJIT header, used by the JIT compiler, so we need to use a different approach
       CAN_USE_MJIT_HEADER = RUBY_VERSION >= '2.6'
@@ -14,6 +16,10 @@ module Datadog
       # system may not be supported.
       # rubocop:disable Metrics/ModuleLength
       module Supported
+        private_class_method def self.explain_issue(*reason, suggested:)
+          { reason: reason, suggested: suggested }
+        end
+
         def self.supported?
           unsupported_reason.nil?
         end
@@ -29,148 +35,146 @@ module Datadog
             libddprof_not_usable?
         end
 
+        # This banner will show up in the logs/terminal while compiling the native extension
+        def self.failure_banner_for(reason:, suggested:)
+          prettify_lines = proc { |lines| lines.map { |line| "| #{line.ljust(76)} |" }.join("\n") }
+          %(
++------------------------------------------------------------------------------+
+| Could not compile the Datadog Continuous Profiler because                    |
+#{prettify_lines.call(reason)}
+|                                                                              |
+| The Datadog Continuous Profiler will not be available,                       |
+| but all other ddtrace features will work fine!                               |
+|                                                                              |
+#{prettify_lines.call(suggested)}
++------------------------------------------------------------------------------+
+          )
+        end
+
+        # This will be saved in a file to later be presented while operating the gem
+        def self.render_skipped_reason_file(reason:, suggested:)
+          [*reason, *suggested].join(' ')
+        end
+
+        CONTACT_SUPPORT = [
+          'For help solving this issue, please contact Datadog support at',
+          '<https://docs.datadoghq.com/help/>.',
+        ].freeze
+
+        REPORT_ISSUE = [
+          'If you needed to use this, please tell us why on',
+          '<https://github.com/DataDog/dd-trace-rb/issues/new> so we can fix it :)',
+        ].freeze
+
+        GET_IN_TOUCH = [
+          "Get in touch with us if you're interested in profiling your app!"
+        ].freeze
+
+        # Validation for this check is done in extconf.rb because it relies on mkmf
+        FAILED_TO_CONFIGURE_LIBDDPROF = explain_issue(
+          'there was a problem in setting up the `libddprof` dependency.',
+          suggested: CONTACT_SUPPORT,
+        )
+
+        # Validation for this check is done in extconf.rb because it relies on mkmf
+        COMPILATION_BROKEN = explain_issue(
+          'compilation of the Ruby VM just-in-time header failed.',
+          'Your C compiler or Ruby VM just-in-time compiler seem to be broken.',
+          suggested: CONTACT_SUPPORT,
+        )
+
         private_class_method def self.disabled_via_env?
+          disabled_via_env = explain_issue(
+            'the `DD_PROFILING_NO_EXTENSION` environment variable is/was set to',
+            '`true` during installation.',
+            suggested: REPORT_ISSUE,
+          )
+
           return unless ENV[ENV_NO_EXTENSION].to_s.strip.downcase == 'true'
 
-          DISABLED_VIA_ENV
+          disabled_via_env
         end
 
         private_class_method def self.on_jruby?
-          JRUBY_NOT_SUPPORTED if RUBY_ENGINE == 'jruby'
+          jruby_not_supported = explain_issue(
+            'JRuby is not supported by the Datadog Continuous Profiler.',
+            suggested: GET_IN_TOUCH,
+          )
+
+          jruby_not_supported if RUBY_ENGINE == 'jruby'
         end
 
         private_class_method def self.on_truffleruby?
-          TRUFFLERUBY_NOT_SUPPORTED if RUBY_ENGINE == 'truffleruby'
+          truffleruby_not_supported = explain_issue(
+            'TruffleRuby is not supported by the ddtrace gem.',
+            suggested: GET_IN_TOUCH,
+          )
+
+          truffleruby_not_supported if RUBY_ENGINE == 'truffleruby'
         end
 
         # See https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#microsoft-windows-support for current
         # state of Windows support in ddtrace.
         private_class_method def self.on_windows?
-          WINDOWS_NOT_SUPPORTED if Gem.win_platform?
+          windows_not_supported = explain_issue(
+            'Microsoft Windows is not supported by the Datadog Continuous Profiler.',
+            suggested: GET_IN_TOUCH,
+          )
+
+          windows_not_supported if Gem.win_platform?
         end
 
         private_class_method def self.on_unknown_os?
-          UNKNOWN_OS_NOT_SUPPORTED unless RUBY_PLATFORM.include?('darwin') || RUBY_PLATFORM.include?('linux')
+          unknown_os_not_supported = explain_issue(
+            'your operating system is not supported by the Datadog Continuous Profiler.',
+            suggested: GET_IN_TOUCH,
+          )
+
+          unknown_os_not_supported unless RUBY_PLATFORM.include?('darwin') || RUBY_PLATFORM.include?('linux')
         end
 
         private_class_method def self.not_on_amd64_or_arm64?
-          ARCHITECTURE_NOT_SUPPORTED unless (RUBY_PLATFORM.start_with?('x86_64') || RUBY_PLATFORM.start_with?('aarch64'))
+          architecture_not_supported = explain_issue(
+            'your CPU architecture is not supported by the Datadog Continuous Profiler.',
+            suggested: GET_IN_TOUCH,
+          )
+
+          architecture_not_supported unless RUBY_PLATFORM.start_with?('x86_64', 'aarch64')
         end
 
         # On some Rubies, we require the mjit header to be present. If Ruby was installed without MJIT support, we also skip
         # building the extension.
         private_class_method def self.expected_to_use_mjit_but_mjit_is_disabled?
-          RUBY_WITHOUT_MJIT if CAN_USE_MJIT_HEADER && RbConfig::CONFIG['MJIT_SUPPORT'] != 'yes'
+          ruby_without_mjit = explain_issue(
+            'your Ruby has been compiled without JIT support (--disable-jit-support).',
+            'The profiling native extension requires a Ruby compiled with JIT support,',
+            'even if the JIT is not in use by the application itself.',
+            suggested: CONTACT_SUPPORT,
+          )
+
+          ruby_without_mjit if CAN_USE_MJIT_HEADER && RbConfig::CONFIG['MJIT_SUPPORT'] != 'yes'
         end
 
         private_class_method def self.libddprof_not_usable?
-          return LIBDDPROF_NO_BINARIES unless Libddprof.binaries?
+          libddprof_no_binaries = explain_issue(
+            'the `libddprof` gem installed on your system is missing platform-specific',
+            'binaries. Make sure you install a platform-specific version of the gem,',
+            'and that you are not enabling the `force_ruby_platform` bundler option,',
+            'nor the `BUNDLE_FORCE_RUBY_PLATFORM` environment variable.',
+            suggested: CONTACT_SUPPORT,
+          )
+          return libddprof_no_binaries unless Libddprof.binaries?
 
           unless Libddprof.pkgconfig_folder
-            current_platform = Gem::Platform.local.to_s
-            %(
-+------------------------------------------------------------------------------+
-| Skipping build of profiling native extension:                                |
-| `libddprof` gem installed on your system is missing binaries for your        |
-| platform variant.                                                            |
-| (Your platform: `#{current_platform}`)
-| (Available binaries: `#{Libddprof.available_binaries})
-|                                                                              |
-| The Datadog Continuous Profiler will not be available,                       |
-| but all other ddtrace features will work fine!                               |
-|                                                                              |
-| For help solving this issue, please contact Datadog support at               |
-| <https://docs.datadoghq.com/help/>.                                          |
-+------------------------------------------------------------------------------+
-)
+            explain_issue(
+              'the `libddprof` gem installed on your system is missing binaries for your',
+              'platform variant.',
+              "(Your platform: `#{Gem::Platform.local}`)",
+              "(Available binaries: `#{Libddprof.available_binaries})",
+              suggested: CONTACT_SUPPORT,
+            )
           end
         end
-
-        DISABLED_VIA_ENV = %(
-+------------------------------------------------------------------------------+
-| Skipping build of profiling native extension:                                |
-| `DD_PROFILING_NO_EXTENSION` environment variable is set to `true`.           |
-|                                                                              |
-| The Datadog Continuous Profiler will not be available,                       |
-| but all other ddtrace features will work fine!                               |
-|                                                                              |
-| If you needed to use this, please tell us why on                             |
-| <https://github.com/DataDog/dd-trace-rb/issues/new> so we can fix it :\)      |
-+------------------------------------------------------------------------------+
-).freeze
-
-        JRUBY_NOT_SUPPORTED = %(
-+------------------------------------------------------------------------------+
-| Skipping build of profiling native extension:                                |
-| JRuby is not supported by the Datadog Continuous Profiler.                   |
-|                                                                              |
-| All other ddtrace features will work fine!                                   |
-|                                                                              |
-| Get in touch with us if you're interested in profiling JRuby!                |
-+------------------------------------------------------------------------------+
- ).freeze
-
-        TRUFFLERUBY_NOT_SUPPORTED = %(
-+------------------------------------------------------------------------------+
-| Skipping build of profiling native extension:                                |
-| TruffleRuby is not supported by the ddtrace gem.                             |
-|                                                                              |
-| Get in touch with us if you're interested in profiling TruffleRuby!          |
-+------------------------------------------------------------------------------+
-).freeze
-
-        WINDOWS_NOT_SUPPORTED = %(
-+------------------------------------------------------------------------------+
-| Skipping build of profiling native extension:                                |
-| Microsoft Windows is not supported by the Datadog Continuous Profiler.       |
-|                                                                              |
-| Get in touch with us if you're interested in profiling Ruby on Windows!      |
-+------------------------------------------------------------------------------+
-).freeze
-
-        UNKNOWN_OS_NOT_SUPPORTED = %(
-+------------------------------------------------------------------------------+
-| Skipping build of profiling native extension:                                |
-| Current operating system is not supported by the Datadog Continuous Profiler.|
-+------------------------------------------------------------------------------+
-).freeze
-
-        ARCHITECTURE_NOT_SUPPORTED = %(
-+------------------------------------------------------------------------------+
-| Skipping build of profiling native extension:                                |
-| Your CPU architecture is not supported by the Datadog Continuous Profiler.   |
-|                                                                              |
-| Get in touch with us if you're interested in profiling Ruby!                 |
-+------------------------------------------------------------------------------+
-).freeze
-
-        RUBY_WITHOUT_MJIT = %(
-+------------------------------------------------------------------------------+
-| Skipping build of profiling native extension:                                |
-| Your Ruby has been compiled without JIT support (--disable-jit-support).     |
-| The profiling native extension requires a Ruby compiled with JIT support,    |
-| even if the JIT is not in use by the application itself.                     |
-|                                                                              |
-| The Datadog Continuous Profiler will not be available,                       |
-| but all other ddtrace features will work fine!                               |
-+------------------------------------------------------------------------------+
-).freeze
-
-        LIBDDPROF_NO_BINARIES = %(
-+------------------------------------------------------------------------------+
-| Skipping build of profiling native extension:                                |
-| `libddprof` gem installed on your system is missing platform-specific        |
-| binaries. Make sure you install a platform-specific version of the gem,      |
-| and that you are not enabling the `force_ruby_platform` bundler option,      |
-| nor the `BUNDLE_FORCE_RUBY_PLATFORM` environment variable.                   |
-|                                                                              |
-| The Datadog Continuous Profiler will not be available,                       |
-| but all other ddtrace features will work fine!                               |
-|                                                                              |
-| For help solving this issue, please contact Datadog support at               |
-| <https://docs.datadoghq.com/help/>.                                          |
-+------------------------------------------------------------------------------+
-).freeze
       end
       # rubocop:enable Metrics/ModuleLength
     end

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -172,7 +172,7 @@ module Datadog
             'the `libddprof` gem installed on your system is missing binaries for your',
             'platform variant.',
             "(Your platform: `#{Gem::Platform.local}`)",
-            "(Available binaries: ",
+            '(Available binaries: ',
             "`#{Libddprof.available_binaries.join('`, `')}`)",
             suggested: CONTACT_SUPPORT,
           )

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -168,24 +168,16 @@ module Datadog
         end
 
         private_class_method def self.libddprof_not_usable?
-          libddprof_no_binaries = explain_issue(
-            'the `libddprof` gem installed on your system is missing platform-specific',
-            'binaries. Make sure you install a platform-specific version of the gem,',
-            'and that you are not enabling the `force_ruby_platform` bundler option,',
-            'nor the `BUNDLE_FORCE_RUBY_PLATFORM` environment variable.',
+          no_binaries_for_current_platform = explain_issue(
+            'the `libddprof` gem installed on your system is missing binaries for your',
+            'platform variant.',
+            "(Your platform: `#{Gem::Platform.local}`)",
+            "(Available binaries: ",
+            "`#{Libddprof.available_binaries.join('`, `')}`)",
             suggested: CONTACT_SUPPORT,
           )
-          return libddprof_no_binaries unless Libddprof.binaries?
 
-          unless Libddprof.pkgconfig_folder
-            explain_issue(
-              'the `libddprof` gem installed on your system is missing binaries for your',
-              'platform variant.',
-              "(Your platform: `#{Gem::Platform.local}`)",
-              "(Available binaries: `#{Libddprof.available_binaries})",
-              suggested: CONTACT_SUPPORT,
-            )
-          end
+          no_binaries_for_current_platform unless Libddprof.pkgconfig_folder
         end
       end
       # rubocop:enable Metrics/ModuleLength

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -22,13 +22,9 @@ module Datadog
             on_truffleruby? ||
             on_windows? ||
             on_unknown_os? ||
-            # TODO: Temporarily disabled for PR https://github.com/DataDog/dd-trace-rb/pull/1885; will be updated in
-            # follow-up PR
-            # not_on_x86_64? ||
-            expected_to_use_mjit_but_mjit_is_disabled?
-          # TODO: Temporarily disabled for PR https://github.com/DataDog/dd-trace-rb/pull/1885; will be updated in
-          # follow-up PR
-          # libddprof_not_usable?
+            not_on_x86_64? ||
+            expected_to_use_mjit_but_mjit_is_disabled? ||
+            libddprof_not_usable?
         end
 
         private_class_method def self.disabled_via_env?

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -56,7 +56,7 @@ module Datadog
 
         contents = file_api.read(skipped_reason_file).strip
         contents unless contents.empty?
-      rescue StandardError => _e
+      rescue StandardError
         # Do nothing
       end
     end

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -10,9 +10,6 @@ module Datadog
     GOOGLE_PROTOBUF_MINIMUM_VERSION = Gem::Version.new('3.0')
     private_constant :GOOGLE_PROTOBUF_MINIMUM_VERSION
 
-    SKIPPED_NATIVE_EXTENSION_ONLY_ONCE = Core::Utils::OnlyOnce.new
-    private_constant :SKIPPED_NATIVE_EXTENSION_ONLY_ONCE
-
     def self.supported?
       unsupported_reason.nil?
     end
@@ -21,7 +18,7 @@ module Datadog
       # NOTE: Only the first matching reason is returned, so try to keep a nice order on reasons -- e.g. tell users
       # first that they can't use this on JRuby before telling them that they are missing protobuf
 
-      ruby_engine_unsupported? ||
+      native_library_compilation_skipped? ||
         native_library_failed_to_load? ||
         protobuf_gem_unavailable? ||
         protobuf_version_unsupported? ||
@@ -44,8 +41,24 @@ module Datadog
       !!profiler
     end
 
-    private_class_method def self.ruby_engine_unsupported?
-      'JRuby is not supported' if RUBY_ENGINE == 'jruby'
+    private_class_method def self.native_library_compilation_skipped?
+      skipped_reason = try_reading_skipped_reason_file
+
+      "Your ddtrace installation is missing support for the Continuous Profiler because #{skipped_reason}" if skipped_reason
+    end
+
+    private_class_method def self.try_reading_skipped_reason_file(file_api = File)
+      # This file, if it exists, is recorded by extconf.rb during compilation of the native extension
+      skipped_reason_file = "#{__dir__}/../../ext/ddtrace_profiling_native_extension/skipped_reason.txt"
+
+      begin
+        return unless file_api.exist?(skipped_reason_file)
+
+        contents = file_api.read(skipped_reason_file).strip
+        contents unless contents.empty?
+      rescue StandardError => _e
+        # Do nothing
+      end
     end
 
     private_class_method def self.protobuf_gem_unavailable?
@@ -97,8 +110,7 @@ module Datadog
           'This can happen when google-protobuf is missing its native components. ' \
           'To fix this, try removing and reinstalling the gem, forcing it to recompile the components: ' \
           '`gem uninstall google-protobuf -a; BUNDLE_FORCE_RUBY_PLATFORM=true bundle install`. ' \
-          'If the error persists, please contact support via <https://docs.datadoghq.com/help/> or ' \
-          'file a bug at <https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug>.'
+          'If the error persists, please contact Datadog support at <https://docs.datadoghq.com/help/>.'
         )
         @protobuf_loaded = false
       end
@@ -113,26 +125,12 @@ module Datadog
           "'#{exception.class.name} #{exception.message}' at '#{exception.backtrace.first}'"
         else
           'The profiling native extension did not load correctly. ' \
-          'If the error persists, please contact support via <https://docs.datadoghq.com/help/> or ' \
-          'file a bug at <https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug>.'
+          'For help solving this issue, please contact Datadog support at <https://docs.datadoghq.com/help/>.' \
         end
       end
     end
 
     private_class_method def self.try_loading_native_library
-      if Core::Environment::VariableHelpers.env_to_bool('DD_PROFILING_NO_EXTENSION', false)
-        SKIPPED_NATIVE_EXTENSION_ONLY_ONCE.run do
-          Kernel.warn(
-            '[DDTRACE] Skipped loading of profiling native extension due to DD_PROFILING_NO_EXTENSION environment ' \
-            'variable being set. ' \
-            'This option is experimental and will lead to the profiler not working in future releases. ' \
-            'If you needed to use this, please tell us why on <https://github.com/DataDog/dd-trace-rb/issues/new>.'
-          )
-        end
-
-        return [true, nil]
-      end
-
       begin
         require 'datadog/profiling/load_native_extension'
 
@@ -164,6 +162,6 @@ module Datadog
       true
     end
 
-    load_profiling if supported?
+    load_profiling
   end
 end

--- a/lib/datadog/profiling/scheduler.rb
+++ b/lib/datadog/profiling/scheduler.rb
@@ -114,7 +114,7 @@ module Datadog
         # Sleep for a bit to cause misalignment between profilers in multi-process applications
         #
         # When not being run in a loop, it means the scheduler has not been started or was stopped, and thus
-        # a) it's being shutting down (and is trying to report the last profile)
+        # a) it's being shut down (and is trying to report the last profile)
         # b) it's being run as a one-shot, usually in a test
         # ...so in those cases we don't sleep
         #

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -950,6 +950,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
         subject(:http_exporter) { profiler.scheduler.exporters.first }
 
         before do
+          allow(File).to receive(:exist?).and_call_original
           allow(File).to receive(:exist?).with('/var/run/datadog/apm.socket').and_return(false)
         end
 

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -57,10 +57,24 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
         it { is_expected.to include 'Windows' }
       end
 
-      context 'when not on Windows' do
+      context 'when on macOS' do
+        around { |example| ClimateControl.modify('DD_PROFILING_MACOS_TESTING' => nil) { example.run } }
+
+        before { stub_const('RUBY_PLATFORM', 'x86_64-darwin19') }
+
+        it { is_expected.to include 'macOS' }
+
+        context 'when macOS testing override is enabled' do
+          around { |example| ClimateControl.modify('DD_PROFILING_MACOS_TESTING' => 'true') { example.run } }
+
+          it { is_expected.to be nil }
+        end
+      end
+
+      context 'when not on Windows or macOS' do
         before { expect(Gem).to receive(:win_platform?).and_return(false) }
 
-        context 'when not on macOS or Linux' do
+        context 'when not on Linux' do
           before { stub_const('RUBY_PLATFORM', 'sparc-opensolaris') }
 
           it { is_expected.to include 'operating system is not supported' }

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -63,15 +63,13 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
           it { is_expected.to include 'operating system is not supported' }
         end
 
-        context 'when not on x86-64' do
-          before { stub_const('RUBY_PLATFORM', 'aarch64-linux') }
+        context 'when not on amd64 or arm64' do
+          before { stub_const('RUBY_PLATFORM', 'mipsel-linux') }
 
           it { is_expected.to include 'architecture is not supported' }
         end
 
-        context 'when on x86-64 linux' do
-          before { stub_const('RUBY_PLATFORM', 'x86_64-linux') }
-
+        shared_examples 'mjit header validation' do
           shared_examples 'libddprof usable' do
             context 'when libddprof is not available' do
               before do
@@ -131,6 +129,18 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
               include_examples 'libddprof usable'
             end
           end
+        end
+
+        context 'when on amd64 (x86-64) linux' do
+          before { stub_const('RUBY_PLATFORM', 'x86_64-linux') }
+
+          include_examples 'mjit header validation'
+        end
+
+        context 'when on arm64 (aarch64) linux' do
+          before { stub_const('RUBY_PLATFORM', 'aarch64-linux') }
+
+          include_examples 'mjit header validation'
         end
       end
     end

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -21,7 +21,10 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
   end
 
   describe '.unsupported_reason' do
-    subject(:unsupported_reason) { described_class.unsupported_reason }
+    subject(:unsupported_reason) do
+      reason = described_class.unsupported_reason
+      reason.fetch(:reason).join("\n") if reason
+    end
 
     before do
       allow(RbConfig::CONFIG).to receive(:[]).and_call_original

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -63,22 +63,16 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
         before { stub_const('RUBY_PLATFORM', 'x86_64-darwin19') }
 
         it { is_expected.to include 'macOS' }
-
-        context 'when macOS testing override is enabled' do
-          around { |example| ClimateControl.modify('DD_PROFILING_MACOS_TESTING' => 'true') { example.run } }
-
-          it { is_expected.to be nil }
-        end
       end
 
-      context 'when not on Windows or macOS' do
+      context 'when not on Linux' do
+        before { stub_const('RUBY_PLATFORM', 'sparc-opensolaris') }
+
+        it { is_expected.to include 'operating system is not supported' }
+      end
+
+      context 'when on Linux or on macOS with testing override enabled' do
         before { expect(Gem).to receive(:win_platform?).and_return(false) }
-
-        context 'when not on Linux' do
-          before { stub_const('RUBY_PLATFORM', 'sparc-opensolaris') }
-
-          it { is_expected.to include 'operating system is not supported' }
-        end
 
         context 'when not on amd64 or arm64' do
           before { stub_const('RUBY_PLATFORM', 'mipsel-linux') }
@@ -145,6 +139,12 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
 
         context 'when on arm64 (aarch64) linux' do
           before { stub_const('RUBY_PLATFORM', 'aarch64-linux') }
+
+          include_examples 'mjit header validation'
+        end
+
+        context 'when macOS testing override is enabled' do
+          around { |example| ClimateControl.modify('DD_PROFILING_MACOS_TESTING' => 'true') { example.run } }
 
           include_examples 'mjit header validation'
         end

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -82,29 +82,19 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
 
         shared_examples 'mjit header validation' do
           shared_examples 'libddprof usable' do
-            context 'when libddprof DOES NOT have binaries' do
-              before { expect(Libddprof).to receive(:binaries?).and_return(false) }
+            context 'when libddprof DOES NOT HAVE binaries for the current platform' do
+              before do
+                expect(Libddprof).to receive(:pkgconfig_folder).and_return(nil)
+                expect(Libddprof).to receive(:available_binaries).and_return(%w[fooarch-linux bararch-linux-musl])
+              end
 
-              it { is_expected.to include 'gem installed on your system is missing platform-specific' }
+              it { is_expected.to include 'platform variant' }
             end
 
-            context 'when libddprof and DOES have binaries' do
-              before { expect(Libddprof).to receive(:binaries?).and_return(true) }
+            context 'when libddprof HAS BINARIES for the current platform' do
+              before { expect(Libddprof).to receive(:pkgconfig_folder).and_return('/simulated/pkgconfig_folder') }
 
-              context 'but DOES NOT HAVE binaries for the current platform' do
-                before do
-                  expect(Libddprof).to receive(:pkgconfig_folder).and_return(nil)
-                  expect(Libddprof).to receive(:available_binaries).and_return(%w[fooarch-linux bararch-linux-musl])
-                end
-
-                it { is_expected.to include 'platform variant' }
-              end
-
-              context 'and HAS BINARIES for the current platform' do
-                before { expect(Libddprof).to receive(:pkgconfig_folder).and_return('/simulated/pkgconfig_folder') }
-
-                it { is_expected.to be nil }
-              end
+              it('marks the native extension as supported') { is_expected.to be nil }
             end
           end
 

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -114,13 +114,13 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
             end
           end
 
-          context 'when Ruby CAN NOT use the MJIT header' do
+          context 'on a Ruby version where we CAN NOT use the MJIT header' do
             before { stub_const('Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER', false) }
 
             include_examples 'libddprof usable'
           end
 
-          context 'when Ruby CAN use the MJIT header' do
+          context 'on a Ruby version where we CAN use the MJIT header' do
             before { stub_const('Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER', true) }
 
             context 'but DOES NOT have MJIT support' do

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -136,6 +136,8 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
         context 'when macOS testing override is enabled' do
           around { |example| ClimateControl.modify('DD_PROFILING_MACOS_TESTING' => 'true') { example.run } }
 
+          before { stub_const('RUBY_PLATFORM', 'x86_64-darwin19') }
+
           include_examples 'mjit header validation'
         end
       end

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -63,53 +63,51 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
           it { is_expected.to include 'operating system is not supported' }
         end
 
-        # TODO: Temporarily disabled for PR https://github.com/DataDog/dd-trace-rb/pull/1885; will be updated in
-        # follow-up PR
-        # context 'when not on x86-64' do
-        #   before { stub_const('RUBY_PLATFORM', 'aarch64-linux') }
+        context 'when not on x86-64' do
+          before { stub_const('RUBY_PLATFORM', 'aarch64-linux') }
 
-        #   it { is_expected.to include 'architecture is not supported' }
-        # end
+          it { is_expected.to include 'architecture is not supported' }
+        end
 
         context 'when on x86-64 linux' do
           before { stub_const('RUBY_PLATFORM', 'x86_64-linux') }
 
           shared_examples 'libddprof usable' do
-            # context 'when libddprof is not available' do
-            #   before do
-            #     allow(described_class)
-            #       .to receive(:require).with('libddprof').and_raise(LoadError.new('Testing failed require'))
-            #   end
+            context 'when libddprof is not available' do
+              before do
+                allow(described_class)
+                  .to receive(:require).with('libddprof').and_raise(LoadError.new('Testing failed require'))
+              end
 
-            #   it { is_expected.to include '`libddprof` gem is not available' }
-            # end
+              it { is_expected.to include '`libddprof` gem is not available' }
+            end
 
-            # context 'when libddprof is available' do
-            #   context 'but DOES NOT have binaries' do
-            #     before { expect(Libddprof).to receive(:binaries?).and_return(false) }
+            context 'when libddprof is available' do
+              context 'but DOES NOT have binaries' do
+                before { expect(Libddprof).to receive(:binaries?).and_return(false) }
 
-            #     it { is_expected.to include 'gem installed on your system is missing platform-specific' }
-            #   end
+                it { is_expected.to include 'gem installed on your system is missing platform-specific' }
+              end
 
-            #   context 'and DOES have binaries' do
-            #     before { expect(Libddprof).to receive(:binaries?).and_return(true) }
+              context 'and DOES have binaries' do
+                before { expect(Libddprof).to receive(:binaries?).and_return(true) }
 
-            #     context 'but DOES NOT HAVE binaries for the current platform' do
-            #       before do
-            #         expect(Libddprof).to receive(:pkgconfig_folder).and_return(nil)
-            #         expect(Libddprof).to receive(:available_binaries).and_return(%w[fooarch-linux bararch-linux-musl])
-            #       end
+                context 'but DOES NOT HAVE binaries for the current platform' do
+                  before do
+                    expect(Libddprof).to receive(:pkgconfig_folder).and_return(nil)
+                    expect(Libddprof).to receive(:available_binaries).and_return(%w[fooarch-linux bararch-linux-musl])
+                  end
 
-            #       it { is_expected.to include 'platform variant' }
-            #     end
+                  it { is_expected.to include 'platform variant' }
+                end
 
-            #     context 'and HAS BINARIES for the current platform' do
-            #       before { expect(Libddprof).to receive(:pkgconfig_folder).and_return('/simulated/pkgconfig_folder') }
+                context 'and HAS BINARIES for the current platform' do
+                  before { expect(Libddprof).to receive(:pkgconfig_folder).and_return('/simulated/pkgconfig_folder') }
 
-            it { is_expected.to be nil }
-            #     end
-            #   end
-            # end
+                  it { is_expected.to be nil }
+                end
+              end
+            end
           end
 
           context 'when Ruby CAN NOT use the MJIT header' do

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -69,7 +69,21 @@ module ProfileHelpers
   def skip_if_profiling_not_supported(testcase)
     testcase.skip('Profiling is not supported on JRuby') if PlatformHelpers.jruby?
     testcase.skip('Profiling is not supported on TruffleRuby') if PlatformHelpers.truffleruby?
-    testcase.skip('Profiling is not supported on macOS') if PlatformHelpers.mac?
+
+    # Profiling is not officially supported on macOS due to missing libddprof binaries,
+    # but it's still useful to allow it to be enabled for development.
+    if PlatformHelpers.mac? && ENV['DD_PROFILING_MACOS_TESTING'] != 'true'
+      testcase.skip(
+        'Profiling is not supported on macOS. If you still want to run these specs, you can use ' \
+        'DD_PROFILING_MACOS_TESTING=true to override this check.'
+      )
+    end
+
+    return if Datadog::Profiling.supported?
+
+    # Ensure profiling was loaded correctly
+    raise "Profiling does not seem to be available: #{Datadog::Profiling.unsupported_reason}. " \
+      'Try running `bundle exec rake compile` before running this test.'
   end
 end
 

--- a/spec/datadog/profiling_spec.rb
+++ b/spec/datadog/profiling_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Datadog::Profiling do
     end
 
     context 'with the profiler instance available' do
-      let(:result) { instance_double(Datadog::Profiling::Profiler) }
+      let(:result) { instance_double('Datadog::Profiling::Profiler') }
       it 'starts the profiler instance' do
         expect(result).to receive(:start)
         is_expected.to be(true)
@@ -46,14 +46,18 @@ RSpec.describe Datadog::Profiling do
   describe '::unsupported_reason' do
     subject(:unsupported_reason) { described_class.unsupported_reason }
 
-    context 'when JRuby is used' do
-      before { stub_const('RUBY_ENGINE', 'jruby') }
+    context 'when the profiling native library was not compiled' do
+      before do
+        expect(described_class).to receive(:try_reading_skipped_reason_file).and_return('fake skipped reason')
+      end
 
-      it { is_expected.to include 'JRuby' }
+      it { is_expected.to include 'missing support for the Continuous Profiler' }
     end
 
-    context 'when not using JRuby' do
-      before { stub_const('RUBY_ENGINE', 'ruby') }
+    context 'when the profiling native library was compiled' do
+      before do
+        expect(described_class).to receive(:try_reading_skipped_reason_file).and_return nil
+      end
 
       context 'when the profiling native library fails to be loaded with a exception' do
         let(:loaderror) do
@@ -73,7 +77,7 @@ RSpec.describe Datadog::Profiling do
 
       context "when the profiling native library fails to be loaded but there's no exception" do
         before do
-          expect(described_class).to receive(:try_loading_native_library).and_return [false, nil]
+          expect(described_class).to receive(:try_loading_native_library).and_return([false, nil])
         end
 
         it { is_expected.to include 'profiling native extension did not load correctly' }
@@ -81,7 +85,7 @@ RSpec.describe Datadog::Profiling do
 
       context "when the profiling native library is available and 'google-protobuf'" do
         before do
-          expect(described_class).to receive(:try_loading_native_library).and_return [true, nil]
+          expect(described_class).to receive(:try_loading_native_library).and_return([true, nil])
         end
 
         context 'is not available' do
@@ -178,8 +182,6 @@ RSpec.describe Datadog::Profiling do
 
     let(:native_extension_require) { 'datadog/profiling/load_native_extension' }
 
-    around { |example| ClimateControl.modify('DD_PROFILING_NO_EXTENSION' => nil) { example.run } }
-
     context 'when the profiling native library loads successfully' do
       before do
         expect(described_class)
@@ -221,33 +223,56 @@ RSpec.describe Datadog::Profiling do
 
       it { is_expected.to eq [false, nil] }
     end
+  end
 
-    context "when DD_PROFILING_NO_EXTENSION is set to 'true'" do
+  describe '::try_reading_skipped_reason_file' do
+    subject(:try_reading_skipped_reason_file) { described_class.send(:try_reading_skipped_reason_file, file_api) }
+
+    let(:file_api) { class_double(File, exist?: exist?, read: read) }
+    let(:exist?) { true }
+    let(:read) { '' }
+
+    it 'tries to read the skipped_reason.txt file in the native extension folder' do
+      expected_path = File.expand_path('../../ext/ddtrace_profiling_native_extension/skipped_reason.txt', __dir__)
+
+      expect(file_api).to receive(:exist?) do |path|
+        expect(File.expand_path(path)).to eq expected_path
+      end.and_return(true)
+
+      expect(file_api).to receive(:read) do |path|
+        expect(File.expand_path(path)).to eq expected_path
+      end.and_return('')
+
+      try_reading_skipped_reason_file
+    end
+
+    context 'when file does not exist' do
+      let(:exist?) { false }
+
+      it { is_expected.to be nil }
+    end
+
+    context 'when file fails to open' do
+      let(:exist?) { true }
+
       before do
-        allow(Kernel).to receive(:warn)
-        described_class.const_get(:SKIPPED_NATIVE_EXTENSION_ONLY_ONCE).send(:reset_ran_once_state_for_tests)
+        expect(file_api).to receive(:read) { File.open('this-will-fail') }
       end
 
-      around { |example| ClimateControl.modify('DD_PROFILING_NO_EXTENSION' => 'true') { example.run } }
+      it { is_expected.to be nil }
+    end
 
-      it { is_expected.to eq [true, nil] }
+    context 'when file is empty' do
+      let(:read) { " \t\n" }
 
-      it 'logs a warning' do
-        expect(Kernel).to receive(:warn).with(/DD_PROFILING_NO_EXTENSION/)
+      it { is_expected.to be nil }
+    end
 
-        try_loading_native_library
-      end
+    context 'when file exists and has content' do
+      let(:read) { 'skipped reason content' }
 
-      it 'does not try to require the native extension' do
-        expect(described_class).to_not receive(:require)
-
-        try_loading_native_library
-      end
-
-      it 'does not try to call NativeExtension.native_working?' do
-        stub_const('Datadog::Profiling::NativeExtension', double('native_extension double which should not be used'))
-
-        try_loading_native_library
+      it 'returns the content' do
+        is_expected.to eq 'skipped reason content'
       end
     end
   end


### PR DESCRIPTION
In #1885 we bootstrapped support for libddprof in ddtrace. This PR adds the final bits needed to make it an actual dependency of ddtrace.

This PR:
* Upgrades libddprof to 0.6.0.1.0 (latest release)
* Improves detection and error messages of setups we don't support
* Drops profiler support for macOS. The profiler support wasn't great on macOS already -- we only supported wall-clock and were missing cpu-time data. libddprof currently doesn't ship binaries for macOS, so we can't suport it anymore until that's changed.
* Adds a way to force-enable using libddprof on macOS, for profiling development, aka I use it myself. It does work on macOS, the main problem for restoring support is solving the libddprof macOS distribution story.
* Adds a way to record the specific reason why the profiling native extension didn't compile at installation time, so that we can show that information to customers at runtime when they try to turn on profiler.

Relevant Q&A:
* Q: What's the impact on ddtrace customers that aren't on the supported libddprof platforms?
* A: ddtrace will still install and be usable. When those customers try to turn on profiling, they'll get a nice log message explaining why it can't be turned on, but otherwise their application will work, including using all other Datadog products supported by ddtrace.

* Q: What if compilation fails?
* A: Users will be presented with an error message that tells them that they can use the `DD_PROFILING_NO_EXTENSION`  environment variable set to `true` to skip any attempts to compile the code.

* Q: What's the impact of merging this PR?
* A: Only customers on x86-64 and 64-bit ARM Linux will be able to use the profiler (no more macOS; windows wasn't supported anyway). The profiling native extension will no longer be optional. Other than that, the current almost-100%-pure-Ruby codepaths will continue to be in use for the time being, this PR is only about enabling later work.

Final note: Some of the commits in this PR were extracted from #1923. I felt that PR had accumulated too many changes, so I've decided to break it down into more focused PRs.