### PR TITLE
Fix have_metadata RSpec helper

### DIFF
--- a/spec/support/span_helpers.rb
+++ b/spec/support/span_helpers.rb
@@ -89,11 +89,27 @@ module SpanHelpers
     end
   end
 
-  RSpec::Matchers.define :have_metadata do |**tags|
+  # @param tags [Hash] key value pairs to tags/metrics to assert on
+  RSpec::Matchers.define :have_metadata do |tags|
     match do |actual|
       tags.all? do |key, value|
-        actual.get_tag(key) == value
+        values_match? value, actual.get_tag(key)
       end
+    end
+
+    match_when_negated do |actual|
+      if tags.respond_to?(:any?)
+        tags.any? do |key, value|
+          !values_match? value, actual.get_tag(key)
+        end
+      else
+        # Allows for `expect(span).to_not have_metadata('my.tag')` syntax
+        values_match? nil, actual.get_tag(tags)
+      end
+    end
+
+    def description_of(actual)
+      "Span with metadata #{actual.send(:meta).merge(actual.send(:metrics))}"
     end
   end
 


### PR DESCRIPTION
While using the `have_metadata` RSpec custom helper, I noticed it was working as I expected.
It was always returning "match", regardless of the expectation provided.

Turns out it's because the matcher argument is positional, not keyword as we previously had:
```diff
-  RSpec::Matchers.define :have_metadata do |**tags|
+  RSpec::Matchers.define :have_metadata do |tags|
```

The argument supported is also always a single Hash argument.

This PR addresses that.

In fixing this, one test was shown to be incorrect: https://github.com/DataDog/dd-trace-rb/blob/017624521d2f73643be30a5ee41e48a226a4dea1/spec/ddtrace/transport/trace_formatter_spec.rb#L147-L155

This happened because the subject under test (`format!`) is invoked in an outer `before` block, and thus executed before this test's `before` block with the mocking `allow(root_span).to receive(:get_tag)...` can execute.

The test was now failing with the fixed `have_metadata` matcher, thus I fixed it in this PR.
The change in `trace_formatter_spec.rb` is large because I had to remove the `before { format! }` block, meaning many tests now have to explicitly invoke the subject.