### PR TITLE
Add convenient interface for getting and setting tags using `[]` and `[]=` respectively.

### DIFF
--- a/lib/datadog/tracing/metadata/tagging.rb
+++ b/lib/datadog/tracing/metadata/tagging.rb
@@ -72,10 +72,10 @@ module Datadog
 
         # Convenient interface for setting a single tag.
         alias []= set_tag
-        
+
         # Convenient interface for getting a single tag.
         alias [] get_tag
-        
+
         # Return the metric with the given key, nil if it doesn't exist.
         def get_metric(key)
           metrics[key] || meta[key]

--- a/lib/datadog/tracing/metadata/tagging.rb
+++ b/lib/datadog/tracing/metadata/tagging.rb
@@ -70,6 +70,12 @@ module Datadog
           meta.delete(key)
         end
 
+        # Convenient interface for setting a single tag.
+        alias []= set_tag
+        
+        # Convenient interface for getting a single tag.
+        alias [] get_tag
+        
         # Return the metric with the given key, nil if it doesn't exist.
         def get_metric(key)
           metrics[key] || meta[key]


### PR DESCRIPTION
Fixes https://github.com/DataDog/dd-trace-rb/issues/2075

I respect that you may not want to do this, but I think this would be a pretty practical and ergonomic improvement to the span interface.