### PR TITLE
Span and trace IDs should not be zero

### DIFF
--- a/lib/datadog/core/utils.rb
+++ b/lib/datadog/core/utils.rb
@@ -19,7 +19,7 @@ module Datadog
       # This method is thread-safe and fork-safe.
       def self.next_id
         after_fork! { reset! }
-        id_rng.rand(Tracing::Span::RUBY_MAX_ID) # TODO: This should never return zero
+        id_rng.rand(1..Tracing::Span::RUBY_MAX_ID)
       end
 
       def self.id_rng

--- a/lib/datadog/core/utils.rb
+++ b/lib/datadog/core/utils.rb
@@ -9,6 +9,9 @@ module Datadog
     # @public_api
     module Utils
       extend Forking
+      
+      # Excludes zero from possible values
+      ID_RANGE = (1..Tracing::Span::RUBY_MAX_ID).freeze
 
       EMPTY_STRING = ''.encode(::Encoding::UTF_8).freeze
       # We use a custom random number generator because we want no interference
@@ -19,7 +22,7 @@ module Datadog
       # This method is thread-safe and fork-safe.
       def self.next_id
         after_fork! { reset! }
-        id_rng.rand(1..Tracing::Span::RUBY_MAX_ID)
+        id_rng.rand(ID_RANGE)
       end
 
       def self.id_rng

--- a/lib/datadog/core/utils.rb
+++ b/lib/datadog/core/utils.rb
@@ -9,9 +9,6 @@ module Datadog
     # @public_api
     module Utils
       extend Forking
-      
-      # Excludes zero from possible values
-      ID_RANGE = (1..Tracing::Span::RUBY_MAX_ID).freeze
 
       EMPTY_STRING = ''.encode(::Encoding::UTF_8).freeze
       # We use a custom random number generator because we want no interference
@@ -22,7 +19,7 @@ module Datadog
       # This method is thread-safe and fork-safe.
       def self.next_id
         after_fork! { reset! }
-        id_rng.rand(ID_RANGE)
+        id_rng.rand(Tracing::Span::RUBY_ID_RANGE)
       end
 
       def self.id_rng

--- a/lib/datadog/tracing/span.rb
+++ b/lib/datadog/tracing/span.rb
@@ -28,6 +28,9 @@ module Datadog
       # The range of IDs also has to consider portability across different languages and platforms.
       RUBY_MAX_ID = (1 << 62) - 1
 
+      # Excludes zero from possible values
+      RUBY_ID_RANGE = (1..RUBY_MAX_ID).freeze
+
       # While we only generate 63-bit integers due to limitations in other languages, we support
       # parsing 64-bit integers for distributed tracing since an upstream system may generate one
       EXTERNAL_MAX_ID = 1 << 64


### PR DESCRIPTION
**What does this PR do?**
Fix a TODO by making sure span and trace IDs are greater than zero. 

**Motivation**
The Agent [drops IDs == 0](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/normalizer.go#L42-L49), in the unlikely case random returns zero we would drop that span/trace.
