### PR TITLE
[PROF-4756] Cleanups for profiling `Forking` monkey patch

### DIFF
--- a/lib/datadog/profiling/ext/forking.rb
+++ b/lib/datadog/profiling/ext/forking.rb
@@ -5,6 +5,11 @@ module Datadog
     module Ext
       # Monkey patches `Kernel#fork`, adding a `Kernel#at_fork` callback mechanism which is used to restore
       # profiling abilities after the VM forks.
+      #
+      # Known limitations: Does not handle `BasicObject`s that include `Kernel` directly; e.g.
+      # `Class.new(BasicObject) { include(::Kernel); def call; fork { }; end }.new.call`.
+      #
+      # This will be fixed once we moved to hooking into `Process._fork`
       module Forking
         def self.supported?
           Process.respond_to?(:fork)

--- a/lib/datadog/profiling/ext/forking.rb
+++ b/lib/datadog/profiling/ext/forking.rb
@@ -23,6 +23,9 @@ module Datadog
         end
 
         # Extensions for kernel
+        #
+        # TODO: Consider hooking into `Process._fork` on Ruby 3.1+ instead, see
+        #       https://github.com/ruby/ruby/pull/5017 and https://bugs.ruby-lang.org/issues/17795
         module Kernel
           FORK_STAGES = [:prepare, :parent, :child].freeze
 

--- a/spec/datadog/profiling/ext/forking_spec.rb
+++ b/spec/datadog/profiling/ext/forking_spec.rb
@@ -1,22 +1,16 @@
 # typed: false
 
-require 'spec_helper'
 require 'datadog/profiling/spec_helper'
 
-require 'datadog/profiling'
 require 'datadog/profiling/ext/forking'
 
 RSpec.describe Datadog::Profiling::Ext::Forking do
   describe '::apply!' do
+    before { skip_if_profiling_not_supported(self) }
+
     subject(:apply!) { described_class.apply! }
 
-    let(:toplevel_receiver) do
-      if TOPLEVEL_BINDING.respond_to?(:receiver)
-        TOPLEVEL_BINDING.receiver
-      else
-        TOPLEVEL_BINDING.eval('self')
-      end
-    end
+    let(:toplevel_receiver) { TOPLEVEL_BINDING.receiver }
 
     context 'when forking is supported' do
       around do |example|
@@ -56,9 +50,6 @@ RSpec.describe Datadog::Profiling::Ext::Forking do
         #       The results of this will carry over into other tests...
         #       Just assert that the receiver was patched instead.
         #       Unfortunately means we can't test if "fork" works in main Object.
-        # expect(toplevel_receiver.class)
-        #   .to receive(:extend)
-        #   .with(described_class::Kernel)
 
         apply!
 


### PR DESCRIPTION
**What does this PR do?**:

This PR includes a handful of small cleanups to the `Forking` monkey patch. I suggest reviewing it commit-by-commit.

**Motivation**:

This part of the code hasn't been touched in a while but a customer ran into an issue where the `Process.daemon` API (which also triggers `fork`) is skipping the `Forking` monkey patch.

While investigating the issue, I ended up going in and adding a number of comments and cleanups. I'll submit the actual fix separately.

**How to test the change?**:

There's existing test coverage for this feature, and it's still passing.
