### PR TITLE
Fix:SpanFilter with unordered spans

### DIFF
--- a/lib/datadog/tracing/pipeline/span_filter.rb
+++ b/lib/datadog/tracing/pipeline/span_filter.rb
@@ -1,14 +1,17 @@
 # typed: true
 
-require 'set'
 require 'datadog/tracing/pipeline/span_processor'
 
 module Datadog
   module Tracing
     module Pipeline
-      # SpanFilter implements a processor that filters entire span subtrees
+      # SpanFilter implements a processor that filters entire span subtrees.
       # This processor executes the configured `operation` for each {Datadog::Tracing::Span}
       # in a {Datadog::Tracing::TraceSegment}.
+      #
+      # When a span is filtered out, all its children spans are also removed from the trace.
+      # This is required to avoid having orphan spans that do not connect to other spans
+      # in the trace.
       #
       # If `operation` returns a truthy value for a span, that span is kept,
       # otherwise the span is removed from the trace.
@@ -20,12 +23,27 @@ module Datadog
         # parent spans, then the code below will need to be updated.
         # @!visibility private
         def call(trace)
-          deleted = Set.new
+          spans = trace.spans
+          spans.each do |span|
+            next unless drop_it?(span)
 
-          trace.spans.delete_if do |span|
-            should_delete = deleted.include?(span.parent_id) || drop_it?(span)
-            deleted << span.id if should_delete
-            should_delete
+            remove_children!(spans, span.id) # Modifies `spans`
+
+            # Because {#remove_children!} could have changed the indexes
+            # of `spans`, we can't simply remove `span` from its original place.
+            # This prevents us from using most of the element removal
+            # methods in the Array API.
+            #
+            # Instead, we have to find `span` again in `spans` and remove it.
+            #
+            # We use `delete_at` instead of `delete` as `delete` will
+            # scan the whole array looking for all object equality matches.
+            # We don't need to scan the whole array, only the first occurrence of
+            # `span` is enough. If there are multiple instances of `span` in the
+            # array, we'll eventually check it in this loop iteration, but that
+            # shouldn't be possible as such a trace with duplicate spans
+            # wouldn't be valid.
+            spans.delete_at(spans.index(span))
           end
 
           trace
@@ -35,6 +53,18 @@ module Datadog
 
         def drop_it?(span)
           @operation.call(span) rescue false
+        end
+
+        # Removes a span subtree, starting with spans
+        # that is a children of parent_span_id.
+        # This method modifies the provided Array of spans.
+        def remove_children!(spans, parent_span_id)
+          spans.each do |span|
+            if span.parent_id == parent_span_id
+              remove_children!(spans, span.id)
+              spans.delete_at(spans.index(span))
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #2038

This PR ensures all spans in a trace subtree are removed when a parent span is removed.

This wasn't the case today, as a parent parent finishes after its children, and thus is appended to the internal trace span array after its children.

Reversing the search order can help, but does not guarantee the complete removal.

This PR tries to use the most efficient APIs possible to iterate and manipulate spans array.