### PR TITLE
Bump debase-ruby_core_source maximum version to latest version

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   #
   # Because we only use this for older Rubies, and we consider it "feature-complete" for those older Rubies,
   # we're pinning it at the latest available version and will manually bump the dependency as needed.
-  spec.add_dependency 'debase-ruby_core_source', '<= 0.10.15'
+  spec.add_dependency 'debase-ruby_core_source', '<= 0.10.16'
 
   # Used by appsec
   spec.add_dependency 'libddwaf', '~> 1.3.0.1.0'


### PR DESCRIPTION
I've reviewed the latest version and it looks good <https://my.diffend.io/gems/debase-ruby_core_source/0.10.15/0.10.16>, and it even removes old 1.9 cruft.