### PR TITLE
Lint:Ensure multi-line arguments align close to left margin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -373,6 +373,15 @@ Naming/FileName:
 Style/OptionalBooleanParameter:
   Enabled: false
 
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
 Lint/UnusedBlockArgument:
   # Required keyword arguments normally cannot be omitted or renamed:
   # Example: in `proc{|unused:|}`, `unused` cannot be renamed to `_unused`.

--- a/Rakefile
+++ b/Rakefile
@@ -364,7 +364,7 @@ namespace :coverage do
     require 'simplecov'
 
     resultset_files = Dir["#{ENV.fetch('COVERAGE_DIR', 'coverage')}/.resultset.json"] +
-                      Dir["#{ENV.fetch('COVERAGE_DIR', 'coverage')}/versions/**/.resultset.json"]
+      Dir["#{ENV.fetch('COVERAGE_DIR', 'coverage')}/versions/**/.resultset.json"]
 
     SimpleCov.collate resultset_files do
       coverage_dir "#{ENV.fetch('COVERAGE_DIR', 'coverage')}/report"

--- a/lib/datadog/appsec/contrib/rails/patcher.rb
+++ b/lib/datadog/appsec/contrib/rails/patcher.rb
@@ -59,7 +59,7 @@ module Datadog
             # Add trace middleware
             if include_middleware?(Datadog::Tracing::Contrib::Rack::TraceMiddleware, app)
               app.middleware.insert_after(Datadog::Tracing::Contrib::Rack::TraceMiddleware,
-                                          Datadog::AppSec::Contrib::Rack::RequestMiddleware)
+                Datadog::AppSec::Contrib::Rack::RequestMiddleware)
             else
               app.middleware.insert_before(0, Datadog::AppSec::Contrib::Rack::RequestMiddleware)
             end
@@ -82,8 +82,8 @@ module Datadog
 
               if request_response && request_response.any? { |action, _event| action == :block }
                 @_response = ::ActionDispatch::Response.new(403,
-                                                            { 'Content-Type' => 'text/html' },
-                                                            [Datadog::AppSec::Assets.blocked])
+                  { 'Content-Type' => 'text/html' },
+                  [Datadog::AppSec::Assets.blocked])
                 request_return = @_response.body
               end
 

--- a/lib/datadog/appsec/contrib/sinatra/patcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/patcher.rb
@@ -32,8 +32,8 @@ module Datadog
 
               if tracing_sinatra_framework.include_middleware?(tracing_middleware, builder)
                 tracing_sinatra_framework.add_middleware_after(tracing_middleware,
-                                                               Datadog::AppSec::Contrib::Rack::RequestMiddleware,
-                                                               builder)
+                  Datadog::AppSec::Contrib::Rack::RequestMiddleware,
+                  builder)
               else
                 tracing_sinatra_framework.add_middleware(Datadog::AppSec::Contrib::Rack::RequestMiddleware, builder)
               end
@@ -60,8 +60,8 @@ module Datadog
 
             if request_response && request_response.any? { |action, _event| action == :block }
               self.response = ::Sinatra::Response.new([Datadog::AppSec::Assets.blocked],
-                                                      403,
-                                                      { 'Content-Type' => 'text/html' })
+                403,
+                { 'Content-Type' => 'text/html' })
               request_return = nil
             end
 

--- a/lib/datadog/appsec/reactive/operation.rb
+++ b/lib/datadog/appsec/reactive/operation.rb
@@ -8,8 +8,8 @@ module Datadog
       # Reactive Engine nested operation tracking
       class Operation
         attr_reader :reactive,
-                    :parent,
-                    :name
+          :parent,
+          :name
 
         def initialize(name, parent = nil, reactive_engine = nil)
           Datadog.logger.debug { "operation: #{name} initialize" }

--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -119,8 +119,8 @@ module Datadog
           build_id = env['BUILD_BUILDID']
 
           if build_id &&
-             (team_foundation_server_uri = env['SYSTEM_TEAMFOUNDATIONSERVERURI']) &&
-             (team_project_id = env['SYSTEM_TEAMPROJECTID'])
+              (team_foundation_server_uri = env['SYSTEM_TEAMFOUNDATIONSERVERURI']) &&
+              (team_project_id = env['SYSTEM_TEAMPROJECTID'])
 
             pipeline_url = "#{team_foundation_server_uri}#{team_project_id}/_build/results?buildId=#{build_id}"
 

--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -221,9 +221,9 @@ module Datadog
 
           @uds_fallback =
             if configured_hostname.nil? &&
