### PR TITLE
Replace `libddprof` dependency with `libdatadog`, and upgrade to 0.7.0

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -64,8 +64,8 @@ Gem::Specification.new do |spec|
   # Used by appsec
   spec.add_dependency 'libddwaf', '~> 1.3.0.2.0'
 
-  # Used by profiling
-  spec.add_dependency 'libddprof', '~> 0.6.0.1.0'
+  # Used by profiling (and possibly others in the future)
+  spec.add_dependency 'libdatadog', '~> 0.7.0.1.0.rc1'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb', 'ext/ddtrace_profiling_loader/extconf.rb']
 end

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'libddwaf', '~> 1.3.0.2.0'
 
   # Used by profiling (and possibly others in the future)
-  spec.add_dependency 'libdatadog', '~> 0.7.0.1.0.rc1'
+  spec.add_dependency 'libdatadog', '~> 0.7.0.1.0'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb', 'ext/ddtrace_profiling_loader/extconf.rb']
 end

--- a/ext/ddtrace_profiling_loader/ddtrace_profiling_loader.c
+++ b/ext/ddtrace_profiling_loader/ddtrace_profiling_loader.c
@@ -20,7 +20,7 @@
 // This idea was shamelessly stolen from @lloeki's work in https://github.com/rubyjs/mini_racer/pull/179, big thanks!
 //
 // Extra note: Currently (May 2022), that we know of, the profiling native extension only exposes one potentially
-// problematic symbol: `rust_eh_personality` (coming from libddprof/libdatadog).
+// problematic symbol: `rust_eh_personality` (coming from libdatadog).
 // Future versions of Rust have been patched not to expose this
 // (see https://github.com/rust-lang/rust/pull/95604#issuecomment-1108563434) so we may want to revisit the need
 // for this loader in the future, and perhaps delete it if we no longer require its services :)

--- a/ext/ddtrace_profiling_native_extension/NativeExtensionDesign.md
+++ b/ext/ddtrace_profiling_native_extension/NativeExtensionDesign.md
@@ -2,7 +2,7 @@
 
 The profiling native extension is used to:
 1. Implement features which are expensive (in terms of resources) or otherwise impossible to implement using Ruby code.
-2. Bridge between Ruby-specific profiling features and [`libddprof`](https://github.com/DataDog/libddprof), a Rust-based
+2. Bridge between Ruby-specific profiling features and [`libdatadog`](https://github.com/DataDog/libdatadog), a Rust-based
 library with common profiling functionality.
 
 Due to (1), this extension is quite coupled with MRI Ruby ("C Ruby") internals, and is not intended to support other rubies such as

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -138,8 +138,8 @@ end
 # In Ruby 2.1, living_threads were stored in a hashmap (st)
 $defs << '-DUSE_LEGACY_LIVING_THREADS_ST' if RUBY_VERSION < '2.2'
 
-# If we got here, libddprof is available and loaded
-ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libddprof.pkgconfig_folder}"
+# If we got here, libdatadog is available and loaded
+ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libdatadog.pkgconfig_folder}"
 Logging.message(" [ddtrace] PKG_CONFIG_PATH set to #{ENV['PKG_CONFIG_PATH'].inspect}\n")
 
 unless pkg_config('ddprof_ffi_with_rpath')
@@ -148,17 +148,17 @@ unless pkg_config('ddprof_ffi_with_rpath')
       Datadog::Profiling::NativeExtensionHelpers::Supported::PKG_CONFIG_IS_MISSING
     else
       # Less specific error message
-      Datadog::Profiling::NativeExtensionHelpers::Supported::FAILED_TO_CONFIGURE_LIBDDPROF
+      Datadog::Profiling::NativeExtensionHelpers::Supported::FAILED_TO_CONFIGURE_LIBDATADOG
     end
   )
 end
 
