### PR TITLE
Add simple benchmark test for telemetry

### DIFF
--- a/spec/ddtrace/benchmark/telemetry_spec.rb
+++ b/spec/ddtrace/benchmark/telemetry_spec.rb
@@ -1,0 +1,54 @@
+# typed: ignore
+
+require 'spec_helper'
+
+require 'benchmark'
+require 'ddtrace'
+
+RSpec.describe 'Telemetry Benchmark' do
+  let(:enabled) { 'true' }
+
+  around do |example|
+    ClimateControl.modify(Datadog::Core::Telemetry::Ext::ENV_ENABLED => enabled) do
+      example.run
+    end
+  end
+
+  before do
+    skip('Benchmark results not currently captured in CI') if ENV.key?('CI')
+
+    # Create double to swallow log output
+    logger = double(Datadog::Core::Logger)
+    allow(logger).to receive(:debug)
+    allow(logger).to receive(:info)
+    allow(logger).to receive(:warn)
+    allow(logger).to receive(:error)
+    allow(Datadog).to receive(:logger).and_return(logger)
+  end
+
+  include Benchmark
+
+  context 'telemetry disabled' do
+    let(:enabled) { 'false' }
+
+    it do
+      Benchmark.benchmark(Benchmark::CAPTION, 30, Benchmark::FORMAT) do |x|
+        x.report('#configure') { Datadog.configure {} }
+        x.report('#integration_change') { Datadog.configure { |c| c.tracing.instrument :rake } }
+        x.report('#close') { Datadog::Tracing.shutdown! }
+      end
+    end
+  end
+
+  context 'telemetry enabled' do
+    let(:enabled) { 'true' }
+
+    it do
+      Benchmark.benchmark(Benchmark::CAPTION, 30, Benchmark::FORMAT) do |x|
+        x.report('#configure') { Datadog.configure {} }
+        x.report('#integration_change') { Datadog.configure { |c| c.tracing.instrument :rake } }
+        x.report('#close') { Datadog::Tracing.shutdown! }
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds a simple benchmarking test to compare the time it takes to run a configure block with telemetry enabled vs. without. 

There seems to be quite a bit of variance between test runs:
![image](https://user-images.githubusercontent.com/32009013/177893635-99741e8a-aafb-47ef-997f-e48f7599fba8.png)

![image](https://user-images.githubusercontent.com/32009013/177893572-ca8dd2d0-3d9f-4841-863c-2062d48a6a80.png)

**Motivation**
<!-- What inspired you to submit this pull request? -->
Comparing performance is important to ensure we're not adding a lot of overhead by sending telemetry requests

**Additional Notes**
<!-- Anything else we should know when reviewing? -->
I also ran these tests in a rails app to test behavior with requests being sent via the agent:
```
with telemetry enabled:
                                 user       system     total        real
#app-started                     0.002635   0.004334   0.006969 (  0.330376)
#integrations-change             0.003728   0.000769   0.004497 (  0.208753)

without telemetry:
                                 user       system     total        real
#app-started                     0.000000   0.001966   0.001966 (  0.001964)
#integrations-change             0.001939   0.000000   0.001939 (  0.001940)
```
**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
The test file can be run locally to verify the results