### PR TITLE
Allow passing request_queuing option to Rack through Rails tracer

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1579,6 +1579,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `cache_service` | Cache service name used when tracing cache activity | `'<app_name>-cache'` |
 | `database_service` | Database service name used when tracing database activity | `'<app_name>-<adapter_name>'` |
 | `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `true` |
+| `request_queuing` | Track HTTP request time spent in the queue of the frontend server. See [HTTP request queuing](#http-request-queuing) for setup details. Set to `true` to enable. | `false` |
 | `exception_controller` | Class or Module which identifies a custom exception controller class. Tracer provides improved error behavior when it can identify custom exception controllers. By default, without this option, it 'guesses' what a custom exception controller looks like. Providing this option aids this identification. | `nil` |
 | `middleware` | Add the trace middleware to the Rails application. Set to `false` if you don't want the middleware to load. | `true` |
 | `middleware_names` | Enables any short-circuited middleware requests to display the middleware name as a resource for the trace. | `false` |

--- a/lib/datadog/tracing/contrib/rails/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rails/configuration/settings.rb
@@ -47,6 +47,9 @@ module Datadog
             end
 
             option :distributed_tracing, default: true
+
+            option :request_queuing, default: false
+
             option :exception_controller do |o|
               o.on_set do |value|
                 # Update ActionPack exception controller too

--- a/lib/datadog/tracing/contrib/rails/framework.rb
+++ b/lib/datadog/tracing/contrib/rails/framework.rb
@@ -68,7 +68,8 @@ module Datadog
               application: ::Rails.application,
               service_name: rails_config[:service_name],
               middleware_names: rails_config[:middleware_names],
-              distributed_tracing: rails_config[:distributed_tracing]
+              distributed_tracing: rails_config[:distributed_tracing],
+              request_queuing: rails_config[:request_queuing]
             )
           end
 


### PR DESCRIPTION
Supporting this means I don't need to add and hacky overrides