### PR TITLE
Update appraisal gemfile.lock with platform aarch64-linux

### DIFF
--- a/gemfiles/ruby_3.0.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.2.0)
       debase-ruby_core_source (= 0.10.16)
-      libddprof (~> 0.6.0.1.0)
+      libdatadog (~> 0.7.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1407,6 +1407,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    google-protobuf (3.19.4)
     google-protobuf (3.19.4-x86_64-linux)
     googleapis-common-protos-types (1.3.0)
       google-protobuf (~> 3.14)
@@ -1418,6 +1419,9 @@ GEM
       rack (>= 1.3.0)
       rack-accept
     graphql (2.0.6)
+    grpc (1.45.0)
+      google-protobuf (~> 3.19)
+      googleapis-common-protos-types (~> 1.0)
     grpc (1.45.0-x86_64-linux)
       google-protobuf (~> 3.19)
       googleapis-common-protos-types (~> 1.0)
@@ -1443,8 +1447,8 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
-    libddprof (0.6.0.1.0-x86_64-linux)
-    libddwaf (1.3.0.2.0-x86_64-linux)
+    libdatadog (0.7.0.1.0-aarch64-linux)
+    libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)
@@ -1481,6 +1485,8 @@ GEM
       net-protocol
       timeout
     netrc (0.11.0)
+    nokogiri (1.13.3-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.13.3-x86_64-linux)
       racc (~> 1.4)
     opentracing (0.5.0)
@@ -1575,6 +1581,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -1617,17 +1625,9 @@ GEM
       rake (~> 12.3)
       serverengine (~> 2.1.0)
       thor
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sqlite3 (1.4.2)
     statsd-ruby (1.5.0)
     sucker_punch (3.0.1)
@@ -1661,6 +1661,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -1720,6 +1721,7 @@ DEPENDENCIES
   rspec_junit_formatter (>= 0.5.1)
   rspec_n (~> 1.3)
   rubocop (~> 1.10)
+  rubocop-packaging (~> 0.5)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   ruby-kafka (>= 0.7.10)
@@ -1731,8 +1733,6 @@ DEPENDENCIES
   simplecov!
   sinatra
   sneakers (>= 2.12.0)
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   sqlite3 (>= 1.4.2)
   sucker_punch
   typhoeus

--- a/gemfiles/ruby_3.0.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.2.0)
       debase-ruby_core_source (= 0.10.16)
-      libddprof (~> 0.6.0.1.0)
+      libdatadog (~> 0.7.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -59,13 +59,14 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.15.5)
+    google-protobuf (3.19.4)
     google-protobuf (3.19.4-x86_64-linux)
     graphql (1.12.24)
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddprof (0.6.0.1.0-x86_64-linux)
-    libddwaf (1.3.0.2.0-x86_64-linux)
+    libdatadog (0.7.0.1.0-aarch64-linux)
+    libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -129,6 +130,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -138,14 +141,6 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.1.0)
     warning (1.2.1)
@@ -158,6 +153,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -191,12 +187,11 @@ DEPENDENCIES
   rspec_junit_formatter (>= 0.5.1)
   rspec_n (~> 1.3)
   rubocop (~> 1.10)
+  rubocop-packaging (~> 0.5)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.0.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.2.0)
       debase-ruby_core_source (= 0.10.16)
-      libddprof (~> 0.6.0.1.0)
+      libdatadog (~> 0.7.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -46,12 +46,13 @@ GEM
     docile (1.4.0)
     dogstatsd-ruby (4.8.3)
     ffi (1.15.5)
+    google-protobuf (3.19.4)
     google-protobuf (3.19.4-x86_64-linux)
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddprof (0.6.0.1.0-x86_64-linux)
-    libddwaf (1.3.0.2.0-x86_64-linux)
+    libdatadog (0.7.0.1.0-aarch64-linux)
+    libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -109,6 +110,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -118,14 +121,6 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.1.0)
     warning (1.2.1)
@@ -138,6 +133,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -167,12 +163,11 @@ DEPENDENCIES
   rspec_junit_formatter (>= 0.5.1)
   rspec_n (~> 1.3)
   rubocop (~> 1.10)
+  rubocop-packaging (~> 0.5)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.0.3_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.2.0)
       debase-ruby_core_source (= 0.10.16)
-      libddprof (~> 0.6.0.1.0)
+      libdatadog (~> 0.7.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -64,12 +64,13 @@ GEM
     dogstatsd-ruby (5.4.0)
     ffi (1.15.5)
     gherkin (5.1.0)
+    google-protobuf (3.19.4)
     google-protobuf (3.19.4-x86_64-linux)
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddprof (0.6.0.1.0-x86_64-linux)
-    libddwaf (1.3.0.2.0-x86_64-linux)
+    libdatadog (0.7.0.1.0-aarch64-linux)
+    libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -129,6 +130,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -138,14 +141,6 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.1.0)
     warning (1.2.1)
