### PR TITLE
Remove outdated note about profiling being beta

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2664,8 +2664,6 @@ However, additional instrumentation provided by Datadog can be activated alongsi
 
 ### Profiling
 
-*Currently available as BETA feature.*
-
 `ddtrace` can produce profiles that measure method-level application resource usage within production environments. These profiles can give insight into resources spent in Ruby code outside of existing trace instrumentation.
 
 **Setup**


### PR DESCRIPTION
**What does this PR do?**
Remove outdated note about profiling being beta

**Motivation**
Ooops! Profiling has been GA since December, but we totally missed this one line in the documentation.

**Additional Notes**
Here's a picture of me facepalming:
![Screen Shot 2022-06-28 at 17 16 14](https://user-images.githubusercontent.com/2785847/176229581-4d845429-c962-4168-bddd-44fc20e466ae.png)

**How to test the change?**
Look at diff :) 