-               configured_port.nil? &&
-               deprecated_for_removal_transport_configuration_proc.nil? &&
-               File.exist?(Transport::Ext::UnixSocket::DEFAULT_PATH)
+                configured_port.nil? &&
+                deprecated_for_removal_transport_configuration_proc.nil? &&
+                File.exist?(Transport::Ext::UnixSocket::DEFAULT_PATH)
 
               Transport::Ext::UnixSocket::DEFAULT_PATH
             end

--- a/lib/datadog/core/diagnostics/environment_logger.rb
+++ b/lib/datadog/core/diagnostics/environment_logger.rb
@@ -151,7 +151,7 @@ module Datadog
         def sampling_rules
           sampler = Datadog.configuration.tracing.sampler
           return nil unless sampler.is_a?(Tracing::Sampling::PrioritySampler) &&
-                            sampler.priority_sampler.is_a?(Tracing::Sampling::RuleSampler)
+            sampler.priority_sampler.is_a?(Tracing::Sampling::RuleSampler)
 
           sampler.priority_sampler.rules.map do |rule|
             next unless rule.is_a?(Tracing::Sampling::SimpleRule)

--- a/lib/datadog/profiling/transport/http.rb
+++ b/lib/datadog/profiling/transport/http.rb
@@ -101,11 +101,11 @@ module Datadog
 
         # Add adapters to registry
         Datadog::Transport::HTTP::Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::Net,
-                                                        Datadog::Transport::Ext::HTTP::ADAPTER)
+          Datadog::Transport::Ext::HTTP::ADAPTER)
         Datadog::Transport::HTTP::Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::Test,
-                                                        Datadog::Transport::Ext::Test::ADAPTER)
+          Datadog::Transport::Ext::Test::ADAPTER)
         Datadog::Transport::HTTP::Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::UnixSocket,
-                                                        Datadog::Transport::Ext::UnixSocket::ADAPTER)
+          Datadog::Transport::Ext::UnixSocket::ADAPTER)
       end
     end
   end

--- a/lib/datadog/tracing/contrib/active_support/cache/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/active_support/cache/instrumentation.rb
@@ -22,12 +22,12 @@ module Datadog
               # to avoid any kind of issue.
               current_span = Tracing.active_span
               return if current_span.try(:name) == Ext::SPAN_CACHE &&
-                        (
-                          payload[:action] == Ext::RESOURCE_CACHE_GET &&
-                          current_span.try(:resource) == Ext::RESOURCE_CACHE_GET ||
-                          payload[:action] == Ext::RESOURCE_CACHE_MGET &&
-                          current_span.try(:resource) == Ext::RESOURCE_CACHE_MGET
-                        )
+                (
+                  payload[:action] == Ext::RESOURCE_CACHE_GET &&
+                  current_span.try(:resource) == Ext::RESOURCE_CACHE_GET ||
+                  payload[:action] == Ext::RESOURCE_CACHE_MGET &&
+                  current_span.try(:resource) == Ext::RESOURCE_CACHE_MGET
+                )
 
               tracing_context = payload.fetch(:tracing_context)
 

--- a/lib/datadog/tracing/contrib/extensions.rb
+++ b/lib/datadog/tracing/contrib/extensions.rb
@@ -86,8 +86,8 @@ module Datadog
                 # if patching failed, only log output if verbosity is unset
                 # or if patching failure is due to compatibility or integration specific reasons
                 next unless !ignore_integration_load_errors ||
-                            ((patch_results[:available] && patch_results[:loaded]) &&
-                            (!patch_results[:compatible] || !patch_results[:patchable]))
+                  ((patch_results[:available] && patch_results[:loaded]) &&
+                  (!patch_results[:compatible] || !patch_results[:patchable]))
 
                 desc = "Available?: #{patch_results[:available]}"
                 desc += ", Loaded? #{patch_results[:loaded]}"

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -240,11 +240,11 @@ RSpec.describe Datadog::Core::Configuration::Settings do
     describe '#instance=' do
       let(:logger) do
         double(:logger,
-               debug: true,
-               info: true,
-               warn: true,
-               error: true,
-               level: true)
+          debug: true,
+          info: true,
+          warn: true,
+          error: true,
+          level: true)
       end
 
       it 'updates the #instance setting' do

