### PR TITLE
Doc-YARD:Fix documented type of min_spans_threshold

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -505,7 +505,7 @@ module Datadog
             # are always flushed immediately.
             #
             # @default 500
-            # @return [Boolean]
+            # @return [Integer]
             option :min_spans_threshold, default: 500
           end
 


### PR DESCRIPTION
This PR fixes the YARD documentation return type of `c.tracing.partial_flush.min_spans_threshold`.
