### PR TITLE
Implement private attributes `service_entry` for span

### DIFF
--- a/lib/datadog/tracing/span.rb
+++ b/lib/datadog/tracing/span.rb
@@ -81,7 +81,8 @@ module Datadog
         start_time: nil,
         status: 0,
         type: span_type,
-        trace_id: nil
+        trace_id: nil,
+        top_level: nil
       )
         @name = Core::Utils::SafeDup.frozen_or_dup(name)
         @service = Core::Utils::SafeDup.frozen_or_dup(service)
@@ -106,6 +107,8 @@ module Datadog
         # duration_start and duration_end track monotonic clock, and may remain nil in cases where it
         # is known that we have to use wall clock to measure duration.
         @duration = duration
+
+        @top_level = top_level
       end
 
       # Return whether the duration is started or not
@@ -209,6 +212,10 @@ module Datadog
       # @return [Integer] in nanoseconds since Epoch
       def duration_nano
         (duration * 1e9).to_i
+      end
+
+      def top_level?
+        !!@top_level
       end
     end
   end

--- a/lib/datadog/tracing/span.rb
+++ b/lib/datadog/tracing/span.rb
@@ -222,7 +222,7 @@ module Datadog
       #
       # @return [Boolean] `true` if the span is a serivce entry span
       def service_entry?
-        !!@service_entry
+        @service_entry == true
       end
     end
   end

--- a/lib/datadog/tracing/span.rb
+++ b/lib/datadog/tracing/span.rb
@@ -82,7 +82,7 @@ module Datadog
         status: 0,
         type: span_type,
         trace_id: nil,
-        top_level: nil
+        service_entry: nil
       )
         @name = Core::Utils::SafeDup.frozen_or_dup(name)
         @service = Core::Utils::SafeDup.frozen_or_dup(service)
@@ -108,7 +108,11 @@ module Datadog
         # is known that we have to use wall clock to measure duration.
         @duration = duration
 
-        @top_level = top_level
+        # https://docs.datadoghq.com/tracing/visualization/#service-entry-span
+        # A span is a service entry span when it is the entrypoint method for a request to a service.
+        # You can visualize this within Datadog APM when the color of the immediate parent on a flame graph is a different
+        # color. Services are also listed on the right when viewing a flame graph.
+        @service_entry = service_entry
       end
 
       # Return whether the duration is started or not
@@ -214,8 +218,8 @@ module Datadog
         (duration * 1e9).to_i
       end
 
-      def top_level?
-        !!@top_level
+      def service_entry?
+        !!@service_entry
       end
     end
   end

--- a/lib/datadog/tracing/span.rb
+++ b/lib/datadog/tracing/span.rb
@@ -66,6 +66,7 @@ module Datadog
       # * +type+: the type of the span (such as +http+, +db+ and so on)
       # * +parent_id+: the identifier of the parent span
       # * +trace_id+: the identifier of the root span for this trace
+      # * +service_entry+: whether it is a service entry span.
       # TODO: Remove span_type
       def initialize(
         name,
@@ -108,10 +109,6 @@ module Datadog
         # is known that we have to use wall clock to measure duration.
         @duration = duration
 
-        # https://docs.datadoghq.com/tracing/visualization/#service-entry-span
-        # A span is a service entry span when it is the entrypoint method for a request to a service.
-        # You can visualize this within Datadog APM when the color of the immediate parent on a flame graph is a different
-        # color. Services are also listed on the right when viewing a flame graph.
         @service_entry = service_entry
       end
 
@@ -218,6 +215,12 @@ module Datadog
         (duration * 1e9).to_i
       end
 
+      # https://docs.datadoghq.com/tracing/visualization/#service-entry-span
+      # A span is a service entry span when it is the entrypoint method for a request to a service.
+      # You can visualize this within Datadog APM when the color of the immediate parent on a flame graph is a different
+      # color. Services are also listed on the right when viewing a flame graph.
+      #
+      # @return [Boolean] `true` if the span is a serivce entry span
       def service_entry?
         !!@service_entry
       end

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -437,8 +437,6 @@ module Datadog
         :parent,
         :span
 
-      attr_writer :top_level
-
       if RUBY_VERSION < '2.2' # nil.dup only fails in Ruby 2.1
         # Ensures #initialize can call nil.dup safely
         module RefineNil
@@ -471,7 +469,7 @@ module Datadog
           status: @status,
           type: @type,
           trace_id: @trace_id,
-          top_level: parent.nil? || (service && parent.service != service)
+          service_entry: parent.nil? || (service && parent.service != service)
         )
       end
 

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -471,12 +471,8 @@ module Datadog
           status: @status,
           type: @type,
           trace_id: @trace_id,
