### PR TITLE
Compute top-level span in tracer

### DIFF
--- a/lib/datadog/tracing/metadata/ext.rb
+++ b/lib/datadog/tracing/metadata/ext.rb
@@ -22,6 +22,9 @@ module Datadog
 
         TAG_KIND = 'span.kind'
 
+        # Set this tag to `1.0` if the span is a Service Entry span.
+        TAG_TOP_LEVEL = '_dd.top_level'
+
         # Defines constants for trace analytics
         # @public_api
         module Analytics

--- a/lib/datadog/tracing/span.rb
+++ b/lib/datadog/tracing/span.rb
@@ -110,6 +110,9 @@ module Datadog
         @duration = duration
 
         @service_entry = service_entry
+
+        # Mark with the service entry span metric, if applicable
+        set_metric(Metadata::Ext::TAG_TOP_LEVEL, 1.0) if service_entry
       end
 
       # Return whether the duration is started or not

--- a/spec/datadog/tracing/span_spec.rb
+++ b/spec/datadog/tracing/span_spec.rb
@@ -51,6 +51,32 @@ RSpec.describe Datadog::Tracing::Span do
         end
       end
     end
+
+    context 'service_entry' do
+      context 'with nil' do
+        let(:span_options) { { service_entry: nil } }
+
+        it 'does not tag as top-level' do
+          expect(span).to_not have_metadata('_dd.top_level')
+        end
+      end
+
+      context 'with false' do
+        let(:span_options) { { service_entry: false } }
+
+        it 'does not tag as top-level' do
+          expect(span).to_not have_metadata('_dd.top_level')
+        end
+      end
+
+      context 'with true' do
+        let(:span_options) { { service_entry: true } }
+
+        it 'tags as top-level' do
+          expect(span).to have_metadata('_dd.top_level' => 1.0)
+        end
+      end
+    end
   end
 
   context 'ids' do


### PR DESCRIPTION
This PR is the first step towards early top level detection in the tracer.

As a preamble, the definition of top-level span is:

> A span is defined as a top level if any of the following are true:
> * It’s a root span
> * Its parent has a different service
> * It’s a local root in a distributed trace (local root of flushed trace in an agent)


After the introduction of the `service_entry` attribute in #2080, now know how to calculate the effective top-level spans in a trace, [exactly how the agent does](https://github.com/DataDog/datadog-agent/blob/b4542cc65a1289cfe72903e52c9ed4d219d6453b/pkg/trace/traceutil/trace.go#L116-L132). Both the tracer and agent must follow the definition in previous paragraph.

[For every trace received, the agent calculate the top-level spans and tags them with `_dd.top_level`](https://github.com/DataDog/datadog-agent/blob/b4542cc65a1289cfe72903e52c9ed4d219d6453b/pkg/trace/agent/agent.go#L278-L282).
This is the default case. But if we send a [special header, (`Datadog-Client-Computed-Top-Level`)](https://github.com/DataDog/datadog-agent/blob/b4542cc65a1289cfe72903e52c9ed4d219d6453b/pkg/trace/api/api.go#L359-L361), the agent will [skip calculating the top-level spans itself](https://github.com/DataDog/datadog-agent/blob/b4542cc65a1289cfe72903e52c9ed4d219d6453b/pkg/trace/agent/agent.go#L278-L282).

With this PR, this is he trace timeline:
1. Tracer sends the trace tagged with top-level tags
2. Agent does not find the special HTTP header
3. Agent calculates the top-level spans again, and marks the exact same spans with the `_dd.top_level` metric.

This means that the traces are effectively the same, but each top-level span received the tagging, `span.set_metric('_dd.top_level', 1.0)`, twice, having no ill-effect.

## Follow up work

Introduce the special header https://github.com/DataDog/datadog-agent/blob/b4542cc65a1289cfe72903e52c9ed4d219d6453b/pkg/trace/api/api.go#L359-L361 to allow for the Agent to completely skip top-level calculation.