### PR TITLE
Add per-thread context tracking to CpuAndWallTime profiling collector

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -8,20 +8,36 @@
 
 static VALUE collectors_cpu_and_wall_time_class = Qnil;
 
+// Contains state for a single CpuAndWallTime instance
 struct cpu_and_wall_time_collector_state {
   // Note: Places in this file that usually need to be changed when this struct is changed are tagged with
   // "Update this when modifying state struct"
+
+  // Required by Datadog::Profiling::Collectors::Stack as a scratch buffer during sampling
   sampling_buffer *sampling_buffer;
+  // Hashmap <Thread Object, struct per_thread_context>
+  st_table *hash_map_per_thread_context;
+  // Datadog::Profiling::StackRecorder instance
   VALUE recorder_instance;
+};
+
+// Tracks per-thread state
+struct per_thread_context {
 };
 
 static void cpu_and_wall_time_collector_typed_data_mark(void *state_ptr);
 static void cpu_and_wall_time_collector_typed_data_free(void *state_ptr);
+static int hash_map_per_thread_context_mark(st_data_t key_thread, st_data_t _value, st_data_t _argument);
+static int hash_map_per_thread_context_free_values(st_data_t _thread, st_data_t value_per_thread_context, st_data_t _argument);
 static VALUE _native_new(VALUE klass);
 static VALUE _native_initialize(VALUE self, VALUE collector_instance, VALUE recorder_instance, VALUE max_frames);
 static VALUE _native_sample(VALUE self, VALUE collector_instance);
 static void sample(VALUE collector_instance);
 static VALUE _native_thread_list(VALUE self);