-          top_level: top_level?
+          top_level: parent.nil? || (service && parent.service != service)
         )
-      end
-
-      def top_level?
-        !!@top_level
       end
 
       # Set this span's parent, inheriting any properties not explicitly set.

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -437,6 +437,8 @@ module Datadog
         :parent,
         :span
 
+      attr_writer :top_level
+
       if RUBY_VERSION < '2.2' # nil.dup only fails in Ruby 2.1
         # Ensures #initialize can call nil.dup safely
         module RefineNil
@@ -468,8 +470,13 @@ module Datadog
           start_time: @start_time,
           status: @status,
           type: @type,
-          trace_id: @trace_id
+          trace_id: @trace_id,
+          top_level: top_level?
         )
+      end
+
+      def top_level?
+        !!@top_level
       end
 
       # Set this span's parent, inheriting any properties not explicitly set.

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -343,6 +343,8 @@ module Datadog
       def activate_span!(span_op)
         parent = @active_span
 
+        span_op.__send__(:top_level=, true) if parent.nil? || (span_op.service && parent.service != span_op.service)
+
         span_op.send(:parent=, parent) unless parent.nil?
 
         @active_span = span_op

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -343,8 +343,6 @@ module Datadog
       def activate_span!(span_op)
         parent = @active_span
 
-        span_op.__send__(:top_level=, true) if parent.nil? || (span_op.service && parent.service != span_op.service)
-
         span_op.send(:parent=, parent) unless parent.nil?
 
         @active_span = span_op

--- a/spec/datadog/tracing/span_operation_spec.rb
+++ b/spec/datadog/tracing/span_operation_spec.rb
@@ -529,8 +529,8 @@ RSpec.describe Datadog::Tracing::SpanOperation do
     context 'identifying service_entry_span' do
       context 'when service of root and child are `nil`' do
         it do
-          root_span_op = described_class.new("root")
-          child_span_op = described_class.new("child_1", child_of: root_span_op)
+          root_span_op = described_class.new('root')
+          child_span_op = described_class.new('child_1', child_of: root_span_op)
 
           root_span_op.measure do
             child_span_op.measure do
@@ -548,8 +548,8 @@ RSpec.describe Datadog::Tracing::SpanOperation do
 
       context 'when service of root and child are identical' do
         it do
-          root_span_op = described_class.new("root", service: 'root_service')
-          child_span_op = described_class.new("child_1", child_of: root_span_op, service: root_span_op.service)
+          root_span_op = described_class.new('root', service: 'root_service')
+          child_span_op = described_class.new('child_1', child_of: root_span_op, service: root_span_op.service)
 
           root_span_op.measure do
             child_span_op.measure do
@@ -567,8 +567,8 @@ RSpec.describe Datadog::Tracing::SpanOperation do
 
       context 'when service of root and child are different' do
         it do
-          root_span_op = described_class.new("root")
-          child_span_op = described_class.new("child_1", child_of: root_span_op, service: 'child_service')
+          root_span_op = described_class.new('root')
+          child_span_op = described_class.new('child_1', child_of: root_span_op, service: 'child_service')
 
           root_span_op.measure do
             child_span_op.measure do
@@ -586,8 +586,8 @@ RSpec.describe Datadog::Tracing::SpanOperation do
 
       context 'when service of root and child are different, overriden within the measure block' do
         it do
-          root_span_op = described_class.new("root")
-          child_span_op = described_class.new("child_1", child_of: root_span_op)
+          root_span_op = described_class.new('root')
+          child_span_op = described_class.new('child_1', child_of: root_span_op)
 
           root_span_op.measure do
             child_span_op.measure do |span_op|

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -2187,7 +2187,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
   end
 
   describe 'integration tests' do
-    context 'top_level attributes' do
+    context 'service_entry attributes' do
       context 'when service not given' do
         it do
           trace_op.measure('root') do |_, trace|
@@ -2205,7 +2205,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           expect(trace_segment.spans.map(&:service)).to all(be_nil)
 
           hash = trace_segment.spans.each_with_object({}) do |span, h|
