### PR TITLE
Fix processor spec segfault

### DIFF
--- a/spec/datadog/appsec/processor_spec.rb
+++ b/spec/datadog/appsec/processor_spec.rb
@@ -246,7 +246,8 @@ RSpec.describe Datadog::AppSec::Processor do
 
     let(:input) { input_scanner }
 
-    subject(:context) { described_class.new.new_context }
+    let(:processor) { described_class.new }
+    subject(:context) { processor.new_context }
 
     it { is_expected.to be_a Datadog::AppSec::Processor::Context }
 


### PR DESCRIPTION
Processor being unreferenced means it can be garbage collected, which leads to the WAF handle being reaped while it is still needed.

This does not affect code in `lib` which properly retains `Processor` beyond `Context` lifespan.

See https://github.com/DataDog/libddwaf/issues/76