### PR TITLE
Fix object_id usage as thread local key

### DIFF
--- a/lib/datadog/opentracer/thread_local_scope_manager.rb
+++ b/lib/datadog/opentracer/thread_local_scope_manager.rb
@@ -47,11 +47,13 @@ module Datadog
       # but the VM is allowed to reuse `object_id`, allow for the possibility that
       # a new FiberLocalContext would be able to read an old FiberLocalContext's
       # value.
-      @mutex = Mutex.new
-      @unique_instance_id = Datadog::Core::Utils::Sequence.new
+      UNIQUE_INSTANCE_MUTEX = Mutex.new
+      UNIQUE_INSTANCE_GENERATOR = Datadog::Core::Utils::Sequence.new
+
+      private_constant :UNIQUE_INSTANCE_MUTEX, :UNIQUE_INSTANCE_GENERATOR
 
       def self.next_instance_id
-        @mutex.synchronize { @unique_instance_id.next }
+        UNIQUE_INSTANCE_MUTEX.synchronize { UNIQUE_INSTANCE_GENERATOR.next }
       end
 
       private

--- a/lib/datadog/tracing/context_provider.rb
+++ b/lib/datadog/tracing/context_provider.rb
@@ -1,5 +1,6 @@
 # typed: true
 
+require 'datadog/core/utils/sequence'
 require 'datadog/tracing/context'
 
 module Datadog
@@ -47,7 +48,7 @@ module Datadog
       # To support multiple tracers simultaneously, each {Datadog::Tracing::FiberLocalContext}
       # instance has its own fiber-local variable.
       def initialize
-        @key = "datadog_context_#{object_id}".to_sym
+        @key = "datadog_context_#{FiberLocalContext.next_instance_id}".to_sym
 
         self.local = Context.new
       end
@@ -60,6 +61,18 @@ module Datadog
       # Return the fiber-local context.
       def local(storage = Thread.current)
         storage[@key] ||= Context.new
+      end
+
+      # Ensure two instances of {FiberLocalContext} do not conflict.
+      # We previously used {FiberLocalContext#object_id} to ensure uniqueness
+      # but the VM is allowed to reuse `object_id`, allow for the possibility that
+      # a new FiberLocalContext would be able to read an old FiberLocalContext's
+      # value.
+      @mutex = Mutex.new
+      @unique_instance_id = Datadog::Core::Utils::Sequence.new
+
+      def self.next_instance_id
+        @mutex.synchronize { @unique_instance_id.next }
       end
     end
   end

--- a/lib/datadog/tracing/context_provider.rb
+++ b/lib/datadog/tracing/context_provider.rb
@@ -68,11 +68,11 @@ module Datadog
       # but the VM is allowed to reuse `object_id`, allow for the possibility that
       # a new FiberLocalContext would be able to read an old FiberLocalContext's
       # value.
-      @mutex = Mutex.new
-      @unique_instance_id = Datadog::Core::Utils::Sequence.new
+      UNIQUE_INSTANCE_MUTEX = Mutex.new
+      UNIQUE_INSTANCE_GENERATOR = Datadog::Core::Utils::Sequence.new
 
       def self.next_instance_id
-        @mutex.synchronize { @unique_instance_id.next }
+        UNIQUE_INSTANCE_MUTEX.synchronize { UNIQUE_INSTANCE_GENERATOR.next }
       end
     end
   end

--- a/lib/datadog/tracing/context_provider.rb
+++ b/lib/datadog/tracing/context_provider.rb
@@ -71,6 +71,8 @@ module Datadog
       UNIQUE_INSTANCE_MUTEX = Mutex.new
       UNIQUE_INSTANCE_GENERATOR = Datadog::Core::Utils::Sequence.new
 
+      private_constant :UNIQUE_INSTANCE_MUTEX, :UNIQUE_INSTANCE_GENERATOR
+
       def self.next_instance_id
         UNIQUE_INSTANCE_MUTEX.synchronize { UNIQUE_INSTANCE_GENERATOR.next }
       end

--- a/lib/datadog/tracing/context_provider.rb
+++ b/lib/datadog/tracing/context_provider.rb
@@ -31,6 +31,7 @@ module Datadog
         # that were generated from the parent process. Reset it such
         # that it acts like a distributed trace.
         current_context.after_fork! do
+          # TODO: Only assign to `self.context` when working on the current thread (`key == nil`)
           current_context = self.context = current_context.fork_clone
         end
 


### PR DESCRIPTION
I stumbled upon this flaky error: https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/6331/workflows/02b56e62-53d7-4d50-ac12-f3e84194bf8f/jobs/234310/parallel-runs/1
```
Failures:

  1) Datadog::Tracing::FiberLocalContext#initialize create one fiber-local variable
     Failure/Error: expect { fiber_local_context }.to change { Thread.current.keys.size }.by(1)
       expected `Thread.current.keys.size` to have changed by 1, but was changed by 0
     # ./spec/datadog/tracing/context_provider_spec.rb:100:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:216:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:108:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

It happens because we use `object_id` as a thread local key and `object_id` can be reused after garbage collection, causing collision between a recently garbage collected instance of `FiberLocalContext` and a new one.

This PR addresses this issue in two places where we use `object_id` as a thread local key by creating a thread-safe counter for each of the object instances.

**If there's an easier/cheaper way to get a unique identifier please let me know!**