@@ -158,6 +153,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -188,12 +184,11 @@ DEPENDENCIES
   rspec_junit_formatter (>= 0.5.1)
   rspec_n (~> 1.3)
   rubocop (~> 1.10)
+  rubocop-packaging (~> 0.5)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.0.3_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.2.0)
       debase-ruby_core_source (= 0.10.16)
-      libddprof (~> 0.6.0.1.0)
+      libdatadog (~> 0.7.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -82,14 +82,15 @@ GEM
     docile (1.4.0)
     dogstatsd-ruby (5.4.0)
     ffi (1.15.5)
+    google-protobuf (3.19.4)
     google-protobuf (3.19.4-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddprof (0.6.0.1.0-x86_64-linux)
-    libddwaf (1.3.0.2.0-x86_64-linux)
+    libdatadog (0.7.0.1.0-aarch64-linux)
+    libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -155,6 +156,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -164,14 +167,6 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.2.1)
@@ -189,6 +184,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -219,12 +215,11 @@ DEPENDENCIES
   rspec_junit_formatter (>= 0.5.1)
   rspec_n (~> 1.3)
   rubocop (~> 1.10)
+  rubocop-packaging (~> 0.5)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.0.3_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.2.0)
       debase-ruby_core_source (= 0.10.16)
-      libddprof (~> 0.6.0.1.0)
+      libdatadog (~> 0.7.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -82,14 +82,15 @@ GEM
     docile (1.4.0)
     dogstatsd-ruby (5.4.0)
     ffi (1.15.5)
+    google-protobuf (3.19.4)
     google-protobuf (3.19.4-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddprof (0.6.0.1.0-x86_64-linux)
-    libddwaf (1.3.0.2.0-x86_64-linux)
+    libdatadog (0.7.0.1.0-aarch64-linux)
+    libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -155,6 +156,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -164,14 +167,6 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.2.1)
@@ -189,6 +184,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -219,12 +215,11 @@ DEPENDENCIES
   rspec_junit_formatter (>= 0.5.1)
   rspec_n (~> 1.3)
   rubocop (~> 1.10)
+  rubocop-packaging (~> 0.5)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.0.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.2.0)
       debase-ruby_core_source (= 0.10.16)
-      libddprof (~> 0.6.0.1.0)
+      libdatadog (~> 0.7.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -110,6 +110,7 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    google-protobuf (3.19.4)
     google-protobuf (3.19.4-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
@@ -117,8 +118,8 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddprof (0.6.0.1.0-x86_64-linux)
-    libddwaf (1.3.0.2.0-x86_64-linux)
+    libdatadog (0.7.0.1.0-aarch64-linux)
+    libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)
@@ -145,6 +146,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.3-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.13.3-x86_64-linux)
       racc (~> 1.4)
     opentracing (0.5.0)
@@ -232,6 +235,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -241,14 +246,6 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -275,6 +272,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -308,12 +306,11 @@ DEPENDENCIES
   rspec_junit_formatter (>= 0.5.1)
   rspec_n (~> 1.3)
   rubocop (~> 1.10)
+  rubocop-packaging (~> 0.5)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_3.0.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.2.0)
       debase-ruby_core_source (= 0.10.16)
-      libddprof (~> 0.6.0.1.0)
+      libdatadog (~> 0.7.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -110,6 +110,7 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    google-protobuf (3.19.4)
     google-protobuf (3.19.4-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
@@ -117,8 +118,8 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddprof (0.6.0.1.0-x86_64-linux)
-    libddwaf (1.3.0.2.0-x86_64-linux)
+    libdatadog (0.7.0.1.0-aarch64-linux)
+    libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)
@@ -144,6 +145,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.3-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.13.3-x86_64-linux)
       racc (~> 1.4)
     opentracing (0.5.0)
@@ -232,6 +235,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -241,14 +246,6 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -275,6 +272,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -308,12 +306,11 @@ DEPENDENCIES
   rspec_junit_formatter (>= 0.5.1)
   rspec_n (~> 1.3)
   rubocop (~> 1.10)
+  rubocop-packaging (~> 0.5)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_3.0.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.2.0)
       debase-ruby_core_source (= 0.10.16)
-      libddprof (~> 0.6.0.1.0)
+      libdatadog (~> 0.7.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -110,6 +110,7 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    google-protobuf (3.19.4)
     google-protobuf (3.19.4-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
@@ -117,8 +118,8 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddprof (0.6.0.1.0-x86_64-linux)
-    libddwaf (1.3.0.2.0-x86_64-linux)
+    libdatadog (0.7.0.1.0-aarch64-linux)
+    libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)
@@ -144,6 +145,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.3-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.13.3-x86_64-linux)
       racc (~> 1.4)
     opentracing (0.5.0)
