### PR TITLE
Telemetry/app heartbeat

### DIFF
--- a/integration/apps/rails-five/app/controllers/health_controller.rb
+++ b/integration/apps/rails-five/app/controllers/health_controller.rb
@@ -16,7 +16,7 @@ class HealthController < ApplicationController
       profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') },
       telemetry_enabled: Datadog.configuration.telemetry.enabled,
       telemetry_client_enabled: Datadog.send(:components).telemetry.enabled,
-      telemetry_threads: Thread.list.map(&:name).select { |it| it && it.include?('Telemetry') }
+      telemetry_worker_enabled: Datadog.send(:components).telemetry.worker.enabled?
     }
   end
 end

--- a/integration/apps/rails-five/app/controllers/health_controller.rb
+++ b/integration/apps/rails-five/app/controllers/health_controller.rb
@@ -15,7 +15,8 @@ class HealthController < ApplicationController
       profiler_available: Datadog::Profiling.start_if_enabled,
       profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') },
       telemetry_enabled: Datadog.configuration.telemetry.enabled,
-      telemetry_client_enabled: Datadog.send(:components).telemetry.enabled
+      telemetry_client_enabled: Datadog.send(:components).telemetry.enabled,
+      telemetry_threads: Thread.list.map(&:name).select { |it| it && it.include?('Telemetry') }
     }
   end
 end

--- a/integration/apps/rails-five/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-five/spec/integration/basic_spec.rb
@@ -23,10 +23,11 @@ RSpec.describe 'Basic scenarios' do
       )
     end
 
-    it 'should be sending telemetry app-started event' do
+    it 'should be sending telemetry events' do
       expect(json_result).to include(
         telemetry_enabled: true,
-        telemetry_client_enabled: true
+        telemetry_client_enabled: true,
+        telemetry_threads: contain_exactly('Datadog::Core::Telemetry::Heartbeat')
       )
     end
 

--- a/integration/apps/rails-five/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-five/spec/integration/basic_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Basic scenarios' do
       expect(json_result).to include(
         telemetry_enabled: true,
         telemetry_client_enabled: true,
-        telemetry_threads: contain_exactly('Datadog::Core::Telemetry::Heartbeat')
+        telemetry_worker_enabled: true
       )
     end
 

--- a/integration/apps/rails-seven/app/controllers/health_controller.rb
+++ b/integration/apps/rails-seven/app/controllers/health_controller.rb
@@ -16,7 +16,7 @@ class HealthController < ApplicationController
       profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') },
       telemetry_enabled: Datadog.configuration.telemetry.enabled,
       telemetry_client_enabled: Datadog.send(:components).telemetry.enabled,
-      telemetry_threads: Thread.list.map(&:name).select { |it| it && it.include?('Telemetry') }
+      telemetry_worker_enabled: Datadog.send(:components).telemetry.worker.enabled?
     }
   end
 end

--- a/integration/apps/rails-seven/app/controllers/health_controller.rb
+++ b/integration/apps/rails-seven/app/controllers/health_controller.rb
@@ -15,7 +15,8 @@ class HealthController < ApplicationController
       profiler_available: Datadog::Profiling.start_if_enabled,
       profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') },
       telemetry_enabled: Datadog.configuration.telemetry.enabled,
-      telemetry_client_enabled: Datadog.send(:components).telemetry.enabled
+      telemetry_client_enabled: Datadog.send(:components).telemetry.enabled,
+      telemetry_threads: Thread.list.map(&:name).select { |it| it && it.include?('Telemetry') }
     }
   end
 end

--- a/integration/apps/rails-seven/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-seven/spec/integration/basic_spec.rb
@@ -23,10 +23,11 @@ RSpec.describe 'Basic scenarios' do
       )
     end
 
-    it 'should be sending telemetry app-started event' do
+    it 'should be sending telemetry events' do
       expect(json_result).to include(
         telemetry_enabled: true,
-        telemetry_client_enabled: true
+        telemetry_client_enabled: true,
+        telemetry_threads: contain_exactly('Datadog::Core::Telemetry::Heartbeat')
       )
     end
 

--- a/integration/apps/rails-seven/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-seven/spec/integration/basic_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Basic scenarios' do
       expect(json_result).to include(
         telemetry_enabled: true,
         telemetry_client_enabled: true,
-        telemetry_threads: contain_exactly('Datadog::Core::Telemetry::Heartbeat')
+        telemetry_worker_enabled: true
       )
     end
 

