### PR TITLE
[Single Span Sampling] Add single span sampling rule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,6 +407,7 @@ jobs:
       - environment:
           *container_base_environment
         image: ivoanjo/docker-library:ddtrace_rb_2_5_9
+    resource_class: small
     steps:
       - checkout
       - run:
@@ -428,6 +429,7 @@ jobs:
       - environment:
           *container_base_environment
         image: ivoanjo/docker-library:ddtrace_rb_2_5_9
+    resource_class: small
     steps:
       - run:
           name: Check if this commit author has publishing credentials
@@ -466,42 +468,55 @@ job_configuration:
     <<: *filters_all_branches_and_tags
     ruby_version: '2.1'
     image: ivoanjo/docker-library:ddtrace_rb_2_1_10
+    resource_class_to_use: medium+
   - &config-2_2
     <<: *filters_all_branches_and_tags
     ruby_version: '2.2'
     image: ivoanjo/docker-library:ddtrace_rb_2_2_10
+    resource_class_to_use: medium+
   - &config-2_3
     <<: *filters_all_branches_and_tags
     ruby_version: '2.3'
     image: ivoanjo/docker-library:ddtrace_rb_2_3_8
+    resource_class_to_use: medium+
   - &config-2_4
     <<: *filters_all_branches_and_tags
     ruby_version: '2.4'
     image: ivoanjo/docker-library:ddtrace_rb_2_4_10
+    resource_class_to_use: medium+
   - &config-2_5
     <<: *filters_all_branches_and_tags
     ruby_version: '2.5'
     image: ivoanjo/docker-library:ddtrace_rb_2_5_9
+    resource_class_to_use: medium+
   - &config-2_6
     <<: *filters_all_branches_and_tags
     ruby_version: '2.6'
     image: ivoanjo/docker-library:ddtrace_rb_2_6_7
+    resource_class_to_use: medium+
   - &config-2_7
     <<: *filters_all_branches_and_tags
     ruby_version: '2.7'
     image: ivoanjo/docker-library:ddtrace_rb_2_7_3
+    resource_class_to_use: medium+
+  - &config-2_7-small
+    <<: *config-2_7
+    resource_class_to_use: small
   - &config-3_0
     <<: *filters_all_branches_and_tags
     ruby_version: '3.0'
     image: ivoanjo/docker-library:ddtrace_rb_3_0_3
+    resource_class_to_use: medium+
   - &config-3_1
     <<: *filters_all_branches_and_tags
     ruby_version: '3.1'
     image: ivoanjo/docker-library:ddtrace_rb_3_1_1
+    resource_class_to_use: medium+
   - &config-3_2
     <<: *filters_all_branches_and_tags
     ruby_version: '3.2'
     image: ivoanjo/docker-library:ddtrace_rb_3_2_0_preview1
+    resource_class_to_use: medium+
     # ADD NEW RUBIES HERE
   - &config-jruby-9_2_8_0 # Test with older 9.2 release because 9.2.9.0 changed behavior, see https://github.com/DataDog/dd-trace-rb/pull/1409
     <<: *filters_all_branches_and_tags
@@ -529,17 +544,17 @@ workflows:
   build-and-test:
     jobs:
       - orb/lint:
-          <<: *config-2_6
+          <<: *config-2_7-small
           name: lint
           requires:
-            - build-2.6
+            - build-2.7
       - orb/sorbet_type_checker:
-          <<: *config-2_6
+          <<: *config-2_7-small
           name: sorbet_type_checker
           requires:
-            - build-2.6
+            - build-2.7
       - orb/coverage:
-          <<: *config-2_7
+          <<: *config-2_7-small
           name: coverage
           requires:
             - test-2.1
@@ -559,7 +574,7 @@ workflows:
             - test-jruby-9.3-latest
             # soon™️ - test-truffleruby-21.0.0
       - orb/changelog:
-          <<: *config-2_7
+          <<: *config-2_7-small
           name: changelog
           requires:
             - build-2.7

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,8 +14,13 @@ assignees: ''
 <!-- What should be happening. -->
 
 **Steps to reproduce**
