### PR TITLE
[PROF-5774] Remove support for profiling Ruby 2.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ namespace :spec do
                         ' spec/**/auto_instrument_spec.rb'
     t.rspec_opts = args.to_a.join(' ')
   end
-  if RUBY_ENGINE == 'ruby' && OS.linux?
+  if RUBY_ENGINE == 'ruby' && OS.linux? && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.0')
     # "bundle exec rake compile" currently only works on MRI Ruby on Linux
     Rake::Task[:main].enhance([:compile])
   end

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -124,7 +124,7 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
 |       |                            | 2.4     | Full                                 | Latest              |
 |       |                            | 2.3     | Full                                 | Latest              |
 |       |                            | 2.2     | Full                                 | Latest              |
-|       |                            | 2.1     | Full                                 | Latest              |
+|       |                            | 2.1     | Full (except for Profiling)          | Latest              |
 |       |                            | 2.0     | EOL since June 7th, 2021             | < 0.50.0            |
 |       |                            | 1.9.3   | EOL since August 6th, 2020           | < 0.27.0            |
 |       |                            | 1.9.1   | EOL since August 6th, 2020           | < 0.27.0            |
@@ -143,7 +143,7 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
 
 | Type        | Documentation                                   | Version               | Gem version support |
 | ----------- | ----------------------------------------------- | --------------------- | ------------------- |
-| OpenTracing | https://github.com/opentracing/opentracing-ruby | 0.4.1+ (w/ Ruby 2.1+) | >= 0.16.0           |
+| OpenTracing | https://github.com/opentracing/opentracing-ruby | 0.4.1+                | >= 0.16.0           |
 
 *Full* support indicates all tracer features are available.
 

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -137,8 +137,8 @@ void sample_thread(VALUE thread, sampling_buffer* buffer, VALUE recorder_instanc
       // **IMPORTANT**: Be very careful when calling any `rb_profile_frame_...` API with a non-Ruby frame, as legacy
       // Rubies may assume that what's in a buffer will lead to a Ruby frame.
       //
-      // In particular for Ruby 2.2 and below the buffer contains a Ruby string (see the notes on our custom
-      // rb_profile_frames for Ruby 2.2 and below) and CALLING **ANY** OF THOSE APIs ON IT WILL CAUSE INSTANT VM CRASHES
+      // In particular for Ruby 2.2 the buffer contains a Ruby string (see the notes on our custom
+      // rb_profile_frames for Ruby 2.2) and CALLING **ANY** OF THOSE APIs ON IT WILL CAUSE INSTANT VM CRASHES
 
 #ifndef USE_LEGACY_RB_PROFILE_FRAMES // Modern Rubies
       name = ddtrace_rb_profile_frame_method_name(buffer->stack_buffer[i]);

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -86,6 +86,7 @@ module Datadog
             on_macos? ||
             on_unknown_os? ||
             not_on_amd64_or_arm64? ||
+            on_ruby_2_1? ||
             expected_to_use_mjit_but_mjit_is_disabled? ||
             libdatadog_not_usable?
         end
@@ -146,6 +147,10 @@ module Datadog
 
         GET_IN_TOUCH = [
           "Get in touch with us if you're interested in profiling your app!"
+        ].freeze
+
+        UPGRADE_RUBY = [
+          "Upgrade to a modern Ruby to enable profiling for your app."
         ].freeze
 
         # Validation for this check is done in extconf.rb because it relies on mkmf
@@ -240,6 +245,15 @@ module Datadog
           )
 
           architecture_not_supported unless RUBY_PLATFORM.start_with?('x86_64', 'aarch64')
+        end
+
+        private_class_method def self.on_ruby_2_1?
+          ruby_version_not_supported = explain_issue(
+            'your Ruby version (2.1) is too old to be supported.',
+            suggested: UPGRADE_RUBY,
+          )
+
+          ruby_version_not_supported if RUBY_VERSION.start_with?('2.1.')
         end
 
         # On some Rubies, we require the mjit header to be present. If Ruby was installed without MJIT support, we also skip

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -150,7 +150,7 @@ module Datadog
         ].freeze
 
         UPGRADE_RUBY = [
-          "Upgrade to a modern Ruby to enable profiling for your app."
+          'Upgrade to a modern Ruby to enable profiling for your app.'
         ].freeze
 
         # Validation for this check is done in extconf.rb because it relies on mkmf

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -249,7 +249,7 @@ module Datadog
 
         private_class_method def self.on_ruby_2_1?
           ruby_version_not_supported = explain_issue(
-            'your Ruby version (2.1) is too old to be supported.',
+            'the profiler only supports Ruby 2.2 or newer.',
             suggested: UPGRADE_RUBY,
           )
 

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -6,11 +6,7 @@
 // so we use PRIVATE_VM_API_ACCESS_SKIP_RUBY_INCLUDES to be able to include private_vm_api_access.h on that file
 // without also dragging the incompatible includes
 #ifndef PRIVATE_VM_API_ACCESS_SKIP_RUBY_INCLUDES