--- a/integration/apps/rails-six/app/controllers/health_controller.rb
+++ b/integration/apps/rails-six/app/controllers/health_controller.rb
@@ -16,7 +16,7 @@ class HealthController < ApplicationController
       profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') },
       telemetry_enabled: Datadog.configuration.telemetry.enabled,
       telemetry_client_enabled: Datadog.send(:components).telemetry.enabled,
-      telemetry_threads: Thread.list.map(&:name).select { |it| it && it.include?('Telemetry') }
+      telemetry_worker_enabled: Datadog.send(:components).telemetry.worker.enabled?
     }
   end
 end

--- a/integration/apps/rails-six/app/controllers/health_controller.rb
+++ b/integration/apps/rails-six/app/controllers/health_controller.rb
@@ -15,7 +15,8 @@ class HealthController < ApplicationController
       profiler_available: Datadog::Profiling.start_if_enabled,
       profiler_threads: Thread.list.map(&:name).select { |it| it && it.include?('Profiling') },
       telemetry_enabled: Datadog.configuration.telemetry.enabled,
-      telemetry_client_enabled: Datadog.send(:components).telemetry.enabled
+      telemetry_client_enabled: Datadog.send(:components).telemetry.enabled,
+      telemetry_threads: Thread.list.map(&:name).select { |it| it && it.include?('Telemetry') }
     }
   end
 end

--- a/integration/apps/rails-six/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-six/spec/integration/basic_spec.rb
@@ -23,10 +23,11 @@ RSpec.describe 'Basic scenarios' do
       )
     end
 
-    it 'should be sending telemetry app-started event' do
+    it 'should be sending telemetry events' do
       expect(json_result).to include(
         telemetry_enabled: true,
-        telemetry_client_enabled: true
+        telemetry_client_enabled: true,
+        telemetry_threads: contain_exactly('Datadog::Core::Telemetry::Heartbeat')
       )
     end
 

--- a/integration/apps/rails-six/spec/integration/basic_spec.rb
+++ b/integration/apps/rails-six/spec/integration/basic_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Basic scenarios' do
       expect(json_result).to include(
         telemetry_enabled: true,
         telemetry_client_enabled: true,
-        telemetry_threads: contain_exactly('Datadog::Core::Telemetry::Heartbeat')
+        telemetry_worker_enabled: true
       )
     end
 

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -59,6 +59,7 @@ module Datadog
 
             # Reuse a previous instance of the telemetry client if it already exists
             if settings.telemetry.enabled
+              previous_components.telemetry.reenable!
               previous_components.telemetry.integrations_change!
             else
               previous_components.telemetry.disable!

--- a/lib/datadog/core/telemetry/client.rb
+++ b/lib/datadog/core/telemetry/client.rb
@@ -1,6 +1,7 @@
 # typed: true
 
 require 'datadog/core/telemetry/emitter'
+require 'datadog/core/telemetry/heartbeat'
 require 'datadog/core/utils/sequence'
 
 module Datadog
@@ -18,10 +19,22 @@ module Datadog
           @enabled = enabled
           @emitter = Emitter.new(sequence: sequence)
           started!
+          @worker = Telemetry::Heartbeat.new(enabled: @enabled) do
+            heartbeat!
+          end
+          @stopped = false
+        end
+
+        def reenable!
+          unless @enabled
+            @enabled = true
+            @worker.enabled = true
+          end
         end
 
         def disable!
           @enabled = false
+          @worker.enabled = false
         end
 
         def started!
@@ -31,6 +44,12 @@ module Datadog
         end
 
         def stop!
+          return if @stopped
+
+          @worker.stop
+
+          @stopped = true
+
           return unless @enabled
 
           @emitter.request('app-closing')
@@ -40,6 +59,12 @@ module Datadog
           return unless @enabled
 
           @emitter.request('app-integrations-change')
+        end
+
+        def heartbeat!
+          return unless @enabled
+
+          @emitter.request('app-heartbeat')
         end
       end
     end

--- a/lib/datadog/core/telemetry/client.rb
+++ b/lib/datadog/core/telemetry/client.rb
@@ -11,7 +11,8 @@ module Datadog
       class Client
         attr_reader \
           :enabled,
-          :emitter
+          :emitter,
+          :worker
 
         # @param enabled [Boolean] Determines whether telemetry events should be sent to the API
         # @param sequence [Datadog::Core::Utils::Sequence] Sequence object that stores and increments a counter
