### PR TITLE
Create Telemetry Event class

### DIFF
--- a/lib/datadog/core/telemetry/collector.rb
+++ b/lib/datadog/core/telemetry/collector.rb
@@ -193,7 +193,7 @@ module Datadog
         end
 
         def appsec_version
-          tracer_version if Datadog.configuration.appsec.enabled
+          tracer_version if Datadog.configuration.respond_to?(:appsec) && Datadog.configuration.appsec.enabled
         end
 
         def agent_transport

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -18,23 +18,19 @@ module Datadog
         ERROR_BAD_API_VERSION = ":api_version must be one of ['v1']".freeze
 
         attr_reader \
-          :request_type,
           :api_version
-
-        attr_accessor \
-          :seq_id
 
         # @param api_version [String] telemetry API version to request; defaults to `v1`
         def initialize(api_version: API_VERSION)
           raise ArgumentError, ERROR_BAD_API_VERSION unless ALLOWED_API_VERSIONS.include?(api_version)
 
-          @seq_id = 1
           @api_version = api_version
         end
 
         # Forms a TelemetryRequest object based on the event request_type
         # @param request_type [String] the type of telemetry request to collect data for
-        def telemetry_request(request_type:)
+        # @param seq_id [Integer] the ID of the request; incremented each time a telemetry request is sent to the API
+        def telemetry_request(request_type:, seq_id:)
           Telemetry::V1::TelemetryRequest.new(
             api_version: @api_version,
             application: application,
@@ -42,7 +38,7 @@ module Datadog
             payload: payload(request_type),
             request_type: request_type,
             runtime_id: runtime_id,
-            seq_id: @seq_id,
+            seq_id: seq_id,
             tracer_time: tracer_time,
           )
         end

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -14,7 +14,8 @@ module Datadog
         include Telemetry::Collector
 
         API_VERSION = 'v1'.freeze
-        ERROR_BAD_API_VERSION = ':api_version must not be nil'.freeze
+        ALLOWED_API_VERSIONS = ['v1'.freeze].freeze
+        ERROR_BAD_API_VERSION = ":api_version must be one of ['v1']".freeze
 
         attr_reader \
           :request_type,
@@ -25,7 +26,7 @@ module Datadog
 
         # @param api_version [String] telemetry API version to request; defaults to `v1`
         def initialize(api_version: API_VERSION)
-          raise ArgumentError, ERROR_BAD_API_VERSION if api_version.nil?
+          raise ArgumentError, ERROR_BAD_API_VERSION unless ALLOWED_API_VERSIONS.include?(api_version)
 
           @seq_id = 1
           @api_version = api_version
