### PR TITLE
Fix gem badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Datadog Trace Client
 
-![Gem](https://img.shields.io/gem/v/ddtrace)
+[![Gem](https://img.shields.io/gem/v/ddtrace)](https://rubygems.org/gems/ddtrace/)
 [![CircleCI](https://circleci.com/gh/DataDog/dd-trace-rb/tree/master.svg?style=svg&circle-token=b0bd5ef866ec7f7b018f48731bb495f2d1372cc1)](https://circleci.com/gh/DataDog/dd-trace-rb/tree/master)
 [![codecov](https://codecov.io/gh/DataDog/dd-trace-rb/branch/master/graph/badge.svg)](https://app.codecov.io/gh/DataDog/dd-trace-rb/branch/master)
 [![YARD documentation](https://img.shields.io/badge/YARD-documentation-blue)](https://www.rubydoc.info/gems/ddtrace/)


### PR DESCRIPTION
Hyperlink it to https://rubygems.org/gems/ddtrace/