--- a/spec/datadog/core/runtime/metrics_spec.rb
+++ b/spec/datadog/core/runtime/metrics_spec.rb
@@ -118,14 +118,14 @@ RSpec.describe Datadog::Core::Runtime::Metrics do
     shared_examples_for 'a flush of all runtime metrics' do
       context 'including ClassCount' do
         it_behaves_like 'runtime metric flush',
-                        Datadog::Core::Environment::ClassCount,
-                        Datadog::Core::Runtime::Ext::Metrics::METRIC_CLASS_COUNT
+          Datadog::Core::Environment::ClassCount,
+          Datadog::Core::Runtime::Ext::Metrics::METRIC_CLASS_COUNT
       end
 
       context 'including ThreadCount' do
         it_behaves_like 'runtime metric flush',
-                        Datadog::Core::Environment::ThreadCount,
-                        Datadog::Core::Runtime::Ext::Metrics::METRIC_THREAD_COUNT
+          Datadog::Core::Environment::ThreadCount,
+          Datadog::Core::Runtime::Ext::Metrics::METRIC_THREAD_COUNT
       end
 
       context 'including GC stats' do

--- a/spec/datadog/profiling/collectors/old_stack_spec.rb
+++ b/spec/datadog/profiling/collectors/old_stack_spec.rb
@@ -738,7 +738,7 @@ RSpec.describe Datadog::Profiling::Collectors::OldStack do
 
       it 'does not affect Ruby < 2.3 nor Ruby >= 2.7' do
         unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3') ||
-               Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7')
+            Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7')
           skip 'Test case only applies to Ruby < 2.3 or Ruby >= 2.7'
         end
 
@@ -749,7 +749,7 @@ RSpec.describe Datadog::Profiling::Collectors::OldStack do
 
       it 'affects Ruby >= 2.3 and < 2.7' do
         unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3') &&
-               Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7')
+            Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7')
           skip 'Test case only applies to Ruby >= 2.3 and < 2.7'
         end
 

--- a/spec/datadog/profiling/pprof/builder_spec.rb
+++ b/spec/datadog/profiling/pprof/builder_spec.rb
@@ -141,13 +141,13 @@ RSpec.describe Datadog::Profiling::Pprof::Builder do
 
       expect(Perftools::Profiles::Function)
         .to receive(:new).with(hash_including(filename: string_id_for(filename), name: string_id_for(function_name)))
-                         .and_return(function)
+        .and_return(function)
 
       expect(build_location).to be_a_kind_of(Perftools::Profiles::Location)
       expect(build_location.to_h).to match(hash_including(id: location_id,
-                                                          line: [{
-                                                            function_id: function.id, line: line_number
-                                                          }]))
+        line: [{
+          function_id: function.id, line: line_number
+        }]))
     end
   end
 

--- a/spec/datadog/tracing/contrib/action_mailer/helpers.rb
+++ b/spec/datadog/tracing/contrib/action_mailer/helpers.rb
@@ -21,10 +21,10 @@ RSpec.shared_context 'ActionMailer helpers' do
 
         def test_mail(_arg)
           mail(to: 'test@example.com',
-               body: 'sk test',
-               subject: 'miniswan',
-               bcc: 'test_a@example.com,test_b@example.com',
-               cc: ['test_c@example.com', 'test_d@example.com'])
+            body: 'sk test',
+            subject: 'miniswan',
+            bcc: 'test_a@example.com,test_b@example.com',
+            cc: ['test_c@example.com', 'test_d@example.com'])
         end
       end
     )

--- a/spec/datadog/tracing/contrib/active_record/configuration/resolver_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/configuration/resolver_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe Datadog::Tracing::Contrib::ActiveRecord::Configuration::Resolver 
 
         expect(resolver.configurations)
           .to eq({
-                   adapter: 'adapter',
-                   host: 'host',
-                   port: 123
-                 } => config)
+            adapter: 'adapter',
+            host: 'host',
+            port: 123
+          } => config)
       end
     end
 

--- a/spec/datadog/tracing/contrib/active_record/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/tracer_spec.rb
@@ -105,9 +105,9 @@ RSpec.describe 'ActiveRecord instrumentation' do
             Datadog.configure do |c|
               c.tracing.instrument :active_record, service_name: 'bad-no-match'
               c.tracing.instrument :active_record, describes: { makara_role: primary_role },
-                                                   service_name: primary_service_name
+                service_name: primary_service_name
               c.tracing.instrument :active_record, describes: { makara_role: secondary_role },
-                                                   service_name: secondary_service_name
+                service_name: secondary_service_name
             end
           end
 

