### PR TITLE
Tweak docker-compose setup for arm64 machines

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -542,7 +542,6 @@ services:
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   ddagent:
     image: datadog/agent
-    platform: linux/x86_64
     environment:
       - DD_APM_ENABLED=true
       - DD_BIND_HOST=0.0.0.0
@@ -558,7 +557,6 @@ services:
       - ddagent_var_run:/var/run/datadog
   elasticsearch:
     image: elasticsearch:8.1.3
-    platform: linux/x86_64
     expose:
       - "9200"
       - "9300"
@@ -569,17 +567,15 @@ services:
       # Ensure production cluster requirements are not enforced
       - discovery.type=single-node
       - xpack.security.enabled=false
-      - ES_JAVA_OPTS="-Xms750m -Xmx750m"
+      - ES_JAVA_OPTS=-Xmx750m
   memcached:
     image: memcached:1.5-alpine
-    platform: linux/x86_64
     expose:
       - "11211"
     ports:
       - "${TEST_MEMCACHED_PORT}:11211"
   mongodb:
-    image: mongo:3.5
-    platform: linux/x86_64
+    image: mongo:3.6
     expose:
       - "27017"
     ports:
@@ -598,7 +594,6 @@ services:
       - "${TEST_MYSQL_PORT}:3306"
   postgres:
     image: postgres:9.6
-    platform: linux/x86_64
     environment:
       - POSTGRES_PASSWORD=$TEST_POSTGRES_PASSWORD
       - POSTGRES_USER=$TEST_POSTGRES_USER
@@ -616,8 +611,7 @@ services:
     ports:
       - "${TEST_PRESTO_PORT}:8080"
   redis:
-    image: redis:3.0
-    platform: linux/x86_64
+    image: redis:3.2
     expose:
       - "6379"
     ports:


### PR DESCRIPTION
**What does this PR do?**:

Update docker-compose configuration used for development/CI to improve compatibility with arm64 machines.

**Motivation**:

I've been pairing with @TonyCTHsu on getting our docker-compose to a state where it can run and pass the entire test suite when run on an arm64 machine.

The following configuration is an improvement on the status quo (as far as we know, only mongodb seems to be failing on arm64 at the moment), and still happily runs on x86-64, as well still being green in CI.

Note for anyone running stuff on arm64: docker-compose/docker only consider the `platform` setting when first downloading an image, so you'll probably need to delete the existing linux/x86_64 images for docker to realize it can download arm64 images instead.

**Additional Notes**:

It's hard to test arm64 changes without having access to a machine, so please report any issues that we might've missed!

**How to test the change?**:

* Confirm test suite still runs and passes on an x86-64 machine and in CI

(Reportedly, at least mongo still fails in arm64, but we're getting there)