@@ -44,11 +45,8 @@ module Datadog
         end
 
         def stop!
-          return if @stopped
-
           @worker.stop
-
-          @stopped = true
+          @worker.join
 
           return unless @enabled
 
@@ -60,6 +58,8 @@ module Datadog
 
           @emitter.request('app-integrations-change')
         end
+
+        private
 
         def heartbeat!
           return unless @enabled

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -44,7 +44,7 @@ module Datadog
           case request_type
           when 'app-started'
             app_started
-          when 'app-closing'
+          when 'app-closing', 'app-heartbeat'
             {}
           when 'app-integrations-change'
             app_integrations_change

--- a/lib/datadog/core/telemetry/heartbeat.rb
+++ b/lib/datadog/core/telemetry/heartbeat.rb
@@ -1,6 +1,4 @@
-# typed: true
-
-require 'datadog/core/utils/time'
+# typed: false
 
 require 'datadog/core/worker'
 require 'datadog/core/workers/polling'

--- a/lib/datadog/core/telemetry/heartbeat.rb
+++ b/lib/datadog/core/telemetry/heartbeat.rb
@@ -23,6 +23,8 @@ module Datadog
           start
         end
 
+        private
+
         def start
           perform
         end

--- a/lib/datadog/core/telemetry/heartbeat.rb
+++ b/lib/datadog/core/telemetry/heartbeat.rb
@@ -1,0 +1,32 @@
+# typed: true
+
+require 'datadog/core/utils/time'
+
+require 'datadog/core/worker'
+require 'datadog/core/workers/polling'
+
+module Datadog
+  module Core
+    module Telemetry
+      # Periodically (every DEFAULT_INTERVAL_SECONDS) sends a heartbeat event to the telemetry API.
+      class Heartbeat < Core::Worker
+        include Core::Workers::Polling
+
+        DEFAULT_INTERVAL_SECONDS = 60
+
+        def initialize(enabled: true, interval: DEFAULT_INTERVAL_SECONDS, &block)
+          # Workers::Polling settings
+          self.enabled = enabled
+          # Workers::IntervalLoop settings
+          self.loop_base_interval = interval
+          super(&block)
+          start
+        end
+
+        def start
+          perform
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -263,6 +263,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
         before do
           allow(telemetry_client).to receive(:disable!)
+          allow(telemetry_client).to receive(:reenable!)
           allow(telemetry_client).to receive(:integrations_change!)
           allow(settings.telemetry).to receive(:enabled).and_return(enabled)
           allow(previous_components).to receive(:telemetry).and_return(telemetry_client)
@@ -272,6 +273,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
           let(:enabled) { true }
 
           it do
+            expect(telemetry_client).to receive(:reenable!)
             expect(telemetry_client).to receive(:integrations_change!)
 
             build_telemetry

--- a/spec/datadog/core/telemetry/client_spec.rb
+++ b/spec/datadog/core/telemetry/client_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe Datadog::Core::Telemetry::Client do
   end
 
   describe '#initialize' do
+    after do
+      client.worker.stop(true)
+      client.worker.join
+    end
+
     context 'when no params provided' do
       subject(:client) { described_class.new }
       it { is_expected.to be_a_kind_of(described_class) }
@@ -26,6 +31,7 @@ RSpec.describe Datadog::Core::Telemetry::Client do
       let(:enabled) { false }
       it { is_expected.to be_a_kind_of(described_class) }
       it { expect(client.enabled).to be(false) }
+      it { expect(client.worker.enabled?).to be(false) }
     end
 
     context 'when enabled' do
@@ -33,18 +39,54 @@ RSpec.describe Datadog::Core::Telemetry::Client do
 
       it do
         client
-
         expect(emitter).to have_received(:request).with('app-started')
+        expect(client.worker.enabled?).to be(true)
       end
     end
   end
 
   describe '#disable!' do
+    after do
+      client.worker.stop(true)
+      client.worker.join
+    end
+
     it { expect { client.disable! }.to change { client.enabled }.from(true).to(false) }
+    it { expect { client.disable! }.to change { client.worker.enabled? }.from(true).to(false) }
+  end
+
+  describe '#reenable!' do
+    after do
+      client.worker.stop(true)
+      client.worker.join
+    end
+
+    context 'when already enabled' do
+      it do
+        expect(client.enabled).to be(true)
+        expect(client.worker.enabled?).to be(true)
+
+        client.reenable!
+
+        expect(client.enabled).to be(true)
+        expect(client.worker.enabled?).to be(true)
+      end
+    end
+
+    context 'when disabled' do
+      let(:enabled) { false }
+      it { expect { client.reenable! }.to change { client.enabled }.from(false).to(true) }
+      it { expect { client.reenable! }.to change { client.worker.enabled? }.from(false).to(true) }
+    end
   end
 
   describe '#started!' do
     subject(:started!) { client.started! }
