### PR TITLE
[PROF-5793] I unleashed the zombie apocalypse when running our test suite

### DIFF
--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -58,19 +58,6 @@ RSpec.describe Datadog::Profiling::NativeExtension do
         it { is_expected.to be_a_kind_of(Integer) }
       end
 
-      context 'when called with a Process::Waiter instance' do
-        # In Ruby 2.3 to 2.6, `Process.detach` creates a special `Thread` subclass named `Process::Waiter`
-        # that is improperly initialized and some operations on it can trigger segfaults, see
-        # https://bugs.ruby-lang.org/issues/17807.
-        #
-        # Thus, let's exercise our code with one of these objects to ensure future changes don't introduce regressions.
-        let(:thread) { Process.detach(fork { sleep }) }
-
-        it 'is expected to be a kind of Integer' do
-          expect_in_fork { is_expected.to be_a_kind_of(Integer) }
-        end
-      end
-
       context 'when called with a non-thread object' do
         let(:thread) { :potato }
 


### PR DESCRIPTION
*cof* *ahem* now that I got your attention, some of the specs using `Process.detach` really were leaving behind "zombie" forked processes that never terminated.

I've reviewed all uses of this API and re-ran the test suite both on Linux as well as macOS to ensure no zombie processes are left behind.

P.s.: I could not resist the PR title :)

---

**What does this PR do?**:

Makes sure no "zombie" processes are left behind after executing the test suite.

**Motivation**:

I do not look forward to the zombie apocalypse. I only know computers, which would become quite useless.

**Additional Notes**:

I am not available for birthday party bookings.

**How to test the change?**

Run the full test suite, and then run `ps aux | grep ruby` and `ps aux | grep rspec` to guarantee that no processes are left alive.