### PR TITLE
Small improvements to documentation, user experience, and debugging of the profiling native extension

### DIFF
--- a/ext/ddtrace_profiling_native_extension/NativeExtensionDesign.md
+++ b/ext/ddtrace_profiling_native_extension/NativeExtensionDesign.md
@@ -18,6 +18,11 @@ the gem. Setting `DD_PROFILING_NO_EXTENSION` at installation time skips compilat
 In past releases, it was possible for the profiler to run without the native extension, but that's no longer the case,
 and disabling the extension will disable profiling.
 
+## Who is this page for?
+
+This documentation is intended to be used by dd-trace-rb developers. Please see the `docs/` folder for user-level
+documentation.
+
 ## Must not block or break users that cannot use it
 
 The profiling native extension is (and must always be) designed to **not cause failures** during gem installation, even
@@ -66,6 +71,8 @@ Because these private header files are not included in regular Ruby installation
 2. for Ruby versions < 2.6 (legacy Rubies) we make use of the `debase-ruby_core_source` gem
 
 Functions which make use of these headers are defined in the <private_vm_api_acccess.c> file.
+
+There is currently no way for disabling usage of the private MJIT header for Ruby 2.6+.
 
 **Important Note**: Our medium/long-term plan is to stop relying on all private Ruby headers, and instead request and
 contribute upstream changes so that they become official public VM APIs.

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -169,6 +169,10 @@ $LDFLAGS += \
   "#{Datadog::Profiling::NativeExtensionHelpers.libdatadog_folder_relative_to_native_lib_folder}"
 Logging.message(" [ddtrace] After pkg-config $LDFLAGS were set to: #{$LDFLAGS.inspect}\n")
 
+Logging.message(" [ddtrace] Using compiler:\n")
+xsystem("#{CONFIG['CC']} --version")
+Logging.message(" [ddtrace] End of compiler information\n")
+
 # Tag the native extension library with the Ruby version and Ruby platform.
 # This makes it easier for development (avoids "oops I forgot to rebuild when I switched my Ruby") and ensures that
 # the wrong library is never loaded.

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -138,6 +138,8 @@ module Datadog
         CONTACT_SUPPORT = [
           'For help solving this issue, please contact Datadog support at',
           '<https://docs.datadoghq.com/help/>.',
+          'You can also check out the Continuous Profiler troubleshooting page at',
+          '<https://dtdg.co/ruby-profiler-troubleshooting>.'
         ].freeze
 
         REPORT_ISSUE = [


### PR DESCRIPTION
**What does this PR do?**:

This PR includes three small changes related to the profiling native extension. I recommend reviewing commit-by-commit.

These changes:
* Improve our documentation around the profiling native extension
* Add more information to the compilation log (the compiler version)
* Suggest that users look at the profiler troubleshooting page when there's an issue 

**Motivation**:

While looking into support tickets, I thought we could do these small improvements to help the customer experience, as well as improve our support experience.

**How to test the change?**:

You can simulate a compilation failure in the profiler by running (in a docker container) ```rm `which pkg-config` ``` and then `bundle exec rake clean compile`.

Otherwise, if the profiler builds and starts up, then the changes are working correctly.