### PR TITLE
Add service tag to health metrics

### DIFF
--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -19,11 +19,13 @@ module Datadog
       class Components
         class << self
           def build_health_metrics(settings)
-            settings = settings.diagnostics.health_metrics
-            options = { enabled: settings.enabled }
-            options[:statsd] = settings.statsd unless settings.statsd.nil?
+            health_settings = settings.diagnostics.health_metrics
 
-            Core::Diagnostics::Health::Metrics.new(**options)
+            Core::Diagnostics::Health::Metrics.new(
+              service: settings.service,
+              enabled: health_settings.enabled,
+              statsd: health_settings.statsd
+            )
           end
 
           def build_logger(settings)

--- a/lib/datadog/core/diagnostics/health.rb
+++ b/lib/datadog/core/diagnostics/health.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 require 'datadog/core/diagnostics/ext'
 require 'datadog/core/metrics/client'
@@ -10,6 +10,13 @@ module Datadog
       module Health
         # Health metrics for diagnostics
         class Metrics < Core::Metrics::Client
+          def initialize(service:, enabled: true, statsd: nil)
+            super(enabled: enabled, statsd: statsd)
+            @service = service
+
+            @tags = compile_tags!
+          end
+
           count :api_errors, Ext::Health::Metrics::METRIC_API_ERRORS
           count :api_requests, Ext::Health::Metrics::METRIC_API_REQUESTS
           count :api_responses, Ext::Health::Metrics::METRIC_API_RESPONSES
@@ -30,6 +37,26 @@ module Datadog
           gauge :queue_max_length, Ext::Health::Metrics::METRIC_QUEUE_MAX_LENGTH
           gauge :queue_spans, Ext::Health::Metrics::METRIC_QUEUE_SPANS
           gauge :sampling_service_cache_length, Ext::Health::Metrics::METRIC_SAMPLING_SERVICE_CACHE_LENGTH
+
+          def default_metric_options
+            return super unless @tags
+
+            # Return dupes, so that the constant isn't modified,
+            # and defaults are unfrozen for mutation in Statsd.
+            super.tap do |options|
+              options[:tags] = options[:tags].dup
+              options[:tags] << @tags
+            end
+          end
+
+          private
+
+          # Cache tag strings to avoid recreating them on every flush operation.
+          def compile_tags!
+            return unless @service
+
+            "#{Environment::Ext::TAG_SERVICE}:#{@service}".freeze
+          end
         end
       end
     end

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -95,7 +95,13 @@ RSpec.describe Datadog::Core::Configuration::Components do
     context 'given settings' do
       shared_examples_for 'new health metrics' do
         let(:health_metrics) { instance_double(Datadog::Core::Diagnostics::Health::Metrics) }
-        let(:default_options) { { enabled: settings.diagnostics.health_metrics.enabled } }
+        let(:default_options) do
+          {
+            service: settings.service,
+            enabled: settings.diagnostics.health_metrics.enabled,
+            statsd: settings.diagnostics.health_metrics.statsd,
+          }
+        end
         let(:options) { {} }
 
         before do
@@ -136,6 +142,18 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
         it_behaves_like 'new health metrics' do
           let(:options) { { statsd: statsd } }
+        end
+      end
+
+      context 'with :service' do
+        let(:service) { double('service') }
+
+        before do
+          allow(settings).to receive(:service).and_return(service)
+        end
+
+        it_behaves_like 'new health metrics' do
+          let(:options) { { service: service } }
         end
       end
     end


### PR DESCRIPTION
Currently health metrics are sent without a `service` tag, with only the `env` tag.

This means that all services in the same `env` will get their health metrics merged together. This makes these metrics not useful.

This PR adds the `service` tag, collected from `c.service`, to all statsd metrics generated for health metrics.

No service name being set (`c.service == nil`) is still supported (metrics will be send successfully without a `service`), but not very useful in practice.

For Runtime Metrics, this currently works because runtime metrics collect service names from spans being flushed, thus populating an internal list of services.