### PR TITLE
[Single Span Sampling] Add single span parser

### DIFF
--- a/lib/datadog/tracing/sampling/rate_limiter.rb
+++ b/lib/datadog/tracing/sampling/rate_limiter.rb
@@ -39,6 +39,9 @@ module Datadog
         def initialize(rate, max_tokens = rate)
           super()
 
+          raise ArgumentError, "rate must be a number: #{rate}" unless rate.is_a?(Numeric)
+          raise ArgumentError, "max_tokens must be a number: #{max_tokens}" unless max_tokens.is_a?(Numeric)
+
           @rate = rate
           @max_tokens = max_tokens
 

--- a/lib/datadog/tracing/sampling/span/matcher.rb
+++ b/lib/datadog/tracing/sampling/span/matcher.rb
@@ -6,6 +6,8 @@ module Datadog
       module Span
         # Checks if a span conforms to a matching criteria.
         class Matcher
+          attr_reader :name, :service
+
           # Pattern that matches any string
           MATCH_ALL_PATTERN = '*'
 
@@ -52,6 +54,13 @@ module Datadog
             def match?(span)
               @name === span.name && @service === span.service
             end
+          end
+
+          def ==(other)
+            return super unless other.is_a?(Matcher)
+
+            name == other.name &&
+              service == other.service
           end
 
           private

--- a/lib/datadog/tracing/sampling/span/rule.rb
+++ b/lib/datadog/tracing/sampling/span/rule.rb
@@ -67,6 +67,14 @@ module Datadog
               :rejected
             end
           end
+
+          def ==(other)
+            return super unless other.is_a?(Rule)
+
+            matcher == other.matcher &&
+              sample_rate == other.sample_rate &&
+              rate_limit == other.rate_limit
+          end
         end
       end
     end

--- a/lib/datadog/tracing/sampling/span/rule_parser.rb
+++ b/lib/datadog/tracing/sampling/span/rule_parser.rb
@@ -41,14 +41,12 @@ module Datadog
             # @return [nil] if parsing failed
             def parse_list(rules)
               unless rules.is_a?(Array)
-                # Using JSON terminology for the expected error type
                 Datadog.logger.warn("Span Sampling Rules are not an array: #{rules.inspect}")
                 return nil
               end
 
               parsed = rules.map do |hash|
                 unless hash.is_a?(Hash)
-                  # Using JSON terminology for the expected error type
                   Datadog.logger.warn("Span Sampling Rule is not a key-value object: #{hash.inspect}")
                   return nil
                 end

--- a/lib/datadog/tracing/sampling/span/rule_parser.rb
+++ b/lib/datadog/tracing/sampling/span/rule_parser.rb
@@ -23,8 +23,9 @@ module Datadog
             def parse_json(rules)
               begin
                 list = JSON.parse(rules)
-              rescue JSON::ParserError => e
-                Datadog.logger.warn("Error parsing Span Sampling Rules \"#{e}\" for rules: #{rules}")
+              rescue => e
+                Datadog.logger.warn("Error parsing Span Sampling Rules `#{rules}`. "\
+                                    "Cause #{e.class.name} #{e.message} Location: #{Array(e.backtrace).first}")
                 return nil
               end
 

--- a/lib/datadog/tracing/sampling/span/rule_parser.rb
+++ b/lib/datadog/tracing/sampling/span/rule_parser.rb
@@ -24,8 +24,8 @@ module Datadog
               begin
                 list = JSON.parse(rules)
               rescue => e
-                Datadog.logger.warn("Error parsing Span Sampling Rules `#{rules}`. "\
-                                    "Cause #{e.class.name} #{e.message} Location: #{Array(e.backtrace).first}")
+                Datadog.logger.warn("Error parsing Span Sampling Rules `#{rules.inspect}`: "\
+                                    "#{e.class.name} #{e.message} at #{Array(e.backtrace).first}")
                 return nil
               end
 
@@ -42,21 +42,21 @@ module Datadog
             def parse_list(rules)
               unless rules.is_a?(Array)
                 # Using JSON terminology for the expected error type
-                Datadog.logger.warn("Span Sampling Rules are not an array: #{JSON.dump(rules)}")
+                Datadog.logger.warn("Span Sampling Rules are not an array: #{rules.inspect}")
                 return nil
               end
 
               parsed = rules.map do |hash|
                 unless hash.is_a?(Hash)
                   # Using JSON terminology for the expected error type
