### PR TITLE
[PROF-4756] Fix profiler not restarting on `Process.daemon`

### DIFF
--- a/lib/datadog/profiling/scheduler.rb
+++ b/lib/datadog/profiling/scheduler.rb
@@ -69,6 +69,7 @@ module Datadog
       def after_fork
         # Clear any existing profiling state.
         # We don't want the child process to report profiling data from its parent.
+        Datadog.logger.debug('Flushing exporter in child process #after_fork and discarding data')
         exporter.flush
       end
 

--- a/spec/datadog/profiling/ext/forking_spec.rb
+++ b/spec/datadog/profiling/ext/forking_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe Datadog::Profiling::Ext::Forking do
   end
 
   describe Datadog::Profiling::Ext::Forking::ProcessDaemonPatch do
-    let(:process_module) { ::Process.dup }
+    let(:process_module) { Module.new { def self.daemon(nochdir = nil, noclose = nil); end } }
     let(:child_callback) { double('child', call: true) }
 
     before do


### PR DESCRIPTION
**What does this PR do?**:

Extend the `Forking` monkey patch to also cover the `Process.daemon` API (that is another way of forking a Ruby process).

**Motivation**:

When the Ruby VM `fork`s, only the thread that called `fork` survives in the child process.

Thus, we have the `Forking` monkey patch which allows us to run callbacks in the child process, including restarting the profiler.

But there's a less known API in Ruby that also makes use of forking -- `Process.daemon`. One example of using this API is when calling `rails server -d`; that `-d` makes Rails call this API.

Because we were missing monkey patching `Process.daemon`, the profiler would not restart on `Process.daemon`. A customer using exactly `rails server -d` ran into this issue.

**Additional Notes**:

This PR is on top of #2149 just to avoid any conflicts because of close by lines being removed, but both PRs are entirely independent.

**How to test the change?**

Easy one-liner to validate that the profiler restarts after becoming a daemon:

    $ DD_TRACE_DEBUG=true DD_PROFILING_ENABLED=true bundle exec ddtracerb exec ruby -e 'Process.daemon(nil, true); exit!'
    D, [#38994] (dd-trace-rb/lib/datadog/core/configuration/components.rb:371:in `startup!') Profiling started
    D, [#38994] (dd-trace-rb/lib/datadog/core/workers/async.rb:133:in `start_worker') Starting thread for: #<Datadog::Profiling::Collectors::OldStack:0x00007fb9c828b3e0>
    D, [#38994] (dd-trace-rb/lib/datadog/core/workers/async.rb:133:in `start_worker') Starting thread for: #<Datadog::Profiling::Scheduler:0x00007fb9c8289ab8>
     # <-- notice the PID change here
    D, [#39013] (dd-trace-rb/lib/datadog/core/workers/async.rb:133:in `start_worker') Starting thread for: #<Datadog::Profiling::Collectors::OldStack:0x00007fb9c828b3e0>
    D, [#39013] (dd-trace-rb/lib/datadog/core/workers/async.rb:133:in `start_worker') Starting thread for: #<Datadog::Profiling::Scheduler:0x00007fb9c8289ab8>

The daemon mode seems... broken(?) in Rails 7. With puma, no webserver would be started, and with webrick, a process would stay behind but not reply to any HTTP requests.

Nevertheless, I believe this fix should be enough (the customer reported this a long ago, this was a low priority fix).