### PR TITLE
[PROF-5808] Add `ENFORCE_TYPE` as user-friendly alternative to `Check_Type`

### DIFF
--- a/ext/ddtrace_profiling_native_extension/NativeExtensionDesign.md
+++ b/ext/ddtrace_profiling_native_extension/NativeExtensionDesign.md
@@ -49,7 +49,7 @@ We avoid issues using a combination of:
 
 Non-exhaustive list of APIs that cause exceptions to be raised:
 
-* `Check_TypedStruct`, `Check_Type`
+* `Check_TypedStruct`, `Check_Type`, `ENFORCE_TYPE`
 * `rb_funcall`
 * `rb_thread_call_without_gvl`, `rb_thread_call_without_gvl2`
 * [Numeric conversion APIs, e.g. `NUM2LONG`, `NUM2INT`, etc.](https://silverhammermba.github.io/emberb/c/?#translation)

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -2,6 +2,7 @@
 #include <ruby/debug.h>
 #include "extconf.h"
 #include "libddprof_helpers.h"
+#include "ruby_helpers.h"
 #include "private_vm_api_access.h"
 #include "stack_recorder.h"
 #include "collectors_stack.h"
@@ -41,8 +42,8 @@ void collectors_stack_init(VALUE profiling_module) {
 // This method exists only to enable testing Datadog::Profiling::Collectors::Stack behavior using RSpec.
 // It SHOULD NOT be used for other purposes.
 static VALUE _native_sample(VALUE self, VALUE thread, VALUE recorder_instance, VALUE metric_values_hash, VALUE labels_array, VALUE max_frames) {
-  Check_Type(metric_values_hash, T_HASH);
-  Check_Type(labels_array, T_ARRAY);
+  ENFORCE_TYPE(metric_values_hash, T_HASH);
+  ENFORCE_TYPE(labels_array, T_ARRAY);
 
   if (RHASH_SIZE(metric_values_hash) != ENABLED_VALUE_TYPES_COUNT) {
     rb_raise(

--- a/ext/ddtrace_profiling_native_extension/http_transport.c
+++ b/ext/ddtrace_profiling_native_extension/http_transport.c
@@ -63,13 +63,13 @@ void http_transport_init(VALUE profiling_module) {
 }
 
 inline static ddprof_ffi_ByteSlice byte_slice_from_ruby_string(VALUE string) {
-  Check_Type(string, T_STRING);
+  ENFORCE_TYPE(string, T_STRING);
   ddprof_ffi_ByteSlice byte_slice = {.ptr = (uint8_t *) StringValuePtr(string), .len = RSTRING_LEN(string)};
   return byte_slice;
 }
 
 static VALUE _native_validate_exporter(VALUE self, VALUE exporter_configuration) {
-  Check_Type(exporter_configuration, T_ARRAY);
+  ENFORCE_TYPE(exporter_configuration, T_ARRAY);
   ddprof_ffi_NewProfileExporterV3Result exporter_result = create_exporter(exporter_configuration, rb_ary_new());
 
   VALUE failure_tuple = handle_exporter_failure(exporter_result);
@@ -83,8 +83,8 @@ static VALUE _native_validate_exporter(VALUE self, VALUE exporter_configuration)
 }
 
 static ddprof_ffi_NewProfileExporterV3Result create_exporter(VALUE exporter_configuration, VALUE tags_as_array) {
-  Check_Type(exporter_configuration, T_ARRAY);
-  Check_Type(tags_as_array, T_ARRAY);
+  ENFORCE_TYPE(exporter_configuration, T_ARRAY);
+  ENFORCE_TYPE(tags_as_array, T_ARRAY);
 
   // This needs to be called BEFORE convert_tags since it can raise an exception and thus cause the ddprof_ffi_Vec_tag
   // to be leaked.
@@ -111,7 +111,7 @@ static VALUE handle_exporter_failure(ddprof_ffi_NewProfileExporterV3Result expor
 }
 
 static ddprof_ffi_EndpointV3 endpoint_from(VALUE exporter_configuration) {
-  Check_Type(exporter_configuration, T_ARRAY);
+  ENFORCE_TYPE(exporter_configuration, T_ARRAY);
 
   ID working_mode = SYM2ID(rb_ary_entry(exporter_configuration, 0)); // SYM2ID verifies its input so we can do this safely
 
@@ -122,13 +122,13 @@ static ddprof_ffi_EndpointV3 endpoint_from(VALUE exporter_configuration) {
   if (working_mode == agentless_id) {
     VALUE site = rb_ary_entry(exporter_configuration, 1);
     VALUE api_key = rb_ary_entry(exporter_configuration, 2);
-    Check_Type(site, T_STRING);
-    Check_Type(api_key, T_STRING);
+    ENFORCE_TYPE(site, T_STRING);
+    ENFORCE_TYPE(api_key, T_STRING);
 
     return ddprof_ffi_EndpointV3_agentless(char_slice_from_ruby_string(site), char_slice_from_ruby_string(api_key));
   } else { // agent_id
     VALUE base_url = rb_ary_entry(exporter_configuration, 1);
-    Check_Type(base_url, T_STRING);
+    ENFORCE_TYPE(base_url, T_STRING);
 
     return ddprof_ffi_EndpointV3_agent(char_slice_from_ruby_string(base_url));
   }
@@ -136,7 +136,7 @@ static ddprof_ffi_EndpointV3 endpoint_from(VALUE exporter_configuration) {
 
 __attribute__((warn_unused_result))
 static ddprof_ffi_Vec_tag convert_tags(VALUE tags_as_array) {
-  Check_Type(tags_as_array, T_ARRAY);
+  ENFORCE_TYPE(tags_as_array, T_ARRAY);
 
   long tags_count = RARRAY_LEN(tags_as_array);
   ddprof_ffi_Vec_tag tags = ddprof_ffi_Vec_tag_new();
@@ -146,7 +146,7 @@ static ddprof_ffi_Vec_tag convert_tags(VALUE tags_as_array) {
 
     if (!RB_TYPE_P(name_value_pair, T_ARRAY)) {
       ddprof_ffi_Vec_tag_drop(tags);
-      Check_Type(name_value_pair, T_ARRAY);
+      ENFORCE_TYPE(name_value_pair, T_ARRAY);
     }
 
     // Note: We can index the array without checking its size first because rb_ary_entry returns Qnil if out of bounds
@@ -155,8 +155,8 @@ static ddprof_ffi_Vec_tag convert_tags(VALUE tags_as_array) {
 
     if (!(RB_TYPE_P(tag_name, T_STRING) && RB_TYPE_P(tag_value, T_STRING))) {
       ddprof_ffi_Vec_tag_drop(tags);
-      Check_Type(tag_name, T_STRING);
-      Check_Type(tag_value, T_STRING);
+      ENFORCE_TYPE(tag_name, T_STRING);
+      ENFORCE_TYPE(tag_value, T_STRING);
     }
 
     ddprof_ffi_PushTagResult push_result =
@@ -272,18 +272,18 @@ static VALUE _native_do_export(
   VALUE code_provenance_data,
   VALUE tags_as_array
 ) {
-  Check_Type(upload_timeout_milliseconds, T_FIXNUM);
-  Check_Type(start_timespec_seconds, T_FIXNUM);
-  Check_Type(start_timespec_nanoseconds, T_FIXNUM);
-  Check_Type(finish_timespec_seconds, T_FIXNUM);
-  Check_Type(finish_timespec_nanoseconds, T_FIXNUM);
-  Check_Type(pprof_file_name, T_STRING);
-  Check_Type(pprof_data, T_STRING);
-  Check_Type(code_provenance_file_name, T_STRING);
+  ENFORCE_TYPE(upload_timeout_milliseconds, T_FIXNUM);
+  ENFORCE_TYPE(start_timespec_seconds, T_FIXNUM);
+  ENFORCE_TYPE(start_timespec_nanoseconds, T_FIXNUM);
+  ENFORCE_TYPE(finish_timespec_seconds, T_FIXNUM);
+  ENFORCE_TYPE(finish_timespec_nanoseconds, T_FIXNUM);
+  ENFORCE_TYPE(pprof_file_name, T_STRING);
+  ENFORCE_TYPE(pprof_data, T_STRING);
+  ENFORCE_TYPE(code_provenance_file_name, T_STRING);
 
   // Code provenance can be disabled and in that case will be set to nil
   bool have_code_provenance = !NIL_P(code_provenance_data);
-  if (have_code_provenance) Check_Type(code_provenance_data, T_STRING);
+  if (have_code_provenance) ENFORCE_TYPE(code_provenance_data, T_STRING);
 
   uint64_t timeout_milliseconds = NUM2ULONG(upload_timeout_milliseconds);
 

--- a/ext/ddtrace_profiling_native_extension/libddprof_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/libddprof_helpers.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <ddprof/ffi.h>
+#include "ruby_helpers.h"
 
 inline static ddprof_ffi_CharSlice char_slice_from_ruby_string(VALUE string) {
-  Check_Type(string, T_STRING);
+  ENFORCE_TYPE(string, T_STRING);
   ddprof_ffi_CharSlice char_slice = {.ptr = StringValuePtr(string), .len = RSTRING_LEN(string)};
   return char_slice;
 }

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.c
@@ -1,0 +1,25 @@
+#include "ruby_helpers.h"
+
+void raise_unexpected_type(
+  VALUE value,
+  enum ruby_value_type type,
+  const char *value_name,
+  const char *type_name,
+  const char *file,
+  int line,
+  const char* function_name
+) {
+  rb_exc_raise(
+    rb_exc_new_str(
+      rb_eTypeError,
+      rb_sprintf("wrong argument %"PRIsVALUE" for '%s' (expected a %s) at %s:%d:in `%s'",
+        rb_inspect(value),
+        value_name,
+        type_name,
+        file,
+        line,
+        function_name
+      )
+    )
+  );
+}

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.h
@@ -31,3 +31,22 @@ static inline int check_if_pending_exception(void) {
   rb_protect(process_pending_interruptions, Qnil, &pending_exception);
   return pending_exception;
 }
+
+#define ADD_QUOTES_HELPER(x) #x
+#define ADD_QUOTES(x) ADD_QUOTES_HELPER(x)
+
+// Ruby has a Check_Type(value, type) that is roughly equivalent to this BUT Ruby's version is rather cryptic when it fails
+// e.g. "wrong argument type nil (expected String)". This is a replacement that prints more information to help debugging.
+#define ENFORCE_TYPE(value, type) \
+  { if (RB_UNLIKELY(!RB_TYPE_P(value, type))) raise_unexpected_type(value, type, ADD_QUOTES(value), ADD_QUOTES(type), __FILE__, __LINE__, __func__); }
+
+// Called by ENFORCE_TYPE; should not be used directly
+void raise_unexpected_type(
+  VALUE value,
+  enum ruby_value_type type,
+  const char *value_name,
+  const char *type_name,
+  const char *file,
+  int line,
+  const char* function_name
+);

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.h
@@ -9,6 +9,11 @@ static inline VALUE process_pending_interruptions(VALUE _unused) {
   return Qnil;
 }
 
+// RB_UNLIKELY is not supported on Ruby 2.2 and 2.3
+#ifndef RB_UNLIKELY
+  #define RB_UNLIKELY(x) x
+#endif
+
 // Calls process_pending_interruptions BUT "rescues" any exceptions to be raised, returning them instead as
 // a non-zero `pending_exception`.
 //


### PR DESCRIPTION
**Motivation**:

While investigating #2151, I realized that `Check_Type`'s error message: `TypeError: wrong argument type nil (expected String)` is very hard to debug in functions that do many `Check_Type` verifications (such as `_native_do_export`).

**What does this PR do?**:

To fix this, I've created a new `ENFORCE_TYPE` helper which behaves similarly, but generates error messages such as:

```
TypeError: wrong argument nil for 'pprof_file_name' (expected a RUBY_T_STRING) at ../../../../ext/ddtrace_profiling_native_extension/http_transport.c:280:in `_native_do_export'
```

Hopefully this message will help us get to the bottom of the issue.

I've modified every other use of `Check_Type` in the profiling native extension to use this new helper, in case we need to debug similar issues in the future.

**Additional notes**:

This PR is on top of #2152 to facilitate testing both together, but is otherwise independent.

**How to test the change?**:

Existing tests should already cover this. To trigger the issue manually, use for instance:

```ruby
[3] pry(main)> Datadog::Profiling::HttpTransport._native_do_export(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
TypeError: wrong argument nil for 'upload_timeout_milliseconds' (expected a RUBY_T_FIXNUM) at ../../../../ext/ddtrace_profiling_native_extension/http_transport.c:275:in `_native_do_export'
from (pry):3:in `_native_do_export'
```

Issue #2151