-# See comments on the helper method being used for why we need to additionally set this
+# See comments on the helper method being used for why we need to additionally set this.
 # The extremely excessive escaping around ORIGIN below seems to be correct and was determined after a lot of
 # experimentation. We need to get these special characters across a lot of tools untouched...
 $LDFLAGS += \
   ' -Wl,-rpath,$$$\\\\{ORIGIN\\}/' \
-  "#{Datadog::Profiling::NativeExtensionHelpers.libddprof_folder_relative_to_native_lib_folder}"
+  "#{Datadog::Profiling::NativeExtensionHelpers.libdatadog_folder_relative_to_native_lib_folder}"
 Logging.message(" [ddtrace] After pkg-config $LDFLAGS were set to: #{$LDFLAGS.inspect}\n")
 
 # Tag the native extension library with the Ruby version and Ruby platform.

--- a/ext/ddtrace_profiling_native_extension/http_transport.c
+++ b/ext/ddtrace_profiling_native_extension/http_transport.c
@@ -229,39 +229,31 @@ static VALUE perform_export(
 
   while (!args.send_ran && !pending_exception) {
     rb_thread_call_without_gvl2(call_exporter_without_gvl, &args, interrupt_exporter_call, cancel_token);
+
+    // To make sure we don't leak memory, we never check for pending exceptions if send ran
     if (!args.send_ran) pending_exception = check_if_pending_exception();
   }
 
-  VALUE ruby_status;
-  VALUE ruby_result;
+  // Cleanup exporter and token, no longer needed
+  ddprof_ffi_CancellationToken_drop(cancel_token);
+  ddprof_ffi_NewProfileExporterV3Result_drop(valid_exporter_result);
 
   if (pending_exception) {
-    // We're in a weird situation that libddprof doesn't quite support. The ddprof_ffi_Request payload is dynamically
-    // allocated and needs to be freed, but libddprof doesn't have an API for dropping a request.
-    //
-    // There's plans to add a `ddprof_ffi_Request_drop`
-    // (https://github.com/DataDog/dd-trace-rb/pull/1923#discussion_r882096221); once that happens, we can use it here.
-    //
-    // As a workaround, we get libddprof to clean up the request by asking for the send to be cancelled, and then calling
-    // it anyway. This will make libddprof free the request and return immediately which gets us the expected effect.
-    interrupt_exporter_call((void *) cancel_token);
-    call_exporter_without_gvl((void *) &args);
+    // If we got here send did not run, so we need to explicitly dispose of the request
+    ddprof_ffi_Request_drop(request);
+
+    // Let Ruby propagate the exception. This will not return.
+    rb_jump_tag(pending_exception);
   }
 
   ddprof_ffi_SendResult result = args.result;
   bool success = result.tag == DDPROF_FFI_SEND_RESULT_HTTP_RESPONSE;
 
-  ruby_status = success ? ok_symbol : error_symbol;
-  ruby_result = success ? UINT2NUM(result.http_response.code) : ruby_string_from_vec_u8(result.err);
+  VALUE ruby_status = success ? ok_symbol : error_symbol;
+  VALUE ruby_result = success ? UINT2NUM(result.http_response.code) : ruby_string_from_vec_u8(result.err);
 
-  // Clean up all dynamically-allocated things
   ddprof_ffi_SendResult_drop(args.result);
-  ddprof_ffi_CancellationToken_drop(cancel_token);
-  ddprof_ffi_NewProfileExporterV3Result_drop(valid_exporter_result);
-  // The request itself does not need to be freed as libddprof takes care of it.
-
-  // We've cleaned up everything, so if there's an exception to be raised, let's have it
-  if (pending_exception) rb_jump_tag(pending_exception);
+  // The request itself does not need to be freed as libddprof takes care of it as part of sending.
 
   return rb_ary_new_from_args(2, ruby_status, ruby_result);
 }

