### PR TITLE
[Single Span Sampling] Span Sampler

### DIFF
--- a/lib/datadog/tracing/sampling/span/sampler.rb
+++ b/lib/datadog/tracing/sampling/span/sampler.rb
@@ -1,0 +1,45 @@
+module Datadog
+  module Tracing
+    module Sampling
+      module Span
+        # Applies a set of rules to a span.
+        # This class is used to apply sampling operations to all
+        # spans in the tracer.
+        #
+        # Span sampling is distinct from trace sampling: span
+        # sampling can keep a span that is part of tracer that was
+        # rejected by trace sampling.
+        #
+        # This class only applies operations to spans that are part
+        # of traces that were rejected by trace sampling. There's no
+        # reason to try to sample spans that are already kept by
+        # the trace sampler.
+        class Sampler
+          # Receives sampling rules to apply to individual spans.
+          #
+          # @param [Array<Datadog::Tracing::Sampling::Span::Rule>] rules list of rules to apply to spans
+          def initialize(rules = [])
+            @rules = rules
+          end
+
+          # Applies sampling rules to the span if the trace has been rejected.
+          #
+          # If multiple rules match, only the first one is applied.
+          #
+          # @param [Datadog::Tracing::TraceOperation] trace_op trace for the provided span
+          # @param [Datadog::Tracing::SpanOperation] span_op Span to apply sampling rules
+          # @return [void]
+          def sample!(trace_op, span_op)
+            return if trace_op.sampled?
+
+            # Return as soon as one rule returns non-nil
+            # DEV: `all?{|x|x.nil?}` is faster than `any?{|x|!x.nil?}`
+            @rules.all? do |rule|
+              rule.sample!(span_op).nil?
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/tracing/sampling/span/sampler.rb
+++ b/lib/datadog/tracing/sampling/span/sampler.rb
@@ -32,11 +32,12 @@ module Datadog
           def sample!(trace_op, span_op)
             return if trace_op.sampled?
 
-            # Return as soon as one rule returns non-nil
-            # DEV: `all?{|x|x.nil?}` is faster than `any?{|x|!x.nil?}`
-            @rules.all? do |rule|
-              rule.sample!(span_op).nil?
+            # Return as soon as one rule matches
+            @rules.any? do |rule|
+              rule.sample!(span_op) != :not_matched
             end
+
+            nil
           end
         end
       end

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -472,7 +472,7 @@ module Datadog
         end
       end
 
-      SAMPLE_TRACE_LOG_ONLY_ONCE = Utils::OnlyOnce.new
+      SAMPLE_TRACE_LOG_ONLY_ONCE = Core::Utils::OnlyOnce.new
       private_constant :SAMPLE_TRACE_LOG_ONLY_ONCE
 
       def sample_span(trace_op, span)
@@ -485,7 +485,7 @@ module Datadog
         end
       end
 
-      SAMPLE_SPAN_LOG_ONLY_ONCE = Utils::OnlyOnce.new
+      SAMPLE_SPAN_LOG_ONLY_ONCE = Core::Utils::OnlyOnce.new
       private_constant :SAMPLE_SPAN_LOG_ONLY_ONCE
 
       # Flush finished spans from the trace buffer, send them to writer.
@@ -500,7 +500,7 @@ module Datadog
         end
       end
 
-      FLUSH_TRACE_LOG_ONLY_ONCE = Utils::OnlyOnce.new
+      FLUSH_TRACE_LOG_ONLY_ONCE = Core::Utils::OnlyOnce.new
       private_constant :FLUSH_TRACE_LOG_ONLY_ONCE
 
       # Send the trace to the writer to enqueue the spans list in the agent

