### PR TITLE
Reduce profiling log noise during test suite execution

### DIFF
--- a/spec/datadog/core/configuration_spec.rb
+++ b/spec/datadog/core/configuration_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe Datadog::Core::Configuration do
           # Enable
           test_class.configure do |c|
             c.diagnostics.debug = true
+            c.logger.instance = Datadog::Core::Logger.new(StringIO.new)
           end
 
           # Assert state change

--- a/spec/datadog/core/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/core/diagnostics/environment_logger_spec.rb
@@ -187,7 +187,12 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
       end
 
       context 'with debug enabled' do
-        before { Datadog.configure { |c| c.diagnostics.debug = true } }
+        before do
+          Datadog.configure do |c|
+            c.diagnostics.debug = true
+            c.logger.instance = Datadog::Core::Logger.new(StringIO.new)
+          end
+        end
 
         it { is_expected.to include debug: true }
       end

--- a/spec/datadog/profiling/integration_spec.rb
+++ b/spec/datadog/profiling/integration_spec.rb
@@ -127,6 +127,8 @@ RSpec.describe 'profiling integration test' do
 
     context 'with tracing' do
       around do |example|
+        Datadog.configuration.diagnostics.startup_logs.enabled = false
+
         Datadog::Tracing.trace('profiler.test') do |span, trace|
           @current_span = span
           @current_root_span = trace.send(:root_span)

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -1,26 +1,9 @@
 # typed: false
 
-require 'datadog/profiling/native_extension'
+require 'datadog/profiling/spec_helper'
 
 RSpec.describe Datadog::Profiling::NativeExtension do
-  before do
-    skip 'Profiling is not supported on JRuby' if PlatformHelpers.jruby?
-    skip 'Profiling is not supported on TruffleRuby' if PlatformHelpers.truffleruby?
-
-    begin
-      require "ddtrace_profiling_native_extension.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
-    rescue LoadError
-      if PlatformHelpers.mac?
-        skip 'Skipping profiling native extension specs: extension does not seem' \
-          'to be available. (Note that on macOS the extension can only be built if ' \
-          'libddprof is also manually rebuilt from source, since there are no ' \
-          'precompiled macOS binaries for libddprof).'
-      else
-        raise 'Profiling native extension does not seem to be compiled. ' \
-          'Try running `bundle exec rake compile` before running this test.'
-      end
-    end
-  end
+  before { skip_if_profiling_not_supported(self) }
 
   describe '.working?' do
     subject(:working?) { described_class.send(:working?) }

--- a/spec/support/log_helpers.rb
+++ b/spec/support/log_helpers.rb
@@ -65,7 +65,10 @@ module LogHelpers
     end
 
     after do
-      Datadog.configure { |c| c.logger.instance = @default_logger }
+      Datadog.configure do |c|
+        c.logger.instance = @default_logger
+        c.diagnostics.debug = false
+      end
     end
 
     # Checks buffer to see if it contains lines that match all patterns.


### PR DESCRIPTION
I really dislike extra noise during RSpec runs, so here's a bunch of tiny fixes to prevent profiling-related logs that had escaped my earlier attempts :)