--- a/ext/ddtrace_profiling_native_extension/http_transport.c
+++ b/ext/ddtrace_profiling_native_extension/http_transport.c
@@ -252,7 +252,7 @@ static VALUE perform_export(
   bool success = result.tag == DDPROF_FFI_SEND_RESULT_HTTP_RESPONSE;
 
   ruby_status = success ? ok_symbol : error_symbol;
-  ruby_result = success ? UINT2NUM(result.http_response.code) : ruby_string_from_vec_u8(result.failure);
+  ruby_result = success ? UINT2NUM(result.http_response.code) : ruby_string_from_vec_u8(result.err);
 
   // Clean up all dynamically-allocated things
   ddprof_ffi_SendResult_drop(args.result);

--- a/ext/ddtrace_profiling_native_extension/http_transport.c
+++ b/ext/ddtrace_profiling_native_extension/http_transport.c
@@ -166,7 +166,7 @@ static ddprof_ffi_Vec_tag convert_tags(VALUE tags_as_array) {
       VALUE err_details = ruby_string_from_vec_u8(push_result.err);
       ddprof_ffi_PushTagResult_drop(push_result);
 
-      // libddprof validates tags and may catch invalid tags that ddtrace didn't actually catch.
+      // libdatadog validates tags and may catch invalid tags that ddtrace didn't actually catch.
       // We warn users about such tags, and then just ignore them.
       safely_log_failure_to_process_tag(tags, err_details);
     } else {
@@ -193,7 +193,7 @@ static void safely_log_failure_to_process_tag(ddprof_ffi_Vec_tag tags, VALUE err
   }
 }
 
-// Note: This function handles a bunch of libddprof dynamically-allocated objects, so it MUST not use any Ruby APIs
+// Note: This function handles a bunch of libdatadog dynamically-allocated objects, so it MUST not use any Ruby APIs
 // which can raise exceptions, otherwise the objects will be leaked.
 static VALUE perform_export(
   ddprof_ffi_NewProfileExporterV3Result valid_exporter_result, // Must be called with a valid exporter result
@@ -253,7 +253,7 @@ static VALUE perform_export(
   VALUE ruby_result = success ? UINT2NUM(result.http_response.code) : ruby_string_from_vec_u8(result.err);
 
   ddprof_ffi_SendResult_drop(args.result);
-  // The request itself does not need to be freed as libddprof takes care of it as part of sending.
+  // The request itself does not need to be freed as libdatadog takes care of it as part of sending.
 
   return rb_ary_new_from_args(2, ruby_status, ruby_result);
 }

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -31,9 +31,9 @@ void stack_recorder_init(VALUE profiling_module) {
 
   // Instances of the StackRecorder class are "TypedData" objects.
   // "TypedData" objects are special objects in the Ruby VM that can wrap C structs.
-  // In our case, we're going to keep a libddprof profile reference inside our object.
+  // In our case, we're going to keep a libdatadog profile reference inside our object.
   //
-  // Because Ruby doesn't know how to initialize libddprof profiles, we MUST override the allocation function for objects
+  // Because Ruby doesn't know how to initialize libdatadog profiles, we MUST override the allocation function for objects
   // of this class so that we can manage this part. Not overriding or disabling the allocation function is a common
   // gotcha for "TypedData" objects that can very easily lead to VM crashes, see for instance
   // https://bugs.ruby-lang.org/issues/18007 for a discussion around this.
@@ -105,7 +105,7 @@ static VALUE _native_serialize(VALUE self, VALUE recorder_instance) {
   ddprof_ffi_Timespec ddprof_start = serialized_profile.ok.start;
   ddprof_ffi_Timespec ddprof_finish = serialized_profile.ok.end;
 
-  // Clean up libddprof object to avoid leaking in case ruby_time_from raises an exception
+  // Clean up libdatadog object to avoid leaking in case ruby_time_from raises an exception
   ddprof_ffi_SerializeResult_drop(serialized_profile);
 
   VALUE start = ruby_time_from(ddprof_start);

--- a/lib/datadog/profiling/http_transport.rb
+++ b/lib/datadog/profiling/http_transport.rb
@@ -28,7 +28,7 @@ module Datadog
           upload_timeout_milliseconds: @upload_timeout_milliseconds,
 
           # why "timespec"?
-          # libddprof represents time using POSIX's struct timespec, see
+          # libdatadog represents time using POSIX's struct timespec, see
           # https://www.gnu.org/software/libc/manual/html_node/Time-Types.html
           # aka it represents the seconds part separate from the nanoseconds part
           start_timespec_seconds: flush.start.tv_sec,

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -12,8 +12,8 @@ require 'socket'
 # between the Ruby code and the native methods, and thus in this class we have a bunch of tests to make sure the
 # native methods are invoked correctly.
 #
-# We also have "integration" specs, where we exercise the Ruby code together with the C code and libddprof to ensure
-# that things come out of libddprof as we expected.
+# We also have "integration" specs, where we exercise the Ruby code together with the C code and libdatadog to ensure
+# that things come out of libdatadog as we expected.
 RSpec.describe Datadog::Profiling::HttpTransport do
   before { skip_if_profiling_not_supported(self) }
 

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers do
 
         expect(relative_path).to start_with('../')
         expect(File.exist?(full_libdatadog_path))
-          .to be(true), "Libddprof not available in expected path: #{full_libdatadog_path.inspect}"
+          .to be(true), "Libdatadog not available in expected path: #{full_libdatadog_path.inspect}"
       end
     end
 

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -5,37 +5,37 @@ require 'ext/ddtrace_profiling_native_extension/native_extension_helpers'
 require 'datadog/profiling/spec_helper'
 
 RSpec.describe Datadog::Profiling::NativeExtensionHelpers do
-  describe '.libddprof_folder_relative_to_native_lib_folder' do
-    context 'when libddprof is available' do
+  describe '.libdatadog_folder_relative_to_native_lib_folder' do
+    context 'when libdatadog is available' do
       before do
         skip_if_profiling_not_supported(self)
-        if PlatformHelpers.mac? && Libddprof.pkgconfig_folder.nil? && ENV['LIBDDPROF_VENDOR_OVERRIDE'].nil?
-          raise 'You have a libddprof setup without macOS support. Did you forget to set LIBDDPROF_VENDOR_OVERRIDE?'
+        if PlatformHelpers.mac? && Libdatadog.pkgconfig_folder.nil? && ENV['LIBDATADOG_VENDOR_OVERRIDE'].nil?
+          raise 'You have a libdatadog setup without macOS support. Did you forget to set LIBDATADOG_VENDOR_OVERRIDE?'
         end
       end
 
-      it 'returns a relative path to libddprof folder from the gem lib folder' do
-        relative_path = described_class.libddprof_folder_relative_to_native_lib_folder
+      it 'returns a relative path to libdatadog folder from the gem lib folder' do
+        relative_path = described_class.libdatadog_folder_relative_to_native_lib_folder
 
         # RbConfig::CONFIG['SOEXT'] was only introduced in Ruby 2.5, so we have a fallback for older Rubies...
-        libddprof_extension =
+        libdatadog_extension =
           RbConfig::CONFIG['SOEXT'] ||
           ('so' if PlatformHelpers.linux?) ||
           ('dylib' if PlatformHelpers.mac?) ||
           raise('Missing SOEXT for current platform')
 
         gem_lib_folder = "#{Gem.loaded_specs['ddtrace'].gem_dir}/lib"
-        full_libddprof_path = "#{gem_lib_folder}/#{relative_path}/libddprof_ffi.#{libddprof_extension}"
+        full_libdatadog_path = "#{gem_lib_folder}/#{relative_path}/libddprof_ffi.#{libdatadog_extension}"
 
         expect(relative_path).to start_with('../')
-        expect(File.exist?(full_libddprof_path))
-          .to be(true), "Libddprof not available in expected path: #{full_libddprof_path.inspect}"
+        expect(File.exist?(full_libdatadog_path))
+          .to be(true), "Libddprof not available in expected path: #{full_libdatadog_path.inspect}"
       end
     end
 
-    context 'when libddprof is unsupported' do
+    context 'when libdatadog is unsupported' do
       it do
-        expect(described_class.libddprof_folder_relative_to_native_lib_folder(libddprof_pkgconfig_folder: nil)).to be nil
+        expect(described_class.libdatadog_folder_relative_to_native_lib_folder(libdatadog_pkgconfig_folder: nil)).to be nil
       end
     end
   end
@@ -119,18 +119,18 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
         end
 
         shared_examples 'mjit header validation' do
-          shared_examples 'libddprof usable' do
-            context 'when libddprof DOES NOT HAVE binaries for the current platform' do
+          shared_examples 'libdatadog usable' do
+            context 'when libdatadog DOES NOT HAVE binaries for the current platform' do
               before do
-                expect(Libddprof).to receive(:pkgconfig_folder).and_return(nil)
-                expect(Libddprof).to receive(:available_binaries).and_return(%w[fooarch-linux bararch-linux-musl])
+                expect(Libdatadog).to receive(:pkgconfig_folder).and_return(nil)
+                expect(Libdatadog).to receive(:available_binaries).and_return(%w[fooarch-linux bararch-linux-musl])
               end
 
               it { is_expected.to include 'platform variant' }
             end
 
-            context 'when libddprof HAS BINARIES for the current platform' do
-              before { expect(Libddprof).to receive(:pkgconfig_folder).and_return('/simulated/pkgconfig_folder') }
+            context 'when libdatadog HAS BINARIES for the current platform' do
+              before { expect(Libdatadog).to receive(:pkgconfig_folder).and_return('/simulated/pkgconfig_folder') }
 
               it('marks the native extension as supported') { is_expected.to be nil }
             end
@@ -139,7 +139,7 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
           context 'on a Ruby version where we CAN NOT use the MJIT header' do
             before { stub_const('Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER', false) }
 
-            include_examples 'libddprof usable'
+            include_examples 'libdatadog usable'
           end
 
           context 'on a Ruby version where we CAN use the MJIT header' do
@@ -154,7 +154,7 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
             context 'and DOES have MJIT support' do
               before { expect(RbConfig::CONFIG).to receive(:[]).with('MJIT_SUPPORT').and_return('yes') }
 
-              include_examples 'libddprof usable'
+              include_examples 'libdatadog usable'
             end
           end
         end

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -35,7 +35,7 @@ module ProfileHelpers
     testcase.skip('Profiling is not supported on JRuby') if PlatformHelpers.jruby?
     testcase.skip('Profiling is not supported on TruffleRuby') if PlatformHelpers.truffleruby?
 
-    # Profiling is not officially supported on macOS due to missing libddprof binaries,
+    # Profiling is not officially supported on macOS due to missing libdatadog binaries,
     # but it's still useful to allow it to be enabled for development.
     if PlatformHelpers.mac? && ENV['DD_PROFILING_MACOS_TESTING'] != 'true'
       testcase.skip(

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
   subject(:stack_recorder) { described_class.new }
 
-  # NOTE: A lot of libddprof integration behaviors are tested in the Collectors::Stack specs, since we need actual
-  # samples in order to observe what comes out of libddprof
+  # NOTE: A lot of libdatadog integration behaviors are tested in the Collectors::Stack specs, since we need actual
+  # samples in order to observe what comes out of libdatadog
 
   describe '#serialize' do
     subject(:serialize) { stack_recorder.serialize }


### PR DESCRIPTION
The `libddprof` dependency has been renamed `libdatadog`.

This PR updates dd-trace-rb to use the new version, including a few API changes from the 0.6 to 0.7 release.

I'm marking this PR as a draft because the only `libdatadog` version right now is `0.7.0.1.0.rc1` and I want to avoid releasing a rc1 to customers. Once the final 0.7.0 release hits, we just need to change the `gemspec` and merge.