### PR TITLE
Update images for integration environment

### DIFF
--- a/integration/apps/rack/docker-compose.yml
+++ b/integration/apps/rack/docker-compose.yml
@@ -66,9 +66,7 @@ services:
       #   source: /sys/fs/cgroup/
       #   target: /host/sys/fs/cgroup:ro
   load-tester:
-    build:
-      context: ../../images
-      dockerfile: wrk/Dockerfile
+    image: datadog/dd-apm-demo:wrk
     command: -t10 -c10 -d43200s -s /scripts/scenarios/basic/default.lua http://app/basic/default
     depends_on:
       - app

--- a/integration/apps/rails-five/docker-compose.yml
+++ b/integration/apps/rails-five/docker-compose.yml
@@ -91,9 +91,7 @@ services:
     expose:
       - "6379"
   load-tester:
-    build:
-      context: ../../images
-      dockerfile: wrk/Dockerfile
+    image: datadog/dd-apm-demo:wrk
     command: -t10 -c10 -d43200s -s /scripts/scenarios/basic/default.lua http://app/basic/default
     depends_on:
       - app

--- a/integration/apps/rails-five/docker-compose.yml
+++ b/integration/apps/rails-five/docker-compose.yml
@@ -87,7 +87,7 @@ services:
     expose:
       - "3306"
   redis:
-    image: redis:3.0
+    image: redis:3.2
     expose:
       - "6379"
   load-tester:

--- a/integration/apps/rails-seven/docker-compose.yml
+++ b/integration/apps/rails-seven/docker-compose.yml
@@ -101,9 +101,7 @@ services:
     expose:
       - "6379"
   load-tester:
-    build:
-      context: ../../images
-      dockerfile: wrk/Dockerfile
+    image: datadog/dd-apm-demo:wrk
     command: -t10 -c10 -d43200s -s /scripts/scenarios/basic/default.lua http://nginx/basic/default
     depends_on:
       - app

--- a/integration/apps/rails-seven/docker-compose.yml
+++ b/integration/apps/rails-seven/docker-compose.yml
@@ -97,7 +97,7 @@ services:
     expose:
       - "3306"
   redis:
-    image: redis:3.0
+    image: redis:3.2
     expose:
       - "6379"
   load-tester:

--- a/integration/apps/rails-six/docker-compose.yml
+++ b/integration/apps/rails-six/docker-compose.yml
@@ -91,9 +91,7 @@ services:
     expose:
       - "6379"
   load-tester:
-    build:
-      context: ../../images
-      dockerfile: wrk/Dockerfile
+    image: datadog/dd-apm-demo:wrk
     command: -t10 -c10 -d43200s -s /scripts/scenarios/basic/default.lua http://app/basic/default
     depends_on:
       - app

--- a/integration/apps/rails-six/docker-compose.yml
+++ b/integration/apps/rails-six/docker-compose.yml
@@ -87,7 +87,7 @@ services:
     expose:
       - "3306"
   redis:
-    image: redis:3.0
+    image: redis:3.2
     expose:
       - "6379"
   load-tester:

--- a/integration/apps/sinatra2-classic/docker-compose.yml
+++ b/integration/apps/sinatra2-classic/docker-compose.yml
@@ -64,9 +64,7 @@ services:
       #   source: /sys/fs/cgroup/
       #   target: /host/sys/fs/cgroup:ro
   load-tester:
-    build:
-      context: ../../images
-      dockerfile: wrk/Dockerfile
+    image: datadog/dd-apm-demo:wrk
     command: -t10 -c10 -d43200s -s /scripts/scenarios/basic/default.lua http://app/basic/default
     depends_on:
       - app

--- a/integration/apps/sinatra2-modular/docker-compose.yml
+++ b/integration/apps/sinatra2-modular/docker-compose.yml
@@ -64,9 +64,7 @@ services:
       #   source: /sys/fs/cgroup/
       #   target: /host/sys/fs/cgroup:ro
   load-tester:
-    build:
-      context: ../../images
-      dockerfile: wrk/Dockerfile
+    image: datadog/dd-apm-demo:wrk
     command: -t10 -c10 -d43200s -s /scripts/scenarios/basic/default.lua http://app/basic/fibonacci
     depends_on:
       - app


### PR DESCRIPTION
**What does this PR do?**

1. Update `redis` image
2. Use existing `wrk` image 

**Motivation**

The `redis` image does not working on M1 mac. 
The base image `debian:jessie` for `wrk` does not work on M1 mac, use an existing prebuilt `wrk` image in docker compose file instead building with context.

