### PR TITLE
Lint:first multi-line argument has line break

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# .git-blame-ignore-revs
+# Ensure multi-line arguments align close to left margin
+372f7c20696e30f319cf20622758f7f0ef585875
+# First multi-line argument has line break
+6e8ae58d320d6a48f6c1d21db894d414bdf140b2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -376,6 +376,21 @@ Style/OptionalBooleanParameter:
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 
+Layout/BlockAlignment:
+  EnforcedStyleAlignWith: start_of_block
+
+Layout/FirstArgumentIndentation:
+  EnforcedStyle: consistent
+
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: true
+
+Layout/FirstMethodParameterLineBreak:
+  Enabled: true
+
+Layout/MultilineMethodArgumentLineBreaks:
+  Enabled: true
+
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 

--- a/Rakefile
+++ b/Rakefile
@@ -370,8 +370,10 @@ namespace :coverage do
       coverage_dir "#{ENV.fetch('COVERAGE_DIR', 'coverage')}/report"
       if ENV['CI'] == 'true'
         require 'codecov'
-        formatter SimpleCov::Formatter::MultiFormatter.new([SimpleCov::Formatter::HTMLFormatter,
-                                                            SimpleCov::Formatter::Codecov])
+        formatter SimpleCov::Formatter::MultiFormatter.new(
+          [SimpleCov::Formatter::HTMLFormatter,
+           SimpleCov::Formatter::Codecov]
+        )
       else
         formatter SimpleCov::Formatter::HTMLFormatter
       end

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -42,7 +42,8 @@ unless Datadog::Profiling::NativeExtensionHelpers::Supported.supported?
   skip_building_extension!(Datadog::Profiling::NativeExtensionHelpers::Supported.unsupported_reason)
 end
 
-$stderr.puts(%(
+$stderr.puts(
+  %(
 +------------------------------------------------------------------------------+
 | ** Preparing to build the ddtrace profiling native extension... **           |
 |                                                                              |
@@ -59,7 +60,8 @@ $stderr.puts(%(
 | Thanks for using ddtrace! You rock!                                          |
 +------------------------------------------------------------------------------+
 
-))
+)
+)
 
 # NOTE: we MUST NOT require 'mkmf' before we check the #skip_building_extension? because the require triggers checks
 # that may fail on an environment not properly setup for building Ruby extensions.

--- a/lib/datadog/appsec/contrib/rails/patcher.rb
+++ b/lib/datadog/appsec/contrib/rails/patcher.rb
@@ -58,8 +58,10 @@ module Datadog
           def add_middleware(app)
             # Add trace middleware
             if include_middleware?(Datadog::Tracing::Contrib::Rack::TraceMiddleware, app)
-              app.middleware.insert_after(Datadog::Tracing::Contrib::Rack::TraceMiddleware,
-                Datadog::AppSec::Contrib::Rack::RequestMiddleware)
+              app.middleware.insert_after(
+                Datadog::Tracing::Contrib::Rack::TraceMiddleware,
+                Datadog::AppSec::Contrib::Rack::RequestMiddleware
+              )
             else
               app.middleware.insert_before(0, Datadog::AppSec::Contrib::Rack::RequestMiddleware)
             end
@@ -81,9 +83,11 @@ module Datadog
               end
 
               if request_response && request_response.any? { |action, _event| action == :block }
-                @_response = ::ActionDispatch::Response.new(403,
+                @_response = ::ActionDispatch::Response.new(
+                  403,
                   { 'Content-Type' => 'text/html' },
-                  [Datadog::AppSec::Assets.blocked])
+                  [Datadog::AppSec::Assets.blocked]
+                )
                 request_return = @_response.body
               end
 

--- a/lib/datadog/appsec/contrib/sinatra/patcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/patcher.rb
@@ -31,9 +31,11 @@ module Datadog
               tracing_middleware = Datadog::Tracing::Contrib::Rack::TraceMiddleware
 
               if tracing_sinatra_framework.include_middleware?(tracing_middleware, builder)
-                tracing_sinatra_framework.add_middleware_after(tracing_middleware,
+                tracing_sinatra_framework.add_middleware_after(
+                  tracing_middleware,
                   Datadog::AppSec::Contrib::Rack::RequestMiddleware,
-                  builder)
+                  builder
+                )
               else
                 tracing_sinatra_framework.add_middleware(Datadog::AppSec::Contrib::Rack::RequestMiddleware, builder)
               end
@@ -59,9 +61,11 @@ module Datadog
             end
 
             if request_response && request_response.any? { |action, _event| action == :block }
-              self.response = ::Sinatra::Response.new([Datadog::AppSec::Assets.blocked],
+              self.response = ::Sinatra::Response.new(
+                [Datadog::AppSec::Assets.blocked],
                 403,
-                { 'Content-Type' => 'text/html' })
+                { 'Content-Type' => 'text/html' }
+              )
               request_return = nil
             end
 

--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -127,9 +127,11 @@ module Datadog
             job_url = "#{pipeline_url}&view=logs&j=#{env['SYSTEM_JOBID']}&t=#{env['SYSTEM_TASKINSTANCEID']}"
           end
 
-          branch, tag = branch_or_tag(env['SYSTEM_PULLREQUEST_SOURCEBRANCH'] ||
-                                        env['BUILD_SOURCEBRANCH'] ||
-                                        env['BUILD_SOURCEBRANCHNAME'])
+          branch, tag = branch_or_tag(
+            env['SYSTEM_PULLREQUEST_SOURCEBRANCH'] ||
+            env['BUILD_SOURCEBRANCH'] ||
+            env['BUILD_SOURCEBRANCHNAME']
+          )
 
           {
             TAG_PROVIDER_NAME => 'azurepipelines',

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -419,7 +419,8 @@ module Datadog
                     Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG,
                     Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3,
                     Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_SINGLE_HEADER
-                  ], comma_separated_only: true
+                  ],
+                  comma_separated_only: true
                 )
               end
 
@@ -437,7 +438,8 @@ module Datadog
               o.default do
                 env_to_list(
                   Tracing::Configuration::Ext::Distributed::ENV_PROPAGATION_STYLE_INJECT,
-                  [Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG], comma_separated_only: true # Only inject Datadog headers by default
+                  [Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG],
+                  comma_separated_only: true # Only inject Datadog headers by default
                 )
               end
 

--- a/lib/datadog/opentracer/tracer.rb
+++ b/lib/datadog/opentracer/tracer.rb
@@ -52,13 +52,15 @@ module Datadog
       #   yield the newly-started Scope. If `finish_on_close` is true then the
       #   Span will be finished automatically after the block is executed.
       # @return [Scope] The newly-started and activated Scope
-      def start_active_span(operation_name,
-                            child_of: nil,
-                            references: nil,
-                            start_time: Time.now,
-                            tags: nil,
-                            ignore_active_scope: false,
-                            finish_on_close: true)
+      def start_active_span(
+        operation_name,
+        child_of: nil,
+        references: nil,
+        start_time: Time.now,
+        tags: nil,
+        ignore_active_scope: false,
+        finish_on_close: true
+      )
 
         # When meant to automatically determine the parent,
         # Use the active scope first, otherwise fall back to any
@@ -124,12 +126,14 @@ module Datadog
       #   References#CHILD_OF reference to the ScopeManager#active.
       # @return [Span] the newly-started Span instance, which has not been
       #   automatically registered via the ScopeManager
-      def start_span(operation_name,
-                     child_of: nil,
-                     references: nil,
-                     start_time: Time.now,
-                     tags: nil,
-                     ignore_active_scope: false)
+      def start_span(
+        operation_name,
+        child_of: nil,
+        references: nil,
+        start_time: Time.now,
+        tags: nil,
+        ignore_active_scope: false
+      )
 
         # Derive the OpenTracer::SpanContext to inherit from.
         parent_span_context = inherited_span_context(child_of, ignore_active_scope: ignore_active_scope)

--- a/lib/datadog/profiling/http_transport.rb
+++ b/lib/datadog/profiling/http_transport.rb
@@ -80,8 +80,9 @@ module Datadog
       def validate_agent_settings(agent_settings)
         supported_adapters = [Datadog::Transport::Ext::HTTP::ADAPTER, Datadog::Transport::Ext::UnixSocket::ADAPTER]
         unless supported_adapters.include?(agent_settings.adapter)
-          raise ArgumentError, "Unsupported transport configuration for profiling: Adapter #{agent_settings.adapter} " \
-            ' is not supported'
+          raise ArgumentError,
+            "Unsupported transport configuration for profiling: Adapter #{agent_settings.adapter} " \
+                        ' is not supported'
         end
 
         if agent_settings.deprecated_for_removal_transport_configuration_proc

--- a/lib/datadog/profiling/transport/http.rb
+++ b/lib/datadog/profiling/transport/http.rb
@@ -100,12 +100,18 @@ module Datadog
         end
 
         # Add adapters to registry
-        Datadog::Transport::HTTP::Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::Net,
-          Datadog::Transport::Ext::HTTP::ADAPTER)
-        Datadog::Transport::HTTP::Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::Test,
-          Datadog::Transport::Ext::Test::ADAPTER)
-        Datadog::Transport::HTTP::Builder::REGISTRY.set(Datadog::Transport::HTTP::Adapters::UnixSocket,
-          Datadog::Transport::Ext::UnixSocket::ADAPTER)
+        Datadog::Transport::HTTP::Builder::REGISTRY.set(
+          Datadog::Transport::HTTP::Adapters::Net,
+          Datadog::Transport::Ext::HTTP::ADAPTER
+        )
+        Datadog::Transport::HTTP::Builder::REGISTRY.set(
+          Datadog::Transport::HTTP::Adapters::Test,
+          Datadog::Transport::Ext::Test::ADAPTER
+        )
+        Datadog::Transport::HTTP::Builder::REGISTRY.set(
+          Datadog::Transport::HTTP::Adapters::UnixSocket,
+          Datadog::Transport::Ext::UnixSocket::ADAPTER
+        )
       end
     end
   end

--- a/lib/datadog/tracing/contrib/rack/patcher.rb
+++ b/lib/datadog/tracing/contrib/rack/patcher.rb
@@ -91,10 +91,12 @@ module Datadog
               if get_option(:application)
                 MiddlewareNamePatcher.patch
               else
-                Datadog.logger.warn(%(
+                Datadog.logger.warn(
+                  %(
                 Rack :middleware_names requires you to also pass :application.
                 Middleware names have NOT been patched; please provide :application.
-                e.g. use: :rack, middleware_names: true, application: my_rack_app).freeze)
+                e.g. use: :rack, middleware_names: true, application: my_rack_app).freeze
+                )
               end
             end
           end

