### PR TITLE
Rake:Require instrumented task list

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1600,7 +1600,13 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 ### Rake
 
-You can add instrumentation around your Rake tasks by activating the `rake` integration. Each task and its subsequent subtasks will be traced.
+You can add instrumentation around your Rake tasks by activating the `rake` integration and
+providing a list of what Rake tasks need to be instrumented.
+
+**Avoid instrumenting long-running Rake tasks, as such tasks can aggregate large traces in
+memory that are never flushed until the task finishes.**
+
+For long-running tasks, use [Manual instrumentation](#manual-instrumentation) around recurring code paths.
 
 To activate Rake task tracing, add the following to your `Rakefile`:
 
@@ -1610,7 +1616,7 @@ require 'rake'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.tracing.instrument :rake, options
+  c.tracing.instrument :rake, tasks: ['my_task'], **options
 end
 
 task :my_task do
@@ -1627,6 +1633,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | `enabled` | Defines whether Rake tasks should be traced. Useful for temporarily disabling tracing. `true` or `false` | `true` |
 | `quantize` | Hash containing options for quantization of task arguments. See below for more details and examples. | `{}` |
 | `service_name` | Service name used for `rake` instrumentation | `'rake'` |
+| `tasks` | Names of the Rake tasks to instrument | `[]` |
 
 **Configuring task quantization behavior**
 

--- a/lib/datadog/tracing/contrib/rake/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rake/configuration/settings.rb
@@ -1,5 +1,7 @@
 # typed: false
 
+require 'set'
+
 require 'datadog/tracing/contrib/configuration/settings'
 require 'datadog/tracing/contrib/rake/ext'
 
@@ -28,6 +30,19 @@ module Datadog
 
             option :quantize, default: {}
             option :service_name
+
+            # A list of rake tasks, using their string names, to be instrumented.
+            # An empty list, or not setting this option means no task is instrumented.
+            # Automatically instrumenting all Rake tasks can lead to long-running tasks
+            # causing undue memory accumulation, as the trace for such tasks is never flushed.
+            option :tasks do |o|
+              o.default { [] }
+              o.lazy
+              o.on_set do |value|
+                # DEV: It should be possible to modify the value after it's set. E.g. for normalization.
+                options[:tasks].instance_variable_set(:@value, value.map(&:to_s).to_set)
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**Release notes**

Users of the Rake instrumentation will have to explicitly list the tasks that they want instrumented. This was done to **prevent memory bloat issues** that can arise from instrumenting long-running Rake tasks.

From today's configuration:

```ruby
Datadog.configure do |c|
  c.tracing.instrument :rake
end
```

The list of desired Rake tests to instrument should be added:

```ruby
Datadog.configure do |c|
  c.tracing.instrument :rake, tasks: ['task1', 'task2', ...]
end
```

Not providing this list will effectively instrument no Rake tasks.

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR requires the Rake instrumentation to receive an explicit list of task to be instrumented. This list can be a list of String task names, or other values that can be stringified (e.g. it's common to declare Rake tasks with Symbol names).

**Motivation**
<!-- What inspired you to submit this pull request? -->

Long-running Rake tasks, those measured in days, can accumulate a very large active trace in memory. This normally won't be flushed until the application terminates.

Such traces can cause catastrophic memory accumulation, possibly triggering an out-of-memory process shutdown.

Examples of such cases can be found in #2045.

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

I chose to no require users to have all their Rake loaded before invoking `Datadog.configure`: our current documentation suggests that users configure `ddtrace` before Rake task definition, so I chose to maintain compatibility and such flexibility.
Also, the implementation is not very complicated: there's a small performance overhead on non-instrumented tasks, but it boils down to a `Set#include?` call.
The dynamic implementation also allows for dynamic reconfiguration of the `tasks:` configuration list. The eager approach will either "patch" the Rake tasks and never be able to "unpatch", or it will implement the dynamic approach in this PR as well as selective patching.

Testing for the unrelated `when tracing is disabled` case was a bit misleading around tracer `#shutdown!` calls: it was asserting on a `Datadog::Tracing.trace` instance, but another instance of the tracer was used during testing. This PR fixes that.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unit test coverage around Rake tasks is already pretty good. I added the relevant cases introduced in this PR.