### PR TITLE
Actions: Create draft release on release branch push

### DIFF
--- a/.github/workflows/draft-release-on-release-branch-push.yaml
+++ b/.github/workflows/draft-release-on-release-branch-push.yaml
@@ -1,0 +1,94 @@
+name: Draft release on release branch push
+on:
+  create
+
+jobs:
+  draft_release_notes:
+    if: github.event.ref_type == 'branch' && startsWith('${{ github.event.ref }}', 'bump_to_version_')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get release version
+        id: releaseVersion
+        uses: actions/github-script@7a5c598405937d486b0331594b5da2b14db670da # 6.1.0
+        with:
+          result-encoding: string
+          script: |
+            return '${{ github.event.ref }}'.substring('bump_to_version_'.length);
+      - name: Get milestone for version
+        id: milestone
+        uses: actions/github-script@7a5c598405937d486b0331594b5da2b14db670da # 6.1.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const milestones = await github.paginate(github.rest.issues.listMilestones, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all'
+            })
+
+            const milestone = milestones.find(milestone => milestone.title == '${{steps.releaseVersion.outputs.result}}')
+
+            if (milestone) {
+              return milestone.number
+            } else {
+              return null
+            }
+      - name: Generate release notes
+        if: fromJSON(steps.milestone.outputs.result)
+        id: generate
+        uses: actions/github-script@7a5c598405937d486b0331594b5da2b14db670da # 6.1.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script: |
+            const pullRequests = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              base: 'master'
+            })
+
+            var draftText = "> Please categorize the following changes:\n\n"
+            for (let pull of pullRequests) {
+              if (pull.merged_at && pull.milestone && pull.milestone.number == ${{steps.milestone.outputs.result}}) {
+                // Skip PR with only `dev/*` labels, as these represent internal changes
+                if (pull.labels.length > 0 && pull.labels.every(label => label.name.startsWith("dev/"))) {
+                  continue
+                }
+
+                // Add labels to description, to ease categorization
+                var lineItem = "* "
+                for (let label of pull.labels) {
+                  lineItem += label.name.charAt(0).toUpperCase() + label.name.slice(1) + ": "
+                }
+
+                lineItem += pull.title + " (#" + pull.number + ")"
+
+                // Add author if labeled as 'community'
+                if (pull.labels.some(label => label.name == "community")) {
+                  lineItem += " (@" + pull.user.login + ")"
+                }
+
+                draftText += lineItem + "\n"
+              }
+            }
+            draftText += "\n### Added\n\n### Changed\n\n### Fixed\n\n### Removed\n\n"
+
+            // Escape backticks
+            draftText = draftText.replace(/`/g,"\\`")
+
+            return draftText
+      - name: Create draft release
+        if: fromJSON(steps.milestone.outputs.result)
+        uses: actions/github-script@7a5c598405937d486b0331594b5da2b14db670da # 6.1.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: 'v${{ steps.releaseVersion.outputs.result }}',
+              name: '${{ steps.releaseVersion.outputs.result }}',
+              draft: true,
+              body: `${{ steps.generate.outputs.result }}`
+            })


### PR DESCRIPTION
Whenever we start a release, we push a branch called `bump_to_version_x.y.z`, where `x.y.z` is the full version version we intend on releasing. Here's an example for [1.1.0](https://github.com/DataDog/dd-trace-rb/pull/2046) (branch is already deleted).

This PR creates a draft GitHub release in the [Releases section](https://github.com/DataDog/dd-trace-rb/releases) of `dd-trace-rb` containing a draft Changelog with from all the closed PRs for the milestone matching the branch name (Milestone named `x.y.z` in this example).

This Changelog still needs to be curated, but it's very helpful as a starting point. It can be also used to fill out the `Changelog.md` entry for the release at hand.

I've actually used this GH Action in the last release, https://github.com/DataDog/dd-trace-rb/releases/tag/v1.1.0, as you can see the release was not created by me but by the GH bot: 
<img width="186" alt="Screen Shot 2022-05-26 at 3 28 38 PM" src="https://user-images.githubusercontent.com/583503/170589951-90fcb3c2-3ce7-4f5e-a9ff-e01d9915c0d7.png">

There are many improvements we can make, but I'd like to share it now as it is functionally complete and can already save us time during releases.