--- a/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agent_settings_resolver_spec.rb
@@ -545,11 +545,11 @@ RSpec.describe Datadog::Core::Configuration::AgentSettingsResolver do
 
         it 'includes the given proc in the resolved settings as the ' \
           'deprecated_for_removal_transport_configuration_proc and falls back to the defaults' do
-          expect(resolver).to have_attributes(
-            **settings,
-            deprecated_for_removal_transport_configuration_proc: transport_options
-          )
-        end
+            expect(resolver).to have_attributes(
+              **settings,
+              deprecated_for_removal_transport_configuration_proc: transport_options
+            )
+          end
 
         it 'logs a debug message' do
           expect(logger).to receive(:debug)

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -440,8 +440,10 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
           expect(writer.events.after_send).to receive(:subscribe) do |&block|
             expect(block)
-              .to be(Datadog::Core::Configuration::Components
-                       .singleton_class::WRITER_RECORD_ENVIRONMENT_INFORMATION_CALLBACK)
+              .to be(
+                Datadog::Core::Configuration::Components
+                                       .singleton_class::WRITER_RECORD_ENVIRONMENT_INFORMATION_CALLBACK
+              )
           end
 
           expect(writer.events.after_send).to receive(:subscribe) do |&block|

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -239,12 +239,14 @@ RSpec.describe Datadog::Core::Configuration::Settings do
 
     describe '#instance=' do
       let(:logger) do
-        double(:logger,
+        double(
+          :logger,
           debug: true,
           info: true,
           warn: true,
           error: true,
-          level: true)
+          level: true
+        )
       end
 
       it 'updates the #instance setting' do

--- a/spec/datadog/core/configuration_spec.rb
+++ b/spec/datadog/core/configuration_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe Datadog::Core::Configuration do
         before do
           allow(Datadog::Core::Configuration::Components).to receive(:new)
             .and_wrap_original do |m, *args|
-            new_components = m.call(*args)
-            allow(new_components).to receive(:shutdown!)
-            allow(new_components).to receive(:startup!)
-            new_components
-          end
+              new_components = m.call(*args)
+              allow(new_components).to receive(:shutdown!)
+              allow(new_components).to receive(:startup!)
+              new_components
+            end
         end
 
         context 'and components have been initialized' do