-            h[span.name] = span.__send__(:top_level?)
+            h[span.name] = span.__send__(:service_entry?)
           end
           expect(hash['root']).to be true
           expect(hash['children_1']).to be false
@@ -2228,7 +2228,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           trace_segment = trace_op.flush!
 
           hash = trace_segment.spans.each_with_object({}) do |span, h|
-            h[span.name] = span.__send__(:top_level?)
+            h[span.name] = span.__send__(:service_entry?)
           end
 
           expect(hash['root']).to be true
@@ -2252,7 +2252,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           trace_segment = trace_op.flush!
 
           hash = trace_segment.spans.each_with_object({}) do |span, h|
-            h[span.name] = span.__send__(:top_level?)
+            h[span.name] = span.__send__(:service_entry?)
           end
 
           expect(hash['root']).to be true
@@ -2277,7 +2277,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           trace_segment = trace_op.flush!
 
           hash = trace_segment.spans.each_with_object({}) do |span, h|
-            h[span.name] = span.__send__(:top_level?)
+            h[span.name] = span.__send__(:service_entry?)
           end
 
           expect(hash['root']).to be true
@@ -2374,7 +2374,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           resource: 'import_job',
           service: 'job-worker'
         )
-        expect(job_span.__send__(:top_level?)).to be true
+        expect(job_span.__send__(:service_entry?)).to be true
 
         expect(load_data_span).to have_attributes(
           trace_id: trace_id,
@@ -2384,7 +2384,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           resource: 'imports.csv',
           service: 'job-worker'
         )
-        expect(load_data_span.__send__(:top_level?)).to be false
+        expect(load_data_span.__send__(:service_entry?)).to be false
 
         expect(read_file_span).to have_attributes(
           trace_id: trace_id,
@@ -2394,7 +2394,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           resource: 'imports.csv',
           service: 'job-worker'
         )
-        expect(read_file_span.__send__(:top_level?)).to be false
+        expect(read_file_span.__send__(:service_entry?)).to be false
 
         expect(deserialize_span).to have_attributes(
           trace_id: trace_id,
@@ -2404,7 +2404,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           resource: 'inventory',
           service: 'job-worker'
         )
-        expect(deserialize_span.__send__(:top_level?)).to be false
+        expect(deserialize_span.__send__(:service_entry?)).to be false
 
         expect(start_inserts_span).to have_attributes(
           trace_id: trace_id,
@@ -2414,7 +2414,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           resource: 'inventory',
           service: 'job-worker'
         )
-        expect(start_inserts_span.__send__(:top_level?)).to be false
+        expect(start_inserts_span.__send__(:service_entry?)).to be false
 
         expect(db_query_spans).to all(
           have_attributes(
@@ -2426,7 +2426,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
             service: 'database'
           )
         )
-        expect(db_query_spans.map { |s| s.__send__(:top_level?) }).to all(be true)
+        expect(db_query_spans.map { |s| s.__send__(:service_entry?) }).to all(be true)
 
         expect(wait_insert_span).to have_attributes(
           trace_id: trace_id,
@@ -2437,7 +2437,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           service: 'job-worker'
         )
         expect(wait_insert_span.get_tag('worker.count')).to eq(5.0)
-        expect(wait_insert_span.__send__(:top_level?)).to be false
+        expect(wait_insert_span.__send__(:service_entry?)).to be false
 
         expect(update_log_span).to have_attributes(
           trace_id: trace_id,
@@ -2447,7 +2447,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           resource: 'inventory',
           service: 'job-worker'
         )
-        expect(update_log_span.__send__(:top_level?)).to be false
+        expect(update_log_span.__send__(:service_entry?)).to be false
       end
     end
   end

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -2202,14 +2202,11 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
           trace_segment = trace_op.flush!
 
-          expect(trace_segment.spans.map(&:service)).to all(be_nil)
-
-          hash = trace_segment.spans.each_with_object({}) do |span, h|
-            h[span.name] = span.__send__(:service_entry?)
-          end
-          expect(hash['root']).to be true
-          expect(hash['children_1']).to be false
-          expect(hash['children_2']).to be false
+          expect(trace_segment.spans).to include(
+            a_span_with(name: 'root', service_entry?: true),
+            a_span_with(name: 'children_1', service_entry?: false),
+            a_span_with(name: 'children_2', service_entry?: false)
+          )
         end
       end
 
@@ -2227,13 +2224,11 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
           trace_segment = trace_op.flush!
 