--- a/spec/datadog/tracing/contrib/elasticsearch/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/elasticsearch/integration_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Integration do
     context 'when "elastic-transport" gem is loaded with a version' do
       context 'that is less than the minimum' do
         include_context 'loaded gems', :'elastic-transport' => decrement_gem_version(described_class::MINIMUM_VERSION),
-                                       :'elasticsearch-transport' => nil
+          :'elasticsearch-transport' => nil
         it { is_expected.to be false }
       end
 
       context 'that meets the minimum version' do
         include_context 'loaded gems', :'elastic-transport' => described_class::MINIMUM_VERSION,
-                                       :'elasticsearch-transport' => nil
+          :'elasticsearch-transport' => nil
         it { is_expected.to be true }
       end
     end
@@ -73,15 +73,15 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Integration do
     context 'when "elasticsearch-transport" gem is loaded with a version' do
       context 'that is less than the minimum' do
         include_context 'loaded gems',
-                        :'elastic-transport' => nil,
-                        :'elasticsearch-transport' => decrement_gem_version(described_class::MINIMUM_VERSION)
+          :'elastic-transport' => nil,
+          :'elasticsearch-transport' => decrement_gem_version(described_class::MINIMUM_VERSION)
         it { is_expected.to be false }
       end
 
       context 'that meets the minimum version' do
         include_context 'loaded gems',
-                        :'elastic-transport' => nil,
-                        :'elasticsearch-transport' => described_class::MINIMUM_VERSION
+          :'elastic-transport' => nil,
+          :'elasticsearch-transport' => described_class::MINIMUM_VERSION
 
         it { is_expected.to be true }
       end

--- a/spec/datadog/tracing/contrib/elasticsearch/quantize_spec.rb
+++ b/spec/datadog/tracing/contrib/elasticsearch/quantize_spec.rb
@@ -27,11 +27,11 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Quantize do
       it_behaves_like 'a quantized URL', '/my/thing/1two3/abc/', '/my/thing/?/abc/'
       it_behaves_like 'a quantized URL', '/my/thing231/1two3/abc/', '/my/thing?/?/abc/'
       it_behaves_like 'a quantized URL',
-                      '/my/thing/1447990c-811a-4a83-b7e2-c3e8a4a6ff54/_termvector',
-                      '/my/thing/?/_termvector'
+        '/my/thing/1447990c-811a-4a83-b7e2-c3e8a4a6ff54/_termvector',
+        '/my/thing/?/_termvector'
       it_behaves_like 'a quantized URL',
-                      'app_prod/user/1fff2c9dc2f3e/_termvector',
-                      'app_prod/user/?/_termvector'
+        'app_prod/user/1fff2c9dc2f3e/_termvector',
+        'app_prod/user/?/_termvector'
     end
 
     context 'when the URL looks like an index' do
@@ -60,22 +60,22 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Quantize do
           let(:options) { { show: [:title] } }
 
           it_behaves_like 'a quantized body',
-                          '{"query":{"match":{"title":"test","subtitle":"test"}}}',
-                          '{"query":{"match":{"title":"test","subtitle":"?"}}}'
+            '{"query":{"match":{"title":"test","subtitle":"test"}}}',
+            '{"query":{"match":{"title":"test","subtitle":"?"}}}'
         end
 
         context ':all' do
           let(:options) { { show: :all } }
 
           it_behaves_like 'a quantized body',
-                          '{"query":{"match":{"title":"test","subtitle":"test"}}}',
-                          '{"query":{"match":{"title":"test","subtitle":"test"}}}'
+            '{"query":{"match":{"title":"test","subtitle":"test"}}}',
+            '{"query":{"match":{"title":"test","subtitle":"test"}}}'
           it_behaves_like 'a quantized body',
-                          '[{"foo":"foo"},{"bar":"bar"}]',
-                          '[{"foo":"foo"},{"bar":"bar"}]'
+            '[{"foo":"foo"},{"bar":"bar"}]',
+            '[{"foo":"foo"},{"bar":"bar"}]'
           it_behaves_like 'a quantized body',
-                          '["foo","bar"]',
-                          '["foo","bar"]'
+            '["foo","bar"]',
+            '["foo","bar"]'
         end
       end
 
@@ -84,8 +84,8 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Quantize do
           let(:options) { { exclude: [:title] } }
 
           it_behaves_like 'a quantized body',
-                          '{"query":{"match":{"title":"test","subtitle":"test"}}}',
-                          '{"query":{"match":{"subtitle":"?"}}}'
+            '{"query":{"match":{"title":"test","subtitle":"test"}}}',
+            '{"query":{"match":{"subtitle":"?"}}}'
         end
       end
     end
