### PR TITLE
Add unsupported flag for telemetry

### DIFF
--- a/lib/datadog/core/telemetry/client.rb
+++ b/lib/datadog/core/telemetry/client.rb
@@ -10,8 +10,9 @@ module Datadog
       # Telemetry entrypoint, coordinates sending telemetry events at various points in app lifecyle
       class Client
         attr_reader \
-          :enabled,
           :emitter,
+          :enabled,
+          :unsupported,
           :worker
 
         # @param enabled [Boolean] Determines whether telemetry events should be sent to the API
@@ -19,15 +20,17 @@ module Datadog
         def initialize(enabled: true, sequence: Datadog::Core::Utils::Sequence.new(1))
           @enabled = enabled
           @emitter = Emitter.new(sequence: sequence)
+          @stopped = false
+          @unsupported = false
+
           started!
           @worker = Telemetry::Heartbeat.new(enabled: @enabled) do
             heartbeat!
           end
-          @stopped = false
         end
 
         def reenable!
-          unless @enabled
+          unless @enabled || @unsupported
             @enabled = true
             @worker.enabled = true
           end
@@ -41,7 +44,16 @@ module Datadog
         def started!
           return unless @enabled
 
-          @emitter.request('app-started')
+          res = @emitter.request('app-started')
+
+          # Telemetry is only supported by agent versions 7.34 and up
+          if res.not_found?
+            Datadog.logger.debug('Agent does not support telemetry; disabling future telemetry events.')
+            @enabled = false
+            @unsupported = true # Prevent telemetry from getting re-enabled
+          end
+
+          res
         end
 
         def stop!

--- a/lib/datadog/core/telemetry/client.rb
+++ b/lib/datadog/core/telemetry/client.rb
@@ -46,13 +46,11 @@ module Datadog
 
           res = @emitter.request('app-started')
 
-          # Telemetry is only supported by agent versions 7.34 and up
-          if res.not_found?
+          if res.not_found? # Telemetry is only supported by agent versions 7.34 and up
             Datadog.logger.debug('Agent does not support telemetry; disabling future telemetry events.')
             @enabled = false
             @unsupported = true # Prevent telemetry from getting re-enabled
           end
-
           res
         end
 

--- a/lib/datadog/core/telemetry/emitter.rb
+++ b/lib/datadog/core/telemetry/emitter.rb
@@ -30,7 +30,7 @@ module Datadog
                                                                             seq_id: @sequence.next).to_h
             @http_transport.request(request_type: request_type, payload: request.to_json)
           rescue StandardError => e
-            Datadog.logger.info("Unable to send telemetry request for event `#{request_type}`: #{e}")
+            Datadog.logger.debug("Unable to send telemetry request for event `#{request_type}`: #{e}")
           end
         end
       end

--- a/lib/datadog/core/telemetry/emitter.rb
+++ b/lib/datadog/core/telemetry/emitter.rb
@@ -30,7 +30,7 @@ module Datadog
                                                                             seq_id: @sequence.next).to_h
             @http_transport.request(request_type: request_type, payload: request.to_json)
           rescue StandardError => e
-            Datadog.logger.debug("Unable to send telemetry request for event `#{request_type}`: #{e}")
+            Datadog.logger.info("Unable to send telemetry request for event `#{request_type}`: #{e}")
           end
         end
       end

--- a/lib/datadog/core/telemetry/http/adapters/net.rb
+++ b/lib/datadog/core/telemetry/http/adapters/net.rb
@@ -44,7 +44,8 @@ module Datadog
 
                 Response.new(http_response)
               rescue StandardError => e
-                Transport::InternalErrorResponse.new(e)
+                Datadog.logger.debug("Unable to send telemetry event to agent: #{e}")
+                Telemetry::Http::InternalErrorResponse.new(e)
               end
             end
 

--- a/lib/datadog/core/telemetry/http/adapters/net.rb
+++ b/lib/datadog/core/telemetry/http/adapters/net.rb
@@ -34,14 +34,18 @@ module Datadog
             end
 
             def post(env)
-              post = ::Net::HTTP::Post.new(env.path, env.headers)
-              post.body = env.body
+              begin
+                post = ::Net::HTTP::Post.new(env.path, env.headers)
+                post.body = env.body
 
-              http_response = open do |http|
-                http.request(post)
+                http_response = open do |http|
+                  http.request(post)
+                end
+
+                Response.new(http_response)
+              rescue StandardError => e
+                Transport::InternalErrorResponse.new(e)
               end
-
-              Response.new(http_response)
             end
 
             # Data structure for an HTTP Response

--- a/spec/datadog/core/telemetry/client_spec.rb
+++ b/spec/datadog/core/telemetry/client_spec.rb
@@ -141,6 +141,15 @@ RSpec.describe Datadog::Core::Telemetry::Client do
         is_expected.to be(response)
       end
     end
+
+    context 'when internal error returned by emitter' do
+      let(:response) { Datadog::Core::Telemetry::Http::InternalErrorResponse.new('error') }
+
+      it do
+        started!
+        is_expected.to be(response)
+      end
+    end
   end
 
   describe '#stop!' do

