### PR TITLE
[PROF-4902] Track passage of CPU-time between samples

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -182,8 +182,6 @@ Performance/Squeeze: # (new in 1.7)
   Enabled: true
 Performance/StringInclude: # (new in 1.7)
   Enabled: true
-Performance/Sum: # (new in 1.8)
-  Enabled: true
 
 # Requires Ruby 2.2
 Style/HashSyntax:
@@ -211,6 +209,10 @@ Style/CollectionCompact:
 
 # Requires Ruby 2.4
 Performance/RegexpMatch:
+  Enabled: false
+
+# Requires Ruby 2.4
+Performance/Sum:
   Enabled: false
 
 # Requires Ruby 2.5

--- a/ext/ddtrace_profiling_native_extension/clock_id.h
+++ b/ext/ddtrace_profiling_native_extension/clock_id.h
@@ -1,4 +1,24 @@
 #pragma once
 
+#include <stdbool.h>
+#include <time.h>
+
+// Contains the operating-system specific identifier needed to fetch CPU-time, and a flag to indicate if we failed to fetch it
+typedef struct thread_cpu_time_id {
+  bool valid;
+  clockid_t clock_id;
+} thread_cpu_time_id;
+
+// Contains the current cpu time, and a flag to indicate if we failed to fetch it
+typedef struct thread_cpu_time {
+  bool valid;
+  long result_ns;
+} thread_cpu_time;
+
 void self_test_clock_id(void);
+
+// TODO: Remove this after the OldStack profiler gets removed
 VALUE clock_id_for(VALUE self, VALUE thread);
+
+thread_cpu_time_id thread_cpu_time_id_for(VALUE thread);
+thread_cpu_time thread_cpu_time_for(thread_cpu_time_id thread_cpu_time_id);

--- a/ext/ddtrace_profiling_native_extension/clock_id.h
+++ b/ext/ddtrace_profiling_native_extension/clock_id.h
@@ -21,4 +21,4 @@ void self_test_clock_id(void);
 VALUE clock_id_for(VALUE self, VALUE thread);
 
 thread_cpu_time_id thread_cpu_time_id_for(VALUE thread);
-thread_cpu_time thread_cpu_time_for(thread_cpu_time_id thread_cpu_time_id);
+thread_cpu_time thread_cpu_time_for(thread_cpu_time_id time_id);

--- a/ext/ddtrace_profiling_native_extension/clock_id_from_pthread.c
+++ b/ext/ddtrace_profiling_native_extension/clock_id_from_pthread.c
@@ -57,15 +57,15 @@ thread_cpu_time_id thread_cpu_time_id_for(VALUE thread) {
   }
 }
 
