### PR TITLE
Add reverse proxy setup for rails 7 integration

### DIFF
--- a/integration/apps/rails-seven/bin/setup
+++ b/integration/apps/rails-seven/bin/setup
@@ -19,8 +19,7 @@ chdir APP_ROOT do
   puts "\n== Preparing database =="
   database_uri = URI(ENV['DATABASE_URL'])
   system! 'until wget mysql:3306 > /dev/null 2>&1; do : sleep 1; done'
-  system! 'bin/rails db:create'
-  system! 'bin/rails db:migrate'
+  system! 'bin/rails db:prepare'
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'

--- a/integration/apps/rails-seven/config/initializers/datadog.rb
+++ b/integration/apps/rails-seven/config/initializers/datadog.rb
@@ -11,7 +11,7 @@ Datadog.configure do |c|
   if Datadog::DemoEnv.feature?('tracing')
     c.tracing.analytics.enabled = true if Datadog::DemoEnv.feature?('analytics')
 
-    c.tracing.instrument :rails
+    c.tracing.instrument :rails, request_queuing: true
     c.tracing.instrument :redis, service_name: 'acme-redis'
     c.tracing.instrument :resque
   end
@@ -22,10 +22,8 @@ Datadog.configure do |c|
     c.appsec.instrument :rails
   end
 
-  if Datadog::DemoEnv.feature?('profiling')
-    if Datadog::DemoEnv.feature?('pprof_to_file')
-      # Reconfigure transport to write pprof to file
-      c.profiling.exporter.transport = Datadog::DemoEnv.profiler_file_transport
-    end
+  if Datadog::DemoEnv.feature?('profiling') && Datadog::DemoEnv.feature?('pprof_to_file')
+    # Reconfigure transport to write pprof to file
+    c.profiling.exporter.transport = Datadog::DemoEnv.profiler_file_transport
   end
 end

--- a/integration/apps/rails-seven/docker-compose.yml
+++ b/integration/apps/rails-seven/docker-compose.yml
@@ -1,5 +1,15 @@
 version: '3.4'
 services:
+  nginx:
+    image: nginx:stable
+    depends_on:
+      - app
+    expose:
+      - "80"
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
   app:
     build:
       context: .
@@ -94,13 +104,13 @@ services:
     build:
       context: ../../images
       dockerfile: wrk/Dockerfile
-    command: -t10 -c10 -d43200s -s /scripts/scenarios/basic/default.lua http://app/basic/default
+    command: -t10 -c10 -d43200s -s /scripts/scenarios/basic/default.lua http://nginx/basic/default
     depends_on:
       - app
     environment:
-      - HEALTH_CHECK_URL=http://app/health
+      - HEALTH_CHECK_URL=http://nginx/health
       - HEALTH_CHECK_INTERVAL=1
-      - HEALTH_CHECK_MAX_ATTEMPTS=60
+      - HEALTH_CHECK_MAX_ATTEMPTS=120
     volumes:
       - ./data/wrk:/data
       - ../../images/wrk/scripts:/scripts

--- a/integration/apps/rails-seven/nginx.conf
+++ b/integration/apps/rails-seven/nginx.conf
@@ -1,0 +1,15 @@
+events {
+
+}
+
+http {
+  server {
+    listen *:80;
+    server_name localhost;
+
+    location / {
+      proxy_set_header X-Request-Start "t=${msec}";
+      proxy_pass http://app;
+    }
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

Add `nginx` as reverse proxy for rails 7 integration app

**Motivation**

In order to understand `request_queuing` behaviour, a reverse proxy is required