-                  Datadog.logger.warn("Span Sampling Rule is not a key-value object: #{JSON.dump(hash)}")
+                  Datadog.logger.warn("Span Sampling Rule is not a key-value object: #{hash.inspect}")
                   return nil
                 end
 
                 begin
                   parse_rule(hash)
                 rescue => e
-                  Datadog.logger.warn("Cannot parse Span Sampling Rule #{JSON.dump(hash)}: " \
+                  Datadog.logger.warn("Cannot parse Span Sampling Rule #{hash.inspect}: " \
                   "#{e.class.name} #{e} at #{Array(e.backtrace).first}")
                   nil
                 end

--- a/lib/datadog/tracing/sampling/span/rule_parser.rb
+++ b/lib/datadog/tracing/sampling/span/rule_parser.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'datadog/tracing/sampling/span/ext'
+require 'datadog/tracing/sampling/span/matcher'
+require 'datadog/tracing/sampling/span/rule'
+
+module Datadog
+  module Tracing
+    module Sampling
+      module Span
+        # Converts user configuration into {Datadog::Tracing::Sampling::Span::Rule} objects,
+        # handling any parsing errors.
+        module RuleParser
+          class << self
+            # Parses the provided JSON string containing the Single Span
+            # Sampling configuration list.
+            # In case of parsing errors, `nil` is returned.
+            #
+            # @param rules [String] the JSON configuration rules to be parsed
+            # @return [Array<Datadog::Tracing::Sampling::Span::Rule>] a list of parsed rules
+            # @return [nil] if parsing failed
+            def parse_json(rules)
+              begin
+                list = JSON.parse(rules)
+              rescue JSON::ParserError => e
+                Datadog.logger.warn("Error parsing Span Sampling Rules \"#{e}\" for rules: #{rules}")
+                return nil
+              end
+
+              parse_list(list)
+            end
+
+            # Parses a list of Hashes containing the parsed JSON information
+            # for Single Span Sampling configuration.
+            # In case of parsing errors, `nil` is returned.
+            #
+            # @param rules [Array<String] the JSON configuration rules to be parsed
+            # @return [Array<Datadog::Tracing::Sampling::Span::Rule>] a list of parsed rules
+            # @return [nil] if parsing failed
+            def parse_list(rules)
+              unless rules.is_a?(Array)
+                # Using JSON terminology for the expected error type
+                Datadog.logger.warn("Span Sampling Rules are not an array: #{JSON.dump(rules)}")
+                return nil
+              end
+
+              parsed = rules.map do |hash|
+                unless hash.is_a?(Hash)
+                  # Using JSON terminology for the expected error type
+                  Datadog.logger.warn("Span Sampling Rule is not a key-value object: #{JSON.dump(hash)}")
+                  return nil
+                end
+
+                begin
+                  parse_rule(hash)
+                rescue => e
+                  Datadog.logger.warn("Cannot parse Span Sampling Rule #{JSON.dump(hash)}: " \
+                  "#{e.class.name} #{e} at #{Array(e.backtrace).first}")
+                  nil
+                end
+              end
+
+              parsed.compact!
+              parsed
+            end
+
+            private
+
+            def parse_rule(hash)
+              matcher_options = {}
+              if (name_pattern = hash['name'])
+                matcher_options[:name_pattern] = name_pattern
+              end
+
+              if (service_pattern = hash['service'])
+                matcher_options[:service_pattern] = service_pattern
+              end
+
+              matcher = Matcher.new(**matcher_options)
+
+              rule_options = {}
+              if (sample_rate = hash['sample_rate'])
+                rule_options[:sample_rate] = sample_rate
+              end
+
+              if (max_per_second = hash['max_per_second'])
+                rule_options[:rate_limit] = max_per_second
+              end
+
+              Rule.new(matcher, **rule_options)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/sampling/rate_limiter_spec.rb
+++ b/spec/datadog/tracing/sampling/rate_limiter_spec.rb
@@ -18,6 +18,22 @@ RSpec.describe Datadog::Tracing::Sampling::TokenBucket do
     it 'has all tokens available' do
       expect(bucket.available_tokens).to eq(max_tokens)
     end
+
+    context 'with invalid rate' do
+      let(:rate) { :bad }
+
+      it 'raises argument error' do
+        expect { bucket }.to raise_error(ArgumentError, /bad/)
+      end
+    end
+
+    context 'with invalid max_tokens' do
+      let(:max_tokens) { :bad }
+
+      it 'raises argument error' do
+        expect { bucket }.to raise_error(ArgumentError, /bad/)
+      end
+    end
   end
 
   describe '#allow?' do

--- a/spec/datadog/tracing/sampling/span/rule_parser_spec.rb
+++ b/spec/datadog/tracing/sampling/span/rule_parser_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe Datadog::Tracing::Sampling::Span::RuleParser do
 
     context 'valid JSON' do
       context 'not a list' do
-        let(:json_input) { { not: 'list' } }
+        let(:json_input) { { 'not' => 'list' } }
 
         it 'warns and returns nil' do
-          expect(Datadog.logger).to receive(:warn).with(include(rules_string))
+          expect(Datadog.logger).to receive(:warn).with(include(json_input.inspect))
           is_expected.to be(nil)
         end
       end
@@ -76,10 +76,10 @@ RSpec.describe Datadog::Tracing::Sampling::Span::RuleParser do
             end
 
             context 'with an invalid value' do
-              let(:name) { { bad: 'name' } }
+              let(:name) { { 'bad' => 'name' } }
 
               it 'warns and returns nil' do
-                expect(Datadog.logger).to receive(:warn).with(include('{"bad":"name"}') & include('Error'))
+                expect(Datadog.logger).to receive(:warn).with(include(name.inspect) & include('Error'))
                 is_expected.to be_empty
               end
             end
@@ -97,10 +97,10 @@ RSpec.describe Datadog::Tracing::Sampling::Span::RuleParser do
             end
 
             context 'with an invalid value' do
-              let(:service) { { bad: 'service' } }
+              let(:service) { { 'bad' => 'service' } }
 
               it 'warns and returns nil' do
-                expect(Datadog.logger).to receive(:warn).with(include('{"bad":"service"}') & include('Error'))
+                expect(Datadog.logger).to receive(:warn).with(include(service.inspect) & include('Error'))
                 is_expected.to be_empty
               end
             end
@@ -118,10 +118,10 @@ RSpec.describe Datadog::Tracing::Sampling::Span::RuleParser do
             end
 
             context 'with an invalid value' do
-              let(:sample_rate) { { bad: 'sample_rate' } }
+              let(:sample_rate) { { 'bad' => 'sample_rate' } }
 
               it 'warns and returns nil' do
-                expect(Datadog.logger).to receive(:warn).with(include('{"bad":"sample_rate"}') & include('Error'))
+                expect(Datadog.logger).to receive(:warn).with(include(sample_rate.inspect) & include('Error'))
                 is_expected.to be_empty
               end
             end
@@ -139,10 +139,10 @@ RSpec.describe Datadog::Tracing::Sampling::Span::RuleParser do
             end
 
             context 'with an invalid value' do
-              let(:max_per_second) { { bad: 'max_per_second' } }
+              let(:max_per_second) { { 'bad' => 'max_per_second' } }
 
               it 'warns and returns nil' do
-                expect(Datadog.logger).to receive(:warn).with(include('{"bad":"max_per_second"}') & include('Error'))
+                expect(Datadog.logger).to receive(:warn).with(include(max_per_second.inspect) & include('Error'))
                 is_expected.to be_empty
               end
             end

--- a/spec/datadog/tracing/sampling/span/rule_parser_spec.rb
+++ b/spec/datadog/tracing/sampling/span/rule_parser_spec.rb
@@ -1,0 +1,154 @@
+require 'datadog/tracing/sampling/span/rule_parser'
+
+RSpec.describe Datadog::Tracing::Sampling::Span::RuleParser do
+  describe '.parse_json' do
+    subject(:parse) { described_class.parse_json(rules_string) }
+    let(:rules_string) { JSON.dump(json_input) }
+    let(:json_input) { [] }
+
+    shared_examples 'does not modify span' do
+      it { expect { sample! }.to_not(change { span_op.send(:build_span).to_hash }) }
+    end
+
+    context 'invalid JSON' do
+      let(:rules_string) { '-not-json-' }
+
+      it 'warns and returns nil' do
+        expect(Datadog.logger).to receive(:warn).with(include(rules_string))
+        is_expected.to be(nil)
+      end
+    end
+
+    context 'valid JSON' do
+      context 'not a list' do
+        let(:json_input) { { not: 'list' } }
+
+        it 'warns and returns nil' do
+          expect(Datadog.logger).to receive(:warn).with(include(rules_string))
+          is_expected.to be(nil)
+        end
+      end
+
+      context 'a list' do
+        context 'without valid rules' do
+          let(:json_input) { ['not a hash'] }
+
+          it 'warns and returns nil' do
+            expect(Datadog.logger).to receive(:warn).with(include('not a hash'))
+            is_expected.to be(nil)
+          end
+        end
+
+        context 'with valid rules' do
+          let(:json_input) { [rule] }
+
+          let(:rule) do
+            {
+              name: name,
+              service: service,
+              sample_rate: sample_rate,
+              max_per_second: max_per_second,
+            }
+          end
+
+          let(:name) { nil }
+          let(:service) { nil }
+          let(:sample_rate) { nil }
+          let(:max_per_second) { nil }
+
+          context 'and default values' do
+            it 'delegates defaults to the rule and matcher' do
+              is_expected.to contain_exactly(
+                Datadog::Tracing::Sampling::Span::Rule.new(Datadog::Tracing::Sampling::Span::Matcher.new)
+              )
+            end
+          end
+
+          context 'with name' do
+            let(:name) { 'name' }
+
+            it 'sets the rule matcher name' do
+              is_expected.to contain_exactly(
+                Datadog::Tracing::Sampling::Span::Rule.new(
+                  Datadog::Tracing::Sampling::Span::Matcher.new(name_pattern: name)
+                )
+              )
+            end
+
+            context 'with an invalid value' do
+              let(:name) { { bad: 'name' } }
+
+              it 'warns and returns nil' do
+                expect(Datadog.logger).to receive(:warn).with(include('{"bad":"name"}') & include('Error'))
+                is_expected.to be_empty
+              end
+            end
+          end
+
+          context 'with service' do
+            let(:service) { 'service' }
+
+            it 'sets the rule matcher service' do
+              is_expected.to contain_exactly(
+                Datadog::Tracing::Sampling::Span::Rule.new(
+                  Datadog::Tracing::Sampling::Span::Matcher.new(service_pattern: service)
+                )
+              )
+            end
+
+            context 'with an invalid value' do
+              let(:service) { { bad: 'service' } }
+
+              it 'warns and returns nil' do
+                expect(Datadog.logger).to receive(:warn).with(include('{"bad":"service"}') & include('Error'))
+                is_expected.to be_empty
+              end
+            end
+          end
+
+          context 'with sample_rate' do
+            let(:sample_rate) { 1.0 }
+
+            it 'sets the rule matcher service' do
+              is_expected.to contain_exactly(
+                Datadog::Tracing::Sampling::Span::Rule.new(
+                  Datadog::Tracing::Sampling::Span::Matcher.new, sample_rate: sample_rate
+                )
+              )
+            end
+
+            context 'with an invalid value' do
+              let(:sample_rate) { { bad: 'sample_rate' } }
+
+              it 'warns and returns nil' do
+                expect(Datadog.logger).to receive(:warn).with(include('{"bad":"sample_rate"}') & include('Error'))
+                is_expected.to be_empty
+              end
+            end
+          end
+
+          context 'with max_per_second' do
+            let(:max_per_second) { 10 }
+
+            it 'sets the rule matcher service' do
+              is_expected.to contain_exactly(
+                Datadog::Tracing::Sampling::Span::Rule.new(
+                  Datadog::Tracing::Sampling::Span::Matcher.new, rate_limit: max_per_second
+                )
+              )
+            end
+
+            context 'with an invalid value' do
+              let(:max_per_second) { { bad: 'max_per_second' } }
+
+              it 'warns and returns nil' do
+                expect(Datadog.logger).to receive(:warn).with(include('{"bad":"max_per_second"}') & include('Error'))
+                is_expected.to be_empty
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Follows up from #2091 

This PR parses user provided JSON rules into `Datadog::Tracing::Sampling::Span::Rule` objects.

The code ensures that no errors are propagated back to the user in the form of an exception, but all errors are logged to aid in addressing them.

In the future, we'll likely support parsing this data directly from YAML or a global `datadog.conf` JSON, thus a non-JSON specific method, `parse_list`, is also provided in additional to the main `parse_json` method.

A few other changes:
* The `TokenBucket` now is more strict about its inputs, which helps the validation of Single Span sample rules.
* Equality helpers were added to `Rule` and `Matcher` to ease testing.