### PR TITLE
[PROF-4902] Gather thread name during sampling

### DIFF
--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -133,6 +133,8 @@ if RUBY_VERSION < '2.3'
   $defs << '-DNO_RB_TIME_TIMESPEC_NEW'
   # ...the VM changed enough that we need an alternative legacy rb_profile_frames
   $defs << '-DUSE_LEGACY_RB_PROFILE_FRAMES'
+  # ... you couldn't name threads
+  $defs << '-DNO_THREAD_NAMES'
 end
 
 # If we got here, libdatadog is available and loaded

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -107,6 +107,14 @@ bool is_thread_alive(VALUE thread) {
   return thread_struct_from_object(thread)->status != THREAD_KILLED;
 }
 
+VALUE thread_name_for(VALUE thread) {
+  #ifdef NO_THREAD_NAMES
+    return Qnil;
+  #else
+    return thread_struct_from_object(thread)->name;
+  #endif
+}
+
 // -----------------------------------------------------------------------------
 // The sources below are modified versions of code extracted from the Ruby project.
 // Each function is annotated with its origin, why we imported it, and the changes made.

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -15,6 +15,7 @@ rb_nativethread_id_t pthread_id_for(VALUE thread);
 ptrdiff_t stack_depth_for(VALUE thread);
 VALUE ddtrace_thread_list(void);
 bool is_thread_alive(VALUE thread);
+VALUE thread_name_for(VALUE thread);
 
 int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines, bool* is_ruby_frame);
 


### PR DESCRIPTION
**What does this PR do?**:

Adds support for gathering thread names during profiling.

**Motivation**:

I've wanted to support this extra tiny feature for quite a while now: gathering the thread names, not just their IDs.

We already have this feature for the Java and Python profilers, and I like it quite a lot.

**Additional Notes**:

This feature is only being added on the profiling native extension, it won't show up for customers for now since we haven't wired it up for use yet.

**How to test the change?**:

This change includes test coverage.