### PR TITLE
[PROF-4780] Add `TagBuilder` module for building tags to attach to profiles

### DIFF
--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -160,6 +160,7 @@ module Datadog
       require 'datadog/profiling/native_extension'
       require 'datadog/profiling/trace_identifiers/helper'
       require 'datadog/profiling/pprof/pprof_pb'
+      require 'datadog/profiling/tag_builder'
 
       true
     end

--- a/lib/datadog/profiling/tag_builder.rb
+++ b/lib/datadog/profiling/tag_builder.rb
@@ -1,0 +1,48 @@
+# typed: true
+
+module Datadog
+  module Profiling
+    # Builds a hash of default plus user tags to be included in a profile
+    module TagBuilder
+      include Datadog::Profiling::Ext::Transport::HTTP # Tag name constants
+
+      def self.call(
+        settings:,
+        # Unified service tagging
+        env: settings.env,
+        service: settings.service,
+        version: settings.version,
+        # Other metadata
+        host: Core::Environment::Socket.hostname,
+        language: Core::Environment::Identity.lang,
+        pid: Process.pid.to_s,
+        profiler_version: Core::Environment::Identity.tracer_version,
+        runtime_engine: Core::Environment::Identity.lang_engine,
+        runtime_id: Core::Environment::Identity.id,
+        runtime_platform: Core::Environment::Identity.lang_platform,
+        runtime_version: Core::Environment::Identity.lang_version,
+        # User-provided tags
+        user_tags: settings.tags
+      )
+        tags = {
+          # When changing or adding these, make sure they are kept in sync with
+          # https://docs.google.com/spreadsheets/d/1LOGMf4c4Avbtn36uZ2SWvhIGKRPLM1BoWkUP4JYj7hA/ (Datadog internal link)
+          FORM_FIELD_TAG_HOST => host,
+          FORM_FIELD_TAG_LANGUAGE => language,
+          FORM_FIELD_TAG_PID => pid,
+          FORM_FIELD_TAG_PROFILER_VERSION => profiler_version,
+          FORM_FIELD_TAG_RUNTIME => language, # This is known to be repeated from language, above
+          FORM_FIELD_TAG_RUNTIME_ENGINE => runtime_engine,
+          FORM_FIELD_TAG_RUNTIME_ID => runtime_id,
+          FORM_FIELD_TAG_RUNTIME_PLATFORM => runtime_platform,
+          FORM_FIELD_TAG_RUNTIME_VERSION => runtime_version,
+        }
+        tags[FORM_FIELD_TAG_ENV] = env if env
+        tags[FORM_FIELD_TAG_SERVICE] = service if service
+        tags[FORM_FIELD_TAG_VERSION] = version if version
+
+        user_tags.merge(tags)
+      end
+    end
+  end
+end

--- a/spec/datadog/profiling/tag_builder_spec.rb
+++ b/spec/datadog/profiling/tag_builder_spec.rb
@@ -1,0 +1,63 @@
+# typed: false
+
+require 'datadog/profiling/tag_builder'
+
+RSpec.describe Datadog::Profiling::TagBuilder do
+  describe '.call' do
+    let(:settings) { Datadog::Core::Configuration::Settings.new }
+
+    subject(:call) { described_class.call(settings: settings) }
+
+    it 'returns a hash with the tags to be attached to a profile' do
+      expect(call).to include(
+        'host' => Datadog::Core::Environment::Socket.hostname,
+        'language' => 'ruby',
+        'process_id' => Process.pid.to_s,
+        'profiler_version' => start_with('1.'),
+        'runtime' => 'ruby',
+        'runtime_engine' => RUBY_ENGINE,
+        'runtime-id' => Datadog::Core::Environment::Identity.id,
+        'runtime_platform' => RUBY_PLATFORM,
+        'runtime_version' => RUBY_VERSION,
+      )
+    end
+
+    describe 'unified service tagging' do
+      [:env, :service, :version].each do |tag|
+        context "when a #{tag} is defined" do
+          before do
+            settings.send("#{tag}=".to_sym, 'expected_value')
+          end
+
+          it 'includes it as a tag' do
+            expect(call).to include(tag.to_s => 'expected_value')
+          end
+        end
+
+        context "when #{tag} is nil" do
+          before do
+            settings.send("#{tag}=".to_sym, nil)
+          end
+
+          it do
+            expect(call.keys).to_not include(tag.to_s)
+          end
+        end
+      end
+    end
+
+    it 'includes the provided user tags' do
+      settings.tags = { 'foo' => 'bar' }
+
+      expect(call).to include('foo' => 'bar')
+    end
+
+    context 'when there is a conflict between user and metadata tags' do
+      it 'overrides the user-provided tags' do
+        settings.tags = { 'foo' => 'bar', 'language' => 'python' }
+
+        expect(call).to include('foo' => 'bar', 'language' => 'ruby')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This module will be used by the new libddprof-based transport code to build the list of tags to be sent to the backend together with a profile.

Its behavior is a mix of both:
* https://github.com/DataDog/dd-trace-rb/blob/ee2a5eeddee2262ef94cca0a5aabd02439413103/lib/datadog/profiling/transport/http/api/endpoint.rb
* https://github.com/DataDog/dd-trace-rb/blob/ee2a5eeddee2262ef94cca0a5aabd02439413103/lib/datadog/profiling/flush.rb

Both of which I plan to remove in a later PR (which already exists -- https://github.com/DataDog/dd-trace-rb/pull/1924 -- but I kept it as a draft).