### PR TITLE
Add thanks to @miketheman for gifting us access to the `datadog` gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@ For contributing, checkout the [contribution guidelines][contribution docs] and 
 [visualization docs]: https://docs.datadoghq.com/tracing/visualization/
 [contribution docs]: https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md
 [development docs]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
+
+## Special thanks
+
+* [Mike Fiedler](https://github.com/miketheman) for working on a number of Datadog Ruby projects, as well as graciously
+  gifting control of the `datadog` gem


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Add a note of thanks to Mike on the project README.

**Motivation**
We've long been in talks to adopt the `datadog` gem name for future projects, but an issue was that the name was already taken on rubygems.org .

@miketheman was awesome in allowing us to get that name, and all he asked in return was that his contribution not be forgotten, which is extremely fair :)

So, let's thank him! And good luck for current/future endeavors!

P.s.: In the future, if/when we create a repository for the `datadog` gem, let's remember to keep these thanks there as well!

