### PR TITLE
Update profiling development documentation

### DIFF
--- a/lib/datadog/profiling/collectors/stack.rb
+++ b/lib/datadog/profiling/collectors/stack.rb
@@ -3,7 +3,8 @@
 module Datadog
   module Profiling
     module Collectors
-      # Used to gather a stack trace from a given Ruby thread. Almost all of this class is implemented as native code.
+      # Used to gather a stack trace from a given Ruby thread. Stores its output on a `StackRecorder`.
+      # Almost all of this class is implemented as native code.
       #
       # Methods prefixed with _native_ are implemented in `collectors_stack.c`
       class Stack

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -2,7 +2,8 @@
 
 module Datadog
   module Profiling
-    # Used to wrap a ddprof_ffi_Profile in a Ruby object and expose Ruby-level serialization APIs
+    # Stores stack samples in a native libdatadog data structure and expose Ruby-level serialization APIs
+    # Note that `record_sample` is only accessible from native code.
     # Methods prefixed with _native_ are implemented in `stack_recorder.c`
     class StackRecorder
       def serialize


### PR DESCRIPTION
**What does this PR do?**:

A quick update to the `ProfilingDevelopment.md` file with the current state of affairs around the new profiler components.

**Motivation**:

Keep the architecture documented and hopefully accessible to others beyond the profiling team.

**Additional Notes**:

I've left a few gaps and TODOs. I'll fill these up later.

**How to test the change?**:

Does not actually change production code.
