### PR TITLE
CI: Increase build and test jobs to medium+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -466,42 +466,52 @@ job_configuration:
     <<: *filters_all_branches_and_tags
     ruby_version: '2.1'
     image: ivoanjo/docker-library:ddtrace_rb_2_1_10
+    resource_class_to_use: medium+
   - &config-2_2
     <<: *filters_all_branches_and_tags
     ruby_version: '2.2'
     image: ivoanjo/docker-library:ddtrace_rb_2_2_10
+    resource_class_to_use: medium+
   - &config-2_3
     <<: *filters_all_branches_and_tags
     ruby_version: '2.3'
     image: ivoanjo/docker-library:ddtrace_rb_2_3_8
+    resource_class_to_use: medium+
   - &config-2_4
     <<: *filters_all_branches_and_tags
     ruby_version: '2.4'
     image: ivoanjo/docker-library:ddtrace_rb_2_4_10
+    resource_class_to_use: medium+
   - &config-2_5
     <<: *filters_all_branches_and_tags
     ruby_version: '2.5'
     image: ivoanjo/docker-library:ddtrace_rb_2_5_9
+    resource_class_to_use: medium+
   - &config-2_6
     <<: *filters_all_branches_and_tags
     ruby_version: '2.6'
     image: ivoanjo/docker-library:ddtrace_rb_2_6_7
+    resource_class_to_use: medium+
   - &config-2_7
     <<: *filters_all_branches_and_tags
     ruby_version: '2.7'
     image: ivoanjo/docker-library:ddtrace_rb_2_7_3
+    resource_class_to_use: medium+
   - &config-3_0
     <<: *filters_all_branches_and_tags
     ruby_version: '3.0'
     image: ivoanjo/docker-library:ddtrace_rb_3_0_3
+    resource_class_to_use: medium+
   - &config-3_1
     <<: *filters_all_branches_and_tags
     ruby_version: '3.1'
     image: ivoanjo/docker-library:ddtrace_rb_3_1_1
+    resource_class_to_use: medium+
   - &config-3_2
     <<: *filters_all_branches_and_tags
     ruby_version: '3.2'
     image: ivoanjo/docker-library:ddtrace_rb_3_2_0_preview1
+    resource_class_to_use: medium+
     # ADD NEW RUBIES HERE
   - &config-jruby-9_2_8_0 # Test with older 9.2 release because 9.2.9.0 changed behavior, see https://github.com/DataDog/dd-trace-rb/pull/1409
     <<: *filters_all_branches_and_tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,6 +407,7 @@ jobs:
       - environment:
           *container_base_environment
         image: ivoanjo/docker-library:ddtrace_rb_2_5_9
+    resource_class: small
     steps:
       - checkout
       - run:
@@ -428,6 +429,7 @@ jobs:
       - environment:
           *container_base_environment
         image: ivoanjo/docker-library:ddtrace_rb_2_5_9
+    resource_class: small
     steps:
       - run:
           name: Check if this commit author has publishing credentials
@@ -497,6 +499,9 @@ job_configuration:
     ruby_version: '2.7'
     image: ivoanjo/docker-library:ddtrace_rb_2_7_3
     resource_class_to_use: medium+
+  - &config-2_7-small
+    <<: *config-2_7
+    resource_class_to_use: small
   - &config-3_0
     <<: *filters_all_branches_and_tags
     ruby_version: '3.0'
@@ -539,17 +544,17 @@ workflows:
   build-and-test:
     jobs:
       - orb/lint:
-          <<: *config-2_6
+          <<: *config-2_7-small
           name: lint
           requires:
-            - build-2.6
+            - build-2.7
       - orb/sorbet_type_checker:
-          <<: *config-2_6
+          <<: *config-2_7-small
           name: sorbet_type_checker
           requires:
-            - build-2.6
+            - build-2.7
       - orb/coverage:
-          <<: *config-2_7
+          <<: *config-2_7-small
           name: coverage
           requires:
             - test-2.1
@@ -569,7 +574,7 @@ workflows:
             - test-jruby-9.3-latest
             # soon™️ - test-truffleruby-21.0.0
       - orb/changelog:
-          <<: *config-2_7
+          <<: *config-2_7-small
           name: changelog
           requires:
             - build-2.7


### PR DESCRIPTION
We've seen an increased number of jobs failing with the text `Killed` in their job execution. One reason this happens is due to out of container memory.

We can see from our [CircleCI Insights report](https://app.circleci.com/insights/github/DataDog/dd-trace-rb/workflows/build-and-test/jobs?branch=master&reporting-window=last-90-days) that we did indeed hit the memory ceiling in some cases:

Job | Max RAM
-- | --
test-2.6 | 100%
build-3.2 | 99%
test-2.2 | 99%
build-3.1 | 92%
test-2.3 | 90%
test-3.0 | 90%
test-3.1 | 90%
test-2.7 | 88%
test-2.1 | 87%
test-2.5 | 87%
test-2.4 | 85%
test-jruby-9.2-latest | 68%
test-jruby-9.3-latest | 68%
test-jruby-9.2.8.0 | 66%

Performing a cursory look into our recent build failures, there are out of memory failures not captured in the table above (possibly if the container's memory usage spikes too fast, the metrics collection system might not have time to capture that 99% usage before it is killed).

All suspicious errors I found were in our `build` or `test` steps, affecting both new and old versions of Ruby.
JRuby is already running on a larger container, as seen by their maximum 68% Max RAM usage above.

This PR changes the executor for CRuby `build` or `test` from medium (4GiB RAM) to medium+ (6GiB RAM), now matching JRuby's.

I suspect the main reason for `build` failures is the increase in our gemsets, as we are constantly updating dependencies and adding new integrations that need their specific gem version installed.
We also added native code compilation for our own gem, but I suspect the memory usage for our own native code is still small, given our native footprint is small.

### Other things

I've also reduced a few short running jobs (e.g. linter, coverage collection) to use small containers. I don't see these using a large footprint. The main reason here is so that we are intentional and explicit with our container sizing.