@@ -94,27 +94,27 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Quantize do
       context 'is in a format for' do
         describe 'MGet' do
           it_behaves_like 'a quantized body',
-                          '{"ids":["1","2","3"]}',
-                          '{"ids":["?"]}'
+            '{"ids":["1","2","3"]}',
+            '{"ids":["?"]}'
         end
 
         describe 'Search' do
           it_behaves_like 'a quantized body',
-                          '{"query":{"match":{"title":"test"}}}',
-                          '{"query":{"match":{"title":"?"}}}'
+            '{"query":{"match":{"title":"test"}}}',
+            '{"query":{"match":{"title":"?"}}}'
         end
 
         # rubocop:disable Layout/LineLength
         describe 'MSearch' do
           it_behaves_like 'a quantized body',
-                          "{}\n{\"query\":{\"match_all\":{}}}\n{\"index\":\"myindex\",\"type\":\"mytype\"}\n{\"query\":{\"query_string\":{\"query\":\"\\\"test\\\"\"}}}\n{\"search_type\":\"count\"}\n{\"aggregations\":{\"published\":{\"terms\":{\"field\":\"published\"}}}}\n",
-                          "{}\n{\"query\":{\"match_all\":{}}}\n{\"index\":\"?\",\"type\":\"?\"}\n{\"query\":{\"query_string\":{\"query\":\"?\"}}}\n{\"search_type\":\"?\"}\n{\"aggregations\":{\"published\":{\"terms\":{\"field\":\"?\"}}}}"
+            "{}\n{\"query\":{\"match_all\":{}}}\n{\"index\":\"myindex\",\"type\":\"mytype\"}\n{\"query\":{\"query_string\":{\"query\":\"\\\"test\\\"\"}}}\n{\"search_type\":\"count\"}\n{\"aggregations\":{\"published\":{\"terms\":{\"field\":\"published\"}}}}\n",
+            "{}\n{\"query\":{\"match_all\":{}}}\n{\"index\":\"?\",\"type\":\"?\"}\n{\"query\":{\"query_string\":{\"query\":\"?\"}}}\n{\"search_type\":\"?\"}\n{\"aggregations\":{\"published\":{\"terms\":{\"field\":\"?\"}}}}"
         end
 
         describe 'Bulk' do
           it_behaves_like 'a quantized body',
-                          "{\"index\":{\"_index\":\"myindex\",\"_type\":\"mytype\",\"_id\":1}}\n{\"title\":\"foo\"}\n{\"index\":{\"_index\":\"myindex\",\"_type\":\"mytype\",\"_id\":2}}\n{\"title\":\"foo\"}\n",
-                          "{\"index\":{\"_index\":\"myindex\",\"_type\":\"mytype\",\"_id\":1}}\n{\"title\":\"?\"}\n{\"index\":{\"_index\":\"myindex\",\"_type\":\"mytype\",\"_id\":2}}\n{\"title\":\"?\"}"
+            "{\"index\":{\"_index\":\"myindex\",\"_type\":\"mytype\",\"_id\":1}}\n{\"title\":\"foo\"}\n{\"index\":{\"_index\":\"myindex\",\"_type\":\"mytype\",\"_id\":2}}\n{\"title\":\"foo\"}\n",
+            "{\"index\":{\"_index\":\"myindex\",\"_type\":\"mytype\",\"_id\":1}}\n{\"title\":\"?\"}\n{\"index\":{\"_index\":\"myindex\",\"_type\":\"mytype\",\"_id\":2}}\n{\"title\":\"?\"}"
         end
       end
     end

--- a/spec/datadog/tracing/contrib/rails/support/rails3.rb
+++ b/spec/datadog/tracing/contrib/rails/support/rails3.rb
@@ -117,7 +117,7 @@ RSpec.shared_context 'Rails 3 base application' do
     allow(Rails.application.config.action_view).to receive(:delete).with(:stylesheet_expansions).and_return({})
     allow(Rails.application.config.action_view)
       .to receive(:delete).with(:javascript_expansions)
-                          .and_return(defaults: %w[prototype effects dragdrop controls rails])
+      .and_return(defaults: %w[prototype effects dragdrop controls rails])
     allow(Rails.application.config.action_view).to receive(:delete)
       .with(:embed_authenticity_token_in_remote_forms).and_return(true)
   end

