### PR TITLE
Test:Remove leftover from Span#allocations removal

### DIFF
--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -194,25 +194,6 @@ RSpec.describe Datadog::Tracing::Tracer do
           expect(span.name).to eq(name)
         end
 
-        it 'tracks the number of allocations made in the span' do
-          skip 'Test unstable; improve stability before re-enabling.'
-
-          # Create and discard first trace.
-          # When warming up, it might have more allocations than subsequent traces.
-          tracer.trace(name) {}
-          writer.spans
-
-          # Then create traces to compare
-          tracer.trace(name) {}
-          tracer.trace(name) { Object.new }
-
-          first, second = writer.spans
-
-          # Different versions of Ruby will allocate a different number of
-          # objects, so this is what works across the board.
-          expect(second.allocations).to eq(first.allocations + 1)
-        end
-
         context 'with diagnostics debug enabled' do
           include_context 'tracer logging'
 


### PR DESCRIPTION
We likely forgot to remove this test when we did #1891 because it's currently skipped in CI.