-          hash = trace_segment.spans.each_with_object({}) do |span, h|
-            h[span.name] = span.__send__(:service_entry?)
-          end
-
-          expect(hash['root']).to be true
-          expect(hash['children_1']).to be false
-          expect(hash['children_2']).to be false
+          expect(trace_segment.spans).to include(
+            a_span_with(name: 'root', service_entry?: true),
+            a_span_with(name: 'children_1', service_entry?: false),
+            a_span_with(name: 'children_2', service_entry?: false)
+          )
         end
       end
 
@@ -2251,13 +2246,11 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
           trace_segment = trace_op.flush!
 
-          hash = trace_segment.spans.each_with_object({}) do |span, h|
-            h[span.name] = span.__send__(:service_entry?)
-          end
-
-          expect(hash['root']).to be true
-          expect(hash['children_1']).to be true
-          expect(hash['children_2']).to be false
+          expect(trace_segment.spans).to include(
+            a_span_with(name: 'root', service_entry?: true),
+            a_span_with(name: 'children_1', service_entry?: true),
+            a_span_with(name: 'children_2', service_entry?: false)
+          )
         end
       end
 
@@ -2276,13 +2269,11 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
           trace_segment = trace_op.flush!
 
-          hash = trace_segment.spans.each_with_object({}) do |span, h|
-            h[span.name] = span.__send__(:service_entry?)
-          end
-
-          expect(hash['root']).to be true
-          expect(hash['children_1']).to be true
-          expect(hash['children_2']).to be false
+          expect(trace_segment.spans).to include(
+            a_span_with(name: 'root', service_entry?: true),
+            a_span_with(name: 'children_1', service_entry?: true),
+            a_span_with(name: 'children_2', service_entry?: false)
+          )
         end
       end
     end

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -2192,11 +2192,11 @@ RSpec.describe Datadog::Tracing::TraceOperation do
         it do
           trace_op.measure('root') do |_, trace|
             trace.measure('children_1') do
-              sleep(0.01)
+              # sleep(0.01)
             end
 
             trace.measure('children_2') do
-              sleep(0.01)
+              # sleep(0.01)
             end
           end
 
@@ -2217,11 +2217,11 @@ RSpec.describe Datadog::Tracing::TraceOperation do
         it do
           trace_op.measure('root', service: 'service_1') do |_, trace|
             trace.measure('children_1') do
-              sleep(0.01)
+              # sleep(0.01)
             end
 
             trace.measure('children_2') do
-              sleep(0.01)
+              # sleep(0.01)
             end
           end
 
@@ -2241,11 +2241,11 @@ RSpec.describe Datadog::Tracing::TraceOperation do
         it do
           trace_op.measure('root', service: 'service_1') do |_, trace|
             trace.measure('children_1', service: 'service_2') do
-              sleep(0.01)
+              # sleep(0.01)
             end
 
             trace.measure('children_2') do
-              sleep(0.01)
+              # sleep(0.01)
             end
           end
 
@@ -2266,11 +2266,11 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           trace_op.measure('root', service: 'service_1') do |_, trace|
             trace.measure('children_1') do |span|
               span.service = 'service_2'
-              sleep(0.01)
+              # sleep(0.01)
             end
 
             trace.measure('children_2') do
-              sleep(0.01)
+              # sleep(0.01)
             end
           end
 

--- a/spec/support/span_helpers.rb
+++ b/spec/support/span_helpers.rb
@@ -96,4 +96,13 @@ module SpanHelpers
       end
     end
   end
+
+  RSpec::Matchers.define :a_span_with do |expected|
+    match do |actual|
+      actual.instance_of?(Datadog::Tracing::Span) &&
+        expected.all? do |key, value|
+          actual.__send__(key) == value
+        end
+    end
+  end
 end


### PR DESCRIPTION
`top_level_hits` is one of the computed stats required to be collected, hence `top_level` span is required to be identified. 

The logic of a span qualified to be a `top_level` span.

1. root span of the current thread
2. `span.service` is different from its immediate parent's service 

The definition of `top_level` is interchangable with `service_entry` as stated from [public documentation](https://docs.datadoghq.com/tracing/visualization/#service-entry-span).

> A span is a service entry span when it is the entrypoint method for a request to a service. You can visualize this within Datadog APM when the color of the immediate parent on a flame graph is a different color. Services are also listed on the right when viewing a flame graph.


The `service_entry` attribute is kept private, since we would like to prevent our user using it.