--- a/spec/datadog/tracing/sampling/span/sampler_spec.rb
+++ b/spec/datadog/tracing/sampling/span/sampler_spec.rb
@@ -1,0 +1,64 @@
+require 'datadog/tracing/sampling/span/matcher'
+require 'datadog/tracing/sampling/span/rule'
+
+require 'datadog/tracing/sampling/span/sampler'
+
+RSpec.describe Datadog::Tracing::Sampling::Span::Sampler do
+  subject(:sampler) { described_class.new(rules) }
+  let(:rules) { [] }
+
+  let(:trace_op) { Datadog::Tracing::TraceOperation.new }
+  let(:span_op) { Datadog::Tracing::SpanOperation.new('name', service: 'service') }
+
+  describe '#sample!' do
+    subject(:sample!) { sampler.sample!(trace_op, span_op) }
+
+    shared_examples 'does not modify span' do
+      it { expect { sample! }.to_not(change { span_op.send(:build_span).to_hash }) }
+    end
+
+    let(:match_all) { Datadog::Tracing::Sampling::Span::Matcher.new }
+    context 'no matching rules' do
+      it_behaves_like 'does not modify span'
+    end
+
+    context 'with matching rules' do
+      let(:rules) { [Datadog::Tracing::Sampling::Span::Rule.new(match_all, sample_rate: 1.0, rate_limit: 3)] }
+
+      context 'a kept trace' do
+        before { trace_op.keep! }
+
+        it_behaves_like 'does not modify span'
+      end
+
+      context 'a rejected trace' do
+        before { trace_op.reject! }
+
+        it 'sets mechanism, rule rate and rate limit metrics' do
+          sample!
+
+          expect(span_op.get_metric('_dd.span_sampling.mechanism')).to eq(8)
+          expect(span_op.get_metric('_dd.span_sampling.rule_rate')).to eq(1.0)
+          expect(span_op.get_metric('_dd.span_sampling.max_per_second')).to eq(3)
+        end
+
+        context 'multiple rules' do
+          let(:rules) do
+            [
+              Datadog::Tracing::Sampling::Span::Rule.new(match_all, sample_rate: 1.0, rate_limit: 3),
+              Datadog::Tracing::Sampling::Span::Rule.new(match_all, sample_rate: 0.5, rate_limit: 2),
+            ]
+          end
+
+          it 'applies the first matching rule' do
+            sample!
+
+            expect(span_op.get_metric('_dd.span_sampling.mechanism')).to eq(8)
+            expect(span_op.get_metric('_dd.span_sampling.rule_rate')).to eq(1.0)
+            expect(span_op.get_metric('_dd.span_sampling.max_per_second')).to eq(3)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -509,6 +509,26 @@ RSpec.describe Datadog::Tracing::Tracer do
           end
         end
       end
+
+      context 'for span sampling' do
+        let(:tracer_options) { super().merge(span_sampler: span_sampler) }
+        let(:span_sampler) { instance_double(Datadog::Tracing::Sampling::Span::Sampler) }
+        let(:block) do
+          proc do |span_op, trace_op|
+            @span_op = span_op
+            @trace_op = trace_op
+          end
+        end
+
+        before do
+          allow(span_sampler).to receive(:sample!)
+        end
+
+        it 'invokes the span sampler with the current span and trace operation' do
+          trace
+          expect(span_sampler).to have_received(:sample!).with(@trace_op, @span_op.send(:build_span))
+        end
+      end
     end
 
     context 'without a block' do
@@ -570,6 +590,23 @@ RSpec.describe Datadog::Tracing::Tracer do
           expect(parent).to be_root_span
           expect(child.send(:parent)).to be(parent)
           expect(child.end_time).to be > parent.end_time
+        end
+      end
+
+      context 'for span sampling' do
+        let(:tracer_options) { super().merge(span_sampler: span_sampler) }
+        let(:span_sampler) { instance_double(Datadog::Tracing::Sampling::Span::Sampler) }
+
+        before do
+          allow(span_sampler).to receive(:sample!)
+        end
+
+        it 'invokes the span sampler with the current span and trace operation' do
+          span_op = trace
+          trace_op = tracer.active_trace
+          span = span_op.finish
+
+          expect(span_sampler).to have_received(:sample!).with(trace_op, span)
         end
       end
     end

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -526,7 +526,7 @@ RSpec.describe Datadog::Tracing::Tracer do
 
         it 'invokes the span sampler with the current span and trace operation' do
           trace
-          expect(span_sampler).to have_received(:sample!).with(@trace_op, @span_op.send(:build_span))
+          expect(span_sampler).to have_received(:sample!).with(@trace_op, @span_op.finish)
         end
       end
     end


### PR DESCRIPTION
Follow up from #2095 

This PR adds a new Single Span Sampling class that ties up all the previous Single Span Sampling work.

This class alters span tags when spans are finished, based on the provided rules.

At this moment, this is functionally a no-op, as the interface to configure rules will be done in a following PR.