-  #ifdef RUBY_2_1_WORKAROUND
-    #include <thread_native.h>
-  #else
-    #include <ruby/thread_native.h>
-  #endif
+  #include <ruby/thread_native.h>
 #endif
 
 #include "extconf.h"

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.h
@@ -3,7 +3,7 @@
 #include <ddprof/ffi.h>
 
 // Note: Please DO NOT use `VALUE_STRING` anywhere else, instead use `DDPROF_FFI_CHARSLICE_C`.
-// `VALUE_STRING` is only needed because older versions of gcc (4.9.2, used in our Ruby 2.1 and 2.2 CI test images)
+// `VALUE_STRING` is only needed because older versions of gcc (4.9.2, used in our Ruby 2.2 CI test images)
 // tripped when compiling `enabled_value_types` using `-std=gnu99` due to the extra cast that is included in
 // `DDPROF_FFI_CHARSLICE_C` with the following error:
 //

--- a/integration/apps/rack/spec/integration/basic_spec.rb
+++ b/integration/apps/rack/spec/integration/basic_spec.rb
@@ -11,8 +11,10 @@ RSpec.describe 'Basic scenarios' do
     it { is_expected.to be_a_kind_of(Net::HTTPOK) }
   end
 
+  let(:expected_profiler_available) { RUBY_VERSION >= '2.2' }
+
   let(:expected_profiler_threads) do
-    # NOTE: Threads can't be named on Ruby 2.1 and 2.2
+    # NOTE: Threads can't be named on Ruby 2.2
     contain_exactly('Datadog::Profiling::Collectors::OldStack', 'Datadog::Profiling::Scheduler') unless RUBY_VERSION < '2.3'
   end
 
@@ -25,7 +27,7 @@ RSpec.describe 'Basic scenarios' do
 
     it 'should be profiling' do
       expect(json_result).to include(
-        profiler_available: true,
+        profiler_available: expected_profiler_available,
         profiler_threads: expected_profiler_threads,
       )
     end
@@ -49,7 +51,7 @@ RSpec.describe 'Basic scenarios' do
       expect(JSON.parse(body, symbolize_names: true)).to include(
         key: key,
         resque_process: match(/resque/),
-        profiler_available: true,
+        profiler_available: expected_profiler_available,
         profiler_threads: expected_profiler_threads,
       )
     end
@@ -69,7 +71,7 @@ RSpec.describe 'Basic scenarios' do
       expect(JSON.parse(body, symbolize_names: true)).to include(
         key: key,
         sidekiq_process: match(/sidekiq/),
-        profiler_available: true,
+        profiler_available: expected_profiler_available,
         profiler_threads: expected_profiler_threads,
       )
     end

--- a/integration/images/include/build_ddtrace_profiling_native_extension.rb
+++ b/integration/images/include/build_ddtrace_profiling_native_extension.rb
@@ -1,10 +1,14 @@
 #!/usr/bin/env ruby
 
 if local_gem_path = ENV['DD_DEMO_ENV_GEM_LOCAL_DDTRACE']
-  puts "\n== Building profiler native extension =="
-  success =
-    system("export BUNDLE_GEMFILE=#{local_gem_path}/Gemfile && cd #{local_gem_path} && bundle install && bundle exec rake compile")
-  raise 'Failure to compile profiler native extension' unless success
+  if RUBY_VERSION.start_with?('2.1.')
+    puts "\n== Skipping build of profiler native extension on Ruby 2.1 =="
+  else
+    puts "\n== Building profiler native extension =="
+    success =
+      system("export BUNDLE_GEMFILE=#{local_gem_path}/Gemfile && cd #{local_gem_path} && bundle install && bundle exec rake compile")
+    raise 'Failure to compile profiler native extension' unless success
+  end
 else
   puts "\n== Skipping build of profiler native extension, no DD_DEMO_ENV_GEM_LOCAL_DDTRACE set =="
 end

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -23,8 +23,7 @@ module Datadog
         end
       end
 
-      # Used only for Ruby 2.2 and below which don't have the native `rb_time_timespec_new` API
-      # Called from native code
+      # Used only for Ruby 2.2 which doesn't have the native `rb_time_timespec_new` API; called from native code
       def self.ruby_time_from(timespec_seconds, timespec_nanoseconds)
         Time.at(0).utc + timespec_seconds + (timespec_nanoseconds.to_r / 1_000_000_000)
       end

