### PR TITLE
Handle VM interruptions during `StackRecorder` serialization instead of failing

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -15,14 +15,14 @@
 static VALUE missing_string = Qnil;
 
 // Used as scratch space during sampling
-typedef struct sampling_buffer {
+struct sampling_buffer {
   unsigned int max_frames;
   VALUE *stack_buffer;
   int *lines_buffer;
   bool *is_ruby_frame;
   ddprof_ffi_Location *locations;
   ddprof_ffi_Line *lines;
-} sampling_buffer;
+}; // Note: typedef'd in the header to sampling_buffer
 
 static VALUE _native_sample(VALUE self, VALUE thread, VALUE recorder_instance, VALUE metric_values_hash, VALUE labels_array, VALUE max_frames);
 static void maybe_add_placeholder_frames_omitted(VALUE thread, sampling_buffer* buffer, char *frames_omitted_message, int frames_omitted_message_size);

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.h
@@ -3,7 +3,7 @@
 #include <ruby.h>
 
 // Processes any pending interruptions, including exceptions to be raised.
-// If there's an exception to be raised, it raises it.
+// If there's an exception to be raised, it raises it. In that case, this function does not return.
 static inline VALUE process_pending_interruptions(VALUE _unused) {
   rb_thread_check_ints();
   return Qnil;


### PR DESCRIPTION
After fixing the VM interruptions issue for `HttpTransport` in 4cd898e829d34f994973452e4503a88d37b4f99c (#1923), I suspected that the same issue could happen to the `StackRecorder`.

It took a few attempts to reproduce this issue, but the easiest way seems to be to "send ctrl+c to itself" by adding

```c
  #include <signal.h>

  kill(getpid(), SIGINT);
```

before the call to `rb_thread_call_without_gvl2`.

This made the VM flag an interrupt, which as long as no exception was raised (and RSpec has its own interrupt handler) simulated the issue.

TL;DR `rb_thread_call_without_gvl2` can return BEFORE running our code when the VM has a pending interruption, so we need to let the VM do its work, but there's no reason to fail the action (in this case, fail to serialize) if all the VM wants is to run some callback and then we can get on with our work.

So instead we retry running our code until it either runs or the VM actually raises an exception.

The approach here is simpler than in `HttpTransport` because the heap allocations happen only inside `call_serialize_without_gvl`; in `HttpTransport` there are heap allocations done before calling  `rb_thread_call_without_gvl2` and thus a more complex approach is needed.