### PR TITLE
[PROF-4902] Include 'thread id' label when sampling threads

### DIFF
--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -305,8 +305,6 @@ module Datadog
                 old_recorder,
                 trace_identifiers_helper: trace_identifiers_helper,
                 max_frames: settings.profiling.advanced.max_frames
-                # TODO: Provide proc that identifies Datadog worker threads?
-                # ignore_thread: settings.profiling.ignore_profiler
               )
             ]
           end

--- a/lib/datadog/core/utils/time.rb
+++ b/lib/datadog/core/utils/time.rb
@@ -36,10 +36,10 @@ module Datadog
           define_singleton_method(:now, &block)
         end
 
-        def measure
-          before = get_time
+        def measure(unit = :float_second)
+          before = get_time(unit)
           yield
-          after = get_time
+          after = get_time(unit)
           after - before
         end
 

--- a/lib/datadog/profiling/ext.rb
+++ b/lib/datadog/profiling/ext.rb
@@ -9,6 +9,7 @@ module Datadog
       ENV_AGENTLESS = 'DD_PROFILING_AGENTLESS'.freeze
       ENV_ENDPOINT_COLLECTION_ENABLED = 'DD_PROFILING_ENDPOINT_COLLECTION_ENABLED'.freeze
 
+      # TODO: Consider removing this once the Ruby-based pprof encoding is removed and replaced by libdatadog
       module Pprof
         LABEL_KEY_LOCAL_ROOT_SPAN_ID = 'local root span id'.freeze
         LABEL_KEY_SPAN_ID = 'span id'.freeze

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -343,22 +343,11 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     raise 'Unexpected: Serialization failed' unless serialization_result
 
     pprof_data = serialization_result.last
-    decoded_profile = ::Perftools::Profiles::Profile.decode(pprof_data)
 
-    expect(decoded_profile.sample.size).to be 1
-    sample = decoded_profile.sample.first
+    samples = samples_from_pprof(pprof_data)
 
-    sample.location_id.map { |location_id| decode_frame(decoded_profile, location_id) }
-  end
-
-  def decode_frame(decoded_profile, location_id)
-    strings = decoded_profile.string_table
-    location = decoded_profile.location.find { |loc| loc.id == location_id }
-    expect(location.line.size).to be 1
-    line_entry = location.line.first
-    function = decoded_profile.function.find { |func| func.id == line_entry.function_id }
-
-    { base_label: strings[function.name], path: strings[function.filename], lineno: line_entry.line }
+    expect(samples.size).to be 1
+    samples.first.fetch(:locations)
   end
 end
 

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -51,6 +51,32 @@ module ProfileHelpers
     raise "Profiling does not seem to be available: #{Datadog::Profiling.unsupported_reason}. " \
       'Try running `bundle exec rake compile` before running this test.'
   end
+
+  def samples_from_pprof(pprof_data)
+    decoded_profile = ::Perftools::Profiles::Profile.decode(pprof_data)
+
+    string_table = decoded_profile.string_table
+    pretty_sample_types = decoded_profile.sample_type.map { |it| string_table[it.type].to_sym }
+
+    decoded_profile.sample.map do |sample|
+      {
+        locations: sample.location_id.map { |location_id| decode_frame_from_pprof(decoded_profile, location_id) },
+        values: pretty_sample_types.zip(sample.value).to_h,
+        labels: sample.label.map { |it| [string_table[it.key].to_sym, it.str != 0 ? string_table[it.str] : it.num] }.to_h,
+      }
+    end
+  end
+
+  def decode_frame_from_pprof(decoded_profile, location_id)
+    strings = decoded_profile.string_table
+    location = decoded_profile.location.find { |loc| loc.id == location_id }
+    raise 'Unexpected: Multiple lines for location' unless location.line.size == 1
+
+    line_entry = location.line.first
+    function = decoded_profile.function.find { |func| func.id == line_entry.function_id }
+
+    { base_label: strings[function.name], path: strings[function.filename], lineno: line_entry.line }
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       end
 
       it 'encodes the sample with the metrics provided' do
-        expect(samples.first).to include(values: { 'cpu-time': 123, 'cpu-samples': 456, 'wall-time': 789 })
+        expect(samples.first).to include(values: { :'cpu-time' => 123, :'cpu-samples' => 456, :'wall-time' => 789 })
       end
 
       it 'encodes the sample with the labels provided' do

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -79,28 +79,19 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       let(:metric_values) { { 'cpu-time' => 123, 'cpu-samples' => 456, 'wall-time' => 789 } }
       let(:labels) { { 'label_a' => 'value_a', 'label_b' => 'value_b' }.to_a }
 
+      let(:samples) { samples_from_pprof(encoded_pprof) }
+
       before do
         collectors_stack.sample(Thread.current, stack_recorder, metric_values, labels)
-        expect(decoded_profile.sample.size).to be 1
+        expect(samples.size).to be 1
       end
 
       it 'encodes the sample with the metrics provided' do
-        sample = decoded_profile.sample.first
-        strings = decoded_profile.string_table
-
-        decoded_metric_values =
-          sample.value.map.with_index { |value, index| [strings[decoded_profile.sample_type[index].type], value] }.to_h
-
-        expect(decoded_metric_values).to eq metric_values
+        expect(samples.first).to include(values: { 'cpu-time': 123, 'cpu-samples': 456, 'wall-time': 789 })
       end
 
       it 'encodes the sample with the labels provided' do
-        sample = decoded_profile.sample.first
-        strings = decoded_profile.string_table
-
-        decoded_labels = sample.label.map { |label| [strings[label.key], strings[label.str]] }
-
-        expect(decoded_labels).to eq labels
+        expect(samples.first).to include(labels: { label_a: 'value_a', label_b: 'value_b' })
       end
 
       it 'encodes a single empty mapping' do


### PR DESCRIPTION
**What does this PR do?**:

This PR adds the `thread id` label to profiler samples taken using the new `CpuAndWallTime` collector. This behavior already existed for the pure-Ruby `OldStack` collector, I'm just reimplementing it in the profiling native extension. 

Also adds a new helper that is useful when asserting on pprof data, and refactors a few specs to make use of the new helper instead of duplicating pprof parsing code.

**Motivation**:

Have the profiling native extension reach feature parity with the `OldStack` collector.

**Additional Notes**:

In a previous PR, we added a `per_thread_context` structure that can store information for each thread being sampled.

The first bit of information being stored there is the `thread id`, which we will also use to tag all samples with the thread they came from.

**How to test the change?**:

Change includes test coverage.
