### PR TITLE
Fix profiler not building on ruby-head (3.2) due to VM refactoring

### DIFF
--- a/ext/ddtrace_profiling_loader/ddtrace_profiling_loader.c
+++ b/ext/ddtrace_profiling_loader/ddtrace_profiling_loader.c
@@ -41,7 +41,7 @@ static void unload_failed_library(void *handle);
 
 #define DDTRACE_EXPORT __attribute__ ((visibility ("default")))
 
-void DDTRACE_EXPORT Init_ddtrace_profiling_loader() {
+void DDTRACE_EXPORT Init_ddtrace_profiling_loader(void) {
   VALUE datadog_module = rb_define_module("Datadog");
   VALUE profiling_module = rb_define_module_under(datadog_module, "Profiling");
   VALUE loader_module = rb_define_module_under(profiling_module, "Loader");

--- a/ext/ddtrace_profiling_native_extension/clock_id.h
+++ b/ext/ddtrace_profiling_native_extension/clock_id.h
@@ -1,4 +1,4 @@
 #pragma once
 
-void self_test_clock_id();
+void self_test_clock_id(void);
 VALUE clock_id_for(VALUE self, VALUE thread);

--- a/ext/ddtrace_profiling_native_extension/clock_id_from_pthread.c
+++ b/ext/ddtrace_profiling_native_extension/clock_id_from_pthread.c
@@ -13,7 +13,7 @@
 #include "clock_id.h"
 
 // Validate that our home-cooked pthread_id_for() matches pthread_self() for the current thread
-void self_test_clock_id() {
+void self_test_clock_id(void) {
   rb_nativethread_id_t expected_pthread_id = pthread_self();
   rb_nativethread_id_t actual_pthread_id = pthread_id_for(rb_thread_current());
 

--- a/ext/ddtrace_profiling_native_extension/clock_id_noop.c
+++ b/ext/ddtrace_profiling_native_extension/clock_id_noop.c
@@ -8,7 +8,7 @@
 
 #include "clock_id.h"
 
-void self_test_clock_id() { } // Nothing to check
+void self_test_clock_id(void) { } // Nothing to check
 VALUE clock_id_for(VALUE self, VALUE thread) { return Qnil; } // Nothing to return
 
 #endif

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -92,6 +92,9 @@ if RUBY_PLATFORM.include?('linux')
   $defs << '-DHAVE_PTHREAD_GETCPUCLOCKID'
 end
 
+# On older Rubies, there was no struct rb_native_thread. See private_vm_api_acccess.c for details.
+$defs << '-DNO_RB_NATIVE_THREAD' if RUBY_VERSION < '3.2'
+
 # On older Rubies, we need to use a backported version of this function. See private_vm_api_access.h for details.
 $defs << '-DUSE_BACKPORTED_RB_PROFILE_FRAME_METHOD_NAME' if RUBY_VERSION < '3'
 

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -35,7 +35,12 @@ static inline rb_thread_t *thread_struct_from_object(VALUE thread) {
 }
 
 rb_nativethread_id_t pthread_id_for(VALUE thread) {
-  return thread_struct_from_object(thread)->thread_id;
+  // struct rb_native_thread was introduced in Ruby 3.2 (preview2): https://github.com/ruby/ruby/pull/5836
+  #ifndef NO_RB_NATIVE_THREAD
+    return thread_struct_from_object(thread)->nt->thread_id;
+  #else
+    return thread_struct_from_object(thread)->thread_id;
+  #endif
 }
 
 // Returns the stack depth by using the same approach as rb_profile_frames and backtrace_each: get the positions

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -70,7 +70,7 @@ ptrdiff_t stack_depth_for(VALUE thread) {
 
 #ifndef USE_LEGACY_LIVING_THREADS_ST // Ruby > 2.1
 // Tries to match rb_thread_list() but that method isn't accessible to extensions
-VALUE ddtrace_thread_list() {
+VALUE ddtrace_thread_list(void) {
   VALUE result = rb_ary_new();
   rb_thread_t *thread = NULL;
 

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -17,7 +17,7 @@
 
 rb_nativethread_id_t pthread_id_for(VALUE thread);
 ptrdiff_t stack_depth_for(VALUE thread);
-VALUE ddtrace_thread_list();
+VALUE ddtrace_thread_list(void);
 
 int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines, bool* is_ruby_frame);
 

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.h
@@ -26,7 +26,7 @@ static inline VALUE process_pending_interruptions(VALUE _unused) {
 // }
 // ```
 __attribute__((warn_unused_result))
-static inline int check_if_pending_exception() {
+static inline int check_if_pending_exception(void) {
   int pending_exception;
   rb_protect(process_pending_interruptions, Qnil, &pending_exception);
   return pending_exception;


### PR DESCRIPTION
A new `struct rb_native_thread` was introduced to contain the `thread_id` (see  https://github.com/ruby/ruby/pull/5836) and thus we need to add a ifdef for Ruby 3.2.

Fixes #2065

(Note: We don't yet have Ruby 3.2 in our CI setup, so you'll just have to take my word for it that this makes it compile now! Or try it locally on your own machine :P)