### PR TITLE
Tell agent to trust tracer top-level span tagging

### DIFF
--- a/lib/ddtrace/transport/ext.rb
+++ b/lib/ddtrace/transport/ext.rb
@@ -13,6 +13,13 @@ module Datadog
 
         HEADER_CONTAINER_ID = 'Datadog-Container-ID'.freeze
         HEADER_DD_API_KEY = 'DD-API-KEY'.freeze
+        # Tells agent that `_dd.top_level` metrics have been set by the tracer.
+        # The agent will not calculate top-level spans but instead trust the tracer tagging.
+        #
+        # This prevents partially flushed traces being mistakenly marked as top-level.
+        #
+        # Setting this header to any non-empty value enables this feature.
+        HEADER_CLIENT_COMPUTED_TOP_LEVEL = 'Datadog-Client-Computed-Top-Level'.freeze
         HEADER_META_LANG = 'Datadog-Meta-Lang'.freeze
         HEADER_META_LANG_VERSION = 'Datadog-Meta-Lang-Version'.freeze
         HEADER_META_LANG_INTERPRETER = 'Datadog-Meta-Lang-Interpreter'.freeze

--- a/lib/ddtrace/transport/http.rb
+++ b/lib/ddtrace/transport/http.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # typed: true
 
 require 'uri'
@@ -67,6 +69,7 @@ module Datadog
 
       def default_headers
         {
+          Datadog::Transport::Ext::HTTP::HEADER_CLIENT_COMPUTED_TOP_LEVEL => '1',
           Datadog::Transport::Ext::HTTP::HEADER_META_LANG => Datadog::Core::Environment::Ext::LANG,
           Datadog::Transport::Ext::HTTP::HEADER_META_LANG_VERSION => Datadog::Core::Environment::Ext::LANG_VERSION,
           Datadog::Transport::Ext::HTTP::HEADER_META_LANG_INTERPRETER => Datadog::Core::Environment::Ext::LANG_INTERPRETER,

--- a/spec/ddtrace/transport/http_spec.rb
+++ b/spec/ddtrace/transport/http_spec.rb
@@ -169,6 +169,7 @@ RSpec.describe Datadog::Transport::HTTP do
 
     it do
       is_expected.to include(
+        Datadog::Transport::Ext::HTTP::HEADER_CLIENT_COMPUTED_TOP_LEVEL => '1',
         Datadog::Transport::Ext::HTTP::HEADER_META_LANG => Datadog::Core::Environment::Ext::LANG,
         Datadog::Transport::Ext::HTTP::HEADER_META_LANG_VERSION => Datadog::Core::Environment::Ext::LANG_VERSION,
         Datadog::Transport::Ext::HTTP::HEADER_META_LANG_INTERPRETER => Datadog::Core::Environment::Ext::LANG_INTERPRETER,


### PR DESCRIPTION
Follow up from #2137.

This PR lets the Agent know that the tracer has calculated top-level spans and tagged them appropriately.

**This prevents partially flushed trace segments from being considered top-level, which used to create incorrect metrics and increase the resource name cardinality for the affected service name.**

Any value can be set in the HTTP header. The agent simply checks if it's not empty.

(If you are still confused, the description of #2137 has all the information regarding this and the previous PR)