--- a/spec/datadog/core/error_spec.rb
+++ b/spec/datadog/core/error_spec.rb
@@ -99,14 +99,16 @@ RSpec.describe Datadog::Core::Error do
           root_caller = /from.*in `middle'/
 
           expect(error.backtrace)
-            .to match(/
-                       #{wrapper_error_message}.*
-                       #{wrapper_caller}.*
-                       #{middle_error_message}.*
-                       #{middle_caller}.*
-                       #{root_error_message}.*
-                       #{root_caller}.*
-                       /mx)
+            .to match(
+              /
+             #{wrapper_error_message}.*
+             #{wrapper_caller}.*
+             #{middle_error_message}.*
+             #{middle_caller}.*
+             #{root_error_message}.*
+             #{root_caller}.*
+             /mx
+            )
 
           # Expect 2 "first-class" exception lines: 'root cause' and 'wrapper layer'.
           expect(error.backtrace.each_line.reject { |l| l.start_with?("\tfrom") }).to have(3).items

--- a/spec/datadog/opentracer/propagator_spec.rb
+++ b/spec/datadog/opentracer/propagator_spec.rb
@@ -7,9 +7,12 @@ require 'datadog/opentracer'
 RSpec.describe Datadog::OpenTracer::Propagator do
   describe 'implemented class behavior' do
     subject(:propagator_class) do
-      stub_const('TestPropagator', Class.new.tap do |klass|
-        klass.extend(described_class)
-      end)
+      stub_const(
+        'TestPropagator',
+        Class.new.tap do |klass|
+          klass.extend(described_class)
+        end
+      )
     end
 
     describe '#inject' do

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -93,10 +93,12 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     context 'when sampling a top-level eval' do
       let(:do_in_background_thread) do
         proc do
-          eval(%(
+          eval(
+            %(
             ready_queue << true
             sleep
-          ))
+          )
+          )
         end
       end
 
@@ -382,7 +384,8 @@ class DeepStackSimulator
       next if respond_to?(:"deep_stack_#{depth}")
 
       # rubocop:disable Security/Eval
-      eval(%(
+      eval(
+        %(
         def deep_stack_#{depth}                               # def deep_stack_1
           if Thread.current.backtrace.size < @target_depth    #   if Thread.current.backtrace.size < @target_depth
             deep_stack_#{depth + 1}                           #     deep_stack_2
@@ -391,7 +394,11 @@ class DeepStackSimulator
             sleep                                             #     sleep
           end                                                 #   end
         end                                                   # end
-      ), binding, __FILE__, __LINE__ - 9)
+      ),
+        binding,
+        __FILE__,
+        __LINE__ - 12
+      )
       # rubocop:enable Security/Eval
     end
   end

--- a/spec/datadog/profiling/pprof/builder_spec.rb
+++ b/spec/datadog/profiling/pprof/builder_spec.rb
@@ -144,10 +144,14 @@ RSpec.describe Datadog::Profiling::Pprof::Builder do
         .and_return(function)
 
       expect(build_location).to be_a_kind_of(Perftools::Profiles::Location)
-      expect(build_location.to_h).to match(hash_including(id: location_id,
-        line: [{
-          function_id: function.id, line: line_number
-        }]))
+      expect(build_location.to_h).to match(
+        hash_including(
+          id: location_id,
+          line: [{
+            function_id: function.id, line: line_number
+          }]
+        )
+      )
     end
   end
 

--- a/spec/datadog/profiling/transport/http/api/endpoint_spec.rb
+++ b/spec/datadog/profiling/transport/http/api/endpoint_spec.rb
@@ -104,9 +104,11 @@ RSpec.describe Datadog::Profiling::Transport::HTTP::API::Endpoint do
         it 'reports the additional tags as part of the tags field' do
           call
 
-          expect(env.form).to include('tags' => array_including(
-            'test_tag_key:test_tag_value', 'another_tag_key:another_tag_value'
-          ))
+          expect(env.form).to include(
+            'tags' => array_including(
+              'test_tag_key:test_tag_value', 'another_tag_key:another_tag_value'
+            )
+          )
         end
       end
     end

--- a/spec/datadog/tracing/contrib/action_cable/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/action_cable/patcher_spec.rb
@@ -94,13 +94,16 @@ RSpec.describe 'ActionCable patcher' do
 
   context 'with channel' do
     let(:channel_class) do
-      stub_const('ChatChannel', Class.new(ActionCable::Channel::Base) do
-        def subscribed; end
+      stub_const(
+        'ChatChannel',
+        Class.new(ActionCable::Channel::Base) do
+          def subscribed; end
 
-        def unsubscribed; end
+          def unsubscribed; end
 
-        def foo(_data); end
-      end)
+          def foo(_data); end
+        end
+      )
     end
 
     let(:channel_instance) { channel_class.new(connection, '{id: 1}', id: 1) }
@@ -202,11 +205,14 @@ RSpec.describe 'ActionCable patcher' do
 
       let(:data) { { 'action' => 'foo', 'extra' => 'data' } }
       let(:channel_class) do
-        stub_const('ChatChannel', Class.new(ActionCable::Channel::Base) do
-          def foo(_data)
-            transmit({ mock: 'data' }, via: 'streamed from chat_channel')
+        stub_const(
+          'ChatChannel',
+          Class.new(ActionCable::Channel::Base) do
+            def foo(_data)
+              transmit({ mock: 'data' }, via: 'streamed from chat_channel')
+            end
           end
-        end)
+        )
       end
 
       let(:span) { spans.last } # Skip 'perform_action' span

--- a/spec/datadog/tracing/contrib/action_mailer/helpers.rb
+++ b/spec/datadog/tracing/contrib/action_mailer/helpers.rb
@@ -20,11 +20,13 @@ RSpec.shared_context 'ActionMailer helpers' do
         default from: 'test@example.com'
 
         def test_mail(_arg)
-          mail(to: 'test@example.com',
+          mail(
+            to: 'test@example.com',
             body: 'sk test',
             subject: 'miniswan',
             bcc: 'test_a@example.com,test_b@example.com',
-            cc: ['test_c@example.com', 'test_d@example.com'])
+            cc: ['test_c@example.com', 'test_d@example.com']
+          )
         end
       end
     )

--- a/spec/datadog/tracing/contrib/active_model_serializers/helpers.rb
+++ b/spec/datadog/tracing/contrib/active_model_serializers/helpers.rb
@@ -19,43 +19,58 @@ RSpec.shared_context 'AMS serializer' do
 
   if ActiveModelSerializersHelpers.ams_0_10_or_newer?
     before do
-      stub_const('Model', Class.new(ActiveModelSerializers::Model) do
-        attr_writer :id
-      end)
+      stub_const(
+        'Model',
+        Class.new(ActiveModelSerializers::Model) do
+          attr_writer :id
+        end
+      )
 
-      stub_const('TestModel', Class.new(Model) do
-        attributes :name
-      end)
+      stub_const(
+        'TestModel',
+        Class.new(Model) do
+          attributes :name
+        end
+      )
 
-      stub_const('TestModelSerializer', Class.new(ActiveModel::Serializer) do
-        attributes :name
-      end)
+      stub_const(
+        'TestModelSerializer',
+        Class.new(ActiveModel::Serializer) do
+          attributes :name
+        end
+      )
     end
   else
     before do
-      stub_const('Model', Class.new do
-        attr_writer :id
+      stub_const(
+        'Model',
+        Class.new do
+          attr_writer :id
 
-        def initialize(hash = {})
-          @attributes = hash
-        end
+          def initialize(hash = {})
+            @attributes = hash
+          end
 
-        def read_attribute_for_serialization(name)
-          if [:id, 'id'].include?(name)
-            object_id
-          elsif respond_to?(name)
-            send name
-          else
-            @attributes[name]
+          def read_attribute_for_serialization(name)
+            if [:id, 'id'].include?(name)
+              object_id
+            elsif respond_to?(name)
+              send name
+            else
+              @attributes[name]
+            end
           end
         end
-      end)
+      )
 
       stub_const('TestModel', Class.new(Model))
 
-      stub_const('TestModelSerializer', Class.new(ActiveModel::Serializer) do
-        attributes :name
-      end)
+      stub_const(
+        'TestModelSerializer',
+        Class.new(ActiveModel::Serializer) do
+          attributes :name
+        end
+      )
     end
   end
 end

--- a/spec/datadog/tracing/contrib/active_record/configuration/resolver_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/configuration/resolver_spec.rb
@@ -31,11 +31,13 @@ RSpec.describe Datadog::Tracing::Contrib::ActiveRecord::Configuration::Resolver 
         add
 
         expect(resolver.configurations)
-          .to eq({
-            adapter: 'adapter',
-            host: 'host',
-            port: 123
-          } => config)
+          .to eq(
+            {
+              adapter: 'adapter',
+              host: 'host',
+              port: 123
+            } => config
+          )
       end
     end
 
@@ -119,8 +121,9 @@ RSpec.describe Datadog::Tracing::Contrib::ActiveRecord::Configuration::Resolver 
 
         unless matcher == match_all
           expect(resolver.resolve({ host: Object.new }))
-            .to be_nil, "Expected pattern to match only the input, but it's matching everything. "\
-                        'Unless you explicitly wanted to match all patterns, this is unlikely to be desired.'
+            .to be_nil,
+              "Expected pattern to match only the input, but it's matching everything. "\
+                                      'Unless you explicitly wanted to match all patterns, this is unlikely to be desired.'
         end
       end
     end

--- a/spec/datadog/tracing/contrib/active_record/multi_db_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/multi_db_spec.rb
@@ -18,9 +18,12 @@ end
 RSpec.describe 'ActiveRecord multi-database implementation' do
   let(:configuration_options) { { service_name: default_db_service_name } }
   let(:application_record) do
-    stub_const('ApplicationRecord', Class.new(ActiveRecord::Base) do
-      self.abstract_class = true
-    end)
+    stub_const(
+      'ApplicationRecord',
+      Class.new(ActiveRecord::Base) do
+        self.abstract_class = true
+      end
+    )
   end
   let!(:gadget_class) do
     stub_const('Gadget', Class.new(application_record)).tap do |klass|

--- a/spec/datadog/tracing/contrib/active_record/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/tracer_spec.rb
@@ -104,9 +104,11 @@ RSpec.describe 'ActiveRecord instrumentation' do
 
             Datadog.configure do |c|
               c.tracing.instrument :active_record, service_name: 'bad-no-match'
-              c.tracing.instrument :active_record, describes: { makara_role: primary_role },
+              c.tracing.instrument :active_record,
+                describes: { makara_role: primary_role },
                 service_name: primary_service_name
-              c.tracing.instrument :active_record, describes: { makara_role: secondary_role },
+              c.tracing.instrument :active_record,
+                describes: { makara_role: secondary_role },
                 service_name: secondary_service_name
             end
           end

--- a/spec/datadog/tracing/contrib/delayed_job/plugin_spec.rb
+++ b/spec/datadog/tracing/contrib/delayed_job/plugin_spec.rb
@@ -12,20 +12,26 @@ require_relative 'delayed_job_active_record'
 
 RSpec.describe Datadog::Tracing::Contrib::DelayedJob::Plugin, :delayed_job_active_record do
   let(:sample_job_object) do
-    stub_const('SampleJob', Class.new do
-      def perform; end
-    end)
+    stub_const(
+      'SampleJob',
+      Class.new do
+        def perform; end
+      end
+    )
   end
   let(:active_job_sample_job_object) do
-    stub_const('ActiveJobSampleJob', Class.new do
-      def perform; end
+    stub_const(
+      'ActiveJobSampleJob',
+      Class.new do
+        def perform; end
 
-      def job_data
-        {
-          'job_class' => 'UnderlyingJobClass'
-        }
+        def job_data
+          {
+            'job_class' => 'UnderlyingJobClass'
+          }
+        end
       end
-    end)
+    )
   end
 
   let(:configuration_options) { {} }
@@ -89,11 +95,14 @@ RSpec.describe Datadog::Tracing::Contrib::DelayedJob::Plugin, :delayed_job_activ
       let(:error_handler) { proc { @error_handler_called = true } }
 
       let(:sample_job_object) do
-        stub_const('SampleJob', Class.new do
-          def perform
-            raise ZeroDivisionError, 'job error'
+        stub_const(
+          'SampleJob',
+          Class.new do
+            def perform
+              raise ZeroDivisionError, 'job error'
+            end
           end
-        end)
+        )
       end
 
       it 'uses custom error handler' do

--- a/spec/datadog/tracing/contrib/elasticsearch/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/elasticsearch/integration_spec.rb
@@ -58,13 +58,15 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Integration do
 
     context 'when "elastic-transport" gem is loaded with a version' do
       context 'that is less than the minimum' do
-        include_context 'loaded gems', :'elastic-transport' => decrement_gem_version(described_class::MINIMUM_VERSION),
+        include_context 'loaded gems',
+          :'elastic-transport' => decrement_gem_version(described_class::MINIMUM_VERSION),
           :'elasticsearch-transport' => nil
         it { is_expected.to be false }
       end
 
       context 'that meets the minimum version' do
-        include_context 'loaded gems', :'elastic-transport' => described_class::MINIMUM_VERSION,
+        include_context 'loaded gems',
+          :'elastic-transport' => described_class::MINIMUM_VERSION,
           :'elasticsearch-transport' => nil
         it { is_expected.to be true }
       end

--- a/spec/datadog/tracing/contrib/elasticsearch/transport_spec.rb
+++ b/spec/datadog/tracing/contrib/elasticsearch/transport_spec.rb
@@ -56,11 +56,14 @@ RSpec.describe 'Elasticsearch::Transport::Client tracing' do
     end
 
     let(:middleware) do
-      stub_const('MyFaradayMiddleware', Class.new(Faraday::Middleware) do
-        def call(env)
-          @app.call(env)
+      stub_const(
+        'MyFaradayMiddleware',
+        Class.new(Faraday::Middleware) do
+          def call(env)
+            @app.call(env)
+          end
         end
-      end)
+      )
     end
 
     describe 'the handlers' do

--- a/spec/datadog/tracing/contrib/extensions_spec.rb
+++ b/spec/datadog/tracing/contrib/extensions_spec.rb
@@ -17,9 +17,12 @@ RSpec.describe Datadog::Tracing::Contrib::Extensions do
     end
 
     let(:configurable_module) do
-      stub_const('Configurable', Module.new do
-        include Datadog::Tracing::Contrib::Configurable
-      end)
+      stub_const(
+        'Configurable',
+        Module.new do
+          include Datadog::Tracing::Contrib::Configurable
+        end
+      )
     end
 
     before { registry.add(integration_name, integration) }
@@ -154,13 +157,16 @@ RSpec.describe Datadog::Tracing::Contrib::Extensions do
               end
 
               let(:patcher_module) do
-                stub_const('Patcher', Module.new do
-                  include Datadog::Tracing::Contrib::Patcher
+                stub_const(
+                  'Patcher',
+                  Module.new do
+                    include Datadog::Tracing::Contrib::Patcher
 
-                  def self.patch
-                    true
+                    def self.patch
+                      true
+                    end
                   end
-                end)
+                )
               end
             end
 

--- a/spec/datadog/tracing/contrib/graphql/test_types.rb
+++ b/spec/datadog/tracing/contrib/graphql/test_types.rb
@@ -34,26 +34,32 @@ RSpec.shared_context 'GraphQL class-based schema' do
     ot = object_type
     oc = object_class
 
-    stub_const(qtn, Class.new(::GraphQL::Schema::Object) do
-      field ot.graphql_name.downcase, ot, null: false, description: 'Find an object by ID' do
-        argument :id, ::GraphQL::Types::ID, required: true
-      end
+    stub_const(
+      qtn,
+      Class.new(::GraphQL::Schema::Object) do
+        field ot.graphql_name.downcase, ot, null: false, description: 'Find an object by ID' do
+          argument :id, ::GraphQL::Types::ID, required: true
+        end
 
-      define_method ot.graphql_name.downcase do |args|
-        oc.new(args[:id])
+        define_method ot.graphql_name.downcase do |args|
+          oc.new(args[:id])
+        end
       end
-    end)
+    )
   end
 
   let(:object_type) do
     otn = object_type_name
 
-    stub_const(otn, Class.new(::GraphQL::Schema::Object) do
-      field :id, ::GraphQL::Types::ID, null: false
-      field :name, ::GraphQL::Types::String, null: true
-      field :created_at, ::GraphQL::Types::String, null: false
-      field :updated_at, ::GraphQL::Types::String, null: false
-    end)
+    stub_const(
+      otn,
+      Class.new(::GraphQL::Schema::Object) do
+        field :id, ::GraphQL::Types::ID, null: false
+        field :name, ::GraphQL::Types::String, null: true
+        field :created_at, ::GraphQL::Types::String, null: false
+        field :updated_at, ::GraphQL::Types::String, null: false
+      end
+    )
   end
 end
 

--- a/spec/datadog/tracing/contrib/http/request_spec.rb
+++ b/spec/datadog/tracing/contrib/http/request_spec.rb
@@ -274,15 +274,17 @@ RSpec.describe 'net/http requests' do
 
     def expect_request_without_distributed_headers
       # rubocop:disable Style/BlockDelimiters
-      expect(WebMock).to(have_requested(:get, "#{uri}#{path}").with { |req|
-        [
-          Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID,
-          Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID,
-          Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_SAMPLING_PRIORITY
-        ].none? do |header|
-          req.headers.key?(header.split('-').map(&:capitalize).join('-'))
-        end
-      })
+      expect(WebMock).to(
+        have_requested(:get, "#{uri}#{path}").with { |req|
+          [
+            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID,
+            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID,
+            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_SAMPLING_PRIORITY
+          ].none? do |header|
+            req.headers.key?(header.split('-').map(&:capitalize).join('-'))
+          end
+        }
+      )
     end
 
     context 'by default' do
@@ -309,11 +311,13 @@ RSpec.describe 'net/http requests' do
           # The block syntax only works with Ruby < 2.3 and the hash syntax
           # only works with Ruby >= 2.3, so we need to support both.
           if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
-            expect(WebMock).to(have_requested(:get, "#{uri}#{path}").with { |req|
-              distributed_tracing_headers.all? do |(header, value)|
-                req.headers[header.split('-').map(&:capitalize).join('-')] == value.to_s
-              end
-            })
+            expect(WebMock).to(
+              have_requested(:get, "#{uri}#{path}").with { |req|
+                distributed_tracing_headers.all? do |(header, value)|
+                  req.headers[header.split('-').map(&:capitalize).join('-')] == value.to_s
+                end
+              }
+            )
           else
             expect(WebMock).to have_requested(:get, "#{uri}#{path}").with(headers: distributed_tracing_headers)
           end
@@ -353,11 +357,13 @@ RSpec.describe 'net/http requests' do
           # The block syntax only works with Ruby < 2.3 and the hash syntax
           # only works with Ruby >= 2.3, so we need to support both.
           if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
-            expect(WebMock).to(have_requested(:get, "#{uri}#{path}").with { |req|
-              distributed_tracing_headers.all? do |(header, value)|
-                req.headers[header.split('-').map(&:capitalize).join('-')] == value.to_s
-              end
-            })
+            expect(WebMock).to(
+              have_requested(:get, "#{uri}#{path}").with { |req|
+                distributed_tracing_headers.all? do |(header, value)|
+                  req.headers[header.split('-').map(&:capitalize).join('-')] == value.to_s
+                end
+              }
+            )
           else
             expect(WebMock).to have_requested(:get, "#{uri}#{path}").with(headers: distributed_tracing_headers)
           end

--- a/spec/datadog/tracing/contrib/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/patcher_spec.rb
@@ -24,9 +24,12 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
 
         context 'when patcher does not define .patch' do
           let(:patcher) do
-            stub_const('TestPatcher', Class.new do
-              include Datadog::Tracing::Contrib::Patcher
-            end)
+            stub_const(
+              'TestPatcher',
+              Class.new do
+                include Datadog::Tracing::Contrib::Patcher
+              end
+            )
           end
 
           it { expect(patch).to be nil }
@@ -35,13 +38,16 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
         context 'when patcher defines .patch' do
           context 'and .target_version is not defined' do
             let(:patcher) do
-              stub_const('TestPatcher', Class.new do
-                include Datadog::Tracing::Contrib::Patcher
+              stub_const(
+                'TestPatcher',
+                Class.new do
+                  include Datadog::Tracing::Contrib::Patcher
 
-                def self.patch
-                  :patched
+                  def self.patch
+                    :patched
+                  end
                 end
-              end)
+              )
             end
 
             it do
@@ -53,17 +59,20 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
 
           context 'and .target_version is defined' do
             let(:patcher) do
-              stub_const('TestPatcher', Class.new do
-                include Datadog::Tracing::Contrib::Patcher
+              stub_const(
+                'TestPatcher',
+                Class.new do
+                  include Datadog::Tracing::Contrib::Patcher
 
-                def self.patch
-                  :patched
-                end
+                  def self.patch
+                    :patched
+                  end
 
-                def self.target_version
-                  Gem::Version.new(1.0)
+                  def self.target_version
+                    Gem::Version.new(1.0)
+                  end
                 end
-              end)
+              )
             end
 
             it do
@@ -81,13 +90,16 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
 
           context 'and .target_version is not defined' do
             let(:patcher) do
-              stub_const('TestPatcher', Class.new do
-                include Datadog::Tracing::Contrib::Patcher
+              stub_const(
+                'TestPatcher',
+                Class.new do
+                  include Datadog::Tracing::Contrib::Patcher
 
-                def self.patch
-                  raise StandardError, 'Patch error!'
+                  def self.patch
+                    raise StandardError, 'Patch error!'
+                  end
                 end
-              end)
+              )
             end
 
             it 'handles the error' do
@@ -101,17 +113,20 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
 
           context 'and .target_version is defined' do
             let(:patcher) do
-              stub_const('TestPatcher', Class.new do
-                include Datadog::Tracing::Contrib::Patcher
+              stub_const(
+                'TestPatcher',
+                Class.new do
+                  include Datadog::Tracing::Contrib::Patcher
 
-                def self.patch
-                  raise StandardError, 'Patch error!'
-                end
+                  def self.patch
+                    raise StandardError, 'Patch error!'
+                  end
 
-                def self.target_version
-                  Gem::Version.new(1.0)
+                  def self.target_version
+                    Gem::Version.new(1.0)
+                  end
                 end
-              end)
+              )
             end
 
             it 'handles the error' do
@@ -130,9 +145,12 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
 
         context 'when patcher does not define .patch' do
           let(:patcher) do
-            stub_const('TestPatcher', Class.new do
-              include Datadog::Tracing::Contrib::Patcher
-            end)
+            stub_const(
+              'TestPatcher',
+              Class.new do
+                include Datadog::Tracing::Contrib::Patcher
+              end
+            )
           end
 
           context 'and patch has not been applied' do
@@ -148,13 +166,16 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
 
         context 'when patcher defines .patch' do
           let(:patcher) do
-            stub_const('TestPatcher', Class.new do
-              include Datadog::Tracing::Contrib::Patcher
+            stub_const(
+              'TestPatcher',
+              Class.new do
+                include Datadog::Tracing::Contrib::Patcher
 
-              def self.patch
-                :patched
+                def self.patch
+                  :patched
+                end
               end
-            end)
+            )
           end
 
           context 'and patch has not been applied' do
@@ -196,13 +217,16 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
 
         context 'and .target_version is defined' do
           let(:patcher) do
-            stub_const('TestPatcher', Class.new do
-              include Datadog::Tracing::Contrib::Patcher
+            stub_const(
+              'TestPatcher',
+              Class.new do
+                include Datadog::Tracing::Contrib::Patcher
 
-              def self.target_version
-                Gem::Version.new(1.0)
+                def self.target_version
+                  Gem::Version.new(1.0)
+                end
               end
-            end)
+            )
           end
 
           it 'handles the error' do
@@ -220,9 +244,12 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
       subject(:patcher) { patcher_class.new }
 
       let(:patcher_class) do
-        stub_const('TestPatcher', Class.new do
-          include Datadog::Tracing::Contrib::Patcher
-        end)
+        stub_const(
+          'TestPatcher',
+          Class.new do
+            include Datadog::Tracing::Contrib::Patcher
+          end
+        )
       end
 
       describe '#patch' do
@@ -234,13 +261,16 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
 
         context 'when patcher defines #patch' do
           let(:patcher_class) do
-            stub_const('TestPatcher', Class.new do
-              include Datadog::Tracing::Contrib::Patcher
+            stub_const(
+              'TestPatcher',
+              Class.new do
+                include Datadog::Tracing::Contrib::Patcher
 
-              def patch
-                :patched
+                def patch
+                  :patched
+                end
               end
-            end)
+            )
           end
 
           it { expect(patch).to be :patched }
@@ -274,13 +304,16 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
 
         context 'and .target_version is defined' do
           let(:patcher_class) do
-            stub_const('TestPatcher', Class.new do
-              include Datadog::Tracing::Contrib::Patcher
+            stub_const(
+              'TestPatcher',
+              Class.new do
+                include Datadog::Tracing::Contrib::Patcher
 
-              def target_version
-                Gem::Version.new(1.0)
+                def target_version
+                  Gem::Version.new(1.0)
+                end
               end
-            end)
+            )
           end
 
           it 'handles the error' do
@@ -304,9 +337,12 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
 
         context 'when patcher does not define .patch' do
           let(:patcher) do
-            stub_const('TestPatcher', Module.new do
-              include Datadog::Tracing::Contrib::Patcher
-            end)
+            stub_const(
+              'TestPatcher',
+              Module.new do
+                include Datadog::Tracing::Contrib::Patcher
+              end
+            )
           end
 
           it { expect(patch).to be nil }
@@ -315,13 +351,16 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
         context 'when patcher defines .patch' do
           context 'and .target_version is not defined' do
             let(:patcher) do
-              stub_const('TestPatcher', Module.new do
-                include Datadog::Tracing::Contrib::Patcher
+              stub_const(
+                'TestPatcher',
+                Module.new do
+                  include Datadog::Tracing::Contrib::Patcher
 
-                def self.patch
-                  :patched
+                  def self.patch
+                    :patched
+                  end
                 end
-              end)
+              )
             end
 
             it do
@@ -333,17 +372,20 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
 
           context 'and .target_version is defined' do
             let(:patcher) do
-              stub_const('TestPatcher', Module.new do
-                include Datadog::Tracing::Contrib::Patcher
+              stub_const(
+                'TestPatcher',
+                Module.new do
+                  include Datadog::Tracing::Contrib::Patcher
 
-                def self.patch
-                  :patched
-                end
+                  def self.patch
+                    :patched
+                  end
 
-                def self.target_version
-                  Gem::Version.new(1.0)
+                  def self.target_version
+                    Gem::Version.new(1.0)
+                  end
                 end
-              end)
+              )
             end
 
             it do
@@ -361,13 +403,16 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
 
           context 'and .target_version is not defined' do
             let(:patcher) do
-              stub_const('TestPatcher', Module.new do
-                include Datadog::Tracing::Contrib::Patcher
+              stub_const(
+                'TestPatcher',
+                Module.new do
+                  include Datadog::Tracing::Contrib::Patcher
 
-                def self.patch
-                  raise StandardError, 'Patch error!'
+                  def self.patch
+                    raise StandardError, 'Patch error!'
+                  end
                 end
-              end)
+              )
             end
 
             it 'handles the error' do
@@ -381,17 +426,20 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
 
           context 'and .target_version is defined' do
             let(:patcher) do
-              stub_const('TestPatcher', Module.new do
-                include Datadog::Tracing::Contrib::Patcher
+              stub_const(
+                'TestPatcher',
+                Module.new do
+                  include Datadog::Tracing::Contrib::Patcher
 
-                def self.patch
-                  raise StandardError, 'Patch error!'
-                end
+                  def self.patch
+                    raise StandardError, 'Patch error!'
+                  end
 
-                def self.target_version
-                  Gem::Version.new(1.0)
+                  def self.target_version
+                    Gem::Version.new(1.0)
+                  end
                 end
-              end)
+              )
             end
 
             it 'handles the error' do
@@ -410,9 +458,12 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
 
         context 'when patcher does not define .patch' do
           let(:patcher) do
-            stub_const('TestPatcher', Module.new do
-              include Datadog::Tracing::Contrib::Patcher
-            end)
+            stub_const(
+              'TestPatcher',
+              Module.new do
+                include Datadog::Tracing::Contrib::Patcher
+              end
+            )
           end
 
           context 'and patch has not been applied' do
@@ -428,13 +479,16 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
 
         context 'when patcher defines .patch' do
           let(:patcher) do
-            stub_const('TestPatcher', Module.new do
-              include Datadog::Tracing::Contrib::Patcher
+            stub_const(
+              'TestPatcher',
+              Module.new do
+                include Datadog::Tracing::Contrib::Patcher
 
-              def self.patch
-                :patched
+                def self.patch
+                  :patched
+                end
               end
-            end)
+            )
           end
 
           context 'and patch has not been applied' do
@@ -476,13 +530,16 @@ RSpec.describe Datadog::Tracing::Contrib::Patcher do
 
         context 'and .target_version is defined' do
           let(:patcher) do
-            stub_const('TestPatcher', Module.new do
-              include Datadog::Tracing::Contrib::Patcher
+            stub_const(
+              'TestPatcher',
+              Module.new do
+                include Datadog::Tracing::Contrib::Patcher
 
-              def self.target_version
-                Gem::Version.new(1.0)
+                def self.target_version
+                  Gem::Version.new(1.0)
+                end
               end
-            end)
+            )
           end
 
           it 'handles the error' do

--- a/spec/datadog/tracing/contrib/que/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/que/tracer_spec.rb
@@ -15,16 +15,22 @@ RSpec.describe Datadog::Tracing::Contrib::Que::Tracer do
     }
   end
   let(:job_class) do
-    stub_const('TestJobClass', Class.new(::Que::Job) do
-      def run(*args); end
-    end)
+    stub_const(
+      'TestJobClass',
+      Class.new(::Que::Job) do
+        def run(*args); end
+      end
+    )
   end
   let(:error_job_class) do
-    stub_const('ErrorJobClass', Class.new(::Que::Job) do
-      def run(*_args)
-        raise StandardError, 'with some error'
+    stub_const(
+      'ErrorJobClass',
+      Class.new(::Que::Job) do
+        def run(*_args)
+          raise StandardError, 'with some error'
+        end
       end
-    end)
+    )
   end
 
   before do

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -354,17 +354,19 @@ RSpec.describe 'Rack integration tests' do
         let(:routes) do
           proc do
             map '/app/' do
-              run(proc do |env|
-                # This should be considered a web framework that can alter
-                # the request span after routing / controller processing
-                request_span = env[Datadog::Tracing::Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
-                request_span.resource = 'GET /app/'
-                request_span.set_tag('http.method', 'GET_V2')
-                request_span.set_tag('http.status_code', 201)
-                request_span.set_tag('http.url', '/app/static/')
+              run(
+                proc do |env|
+                  # This should be considered a web framework that can alter
+                  # the request span after routing / controller processing
+                  request_span = env[Datadog::Tracing::Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
+                  request_span.resource = 'GET /app/'
+                  request_span.set_tag('http.method', 'GET_V2')
+                  request_span.set_tag('http.status_code', 201)
+                  request_span.set_tag('http.url', '/app/static/')
 
-                [200, { 'Content-Type' => 'text/html' }, ['OK']]
-              end)
+                  [200, { 'Content-Type' => 'text/html' }, ['OK']]
+                end
+              )
             end
           end
         end
@@ -410,15 +412,17 @@ RSpec.describe 'Rack integration tests' do
           let(:routes) do
             proc do
               map '/app/500/' do
-                run(proc do |env|
-                  # this should be considered a web framework that can alter
-                  # the request span after routing / controller processing
-                  request_span = env[Datadog::Tracing::Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
-                  request_span.status = 1
-                  request_span.set_tag('error.stack', 'Handled exception')
+                run(
+                  proc do |env|
+                    # this should be considered a web framework that can alter
+                    # the request span after routing / controller processing
+                    request_span = env[Datadog::Tracing::Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
+                    request_span.status = 1
+                    request_span.set_tag('error.stack', 'Handled exception')
 
-                  [500, { 'Content-Type' => 'text/html' }, ['OK']]
-                end)
+                    [500, { 'Content-Type' => 'text/html' }, ['OK']]
+                  end
+                )
               end
             end
           end
@@ -450,14 +454,16 @@ RSpec.describe 'Rack integration tests' do
           let(:routes) do
             proc do
               map '/app/500/' do
-                run(proc do |env|
-                  # this should be considered a web framework that can alter
-                  # the request span after routing / controller processing
-                  request_span = env[Datadog::Tracing::Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
-                  request_span.set_tag('error.stack', 'Handled exception')
+                run(
+                  proc do |env|
+                    # this should be considered a web framework that can alter
+                    # the request span after routing / controller processing
+                    request_span = env[Datadog::Tracing::Contrib::Rack::Ext::RACK_ENV_REQUEST_SPAN]
+                    request_span.set_tag('error.stack', 'Handled exception')
 
-                  [500, { 'Content-Type' => 'text/html' }, ['OK']]
-                end)
+                    [500, { 'Content-Type' => 'text/html' }, ['OK']]
+                  end
+                )
               end
             end
           end
@@ -530,18 +536,20 @@ RSpec.describe 'Rack integration tests' do
       let(:routes) do
         proc do
           map '/headers/' do
-            run(proc do |_env|
-              response_headers = {
-                'Content-Type' => 'text/html',
-                'Cache-Control' => 'max-age=3600',
-                'ETag' => '"737060cd8c284d8af7ad3082f209582d"',
-                'Expires' => 'Thu, 01 Dec 1994 16:00:00 GMT',
-                'Last-Modified' => 'Tue, 15 Nov 1994 12:45:26 GMT',
-                'X-Request-ID' => 'f058ebd6-02f7-4d3f-942e-904344e8cde5',
-                'X-Fake-Response' => 'Don\'t tag me.'
-              }
-              [200, response_headers, ['OK']]
-            end)
+            run(
+              proc do |_env|
+                response_headers = {
+                  'Content-Type' => 'text/html',
+                  'Cache-Control' => 'max-age=3600',
+                  'ETag' => '"737060cd8c284d8af7ad3082f209582d"',
+                  'Expires' => 'Thu, 01 Dec 1994 16:00:00 GMT',
+                  'Last-Modified' => 'Tue, 15 Nov 1994 12:45:26 GMT',
+                  'X-Request-ID' => 'f058ebd6-02f7-4d3f-942e-904344e8cde5',
+                  'X-Fake-Response' => 'Don\'t tag me.'
+                }
+                [200, response_headers, ['OK']]
+              end
+            )
           end
         end
       end
@@ -549,22 +557,23 @@ RSpec.describe 'Rack integration tests' do
       context 'when configured to tag headers' do
         before do
           Datadog.configure do |c|
-            c.tracing.instrument :rack, headers: {
-              request: [
-                'Cache-Control'
-              ],
-              response: [
-                'Content-Type',
-                'Cache-Control',
-                'Content-Type',
-                'ETag',
-                'Expires',
-                'Last-Modified',
-                # This lowercase 'Id' header doesn't match.
-                # Ensure middleware allows for case-insensitive matching.
-                'X-Request-Id'
-              ]
-            }
+            c.tracing.instrument :rack,
+              headers: {
+                request: [
+                  'Cache-Control'
+                ],
+                response: [
+                  'Content-Type',
+                  'Cache-Control',
+                  'Content-Type',
+                  'ETag',
+                  'Expires',
+                  'Last-Modified',
+                  # This lowercase 'Id' header doesn't match.
+                  # Ensure middleware allows for case-insensitive matching.
+                  'X-Request-Id'
+                ]
+              }
           end
         end
 

--- a/spec/datadog/tracing/contrib/rack/resource_name_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/resource_name_spec.rb
@@ -45,25 +45,31 @@ RSpec.describe 'Rack integration with other middleware' do
     end
 
     let(:auth_middleware) do
-      stub_const('AuthMiddleware', Class.new do
-        def initialize(app)
-          @app = app
-        end
+      stub_const(
+        'AuthMiddleware',
+        Class.new do
+          def initialize(app)
+            @app = app
+          end
 
-        def call(env)
-          return [401, {}, []] if env['HTTP_AUTH_TOKEN'] != '1234'
+          def call(env)
+            return [401, {}, []] if env['HTTP_AUTH_TOKEN'] != '1234'
 
-          @app.call(env)
+            @app.call(env)
+          end
         end
-      end)
+      )
     end
 
     let(:bottom_middleware) do
-      stub_const('BottomMiddleware', Class.new do
-        def call(_)
-          [200, {}, []]
+      stub_const(
+        'BottomMiddleware',
+        Class.new do
+          def call(_)
+            [200, {}, []]
+          end
         end
-      end)
+      )
     end
   end
 

--- a/spec/datadog/tracing/contrib/rails/action_controller_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/action_controller_spec.rb
@@ -5,11 +5,14 @@ require 'datadog/tracing/contrib/rails/rails_helper'
 RSpec.describe 'Rails ActionController' do
   let(:rails_options) { {} }
   let(:controller) do
-    stub_const('TestController', Class.new(base_class) do
-      def index
-        # Do nothing
+    stub_const(
+      'TestController',
+      Class.new(base_class) do
+        def index
+          # Do nothing
+        end
       end
-    end)
+    )
   end
   let(:name) { :index }
   let(:base_class) { ActionController::Base }
@@ -110,11 +113,14 @@ RSpec.describe 'Rails ActionController' do
           let(:observed) { {} }
           let(:controller) do
             observed = self.observed
-            stub_const('TestController', Class.new(base_class) do
-              define_method(:index) do
-                observed[:active_span_resource] = Datadog::Tracing.active_span.resource
+            stub_const(
+              'TestController',
+              Class.new(base_class) do
+                define_method(:index) do
+                  observed[:active_span_resource] = Datadog::Tracing.active_span.resource
+                end
               end
-            end)
+            )
           end
 
           it 'sets the span resource before calling the controller' do

--- a/spec/datadog/tracing/contrib/rails/analytics_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/analytics_spec.rb
@@ -30,11 +30,14 @@ RSpec.describe 'Rails trace analytics' do
     subject(:result) { action.call(env) }
 
     let(:controller) do
-      stub_const('TestController', Class.new(base_class) do
-        def index
-          # Do nothing
+      stub_const(
+        'TestController',
+        Class.new(base_class) do
+          def index
+            # Do nothing
+          end
         end
-      end)
+      )
     end
     let(:name) { :index }
     let(:base_class) { ActionController::Metal }

--- a/spec/datadog/tracing/contrib/rails/disable_env_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/disable_env_spec.rb
@@ -30,11 +30,14 @@ MESSAGE
   let(:controllers) { [controller] }
 
   let(:controller) do
-    stub_const('TestController', Class.new(ActionController::Base) do
-      def index
-        head :ok
+    stub_const(
+      'TestController',
+      Class.new(ActionController::Base) do
+        def index
+          head :ok
+        end
       end
-    end)
+    )
   end
 
   it 'does not instrument' do

--- a/spec/datadog/tracing/contrib/rails/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/middleware_spec.rb
@@ -12,11 +12,14 @@ RSpec.describe 'Rails middleware' do
   let(:controllers) { [controller] }
 
   let(:controller) do
-    stub_const('TestController', Class.new(ActionController::Base) do
-      def index
-        head :ok
+    stub_const(
+      'TestController',
+      Class.new(ActionController::Base) do
+        def index
+          head :ok
+        end
       end
-    end)
+    )
   end
 
   RSpec::Matchers.define :have_kind_of_middleware do |expected|
@@ -40,15 +43,18 @@ RSpec.describe 'Rails middleware' do
   context 'with middleware' do
     context 'that does nothing' do
       let(:middleware) do
-        stub_const('PassthroughMiddleware', Class.new do
-          def initialize(app)
-            @app = app
-          end
+        stub_const(
+          'PassthroughMiddleware',
+          Class.new do
+            def initialize(app)
+              @app = app
+            end
 
-          def call(env)
-            @app.call(env)
+            def call(env)
+              @app.call(env)
+            end
           end
-        end)
+        )
       end
 
       context 'and added after tracing is enabled' do
@@ -72,17 +78,20 @@ RSpec.describe 'Rails middleware' do
 
     context 'that itself creates a span' do
       let(:middleware) do
-        stub_const('CustomSpanMiddleware', Class.new do
-          def initialize(app)
-            @app = app
-          end
+        stub_const(
+          'CustomSpanMiddleware',
+          Class.new do
+            def initialize(app)
+              @app = app
+            end
 
-          def call(env)
-            Datadog::Tracing.trace('custom.test') do
-              @app.call(env)
+            def call(env)
+              Datadog::Tracing.trace('custom.test') do
+                @app.call(env)
+              end
             end
           end
-        end)
+        )
       end
 
       context 'and added after tracing is enabled' do
@@ -115,16 +124,19 @@ RSpec.describe 'Rails middleware' do
 
       let(:rails_middleware) { [middleware] }
       let(:middleware) do
-        stub_const('RaiseExceptionMiddleware', Class.new do
-          def initialize(app)
-            @app = app
-          end
+        stub_const(
+          'RaiseExceptionMiddleware',
+          Class.new do
+            def initialize(app)
+              @app = app
+            end
 
-          def call(env)
-            @app.call(env)
-            raise NotImplementedError
+            def call(env)
+              @app.call(env)
+              raise NotImplementedError
+            end
           end
-        end)
+        )
       end
 
       it do
@@ -158,16 +170,19 @@ RSpec.describe 'Rails middleware' do
 
       let(:rails_middleware) { [middleware] }
       let(:middleware) do
-        stub_const('RaiseNotFoundMiddleware', Class.new do
-          def initialize(app)
-            @app = app
-          end
+        stub_const(
+          'RaiseNotFoundMiddleware',
+          Class.new do
+            def initialize(app)
+              @app = app
+            end
 
-          def call(env)
-            @app.call(env)
-            raise ActionController::RoutingError, '/missing_route'
+            def call(env)
+              @app.call(env)
+              raise ActionController::RoutingError, '/missing_route'
+            end
           end
-        end)
+        )
       end
 
       it do
@@ -202,27 +217,33 @@ RSpec.describe 'Rails middleware' do
 
       let(:rails_middleware) { [middleware] }
       let(:error_class) do
-        stub_const('CustomError', Class.new(StandardError) do
-          def message
-            'Custom error message!'
+        stub_const(
+          'CustomError',
+          Class.new(StandardError) do
+            def message
+              'Custom error message!'
+            end
           end
-        end)
+        )
       end
 
       let(:middleware) do
         # Run this to define the error class
         error_class
 
-        stub_const('RaiseCustomErrorMiddleware', Class.new do
-          def initialize(app)
-            @app = app
-          end
+        stub_const(
+          'RaiseCustomErrorMiddleware',
+          Class.new do
+            def initialize(app)
+              @app = app
+            end
 
-          def call(env)
-            @app.call(env)
-            raise CustomError
+            def call(env)
+              @app.call(env)
+              raise CustomError
+            end
           end
-        end)
+        )
       end
 
       it do

--- a/spec/datadog/tracing/contrib/rails/rails_active_job_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/rails_active_job_spec.rb
@@ -30,14 +30,17 @@ RSpec.describe 'ActiveJob' do
       stub_const('JobDiscardError', Class.new(StandardError))
       stub_const('JobRetryError', Class.new(StandardError))
 
-      stub_const('ExampleJob', Class.new(ActiveJob::Base) do
-        def perform(test_retry: false, test_discard: false)
-          ActiveJob::Base.logger.info 'MINASWAN'
-          JOB_EXECUTIONS.increment
-          raise JobRetryError if test_retry
-          raise JobDiscardError if test_discard
+      stub_const(
+        'ExampleJob',
+        Class.new(ActiveJob::Base) do
+          def perform(test_retry: false, test_discard: false)
+            ActiveJob::Base.logger.info 'MINASWAN'
+            JOB_EXECUTIONS.increment
+            raise JobRetryError if test_retry
+            raise JobDiscardError if test_discard
+          end
         end
-      end)
+      )
       ExampleJob.discard_on(JobDiscardError) if ExampleJob.respond_to?(:discard_on)
       ExampleJob.retry_on(JobRetryError, attempts: 2, wait: 2) { nil } if ExampleJob.respond_to?(:retry_on)
 
@@ -228,11 +231,14 @@ RSpec.describe 'ActiveJob' do
 
     context 'with a Sidekiq::Worker' do
       subject(:worker) do
-        stub_const('EmptyWorker', Class.new do
-          include Sidekiq::Worker
+        stub_const(
+          'EmptyWorker',
+          Class.new do
+            include Sidekiq::Worker
 
-          def perform; end
-        end)
+            def perform; end
+          end
+        )
       end
 
       it 'has correct Sidekiq span' do
@@ -249,9 +255,12 @@ RSpec.describe 'ActiveJob' do
 
     context 'with an ActiveJob' do
       subject(:worker) do
-        stub_const('EmptyJob', Class.new(ActiveJob::Base) do
-          def perform; end
-        end)
+        stub_const(
+          'EmptyJob',
+          Class.new(ActiveJob::Base) do
+            def perform; end
+          end
+        )
       end
 
       it 'has correct Sidekiq span' do

--- a/spec/datadog/tracing/contrib/rails/rails_log_auto_injection_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/rails_log_auto_injection_spec.rb
@@ -21,21 +21,27 @@ RSpec.describe 'Rails Log Auto Injection' do
   end
 
   let(:tagged_logging_controller) do
-    stub_const('TaggedLoggingTestController', Class.new(ActionController::Base) do
-      def index
-        Rails.logger.info('MINASWAN')
-        render inline: '<html> <head> </head> <body> <div> Hello from index </div> </body> </html>'
+    stub_const(
+      'TaggedLoggingTestController',
+      Class.new(ActionController::Base) do
+        def index
+          Rails.logger.info('MINASWAN')
+          render inline: '<html> <head> </head> <body> <div> Hello from index </div> </body> </html>'
+        end
       end
-    end)
+    )
   end
 
   let(:lograge_controller) do
-    stub_const('LogrageTestController', Class.new(ActionController::Base) do
-      def index
-        Rails.logger.info('MINASWAN')
-        render inline: '<html> <head> </head> <body> <div> Hello from index </div> </body> </html>'
+    stub_const(
+      'LogrageTestController',
+      Class.new(ActionController::Base) do
+        def index
+          Rails.logger.info('MINASWAN')
+          render inline: '<html> <head> </head> <body> <div> Hello from index </div> </body> </html>'
+        end
       end
-    end)
+    )
   end
 
   before do

--- a/spec/datadog/tracing/contrib/rails/rails_semantic_logger_auto_injection_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/rails_semantic_logger_auto_injection_spec.rb
@@ -19,12 +19,15 @@ RSpec.describe 'Rails Log Auto Injection' do
   end
 
   let(:semantic_logger_controller) do
-    stub_const('SemanticLoggerTestController', Class.new(ActionController::Base) do
-      def index
-        Rails.logger.info('MINASWAN')
-        render inline: '<html> <head> </head> <body> <div> Hello from index </div> </body> </html>'
+    stub_const(
+      'SemanticLoggerTestController',
+      Class.new(ActionController::Base) do
+        def index
+          Rails.logger.info('MINASWAN')
+          render inline: '<html> <head> </head> <body> <div> Hello from index </div> </body> </html>'
+        end
       end
-    end)
+    )
   end
 
   before do

--- a/spec/datadog/tracing/contrib/rails/railtie_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/railtie_spec.rb
@@ -15,11 +15,14 @@ RSpec.describe 'Rails Railtie' do
   let(:controllers) { [controller] }
 
   let(:controller) do
-    stub_const('TestController', Class.new(ActionController::Base) do
-      def index
-        head :ok
+    stub_const(
+      'TestController',
+      Class.new(ActionController::Base) do
+        def index
+          head :ok
+        end
       end
-    end)
+    )
   end
 
   RSpec::Matchers.define :have_kind_of_middleware do |expected|

--- a/spec/datadog/tracing/contrib/rails/support/middleware.rb
+++ b/spec/datadog/tracing/contrib/rails/support/middleware.rb
@@ -4,18 +4,21 @@ RSpec.shared_context 'Rails middleware' do
   let(:rails_middleware) { [] }
 
   let(:debug_middleware) do
-    stub_const('DebugMiddleware', Class.new do
-      def initialize(app)
-        @app = app
-      end
+    stub_const(
+      'DebugMiddleware',
+      Class.new do
+        def initialize(app)
+          @app = app
+        end
 
-      def call(env)
-        @app.call(env)
-        # rubocop:disable Lint/RescueException
-      rescue Exception => _e
-        raise
-        # ruboco:enable Lint/RescueException
+        def call(env)
+          @app.call(env)
+          # rubocop:disable Lint/RescueException
+        rescue Exception => _e
+          raise
+          # ruboco:enable Lint/RescueException
+        end
       end
-    end)
+    )
   end
 end

--- a/spec/datadog/tracing/contrib/rails/support/models.rb
+++ b/spec/datadog/tracing/contrib/rails/support/models.rb
@@ -2,8 +2,11 @@
 
 RSpec.shared_context 'Rails models' do
   let(:application_record) do
-    stub_const('ApplicationRecord', Class.new(ActiveRecord::Base) do
-      self.abstract_class = true
-    end)
+    stub_const(
+      'ApplicationRecord',
+      Class.new(ActiveRecord::Base) do
+        self.abstract_class = true
+      end
+    )
   end
 end

--- a/spec/datadog/tracing/contrib/redis/configuration/resolver_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/configuration/resolver_spec.rb
@@ -32,10 +32,12 @@ RSpec.describe 'Redis configuration resolver' do
         let(:matcher) { 'redis://127.0.0.1:6379/0' }
 
         it do
-          expect(parsed_key).to eq(host: '127.0.0.1',
+          expect(parsed_key).to eq(
+            host: '127.0.0.1',
             port: 6379,
             db: 0,
-            scheme: 'redis')
+            scheme: 'redis'
+          )
         end
       end
 
@@ -43,10 +45,12 @@ RSpec.describe 'Redis configuration resolver' do
         let(:matcher) { { url: 'redis://127.0.0.1:6379/0' } }
 
         it do
-          expect(parsed_key).to eq(host: '127.0.0.1',
+          expect(parsed_key).to eq(
+            host: '127.0.0.1',
             port: 6379,
             db: 0,
-            scheme: 'redis')
+            scheme: 'redis'
+          )
         end
       end
     end
@@ -62,10 +66,12 @@ RSpec.describe 'Redis configuration resolver' do
       end
 
       it do
-        expect(parsed_key).to eq(host: '127.0.0.1',
+        expect(parsed_key).to eq(
+          host: '127.0.0.1',
           port: 6379,
           db: 0,
-          scheme: 'redis')
+          scheme: 'redis'
+        )
       end
     end
 
@@ -79,10 +85,12 @@ RSpec.describe 'Redis configuration resolver' do
       end
 
       it do
-        expect(parsed_key).to eq(host: '127.0.0.1',
+        expect(parsed_key).to eq(
+          host: '127.0.0.1',
           port: 6379,
           db: 0,
-          scheme: 'redis')
+          scheme: 'redis'
+        )
       end
     end
 
@@ -95,10 +103,12 @@ RSpec.describe 'Redis configuration resolver' do
       end
 
       it do
-        expect(parsed_key).to eq(host: '127.0.0.1',
+        expect(parsed_key).to eq(
+          host: '127.0.0.1',
           port: 6379,
           db: 0,
-          scheme: 'redis')
+          scheme: 'redis'
+        )
       end
     end
   end

--- a/spec/datadog/tracing/contrib/shoryuken/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/shoryuken/tracer_spec.rb
@@ -28,11 +28,14 @@ RSpec.describe Datadog::Tracing::Contrib::Shoryuken::Tracer do
   shared_context 'Shoryuken::Worker' do
     let(:worker_class) do
       qn = queue_name
-      stub_const('TestWorker', Class.new do
-        include Shoryuken::Worker
-        shoryuken_options queue: qn
-        def perform(sqs_msg, body); end
-      end)
+      stub_const(
+        'TestWorker',
+        Class.new do
+          include Shoryuken::Worker
+          shoryuken_options queue: qn
+          def perform(sqs_msg, body); end
+        end
+      )
     end
     let(:worker) { worker_class.new }
     let(:queue_name) { 'default' }

--- a/spec/datadog/tracing/contrib/sidekiq/client_tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/client_tracer_spec.rb
@@ -66,9 +66,12 @@ RSpec.describe 'ClientTracerTest' do
         pending 'Broken in Ruby 3.1.0-preview1, see https://github.com/mperham/sidekiq/issues/5064'
       end
 
-      stub_const('DelayableClass', Class.new do
-        def self.do_work; end
-      end)
+      stub_const(
+        'DelayableClass',
+        Class.new do
+          def self.do_work; end
+        end
+      )
     end
 
     it 'traces with correct resource' do

--- a/spec/datadog/tracing/contrib/sidekiq/server_tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/server_tracer_spec.rb
@@ -42,13 +42,16 @@ RSpec.describe 'Server tracer' do
     let(:job_class) { ErrorWorker }
 
     before do
-      stub_const('ErrorWorker', Class.new do
-        include Sidekiq::Worker
+      stub_const(
+        'ErrorWorker',
+        Class.new do
+          include Sidekiq::Worker
 
-        def perform
-          raise ZeroDivisionError, 'job error'
+          def perform
+            raise ZeroDivisionError, 'job error'
+          end
         end
-      end)
+      )
     end
 
     it 'traces async job run' do
@@ -73,11 +76,14 @@ RSpec.describe 'Server tracer' do
     before do
       allow(Datadog.configuration.tracing).to receive(:[]).with(:sidekiq).and_return(sidekiq_options)
 
-      stub_const('CustomWorker', Class.new do
-        include Sidekiq::Worker
+      stub_const(
+        'CustomWorker',
+        Class.new do
+          include Sidekiq::Worker
 
-        def perform(id) end
-      end)
+          def perform(id) end
+        end
+      )
     end
 
     it 'traces async job run' do
@@ -172,11 +178,14 @@ RSpec.describe 'Server tracer' do
         pending 'Broken in Ruby 3.1.0-preview1, see https://github.com/mperham/sidekiq/issues/5064'
       end
 
-      stub_const('DelayableClass', Class.new do
-        def self.do_work
-          puts 'a'
+      stub_const(
+        'DelayableClass',
+        Class.new do
+          def self.do_work
+            puts 'a'
+          end
         end
-      end)
+      )
     end
 
     it 'traces with correct resource' do

--- a/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
@@ -12,10 +12,13 @@ RSpec.shared_context 'Sidekiq testing' do
   before { configure_sidekiq }
 
   let!(:empty_worker) do
-    stub_const('EmptyWorker', Class.new do
-      include Sidekiq::Worker
-      def perform; end
-    end)
+    stub_const(
+      'EmptyWorker',
+      Class.new do
+        include Sidekiq::Worker
+        def perform; end
+      end
+    )
   end
 end
 

--- a/spec/datadog/tracing/contrib/sidekiq/tracer_configure_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/tracer_configure_spec.rb
@@ -36,13 +36,16 @@ RSpec.describe 'Tracer configuration' do
       let(:error_handler) { proc { @error_handler_called = true } }
 
       before do
-        stub_const('ErrorWorker', Class.new do
-          include Sidekiq::Worker
+        stub_const(
+          'ErrorWorker',
+          Class.new do
+            include Sidekiq::Worker
 
-          def perform
-            raise ZeroDivisionError, 'job error'
+            def perform
+              raise ZeroDivisionError, 'job error'
+            end
           end
-        end)
+        )
       end
 
       it 'uses custom error handler' do

--- a/spec/datadog/tracing/contrib/sinatra/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sinatra/tracer_spec.rb
@@ -524,22 +524,28 @@ RSpec.describe 'Sinatra instrumentation' do
   context 'with modular app' do
     let(:sinatra_app) do
       mount_nested_app = self.mount_nested_app
-      stub_const('NestedApp', Class.new(Sinatra::Base) do
-        register Datadog::Tracing::Contrib::Sinatra::Tracer
+      stub_const(
+        'NestedApp',
+        Class.new(Sinatra::Base) do
+          register Datadog::Tracing::Contrib::Sinatra::Tracer
 
-        get '/nested' do
-          headers['X-Request-ID'] = 'test id'
-          'nested ok'
+          get '/nested' do
+            headers['X-Request-ID'] = 'test id'
+            'nested ok'
+          end
         end
-      end)
+      )
 
       sinatra_routes = self.sinatra_routes
-      stub_const('App', Class.new(Sinatra::Base) do
-        register Datadog::Tracing::Contrib::Sinatra::Tracer
-        use NestedApp if mount_nested_app
+      stub_const(
+        'App',
+        Class.new(Sinatra::Base) do
+          register Datadog::Tracing::Contrib::Sinatra::Tracer
+          use NestedApp if mount_nested_app
 
-        instance_exec(&sinatra_routes)
-      end)
+          instance_exec(&sinatra_routes)
+        end
+      )
     end
 
     let(:app_name) { top_app_name }
@@ -630,9 +636,12 @@ RSpec.describe 'Sinatra instrumentation' do
 
       let(:sinatra_app) do
         sinatra_routes = self.sinatra_routes
-        stub_const('App', Class.new(Sinatra::Base) do
-          instance_exec(&sinatra_routes)
-        end)
+        stub_const(
+          'App',
+          Class.new(Sinatra::Base) do
+            instance_exec(&sinatra_routes)
+          end
+        )
       end
 
       subject(:response) { get url }

--- a/spec/datadog/tracing/distributed/headers/b3_spec.rb
+++ b/spec/datadog/tracing/distributed/headers/b3_spec.rb
@@ -30,8 +30,10 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::B3 do
       end
 
       it do
-        expect(env).to eq(Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 10000.to_s(16),
-          Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 20000.to_s(16))
+        expect(env).to eq(
+          Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 10000.to_s(16),
+          Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 20000.to_s(16)
+        )
       end
 
       [
@@ -50,9 +52,11 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::B3 do
           end
 
           it do
-            expect(env).to eq(Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 50000.to_s(16),
+            expect(env).to eq(
+              Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 50000.to_s(16),
               Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 60000.to_s(16),
-              Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SAMPLED => expected.to_s)
+              Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SAMPLED => expected.to_s
+            )
           end
         end
       end
@@ -67,8 +71,10 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::B3 do
         end
 
         it do
-          expect(env).to eq(Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 90000.to_s(16),
-            Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 100000.to_s(16))
+          expect(env).to eq(
+            Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 90000.to_s(16),
+            Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 100000.to_s(16)
+          )
         end
       end
     end

--- a/spec/datadog/tracing/distributed/headers/datadog_spec.rb
+++ b/spec/datadog/tracing/distributed/headers/datadog_spec.rb
@@ -30,8 +30,10 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::Datadog do
       end
 
       it do
-        expect(env).to eq(Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => '10000',
-          Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '20000')
+        expect(env).to eq(
+          Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => '10000',
+          Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '20000'
+        )
       end
 
       context 'with sampling priority' do
@@ -44,9 +46,11 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::Datadog do
         end
 
         it do
-          expect(env).to eq(Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => '50000',
+          expect(env).to eq(
+            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => '50000',
             Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '60000',
-            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_SAMPLING_PRIORITY => '1')
+            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_SAMPLING_PRIORITY => '1'
+          )
         end
 
         context 'with origin' do
@@ -60,10 +64,12 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::Datadog do
           end
 
           it do
-            expect(env).to eq(Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => '70000',
+            expect(env).to eq(
+              Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => '70000',
               Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '80000',
               Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_SAMPLING_PRIORITY => '1',
-              Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_ORIGIN => 'synthetics')
+              Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_ORIGIN => 'synthetics'
+            )
           end
         end
       end
@@ -78,9 +84,11 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::Datadog do
         end
 
         it do
-          expect(env).to eq(Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => '90000',
+          expect(env).to eq(
+            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => '90000',
             Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '100000',
-            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_ORIGIN => 'synthetics')
+            Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_ORIGIN => 'synthetics'
+          )
         end
       end
     end

--- a/spec/datadog/tracing/distributed/metadata/b3_spec.rb
+++ b/spec/datadog/tracing/distributed/metadata/b3_spec.rb
@@ -25,8 +25,10 @@ RSpec.describe Datadog::Tracing::Distributed::Metadata::B3 do
       end
 
       it do
-        expect(metadata).to eq(Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 10000.to_s(16),
-          Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 20000.to_s(16))
+        expect(metadata).to eq(
+          Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 10000.to_s(16),
+          Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 20000.to_s(16)
+        )
       end
 
       [
@@ -45,9 +47,11 @@ RSpec.describe Datadog::Tracing::Distributed::Metadata::B3 do
           end
 
           it do
-            expect(metadata).to eq(Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 50000.to_s(16),
+            expect(metadata).to eq(
+              Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 50000.to_s(16),
               Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 60000.to_s(16),
-              Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SAMPLED => expected.to_s)
+              Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SAMPLED => expected.to_s
+            )
           end
         end
       end
@@ -62,8 +66,10 @@ RSpec.describe Datadog::Tracing::Distributed::Metadata::B3 do
         end
 
         it do
-          expect(metadata).to eq(Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 90000.to_s(16),
-            Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 100000.to_s(16))
+          expect(metadata).to eq(
+            Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_TRACE_ID => 90000.to_s(16),
+            Datadog::Tracing::Distributed::Headers::Ext::B3_HEADER_SPAN_ID => 100000.to_s(16)
+          )
         end
       end
     end

--- a/spec/datadog/tracing/distributed/metadata/datadog_spec.rb
+++ b/spec/datadog/tracing/distributed/metadata/datadog_spec.rb
@@ -25,8 +25,10 @@ RSpec.describe Datadog::Tracing::Distributed::Metadata::Datadog do
       end
 
       it do
-        expect(metadata).to eq(Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_TRACE_ID => '10000',
-          Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_PARENT_ID => '20000')
+        expect(metadata).to eq(
+          Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_TRACE_ID => '10000',
+          Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_PARENT_ID => '20000'
+        )
       end
 
       context 'with sampling priority' do
@@ -39,9 +41,11 @@ RSpec.describe Datadog::Tracing::Distributed::Metadata::Datadog do
         end
 
         it do
-          expect(metadata).to eq(Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_TRACE_ID => '50000',
+          expect(metadata).to eq(
+            Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_TRACE_ID => '50000',
             Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_PARENT_ID => '60000',
-            Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_SAMPLING_PRIORITY => '1')
+            Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_SAMPLING_PRIORITY => '1'
+          )
         end
 
         context 'with origin' do
@@ -55,10 +59,12 @@ RSpec.describe Datadog::Tracing::Distributed::Metadata::Datadog do
           end
 
           it do
-            expect(metadata).to eq(Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_TRACE_ID => '70000',
+            expect(metadata).to eq(
+              Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_TRACE_ID => '70000',
               Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_PARENT_ID => '80000',
               Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_SAMPLING_PRIORITY => '1',
-              Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_ORIGIN => 'synthetics')
+              Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_ORIGIN => 'synthetics'
+            )
           end
         end
       end
@@ -73,9 +79,11 @@ RSpec.describe Datadog::Tracing::Distributed::Metadata::Datadog do
         end
 
         it do
-          expect(metadata).to eq(Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_TRACE_ID => '90000',
+          expect(metadata).to eq(
+            Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_TRACE_ID => '90000',
             Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_PARENT_ID => '100000',
-            Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_ORIGIN => 'synthetics')
+            Datadog::Tracing::Distributed::Headers::Ext::GRPC_METADATA_ORIGIN => 'synthetics'
+          )
         end
       end
     end

--- a/spec/datadog/tracing/propagation/http_spec.rb
+++ b/spec/datadog/tracing/propagation/http_spec.rb
@@ -20,9 +20,11 @@ RSpec.describe Datadog::Tracing::Propagation::HTTP do
       context 'without any explicit sampling priority or origin' do
         it do
           inject!
-          expect(env).to eq('something' => 'alien',
+          expect(env).to eq(
+            'something' => 'alien',
             'x-datadog-trace-id' => '1000',
-            'x-datadog-parent-id' => '2000')
+            'x-datadog-parent-id' => '2000'
+          )
         end
       end
 
@@ -33,10 +35,12 @@ RSpec.describe Datadog::Tracing::Propagation::HTTP do
           let(:trace_attrs) { { trace_id: 1000, span_id: 2000, trace_sampling_priority: 0 } }
 
           it do
-            expect(env).to eq('something' => 'alien',
+            expect(env).to eq(
+              'something' => 'alien',
               'x-datadog-sampling-priority' => '0',
               'x-datadog-trace-id' => '1000',
-              'x-datadog-parent-id' => '2000')
+              'x-datadog-parent-id' => '2000'
+            )
           end
         end
 
@@ -44,9 +48,11 @@ RSpec.describe Datadog::Tracing::Propagation::HTTP do
           let(:trace_attrs) { { trace_id: 1000, span_id: 2000, trace_sampling_priority: nil } }
 
           it do
-            expect(env).to eq('something' => 'alien',
+            expect(env).to eq(
+              'something' => 'alien',
               'x-datadog-trace-id' => '1000',
-              'x-datadog-parent-id' => '2000')
+              'x-datadog-parent-id' => '2000'
+            )
           end
         end
       end
@@ -58,10 +64,12 @@ RSpec.describe Datadog::Tracing::Propagation::HTTP do
           let(:trace_attrs) { { trace_id: 1000, span_id: 2000, trace_origin: 'synthetics' } }
 
           it do
-            expect(env).to eq('something' => 'alien',
+            expect(env).to eq(
+              'something' => 'alien',
               'x-datadog-origin' => 'synthetics',
               'x-datadog-trace-id' => '1000',
-              'x-datadog-parent-id' => '2000')
+              'x-datadog-parent-id' => '2000'
+            )
           end
         end
 
@@ -69,9 +77,11 @@ RSpec.describe Datadog::Tracing::Propagation::HTTP do
           let(:trace_attrs) { { trace_id: 1000, span_id: 2000, trace_origin: nil } }
 
           it do
-            expect(env).to eq('something' => 'alien',
+            expect(env).to eq(
+              'something' => 'alien',
               'x-datadog-trace-id' => '1000',
-              'x-datadog-parent-id' => '2000')
+              'x-datadog-parent-id' => '2000'
+            )
           end
         end
       end

--- a/spec/datadog/tracing/sampling/rule_sampler_spec.rb
+++ b/spec/datadog/tracing/sampling/rule_sampler_spec.rb
@@ -202,11 +202,14 @@ RSpec.describe Datadog::Tracing::Sampling::RuleSampler do
       context 'that responds to #update' do
         let(:default_sampler) { sampler_class.new }
         let(:sampler_class) do
-          stub_const('TestSampler', Class.new(Datadog::Tracing::Sampling::Sampler) do
-            def update(rates)
-              rates
+          stub_const(
+            'TestSampler',
+            Class.new(Datadog::Tracing::Sampling::Sampler) do
+              def update(rates)
+                rates
+              end
             end
-          end)
+          )
         end
 
         before do

--- a/spec/datadog/tracing/writer_spec.rb
+++ b/spec/datadog/tracing/writer_spec.rb
@@ -126,28 +126,34 @@ RSpec.describe Datadog::Tracing::Writer do
 
         context 'with multiple responses' do
           let(:response1) do
-            instance_double(Datadog::Transport::HTTP::Traces::Response,
+            instance_double(
+              Datadog::Transport::HTTP::Traces::Response,
               internal_error?: false,
               server_error?: false,
               ok?: true,
-              trace_count: 10)
+              trace_count: 10
+            )
           end
           let(:response2) do
-            instance_double(Datadog::Transport::HTTP::Traces::Response,
+            instance_double(
+              Datadog::Transport::HTTP::Traces::Response,
               internal_error?: false,
               server_error?: false,
               ok?: true,
-              trace_count: 20)
+              trace_count: 20
+            )
           end
 
           let(:responses) { [response1, response2] }
 
           context 'and at least one being server error' do
             let(:response2) do
-              instance_double(Datadog::Transport::HTTP::Traces::Response,
+              instance_double(
+                Datadog::Transport::HTTP::Traces::Response,
                 internal_error?: false,
                 server_error?: true,
-                ok?: false)
+                ok?: false
+              )
             end
 
             it do

--- a/spec/ddtrace/transport/io/traces_spec.rb
+++ b/spec/ddtrace/transport/io/traces_spec.rb
@@ -150,8 +150,8 @@ RSpec.describe Datadog::Transport::IO::Traces::Encoder do
             trace.spans.each do |span|
               allow(span).to receive(:to_hash)
                 .and_wrap_original do |m, *_args|
-                m.call.tap { |h| h.delete(missing_id) }
-              end
+                  m.call.tap { |h| h.delete(missing_id) }
+                end
             end
           end
         end

--- a/spec/support/spy_transport.rb
+++ b/spec/support/spy_transport.rb
@@ -66,7 +66,8 @@ class SpyTransport < Datadog::Transport::HTTP::Client
     Datadog::Transport::HTTP::Traces::Response.new(
       Datadog::Transport::HTTP::Adapters::Net::Response.new(
         Net::HTTPResponse.new(1.0, code, code.to_s)
-      ), trace_count: 1
+      ),
+      trace_count: 1
     )
   end
 end


### PR DESCRIPTION
Follow up from #2165

This PR enables all cops that ensure when multi-line arguments are provided, because they are broken down into many lines, that the first argument is also placed in a new line, instead of in-line with the method call.

This addresses the main issues with introducing #2165.

So this:
```ruby
                @_response = ::ActionDispatch::Response.new(403,
                  { 'Content-Type' => 'text/html' },
                  [Datadog::AppSec::Assets.blocked]
```
Becomes this:
```ruby
                @_response = ::ActionDispatch::Response.new(
                  403,
                  { 'Content-Type' => 'text/html' },
                  [Datadog::AppSec::Assets.blocked]
```

You don't have to scan for a possibly "hiding" first argument on the top-right hand side: all multi-line arguments are, well, in multiple lines now.