### PR TITLE
[Single Span Sampling] Add single span matcher

### DIFF
--- a/lib/datadog/tracing/sampling/rate_sampler.rb
+++ b/lib/datadog/tracing/sampling/rate_sampler.rb
@@ -37,11 +37,11 @@ module Datadog
 
         def sample_rate=(sample_rate)
           @sample_rate = sample_rate
-          @sampling_id_threshold = sample_rate * Span::EXTERNAL_MAX_ID
+          @sampling_id_threshold = sample_rate * Tracing::Span::EXTERNAL_MAX_ID
         end
 
         def sample?(trace)
-          ((trace.id * KNUTH_FACTOR) % Span::EXTERNAL_MAX_ID) <= @sampling_id_threshold
+          ((trace.id * KNUTH_FACTOR) % Tracing::Span::EXTERNAL_MAX_ID) <= @sampling_id_threshold
         end
 
         def sample!(trace)

--- a/lib/datadog/tracing/sampling/span/matcher.rb
+++ b/lib/datadog/tracing/sampling/span/matcher.rb
@@ -69,7 +69,7 @@ module Datadog
             pattern.gsub!('\*', '.*') # Any substring
 
             # Patterns have to match the whole input string
-            pattern = "\\A#{pattern}\\Z"
+            pattern = "\\A#{pattern}\\z"
 
             Regexp.new(pattern)
           end

--- a/lib/datadog/tracing/sampling/span/matcher.rb
+++ b/lib/datadog/tracing/sampling/span/matcher.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Tracing
+    module Sampling
+      module Span
+        # Checks if a span conforms to a matching criteria.
+        class Matcher
+          # Pattern that matches any string
+          MATCH_ALL_PATTERN = '*'
+
+          # Matches span name and service to their respective patterns provided.
+          #
+          # The patterns are {String}s with two special characters available:
+          # 1. `?`: matches exactly one of any character.
+          # 2. `*`: matches a substring of any size, including zero.
+          # These patterns can occur any point of the string, any number of times.
+          #
+          # Both {SpanOperation#name} and {SpanOperation#service} must match the provided patterns.
+          #
+          # The whole String has to match the provided patterns: providing a pattern that
+          # matches a portion of the provided String is not considered a match.
+          #
+          # @example web-*
+          #   `'web-*'` will match any string starting with `web-`.
+          # @example cache-?
+          #   `'cache-?'` will match any string starting with `database-` followed by exactly one character.
+          #
+          # @param name_pattern [String] a pattern to be matched against {SpanOperation#name}
+          # @param service_pattern [String] a pattern to be matched against {SpanOperation#service}
+          def initialize(name_pattern: MATCH_ALL_PATTERN, service_pattern: MATCH_ALL_PATTERN)
+            @name = pattern_to_regex(name_pattern)
+            @service = pattern_to_regex(service_pattern)
+          end
+
+          # {Regexp#match?} was added in Ruby 2.4, and it's measurably
+          # the least costly way to get a boolean result for a Regexp match.
+          # @see https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/
+          if Regexp.method_defined?(:match?)
+            # Returns `true` if the span conforms to the configured patterns,
+            # `false` otherwise
+            #
+            # @param [SpanOperation] span
+            # @return [Boolean]
+            def match?(span)
+              # Matching is performed at the end of the lifecycle of a Span,
+              # thus both `name` and `service` are guaranteed to be not `nil`.
+              @name.match?(span.name) && @service.match?(span.service)
+            end
+          else
+            # DEV: Remove when support for Ruby 2.3 and older is removed.
+            def match?(span)
+              @name === span.name && @service === span.service
+            end
+          end
+
+          private
+
+          # @param pattern [String]
+          # @return [Regexp]
+          def pattern_to_regex(pattern)
+            # Ensure no undesired characters are treated as regex.
+            # Our valid special characters, `?` and `*`,
+            # will be escaped so...
+            pattern = Regexp.quote(pattern)
+
+            # ...we account for that here:
+            pattern.gsub!('\?', '.') # Any single character
+            pattern.gsub!('\*', '.*') # Any substring
+
+            # Patterns have to match the whole input string
+            pattern = "\\A#{pattern}\\Z"
+
+            Regexp.new(pattern)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/sampling/span/matcher_spec.rb
+++ b/spec/datadog/tracing/sampling/span/matcher_spec.rb
@@ -91,10 +91,6 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Matcher do
 
     context 'matching on span name and service' do
       let(:matcher) { described_class.new(name_pattern: name_pattern, service_pattern: service_pattern) }
-      let(:span_name) { input }
-      let(:span_service) { input }
-      let(:name_pattern) { input }
-      let(:service_pattern) { input }
 
       context 'when only name matches' do
         let(:span_name) { 'web.get' }

--- a/spec/datadog/tracing/sampling/span/matcher_spec.rb
+++ b/spec/datadog/tracing/sampling/span/matcher_spec.rb
@@ -53,7 +53,11 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Matcher do
       ]
     }.each do |scenario, fixtures|
       context "for '#{scenario}'" do
-        fixtures.each do |pattern:, input:, expected:|
+        fixtures.each do |fixture|
+          pattern = fixture[:pattern]
+          input = fixture[:input]
+          expected = fixture[:expected]
+
           context "with pattern '#{pattern}' and input '#{input}'" do
             context 'matching on span name' do
               let(:matcher) { described_class.new(name_pattern: pattern) }