--- a/spec/datadog/tracing/contrib/redis/configuration/resolver_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/configuration/resolver_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe 'Redis configuration resolver' do
 
         it do
           expect(parsed_key).to eq(host: '127.0.0.1',
-                                   port: 6379,
-                                   db: 0,
-                                   scheme: 'redis')
+            port: 6379,
+            db: 0,
+            scheme: 'redis')
         end
       end
 
@@ -44,9 +44,9 @@ RSpec.describe 'Redis configuration resolver' do
 
         it do
           expect(parsed_key).to eq(host: '127.0.0.1',
-                                   port: 6379,
-                                   db: 0,
-                                   scheme: 'redis')
+            port: 6379,
+            db: 0,
+            scheme: 'redis')
         end
       end
     end
@@ -63,9 +63,9 @@ RSpec.describe 'Redis configuration resolver' do
 
       it do
         expect(parsed_key).to eq(host: '127.0.0.1',
-                                 port: 6379,
-                                 db: 0,
-                                 scheme: 'redis')
+          port: 6379,
+          db: 0,
+          scheme: 'redis')
       end
     end
 
@@ -80,9 +80,9 @@ RSpec.describe 'Redis configuration resolver' do
 
       it do
         expect(parsed_key).to eq(host: '127.0.0.1',
-                                 port: 6379,
-                                 db: 0,
-                                 scheme: 'redis')
+          port: 6379,
+          db: 0,
+          scheme: 'redis')
       end
     end
 
@@ -96,9 +96,9 @@ RSpec.describe 'Redis configuration resolver' do
 
       it do
         expect(parsed_key).to eq(host: '127.0.0.1',
-                                 port: 6379,
-                                 db: 0,
-                                 scheme: 'redis')
+          port: 6379,
+          db: 0,
+          scheme: 'redis')
       end
     end
   end

--- a/spec/datadog/tracing/contrib/sinatra/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sinatra/tracer_spec.rb
@@ -608,9 +608,9 @@ RSpec.describe 'Sinatra instrumentation' do
               expect(trace.resource).to eq(resource)
 
               expect(top_span).to be_request_span resource: 'GET',
-                                                  app_name: top_app_name,
-                                                  matching_app: false,
-                                                  parent: top_rack_span
+                app_name: top_app_name,
+                matching_app: false,
+                parent: top_rack_span
               expect(top_rack_span).not_to be_nil
               expect(top_rack_span).to be_root_span
               expect(top_rack_span.resource).to eq('GET')

--- a/spec/datadog/tracing/contrib/support/matchers.rb
+++ b/spec/datadog/tracing/contrib/support/matchers.rb
@@ -11,9 +11,9 @@
 RSpec::Matchers.define :match_normalized_sql do |expected|
   match do |actual|
     @actual = actual
-              .gsub(/[`"]/, '') # Remove all query token quotations. String quotations are left untouched.
-              .gsub(/\$\d+/, '?') # Convert Postgres placeholder '$1' to '?'
-              .gsub(/:\w+/, '?') # Convert Sqlite placeholder ':value' to '?'
+      .gsub(/[`"]/, '') # Remove all query token quotations. String quotations are left untouched.
+      .gsub(/\$\d+/, '?') # Convert Postgres placeholder '$1' to '?'
+      .gsub(/:\w+/, '?') # Convert Sqlite placeholder ':value' to '?'
 
     values_match?(expected, @actual)
   end

--- a/spec/datadog/tracing/distributed/headers/b3_spec.rb
+++ b/spec/datadog/tracing/distributed/headers/b3_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::B3 do
 
       it do
         expect(env).to eq(Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 10000.to_s(16),
-                          Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 20000.to_s(16))
+          Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 20000.to_s(16))
       end
 
       [
@@ -51,8 +51,8 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::B3 do
 
           it do
             expect(env).to eq(Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 50000.to_s(16),
-                              Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 60000.to_s(16),
-                              Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SAMPLED => expected.to_s)
+              Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 60000.to_s(16),
+              Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SAMPLED => expected.to_s)
           end
         end
       end
@@ -68,7 +68,7 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::B3 do
 
         it do
           expect(env).to eq(Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 90000.to_s(16),
-                            Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 100000.to_s(16))
+            Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 100000.to_s(16))
         end
       end
     end

--- a/spec/datadog/tracing/distributed/headers/datadog_spec.rb
+++ b/spec/datadog/tracing/distributed/headers/datadog_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::Datadog do
 
       it do
         expect(env).to eq(Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => '10000',
-                          Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '20000')
+          Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '20000')
       end
 
       context 'with sampling priority' do
