### PR TITLE
[PROF-4756] Simplify profiling `Forking` monkey patch, making it less generic

### DIFF
--- a/lib/datadog/profiling/ext/forking.rb
+++ b/lib/datadog/profiling/ext/forking.rb
@@ -32,8 +32,6 @@ module Datadog
         # TODO: Consider hooking into `Process._fork` on Ruby 3.1+ instead, see
         #       https://github.com/ruby/ruby/pull/5017 and https://bugs.ruby-lang.org/issues/17795
         module Kernel
-          FORK_STAGES = [:prepare, :parent, :child].freeze
-
           def fork
             # If a block is provided, it must be wrapped to trigger callbacks.
             child_block = if block_given?
@@ -46,9 +44,6 @@ module Datadog
                             end
                           end
 
-            # Trigger :prepare callback
-            ddtrace_at_fork_blocks[:prepare].each(&:call) if ddtrace_at_fork_blocks.key?(:prepare)
-
             # Start fork
             # If a block is provided, use the wrapped version.
             result = child_block.nil? ? super : super(&child_block)
@@ -56,22 +51,14 @@ module Datadog
             # Trigger correct callbacks depending on whether we're in the parent or child.
             # If we're in the fork, result = nil: trigger child callbacks.
             # If we're in the parent, result = fork PID: trigger parent callbacks.
-            # rubocop:disable Style/IfInsideElse
-            if result.nil?
-              # Trigger :child callback
-              ddtrace_at_fork_blocks[:child].each(&:call) if ddtrace_at_fork_blocks.key?(:child)
-            else
-              # Trigger :parent callback
-              ddtrace_at_fork_blocks[:parent].each(&:call) if ddtrace_at_fork_blocks.key?(:parent)
-            end
-            # rubocop:enable Style/IfInsideElse
+            ddtrace_at_fork_blocks[:child].each(&:call) if result.nil? && ddtrace_at_fork_blocks.key?(:child)
 
             # Return PID from #fork
             result
           end
 
-          def at_fork(stage = :prepare, &block)
-            raise ArgumentError, 'Bad \'stage\' for ::at_fork' unless FORK_STAGES.include?(stage)
+          def at_fork(stage, &block)
+            raise ArgumentError, 'Bad \'stage\' for ::at_fork' unless stage == :child
 
             ddtrace_at_fork_blocks[stage] = [] unless ddtrace_at_fork_blocks.key?(stage)
             ddtrace_at_fork_blocks[stage] << block


### PR DESCRIPTION
**What does this PR do?**:

Simplify the profiling `Forking` monkey patch, by removed the unused `:prepare` and `:parent` stages for callbacks.

**Motivation**:

The profiling `Forking` monkey patch only has a single customer: the `Datadog::Profiling::Tasks::Setup` class, which uses it to add an `at_fork(:child)` that takes care of restarting the profiler and fixing up the thread ids after a fork happened.

Since the `Forking` monkey patch affects core Ruby classes, I decided to simplify it, as we're not using the added complexity, and I prefer it being as simple as possible.

My additional motivation is that I'm working on support for monkey patching `Process.daemon`, and this simplifies the amount of code and tests needed to implement the needed functionality.

(We can always undo this if later we find a need for the other callbacks, but in the ~2 years of life of this monkey patch, we haven't needed the extra functionality, so I'll take that as a signal).

**How to test the change?**:

* Validate that test suite is still green
* Run an example application that forks (for instance `DD_PROFILING_ENABLED=true DD_TRACE_DEBUG=true bundle exec ddtracerb exec ruby -e 'fork { sleep }; sleep'`) and validate that the profiler successfully restarts in the child process after the `fork`
