### PR TITLE
[Single Span Sampling] Consider traces rejected solely by priority sampling as rejected

### DIFF
--- a/lib/datadog/tracing/sampling/span/sampler.rb
+++ b/lib/datadog/tracing/sampling/span/sampler.rb
@@ -23,6 +23,9 @@ module Datadog
           end
 
           # Applies sampling rules to the span if the trace has been rejected.
+          # The tracer can be outright rejected, and never reach the transport,
+          # or be set as rejected by priority sampling. In both cases, the trace
+          # is considered rejected for Single Span Sampling purposes.
           #
           # If multiple rules match, only the first one is applied.
           #
@@ -30,7 +33,7 @@ module Datadog
           # @param [Datadog::Tracing::SpanOperation] span_op Span to apply sampling rules
           # @return [void]
           def sample!(trace_op, span_op)
-            return if trace_op.sampled?
+            return if trace_op.sampled? && trace_op.priority_sampled?
 
             # Return as soon as one rule matches
             @rules.any? do |rule|

--- a/lib/datadog/tracing/sampling/span/sampler.rb
+++ b/lib/datadog/tracing/sampling/span/sampler.rb
@@ -23,7 +23,7 @@ module Datadog
           end
 
           # Applies sampling rules to the span if the trace has been rejected.
-          # The tracer can be outright rejected, and never reach the transport,
+          # The trace can be outright rejected, and never reach the transport,
           # or be set as rejected by priority sampling. In both cases, the trace
           # is considered rejected for Single Span Sampling purposes.
           #

--- a/lib/datadog/tracing/sampling/span/sampler.rb
+++ b/lib/datadog/tracing/sampling/span/sampler.rb
@@ -2,18 +2,30 @@ module Datadog
   module Tracing
     module Sampling
       module Span
-        # Applies a set of rules to a span.
-        # This class is used to apply sampling operations to all
-        # spans in the tracer.
+        # Applies Single Span Sampling rules to spans.
+        # When matching the configured rules, a span is ensured to
+        # be processed Datadog App. In other words, a single sampled span
+        # will never be dropped by the tracer or Datadog agent.
         #
-        # Span sampling is distinct from trace sampling: span
-        # sampling can keep a span that is part of tracer that was
-        # rejected by trace sampling.
+        # All spans in a trace are subject to the single sampling rules, if
+        # any rules are configured.
+        #
+        # Single Span Sampling is distinct from trace-level sampling:
+        # Single Span Sampling can ensure a span is kept, even if its
+        # enclosing trace is rejected by trace-level sampling.
         #
         # This class only applies operations to spans that are part
-        # of traces that were rejected by trace sampling. There's no
-        # reason to try to sample spans that are already kept by
-        # the trace sampler.
+        # of traces that was rejected by trace sampling.
+        # A trace is rejected if either of the following conditions is true:
+        # * The priority sampling for a trace is set to either {USER_REJECT} or {AUTO_REJECT}.
+        # * The trace was rejected by internal sampling, thus never flushed.
+        #
+        # Single-sampled spans are tagged and the tracer ensures they will
+        # reach the Datadog App, regardless of their enclosing trace sampling decision.
+        #
+        # Single Span Sampling does not inspect spans that are part of a trace
+        # that has been accepted by trace-level sampling rules: all spans from such
+        # trace are guaranteed to reach the Datadog App.
         class Sampler
           # Receives sampling rules to apply to individual spans.
           #
@@ -22,7 +34,9 @@ module Datadog
             @rules = rules
           end
 
-          # Applies sampling rules to the span if the trace has been rejected.
+
+          # Applies Single Span Sampling rules to the span if the trace has been rejected.
+          #
           # The trace can be outright rejected, and never reach the transport,
           # or be set as rejected by priority sampling. In both cases, the trace
           # is considered rejected for Single Span Sampling purposes.

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -113,8 +113,22 @@ module Datadog
         @finished == true
       end
 
+      # Will this trace be flushed by the tracer transport?
+      # This includes cases where the span is kept solely due to priority sampling.
+      #
+      # This is not the ultimate Datadog App sampling decision. Downstream systems
+      # can decide to reject this trace, especially for cases where priority
+      # sampling is set to AUTO_KEEP.
+      #
+      # @return [Boolean]
       def sampled?
-        @sampled == true || (!@sampling_priority.nil? && @sampling_priority > 0)
+        @sampled == true || priority_sampled?
+      end
+
+      # Has the priority sampling chosen to keep this span?
+      # @return [Boolean]
+      def priority_sampled?
+        !@sampling_priority.nil? && @sampling_priority > 0
       end
 
       def keep!

--- a/spec/datadog/tracing/sampling/span/sampler_spec.rb
+++ b/spec/datadog/tracing/sampling/span/sampler_spec.rb
@@ -60,6 +60,15 @@ RSpec.describe Datadog::Tracing::Sampling::Span::Sampler do
           end
         end
       end
+
+      context 'a trace rejected by priority sampling only' do
+        before do
+          trace_op.keep!
+          trace_op.sampling_priority = Datadog::Tracing::Sampling::Ext::Priority::AUTO_REJECT
+        end
+
+        it_behaves_like 'tags span with sampling decision'
+      end
     end
   end
 end

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -724,6 +724,36 @@ RSpec.describe Datadog::Tracing::TraceOperation do
     end
   end
 
+  describe '#priority_sampled?' do
+    subject(:priority_sampled?) { trace_op.priority_sampled? }
+
+    it { is_expected.to be false }
+
+    context 'when :sampling_priority is set to' do
+      let(:options) { { sampling_priority: sampling_priority } }
+
+      context 'AUTO_KEEP' do
+        let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::AUTO_KEEP }
+        it { is_expected.to be true }
+      end
+
+      context 'AUTO_REJECT' do
+        let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::AUTO_REJECT }
+        it { is_expected.to be false }
+      end
+
+      context 'USER_KEEP' do
+        let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP }
+        it { is_expected.to be true }
+      end
+
+      context 'USER_REJECT' do
+        let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::USER_REJECT }
+        it { is_expected.to be false }
+      end
+    end
+  end
+
   describe '#keep!' do
     subject(:keep!) { trace_op.keep! }
 


### PR DESCRIPTION
The tracer flushes all traces that have not been dropped by the internal sampler (`TraceOperation#sampled == false` means dropped internally). This includes traces that might be dropped due to their Priority Sampling status downstream.

For Single Span Sampling, we need to guarantee that Single Span Sampled spans are kept and thus cannot trust that all spans flushed by the tracer are kept, unless it's both selected by the internal sampler (`TraceOperation#sampled == true`)  the Priority Sampling status are set to keep (`TraceOperation#sampling_priority > 0`).

This logic is different from the logic used to flush traces through the transport: the tracer wants to send all traces that have not been rejected internally OR traces with Priority Sampling > 0. For Single Span Sampling, we only want to apply Single Span Sampling to spans that we know are going to be dropped, either internally or by the agent. This means that there's an intersection of states where these two processes diverge: when the tracer sends the trace to the agent, but it's dropped by priority sampling.

This PR ensures that this intersecting state is correctly handled for Single Span Sampling.

Single Span Sampling is moving the tracer more towards making independent sampling decisions, and thus having a bit more complicated logic, which currently resides in the agent.