### PR TITLE
Link to DevelopmentGuide.md from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ We welcome code contributions to the library, which you can [submit as a pull re
 
 1. **Fork the repository** from https://github.com/DataDog/dd-trace-rb
 2. **Make any changes** for your patch.
-3. **Write tests** that demonstrate how the feature works or how the bug is fixed.
+3. **Write tests** that demonstrate how the feature works or how the bug is fixed. See the [DevelopmentGuide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md) for detailed test instructions.
 4. **Update any documentation** such as `docs/GettingStarted.md`, especially for new features.
 5. **Submit the pull request** from your fork back to the latest revision of the `master` branch on https://github.com/DataDog/dd-trace-rb.
 


### PR DESCRIPTION
We currently have a developer guide file in a standard location (`CONTRIBUTING.md`), but have valuable developer information in `docs/DevelopmentGuide.md`.

This PR links to `docs/DevelopmentGuide.md` from `CONTRIBUTING.md`, in order to make it discoverable.

Overall, I think we might want to refactor these documentations, but I'm not 100% sure what that looks like, so I'm proposing this small improvement for now.

Thanks to @seuros for bringing this to our attention.