@@ -61,7 +62,8 @@ module Datadog
           Telemetry::V1::AppStarted.new(
             dependencies: dependencies,
             integrations: integrations,
-            configuration: configurations
+            configuration: configurations,
+            additional_payload: additional_payload
           )
         end
       end

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -1,0 +1,79 @@
+# typed: true
+
+require 'datadog/core/telemetry/collector'
+require 'datadog/core/telemetry/v1/app_started'
+require 'datadog/core/telemetry/v1/telemetry_request'
+
+module Datadog
+  module Core
+    module Telemetry
+      # Class defining methods to construct a Telemetry event
+      class Event
+        include Kernel
+
+        include Telemetry::Collector
+        include Telemetry::Utils::Validation
+
+        API_VERSION = 'v1'.freeze
+        ERROR_BAD_REQUEST_TYPE = ':request_type must be a non-empty String'.freeze
+        ERROR_BAD_SEQ_ID = ':seq_id must be a non-empty Integer'.freeze
+        ERROR_BAD_API_VERSION = ':api_version must be of type String'.freeze
+
+        attr_reader \
+          :request_type,
+          :seq_id,
+          :api_version
+
+        # @param request_type [String] the type of telemetry request to collect data for
+        # @param seq_id [Integer] the ID to attach to the request, incremented for each new telemetry request
+        # @param api_version [String] telemetry API version to request; defaults to `v1`
+        def initialize(request_type:, seq_id:, api_version: API_VERSION)
+          validate(request_type, seq_id, api_version)
+          @request_type = request_type
+          @seq_id = seq_id
+          @api_version = api_version
+        end
+
+        # Forms a TelemetryRequest object based on the event @request_type
+        def request
+          case @request_type
+          when 'app-started'
+            payload = app_started
+          else
+            raise ArgumentError, "Request type invalid, received request_type: #{@request_type}"
+          end
+          telemetry_request(payload)
+        end
+
+        private
+
+        def validate(request_type, seq_id, api_version)
+          raise ArgumentError, ERROR_BAD_REQUEST_TYPE unless valid_string?(request_type)
+          raise ArgumentError, ERROR_BAD_SEQ_ID unless valid_int?(seq_id)
+          raise ArgumentError, ERROR_BAD_API_VERSION unless valid_string?(api_version)
+        end
+
+        def telemetry_request(payload)
+          Telemetry::V1::TelemetryRequest.new(
+            api_version: @api_version,
+            application: application,
+            host: host,
+            payload: payload,
+            request_type: @request_type,
+            runtime_id: runtime_id,
+            seq_id: @seq_id,
+            tracer_time: tracer_time,
+          )
+        end
+
+        def app_started
+          Telemetry::V1::AppStarted.new(
+            dependencies: dependencies,
+            integrations: integrations,
+            configuration: configurations
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -14,6 +14,7 @@ module Datadog
         include Telemetry::Collector
 
         API_VERSION = 'v1'.freeze
+        ERROR_BAD_API_VERSION = ':api_version must not be nil'.freeze
 
         attr_reader \
           :request_type,
@@ -24,6 +25,8 @@ module Datadog
 
         # @param api_version [String] telemetry API version to request; defaults to `v1`
         def initialize(api_version: API_VERSION)
+          raise ArgumentError, ERROR_BAD_API_VERSION if api_version.nil?
+
           @seq_id = 1
           @api_version = api_version
         end

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -14,17 +14,12 @@ module Datadog
         include Telemetry::Collector
 
         API_VERSION = 'v1'.freeze
-        ALLOWED_API_VERSIONS = ['v1'.freeze].freeze
-        ERROR_BAD_API_VERSION = ":api_version must be one of ['v1']".freeze
 
         attr_reader \
           :api_version
 
-        # @param api_version [String] telemetry API version to request; defaults to `v1`
-        def initialize(api_version: API_VERSION)
-          raise ArgumentError, ERROR_BAD_API_VERSION unless ALLOWED_API_VERSIONS.include?(api_version)
-
-          @api_version = api_version
+        def initialize
+          @api_version = API_VERSION
         end
 
         # Forms a TelemetryRequest object based on the event request_type

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -12,12 +12,8 @@ module Datadog
         include Kernel
 
         include Telemetry::Collector
-        include Telemetry::Utils::Validation
 
         API_VERSION = 'v1'.freeze
-        ERROR_BAD_REQUEST_TYPE = ':request_type must be a non-empty String'.freeze
-        ERROR_BAD_SEQ_ID = ':seq_id must be a non-empty Integer'.freeze
-        ERROR_BAD_API_VERSION = ':api_version must be of type String'.freeze
 
         attr_reader \
           :request_type,
@@ -28,7 +24,6 @@ module Datadog
 
         # @param api_version [String] telemetry API version to request; defaults to `v1`
         def initialize(api_version: API_VERSION)
-          raise ArgumentError, ERROR_BAD_API_VERSION unless valid_string?(api_version)
           @seq_id = 1
           @api_version = api_version
         end
@@ -51,7 +46,6 @@ module Datadog
         private
 
         def payload(request_type)
-          raise ArgumentError, ERROR_BAD_REQUEST_TYPE unless valid_string?(request_type)
           case request_type
           when 'app-started'
             app_started

--- a/spec/datadog/core/telemetry/collector_spec.rb
+++ b/spec/datadog/core/telemetry/collector_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 
-require 'datadog/appsec'
 require 'datadog/core/configuration'
 require 'datadog/core/configuration/agent_settings_resolver'
 require 'datadog/core/environment/ext'
@@ -111,6 +110,8 @@ RSpec.describe Datadog::Core::Telemetry::Collector do
 
       context 'when appsec is enabled' do
         before do
+          require 'datadog/appsec'
+
           stub_const('Datadog::Core::Environment::Ext::TRACER_VERSION', '4.2')
           Datadog.configure do |c|
             c.appsec.enabled = true
@@ -125,6 +126,8 @@ RSpec.describe Datadog::Core::Telemetry::Collector do
       end
 
       context 'when both profiler and appsec are enabled' do
+        require 'datadog/appsec'
+
         before do
           Datadog.configure do |c|
             c.profiling.enabled = true

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -4,30 +4,13 @@ require 'datadog/core/telemetry/event'
 require 'datadog/core/telemetry/v1/shared_examples'
 
 RSpec.describe Datadog::Core::Telemetry::Event do
-  subject(:event) { described_class.new(api_version: api_version) }
-  let(:api_version) { 'v1' }
+  subject(:event) { described_class.new }
 
   describe '#initialize' do
-    subject(:event) { described_class.new(api_version: api_version) }
+    subject(:event) { described_class.new }
 
-    context ':api_version' do
-      let(:api_version) { 'v1' }
-
-      context 'when not provided' do
-        subject(:event) { described_class.new }
-        it { is_expected.to have_attributes(api_version: 'v1') }
-      end
-
-      context 'when provided with valid value' do
-        let(:api_version) { 'v1' }
-        it { is_expected.to have_attributes(api_version: 'v1') }
-      end
-
-      context 'when given invalid value' do
-        let(:api_version) { 'v2' }
-        it { expect { event }.to raise_error(ArgumentError) }
-      end
-    end
+    it { is_expected.to be_a_kind_of(described_class) }
+    it { is_expected.to have_attributes(api_version: 'v1') }
   end
 
   describe '#telemetry_request' do
@@ -37,7 +20,7 @@ RSpec.describe Datadog::Core::Telemetry::Event do
     let(:seq_id) { 1 }
 
     it { is_expected.to be_a_kind_of(Datadog::Core::Telemetry::V1::TelemetryRequest) }
-    it { expect(telemetry_request.api_version).to eql(api_version) }
+    it { expect(telemetry_request.api_version).to eql('v1') }
     it { expect(telemetry_request.request_type).to eql(request_type) }
     it { expect(telemetry_request.seq_id).to be(1) }
 

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+require 'datadog/core/telemetry/event'
+require 'datadog/core/telemetry/v1/shared_examples'
+
+RSpec.describe Datadog::Core::Telemetry::Event do
+  subject(:event) { described_class.new(request_type: request_type, seq_id: seq_id, api_version: api_version) }
+  let(:request_type) { 'app-started' }
+  let(:seq_id) { 1 }
+  let(:api_version) { 'v1' }
+
+  # DD_SERVICE must be set in the application
+  around do |example|
+    ClimateControl.modify(Datadog::Core::Environment::Ext::ENV_SERVICE => 'env_service') do
+      example.run
+    end
+  end
+
+  describe '#initialize' do
+    context ':request_type' do
+      it_behaves_like 'a required string parameter', 'request_type'
+    end
+
+    context 'when :seq_id' do
+      it_behaves_like 'a required int parameter', 'seq_id'
+    end
+
+    context ':api_version' do
+      it_behaves_like 'a required string parameter', 'api_version'
+      context 'defaults to v1 when not provided' do
+        subject(:event) { described_class.new(request_type: request_type, seq_id: seq_id) }
+        it { is_expected.to have_attributes(api_version: 'v1') }
+      end
+    end
+  end
+
+  describe '#request' do
+    subject(:request) { event.request }
+
+    it { is_expected.to be_a_kind_of(Datadog::Core::Telemetry::V1::TelemetryRequest) }
+    it { expect(request.api_version).to eql(api_version) }
+    it { expect(request.request_type).to eql(request_type) }
+    it { expect(request.seq_id).to eql(seq_id) }
+
+    context 'when :request_type' do
+      context 'is app-started' do
+        let(:request_type) { 'app-started' }
+
+        it { expect(request.payload).to be_a_kind_of(Datadog::Core::Telemetry::V1::AppStarted) }
+      end
+
+      context 'is invalid option' do
+        let(:request_type) { 'some-request-type' }
+        it { expect { request }.to raise_error(ArgumentError) }
+      end
+    end
+
+    context('when :api_version') do
+      context 'is valid version' do
+        let(:api_version) { 'v1' }
+        it { expect(request.api_version).to eq('v1') }
+      end
+
+      context 'is not a valid version' do
+        let(:api_version) { 'v2' }
+        it { expect { request }.to raise_error(ArgumentError) }
+      end
+    end
+  end
+end

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -31,9 +31,10 @@ RSpec.describe Datadog::Core::Telemetry::Event do
   end
 
   describe '#telemetry_request' do
-    subject(:telemetry_request) { event.telemetry_request(request_type: request_type) }
+    subject(:telemetry_request) { event.telemetry_request(request_type: request_type, seq_id: seq_id) }
 
     let(:request_type) { 'app-started' }
+    let(:seq_id) { 1 }
 
     it { is_expected.to be_a_kind_of(Datadog::Core::Telemetry::V1::TelemetryRequest) }
     it { expect(telemetry_request.api_version).to eql(api_version) }
@@ -60,6 +61,18 @@ RSpec.describe Datadog::Core::Telemetry::Event do
       context 'is invalid option' do
         let(:request_type) { 'some-request-type' }
         it { expect { telemetry_request }.to raise_error(ArgumentError) }
+      end
+    end
+
+    context 'when :seq_id' do
+      context 'is nil' do
+        let(:seq_id) { nil }
+        it { expect { telemetry_request }.to raise_error(ArgumentError) }
+      end
+
+      context 'is valid' do
+        let(:seq_id) { 2 }
+        it { expect(telemetry_request.payload).to be_a_kind_of(Datadog::Core::Telemetry::V1::AppStarted) }
       end
     end
   end

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -7,19 +7,25 @@ RSpec.describe Datadog::Core::Telemetry::Event do
   subject(:event) { described_class.new(api_version: api_version) }
   let(:api_version) { 'v1' }
 
-  # DD_SERVICE must be set in the application
-  around do |example|
-    ClimateControl.modify(Datadog::Core::Environment::Ext::ENV_SERVICE => 'env_service') do
-      example.run
-    end
-  end
-
   describe '#initialize' do
+    subject(:event) { described_class.new(api_version: api_version) }
+
     context ':api_version' do
-      it_behaves_like 'a required string parameter', 'api_version'
-      context 'defaults to v1 when not provided' do
+      let(:api_version) { 'v1' }
+
+      context 'when not provided' do
         subject(:event) { described_class.new }
         it { is_expected.to have_attributes(api_version: 'v1') }
+      end
+
+      context 'when provided with valid value' do
+        let(:api_version) { 'v1' }
+        it { is_expected.to have_attributes(api_version: 'v1') }
+      end
+
+      context 'when given invalid value' do
+        let(:api_version) { 'v2' }
+        it { expect { event }.to raise_error(ArgumentError) }
       end
     end
   end
@@ -54,18 +60,6 @@ RSpec.describe Datadog::Core::Telemetry::Event do
       context 'is invalid option' do
         let(:request_type) { 'some-request-type' }
         it { expect { telemetry_request }.to raise_error(ArgumentError) }
-      end
-    end
-
-    context('when :api_version') do
-      context 'is nil' do
-        let(:api_version) { nil }
-        it { expect { telemetry_request }.to raise_error(ArgumentError) }
-      end
-
-      context 'is valid version' do
-        let(:api_version) { 'v1' }
-        it { expect(telemetry_request.api_version).to eq('v1') }
       end
     end
   end

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Datadog::Core::Telemetry::Event do
     it { is_expected.to be_a_kind_of(Datadog::Core::Telemetry::V1::TelemetryRequest) }
     it { expect(telemetry_request.api_version).to eql(api_version) }
     it { expect(telemetry_request.request_type).to eql(request_type) }
-    it { expect(telemetry_request.seq_id).to eql(1) }
+    it { expect(telemetry_request.seq_id).to be(1) }
 
     context 'when :request_type' do
       context 'is app-started' do

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -58,14 +58,14 @@ RSpec.describe Datadog::Core::Telemetry::Event do
     end
 
     context('when :api_version') do
+      context 'is nil' do
+        let(:api_version) { nil }
+        it { expect { telemetry_request }.to raise_error(ArgumentError) }
+      end
+
       context 'is valid version' do
         let(:api_version) { 'v1' }
         it { expect(telemetry_request.api_version).to eq('v1') }
-      end
-
-      context 'is not a valid version' do
-        let(:api_version) { 'v2' }
-        it { expect { telemetry_request }.to raise_error(ArgumentError) }
       end
     end
   end

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -4,9 +4,7 @@ require 'datadog/core/telemetry/event'
 require 'datadog/core/telemetry/v1/shared_examples'
 
 RSpec.describe Datadog::Core::Telemetry::Event do
-  subject(:event) { described_class.new(request_type: request_type, seq_id: seq_id, api_version: api_version) }
-  let(:request_type) { 'app-started' }
-  let(:seq_id) { 1 }
+  subject(:event) { described_class.new(api_version: api_version) }
   let(:api_version) { 'v1' }
 
   # DD_SERVICE must be set in the application
@@ -17,53 +15,57 @@ RSpec.describe Datadog::Core::Telemetry::Event do
   end
 
   describe '#initialize' do
-    context ':request_type' do
-      it_behaves_like 'a required string parameter', 'request_type'
-    end
-
-    context 'when :seq_id' do
-      it_behaves_like 'a required int parameter', 'seq_id'
-    end
-
     context ':api_version' do
       it_behaves_like 'a required string parameter', 'api_version'
       context 'defaults to v1 when not provided' do
-        subject(:event) { described_class.new(request_type: request_type, seq_id: seq_id) }
+        subject(:event) { described_class.new }
         it { is_expected.to have_attributes(api_version: 'v1') }
       end
     end
   end
 
-  describe '#request' do
-    subject(:request) { event.request }
+  describe '#telemetry_request' do
+    subject(:telemetry_request) { event.telemetry_request(request_type: request_type) }
+
+    let(:request_type) { 'app-started' }
 
     it { is_expected.to be_a_kind_of(Datadog::Core::Telemetry::V1::TelemetryRequest) }
-    it { expect(request.api_version).to eql(api_version) }
-    it { expect(request.request_type).to eql(request_type) }
-    it { expect(request.seq_id).to eql(seq_id) }
+    it { expect(telemetry_request.api_version).to eql(api_version) }
+    it { expect(telemetry_request.request_type).to eql(request_type) }
+    it { expect(telemetry_request.seq_id).to eql(1) }
 
     context 'when :request_type' do
       context 'is app-started' do
         let(:request_type) { 'app-started' }
 
-        it { expect(request.payload).to be_a_kind_of(Datadog::Core::Telemetry::V1::AppStarted) }
+        it { expect(telemetry_request.payload).to be_a_kind_of(Datadog::Core::Telemetry::V1::AppStarted) }
+      end
+
+      context 'is nil' do
+        let(:request_type) { nil }
+        it { expect { telemetry_request }.to raise_error(ArgumentError) }
+      end
+
+      context 'is empty string' do
+        let(:request_type) { '' }
+        it { expect { telemetry_request }.to raise_error(ArgumentError) }
       end
 
       context 'is invalid option' do
         let(:request_type) { 'some-request-type' }
-        it { expect { request }.to raise_error(ArgumentError) }
+        it { expect { telemetry_request }.to raise_error(ArgumentError) }
       end
     end
 
     context('when :api_version') do
       context 'is valid version' do
         let(:api_version) { 'v1' }
-        it { expect(request.api_version).to eq('v1') }
+        it { expect(telemetry_request.api_version).to eq('v1') }
       end
 
       context 'is not a valid version' do
         let(:api_version) { 'v2' }
-        it { expect { request }.to raise_error(ArgumentError) }
+        it { expect { telemetry_request }.to raise_error(ArgumentError) }
       end
     end
   end

--- a/spec/datadog/core/telemetry/v1/shared_examples.rb
+++ b/spec/datadog/core/telemetry/v1/shared_examples.rb
@@ -57,3 +57,20 @@ RSpec.shared_examples 'an optional boolean parameter' do |argument|
     it { is_expected.to be_a_kind_of(described_class) }
   end
 end
+
+RSpec.shared_examples 'a required int parameter' do |argument|
+  context 'is nil' do
+    let(argument.to_sym) { nil }
+    it { expect { subject }.to raise_error(ArgumentError) }
+  end
+
+  context 'is string' do
+    let(argument.to_sym) { '42' }
+    it { expect { subject }.to raise_error(ArgumentError) }
+  end
+
+  context 'is valid int' do
+    let(argument.to_sym) { 42 }
+    it { is_expected.to be_a_kind_of(described_class) }
+  end
+end

--- a/spec/datadog/core/telemetry/v1/shared_examples.rb
+++ b/spec/datadog/core/telemetry/v1/shared_examples.rb
@@ -57,20 +57,3 @@ RSpec.shared_examples 'an optional boolean parameter' do |argument|
     it { is_expected.to be_a_kind_of(described_class) }
   end
 end
-
-RSpec.shared_examples 'a required int parameter' do |argument|
-  context 'is nil' do
-    let(argument.to_sym) { nil }
-    it { expect { subject }.to raise_error(ArgumentError) }
-  end
-
-  context 'is string' do
-    let(argument.to_sym) { '42' }
-    it { expect { subject }.to raise_error(ArgumentError) }
-  end
-
-  context 'is valid int' do
-    let(argument.to_sym) { 42 }
-    it { is_expected.to be_a_kind_of(described_class) }
-  end
-end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Continuing from #2102, this PR adds an `Event` class to construct a telemetry request event based on the `request_type`. Currently only `app-started` is implemented.

**Motivation**
<!-- What inspired you to submit this pull request? -->
This event class ensures that we are constructing a well-formed telemetry request object.

**Additional Notes**
<!-- Anything else we should know when reviewing? -->
Some questions:
- Does it make sense to allow users to pass in an `api_version` if the only supported version right now is `v1`?
- Should a new `Event` class be instantiated each time a telemetry request needs to be made (i.e. does it make more sense to have the initialization return a `TelemetryRequest` object and to remove the `telemetry_request` function)? Or does this make more sense as a module and not a class?

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Unit tests were added to test the new class.