-<!-- How can we reproduce this issue in order to diagnose it?
-Code snippets and sample apps are encouraged! -->
+<!--
+  How can we reproduce this issue in order to diagnose it?
+  Code snippets, log messages, screenshots and sample apps are encouraged!
+-->
+
+**How does `ddtrace` help you?**
+<!-- Optionally, tell us why and how you're using ddtrace, and what your overall experience with it is! -->
 
 **Environment**
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,3 +6,18 @@ labels: community, feature-request
 assignees: ''
 
 ---
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the goal of the feature**
+<!-- A clear and concise description of what you want to happen, and how it may used or behave. -->
+
+**Describe alternatives you've considered**
+<!-- Optionally, provide description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->
+
+**How does `ddtrace` help you?**
+<!-- Optionally, tell us why and how you're using ddtrace, and what your overall experience with it is! -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--
+Check out the
+https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
+for guidance on how to set up your development environment,
+run the test suite, write new integrations, and more.
+-->
+
+**What does this PR do?**
+<!-- A brief description of the change being made with this pull request. -->
+
+**Motivation**
+<!-- What inspired you to submit this pull request? -->
+
+**Additional Notes**
+<!-- Anything else we should know when reviewing? -->
+
+**How to test the change?**
+<!--
+Describe here how the change can be validated.
+You are strongly encouraged to provide automated tests for this PR (unit or integration).
+If this change cannot be feasibly tested, please explain why,
+unless the change does not modify code (e.g. only modifies docs, comments).
+-->

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -108,7 +108,7 @@ Style/CaseEquality:
 # New cops since Rubocop 1.0.
 # We have to explicitly opt-in for new cops to apply
 # before the next major release.
