### PR TITLE
Correctly set the default service based off of Rails config

### DIFF
--- a/lib/datadog/tracing/contrib/rails/framework.rb
+++ b/lib/datadog/tracing/contrib/rails/framework.rb
@@ -36,18 +36,14 @@ module Datadog
             #       used to reconfigure tracer components with Rails-sourced defaults.
             #       This is a trade-off we take to get nice defaults.
             Datadog.configure do |datadog_config|
+              rails_config = datadog_config.tracing[:rails]
+
               # By default, default service would be guessed from the script
               # being executed, but here we know better, get it from Rails config.
               # Don't set this if service has been explicitly provided by the user.
-              rails_service_name = Datadog.configuration.tracing[:rails][:service_name] \
-                                    || Datadog.configuration.service_without_fallback \
-                                    || Utils.app_name
-
-              datadog_config.service ||= rails_service_name
-            end
-
-            Datadog.configure do |datadog_config|
-              rails_config = datadog_config.tracing[:rails]
+              if datadog_config.service_without_fallback.nil?
+                datadog_config.service = rails_config[:service_name] || Utils.app_name
+              end
 
               activate_rack!(datadog_config, rails_config)
               activate_action_cable!(datadog_config, rails_config)

--- a/spec/datadog/tracing/contrib/rails/defaults_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/defaults_spec.rb
@@ -6,42 +6,40 @@ RSpec.describe 'Rails defaults' do
   include_context 'Rails test application'
 
   context 'when Datadog.configuration.service' do
-    before do
-      Datadog.configure { |c| c.service = default_service }
-      app
-    end
-
-    after { Datadog.configure { |c| c.service = nil } }
+    after { without_warnings { Datadog.configuration.reset! } }
 
     context 'is not configured' do
-      let(:default_service) { nil }
+      before { app }
 
       describe 'Datadog.configuration.service' do
         subject(:global_default_service) { Datadog.configuration.service }
 
-        it { expect(global_default_service).to match(/rails/) }
+        it { expect(global_default_service).to start_with('rails') }
       end
 
       describe 'Global tracer default_service' do
         subject(:tracer_default_service) { Datadog::Tracing.send(:tracer).default_service }
 
-        it { expect(tracer_default_service).to match(/rails/) }
+        it { expect(tracer_default_service).to start_with('rails') }
       end
     end
 
     context 'is configured' do
-      let(:default_service) { 'default-service' }
+      before do
+        Datadog.configure { |c| c.service = 'default-service' }
+        app
+      end
 
       describe 'Datadog.configuration.service' do
         subject(:global_default_service) { Datadog.configuration.service }
 
-        it { expect(global_default_service).to be default_service }
+        it { expect(global_default_service).to eq('default-service') }
       end
 
       describe 'Global tracer default_service' do
         subject(:tracer_default_service) { Datadog::Tracing.send(:tracer).default_service }
 
-        it { expect(tracer_default_service).to eq(default_service) }
+        it { expect(tracer_default_service).to eq('default-service') }
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**

While the code comment states:

> By default, default service would be guessed from the script being executed, but here we know better, get it from Rails config.

In practice, because `Datadog.configuration.service` is *always* present ([here](https://github.com/DataDog/dd-trace-rb/blob/26e8a2da7f04e446e109993b6276746dcbbd46f9/lib/datadog/core/configuration/settings.rb#L271-L287)), `||=` will never set anything.

Now, the Rails framework integration leverages `Datadog.configuration.service_without_fallback` to determine if `Datadog.configuration.service` should be set.

**Motivation**

When adding ddtrace to a new project, I was surprised to see `dd.service=rails` in the log correlation output, when the application name was definitely *not* `"rails"`. Looking further into the reasons why, I found this subtle bug (at least, I think it's a bug!).

**How to test the change?**

Assuming I get some confirmation that this is indeed an appropriate change, I will figure out how best to unit test it.