### PR TITLE
Add env var for debugging profiling native extension compilation issues + Log `PKG_CONFIG_PATH` to mkmf.log

### DIFF
--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -28,7 +28,8 @@ def skip_building_extension!(reason)
   if fail_install_if_missing_extension
     require 'mkmf'
     Logging.message(
-      "\nFailure cause: #{Datadog::Profiling::NativeExtensionHelpers::Supported.render_skipped_reason_file(**reason)}"
+      ' [ddtrace] Failure cause: ' \
+      "#{Datadog::Profiling::NativeExtensionHelpers::Supported.render_skipped_reason_file(**reason)}\n"
     )
   else
     File.write('Makefile', 'all install clean: # dummy makefile that does nothing')
@@ -139,6 +140,7 @@ $defs << '-DUSE_LEGACY_LIVING_THREADS_ST' if RUBY_VERSION < '2.2'
 
 # If we got here, libddprof is available and loaded
 ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libddprof.pkgconfig_folder}"
+Logging.message(" [ddtrace] PKG_CONFIG_PATH set to '#{ENV['PKG_CONFIG_PATH']}'\n")
 unless pkg_config('ddprof_ffi_with_rpath')
   skip_building_extension!(Datadog::Profiling::NativeExtensionHelpers::Supported::FAILED_TO_CONFIGURE_LIBDDPROF)
 end

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -140,7 +140,7 @@ $defs << '-DUSE_LEGACY_LIVING_THREADS_ST' if RUBY_VERSION < '2.2'
 
 # If we got here, libddprof is available and loaded
 ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libddprof.pkgconfig_folder}"
-Logging.message(" [ddtrace] PKG_CONFIG_PATH set to '#{ENV['PKG_CONFIG_PATH']}'\n")
+Logging.message(" [ddtrace] PKG_CONFIG_PATH set to #{ENV['PKG_CONFIG_PATH'].inspect}\n")
 unless pkg_config('ddprof_ffi_with_rpath')
   skip_building_extension!(Datadog::Profiling::NativeExtensionHelpers::Supported::FAILED_TO_CONFIGURE_LIBDDPROF)
 end


### PR DESCRIPTION
To avoid impacting customers, whenever we detect an issue which would've led to the profiling native extension compilation to fail, we instead skip the compilation.

This ensures that customers (especially those *not* using profiling) don't get impacted at installation time.

Instead, at execution time, if they do try to enable profiling, they'll get a message such as

```
WARN -- ddtrace: [ddtrace] Profiling was requested but is not supported,
profiling disabled: Your ddtrace installation is missing support for the
Continuous Profiler because there was a problem in setting up the
libddprof dependency. For help solving this issue, please contact
Datadog support at https://docs.datadoghq.com/help/.
```

But while investigating one such issue reported by a customer (<https://github.com/DataDog/dd-trace-rb/issues/2068>), I found that it's helpful to have a way to break during installation, because that will make Ruby print extra debug information, including the location of the `mkmf.log` log file which can be useful when debugging issues.

Thus, I've added a new `DD_PROFILING_FAIL_INSTALL_IF_MISSING_EXTENSION` environment variable that support can request customers set to `true` to force a failure at installation time.

Here's how it looks when I simulate a broken `libddprof` setup by renaming a file:

```
 # Installs successfully, but profiling will not work:

$ gem install pkg/ddtrace-1.1.0.gem
Building native extensions. This could take a while...
Successfully installed ddtrace-1.1.0
Parsing documentation for ddtrace-1.1.0
Done installing documentation for ddtrace after 3 seconds
1 gem installed

 # Force failure to show up at gem installation time:

$ DD_PROFILING_FAIL_INSTALL_IF_MISSING_EXTENSION=true gem install pkg/ddtrace-1.1.0.gem
Building native extensions. This could take a while...
ERROR:  Error installing pkg/ddtrace-1.1.0.gem:
  ERROR: Failed to build gem native extension.

    current directory: ~/.rvm/gems/ruby-2.7.6/gems/ddtrace-1.1.0/ext/ddtrace_profiling_native_extension
~/.rvm/rubies/ruby-2.7.6/bin/ruby -I ~/.rvm/rubies/ruby-2.7.6/lib/ruby/2.7.0 -r ./siteconf20220607-83731-8dqh3w.rb extconf.rb

+------------------------------------------------------------------------------+
| ** Preparing to build the ddtrace profiling native extension... **           |
|                                                                              |
| If you run into any failures during this step, you can set the               |
| `DD_PROFILING_NO_EXTENSION` environment variable to `true` e.g.              |
| `$ DD_PROFILING_NO_EXTENSION=true bundle install` to skip this step.         |
|                                                                              |
| If you disable this extension, the Datadog Continuous Profiler will          |
| not be available, but all other ddtrace features will work fine!             |
|                                                                              |
| If you needed to use this, please tell us why on                             |
| <https://github.com/DataDog/dd-trace-rb/issues/new> so we can fix it :)      |
|                                                                              |
| Thanks for using ddtrace! You rock!                                          |
+------------------------------------------------------------------------------+

+------------------------------------------------------------------------------+
| Could not compile the Datadog Continuous Profiler because                    |
| there was a problem in setting up the `libddprof` dependency.                |
|                                                                              |
| Failing installation immediately because the                                 |
| `DD_PROFILING_FAIL_INSTALL_IF_MISSING_EXTENSION` environment variable is set |
| to `true`.                                                                   |
| When contacting support, please include the <mkmf.log> file that is shown    |
| below.                                                                       |
|                                                                              |
| For help solving this issue, please contact Datadog support at               |
| <https://docs.datadoghq.com/help/>.                                          |
+------------------------------------------------------------------------------+

*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
  --with-opt-dir
  --with-opt-include
  --without-opt-include=${opt-dir}/include
  --with-opt-lib
  --without-opt-lib=${opt-dir}/lib
  --with-make-prog
  --without-make-prog
  --srcdir=.
  --curdir
  --ruby=~/.rvm/rubies/ruby-2.7.6/bin/$(RUBY_BASE_NAME)
  --with-ddprof_ffi_with_rpath_x-config
  --without-ddprof_ffi_with_rpath_x-config
  --with-pkg-config
  --without-pkg-config

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  ~/.rvm/gems/ruby-2.7.6/extensions/x86_64-darwin-20/2.7.0/ddtrace-1.1.0/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in ~/.rvm/gems/ruby-2.7.6/gems/ddtrace-1.1.0 for inspection.
Results logged to ~/.rvm/gems/ruby-2.7.6/extensions/x86_64-darwin-20/2.7.0/ddtrace-1.1.0/gem_make.out
```

You'll notice that a bunch more useful information shows up, including the path to `mkmf.log`, which can provide extra information.

---

As part of this PR, I've also added logging of the `PKG_CONFIG_PATH` to the mkmf.log, so that we can use it to investigate #2068.