--- a/spec/datadog/tracing/sampling/span/matcher_spec.rb
+++ b/spec/datadog/tracing/sampling/span/matcher_spec.rb
@@ -1,0 +1,122 @@
+require 'datadog/tracing/sampling/span/matcher'
+
+RSpec.describe Datadog::Tracing::Sampling::Span::Matcher do
+  let(:span_op) { Datadog::Tracing::SpanOperation.new(span_name, service: span_service) }
+  let(:span_name) { 'operation.name' }
+  let(:span_service) { '' }
+
+  describe '#match?' do
+    subject(:match?) { matcher.match?(span_op) }
+
+    {
+      'plain string pattern' => [
+        { pattern: 'web', input: 'web', expected: true },
+        { pattern: 'web one', input: 'web one', expected: true },
+        { pattern: 'web', input: 'my-web', expected: false },
+      ],
+      '* pattern' => [
+        { pattern: 'web*', input: 'web', expected: true },
+        { pattern: 'web*', input: 'web-one', expected: true },
+        { pattern: 'web*', input: 'pre-web', expected: false },
+        { pattern: '*web', input: 'pre-web', expected: true },
+        { pattern: '*web', input: 'web-post', expected: false },
+        { pattern: 'web*one', input: 'web-site-one', expected: true },
+        { pattern: 'web*one', input: 'webone', expected: true },
+        { pattern: 'web*site*one', input: 'web--site  one', expected: true },
+        { pattern: 'web*site*one', input: 'web-nice-one', expected: false },
+      ],
+      '? pattern' => [
+        { pattern: 'web?', input: 'web', expected: false },
+        { pattern: 'web?', input: 'web1', expected: true },
+        { pattern: 'web?', input: '1web', expected: false },
+        { pattern: '?web', input: '1web', expected: true },
+        { pattern: '?web', input: 'web1', expected: false },
+        { pattern: 'web?one', input: 'web-one', expected: true },
+        { pattern: 'web?one', input: 'webone', expected: false },
+        { pattern: 'web?one', input: 'web-site-one', expected: false },
+        { pattern: 'web?site?one', input: 'web-site-one', expected: true },
+        { pattern: 'web?site?one', input: 'web-nice-one', expected: false },
+      ],
+      'mixed * and ? pattern' => [
+        { pattern: '*web?', input: 'pre-web1', expected: true },
+        { pattern: '*web?', input: 'web', expected: false },
+        { pattern: '?web*', input: '1web-post', expected: true },
+        { pattern: '?web*', input: 'web', expected: false },
+        { pattern: 'web?one*', input: 'web-one-post', expected: true },
+        { pattern: 'web?one*', input: 'webone', expected: false },
+        { pattern: 'web*one?', input: 'web-one1', expected: true },
+        { pattern: 'web*one?', input: 'webne1', expected: false },
+        { pattern: 'web*site?one', input: 'web--site one', expected: true },
+        { pattern: 'web*site?one', input: 'web--siteone', expected: false },
+        { pattern: 'web?site*one', input: 'web-site  one', expected: true },
+        { pattern: 'web?site*one', input: 'web-sitene', expected: false },
+      ]
+    }.each do |scenario, fixtures|
+      context "for '#{scenario}'" do
+        fixtures.each do |pattern:, input:, expected:|
+          context "with pattern '#{pattern}' and input '#{input}'" do
+            context 'matching on span name' do
+              let(:matcher) { described_class.new(name_pattern: pattern) }
+              let(:span_name) { input }
+
+              it "does #{'not ' unless expected}match" do
+                is_expected.to eq(expected)
+              end
+            end
+
+            context 'matching on span service' do
+              let(:matcher) { described_class.new(service_pattern: pattern) }
+              let(:span_service) { input }
+
+              it "does #{'not ' unless expected}match" do
+                is_expected.to eq(expected)
+              end
+            end
+
+            context 'matching on span name and service' do
+              context 'with the same matching scenario for both fields' do
+                let(:matcher) { described_class.new(name_pattern: pattern, service_pattern: pattern) }
+                let(:span_name) { input }
+                let(:span_service) { input }
+
+                it "does #{'not ' unless expected}match" do
+                  is_expected.to eq(expected)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'matching on span name and service' do
+      let(:matcher) { described_class.new(name_pattern: name_pattern, service_pattern: service_pattern) }
+      let(:span_name) { input }
+      let(:span_service) { input }
+      let(:name_pattern) { input }
+      let(:service_pattern) { input }
+
+      context 'when only name matches' do
+        let(:span_name) { 'web.get' }
+        let(:span_service) { 'server' }
+        let(:name_pattern) { 'web.*' }
+        let(:service_pattern) { 'server2' }
+
+        context 'does not match' do
+          it { is_expected.to eq(false) }
+        end
+      end
+
+      context 'when only service matches' do
+        let(:span_name) { 'web.get' }
+        let(:span_service) { 'server' }
+        let(:name_pattern) { 'web.post' }
+        let(:service_pattern) { 'server' }
+
+        context 'does not match' do
+          it { is_expected.to eq(false) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the first class that will support work to allow users to set sampling decisions on individual spans.

These single span sampling decisions can override the trace level sampling decision when the trace level decision is to drop the trace. This allows users to keep important spans, especially the ones used to calculate business metrics or perform aggregated reports in their Datadog App.

The specific mechanisms for how flushing and tagging work will be implemented later. This PR only creates a pattern matcher.

This matcher processes a simple matching language and matches the provided patterns with a SpanOperation.