### PR TITLE
Stats computation with DDSketch

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -67,5 +67,7 @@ Gem::Specification.new do |spec|
   # Used by profiling
   spec.add_dependency 'libddprof', '~> 0.6.0.1.0'
 
+  spec.add_dependency 'ddsketch'
+
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb', 'ext/ddtrace_profiling_loader/extconf.rb']
 end

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -10,6 +10,9 @@ require 'datadog/core/workers/runtime_metrics'
 require 'datadog/tracing/tracer'
 require 'datadog/tracing/flush'
 require 'datadog/tracing/sync_writer'
+require 'datadog/tracing/stats/computer'
+require 'datadog/tracing/stats/repository'
+require 'datadog/tracing/stats/writer'
 
 module Datadog
   module Core
@@ -77,7 +80,26 @@ module Datadog
               sampler: sampler,
               writer: writer,
               tags: build_tracer_tags(settings),
+              stats_writer: build_stats_writer(settings)
             )
+          end
+
+          def build_stats_writer(settings)
+            return Tracing::Stats::NullWriter.new unless settings.tracing.stats_computer.enabled
+
+            require 'ddsketch'
+
+            # unless DDSketch.supported?
+            #   # Override and disable the settings
+            #   settings.tracing.stats_computer.enabled = false
+            #   return Tracing::NullStatsComputer.new
+            # end
+
+            Tracing::Stats::Writer.new
+          end
+
+          def build_stats_computer(settings)
+            Tracing::Stats::Computer.new
           end
 
           def build_trace_flush(settings)

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -391,6 +391,13 @@ module Datadog
             end
           end
 
+          settings :stats_computer do
+            option :enabled do |o|
+              o.default { env_to_bool(Tracing::Configuration::Ext::StatsComputation::ENV_TRACE_STATS_COMPUTATION_ENABLED, nil) }
+              o.lazy
+            end
+          end
+
           # [Distributed Tracing](https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#distributed-tracing) propagation
           # style configuration.
           #

--- a/lib/datadog/tracing/configuration/ext.rb
+++ b/lib/datadog/tracing/configuration/ext.rb
@@ -9,6 +9,10 @@ module Datadog
           ENV_TRACE_ANALYTICS_ENABLED = 'DD_TRACE_ANALYTICS_ENABLED'.freeze
         end
 
+        module StatsComputation
+          ENV_TRACE_STATS_COMPUTATION_ENABLED = 'DD_TRACE_STATS_COMPUTATION_ENABLED'.freeze
+        end
+
         # @public_api
         module Correlation
           ENV_LOGS_INJECTION_ENABLED = 'DD_LOGS_INJECTION'.freeze

--- a/lib/datadog/tracing/span.rb
+++ b/lib/datadog/tracing/span.rb
@@ -201,12 +201,18 @@ module Datadog
         end
       end
 
-      private
+      def error?
+        @status == Metadata::Ext::Errors::STATUS
+      end
 
       # Used for serialization
       # @return [Integer] in nanoseconds since Epoch
       def start_time_nano
-        @start_time.to_i * 1000000000 + @start_time.nsec
+        @start_time.to_i * 1e9 + @start_time.nsec
+      end
+
+      def end_time_nano
+        @end_time.to_i * 1e9 + @end_time.nsec
       end
 
       # Used for serialization