--- a/spec/datadog/core/telemetry/client_spec.rb
+++ b/spec/datadog/core/telemetry/client_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe Datadog::Core::Telemetry::Client do
   let(:sequence) { Datadog::Core::Utils::Sequence.new(1) }
   let(:emitter) { double(Datadog::Core::Telemetry::Emitter) }
   let(:response) { double(Datadog::Core::Telemetry::Http::Adapters::Net::Response) }
+  let(:not_found) { false }
 
   before do
     allow(Datadog::Core::Telemetry::Emitter).to receive(:new).and_return(emitter)
     allow(emitter).to receive(:request).and_return(response)
+    allow(response).to receive(:not_found?).and_return(not_found)
   end
 
   describe '#initialize' do
@@ -41,6 +43,24 @@ RSpec.describe Datadog::Core::Telemetry::Client do
         client
         expect(emitter).to have_received(:request).with('app-started')
         expect(client.worker.enabled?).to be(true)
+      end
+
+      context 'when response returns 404' do
+        let(:not_found) { true }
+
+        before do
+          logger = double(Datadog::Core::Logger)
+          allow(logger).to receive(:debug)
+          allow(Datadog).to receive(:logger).and_return(logger)
+        end
+
+        it do
+          expect(client.enabled).to be(false)
+          expect(client.unsupported).to be(true)
+          expect(Datadog.logger).to have_received(:debug) do |message|
+            expect(message).to eq('Agent does not support telemetry; disabling future telemetry events.')
+          end
+        end
       end
     end
   end
@@ -77,6 +97,23 @@ RSpec.describe Datadog::Core::Telemetry::Client do
       let(:enabled) { false }
       it { expect { client.reenable! }.to change { client.enabled }.from(false).to(true) }
       it { expect { client.reenable! }.to change { client.worker.enabled? }.from(false).to(true) }
+
+      context 'when unsupported' do
+        let(:unsupported_client) { client.instance_variable_set(:@unsupported, true) }
+        before do
+          allow(described_class).to receive(:new).and_return(unsupported_client)
+        end
+
+        it do
+          expect(client.enabled).to be(false)
+          expect(client.worker.enabled?).to be(false)
+
+          client.reenable!
+
+          expect(client.enabled).to be(false)
+          expect(client.worker.enabled?).to be(false)
+        end
+      end
     end
   end
 
@@ -98,6 +135,7 @@ RSpec.describe Datadog::Core::Telemetry::Client do
 
     context 'when enabled' do
       let(:enabled) { true }
+
       it do
         started!
         is_expected.to be(response)

--- a/spec/datadog/core/telemetry/emitter_spec.rb
+++ b/spec/datadog/core/telemetry/emitter_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Datadog::Core::Telemetry::Emitter do
 
     before do
       logger = double(Datadog::Core::Logger)
-      allow(logger).to receive(:info)
+      allow(logger).to receive(:debug)
       allow(Datadog).to receive(:logger).and_return(logger)
     end
 
@@ -53,7 +53,7 @@ RSpec.describe Datadog::Core::Telemetry::Emitter do
         let(:request_type) { 'app' }
         it do
           request
-          expect(Datadog.logger).to have_received(:info) do |message|
+          expect(Datadog.logger).to have_received(:debug) do |message|
             expect(message).to include('Unable to send telemetry request')
           end
         end
@@ -67,7 +67,7 @@ RSpec.describe Datadog::Core::Telemetry::Emitter do
 
           it 'no logs are produced' do
             is_expected.to eq(response)
-            expect(Datadog.logger).to_not have_received(:info)
+            expect(Datadog.logger).to_not have_received(:debug)
           end
 
           it 'seq_id is incremented' do

--- a/spec/datadog/core/telemetry/http/adapters/net_spec.rb
+++ b/spec/datadog/core/telemetry/http/adapters/net_spec.rb
@@ -99,11 +99,18 @@ RSpec.describe Datadog::Core::Telemetry::Http::Adapters::Net do
 
     let(:http_response) { double('http_response') }
 
-    before { expect(http_connection).to receive(:request).and_return(http_response) }
+    context 'when request goes through' do
+      before { expect(http_connection).to receive(:request).and_return(http_response) }
 
-    it 'produces a response' do
-      is_expected.to be_a_kind_of(described_class::Response)
-      expect(post.http_response).to be(http_response)
+      it 'produces a response' do
+        is_expected.to be_a_kind_of(described_class::Response)
+        expect(post.http_response).to be(http_response)
+      end
+    end
+
+    context 'when error in connecting to agent' do
+      before { expect(http_connection).to receive(:request).and_raise(StandardError) }
+      it { expect(post).to be_a_kind_of(Datadog::Core::Telemetry::Http::InternalErrorResponse) }
     end
   end
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
To protect against older agent versions that do not support telemetry, when the requested path is not found, set `@unsupported=true` in the `Client` and disable future telemetry events. Additionally, this changes all log levels related to telemetry to `debug` rather than `info`.

**Motivation**
<!-- What inspired you to submit this pull request? -->
These changes were made to prevent errors from telemetry causing unnecessary info logs from being logged.

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Unit tests were added to test the new expected behavior