### PR TITLE
Build native extension in `bin/setup` for integration app

### DIFF
--- a/integration/apps/rack/bin/setup
+++ b/integration/apps/rack/bin/setup
@@ -12,6 +12,7 @@ end
 
 chdir APP_ROOT do
   puts "\n== Installing dependencies =="
+  require '/vendor/dd-demo/build_ddtrace_profiling_native_extension' if ENV['DD_DEMO_ENV_BUILD_PROFILING_EXTENSION'] == 'true'
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 end

--- a/integration/apps/rails-five/bin/setup
+++ b/integration/apps/rails-five/bin/setup
@@ -13,6 +13,7 @@ end
 
 chdir APP_ROOT do
   puts "\n== Installing dependencies =="
+  require '/vendor/dd-demo/build_ddtrace_profiling_native_extension' if ENV['DD_DEMO_ENV_BUILD_PROFILING_EXTENSION'] == 'true'
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 

--- a/integration/apps/rails-seven/bin/setup
+++ b/integration/apps/rails-seven/bin/setup
@@ -13,6 +13,7 @@ end
 
 chdir APP_ROOT do
   puts "\n== Installing dependencies =="
+  require '/vendor/dd-demo/build_ddtrace_profiling_native_extension' if ENV['DD_DEMO_ENV_BUILD_PROFILING_EXTENSION'] == 'true'
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 

--- a/integration/apps/rails-six/bin/setup
+++ b/integration/apps/rails-six/bin/setup
@@ -13,6 +13,7 @@ end
 
 chdir APP_ROOT do
   puts "\n== Installing dependencies =="
+  require '/vendor/dd-demo/build_ddtrace_profiling_native_extension' if ENV['DD_DEMO_ENV_BUILD_PROFILING_EXTENSION'] == 'true'
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 

--- a/integration/apps/rspec/bin/setup
+++ b/integration/apps/rspec/bin/setup
@@ -12,6 +12,7 @@ end
 
 chdir APP_ROOT do
   puts "\n== Installing dependencies =="
+  require '/vendor/dd-demo/build_ddtrace_profiling_native_extension' if ENV['DD_DEMO_ENV_BUILD_PROFILING_EXTENSION'] == 'true'
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 

--- a/integration/apps/ruby/bin/setup
+++ b/integration/apps/ruby/bin/setup
@@ -12,6 +12,7 @@ end
 
 chdir APP_ROOT do
   puts "\n== Installing dependencies =="
+  require '/vendor/dd-demo/build_ddtrace_profiling_native_extension' if ENV['DD_DEMO_ENV_BUILD_PROFILING_EXTENSION'] == 'true'
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 end

--- a/integration/apps/sinatra2_modular/bin/setup
+++ b/integration/apps/sinatra2_modular/bin/setup
@@ -12,6 +12,7 @@ end
 
 chdir APP_ROOT do
   puts "\n== Installing dependencies =="
+  require '/vendor/dd-demo/build_ddtrace_profiling_native_extension' if ENV['DD_DEMO_ENV_BUILD_PROFILING_EXTENSION'] == 'true'
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 end


### PR DESCRIPTION
**What does this PR do?**

Add building native extension in `bin/setup` for integration app

**Motivation**

User would follow the `README.md` for integration app setup

```
1. `cp .envrc.sample .envrc` and add your Datadog API key.
2. `direnv allow` to load the env var.
3. `docker-compose run --rm app bin/setup`
```
The third step would fail with 

```== Installing dependencies ==
Run: gem install bundler --conservative
[DEPRECATED] This Gemfile does not include an explicit global source. Not using an explicit global source may result in a different lockfile being generated depending on the gems you have installed locally before bundler is run. Instead, define a global source in your Gemfile like this: source "https://rubygems.org".
The following gems are missing
 * libdatadog (0.7.0.1.0)
Install missing gems with `bundle install`
Run: bundle install
[DEPRECATED] This Gemfile does not include an explicit global source. Not using an explicit global source may result in a different lockfile being generated depending on the gems you have installed locally before bundler is run. Instead, define a global source in your Gemfile like this: source "https://rubygems.org".
Fetching gem metadata from https://rubygems.org/.......
Your bundle is locked to libdatadog (0.7.0.1.0-aarch64-linux) from locally installed gems, but that version can no longer be found in that source. That means the author of
libdatadog (0.7.0.1.0-aarch64-linux) has removed it. You'll need to update your bundle to a version other than libdatadog (0.7.0.1.0-aarch64-linux) that hasn't been removed
in order to install.

== Command ["bundle install"] failed ==```