@@ -45,8 +45,8 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::Datadog do
 
         it do
           expect(env).to eq(Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => '50000',
-                            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '60000',
-                            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_SAMPLING_PRIORITY => '1')
+            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '60000',
+            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_SAMPLING_PRIORITY => '1')
         end
 
         context 'with origin' do
@@ -61,9 +61,9 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::Datadog do
 
           it do
             expect(env).to eq(Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => '70000',
-                              Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '80000',
-                              Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_SAMPLING_PRIORITY => '1',
-                              Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_ORIGIN => 'synthetics')
+              Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '80000',
+              Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_SAMPLING_PRIORITY => '1',
+              Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_ORIGIN => 'synthetics')
           end
         end
       end
@@ -79,8 +79,8 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::Datadog do
 
         it do
           expect(env).to eq(Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => '90000',
-                            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '100000',
-                            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_ORIGIN => 'synthetics')
+            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '100000',
+            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_ORIGIN => 'synthetics')
         end
       end
     end

--- a/spec/datadog/tracing/distributed/metadata/b3_spec.rb
+++ b/spec/datadog/tracing/distributed/metadata/b3_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Datadog::Tracing::Distributed::Metadata::B3 do
 
       it do
         expect(metadata).to eq(Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 10000.to_s(16),
-                               Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 20000.to_s(16))
+          Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 20000.to_s(16))
       end
 
       [
@@ -46,8 +46,8 @@ RSpec.describe Datadog::Tracing::Distributed::Metadata::B3 do
 
           it do
             expect(metadata).to eq(Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 50000.to_s(16),
-                                   Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 60000.to_s(16),
-                                   Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SAMPLED => expected.to_s)
+              Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 60000.to_s(16),
+              Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SAMPLED => expected.to_s)
           end
         end
       end
@@ -63,7 +63,7 @@ RSpec.describe Datadog::Tracing::Distributed::Metadata::B3 do
 
         it do
           expect(metadata).to eq(Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 90000.to_s(16),
-                                 Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 100000.to_s(16))
+            Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 100000.to_s(16))
         end
       end
     end

--- a/spec/datadog/tracing/distributed/metadata/datadog_spec.rb
+++ b/spec/datadog/tracing/distributed/metadata/datadog_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Datadog::Tracing::Distributed::Metadata::Datadog do
 
       it do
         expect(metadata).to eq(Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_TRACE_ID => '10000',
-                               Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_PARENT_ID => '20000')
+          Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_PARENT_ID => '20000')
       end
 
       context 'with sampling priority' do
@@ -40,8 +40,8 @@ RSpec.describe Datadog::Tracing::Distributed::Metadata::Datadog do
 
         it do
           expect(metadata).to eq(Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_TRACE_ID => '50000',
-                                 Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_PARENT_ID => '60000',
-                                 Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_SAMPLING_PRIORITY => '1')
+            Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_PARENT_ID => '60000',
+            Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_SAMPLING_PRIORITY => '1')
         end
 
         context 'with origin' do
@@ -56,9 +56,9 @@ RSpec.describe Datadog::Tracing::Distributed::Metadata::Datadog do
 
           it do
             expect(metadata).to eq(Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_TRACE_ID => '70000',
-                                   Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_PARENT_ID => '80000',
-                                   Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_SAMPLING_PRIORITY => '1',
-                                   Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_ORIGIN => 'synthetics')
+              Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_PARENT_ID => '80000',
+              Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_SAMPLING_PRIORITY => '1',
+              Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_ORIGIN => 'synthetics')
           end
         end
       end
@@ -74,8 +74,8 @@ RSpec.describe Datadog::Tracing::Distributed::Metadata::Datadog do
 
         it do
           expect(metadata).to eq(Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_TRACE_ID => '90000',
-                                 Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_PARENT_ID => '100000',
-                                 Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_ORIGIN => 'synthetics')
+            Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_PARENT_ID => '100000',
+            Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_ORIGIN => 'synthetics')
         end
       end
     end

--- a/spec/datadog/tracing/propagation/http_spec.rb
+++ b/spec/datadog/tracing/propagation/http_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Datadog::Tracing::Propagation::HTTP do
         it do
           inject!
           expect(env).to eq('something' => 'alien',
-                            'x-datadog-trace-id' => '1000',
-                            'x-datadog-parent-id' => '2000')
+            'x-datadog-trace-id' => '1000',
+            'x-datadog-parent-id' => '2000')
         end
       end
 
