### PR TITLE
[PROF-4780] Temporarily rename Datadog::Profiling::Flush to OldFlush

### DIFF
--- a/benchmarks/profiler_submission.rb
+++ b/benchmarks/profiler_submission.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 # Used to quickly run benchmark under RSpec as part of the usual test suite, to validate it didn't bitrot
 VALIDATE_BENCHMARK_MODE = ENV['VALIDATE_BENCHMARK'] == 'true'
@@ -61,7 +61,7 @@ class ProfilerSubmission
 
     # @ivoanjo: Hack to allow unmarshalling the old data; this will all need to be redesigned once we start using
     # libddprof for profile encoding, so I decided to take a shorter route for now.
-    original_flush_class = Datadog::Profiling::Flush
+    original_flush_class = defined?(Datadog::Profiling::Flush) && Datadog::Profiling::Flush
     Datadog::Profiling.const_set(:Flush, OldFlush)
     @flush = Marshal.load(
       Zlib::GzipReader.new(File.open(ENV['FLUSH_DUMP_FILE'] || 'benchmarks/data/profiler-submission-marshal.gz'))

--- a/lib/datadog/profiling/flush.rb
+++ b/lib/datadog/profiling/flush.rb
@@ -6,7 +6,7 @@ require 'datadog/core/environment/socket'
 module Datadog
   module Profiling
     # Entity class used to represent metadata for a given profile
-    Flush = Struct.new(
+    OldFlush = Struct.new(
       :start,
       :finish,
       :event_groups,

--- a/lib/datadog/profiling/recorder.rb
+++ b/lib/datadog/profiling/recorder.rb
@@ -75,7 +75,7 @@ module Datadog
 
         code_provenance = @code_provenance_collector.refresh.generate_json if @code_provenance_collector
 
-        Flush.new(
+        OldFlush.new(
           start: start,
           finish: finish,
           event_groups: event_groups,

--- a/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -3682,7 +3682,7 @@ class Datadog::Profiling::Collectors::Stack
   include ::Datadog::Core::Workers::Polling::PrependedMethods
 end
 
-class Datadog::Profiling::Flush
+class Datadog::Profiling::OldFlush
   def self.[](*arg); end
 
   def self.members(); end

--- a/spec/datadog/profiling/encoding/profile_spec.rb
+++ b/spec/datadog/profiling/encoding/profile_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Datadog::Profiling::Encoding::Profile::Protobuf do
     subject(:encode) { described_class.encode(flush) }
 
     let(:flush) do
-      instance_double(Datadog::Profiling::Flush, event_groups: event_groups, start: start_time, finish: finish_time)
+      instance_double(Datadog::Profiling::OldFlush, event_groups: event_groups, start: start_time, finish: finish_time)
     end
     let(:event_groups) { [event_group] }
     let(:event_group) { instance_double(Datadog::Profiling::EventGroup, event_class: event_class, events: events) }

--- a/spec/datadog/profiling/exporter_spec.rb
+++ b/spec/datadog/profiling/exporter_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Datadog::Profiling::Exporter do
   describe '#export' do
     subject(:export) { exporter.export(flush) }
 
-    let(:flush) { instance_double(Datadog::Profiling::Flush) }
+    let(:flush) { instance_double(Datadog::Profiling::OldFlush) }
     let(:result) { double('result') }
 
     before do

--- a/spec/datadog/profiling/flush_spec.rb
+++ b/spec/datadog/profiling/flush_spec.rb
@@ -1,6 +1,6 @@
 # typed: false
 
-RSpec.describe Datadog::Profiling::Flush do
+RSpec.describe Datadog::Profiling::OldFlush do
   describe '#new' do
     let(:start) { double('start') }
     let(:finish) { double('finish') }

--- a/spec/datadog/profiling/recorder_spec.rb
+++ b/spec/datadog/profiling/recorder_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Datadog::Profiling::Recorder do
       context 'whose buffer returns events' do
         let(:events) { [event_class.new, event_class.new] }
 
-        it { is_expected.to be_a_kind_of(Datadog::Profiling::Flush) }
+        it { is_expected.to be_a_kind_of(Datadog::Profiling::OldFlush) }
 
         it do
           is_expected.to have_attributes(
@@ -153,7 +153,7 @@ RSpec.describe Datadog::Profiling::Recorder do
       end
 
       context 'whose buffer returns no events' do
-        it { is_expected.to be_a_kind_of(Datadog::Profiling::Flush) }
+        it { is_expected.to be_a_kind_of(Datadog::Profiling::OldFlush) }
         it { expect(flush.event_groups).to be_empty }
       end
 

--- a/spec/datadog/profiling/scheduler_spec.rb
+++ b/spec/datadog/profiling/scheduler_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Datadog::Profiling::Scheduler do
     let(:flush_start) { Time.now }
     let(:flush_finish) { flush_start + 1 }
     let(:flush) do
-      instance_double(Datadog::Profiling::Flush, event_count: event_count, start: flush_start, finish: flush_finish)
+      instance_double(Datadog::Profiling::OldFlush, event_count: event_count, start: flush_start, finish: flush_finish)
     end
 
     before { expect(recorder).to receive(:flush).and_return(flush) }

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -31,7 +31,7 @@ module ProfileHelpers
     finish = start + 10
     event_groups = [Datadog::Profiling::EventGroup.new(Datadog::Profiling::Events::StackSample, stack_samples)]
 
-    Datadog::Profiling::Flush.new(
+    Datadog::Profiling::OldFlush.new(
       start: start,
       finish: finish,
       event_groups: event_groups,

--- a/spec/datadog/profiling/transport/client_spec.rb
+++ b/spec/datadog/profiling/transport/client_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Datadog::Profiling::Transport::Client do
     describe '#send_profiling_flush' do
       subject(:send_profiling_flush) { client.send_profiling_flush(flush) }
 
-      let(:flush) { instance_double(Datadog::Profiling::Flush) }
+      let(:flush) { instance_double(Datadog::Profiling::OldFlush) }
 
       it { expect { send_profiling_flush }.to raise_error(NotImplementedError) }
     end

--- a/spec/datadog/profiling/transport/http/client_spec.rb
+++ b/spec/datadog/profiling/transport/http/client_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Datadog::Profiling::Transport::HTTP::Client do
 
     subject(:send_profiling_flush) { client.send_profiling_flush(flush) }
 
-    let(:flush) { instance_double(Datadog::Profiling::Flush) }
+    let(:flush) { instance_double(Datadog::Profiling::OldFlush) }
 
     context 'when request was successful' do
       before do

--- a/spec/datadog/profiling/transport/io/client_spec.rb
+++ b/spec/datadog/profiling/transport/io/client_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Datadog::Profiling::Transport::IO::Client do
   describe '#send_profiling_flush' do
     subject(:send_profiling_flush) { client.send_profiling_flush(flush) }
 
-    let(:flush) { instance_double(Datadog::Profiling::Flush) }
+    let(:flush) { instance_double(Datadog::Profiling::OldFlush) }
     let(:encoded_events) { double('encoded events') }
     let(:result) { double('IO result') }
 

--- a/spec/datadog/profiling/transport/request_spec.rb
+++ b/spec/datadog/profiling/transport/request_spec.rb
@@ -8,7 +8,7 @@ require 'datadog/profiling/transport/request'
 RSpec.describe Datadog::Profiling::Transport::Request do
   subject(:request) { described_class.new(flush) }
 
-  let(:flush) { instance_double(Datadog::Profiling::Flush) }
+  let(:flush) { instance_double(Datadog::Profiling::OldFlush) }
 
   it { is_expected.to be_a_kind_of(Datadog::Transport::Request) }
 


### PR DESCRIPTION
As part of the ongoing refactoring work to report profiling data using libddprof, the `Flush` class is going to need to change its shape.

To enable incremental development of the new code side-by-side with the old code, let's rename the existing class to `OldFlush` so that the new code can take over its name.

Note that the existing Ruby profiler keeps working with the new class name! So this PR can be merged independently of any other libddprof-related PR :)