+static struct per_thread_context *get_or_create_context_for(VALUE thread, struct cpu_and_wall_time_collector_state *state);
+static VALUE _native_inspect(VALUE self, VALUE collector_instance);
+static VALUE per_thread_context_st_table_as_ruby_hash(struct cpu_and_wall_time_collector_state *state);
+static int per_thread_context_as_ruby_hash(st_data_t key_thread, st_data_t value_context, st_data_t result_hash);
 
 void collectors_cpu_and_wall_time_init(VALUE profiling_module) {
   VALUE collectors_module = rb_define_module_under(profiling_module, "Collectors");
@@ -40,6 +56,7 @@ void collectors_cpu_and_wall_time_init(VALUE profiling_module) {
   rb_define_singleton_method(collectors_cpu_and_wall_time_class, "_native_initialize", _native_initialize, 3);
   rb_define_singleton_method(collectors_cpu_and_wall_time_class, "_native_sample", _native_sample, 1);
   rb_define_singleton_method(collectors_cpu_and_wall_time_class, "_native_thread_list", _native_thread_list, 0);
+  rb_define_singleton_method(collectors_cpu_and_wall_time_class, "_native_inspect", _native_inspect, 1);
 }
 
 // This structure is used to define a Ruby object that stores a pointer to a struct cpu_and_wall_time_collector_state
@@ -55,11 +72,14 @@ static const rb_data_type_t cpu_and_wall_time_collector_typed_data = {
   .flags = RUBY_TYPED_FREE_IMMEDIATELY
 };
 
+// This function is called by the Ruby GC to give us a chance to mark any Ruby objects that we're holding on to,
+// so that they don't get garbage collected
 static void cpu_and_wall_time_collector_typed_data_mark(void *state_ptr) {
   struct cpu_and_wall_time_collector_state *state = (struct cpu_and_wall_time_collector_state *) state_ptr;
 
   // Update this when modifying state struct
   rb_gc_mark(state->recorder_instance);
+  st_foreach(state->hash_map_per_thread_context, hash_map_per_thread_context_mark, 0 /* unused */);
 }
 
 static void cpu_and_wall_time_collector_typed_data_free(void *state_ptr) {
@@ -71,7 +91,26 @@ static void cpu_and_wall_time_collector_typed_data_free(void *state_ptr) {
   // pointers that have been set NULL there may still be NULL here.
   if (state->sampling_buffer != NULL) sampling_buffer_free(state->sampling_buffer);
 
+  // Free each entry in the map
+  st_foreach(state->hash_map_per_thread_context, hash_map_per_thread_context_free_values, 0 /* unused */);
+  // ...and then the map
+  st_free_table(state->hash_map_per_thread_context);
+
   ruby_xfree(state);
+}
+
+// Mark Ruby thread references we keep as keys in hash_map_per_thread_context
+static int hash_map_per_thread_context_mark(st_data_t key_thread, st_data_t _value, st_data_t _argument) {
+  VALUE thread = (VALUE) key_thread;
+  rb_gc_mark(thread);
+  return ST_CONTINUE;
+}
+
+// Used to clear each of the per_thread_contexts inside the hash_map_per_thread_context
+static int hash_map_per_thread_context_free_values(st_data_t _thread, st_data_t value_per_thread_context, st_data_t _argument) {
+  struct per_thread_context *per_thread_context = (struct per_thread_context*) value_per_thread_context;
+  ruby_xfree(per_thread_context);
+  return ST_CONTINUE;
 }
 
 static VALUE _native_new(VALUE klass) {
@@ -79,6 +118,9 @@ static VALUE _native_new(VALUE klass) {
 
   // Update this when modifying state struct
   state->sampling_buffer = NULL;
+  state->hash_map_per_thread_context =
+   // "numtable" is an awful name, but TL;DR it's what should be used when keys are `VALUE`s.
+    st_init_numtable();
   state->recorder_instance = Qnil;
 
   return TypedData_Wrap_Struct(collectors_cpu_and_wall_time_class, &cpu_and_wall_time_collector_typed_data, state);
@@ -95,6 +137,7 @@ static VALUE _native_initialize(VALUE self, VALUE collector_instance, VALUE reco
 
   // Update this when modifying state struct
   state->sampling_buffer = sampling_buffer_new(max_frames_requested);
+  // hash_map_per_thread_context is already initialized, nothing to do here
   state->recorder_instance = recorder_instance;
 
   return Qtrue;
@@ -116,6 +159,7 @@ static void sample(VALUE collector_instance) {
   const long thread_count = RARRAY_LEN(threads);
   for (long i = 0; i < thread_count; i++) {
     VALUE thread = RARRAY_AREF(threads, i);
+    struct per_thread_context *thread_context = get_or_create_context_for(thread, state);
 
     int64_t metric_values[ENABLED_VALUE_TYPES_COUNT] = {0};
 
@@ -138,4 +182,53 @@ static void sample(VALUE collector_instance) {
 // It SHOULD NOT be used for other purposes.
 static VALUE _native_thread_list(VALUE self) {
   return ddtrace_thread_list();
+}
+
+static struct per_thread_context *get_or_create_context_for(VALUE thread, struct cpu_and_wall_time_collector_state *state) {
+  struct per_thread_context* thread_context = NULL;
+  st_data_t value_context = 0;
+
+  if (st_lookup(state->hash_map_per_thread_context, (st_data_t) thread, &value_context)) {
+    thread_context = (struct per_thread_context*) value_context;
+  } else {
+    thread_context = ruby_xcalloc(1, sizeof(struct per_thread_context));
+    // FIXME FIXME! Right now we never remove threads from this map! So as long as the sampler object is alive, this
+    // will leak threads!
+    st_insert(state->hash_map_per_thread_context, (st_data_t) thread, (st_data_t) thread_context);
+  }
+
+  return thread_context;
+}
+
+static VALUE _native_inspect(VALUE self, VALUE collector_instance) {
+  struct cpu_and_wall_time_collector_state *state;
+  TypedData_Get_Struct(collector_instance, struct cpu_and_wall_time_collector_state, &cpu_and_wall_time_collector_typed_data, state);
+
+  VALUE result = rb_str_new2(" (native state)");
+
+  // Update this when modifying state struct
+  rb_str_concat(result, rb_sprintf(" hash_map_per_thread_context=%"PRIsVALUE, per_thread_context_st_table_as_ruby_hash(state)));
+  rb_str_concat(result, rb_sprintf(" recorder_instance=%"PRIsVALUE, state->recorder_instance));
+
+  return result;
+}
+
+static VALUE per_thread_context_st_table_as_ruby_hash(struct cpu_and_wall_time_collector_state *state) {
+  VALUE result = rb_hash_new();
+  st_foreach(state->hash_map_per_thread_context, per_thread_context_as_ruby_hash, result);
+  return result;
+}
+
+#define VALUE_COUNT(array) (sizeof(array) / sizeof(VALUE))
+
+static int per_thread_context_as_ruby_hash(st_data_t key_thread, st_data_t value_context, st_data_t result_hash) {
+  VALUE thread = (VALUE) key_thread;
+  VALUE result = (VALUE) result_hash;
+  VALUE context_as_hash = rb_hash_new();
+  rb_hash_aset(result_hash, thread, context_as_hash);
+
+  VALUE arguments[] = {};
+  for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(context_as_hash, arguments[i], arguments[i+1]);
+
+  return ST_CONTINUE;
 }

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -199,8 +199,6 @@ static struct per_thread_context *get_or_create_context_for(VALUE thread, struct
     thread_context = (struct per_thread_context*) value_context;
   } else {
     thread_context = ruby_xcalloc(1, sizeof(struct per_thread_context));
-    // FIXME FIXME! Right now we never remove threads from this map! So as long as the sampler object is alive, this
-    // will leak threads!
     st_insert(state->hash_map_per_thread_context, (st_data_t) thread, (st_data_t) thread_context);
   }
 
@@ -244,16 +242,11 @@ static void remove_context_for_dead_threads(struct cpu_and_wall_time_collector_s
   st_foreach(state->hash_map_per_thread_context, remove_if_dead_thread, 0 /* unused */);
 }
 
-static bool thread_alive(VALUE thread) {
-  // TODO: FIX THIS TO ACTUALLY WORK
-  return true;
-}
-
 static int remove_if_dead_thread(st_data_t key_thread, st_data_t value_context, st_data_t _argument) {
   VALUE thread = (VALUE) key_thread;
   struct per_thread_context* thread_context = (struct per_thread_context*) value_context;
 
-  if (thread_alive(thread)) return ST_CONTINUE;
+  if (is_thread_alive(thread)) return ST_CONTINUE;
 
   ruby_xfree(thread_context);
   return ST_DELETE;

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -129,6 +129,10 @@ static int ddtrace_thread_list_each(st_data_t thread_object, st_data_t _value, v
 }
 #endif // USE_LEGACY_LIVING_THREADS_ST
 
+bool is_thread_alive(VALUE thread) {
+  return thread_struct_from_object(thread)->status != THREAD_KILLED;
+}
+
 // -----------------------------------------------------------------------------
 // The sources below are modified versions of code extracted from the Ruby project.
 // Each function is annotated with its origin, why we imported it, and the changes made.

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -18,6 +18,7 @@
 rb_nativethread_id_t pthread_id_for(VALUE thread);
 ptrdiff_t stack_depth_for(VALUE thread);
 VALUE ddtrace_thread_list(void);
+bool is_thread_alive(VALUE thread);
 
 int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines, bool* is_ruby_frame);
 

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time.rb
@@ -23,6 +23,13 @@ module Datadog
         def thread_list
           self.class._native_thread_list
         end
+
+        def inspect
+          # Compose Ruby's default inspect with our custom inspect for the native parts
+          result = super()
+          result[-1] = "#{self.class._native_inspect(self)}>"
+          result
+        end
       end
     end
   end

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time.rb
@@ -24,6 +24,12 @@ module Datadog
           self.class._native_thread_list
         end
 
+        # This method exists only to enable testing Datadog::Profiling::Collectors::CpuAndWallTime behavior using RSpec.
+        # It SHOULD NOT be used for other purposes.
+        def per_thread_context
+          self.class._native_per_thread_context(self)
+        end
+
         def inspect
           # Compose Ruby's default inspect with our custom inspect for the native parts
           result = super()

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
@@ -11,39 +11,39 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
 
   subject(:cpu_and_wall_time_collector) { described_class.new(recorder: recorder, max_frames: max_frames) }
 
+  let(:ready_queue) { Queue.new }
+  let!(:t1) do
+    Thread.new(ready_queue) do |ready_queue|
+      ready_queue << true
+      sleep
+    end
+  end
+  let!(:t2) do
+    Thread.new(ready_queue) do |ready_queue|
+      ready_queue << true
+      sleep
+    end
+  end
+  let!(:t3) do
+    Thread.new(ready_queue) do |ready_queue|
+      ready_queue << true
+      sleep
+    end
+  end
+
+  before do
+    3.times { ready_queue.pop }
+    expect(Thread.list).to include(Thread.main, t1, t2, t3)
+  end
+
+  after do
+    [t1, t2, t3].each do |thread|
+      thread.kill
+      thread.join
+    end
+  end
+
   describe '#sample' do
-    let(:ready_queue) { Queue.new }
-    let!(:t1) do
-      Thread.new(ready_queue) do |ready_queue|
-        ready_queue << true
-        sleep
-      end
-    end
-    let!(:t2) do
-      Thread.new(ready_queue) do |ready_queue|
-        ready_queue << true
-        sleep
-      end
-    end
-    let!(:t3) do
-      Thread.new(ready_queue) do |ready_queue|
-        ready_queue << true
-        sleep
-      end
-    end
-
-    before do
-      3.times { ready_queue.pop }
-      expect(Thread.list).to include(Thread.main, t1, t2, t3)
-    end
-
-    after do
-      [t1, t2, t3].each do |thread|
-        thread.kill
-        thread.join
-      end
-    end
-
     it 'samples all threads' do
       all_threads = Thread.list
 
@@ -64,40 +64,44 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
   end
 
   describe '#thread_list' do
-    let(:ready_queue) { Queue.new }
-    let!(:t1) do
-      Thread.new(ready_queue) do |ready_queue|
-        ready_queue << true
-        sleep
-      end
-    end
-    let!(:t2) do
-      Thread.new(ready_queue) do |ready_queue|
-        ready_queue << true
-        sleep
-      end
-    end
-    let!(:t3) do
-      Thread.new(ready_queue) do |ready_queue|
-        ready_queue << true
-        sleep
-      end
-    end
-
-    before do
-      3.times { ready_queue.pop }
-      expect(Thread.list).to include(Thread.main, t1, t2, t3)
-    end
-
-    after do
-      [t1, t2, t3].each do |thread|
-        thread.kill
-        thread.join
-      end
-    end
-
     it "returns the same as Ruby's Thread.list" do
       expect(cpu_and_wall_time_collector.thread_list).to eq Thread.list
+    end
+  end
+
+  # Validate that we correctly clean up and don't leak per_thread_context
+  describe '#per_thread_context' do
+    context 'before sampling' do
+      it do
+        expect(cpu_and_wall_time_collector.per_thread_context).to be_empty
+      end
+    end
+
+    context 'after sampling' do
+      before do
+        cpu_and_wall_time_collector.sample
+      end
+
+      it 'contains all the sampled threads' do
+        expect(cpu_and_wall_time_collector.per_thread_context.keys).to include(Thread.main, t1, t2, t3)
+      end
+    end
+
+    context 'after sampling multiple times' do
+      it 'contains only the threads still alive' do
+        cpu_and_wall_time_collector.sample
+
+        # All alive threads still in there
+        expect(cpu_and_wall_time_collector.per_thread_context.keys).to include(Thread.main, t1, t2, t3)
+
+        # Get rid of t2
+        t2.kill
+        t2.join
+
+        cpu_and_wall_time_collector.sample
+        expect(cpu_and_wall_time_collector.per_thread_context.keys).to_not include(t2)
+        expect(cpu_and_wall_time_collector.per_thread_context.keys).to include(Thread.main, t1, t3)
+      end
     end
   end
 end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
@@ -4,13 +4,14 @@ require 'datadog/profiling/spec_helper'
 require 'datadog/profiling/collectors/cpu_and_wall_time'
 
 RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
-  before { skip_if_profiling_not_supported(self) }
+  before do
+    skip_if_profiling_not_supported(self)
+
+    3.times { ready_queue.pop }
+    expect(Thread.list).to include(Thread.main, t1, t2, t3)
+  end
 
   let(:recorder) { Datadog::Profiling::StackRecorder.new }
-  let(:max_frames) { 123 }
-
-  subject(:cpu_and_wall_time_collector) { described_class.new(recorder: recorder, max_frames: max_frames) }
-
   let(:ready_queue) { Queue.new }
   let!(:t1) do
     Thread.new(ready_queue) do |ready_queue|
@@ -30,11 +31,9 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
       sleep
     end
   end
+  let(:max_frames) { 123 }
 
-  before do
-    3.times { ready_queue.pop }
-    expect(Thread.list).to include(Thread.main, t1, t2, t3)
-  end
+  subject(:cpu_and_wall_time_collector) { described_class.new(recorder: recorder, max_frames: max_frames) }
 
   after do
     [t1, t2, t3].each do |thread|


### PR DESCRIPTION
The new `Datadog::Profiling::Collectors::CpuAndWallTime` collector will replace the existing `Datadog::Profiling::Collectors::OldStack`. It's still not in use yet, and I'm building it up bit by bit.

One key thing we need to do for Cpu/Wall-clock time sampling is to store some amount of information per-thread. E.g. in the `OldStack` collector we store the "last cpu time" and "last wall clock" as instance variables of each thread object, so that then we can compare how values have changed between two samples.

In this PR, I'm reimplementing this same idea, but in C. I'm adding a hash where the key is the Ruby `Thread` object, and the value is a pointer to a `struct per_thread_context` where I'll keep the same things. (Note that in this PR the structure is left empty, since I was just focused on adding and managing it, I'm not yet storing anything)

Unfortunately doing this in C is a bit more verbose:
* We need to implement marking so that Ruby knows we have references to the thread objects (and we don't retain references to garbage-collected threads)
* We also need to clean up threads that die from the hash

I also took the opportunity to implement an `#inspect` method that exposes some of the native guts, for debugging.