### PR TITLE
Bump mysql image used for testing for improved arm64 compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -582,7 +582,6 @@ services:
       - "${TEST_MONGODB_PORT}:27017"
   mysql:
     image: mysql:8
-    platform: linux/x86_64
     environment:
       - MYSQL_DATABASE=$TEST_MYSQL_DB
       - MYSQL_ROOT_PASSWORD=$TEST_MYSQL_ROOT_PASSWORD

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -581,7 +581,7 @@ services:
     ports:
       - "${TEST_MONGODB_PORT}:27017"
   mysql:
-    image: mysql:5.6
+    image: mysql:8
     platform: linux/x86_64
     environment:
       - MYSQL_DATABASE=$TEST_MYSQL_DB


### PR DESCRIPTION
**What does this PR do?**:

Upgrade the mysql image used for testing in CI to a more modern version.

**Motivation**:

According to @TonyCTHsu this version works well on arm64, and it still seems to work fine on all Ruby versions in CI, so this is more of a "why not" change.

**Additional Notes**: 

This is a follow-up to #2171.

**How to test the change?**:

* Check that our mysql integration tests are still passing.