### PR TITLE
Lint:Add Rubocop Packaging extension

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 require:
+  - rubocop-packaging
   - rubocop-performance
   - rubocop-rspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'yard', '~> 0.9'
 
 if RUBY_VERSION >= '2.4.0'
   gem 'rubocop', '~> 1.10', require: false
+  gem 'rubocop-packaging', '~> 0.5', require: false
   gem 'rubocop-performance', '~> 1.9', require: false
   gem 'rubocop-rspec', '~> 2.2', require: false
 end

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -29,17 +29,20 @@ Gem::Specification.new do |spec|
     raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
   end
 
-  # rubocop:disable all
-  # DEV: `spec.files` is more problematic than a simple Rubocop pass.
   spec.files =
-    `git ls-files -z`
-    .split("\x0")
-    .reject { |f| f.match(%r{^(test|spec|features|[.]circleci|[.]github|[.]dd-ci|benchmarks|gemfiles|integration|tasks|sorbet|yard)/}) }
-    .reject do |f|
-      ['.dockerignore', '.env', '.gitattributes', '.gitlab-ci.yml', '.rspec', '.rubocop.yml',
-       '.rubocop_todo.yml', '.simplecov', 'Appraisals', 'Gemfile', 'Rakefile', 'docker-compose.yml', '.pryrc', '.yardopts'].include?(f)
-    end
-  # rubocop:enable all
+    Dir[*%w[
+      CHANGELOG.md
+      LICENSE*
+      NOTICE
+      README.md
+      bin/**/*
+      docs/**/*.md
+      ext/**/*
+      lib/**/*
+    ]]
+    .select { |fn| File.file?(fn) } # We don't want directories, only files
+    .reject { |fn| fn.end_with?('.so', '.bundle') } # Exclude local profiler binary artifacts
+
   spec.executables   = ['ddtracerb']
   spec.require_paths = ['lib']
 

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |spec|
       NOTICE
       README.md
       bin/**/*
-      docs/**/*.md
       ext/**/*
       lib/**/*
     ]]

--- a/spec/ddtrace/release_gem_spec.rb
+++ b/spec/ddtrace/release_gem_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'gem release process' do
           .dockerignore
           .editorconfig
           .env
+          .git-blame-ignore-revs
           .gitattributes
           .gitignore
           .gitlab-ci.yml
@@ -27,12 +28,13 @@ RSpec.describe 'gem release process' do
           docker-compose.yml
         ]
 
+        directories_excluded = %r{^(spec|docs|\.circleci|\.github|benchmarks|gemfiles|integration|tasks|sorbet|yard)/}
+
         expect(files)
           .to match_array(
             `git ls-files -z`
               .split("\x0")
-              .reject { |f| f.match(%r{^(spec|\.circleci|\.github|benchmarks|gemfiles|integration|tasks|sorbet|yard)/}) }
-              .reject { |f| f.match(%r{^docs/.*\.png}) }
+              .reject { |f| f.match(directories_excluded) }
               .reject { |f| single_files_excluded.include?(f) }
           )
       end

--- a/spec/ddtrace/release_gem_spec.rb
+++ b/spec/ddtrace/release_gem_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe 'gem release process' do
+  context 'ddtrace.gemspec' do
+    context 'files' do
+      subject(:files) { Gem::Specification.load('ddtrace.gemspec').files }
+
+      # It's easy to forget to ship new files, especially when a new paradigm is
+      # introduced (e.g. introducing native files requires the inclusion `ext/`)
+      it 'includes all important files' do
+        single_files_excluded = %w[
+          .dockerignore
+          .editorconfig
+          .env
+          .gitattributes
+          .gitignore
+          .gitlab-ci.yml
+          .pryrc
+          .rspec
+          .rubocop.yml
+          .rubocop_todo.yml
+          .simplecov
+          .yardopts
+          Appraisals
+          CONTRIBUTING.md
+          Gemfile
+          Rakefile
+          ddtrace.gemspec
+          docker-compose.yml
+        ]
+
+        expect(files)
+          .to match_array(
+            `git ls-files -z`
+              .split("\x0")
+              .reject { |f| f.match(%r{^(spec|\.circleci|\.github|benchmarks|gemfiles|integration|tasks|sorbet|yard)/}) }
+              .reject { |f| f.match(%r{^docs/.*\.png}) }
+              .reject { |f| single_files_excluded.include?(f) }
+          )
+      end
+    end
+  end
+end

--- a/tasks/release_gem.rake
+++ b/tasks/release_gem.rake
@@ -1,4 +1,13 @@
-desc 'create a new indexed repository'
+Rake::Task["build"].enhance(["build:pre_check"])
+
+desc 'Checks executed before gem is built'
+task :'build:pre_check' do
+  require 'rspec'
+  ret = RSpec::Core::Runner.run(['spec/ddtrace/release_gem_spec.rb'])
+  raise "Release tests failed! See error output above." if ret != 0
+end
+
+desc 'Create a new indexed repository'
 task :'release:gem' do
   raise 'Missing environment variable S3_DIR' if !S3_DIR || S3_DIR.empty?
   # load existing deployed gems


### PR DESCRIPTION
Follow up to #2160.

This PR adds the [Rubocop Packaging](https://docs.rubocop.org/rubocop-packaging/index.html) extension to ddtrace.

Working towards implementing #2077, I noticed that Rubocop Packaging has cops that will allow us to ensure we are using `require_relative` correctly.

In particular, we still want to use `require` in our test suite, which can be ensured by the [Packaging/RequireRelativeHardcodingLib cop](https://docs.rubocop.org/rubocop-packaging/cops_packaging.html#packagingrequirerelativehardcodinglib).
The reason this is important is because downstream services might want to run our test suite while testing the system installed `ddtrace`, [as explained here](https://docs.rubocop.org/rubocop-packaging/cops_packaging.html#packagingrequirerelativehardcodinglib):

> Debian has a testing infrastructure that is designed to test packages in their installed form, i.e., closer to how an end-user would use it than to how a developer working against it. For this to work, the test-suite must load code that’s installed system-wide, instead of the code in the source tree.