--- a/lib/datadog/tracing/stats/computer.rb
+++ b/lib/datadog/tracing/stats/computer.rb
@@ -1,0 +1,49 @@
+require 'datadog/tracing/stats/repository'
+
+module Datadog
+  module Tracing
+    module Stats
+      # TOP-LEVEL class description
+      class NullComputer
+        def perform(_); end
+      end
+
+      # TOP-LEVEL class description
+      class Computer
+        # include Core::Workers::Async::Thread
+
+        attr_reader :repository
+
+        def initialize
+          @repository = Repository.new
+        end
+
+        # Asynchronously
+        def perform(trace_segment)
+          origin = trace_segment.origin
+          candidates = trace_segment.spans.select do |span|
+            span.__send__(:service_entry?) ||
+              span.get_metric(Datadog::Tracing::Metadata::Ext::Analytics::TAG_MEASURED) == 1
+          end
+
+          candidates.each do |span|
+            bucket_size_ns = 10 * 1e9
+            bucket_time_ns = span.end_time_nano - (span.end_time_nano % bucket_size_ns)
+
+            # memory issue
+            agg_key = [
+              span.name,
+              span.service,
+              span.resource, # obfuscate
+              span.type,
+              span.status,
+              origin == 'synthetics'
+            ]
+
+            repository.update!(bucket_time_ns, agg_key, span)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/tracing/stats/repository.rb
+++ b/lib/datadog/tracing/stats/repository.rb
@@ -1,0 +1,57 @@
+module Datadog
+  module Tracing
+    module Stats
+      # TOP-LEVEL description
+      class Repository
+        attr_reader :data, :mutex
+
+        def initialize
+          @data = Hash.new do |hash, key|
+            hash[key] = Hash.new { |nested_hash, k| nested_hash[k] = Stats.new }
+          end
+          @mutex = Mutex.new
+        end
+
+        def update!(k1, k2, span)
+          mutex.synchronize do
+            data[k1][k2].update!(span)
+          end
+        end
+
+        def flush!
+          mutex.synchronize do
+            # TODO: serialize & send request
+            @data.clear
+          end
+        end
+
+        # TOP-LEVEL description
+        class Stats
+          attr_reader :hits, :top_level_hits, :duration, :errors, :err_distribution, :ok_distribution
+
+          def initialize
+            @hits = 0
+            @top_level_hits = 0
+            @duration = 0
+            @errors = 0
+            @err_distribution = DDSketch::LogCollapsingLowestDenseSketch.new(relative_accuracy: 0.00775, bin_limit: 2048)
+            @ok_distribution  = DDSketch::LogCollapsingLowestDenseSketch.new(relative_accuracy: 0.00775, bin_limit: 2048)
+          end
+
+          def update!(span)
+            @hits += 1
+            @duration += span.duration_nano
+            @top_level_hits += 1 if span.__send__(:service_entry?)
+
+            if span.error?
+              @errors += 1
+              @err_distribution.add(span.duration_nano)
+            else
+              @ok_distribution.add(span.duration_nano)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

Currently, sending 100% of traces from the application to the Datadog Agent was hitting multiple limits:
-  High cost of encoding traces in the application
-  High cost of decoding & handling traces in the Datadog Agent
-  Customer imposed CPU limits on trace agent to control ingestion costs

When the agent CPU limit is reached, the trace agent is unscheduled and temporarily unavailable (for example, on Kubernetes, the pod is killed) for multiple seconds. The tracers retry sending payloads if the agent can’t be reached, but if the situation is persistent, tracers will drop payloads. We have no control over this payload dropping, thus it leads to incomplete traces, and wrong stats.

The current solution is to drop a portion of the traffic in the tracer, and have the agent naively upscale stats. But this leads to incomplete traces, and inexact stats.

To solve this problem, we decided to compute stats directly in the tracer, and so being able to do sampling of traces directly in the application without affecting the fidelity of stats.

### What does this PR do?

##### An simplified illustration of design

![stats_computation_design_20220622](https://user-images.githubusercontent.com/16049123/177984769-965b675b-2b1e-4cc3-a84a-50706c5571a3.png)

#### Configuration

- [x] Configure with environment variable `DD_TRACE_STATS_COMPUTATION_ENABLED`, default is `false`
- [x] Import [DDSketch](https://github.com/DataDog/ddsketch-ruby)
- [ ] Check `google-protobuf` dependency

#### Collect data
- [x] Identify candidates(service_entry_span or `'_dd.measured' == 1`) for stats computation
- [x] Calculate bucket_time
- [x] Calculate aggregation key, see [Obfuscation](#obfuscation)
- [x] Collect stats with `ddsketch`

#### Transport data to agent
- [ ] Flush the data every 10 second 
- [ ] Agent endpoint `v0.6/stats`
- [ ] Serialise `ddsketch` object into protobuf before encoded into message pack for stats request

#### Optimize resource
- [ ] Update request header for traces with `Datadog-Client-Computed-Stats: yes`, to avoid duplicate stats computation in agent
- [ ] Drop p0 trace

### Additional Notes

#### Obfuscation

Obfuscation is recommended to apply for `span.resource`, in order to reduce the cardinality of data. However, currently, we have not reach consensus on its specification and implementation across different languages.

_Question: Can stats computation in tracer work without obfuscating resource?_ 

Answer: Yes, but the design is not efficient. It would prevent data being aggregated in the same bucket and defies the purpose of leveraging `DDSketch`. Eventually, Datadog agent would still obfuscate the resource and merge those sketches.

### How to test the change?
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
TBD