-Gemspec/DateAssignment: # (new in 1.10)
+Gemspec/DeprecatedAttributeAssignment: # (Gemspec/DateAssignment integrated in 1.31.0)
   Enabled: true
 Layout/SpaceBeforeBrackets: # (new in 1.7)
   Enabled: true

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1579,6 +1579,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `cache_service` | Cache service name used when tracing cache activity | `'<app_name>-cache'` |
 | `database_service` | Database service name used when tracing database activity | `'<app_name>-<adapter_name>'` |
 | `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) so that this service trace is connected with a trace of another service if tracing headers are received | `true` |
+| `request_queuing` | Track HTTP request time spent in the queue of the frontend server. See [HTTP request queuing](#http-request-queuing) for setup details. Set to `true` to enable. | `false` |
 | `exception_controller` | Class or Module which identifies a custom exception controller class. Tracer provides improved error behavior when it can identify custom exception controllers. By default, without this option, it 'guesses' what a custom exception controller looks like. Providing this option aids this identification. | `nil` |
 | `middleware` | Add the trace middleware to the Rails application. Set to `false` if you don't want the middleware to load. | `true` |
 | `middleware_names` | Enables any short-circuited middleware requests to display the middleware name as a resource for the trace. | `false` |
@@ -1780,6 +1781,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | --- | ----------- | ------- |
 | `distributed_tracing` | Enables [distributed tracing](#distributed-tracing) | `true` |
 | `service_name` | Service name for `rest_client` instrumentation. | `'rest_client'` |
+| `split_by_domain` | Uses the request domain as the service name when set to `true`. | `false` |
 
 ### RSpec
 

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -505,7 +505,7 @@ module Datadog
             # are always flushed immediately.
             #
             # @default 500
-            # @return [Boolean]
+            # @return [Integer]
             option :min_spans_threshold, default: 500
           end
 

--- a/lib/datadog/core/environment/platform.rb
+++ b/lib/datadog/core/environment/platform.rb
@@ -1,0 +1,40 @@
+# typed: false
+
+require 'etc'
+
+require 'datadog/core/environment/identity'
+
+module Datadog
+  module Core
+    module Environment
+      # For gathering information about the platform
+      module Platform
+        module_function
+
+        # @return [String] name of host; `uname -n`
+        def hostname
+          Identity.lang_version >= '2.2' ? Etc.uname[:nodename] : nil
+        end
+
+        # @return [String] name of kernel; `uname -s`
+        def kernel_name
+          Identity.lang_version >= '2.2' ? Etc.uname[:sysname] : Gem::Platform.local.os.capitalize
+        end
+
+        # @return [String] kernel release; `uname -r`
+        def kernel_release
+          if Identity.lang_engine == 'jruby'
+            Etc.uname[:version] # Java's `os.version` maps to `uname -r`
+          elsif Identity.lang_version >= '2.2'
+            Etc.uname[:release]
+          end
+        end
+
+        # @return [String] kernel version; `uname -v`
+        def kernel_version
+          Etc.uname[:version] if Identity.lang_engine != 'jruby' && Identity.lang_version >= '2.2'
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/utils.rb
+++ b/lib/datadog/core/utils.rb
@@ -19,7 +19,7 @@ module Datadog
       # This method is thread-safe and fork-safe.
       def self.next_id
         after_fork! { reset! }
-        id_rng.rand(Tracing::Span::RUBY_MAX_ID) # TODO: This should never return zero
+        id_rng.rand(Tracing::Span::RUBY_ID_RANGE)
       end
 
       def self.id_rng

--- a/lib/datadog/opentracer/thread_local_scope_manager.rb
+++ b/lib/datadog/opentracer/thread_local_scope_manager.rb
@@ -1,10 +1,19 @@
-# typed: true
+# typed: false
+
+require 'datadog/core/utils/sequence'
 
 module Datadog
   module OpenTracer
     # OpenTracing adapter for thread local scope management
     # @public_api
     class ThreadLocalScopeManager < ScopeManager
+      def initialize(*args, &block)
+        super(*args, &block)
+        @thread_key = "dd_opentracer_context_#{ThreadLocalScopeManager.next_instance_id}".to_sym
+      end
+
+      ruby2_keywords :initialize if respond_to?(:ruby2_keywords, true)
+
       # Make a span instance active.
       #
       # @param span [Span] the Span that should become active
@@ -30,13 +39,27 @@ module Datadog
       # (as Reference#CHILD_OF) of any newly-created Span at Tracer#start_active_span
       # or Tracer#start_span time.
       def active
-        Thread.current[object_id.to_s]
+        Thread.current[@thread_key]
+      end
+
+      # Ensure two instances of {FiberLocalContext} do not conflict.
+      # We previously used {FiberLocalContext#object_id} to ensure uniqueness
+      # but the VM is allowed to reuse `object_id`, allow for the possibility that
+      # a new FiberLocalContext would be able to read an old FiberLocalContext's
+      # value.
+      UNIQUE_INSTANCE_MUTEX = Mutex.new
+      UNIQUE_INSTANCE_GENERATOR = Datadog::Core::Utils::Sequence.new
+
+      private_constant :UNIQUE_INSTANCE_MUTEX, :UNIQUE_INSTANCE_GENERATOR
+
+      def self.next_instance_id
+        UNIQUE_INSTANCE_MUTEX.synchronize { UNIQUE_INSTANCE_GENERATOR.next }
       end
 
       private
 
       def set_scope(scope)
-        Thread.current[object_id.to_s] = scope
+        Thread.current[@thread_key] = scope
       end
     end
   end

--- a/lib/datadog/tracing/contrib/rails/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rails/configuration/settings.rb
@@ -47,6 +47,9 @@ module Datadog
             end
 
             option :distributed_tracing, default: true
+
+            option :request_queuing, default: false
+
             option :exception_controller do |o|
               o.on_set do |value|
                 # Update ActionPack exception controller too

--- a/lib/datadog/tracing/contrib/rails/framework.rb
+++ b/lib/datadog/tracing/contrib/rails/framework.rb
@@ -68,7 +68,8 @@ module Datadog
               application: ::Rails.application,
               service_name: rails_config[:service_name],
               middleware_names: rails_config[:middleware_names],
-              distributed_tracing: rails_config[:distributed_tracing]
+              distributed_tracing: rails_config[:distributed_tracing],
+              request_queuing: rails_config[:request_queuing]
             )
           end
 

--- a/lib/datadog/tracing/contrib/rest_client/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rest_client/configuration/settings.rb
@@ -28,6 +28,7 @@ module Datadog
 
             option :distributed_tracing, default: true
             option :service_name, default: Ext::DEFAULT_PEER_SERVICE_NAME
+            option :split_by_domain, default: false
           end
         end
       end

--- a/lib/datadog/tracing/contrib/rest_client/request_patch.rb
+++ b/lib/datadog/tracing/contrib/rest_client/request_patch.rb
@@ -54,7 +54,7 @@ module Datadog
             def datadog_trace_request(uri)
               span = Tracing.trace(
                 Ext::SPAN_REQUEST,
-                service: datadog_configuration[:service_name],
+                service: datadog_configuration[:split_by_domain] ? uri.host : datadog_configuration[:service_name],
                 span_type: Tracing::Metadata::Ext::HTTP::TYPE_OUTBOUND
               )
 

--- a/lib/datadog/tracing/sampling/rate_sampler.rb
+++ b/lib/datadog/tracing/sampling/rate_sampler.rb
@@ -20,6 +20,9 @@ module Datadog
         # * +sample_rate+: the sample rate as a {Float} between 0.0 and 1.0. 0.0
         #   means that no trace will be sampled; 1.0 means that all traces will be
         #   sampled.
+        #
+        # DEV-2.0: Allow for `sample_rate` zero (drop all) to be allowed. This eases
+        # DEV-2.0: usage for many consumers of the {RateSampler} class.
         def initialize(sample_rate = 1.0)
           super()
 

--- a/lib/datadog/tracing/sampling/span/ext.rb
+++ b/lib/datadog/tracing/sampling/span/ext.rb
@@ -6,6 +6,12 @@ module Datadog
       module Span
         # Checks if a span conforms to a matching criteria.
         class Ext
+          # Accept all spans (100% retention).
+          DEFAULT_SAMPLE_RATE = 1.0
+          # Unlimited.
+          # @see Datadog::Tracing::Sampling::TokenBucket
+          DEFAULT_MAX_PER_SECOND = -1
+
           # Sampling decision method used to come to the sampling decision for this span
           TAG_MECHANISM = '_dd.span_sampling.mechanism'
           # Sampling rate applied to this span, if a rule applies

--- a/lib/datadog/tracing/sampling/span/ext.rb
+++ b/lib/datadog/tracing/sampling/span/ext.rb
@@ -8,11 +8,10 @@ module Datadog
         class Ext
           # Sampling decision method used to come to the sampling decision for this span
           TAG_MECHANISM = '_dd.span_sampling.mechanism'
-          # Sampling rate applied to this span
+          # Sampling rate applied to this span, if a rule applies
           TAG_RULE_RATE = '_dd.span_sampling.rule_rate'
-          # Effective sampling ratio for the rate limiter configured for this span
-          # @see Datadog::Tracing::Sampling::TokenBucket#effective_rate
-          TAG_LIMIT_RATE = '_dd.span_sampling.limit_rate'
+          # Rate limit configured for this span, if a rule applies
+          TAG_MAX_PER_SECOND = '_dd.span_sampling.max_per_second'
 
           # This span was sampled on account of a Span Sampling Rule
           # @see Datadog::Tracing::Sampling::Span::Rule

--- a/lib/datadog/tracing/sampling/span/ext.rb
+++ b/lib/datadog/tracing/sampling/span/ext.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Tracing
+    module Sampling
+      module Span
+        # Checks if a span conforms to a matching criteria.
+        class Ext
+          # Sampling decision method used to come to the sampling decision for this span
+          TAG_MECHANISM = '_dd.span_sampling.mechanism'
+          # Sampling rate applied to this span
+          TAG_RULE_RATE = '_dd.span_sampling.rule_rate'
+          # Effective sampling ratio for the rate limiter configured for this span
+          # @see Datadog::Tracing::Sampling::TokenBucket#effective_rate
+          TAG_LIMIT_RATE = '_dd.span_sampling.limit_rate'
+
+          # This span was sampled on account of a Span Sampling Rule
+          # @see Datadog::Tracing::Sampling::Span::Rule
+          MECHANISM_SPAN_SAMPLING_RATE = 8
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/tracing/sampling/span/ext.rb
+++ b/lib/datadog/tracing/sampling/span/ext.rb
@@ -4,8 +4,8 @@ module Datadog
   module Tracing
     module Sampling
       module Span
-        # Checks if a span conforms to a matching criteria.
-        class Ext
+        # Single Span Sampling constants.
+        module Ext
           # Accept all spans (100% retention).
           DEFAULT_SAMPLE_RATE = 1.0
           # Unlimited.

--- a/lib/datadog/tracing/sampling/span/rule.rb
+++ b/lib/datadog/tracing/sampling/span/rule.rb
@@ -53,18 +53,18 @@ module Datadog
           # This method modifies the `span` if it matches the provided matcher.
           #
           # @param [Datadog::Tracing::SpanOperation] span_op span to be sampled
-          # @return [Boolean] should this span be sampled?
-          # @return [nil] span did not satisfy the matcher, no changes are made to the span
+          # @return [:kept,:rejected] should this span be sampled?
+          # @return [:not_matched] span did not satisfy the matcher, no changes are made to the span
           def sample!(span_op)
-            return nil unless @matcher.match?(span_op)
+            return :not_matched unless @matcher.match?(span_op)
 
             if @sampler.sample?(span_op) && @rate_limiter.allow?(1)
               span_op.set_metric(Span::Ext::TAG_MECHANISM, Span::Ext::MECHANISM_SPAN_SAMPLING_RATE)
               span_op.set_metric(Span::Ext::TAG_RULE_RATE, @sample_rate)
               span_op.set_metric(Span::Ext::TAG_MAX_PER_SECOND, @rate_limit)
-              true
+              :kept
             else
-              false
+              :rejected
             end
           end
         end

--- a/lib/datadog/tracing/sampling/span/rule.rb
+++ b/lib/datadog/tracing/sampling/span/rule.rb
@@ -12,25 +12,25 @@ module Datadog
         #
         # If a span does not conform to the matcher, no changes are made.
         class Rule
-          attr_reader :matcher, :sampling_rate, :rate_limit
+          attr_reader :matcher, :sample_rate, :rate_limit
 
           # Creates a new span sampling rule.
           #
           # @param [Sampling::Span::Matcher] matcher whether this rule applies to a specific span
-          # @param [Float] sampling_rate span sampling ratio, between 0.0 (0%) and 1.0 (100%).
+          # @param [Float] sample_rate span sampling ratio, between 0.0 (0%) and 1.0 (100%).
           # @param [Numeric] rate_limit maximum number of spans sampled per second. Negative numbers mean unlimited spans.
           def initialize(
             matcher,
-            sampling_rate: Span::Ext::DEFAULT_SAMPLE_RATE,
+            sample_rate: Span::Ext::DEFAULT_SAMPLE_RATE,
             rate_limit: Span::Ext::DEFAULT_MAX_PER_SECOND
           )
 
             @matcher = matcher
-            @sampling_rate = sampling_rate
+            @sample_rate = sample_rate
             @rate_limit = rate_limit
 
             @sampler = Sampling::RateSampler.new
-            @sampler.sample_rate = sampling_rate
+            @sampler.sample_rate = sample_rate
             @rate_limiter = Sampling::TokenBucket.new(rate_limit)
           end
 
@@ -56,7 +56,7 @@ module Datadog
 
             if @sampler.sample?(span_op) && @rate_limiter.allow?(1)
               span_op.set_metric(Span::Ext::TAG_MECHANISM, Span::Ext::MECHANISM_SPAN_SAMPLING_RATE)
-              span_op.set_metric(Span::Ext::TAG_RULE_RATE, @sampling_rate)
+              span_op.set_metric(Span::Ext::TAG_RULE_RATE, @sample_rate)
               span_op.set_metric(Span::Ext::TAG_MAX_PER_SECOND, @rate_limit)
               true
             else

--- a/lib/datadog/tracing/sampling/span/rule.rb
+++ b/lib/datadog/tracing/sampling/span/rule.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'datadog/tracing/sampling/span/ext'
+
+module Datadog
+  module Tracing
+    module Sampling
+      module Span
+        # Span sampling rule that applies a sampling rate if the span
+        # matches the provided {Matcher}.
+        # Additionally, a rate limiter is also applied.
+        #
+        # If a span does not conform to the matcher, no changes are made.
+        class Rule
+          # Creates a new span sampling rule.
+          #
+          # @param [Sampling::Span::Matcher] matcher whether this rule applies to a specific span
+          # @param [Float] sampling_rate span sampling ratio, between 0.0 (0%) and 1.0 (100%).
+          # @param [Numeric] rate_limit maximum number of spans sampled per second. Negative numbers mean unlimited spans.
+          def initialize(matcher, sampling_rate, rate_limit)
+            @matcher = matcher
+            @sampling_rate = sampling_rate
+            @rate_limit = rate_limit
+
+            @sampler = Sampling::RateSampler.new
+            @sampler.sample_rate = sampling_rate
+            @rate_limiter = Sampling::TokenBucket.new(rate_limit)
+          end
+
+          # This method should only be invoked for spans that are part
+          # of a trace that has been dropped by trace-level sampling.
+          # Invoking it for other spans will cause incorrect sampling
+          # metrics to be reported by the Datadog App.
+          #
+          # Returns `true` if the provided span is sampled.
+          # If the span is dropped due to sampling rate or rate limiting,
+          # it returns `false`.
+          #
+          # Returns `nil` if the span did not meet the matching criteria by the
+          # provided matcher.
+          #
+          # This method modifies the `span` if it matches the provided matcher.
+          #
+          # @param [Datadog::Tracing::SpanOperation] span_op span to be sampled
+          # @return [Boolean] should this span be sampled?
+          # @return [nil] span did not satisfy the matcher, no changes are made to the span
+          def sample!(span_op)
+            return nil unless @matcher.match?(span_op)
+
+            if @sampler.sample?(span_op) && @rate_limiter.allow?(1)
+              span_op.set_metric(Span::Ext::TAG_MECHANISM, Span::Ext::MECHANISM_SPAN_SAMPLING_RATE)
+              span_op.set_metric(Span::Ext::TAG_RULE_RATE, @sampling_rate)
+              span_op.set_metric(Span::Ext::TAG_LIMIT_RATE, @rate_limiter.effective_rate)
+              true
+            else
+              false
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/tracing/sampling/span/rule.rb
+++ b/lib/datadog/tracing/sampling/span/rule.rb
@@ -50,7 +50,7 @@ module Datadog
             if @sampler.sample?(span_op) && @rate_limiter.allow?(1)
               span_op.set_metric(Span::Ext::TAG_MECHANISM, Span::Ext::MECHANISM_SPAN_SAMPLING_RATE)
               span_op.set_metric(Span::Ext::TAG_RULE_RATE, @sampling_rate)
-              span_op.set_metric(Span::Ext::TAG_LIMIT_RATE, @rate_limiter.effective_rate)
+              span_op.set_metric(Span::Ext::TAG_MAX_PER_SECOND, @rate_limit)
               true
             else
               false

--- a/lib/datadog/tracing/sampling/span/rule.rb
+++ b/lib/datadog/tracing/sampling/span/rule.rb
@@ -12,12 +12,19 @@ module Datadog
         #
         # If a span does not conform to the matcher, no changes are made.
         class Rule
+          attr_reader :matcher, :sampling_rate, :rate_limit
+
           # Creates a new span sampling rule.
           #
           # @param [Sampling::Span::Matcher] matcher whether this rule applies to a specific span
           # @param [Float] sampling_rate span sampling ratio, between 0.0 (0%) and 1.0 (100%).
           # @param [Numeric] rate_limit maximum number of spans sampled per second. Negative numbers mean unlimited spans.
-          def initialize(matcher, sampling_rate, rate_limit)
+          def initialize(
+            matcher,
+            sampling_rate: Span::Ext::DEFAULT_SAMPLE_RATE,
+            rate_limit: Span::Ext::DEFAULT_MAX_PER_SECOND
+          )
+
             @matcher = matcher
             @sampling_rate = sampling_rate
             @rate_limit = rate_limit

--- a/lib/datadog/tracing/sampling/span/rule.rb
+++ b/lib/datadog/tracing/sampling/span/rule.rb
@@ -30,6 +30,10 @@ module Datadog
             @rate_limit = rate_limit
 
             @sampler = Sampling::RateSampler.new
+            # Set the sample_rate outside of the initializer to allow for
+            # zero to be a "drop all".
+            # The RateSampler initializer enforces non-zero, falling back to 100% sampling
+            # if zero is provided.
             @sampler.sample_rate = sample_rate
             @rate_limiter = Sampling::TokenBucket.new(rate_limit)
           end

--- a/lib/datadog/tracing/span.rb
+++ b/lib/datadog/tracing/span.rb
@@ -28,6 +28,9 @@ module Datadog
       # The range of IDs also has to consider portability across different languages and platforms.
       RUBY_MAX_ID = (1 << 62) - 1
 
+      # Excludes zero from possible values
+      RUBY_ID_RANGE = (1..RUBY_MAX_ID).freeze
+
       # While we only generate 63-bit integers due to limitations in other languages, we support
       # parsing 64-bit integers for distributed tracing since an upstream system may generate one
       EXTERNAL_MAX_ID = 1 << 64

--- a/spec/datadog/core/environment/platform_spec.rb
+++ b/spec/datadog/core/environment/platform_spec.rb
@@ -1,0 +1,57 @@
+# typed: false
+
+require 'spec_helper'
+require 'datadog/core/environment/platform'
+
+RSpec.describe Datadog::Core::Environment::Platform do
+  describe '::hostname' do
+    subject(:hostname) { described_class.hostname }
+
+    context 'when Ruby version < 2.2', if: Datadog::Core::Environment::Ext::LANG_VERSION < '2.2' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'when Ruby version >= 2.2', if: Datadog::Core::Environment::Ext::LANG_VERSION >= '2.2' do
+      it { is_expected.to be_a_kind_of(String) }
+      it { is_expected.to eql(`uname -n`.strip) }
+    end
+  end
+
+  describe '::kernel_name' do
+    subject(:kernel_name) { described_class.kernel_name }
+    it { is_expected.to be_a_kind_of(String) }
+    it { is_expected.to eql(`uname -s`.strip) }
+  end
+
+  describe '::kernel_release' do
+    subject(:kernel_release) { described_class.kernel_release }
+
+    context 'when Ruby version < 2.2', if: Datadog::Core::Environment::Ext::LANG_VERSION < '2.2' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'when Ruby version >= 2.2', if: Datadog::Core::Environment::Ext::LANG_VERSION >= '2.2' do
+      it { is_expected.to be_a_kind_of(String) }
+      it { is_expected.to eql(`uname -r`.strip) }
+    end
+  end
+
+  describe '::kernel_version' do
+    subject(:kernel_version) { described_class.kernel_version }
+
+    context 'when using JRuby', if: Datadog::Core::Environment::Ext::RUBY_ENGINE == 'jruby' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'when not using JRuby', unless: Datadog::Core::Environment::Ext::RUBY_ENGINE == 'jruby' do
+      context 'when Ruby version < 2.2', if: Datadog::Core::Environment::Ext::LANG_VERSION < '2.2' do
+        it { is_expected.to be_nil }
+      end
+
+      context 'when Ruby version >= 2.2', if: Datadog::Core::Environment::Ext::LANG_VERSION >= '2.2' do
+        it { is_expected.to be_a_kind_of(String) }
+        it { is_expected.to eql(`uname -v`.strip) }
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/contrib/rest_client/request_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/rest_client/request_patch_spec.rb
@@ -306,5 +306,19 @@ RSpec.describe Datadog::Tracing::Contrib::RestClient::RequestPatch do
         end
       end
     end
+
+    context 'when split by domain' do
+      let(:configuration_options) { super().merge(split_by_domain: true) }
+
+      before { request }
+
+      it 'has correct service name' do
+        expect(span.service).to eq('example.com')
+      end
+
+      it_behaves_like 'a peer service span' do
+        let(:peer_hostname) { 'example.com' }
+      end
+    end
   end
 end

--- a/spec/datadog/tracing/sampling/span/rule_spec.rb
+++ b/spec/datadog/tracing/sampling/span/rule_spec.rb
@@ -2,7 +2,7 @@ require 'datadog/tracing/sampling/span/matcher'
 require 'datadog/tracing/sampling/span/rule'
 
 RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
-  subject(:rule) { described_class.new(matcher, sampling_rate, rate_limit) }
+  subject(:rule) { described_class.new(matcher, sampling_rate: sampling_rate, rate_limit: rate_limit) }
   let(:matcher) { instance_double(Datadog::Tracing::Sampling::Span::Matcher) }
   let(:sampling_rate) { 0.0 }
   let(:rate_limit) { 0 }
@@ -10,6 +10,19 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
   let(:span_op) { Datadog::Tracing::SpanOperation.new(span_name, service: span_service) }
   let(:span_name) { 'operation.name' }
   let(:span_service) { '' }
+
+  describe '#initialize' do
+    subject(:rule) { described_class.new(matcher) }
+    context 'default values' do
+      it 'sets sampling rate to 100%' do
+        expect(rule.sampling_rate).to eq(1.0)
+      end
+
+      it 'sets rate limit unlimited' do
+        expect(rule.rate_limit).to eq(-1)
+      end
+    end
+  end
 
   describe '#sample!' do
     subject(:sample!) { rule.sample!(span_op) }

--- a/spec/datadog/tracing/sampling/span/rule_spec.rb
+++ b/spec/datadog/tracing/sampling/span/rule_spec.rb
@@ -2,9 +2,9 @@ require 'datadog/tracing/sampling/span/matcher'
 require 'datadog/tracing/sampling/span/rule'
 
 RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
-  subject(:rule) { described_class.new(matcher, sampling_rate: sampling_rate, rate_limit: rate_limit) }
+  subject(:rule) { described_class.new(matcher, sample_rate: sample_rate, rate_limit: rate_limit) }
   let(:matcher) { instance_double(Datadog::Tracing::Sampling::Span::Matcher) }
-  let(:sampling_rate) { 0.0 }
+  let(:sample_rate) { 0.0 }
   let(:rate_limit) { 0 }
 
   let(:span_op) { Datadog::Tracing::SpanOperation.new(span_name, service: span_service) }
@@ -15,7 +15,7 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
     subject(:rule) { described_class.new(matcher) }
     context 'default values' do
       it 'sets sampling rate to 100%' do
-        expect(rule.sampling_rate).to eq(1.0)
+        expect(rule.sample_rate).to eq(1.0)
       end
 
       it 'sets rate limit unlimited' do
@@ -37,7 +37,7 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
       end
 
       context 'not sampled' do
-        let(:sampling_rate) { 0.0 }
+        let(:sample_rate) { 0.0 }
 
         it 'returns false' do
           is_expected.to eq(false)
@@ -47,7 +47,7 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
       end
 
       context 'sampled' do
-        let(:sampling_rate) { 1.0 }
+        let(:sample_rate) { 1.0 }
 
         context 'rate limited' do
           let(:rate_limit) { 0 }

--- a/spec/datadog/tracing/sampling/span/rule_spec.rb
+++ b/spec/datadog/tracing/sampling/span/rule_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
         end
 
         context 'not rate limited' do
-          let(:rate_limit) { 10 }
+          let(:rate_limit) { 3 }
 
           it 'returns true' do
             is_expected.to eq(true)
@@ -58,7 +58,7 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
 
             expect(span_op.get_metric('_dd.span_sampling.mechanism')).to eq(8)
             expect(span_op.get_metric('_dd.span_sampling.rule_rate')).to eq(1.0)
-            expect(span_op.get_metric('_dd.span_sampling.limit_rate')).to eq(1.0)
+            expect(span_op.get_metric('_dd.span_sampling.max_per_second')).to eq(3)
           end
         end
       end

--- a/spec/datadog/tracing/sampling/span/rule_spec.rb
+++ b/spec/datadog/tracing/sampling/span/rule_spec.rb
@@ -1,0 +1,79 @@
+require 'datadog/tracing/sampling/span/matcher'
+require 'datadog/tracing/sampling/span/rule'
+
+RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
+  subject(:rule) { described_class.new(matcher, sampling_rate, rate_limit) }
+  let(:matcher) { instance_double(Datadog::Tracing::Sampling::Span::Matcher) }
+  let(:sampling_rate) { 0.0 }
+  let(:rate_limit) { 0 }
+
+  let(:span_op) { Datadog::Tracing::SpanOperation.new(span_name, service: span_service) }
+  let(:span_name) { 'operation.name' }
+  let(:span_service) { '' }
+
+  describe '#sample!' do
+    subject(:sample!) { rule.sample!(span_op) }
+
+    shared_examples 'does not modify span' do
+      it { expect { sample! }.to_not(change { span_op.send(:build_span).to_hash }) }
+    end
+
+    context 'when matching' do
+      before do
+        expect(matcher).to receive(:match?).with(span_op).and_return(true)
+      end
+
+      context 'not sampled' do
+        let(:sampling_rate) { 0.0 }
+
+        it 'returns false' do
+          is_expected.to eq(false)
+        end
+
+        it_behaves_like 'does not modify span'
+      end
+
+      context 'sampled' do
+        let(:sampling_rate) { 1.0 }
+
+        context 'rate limited' do
+          let(:rate_limit) { 0 }
+
+          it 'returns false' do
+            is_expected.to eq(false)
+          end
+
+          it_behaves_like 'does not modify span'
+        end
+
+        context 'not rate limited' do
+          let(:rate_limit) { 10 }
+
+          it 'returns true' do
+            is_expected.to eq(true)
+          end
+
+          it 'sets mechanism, rule rate and rate limit metrics' do
+            sample!
+
+            expect(span_op.get_metric('_dd.span_sampling.mechanism')).to eq(8)
+            expect(span_op.get_metric('_dd.span_sampling.rule_rate')).to eq(1.0)
+            expect(span_op.get_metric('_dd.span_sampling.limit_rate')).to eq(1.0)
+          end
+        end
+      end
+    end
+
+    context 'when not matching' do
+      before do
+        expect(matcher).to receive(:match?).with(span_op).and_return(false)
+      end
+
+      it 'returns nil' do
+        is_expected.to be_nil
+      end
+
+      it_behaves_like 'does not modify span'
+    end
+  end
+end

--- a/spec/datadog/tracing/sampling/span/rule_spec.rb
+++ b/spec/datadog/tracing/sampling/span/rule_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
       context 'not sampled' do
         let(:sample_rate) { 0.0 }
 
-        it 'returns false' do
-          is_expected.to eq(false)
+        it 'returns rejected' do
+          is_expected.to eq(:rejected)
         end
 
         it_behaves_like 'does not modify span'
@@ -52,8 +52,8 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
         context 'rate limited' do
           let(:rate_limit) { 0 }
 
-          it 'returns false' do
-            is_expected.to eq(false)
+          it 'returns rejected' do
+            is_expected.to eq(:rejected)
           end
 
           it_behaves_like 'does not modify span'
@@ -62,8 +62,8 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
         context 'not rate limited' do
           let(:rate_limit) { 3 }
 
-          it 'returns true' do
-            is_expected.to eq(true)
+          it 'returns kept' do
+            is_expected.to eq(:kept)
           end
 
           it 'sets mechanism, rule rate and rate limit metrics' do
@@ -83,7 +83,7 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Rule do
       end
 
       it 'returns nil' do
-        is_expected.to be_nil
+        is_expected.to eq(:not_matched)
       end
 
       it_behaves_like 'does not modify span'

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -26,13 +26,6 @@ RSpec.describe Datadog::Tracing::Tracer do
 
   after { tracer.shutdown! }
 
-  shared_context 'parent span' do
-    let(:parent_span) { tracer.start_span('parent', service: service) }
-    let(:service) { 'test-service' }
-    let(:trace_id) { parent_span.trace_id }
-    let(:span_id) { parent_span.span_id }
-  end
-
   describe '::new' do
     context 'given :trace_flush' do
       let(:tracer_options) { super().merge(trace_flush: trace_flush) }
@@ -192,25 +185,6 @@ RSpec.describe Datadog::Tracing::Tracer do
         it 'sets the span name from the name argument' do
           trace
           expect(span.name).to eq(name)
-        end
-
-        it 'tracks the number of allocations made in the span' do
-          skip 'Test unstable; improve stability before re-enabling.'
-
-          # Create and discard first trace.
-          # When warming up, it might have more allocations than subsequent traces.
-          tracer.trace(name) {}
-          writer.spans
-
-          # Then create traces to compare
-          tracer.trace(name) {}
-          tracer.trace(name) { Object.new }
-
-          first, second = writer.spans
-
-          # Different versions of Ruby will allocate a different number of
-          # objects, so this is what works across the board.
-          expect(second.allocations).to eq(first.allocations + 1)
         end
 
         context 'with diagnostics debug enabled' do


### PR DESCRIPTION
Follow up to #2055

This PR adds a sampling rule that applies a sampling rate (between 0% and 100% sampling) to a single span operation.

This rate is only applied if the provided matcher, introduced in #2055, is satisfied.

Additionally, a rate limiter (spans/sec limit) is applied to spans that satisfy both the matcher and sampling rate.

If the span is kept after all these checks, a few metrics are set in the span to let the Datadog App downstream know how the sampling happened: this allows it to adjust rates reported in the App despite receiving only a subset of the spans. It also allows users to know how much rate limiting is affecting their observability.

Also a reminder that the concept of "Single Span Sampling" only applies to spans that are part of traces that were dropped at trace-level sampling. Spans that are part of traces that have been successfully sampled do not need Single Span Sampling to be ingested.