### PR TITLE
Lint:ddtrace.gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,6 @@ AllCops:
     - 'Rakefile'
   Exclude:
     - 'Appraisals'
-    - '*.gemspec'
     - 'lib/ddtrace/**/vendor/**/*.rb'
     - 'lib/datadog/**/vendor/**/*.rb'
     - 'integration/apps/*/bin/*'
@@ -391,4 +390,11 @@ Style/TrailingCommaInHashLiteral:
   Enabled: false
 
 Naming/VariableNumber:
+  Enabled: false
+
+# Requires that the Rubocop linter should be configured to
+# match the same version as `spec.required_rubygems_version` in our gemspec file.
+# This is not currently possible, as we'd like to use updated versions of Rubocop
+# that have already dropped support for our minimum supported Ruby version.
+Gemspec/RequiredRubyVersion:
   Enabled: false

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -1,23 +1,24 @@
-# coding: utf-8
+# frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'ddtrace/version'
 
 Gem::Specification.new do |spec|
   spec.name                  = 'ddtrace'
   spec.version               = DDTrace::VERSION::STRING
-  spec.required_ruby_version = [">= #{DDTrace::VERSION::MINIMUM_RUBY_VERSION}", "< #{DDTrace::VERSION::MAXIMUM_RUBY_VERSION}"]
+  spec.required_ruby_version = [">= #{DDTrace::VERSION::MINIMUM_RUBY_VERSION}",
+                                "< #{DDTrace::VERSION::MAXIMUM_RUBY_VERSION}"]
   spec.required_rubygems_version = '>= 2.0.0'
   spec.authors               = ['Datadog, Inc.']
   spec.email                 = ['dev@datadoghq.com']
 
   spec.summary     = 'Datadog tracing code for your Ruby applications'
-  spec.description = <<-EOS.gsub(/^[\s]+/, '')
+  spec.description = <<-DESC.gsub(/^\s+/, '')
     ddtrace is Datadog’s tracing client for Ruby. It is used to trace requests
     as they flow across web servers, databases and microservices so that developers
     have great visiblity into bottlenecks and troublesome requests.
-  EOS
+  DESC
 
   spec.homepage = 'https://github.com/DataDog/dd-trace-rb'
   spec.license  = 'BSD-3-Clause'
@@ -28,6 +29,8 @@ Gem::Specification.new do |spec|
     raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
   end
 
+  # rubocop:disable all
+  # DEV: `spec.files` is more problematic than a simple Rubocop pass.
   spec.files =
     `git ls-files -z`
     .split("\x0")
@@ -36,21 +39,12 @@ Gem::Specification.new do |spec|
       ['.dockerignore', '.env', '.gitattributes', '.gitlab-ci.yml', '.rspec', '.rubocop.yml',
        '.rubocop_todo.yml', '.simplecov', 'Appraisals', 'Gemfile', 'Rakefile', 'docker-compose.yml', '.pryrc', '.yardopts'].include?(f)
     end
+  # rubocop:enable all
   spec.executables   = ['ddtracerb']
   spec.require_paths = ['lib']
 
-  # Important note: This `if` ONLY works for development. When packaging up the gem, Ruby runs this code, and hardcodes
-  # the output in the `.gem` file that gets uploaded to rubygems. So the decision here gets hardcoded, we don't actually
-  # pick a version depending on the Ruby customers are running, as it may appear.
-  # For more context, see the discussion in
-  # * https://github.com/DataDog/dd-trace-rb/pull/1739
-  # * https://github.com/DataDog/dd-trace-rb/pull/1336
-  if RUBY_VERSION >= '2.2.0'
-    spec.add_dependency 'msgpack'
-  else
-    # msgpack 1.4 fails for Ruby 2.1: https://github.com/msgpack/msgpack-ruby/issues/205
-    spec.add_dependency 'msgpack', '< 1.4'
-  end
+  # Used to serialize traces to send them to the Datadog Agent.
+  spec.add_dependency 'msgpack'
 
   # Used by the profiler native extension to support older Rubies (see NativeExtensionDesign.md for notes)
   #

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -44,6 +44,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Used to serialize traces to send them to the Datadog Agent.
+  #
+  # msgpack 1.4 fails for Ruby 2.1 (see https://github.com/msgpack/msgpack-ruby/issues/205)
+  # so a restriction needs to be manually added for the `Gemfile`.
+  #
+  # We can't add a restriction here, since there's no way to add it only for older
+  # rubies, see #1739 and #1336 for an extended discussion about this
   spec.add_dependency 'msgpack'
 
   # Used by the profiler native extension to support older Rubies (see NativeExtensionDesign.md for notes)


### PR DESCRIPTION
While researching how to enforce `require_relative` with Rubocop, I stumbled upon the [Rubocop extension "RuboCop Packaging"](https://docs.rubocop.org/rubocop-packaging/index.html). This extension ensures we are being good citizens in the way we package our gem.

Turns out, there are a few improvements to be made.

But as I turned on this new cop, I noticed that `ddtrace.gemspec` was excluded from Rubocop currently, and it needed a bit of work just to get it to comply with our current cops.

This PR does just that. A follow up PR will add "RuboCop Packaging" and only includes changes related to the new cops added by it.