### PR TITLE
Fix missing fallback for Sinatra

### DIFF
--- a/lib/datadog/appsec/contrib/sinatra/patcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/patcher.rb
@@ -74,6 +74,12 @@ module Datadog
         # merged with normal params, so we get both
         module RoutePatch
           def process_route(*)
+            env = @request.env
+
+            context = env['datadog.waf.context']
+
+            return super unless context
+
             # process_route is called repeatedly until a route is found.
             # Until then, params has no route params.
             # Capture normal params.


### PR DESCRIPTION
This case happens if AppSec fails to initialise properly, e.g due to making the ruleset setting point to a nonexistent file.

Caught by system tests, this allows the corresponding system test case to be enabled.