### PR TITLE
CI:RSpec documentation format to debug hung tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ job_defaults: &job_defaults
   # TODO: Changing this requires rebuilding all docker images.
   working_directory: /app
   shell: /bin/bash --login
+  environment:
+    - SPEC_OPTS: --format documentation # Ensures it's possible to debug hung tests in CI
 
 test_containers:
   - &job_parameters


### PR DESCRIPTION
This PR changes the RSpec output format in CircleCI from 
```
........
```

to
```
gRPC integration test
  multiple client configurations
    uses the correct configuration information
  request reply
    behaves like associates child spans with the parent
      is expected to eq 4465632251790005042
      behaves like a peer service span
        contains peer hostname tag
        contains peer service tag
  client stream
    behaves like associates child spans with the parent
      is expected to eq 1213191866811280859
      behaves like a peer service span
        contains peer hostname tag
        contains peer service tag
```

This allows us to debug hung jobs, like https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/6554/workflows/201f8b0c-d745-4681-92e3-2a9bead2a0b3/jobs/242672/parallel-runs/17?filterBy=ALL.