-thread_cpu_time thread_cpu_time_for(thread_cpu_time_id thread_cpu_time_id) {
+thread_cpu_time thread_cpu_time_for(thread_cpu_time_id time_id) {
   thread_cpu_time error = (thread_cpu_time) {.valid = false};
 
-  if (!thread_cpu_time_id.valid) { return error; }
+  if (!time_id.valid) { return error; }
 
   struct timespec current_cpu;
 
   // TODO: Include the error code in some way in the output?
-  if (clock_gettime(thread_cpu_time_id.clock_id, &current_cpu) != 0) return error;
+  if (clock_gettime(time_id.clock_id, &current_cpu) != 0) return error;
 
   return (thread_cpu_time) {.valid = true, .result_ns = current_cpu.tv_nsec + (current_cpu.tv_sec * 1000 * 1000 * 1000)};
 }

--- a/ext/ddtrace_profiling_native_extension/clock_id_from_pthread.c
+++ b/ext/ddtrace_profiling_native_extension/clock_id_from_pthread.c
@@ -21,6 +21,7 @@ void self_test_clock_id(void) {
   if (expected_pthread_id != actual_pthread_id) rb_raise(rb_eRuntimeError, "pthread_id_for() self-test failed");
 }
 
+// TODO: Remove this after the OldStack profiler gets removed
 VALUE clock_id_for(DDTRACE_UNUSED VALUE _self, VALUE thread) {
   rb_nativethread_id_t thread_id = pthread_id_for(thread);
 
@@ -40,6 +41,33 @@ VALUE clock_id_for(DDTRACE_UNUSED VALUE _self, VALUE thread) {
         rb_exc_raise(rb_syserr_new(error, "Failed to get clock_id for given thread"));
     }
   }
+}
+
+thread_cpu_time_id thread_cpu_time_id_for(VALUE thread) {
+  rb_nativethread_id_t thread_id = pthread_id_for(thread);
+  clockid_t clock_id;
+
+  int error = pthread_getcpuclockid(thread_id, &clock_id);
+
+  if (error == 0) {
+    return (thread_cpu_time_id) {.valid = true, .clock_id = clock_id};
+  } else {
+    // TODO: Include the error code in some way in the output?
+    return (thread_cpu_time_id) {.valid = false};
+  }
+}
+
+thread_cpu_time thread_cpu_time_for(thread_cpu_time_id thread_cpu_time_id) {
+  thread_cpu_time error = (thread_cpu_time) {.valid = false};
+
+  if (!thread_cpu_time_id.valid) { return error; }
+
+  struct timespec current_cpu;
+
+  // TODO: Include the error code in some way in the output?
+  if (clock_gettime(thread_cpu_time_id.clock_id, &current_cpu) != 0) return error;
+
+  return (thread_cpu_time) {.valid = true, .result_ns = current_cpu.tv_nsec + (current_cpu.tv_sec * 1000 * 1000 * 1000)};
 }
 
 #endif

--- a/ext/ddtrace_profiling_native_extension/clock_id_noop.c
+++ b/ext/ddtrace_profiling_native_extension/clock_id_noop.c
@@ -16,7 +16,7 @@ thread_cpu_time_id thread_cpu_time_id_for(DDTRACE_UNUSED VALUE _thread) {
   return (thread_cpu_time_id) {.valid = false};
 }
 