+
+    after do
+      client.worker.stop(true)
+      client.worker.join
+    end
 
     context 'when disabled' do
       let(:enabled) { false }
@@ -65,10 +107,21 @@ RSpec.describe Datadog::Core::Telemetry::Client do
 
   describe '#stop!' do
     subject(:stop!) { client.stop! }
+    let(:worker) { instance_double(Datadog::Core::Telemetry::Heartbeat) }
+
+    before do
+      allow(Datadog::Core::Telemetry::Heartbeat).to receive(:new).and_return(worker)
+      allow(worker).to receive(:start)
+      allow(worker).to receive(:stop)
+      allow(worker).to receive(:join)
+    end
+
     context 'when disabled' do
       let(:enabled) { false }
       it do
         stop!
+        expect(client.worker).to have_received(:stop)
+        expect(client.worker).to have_received(:join)
         expect(emitter).to_not have_received(:request).with('app-closing')
       end
     end
@@ -77,6 +130,7 @@ RSpec.describe Datadog::Core::Telemetry::Client do
       let(:enabled) { true }
       it do
         stop!
+        expect(client.worker).to have_received(:stop)
         expect(emitter).to have_received(:request).with('app-closing')
       end
 
@@ -86,6 +140,12 @@ RSpec.describe Datadog::Core::Telemetry::Client do
 
   describe '#integrations_change!' do
     subject(:integrations_change!) { client.integrations_change! }
+
+    after do
+      client.worker.stop(true)
+      client.worker.join
+    end
+
     context 'when disabled' do
       let(:enabled) { false }
       it do

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe Datadog::Core::Telemetry::Event do
         it { expect(telemetry_request.payload).to eq({}) }
       end
 
+      context 'is app-heartbeat' do
+        let(:request_type) { 'app-heartbeat' }
+
+        it { expect(telemetry_request.payload).to eq({}) }
+      end
+
       context 'is app-integrations-change' do
         let(:request_type) { 'app-integrations-change' }
 

--- a/spec/datadog/core/telemetry/heartbeat_spec.rb
+++ b/spec/datadog/core/telemetry/heartbeat_spec.rb
@@ -1,0 +1,46 @@
+# typed: false
+
+require 'spec_helper'
+
+require 'datadog/core/telemetry/heartbeat'
+
+RSpec.describe Datadog::Core::Telemetry::Heartbeat do
+  subject(:heartbeat) { described_class.new(enabled: enabled, interval: interval, &block) }
+
+  let(:enabled) { true }
+  let(:interval) { 60 }
+  let(:block) { proc {} }
+
+  after do
+    heartbeat.stop(true)
+    heartbeat.join
+  end
+
+  describe '.new' do
+    context 'when using default settings' do
+      subject(:heartbeat) { described_class.new(&block) }
+      it do
+        is_expected.to have_attributes(
+          enabled?: true,
+          loop_base_interval: 60, # seconds
+          task: block
+        )
+      end
+    end
+
+    context 'when enabled' do
+      let(:enabled) { true }
+
+      it do
+        heartbeat
+
+        try_wait_until { heartbeat.running? }
+        expect(heartbeat).to have_attributes(
+          run_async?: true,
+          running?: true,
+          started?: true
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Create a new worker to send `app-heartbeat` events to the telemetry API every minute.
<img width="913" alt="image" src="https://user-images.githubusercontent.com/32009013/177875693-75089f55-b441-4158-8c61-ac7f51b4a0bc.png">


**Motivation**
<!-- What inspired you to submit this pull request? -->
This is one of the expected telemetry events as specified [here](https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v1/producing-telemetry.md#app-heartbeat)

**Additional Notes**
<!-- Anything else we should know when reviewing? -->
* Does it make sense to inherit from the `Worker` class? Or would it be better to just make a new class that implements a simple thread?
* Currently this sends every minute - we technically do not need to send an event if another telemetry event has been sent in that minute. Is it okay to keep it as is for now, or should I be tracking in the client when an event is sent and only send the heartbeat as needed?

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Unit tests were added + changes were tested in a local rails app to ensure the event was getting sent to the telemetry API