### PR TITLE
Update rubocop.yml to use Gemspec/DeprecatedAttributeAssignment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -108,7 +108,7 @@ Style/CaseEquality:
 # New cops since Rubocop 1.0.
 # We have to explicitly opt-in for new cops to apply
 # before the next major release.
-Gemspec/DateAssignment: # (new in 1.10)
+Gemspec/DeprecatedAttributeAssignment: # (Gemspec/DateAssignment integrated in 1.31.0)
   Enabled: true
 Layout/SpaceBeforeBrackets: # (new in 1.7)
   Enabled: true


### PR DESCRIPTION
`Gemspec/DateAssignment` was integrated into `Gemspec/DeprecatedAttributeassignment` in rubocop 1.31.0 (released today).

Updated `rubocop.yml` based on changelog [here](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md)