### PR TITLE
Tag another test in `workers_integration_spec.rb` as flaky on macOS

### DIFF
--- a/spec/datadog/tracing/workers_integration_spec.rb
+++ b/spec/datadog/tracing/workers_integration_spec.rb
@@ -147,6 +147,8 @@ RSpec.describe 'Datadog::Workers::AsyncTransport integration tests' do
 
     context 'that are filtered' do
       before do
+        skip 'TODO: Test is flaky on macOS' if RUBY_PLATFORM.include?('darwin')
+
         # Activate filter
         filter = Datadog::Tracing::Pipeline::SpanFilter.new do |span|
           span.name[/discard/]


### PR DESCRIPTION
See <https://github.com/DataDog/dd-trace-rb/runs/6503764102?check_suite_focus=true>
for a flaky run for this test.

A bunch of other tests on this file are already skipped on our macOS CI as flaky.