### PR TITLE
GH: Expand on PR template with link to docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,10 @@
+<!--
+Check out the
+https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
+for guidance on how to set up your development environment,
+run the test suite, write new integrations, and more.
+-->
+
 **What does this PR do?**
 <!-- A brief description of the change being made with this pull request. -->
 
@@ -8,4 +15,9 @@
 <!-- Anything else we should know when reviewing? -->
 
 **How to test the change?**
-<!-- Describe here how the change can be validated. -->
+<!--
+Describe here how the change can be validated.
+You are strongly encouraged to provide automated tests for this PR (unit or integration).
+If this change cannot be feasibly tested, please explain why,
+unless the change does not modify code (e.g. only modifies docs, comments).
+-->


### PR DESCRIPTION
Adds a link to https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md to the PR template, to help developers test and clean up their code.

Also, expand the language around testing requirements for the PR