### PR TITLE
Ensure all tags are strings when reporting profile

### DIFF
--- a/lib/datadog/profiling/tag_builder.rb
+++ b/lib/datadog/profiling/tag_builder.rb
@@ -1,5 +1,7 @@
 # typed: true
 
+require 'datadog/core/utils'
+
 module Datadog
   module Profiling
     # Builds a hash of default plus user tags to be included in a profile
@@ -41,7 +43,10 @@ module Datadog
         tags[FORM_FIELD_TAG_SERVICE] = service if service
         tags[FORM_FIELD_TAG_VERSION] = version if version
 
-        user_tags.merge(tags)
+        # Make sure everything is an utf-8 string, to avoid encoding issues in native code/libddprof/further downstream
+        user_tags.merge(tags).map do |key, value|
+          [Datadog::Core::Utils.utf8_encode(key), Datadog::Core::Utils.utf8_encode(value)]
+        end.to_h
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**:

Ensure that the tags passed on to the profiling `HttpTransport` are always strings.

**Motivation**:

A customer reported having their profiles fail with the following issue:

> Unable to report profile. Cause: wrong argument type nil (expected String) Location: /var/cache/bundle/ruby/3.0.0/gems/ddtrace-1.2.0/lib/datadog/profiling/http_transport.rb:115:in _native_do_export'

Unfortunately there's a bunch of data passed in to that function so just from that information it's not possible to be 100% sure which one was `nil`, but while doing a second pass at the code I noticed one way to trigger this would be to have tags that are `nil`.

**Additional Notes**:

Issue #2151

**How to test the change?**

* Unit tests are included
* To trigger the issue manually, you can use `DD_TRACE_DEBUG=true DD_PROFILING_ENABLED=true bundle exec ddtracerb exec ruby -e 'Datadog.configure { |c| c.tags = {foo: nil} }; sleep 5'`. Running before/after this change will show the fix working.