-thread_cpu_time thread_cpu_time_for(DDTRACE_UNUSED thread_cpu_time_id _thread_cpu_time_id) {
+thread_cpu_time thread_cpu_time_for(DDTRACE_UNUSED thread_cpu_time_id _time_id) {
   return (thread_cpu_time) {.valid = false};
 }
 

--- a/ext/ddtrace_profiling_native_extension/clock_id_noop.c
+++ b/ext/ddtrace_profiling_native_extension/clock_id_noop.c
@@ -12,4 +12,12 @@
 void self_test_clock_id(void) { } // Nothing to check
 VALUE clock_id_for(DDTRACE_UNUSED VALUE _self, DDTRACE_UNUSED VALUE _thread) { return Qnil; } // Nothing to return
 
+thread_cpu_time_id thread_cpu_time_id_for(DDTRACE_UNUSED VALUE _thread) {
+  return (thread_cpu_time_id) {.valid = false};
+}
+
+thread_cpu_time thread_cpu_time_for(DDTRACE_UNUSED thread_cpu_time_id _thread_cpu_time_id) {
+  return (thread_cpu_time) {.valid = false};
+}
+
 #endif

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -284,7 +284,9 @@ static int per_thread_context_as_ruby_hash(st_data_t key_thread, st_data_t value
   rb_hash_aset(result, thread, context_as_hash);
 
   VALUE arguments[] = {
-    ID2SYM(rb_intern("thread_id")),  /* => */ LONG2NUM(thread_context->thread_id),
+    ID2SYM(rb_intern("thread_id")),                       /* => */ LONG2NUM(thread_context->thread_id),
+    ID2SYM(rb_intern("thread_cpu_time_id_valid?")),       /* => */ thread_context->thread_cpu_time_id.valid ? Qtrue : Qfalse,
+    ID2SYM(rb_intern("thread_cpu_time_id")),              /* => */ CLOCKID2NUM(thread_context->thread_cpu_time_id.clock_id),
     ID2SYM(rb_intern("cpu_time_at_previous_sample_ns")),  /* => */ LONG2NUM(thread_context->cpu_time_at_previous_sample_ns),
     ID2SYM(rb_intern("wall_time_at_previous_sample_ns")), /* => */ LONG2NUM(thread_context->wall_time_at_previous_sample_ns)
   };

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -184,8 +184,8 @@ static void sample(VALUE collector_instance) {
 
     // FIXME: TODO These are just dummy values for now
     metric_values[CPU_TIME_VALUE_POS] = 12; // FIXME: Placeholder until actually implemented/tested
-    metric_values[CPU_SAMPLES_VALUE_POS] = 34; // FIXME: Placeholder until actually implemented/tested
 
+    metric_values[CPU_SAMPLES_VALUE_POS] = 1;
     metric_values[WALL_TIME_VALUE_POS] = wall_time_elapsed_ns;
 
     VALUE thread_name = thread_name_for(thread);

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -1,5 +1,6 @@
 #include <ruby.h>
 #include "helpers.h"
+#include "clock_id.h"
 #include "collectors_stack.h"
 #include "libdatadog_helpers.h"
 #include "private_vm_api_access.h"
@@ -28,6 +29,8 @@ struct cpu_and_wall_time_collector_state {
 // Tracks per-thread state
 struct per_thread_context {
   long thread_id;
+  thread_cpu_time_id thread_cpu_time_id;
+  long cpu_time_at_previous_sample_ns;  // Can be INVALID_TIME until initialized or if getting it fails for another reason
   long wall_time_at_previous_sample_ns; // Can be INVALID_TIME until initialized
 };
 
@@ -49,6 +52,7 @@ static void remove_context_for_dead_threads(struct cpu_and_wall_time_collector_s
 static int remove_if_dead_thread(st_data_t key_thread, st_data_t value_context, st_data_t _argument);
 static VALUE _native_per_thread_context(VALUE self, VALUE collector_instance);
 static long update_time_since_previous_sample(long *time_at_previous_sample_ns, long current_time_ns);
+static long cpu_time_now_ns(struct per_thread_context *thread_context);
 static long wall_time_now_ns();
 static long thread_id_for(VALUE thread);
 
@@ -177,14 +181,16 @@ static void sample(VALUE collector_instance) {
     VALUE thread = RARRAY_AREF(threads, i);
     struct per_thread_context *thread_context = get_or_create_context_for(thread, state);
 
+    long current_cpu_time_ns = cpu_time_now_ns(thread_context);
+
+    long cpu_time_elapsed_ns =
+      update_time_since_previous_sample(&thread_context->cpu_time_at_previous_sample_ns, current_cpu_time_ns);
     long wall_time_elapsed_ns =
       update_time_since_previous_sample(&thread_context->wall_time_at_previous_sample_ns, current_wall_time_ns);
 
     int64_t metric_values[ENABLED_VALUE_TYPES_COUNT] = {0};
 
-    // FIXME: TODO These are just dummy values for now
-    metric_values[CPU_TIME_VALUE_POS] = 12; // FIXME: Placeholder until actually implemented/tested
-
+    metric_values[CPU_TIME_VALUE_POS] = cpu_time_elapsed_ns;
     metric_values[CPU_SAMPLES_VALUE_POS] = 1;
     metric_values[WALL_TIME_VALUE_POS] = wall_time_elapsed_ns;
 
@@ -241,8 +247,10 @@ static struct per_thread_context *get_or_create_context_for(VALUE thread, struct
 
 static void initialize_context(VALUE thread, struct per_thread_context *thread_context) {
   thread_context->thread_id = thread_id_for(thread);
+  thread_context->thread_cpu_time_id = thread_cpu_time_id_for(thread);
 
   // These will get initialized during actual sampling
+  thread_context->cpu_time_at_previous_sample_ns = INVALID_TIME;
   thread_context->wall_time_at_previous_sample_ns = INVALID_TIME;
 }
 
@@ -277,6 +285,7 @@ static int per_thread_context_as_ruby_hash(st_data_t key_thread, st_data_t value
 
   VALUE arguments[] = {
     ID2SYM(rb_intern("thread_id")),  /* => */ LONG2NUM(thread_context->thread_id),
+    ID2SYM(rb_intern("cpu_time_at_previous_sample_ns")),  /* => */ LONG2NUM(thread_context->cpu_time_at_previous_sample_ns),
     ID2SYM(rb_intern("wall_time_at_previous_sample_ns")), /* => */ LONG2NUM(thread_context->wall_time_at_previous_sample_ns)
   };
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(context_as_hash, arguments[i], arguments[i+1]);
@@ -322,6 +331,19 @@ static long wall_time_now_ns() {
   if (clock_gettime(CLOCK_MONOTONIC, &current_monotonic) != 0) rb_sys_fail("Failed to read CLOCK_MONOTONIC");
 
   return current_monotonic.tv_nsec + (current_monotonic.tv_sec * 1000 * 1000 * 1000);
+}
+
+static long cpu_time_now_ns(struct per_thread_context *thread_context) {
+  thread_cpu_time cpu_time = thread_cpu_time_for(thread_context->thread_cpu_time_id);
+
+  if (!cpu_time.valid) {
+    // Invalidate previous state of the counter (if any), it's no longer accurate. We need to get two good reads
+    // in a row to have an accurate delta.
+    thread_context->cpu_time_at_previous_sample_ns = INVALID_TIME;
+    return 0;
+  }
+
+  return cpu_time.result_ns;
 }
 
 static long thread_id_for(VALUE thread) {

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
@@ -116,6 +116,46 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
 
       expect(t1_sample).to include(values: include(:'cpu-samples' => 5))
     end
+
+    context 'cpu time behavior' do
+      context 'when not on Linux' do
+        before do
+          skip 'The fallback behavior only applies when not on Linux' if PlatformHelpers.linux?
+        end
+
+        it 'sets the cpu-time on every sample to zero' do
+          5.times { cpu_and_wall_time_collector.sample }
+
+          expect(samples).to all include(values: include(:'cpu-time' => 0))
+        end
+      end
+
+      context 'on Linux' do
+        before do
+          skip 'Test only runs on Linux' unless PlatformHelpers.linux?
+        end
+
+        it 'includes the cpu-time for the samples' do
+          rspec_thread_spent_time = Datadog::Core::Utils::Time.measure(:nanosecond) do
+            5.times { cpu_and_wall_time_collector.sample }
+            samples # to trigger serialization
+          end
+
+          # The only thread we're guaranteed has spent some time on cpu is the rspec thread, so let's check we have
+          # some data for it
+          total_cpu_for_rspec_thread =
+            samples
+              .select { |it| it.fetch(:labels).fetch(:'thread id') == Thread.current.object_id }
+              .map { |it| it.fetch(:values).fetch(:'cpu-time') }
+              .reduce(:+)
+
+          # The **wall-clock time** spent by the rspec thread is going to be an upper bound for the cpu time spent,
+          # e.g. if it took 5 real world seconds to run the test, then at most the rspec thread spent those 5 seconds
+          # running on CPU, but possibly it spent slightly less.
+          expect(total_cpu_for_rspec_thread).to be_between(1, rspec_thread_spent_time)
+        end
+      end
+    end
   end
 
   describe '#thread_list' do
@@ -152,6 +192,48 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
         expect(cpu_and_wall_time_collector.per_thread_context.values).to all(
           include(wall_time_at_previous_sample_ns: be_between(@wall_time_before_sample_ns, @wall_time_after_sample_ns))
         )
+      end
+
+      context 'cpu time behavior' do
+        context 'when not on Linux' do
+          before do
+            skip 'The fallback behavior only applies when not on Linux' if PlatformHelpers.linux?
+          end
+
+          it 'sets the cpu_time_at_previous_sample_ns to zero' do
+            expect(cpu_and_wall_time_collector.per_thread_context.values).to all(
+              include(cpu_time_at_previous_sample_ns: 0)
+            )
+          end
+        end
+
+        context 'on Linux' do
+          before do
+            skip 'Test only runs on Linux' unless PlatformHelpers.linux?
+          end
+
+          it 'sets the cpu_time_at_previous_sample_ns to the current cpu clock value' do
+            # It's somewhat difficult to validate the actual value since this is an operating system-specific value
+            # which should only be assessed in relation to other values for the same thread, not in absolute
+            expect(cpu_and_wall_time_collector.per_thread_context.values).to all(
+              include(cpu_time_at_previous_sample_ns: not_be(0))
+            )
+          end
+
+          it 'returns a bigger value for each sample' do
+            sample_values = []
+
+            3.times do
+              cpu_and_wall_time_collector.sample
+
+              sample_values <<
+                cpu_and_wall_time_collector.per_thread_context[Thread.main].fetch(:cpu_time_at_previous_sample_ns)
+            end
+
+            expect(sample_values.uniq.size).to be(3), 'Every sample is expected to have a differ cpu time value'
+            expect(sample_values).to eq(sample_values.sort), 'Samples are expected to be in ascending order'
+          end
+        end
       end
     end
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
@@ -205,6 +205,12 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
               include(cpu_time_at_previous_sample_ns: 0)
             )
           end
+
+          it 'marks the thread_cpu_time_ids as not valid' do
+            expect(cpu_and_wall_time_collector.per_thread_context.values).to all(
+              include(thread_cpu_time_id_valid?: false)
+            )
+          end
         end
 
         context 'on Linux' do
@@ -232,6 +238,12 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
 
             expect(sample_values.uniq.size).to be(3), 'Every sample is expected to have a differ cpu time value'
             expect(sample_values).to eq(sample_values.sort), 'Samples are expected to be in ascending order'
+          end
+
+          it 'marks the thread_cpu_time_ids as valid' do
+            expect(cpu_and_wall_time_collector.per_thread_context.values).to all(
+              include(thread_cpu_time_id_valid?: true)
+            )
           end
         end
       end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
@@ -108,6 +108,14 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
 
       expect(wall_time).to be(wall_time_at_second_sample - wall_time_at_first_sample)
     end
+
+    it 'tags samples with how many times they were seen' do
+      5.times { cpu_and_wall_time_collector.sample }
+
+      t1_sample = samples.find { |it| it.fetch(:labels).fetch(:'thread id') == t1.object_id }
+
+      expect(t1_sample).to include(values: include(:'cpu-samples' => 5))
+    end
   end
 
   describe '#thread_list' do


### PR DESCRIPTION
**What does this PR do?**:

This PR adds support for tracking the passage of CPU-time between samples to the `CpuAndWallTime` collector.

The way this works is similar to wall-clock time: on every sample we get the current value from the OS, and we calculate the  elapsed CPU time from the previous sample (which is stored in `cpu_time_at_previous_sample_ns`).
(The first time a thread is sampled, the elapsed time is set to 0).

It also adds the CPU samples count, which is useful to measure how many samples actually were taken.

**Motivation**:

In #2163 we added tracking of wall-clock time, and this PR adds CPU-time, which is needed to produce CPU profiles aka to figure out how much time different parts of the code spent executing on CPU.

**Additional Notes**:

Like for the old profiler, we only support getting CPU-time on Linux.

I've added a fallback code path so that we can still easily develop and test the profiler on macOS (even though we don't officially support its use).

**How to test the change?**:

This change includes code coverage.
