### PR TITLE
Github: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: File a bug report
+title: ''
+labels: community, bug
+assignees: ''
+
+---
+
+**Current behaviour**
+<!-- What is be happening. -->
+
+**Expected behaviour**
+<!-- What should be happening. -->
+
+**Steps to reproduce**
+<!-- How can we reproduce this issue in order to diagnose it?
+Code snippets and sample apps are encouraged! -->
+
+**Environment**
+
+* **ddtrace version:**
+* **Configuration block (`Datadog.configure ...`):**
+* **Ruby version:**
+* **Operating system:**
+* **Relevant library versions:**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,8 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: community, feature-request
+assignees: ''
+
+---


### PR DESCRIPTION
This PR adds a first version of Github issue templates.

The goal is to have this in place, as opposed to no template 🙂, in order to help users get their issues addressed faster.

You can create as many issues as you'd like in my personal fork, which has this templated enabled: https://github.com/marcotc/dd-trace-rb/issues/new/choose

This is what users will see when they click the "New issue" button:
<img width="437" alt="Screen Shot 2022-06-16 at 1 19 21 PM" src="https://user-images.githubusercontent.com/583503/174156808-6ff84756-a3d9-416d-bd59-854263c85ca4.png">


Here's an example on how a brand bug report comes out:
https://github.com/marcotc/dd-trace-rb/issues/11

And brand new feature request:
https://github.com/marcotc/dd-trace-rb/issues/12

This is not meant to be the end-all of all issue templates, but it's helpful to remove a bit of back and forth when a new issue is opened.