@@ -233,6 +236,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -242,14 +247,6 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -276,6 +273,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -310,12 +308,11 @@ DEPENDENCIES
   rspec_junit_formatter (>= 0.5.1)
   rspec_n (~> 1.3)
   rubocop (~> 1.10)
+  rubocop-packaging (~> 0.5)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_3.0.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.2.0)
       debase-ruby_core_source (= 0.10.16)
-      libddprof (~> 0.6.0.1.0)
+      libdatadog (~> 0.7.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,6 +111,7 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    google-protobuf (3.19.4)
     google-protobuf (3.19.4-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
@@ -118,8 +119,8 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddprof (0.6.0.1.0-x86_64-linux)
-    libddwaf (1.3.0.2.0-x86_64-linux)
+    libdatadog (0.7.0.1.0-aarch64-linux)
+    libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
       actionpack (>= 4)
@@ -145,6 +146,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.3-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.13.3-x86_64-linux)
       racc (~> 1.4)
     opentracing (0.5.0)
@@ -238,6 +241,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -253,14 +258,6 @@ GEM
       redis (>= 4.2.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -287,6 +284,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -321,13 +319,12 @@ DEPENDENCIES
   rspec_junit_formatter (>= 0.5.1)
   rspec_n (~> 1.3)
   rubocop (~> 1.10)
+  rubocop-packaging (~> 0.5)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   sidekiq (>= 6.1.2)
   simplecov!
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_3.0.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.2.0)
       debase-ruby_core_source (= 0.10.16)
-      libddprof (~> 0.6.0.1.0)
+      libdatadog (~> 0.7.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -110,6 +110,7 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    google-protobuf (3.19.4)
     google-protobuf (3.19.4-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
@@ -117,8 +118,8 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddprof (0.6.0.1.0-x86_64-linux)
-    libddwaf (1.3.0.2.0-x86_64-linux)
+    libdatadog (0.7.0.1.0-aarch64-linux)
+    libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
       crass (~> 1.0.2)
@@ -139,6 +140,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.3-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.13.3-x86_64-linux)
       racc (~> 1.4)
     opentracing (0.5.0)
@@ -229,6 +232,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -240,14 +245,6 @@ GEM
       concurrent-ruby (~> 1.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -274,6 +271,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -307,12 +305,11 @@ DEPENDENCIES
   rspec_junit_formatter (>= 0.5.1)
   rspec_n (~> 1.3)
   rubocop (~> 1.10)
+  rubocop-packaging (~> 0.5)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_3.0.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.2.0)
       debase-ruby_core_source (= 0.10.16)
-      libddprof (~> 0.6.0.1.0)
+      libdatadog (~> 0.7.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -46,12 +46,13 @@ GEM
     docile (1.4.0)
     dogstatsd-ruby (5.4.0)
     ffi (1.15.5)
+    google-protobuf (3.19.4)
     google-protobuf (3.19.4-x86_64-linux)
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddprof (0.6.0.1.0-x86_64-linux)
-    libddwaf (1.3.0.2.0-x86_64-linux)
+    libdatadog (0.7.0.1.0-aarch64-linux)
+    libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -124,6 +125,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -139,14 +142,6 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.2.0)
       tilt (~> 2.0)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.10)
     unicode-display_width (2.1.0)
@@ -160,6 +155,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -191,12 +187,11 @@ DEPENDENCIES
   rspec_junit_formatter (>= 0.5.1)
   rspec_n (~> 1.3)
   rubocop (~> 1.10)
+  rubocop-packaging (~> 0.5)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.0.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.2.0)
       debase-ruby_core_source (= 0.10.16)
-      libddprof (~> 0.6.0.1.0)
+      libdatadog (~> 0.7.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -46,12 +46,13 @@ GEM
     docile (1.4.0)
     dogstatsd-ruby (5.4.0)
     ffi (1.15.5)
+    google-protobuf (3.19.4)
     google-protobuf (3.19.4-x86_64-linux)
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libddprof (0.6.0.1.0-x86_64-linux)
-    libddwaf (1.3.0.2.0-x86_64-linux)
+    libdatadog (0.7.0.1.0-aarch64-linux)
+    libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -124,6 +125,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -139,14 +142,6 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.2.0)
       tilt (~> 2.0)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.10)
     unicode-display_width (2.1.0)
@@ -160,6 +155,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -191,12 +187,11 @@ DEPENDENCIES
   rspec_junit_formatter (>= 0.5.1)
   rspec_n (~> 1.3)
   rubocop (~> 1.10)
+  rubocop-packaging (~> 0.5)
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)


### PR DESCRIPTION
**What does this PR do?**
Introduce `aarch64-linux` platform for `gemfile.lock`

**Motivation**
Adding this would make re-resolving for the addition of that platform.