### PR TITLE
Fix docs link not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For contributing, checkout the [contribution guidelines][contribution docs] and 
 
 [setup docs]: https://docs.datadoghq.com/tracing/setup/ruby/
 [api docs]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md
-[gem docs]: http://gems.datadoghq.com/trace/docs/
+[gem docs]: https://s3.amazonaws.com/gems.datadoghq.com/trace/docs/index.html
 [visualization docs]: https://docs.datadoghq.com/tracing/visualization/
 [contribution docs]: https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md
 [development docs]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md


### PR DESCRIPTION
The old `http://gems.datadoghq.com/trace/docs/` link does not seem to load for me on firefox nor chrome. I can see it with curl though...

I suspect this may be related to modern browsers trying to get to an https version of the site, which doesn't work.

Instead, I've replaced the link with one that works over https and seems to be working fine. In the future if/when we fix https support for `gems.datadoghq.com` directly we can go back to the old url :)

Fixes #2057