### PR TITLE
Teach Rest Client integration the `:split_by_domain` option

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1780,6 +1780,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | --- | ----------- | ------- |
 | `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) | `true` |
 | `service_name` | Service name for `rest_client` instrumentation. | `'rest_client'` |
+| `split_by_domain` | Uses the request domain as the service name when set to `true`. | `false` |
 
 ### RSpec
 

--- a/lib/datadog/tracing/contrib/rest_client/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rest_client/configuration/settings.rb
@@ -28,6 +28,7 @@ module Datadog
 
             option :distributed_tracing, default: true
             option :service_name, default: Ext::DEFAULT_PEER_SERVICE_NAME
+            option :split_by_domain, default: false
           end
         end
       end

--- a/lib/datadog/tracing/contrib/rest_client/request_patch.rb
+++ b/lib/datadog/tracing/contrib/rest_client/request_patch.rb
@@ -54,7 +54,7 @@ module Datadog
             def datadog_trace_request(uri)
               span = Tracing.trace(
                 Ext::SPAN_REQUEST,
-                service: datadog_configuration[:service_name],
+                service: datadog_configuration[:split_by_domain] ? uri.host : datadog_configuration[:service_name],
                 span_type: Tracing::Metadata::Ext::HTTP::TYPE_OUTBOUND
               )
 

--- a/spec/datadog/tracing/contrib/rest_client/request_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/rest_client/request_patch_spec.rb
@@ -306,5 +306,19 @@ RSpec.describe Datadog::Tracing::Contrib::RestClient::RequestPatch do
         end
       end
     end
+
+    context 'when split by domain' do
+      let(:configuration_options) { super().merge(split_by_domain: true) }
+
+      before { request }
+
+      it 'has correct service name' do
+        expect(span.service).to eq('example.com')
+      end
+
+      it_behaves_like 'a peer service span' do
+        let(:peer_hostname) { 'example.com' }
+      end
+    end
   end
 end


### PR DESCRIPTION
Rest Client didn't know about this option, and now it does! This should bring it closer to parity with the other external HTTP request library integrations.