### PR TITLE
Send telemetry app-closing event on shutdown

### DIFF
--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -438,6 +438,8 @@ module Datadog
 
           # The telemetry client is stateful, thus needs to be preserved between reconfigurations
           replacement.telemetry = @telemetry if replacement && @telemetry
+
+          @telemetry.stop! if !replacement && @telemetry
         end
       end
       # rubocop:enable Metrics/ClassLength

--- a/lib/datadog/core/telemetry/client.rb
+++ b/lib/datadog/core/telemetry/client.rb
@@ -28,6 +28,12 @@ module Datadog
 
           @emitter.request('app-started')
         end
+
+        def stop!
+          return unless @enabled
+
+          @emitter.request('app-closing')
+        end
       end
     end
   end

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -44,6 +44,8 @@ module Datadog
           case request_type
           when 'app-started'
             app_started
+          when 'app-closing'
+            {}
           else
             raise ArgumentError, "Request type invalid, received request_type: #{@request_type}"
           end

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -1210,6 +1210,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
           .with(true, close_metrics: false)
         expect(components.runtime_metrics.metrics.statsd).to receive(:close)
         expect(components.health_metrics.statsd).to receive(:close)
+        expect(components.telemetry).to receive(:stop!)
 
         shutdown!
       end

--- a/spec/datadog/core/telemetry/client_spec.rb
+++ b/spec/datadog/core/telemetry/client_spec.rb
@@ -53,4 +53,25 @@ RSpec.describe Datadog::Core::Telemetry::Client do
       it { is_expected.to be(response) }
     end
   end
+
+  describe '#stop!' do
+    subject(:stop!) { client.stop! }
+    context 'when disabled' do
+      let(:enabled) { false }
+      it do
+        stop!
+        expect(emitter).to_not have_received(:request).with('app-closing')
+      end
+    end
+
+    context 'when enabled' do
+      let(:enabled) { true }
+      it do
+        stop!
+        expect(emitter).to have_received(:request).with('app-closing')
+      end
+
+      it { is_expected.to be(response) }
+    end
+  end
 end

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe Datadog::Core::Telemetry::Event do
         it { expect(telemetry_request.payload).to be_a_kind_of(Datadog::Core::Telemetry::V1::AppStarted) }
       end
 
+      context 'is app-closing' do
+        let(:request_type) { 'app-closing' }
+
+        it { expect(telemetry_request.payload).to eq({}) }
+      end
+
       context 'is nil' do
         let(:request_type) { nil }
         it { expect { telemetry_request }.to raise_error(ArgumentError) }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR implements the `app-closing` event when a `shutdown` event occurs. There is no required payload for this event type.
<img width="939" alt="image" src="https://user-images.githubusercontent.com/32009013/177624041-fc93f897-491b-4d02-82db-d7145cefb01b.png">

**Motivation**
<!-- What inspired you to submit this pull request? -->
This event is one of the ones specified in the [telemetry spec](https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v1/producing-telemetry.md#app-closing).

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Unit tests were added to cover the relevant changes.