--- a/spec/datadog/profiling/collectors/old_stack_spec.rb
+++ b/spec/datadog/profiling/collectors/old_stack_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe Datadog::Profiling::Collectors::OldStack do
   end
 
   before do
-    skip 'Profiling is not supported on JRuby' if PlatformHelpers.jruby?
-    skip 'Profiling is not supported on TruffleRuby' if PlatformHelpers.truffleruby?
+    skip_if_profiling_not_supported(self)
 
     allow(recorder)
       .to receive(:[])
@@ -86,9 +85,6 @@ RSpec.describe Datadog::Profiling::Collectors::OldStack do
         # See cthread.rb for more details
 
         before do
-          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2')
-            skip 'Test case only applies to Ruby 2.2+ (previous versions did not have the Process::Waiter class)'
-          end
           skip 'Test case only applies to MRI Ruby' if RUBY_ENGINE != 'ruby'
         end
 
@@ -484,9 +480,6 @@ RSpec.describe Datadog::Profiling::Collectors::OldStack do
 
     context 'Process::Waiter crash regression tests' do
       before do
-        if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2')
-          skip 'Test case only applies to Ruby 2.2+ (previous versions did not have the Process::Waiter class)'
-        end
         skip 'Test case only applies to MRI Ruby' if RUBY_ENGINE != 'ruby'
       end
 
@@ -734,12 +727,6 @@ RSpec.describe Datadog::Profiling::Collectors::OldStack do
 
   describe 'Process::Waiter crash regression tests' do
     # Related to https://bugs.ruby-lang.org/issues/17807 ; see comments on main class for details
-
-    before do
-      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2')
-        skip 'Test case only applies to Ruby 2.2+ (previous versions did not have the Process::Waiter class)'
-      end
-    end
 
     let(:process_waiter_thread) { Process.detach(fork { sleep }) }
 

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -358,7 +358,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
 
         if RUBY_VERSION.start_with?('2.2.')
           # Workaround for webrick bug in Ruby 2.2.
-          # This `setup_shutdown_pipe` method was added in 2.2 (so 2.1 is not affected) but it had a bug when webrick
+          # This `setup_shutdown_pipe` method was added in 2.2 but it had a bug when webrick
           # was configured with `DoNotListen: true` and was never called, which led to failures as webrick requires and
           # expects it to have been called.
           # In Ruby 2.3 this was fixed and this method always gets called, even with `DoNotListen: true`.

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
           context 'when on Ruby 2.1' do
             before { stub_const('RUBY_VERSION', '2.1.10') }
 
-            it { is_expected.to include '(2.1) is too old' }
+            it { is_expected.to include 'profiler only supports Ruby 2.2 or newer' }
           end
         end
 

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -34,6 +34,7 @@ module ProfileHelpers
   def skip_if_profiling_not_supported(testcase)
     testcase.skip('Profiling is not supported on JRuby') if PlatformHelpers.jruby?
     testcase.skip('Profiling is not supported on TruffleRuby') if PlatformHelpers.truffleruby?
+    testcase.skip('Profiling is not supported on Ruby 2.1') if RUBY_VERSION.start_with?('2.1.')
 
     # Profiling is not officially supported on macOS due to missing libdatadog binaries,
     # but it's still useful to allow it to be enabled for development.


### PR DESCRIPTION
**What does this PR do?**

This PR remove support for profiling Ruby 2.1 using the Continuous Profiling product. Other products shipped in ddtrace (tracing, application security monitoring, CI, etc) are unaffected.

This dropping of support does not impact our customer's ability to install the latest dd-trace-rb on Ruby 2.1. What it does is

1. Skip compilation of the profiling native extension on Ruby 2.1
2. Print a warning message when customers try to enable profiling on Ruby 2.1 (but does not otherwise block or break their application)

The warning message shown to customers is:

> W, [2022-07-08T14:08:51.295193 #51899]  WARN -- ddtrace: [ddtrace] Profiling was requested but is not supported, profiling disabled: Your ddtrace installation is missing support for the Continuous Profiler because
> ~~your Ruby version (2.1) is too old to be supported~~ the profiler only supports Ruby 2.2 or newer.
> Upgrade to a modern Ruby to enable profiling for your app.

**Motivation**

There is little customer interest on profiling Ruby 2.1, and supporting old Rubies also comes with an extra tax, especially as we build towards the new native profiler.

**Additional Notes**

**I'm opening this PR as a draft not because it's missing anything, but because it MUST only be merged after dd-trace-rb 1.2.0 is released**.

**How to test the change?**

* Run test suite on Ruby 2.1
* Try enabling profiling on a Ruby 2.1 application