@@ -34,9 +34,9 @@ RSpec.describe Datadog::Tracing::Propagation::HTTP do
 
           it do
             expect(env).to eq('something' => 'alien',
-                              'x-datadog-sampling-priority' => '0',
-                              'x-datadog-trace-id' => '1000',
-                              'x-datadog-parent-id' => '2000')
+              'x-datadog-sampling-priority' => '0',
+              'x-datadog-trace-id' => '1000',
+              'x-datadog-parent-id' => '2000')
           end
         end
 
@@ -45,8 +45,8 @@ RSpec.describe Datadog::Tracing::Propagation::HTTP do
 
           it do
             expect(env).to eq('something' => 'alien',
-                              'x-datadog-trace-id' => '1000',
-                              'x-datadog-parent-id' => '2000')
+              'x-datadog-trace-id' => '1000',
+              'x-datadog-parent-id' => '2000')
           end
         end
       end
@@ -59,9 +59,9 @@ RSpec.describe Datadog::Tracing::Propagation::HTTP do
 
           it do
             expect(env).to eq('something' => 'alien',
-                              'x-datadog-origin' => 'synthetics',
-                              'x-datadog-trace-id' => '1000',
-                              'x-datadog-parent-id' => '2000')
+              'x-datadog-origin' => 'synthetics',
+              'x-datadog-trace-id' => '1000',
+              'x-datadog-parent-id' => '2000')
           end
         end
 
@@ -70,8 +70,8 @@ RSpec.describe Datadog::Tracing::Propagation::HTTP do
 
           it do
             expect(env).to eq('something' => 'alien',
-                              'x-datadog-trace-id' => '1000',
-                              'x-datadog-parent-id' => '2000')
+              'x-datadog-trace-id' => '1000',
+              'x-datadog-parent-id' => '2000')
           end
         end
       end

--- a/spec/datadog/tracing/writer_spec.rb
+++ b/spec/datadog/tracing/writer_spec.rb
@@ -127,17 +127,17 @@ RSpec.describe Datadog::Tracing::Writer do
         context 'with multiple responses' do
           let(:response1) do
             instance_double(Datadog::Transport::HTTP::Traces::Response,
-                            internal_error?: false,
-                            server_error?: false,
-                            ok?: true,
-                            trace_count: 10)
+              internal_error?: false,
+              server_error?: false,
+              ok?: true,
+              trace_count: 10)
           end
           let(:response2) do
             instance_double(Datadog::Transport::HTTP::Traces::Response,
-                            internal_error?: false,
-                            server_error?: false,
-                            ok?: true,
-                            trace_count: 20)
+              internal_error?: false,
+              server_error?: false,
+              ok?: true,
+              trace_count: 20)
           end
 
           let(:responses) { [response1, response2] }
@@ -145,9 +145,9 @@ RSpec.describe Datadog::Tracing::Writer do
           context 'and at least one being server error' do
             let(:response2) do
               instance_double(Datadog::Transport::HTTP::Traces::Response,
-                              internal_error?: false,
-                              server_error?: true,
-                              ok?: false)
+                internal_error?: false,
+                server_error?: true,
+                ok?: false)
             end
 
             it do


### PR DESCRIPTION
For my friend, @ivoanjo ❤️ 

This PR reduces the indentation level of multi-line arguments.

From:
```ruby
      expect(build_location.to_h).to match(hash_including(id: location_id,
                                                          line: [{
                                                            function_id: function.id, line: line_number
                                                          }]))
```
To:
```ruby
      expect(build_location.to_h).to match(hash_including(id: location_id,
        line: [{
          function_id: function.id, line: line_number
        }]))
```

2587 white-spaces removed 🙂:
```ruby
git diff head^ | ruby -e "puts ARGF.readlines.select{|x| x.start_with?('-', '+')}.map{|x| s = x.scan(' ').size; x.start_with?('-') ? -s : s}.sum"
# -2587
```

### Follow up

One issue this change has is that it leaves the first parameter in a muiti-line argument block alone, at the top-right side:
```ruby
      expect(build_location.to_h).to match(hash_including(id: location_id,
        line: [{                                        # ^^ This one
          function_id: function.id, line: line_number
        }]))
```

```ruby
                @_response = ::ActionDispatch::Response.new(403,
                  { 'Content-Type' => 'text/html' },      # ^^ This one
                  [Datadog::AppSec::Assets.blocked])
```

This looks a bit off, and hard to scan for all parameters.
I chose to not address that in this PR, because that required adding 5 new cops just to make it not look crazy, so a follow up PR does that work: #2166
Also, that work touches way more files.