### PR TITLE
Tweaks to GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,8 +14,13 @@ assignees: ''
 <!-- What should be happening. -->
 
 **Steps to reproduce**
-<!-- How can we reproduce this issue in order to diagnose it?
-Code snippets and sample apps are encouraged! -->
+<!--
+  How can we reproduce this issue in order to diagnose it?
+  Code snippets, log messages, screenshots and sample apps are encouraged!
+-->
+
+**How does `ddtrace` help you?**
+<!-- Optionally, tell us why and how you're using ddtrace, and what your overall experience with it is! -->
 
 **Environment**
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,3 +6,18 @@ labels: community, feature-request
 assignees: ''
 
 ---
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the goal of the feature**
+<!-- A clear and concise description of what you want to happen, and how it may used or behave. -->
+
+**Describe alternatives you've considered**
+<!-- Optionally, provide description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->
+
+**How does `ddtrace` help you?**
+<!-- Optionally, tell us why and how you're using ddtrace, and what your overall experience with it is! -->


### PR DESCRIPTION
I'd like to thank @marcotc for adding the issue templates in #2090!

Here's a few more tweaks inspired from the [issue templates](https://github.com/DataDog/libdatadog/tree/main/.github/ISSUE_TEMPLATE) we have for `libdatadog`.

For the bug report template:

* Mention log messages and screenshots in "steps to reproduce"   suggestions
* Add a "How does ddtrace help you" section. This helps us to know more about the customer's use case, and also gives some space for customers to hopefully tell us what we're doing well

For the feature request template:

* Add a few sections to guide the feature request.