### PR TITLE
Set global source in Gemfile

### DIFF
--- a/integration/apps/rack/Gemfile
+++ b/integration/apps/rack/Gemfile
@@ -1,5 +1,7 @@
 require 'datadog/demo_env'
 
+source "https://rubygems.org"
+
 source 'https://rubygems.org' do
   gem 'puma'
   gem 'unicorn'

--- a/integration/apps/rack/Gemfile
+++ b/integration/apps/rack/Gemfile
@@ -2,50 +2,48 @@ require 'datadog/demo_env'
 
 source "https://rubygems.org"
 
-source 'https://rubygems.org' do
-  gem 'puma'
-  gem 'unicorn'
-  gem 'rack'
-  if RUBY_VERSION < '2.3'
-    gem 'redis', '< 4.1.1' # 4.1.1 "claims" to support 2.2 but is actually broken
-  else
-    gem 'redis'
-  end
-  if RUBY_VERSION < '2.2'
-    gem 'sidekiq', '< 5' # 5.0.3 checks for older Rubies and breaks, but does not declare it on the gemspec :(
-  else
-    gem 'sidekiq'
-  end
-  gem 'resque'
-  gem 'rake'
-
-  gem 'dogstatsd-ruby'
-  # Choose correct specs for 'ddtrace' demo environment
-  gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
-
-  # Needed for ddtrace profiling
-  google_protobuf_versions = [
-    '~> 3.0',
-    '!= 3.7.0.rc.2',
-    '!= 3.7.0.rc.3',
-    '!= 3.7.0',
-    '!= 3.7.1',
-    '!= 3.8.0.rc.1'
-  ]
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4')
-    gem 'google-protobuf', *google_protobuf_versions
-  else
-    # Bundler resolves incorrect version (too new, incompatible with Ruby <= 2.3)
-    gem 'google-protobuf', *google_protobuf_versions, '< 3.19.2'
-  end
-
-  # Development
-  gem 'pry-byebug'
-  # gem 'pry-stack_explorer', platform: :ruby
-  # gem 'rbtrace'
-  # gem 'ruby-prof'
-
-  gem 'rspec'
-  gem 'rspec-wait'
-  gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick
+gem 'puma'
+gem 'unicorn'
+gem 'rack'
+if RUBY_VERSION < '2.3'
+  gem 'redis', '< 4.1.1' # 4.1.1 "claims" to support 2.2 but is actually broken
+else
+  gem 'redis'
 end
+if RUBY_VERSION < '2.2'
+  gem 'sidekiq', '< 5' # 5.0.3 checks for older Rubies and breaks, but does not declare it on the gemspec :(
+else
+  gem 'sidekiq'
+end
+gem 'resque'
+gem 'rake'
+
+gem 'dogstatsd-ruby'
+# Choose correct specs for 'ddtrace' demo environment
+gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
+
+# Needed for ddtrace profiling
+google_protobuf_versions = [
+  '~> 3.0',
+  '!= 3.7.0.rc.2',
+  '!= 3.7.0.rc.3',
+  '!= 3.7.0',
+  '!= 3.7.1',
+  '!= 3.8.0.rc.1'
+]
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4')
+  gem 'google-protobuf', *google_protobuf_versions
+else
+  # Bundler resolves incorrect version (too new, incompatible with Ruby <= 2.3)
+  gem 'google-protobuf', *google_protobuf_versions, '< 3.19.2'
+end
+
+# Development
+gem 'pry-byebug'
+# gem 'pry-stack_explorer', platform: :ruby
+# gem 'rbtrace'
+# gem 'ruby-prof'
+
+gem 'rspec'
+gem 'rspec-wait'
+gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick

--- a/integration/apps/rails-five/Gemfile
+++ b/integration/apps/rails-five/Gemfile
@@ -2,106 +2,104 @@ require 'datadog/demo_env'
 
 source "https://rubygems.org"
 
-source 'https://rubygems.org' do
   # gem 'rails', '5.2.2'
 
-  google_protobuf_versions = [
-    '~> 3.0',
-    '!= 3.7.0.rc.2',
-    '!= 3.7.0.rc.3',
-    '!= 3.7.0',
-    '!= 3.7.1',
-    '!= 3.8.0.rc.1',
-    '!= 3.20.0.rc.1',
-    '!= 3.20.0.rc.2',
-  ]
+google_protobuf_versions = [
+  '~> 3.0',
+  '!= 3.7.0.rc.2',
+  '!= 3.7.0.rc.3',
+  '!= 3.7.0',
+  '!= 3.7.1',
+  '!= 3.8.0.rc.1',
+  '!= 3.20.0.rc.1',
+  '!= 3.20.0.rc.2',
+]
 
-  rails_version = ['~> 5.2', '>= 5.2.6']
+rails_version = ['~> 5.2', '>= 5.2.6']
 
-  gem 'actioncable', *rails_version
-  gem 'actionmailer', *rails_version
-  gem 'actionpack', *rails_version
-  gem 'actionview', *rails_version
-  gem 'activejob', *rails_version
-  gem 'activemodel', *rails_version
-  gem 'activerecord', *rails_version
-  gem 'railties', *rails_version
+gem 'actioncable', *rails_version
+gem 'actionmailer', *rails_version
+gem 'actionpack', *rails_version
+gem 'actionview', *rails_version
+gem 'activejob', *rails_version
+gem 'activemodel', *rails_version
+gem 'activerecord', *rails_version
+gem 'railties', *rails_version
 
-  gem 'mysql2'
-  gem 'puma'
-  gem 'unicorn'
+gem 'mysql2'
+gem 'puma'
+gem 'unicorn'
 
-  # Choose correct specs for 'ddtrace' demo environment
-  gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
+# Choose correct specs for 'ddtrace' demo environment
+gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
 
-  gem 'dogstatsd-ruby'
-  gem 'ffi'
+gem 'dogstatsd-ruby'
+gem 'ffi'
 
-  # Needed for ddtrace profiling
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4')
-    gem 'google-protobuf', *google_protobuf_versions
-  else
-    # Bundler resolves incorrect version (too new, incompatible with Ruby <= 2.3)
-    gem 'google-protobuf', '< 3.19.2'
-  end
+# Needed for ddtrace profiling
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4')
+  gem 'google-protobuf', *google_protobuf_versions
+else
+  # Bundler resolves incorrect version (too new, incompatible with Ruby <= 2.3)
+  gem 'google-protobuf', '< 3.19.2'
+end
 
-  # Fixes conflict with profiling (patch overwrite in Thread)
-  # Upgrade this to latest when this patch is merged & released.
-  # https://github.com/rollbar/rollbar-gem/pull/1018
-  gem 'rollbar', git: 'https://github.com/rollbar/rollbar-gem.git', ref: '310a9d1743bb44031480b49e8e0cef79ddc870c3'
+# Fixes conflict with profiling (patch overwrite in Thread)
+# Upgrade this to latest when this patch is merged & released.
+# https://github.com/rollbar/rollbar-gem/pull/1018
+gem 'rollbar', git: 'https://github.com/rollbar/rollbar-gem.git', ref: '310a9d1743bb44031480b49e8e0cef79ddc870c3'
 
-  # Gems which give aide to higher performance
-  gem 'hiredis', '~> 0.6', platform: :ruby
-  gem 'multi_json'
-  gem 'oj', '3.3', platform: :ruby
+# Gems which give aide to higher performance
+gem 'hiredis', '~> 0.6', platform: :ruby
+gem 'multi_json'
+gem 'oj', '3.3', platform: :ruby
 
-  gem 'active_model_serializers', '0.9.3'
-  gem 'activerecord-import' # Speeds up mass imports
-  gem 'aws-sdk', '< 2.0'
-  gem 'bcrypt-ruby', platform: :ruby
-  gem 'connection_pool'
-  gem 'devise'
-  gem 'faker', require: false # Make up fake data to put in models for load testing
-  gem 'geoip'
-  gem 'hawk-auth'
-  gem 'httparty'
-  gem 'ipaddress'
-  gem 'rabl', platform: :ruby
-  gem 'rack-cors'
-  gem 'rake'
-  gem 'redis'
-  gem 'resque'
-  # gem 'resque-pool' # Incompatible with Redis 4.0+
-  gem 'resque-scheduler'
-  gem 'tzinfo-data', platforms: [:mingw, :mswin, :jruby]
-  gem 'validates_timeliness', '~> 3.0.8' # Date comparisons
-  gem 'versionist'
-  gem 'warden'
+gem 'active_model_serializers', '0.9.3'
+gem 'activerecord-import' # Speeds up mass imports
+gem 'aws-sdk', '< 2.0'
+gem 'bcrypt-ruby', platform: :ruby
+gem 'connection_pool'
+gem 'devise'
+gem 'faker', require: false # Make up fake data to put in models for load testing
+gem 'geoip'
+gem 'hawk-auth'
+gem 'httparty'
+gem 'ipaddress'
+gem 'rabl', platform: :ruby
+gem 'rack-cors'
+gem 'rake'
+gem 'redis'
+gem 'resque'
+# gem 'resque-pool' # Incompatible with Redis 4.0+
+gem 'resque-scheduler'
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :jruby]
+gem 'validates_timeliness', '~> 3.0.8' # Date comparisons
+gem 'versionist'
+gem 'warden'
 
-  group :development do
-    gem 'annotate'
-    gem 'awesome_print'
-    gem 'bullet'
-  end
+group :development do
+  gem 'annotate'
+  gem 'awesome_print'
+  gem 'bullet'
+end
 
-  group :test do
-    gem 'ci_reporter_rspec'
-    gem 'database_cleaner'
-    gem 'factory_girl_rails', '4.5.0'
-    gem 'rspec'
-    gem 'rspec-collection_matchers'
-    gem 'rspec-rails'
-    gem 'shoulda-matchers', '4.0.1'
-    gem 'simplecov', require: false # Will install simplecov-html as a dependency
-    gem 'timecop'
-    gem 'webmock'
-  end
+group :test do
+  gem 'ci_reporter_rspec'
+  gem 'database_cleaner'
+  gem 'factory_girl_rails', '4.5.0'
+  gem 'rspec'
+  gem 'rspec-collection_matchers'
+  gem 'rspec-rails'
+  gem 'shoulda-matchers', '4.0.1'
+  gem 'simplecov', require: false # Will install simplecov-html as a dependency
+  gem 'timecop'
+  gem 'webmock'
+end
 
-  group :test, :development do
-    gem 'byebug', platform: :ruby
-    gem 'mock_redis', '0.19.0'
-    gem 'parallel_tests'
+group :test, :development do
+  gem 'byebug', platform: :ruby
+  gem 'mock_redis', '0.19.0'
+  gem 'parallel_tests'
 
-    gem 'listen'
-  end
+  gem 'listen'
 end

--- a/integration/apps/rails-five/Gemfile
+++ b/integration/apps/rails-five/Gemfile
@@ -1,5 +1,7 @@
 require 'datadog/demo_env'
 
+source "https://rubygems.org"
+
 source 'https://rubygems.org' do
   # gem 'rails', '5.2.2'
 

--- a/integration/apps/rails-seven/Gemfile
+++ b/integration/apps/rails-seven/Gemfile
@@ -2,107 +2,105 @@ require 'datadog/demo_env'
 
 source "https://rubygems.org"
 
-source "https://rubygems.org" do
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-  # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
-  gem "rails", "~> 7.0.2", ">= 7.0.2.3"
+# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
+gem "rails", "~> 7.0.2", ">= 7.0.2.3"
 
-  # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
-  gem "sprockets-rails"
+# The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
+gem "sprockets-rails"
 
-  # Use sqlite3 as the database for Active Record
-  gem "sqlite3", "~> 1.4"
+# Use sqlite3 as the database for Active Record
+gem "sqlite3", "~> 1.4"
 
-  # Use the Puma web server [https://github.com/puma/puma]
-  gem "puma", "~> 5.0"
+# Use the Puma web server [https://github.com/puma/puma]
+gem "puma", "~> 5.0"
 
-  # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
-  gem "importmap-rails"
+# Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
+gem "importmap-rails"
 
-  # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-  gem "turbo-rails"
+# Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
+gem "turbo-rails"
 
-  # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
-  gem "stimulus-rails"
+# Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
+gem "stimulus-rails"
 
-  # Build JSON APIs with ease [https://github.com/rails/jbuilder]
-  gem "jbuilder"
+# Build JSON APIs with ease [https://github.com/rails/jbuilder]
+gem "jbuilder"
 
-  # Use Redis adapter to run Action Cable in production
-  # gem "redis", "~> 4.0"
+# Use Redis adapter to run Action Cable in production
+# gem "redis", "~> 4.0"
 
-  # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
-  # gem "kredis"
+# Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
+# gem "kredis"
 
-  # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-  # gem "bcrypt", "~> 3.1.7"
+# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
+# gem "bcrypt", "~> 3.1.7"
 
-  # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-  gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 
-  # Reduces boot times through caching; required in config/boot.rb
-  gem "bootsnap", require: false
+# Reduces boot times through caching; required in config/boot.rb
+gem "bootsnap", require: false
 
-  # Use Sass to process CSS
-  # gem "sassc-rails"
+# Use Sass to process CSS
+# gem "sassc-rails"
 
-  # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-  # gem "image_processing", "~> 1.2"
+# Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
+# gem "image_processing", "~> 1.2"
 
-  group :development, :test do
-    # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-    gem "debug", platforms: %i[ mri mingw x64_mingw ]
-  end
-
-  group :development do
-    # Use console on exceptions pages [https://github.com/rails/web-console]
-    gem "web-console"
-
-    # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
-    # gem "rack-mini-profiler"
-
-    # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
-    # gem "spring"
-  end
-
-  group :test do
-    # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-    gem "capybara"
-    gem "selenium-webdriver"
-    gem "webdrivers"
-
-    gem 'rspec'
-    gem 'rspec-collection_matchers'
-    gem 'rspec-rails'
-    gem 'shoulda-matchers'
-
-    gem 'simplecov', require: false # Will install simplecov-html as a dependency
-    gem 'timecop'
-    gem 'webmock'
-  end
-
-  # Custom gems:
-  gem 'aws-sdk'
-  gem 'devise'
-  gem 'httparty'
-  gem 'mysql2'
-  gem 'redis'
-  gem 'resque'
-  gem 'unicorn'
-
-  # Choose correct specs for 'ddtrace' demo environment
-  gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
-  gem 'dogstatsd-ruby'
-  gem 'rollbar'
-
-  google_protobuf_versions = [
-    '~> 3.0',
-    '!= 3.7.0.rc.2',
-    '!= 3.7.0.rc.3',
-    '!= 3.7.0',
-    '!= 3.7.1',
-    '!= 3.8.0.rc.1'
-  ]
-  gem 'google-protobuf', *google_protobuf_versions
+group :development, :test do
+  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+  gem "debug", platforms: %i[ mri mingw x64_mingw ]
 end
+
+group :development do
+  # Use console on exceptions pages [https://github.com/rails/web-console]
+  gem "web-console"
+
+  # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
+  # gem "rack-mini-profiler"
+
+  # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
+  # gem "spring"
+end
+
+group :test do
+  # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
+  gem "capybara"
+  gem "selenium-webdriver"
+  gem "webdrivers"
+
+  gem 'rspec'
+  gem 'rspec-collection_matchers'
+  gem 'rspec-rails'
+  gem 'shoulda-matchers'
+
+  gem 'simplecov', require: false # Will install simplecov-html as a dependency
+  gem 'timecop'
+  gem 'webmock'
+end
+
+# Custom gems:
+gem 'aws-sdk'
+gem 'devise'
+gem 'httparty'
+gem 'mysql2'
+gem 'redis'
+gem 'resque'
+gem 'unicorn'
+
+# Choose correct specs for 'ddtrace' demo environment
+gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
+gem 'dogstatsd-ruby'
+gem 'rollbar'
+
+google_protobuf_versions = [
+  '~> 3.0',
+  '!= 3.7.0.rc.2',
+  '!= 3.7.0.rc.3',
+  '!= 3.7.0',
+  '!= 3.7.1',
+  '!= 3.8.0.rc.1'
+]
+gem 'google-protobuf', *google_protobuf_versions

--- a/integration/apps/rails-seven/Gemfile
+++ b/integration/apps/rails-seven/Gemfile
@@ -1,5 +1,7 @@
 require 'datadog/demo_env'
 
+source "https://rubygems.org"
+
 source "https://rubygems.org" do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 

--- a/integration/apps/rails-six/Gemfile
+++ b/integration/apps/rails-six/Gemfile
@@ -2,108 +2,106 @@ require 'datadog/demo_env'
 
 source "https://rubygems.org"
 
-source 'https://rubygems.org' do
-  google_protobuf_versions = [
-    '~> 3.0',
-    '!= 3.7.0.rc.2',
-    '!= 3.7.0.rc.3',
-    '!= 3.7.0',
-    '!= 3.7.1',
-    '!= 3.8.0.rc.1'
-  ]
+google_protobuf_versions = [
+  '~> 3.0',
+  '!= 3.7.0.rc.2',
+  '!= 3.7.0.rc.3',
+  '!= 3.7.0',
+  '!= 3.7.1',
+  '!= 3.8.0.rc.1'
+]
 
-  rails_version = ['~> 6.1']
+rails_version = ['~> 6.1']
 
-  gem 'actioncable', *rails_version
-  gem 'actionmailer', *rails_version
-  gem 'actionpack', *rails_version
-  gem 'actionview', *rails_version
-  gem 'activejob', *rails_version
-  gem 'activemodel', *rails_version
-  gem 'activerecord', *rails_version
-  gem 'railties', *rails_version
+gem 'actioncable', *rails_version
+gem 'actionmailer', *rails_version
+gem 'actionpack', *rails_version
+gem 'actionview', *rails_version
+gem 'activejob', *rails_version
+gem 'activemodel', *rails_version
+gem 'activerecord', *rails_version
+gem 'railties', *rails_version
 
-  gem 'mysql2'
-  gem 'puma'
-  gem 'unicorn'
+gem 'mysql2'
+gem 'puma'
+gem 'unicorn'
 
-  # Choose correct specs for 'ddtrace' demo environment
-  gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
+# Choose correct specs for 'ddtrace' demo environment
+gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
 
-  gem 'dogstatsd-ruby'
-  gem 'ffi'
-  gem 'google-protobuf', *google_protobuf_versions
+gem 'dogstatsd-ruby'
+gem 'ffi'
+gem 'google-protobuf', *google_protobuf_versions
 
-  # Gems which give aide to higher performance
-  gem 'hiredis', platform: :ruby
-  gem 'multi_json'
-  gem 'oj', platform: :ruby
+# Gems which give aide to higher performance
+gem 'hiredis', platform: :ruby
+gem 'multi_json'
+gem 'oj', platform: :ruby
 
-  # Need to add these because ActionMailer is broken in 6.1.6
-  # https://github.com/rails/rails/pull/44697
+# Need to add these because ActionMailer is broken in 6.1.6
+# https://github.com/rails/rails/pull/44697
+if RUBY_VERSION < '2.6.0'
+  gem 'net-smtp', '0.3.0'
+  gem 'net-imap', '0.2.2'
+else
+  gem 'net-smtp'
+  gem 'net-imap'
+end
+gem 'net-pop'
+
+gem 'active_model_serializers'
+gem 'activerecord-import' # Speeds up mass imports
+gem 'aws-sdk'
+gem 'bcrypt-ruby', platform: :ruby
+gem 'connection_pool'
+gem 'devise'
+gem 'faker', require: false # Make up fake data to put in models for load testing
+gem 'geoip'
+gem 'hawk-auth'
+gem 'httparty'
+gem 'ipaddress'
+gem 'rabl', platform: :ruby
+gem 'rack-cors'
+gem 'rake'
+gem 'redis'
+gem 'resque'
+# gem 'resque-pool' # Incompatible with Redis 4.0+
+gem 'resque-scheduler'
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :jruby]
+gem 'validates_timeliness'
+gem 'versionist'
+gem 'warden'
+gem 'rollbar'
+
+group :development do
+  gem 'annotate'
+  gem 'awesome_print'
+  gem 'bullet'
+end
+
+group :test do
+  gem 'ci_reporter_rspec'
+  gem 'database_cleaner'
+  gem 'factory_girl_rails'
+  gem 'rspec'
+  gem 'rspec-collection_matchers'
+  gem 'rspec-rails'
+
   if RUBY_VERSION < '2.6.0'
-    gem 'net-smtp', '0.3.0'
-    gem 'net-imap', '0.2.2'
+    gem 'shoulda-matchers', '~> 4.5'
   else
-    gem 'net-smtp'
-    gem 'net-imap'
-  end
-  gem 'net-pop'
-
-  gem 'active_model_serializers'
-  gem 'activerecord-import' # Speeds up mass imports
-  gem 'aws-sdk'
-  gem 'bcrypt-ruby', platform: :ruby
-  gem 'connection_pool'
-  gem 'devise'
-  gem 'faker', require: false # Make up fake data to put in models for load testing
-  gem 'geoip'
-  gem 'hawk-auth'
-  gem 'httparty'
-  gem 'ipaddress'
-  gem 'rabl', platform: :ruby
-  gem 'rack-cors'
-  gem 'rake'
-  gem 'redis'
-  gem 'resque'
-  # gem 'resque-pool' # Incompatible with Redis 4.0+
-  gem 'resque-scheduler'
-  gem 'tzinfo-data', platforms: [:mingw, :mswin, :jruby]
-  gem 'validates_timeliness'
-  gem 'versionist'
-  gem 'warden'
-  gem 'rollbar'
-
-  group :development do
-    gem 'annotate'
-    gem 'awesome_print'
-    gem 'bullet'
+    gem 'shoulda-matchers'
   end
 
-  group :test do
-    gem 'ci_reporter_rspec'
-    gem 'database_cleaner'
-    gem 'factory_girl_rails'
-    gem 'rspec'
-    gem 'rspec-collection_matchers'
-    gem 'rspec-rails'
+  gem 'simplecov', require: false # Will install simplecov-html as a dependency
+  gem 'timecop'
+  gem 'webmock'
+end
 
-    if RUBY_VERSION < '2.6.0'
-      gem 'shoulda-matchers', '~> 4.5'
-    else
-      gem 'shoulda-matchers'
-    end
+group :test, :development do
+  gem 'byebug', platform: :ruby
+  gem 'mock_redis'
+  gem 'parallel_tests'
 
-    gem 'simplecov', require: false # Will install simplecov-html as a dependency
-    gem 'timecop'
-    gem 'webmock'
-  end
-
-  group :test, :development do
-    gem 'byebug', platform: :ruby
-    gem 'mock_redis'
-    gem 'parallel_tests'
-
-    gem 'listen'
-  end
+  gem 'listen'
 end

--- a/integration/apps/rails-six/Gemfile
+++ b/integration/apps/rails-six/Gemfile
@@ -1,5 +1,7 @@
 require 'datadog/demo_env'
 
+source "https://rubygems.org"
+
 source 'https://rubygems.org' do
   google_protobuf_versions = [
     '~> 3.0',

--- a/integration/apps/rspec/Gemfile
+++ b/integration/apps/rspec/Gemfile
@@ -2,15 +2,13 @@ require 'datadog/demo_env'
 
 source "https://rubygems.org"
 
-source 'https://rubygems.org' do
-  gem 'ffi'
-  gem 'google-protobuf'
+gem 'ffi'
+gem 'google-protobuf'
 
-  # Choose correct specs for 'ddtrace' demo environment
-  gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
+# Choose correct specs for 'ddtrace' demo environment
+gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
 
-  gem 'byebug'
+gem 'byebug'
 
-  # Testing/CI
-  gem 'rspec'
-end
+# Testing/CI
+gem 'rspec'

--- a/integration/apps/rspec/Gemfile
+++ b/integration/apps/rspec/Gemfile
@@ -1,5 +1,7 @@
 require 'datadog/demo_env'
 
+source "https://rubygems.org"
+
 source 'https://rubygems.org' do
   gem 'ffi'
   gem 'google-protobuf'

--- a/integration/apps/ruby/Gemfile
+++ b/integration/apps/ruby/Gemfile
@@ -2,12 +2,10 @@ require 'datadog/demo_env'
 
 source "https://rubygems.org"
 
-source 'https://rubygems.org' do
-  gem 'ffi'
-  gem 'google-protobuf'
+gem 'ffi'
+gem 'google-protobuf'
 
-  # Choose correct specs for 'ddtrace' demo environment
-  gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
+# Choose correct specs for 'ddtrace' demo environment
+gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
 
-  gem 'byebug'
-end
+gem 'byebug'

--- a/integration/apps/ruby/Gemfile
+++ b/integration/apps/ruby/Gemfile
@@ -1,5 +1,7 @@
 require 'datadog/demo_env'
 
+source "https://rubygems.org"
+
 source 'https://rubygems.org' do
   gem 'ffi'
   gem 'google-protobuf'

--- a/integration/apps/sinatra2-classic/Gemfile
+++ b/integration/apps/sinatra2-classic/Gemfile
@@ -1,5 +1,7 @@
 require 'datadog/demo_env'
 
+source "https://rubygems.org"
+
 source 'https://rubygems.org' do
   gem 'puma'
   gem 'unicorn'

--- a/integration/apps/sinatra2-classic/Gemfile
+++ b/integration/apps/sinatra2-classic/Gemfile
@@ -2,37 +2,35 @@ require 'datadog/demo_env'
 
 source "https://rubygems.org"
 
-source 'https://rubygems.org' do
-  gem 'puma'
-  gem 'unicorn'
-  gem 'sinatra'
+gem 'puma'
+gem 'unicorn'
+gem 'sinatra'
 
-  gem 'dogstatsd-ruby'
-  # Choose correct specs for 'ddtrace' demo environment
-  gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
+gem 'dogstatsd-ruby'
+# Choose correct specs for 'ddtrace' demo environment
+gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
 
-  # Needed for ddtrace profiling
-  google_protobuf_versions = [
-    '~> 3.0',
-    '!= 3.7.0.rc.2',
-    '!= 3.7.0.rc.3',
-    '!= 3.7.0',
-    '!= 3.7.1',
-    '!= 3.8.0.rc.1'
-  ]
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4')
-    gem 'google-protobuf', *google_protobuf_versions
-  else
-    # Bundler resolves incorrect version (too new, incompatible with Ruby <= 2.3)
-    gem 'google-protobuf', *google_protobuf_versions, '< 3.19.2'
-  end
-
-  # Development
-  gem 'pry-byebug'
-  # gem 'pry-stack_explorer', platform: :ruby
-  # gem 'rbtrace'
-  # gem 'ruby-prof'
-  gem 'rspec'
-  gem 'rspec-wait'
-  gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick
+# Needed for ddtrace profiling
+google_protobuf_versions = [
+  '~> 3.0',
+  '!= 3.7.0.rc.2',
+  '!= 3.7.0.rc.3',
+  '!= 3.7.0',
+  '!= 3.7.1',
+  '!= 3.8.0.rc.1'
+]
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4')
+  gem 'google-protobuf', *google_protobuf_versions
+else
+  # Bundler resolves incorrect version (too new, incompatible with Ruby <= 2.3)
+  gem 'google-protobuf', *google_protobuf_versions, '< 3.19.2'
 end
+
+# Development
+gem 'pry-byebug'
+# gem 'pry-stack_explorer', platform: :ruby
+# gem 'rbtrace'
+# gem 'ruby-prof'
+gem 'rspec'
+gem 'rspec-wait'
+gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick

--- a/integration/apps/sinatra2-modular/Gemfile
+++ b/integration/apps/sinatra2-modular/Gemfile
@@ -1,5 +1,7 @@
 require 'datadog/demo_env'
 
+source "https://rubygems.org"
+
 source 'https://rubygems.org' do
   gem 'puma'
   gem 'unicorn'

--- a/integration/apps/sinatra2-modular/Gemfile
+++ b/integration/apps/sinatra2-modular/Gemfile
@@ -2,38 +2,36 @@ require 'datadog/demo_env'
 
 source "https://rubygems.org"
 
-source 'https://rubygems.org' do
-  gem 'puma'
-  gem 'unicorn'
-  gem 'sinatra'
-  gem 'sinatra-router'
+gem 'puma'
+gem 'unicorn'
+gem 'sinatra'
+gem 'sinatra-router'
 
-  gem 'dogstatsd-ruby'
-  # Choose correct specs for 'ddtrace' demo environment
-  gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
+gem 'dogstatsd-ruby'
+# Choose correct specs for 'ddtrace' demo environment
+gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
 
-  # Needed for ddtrace profiling
-  google_protobuf_versions = [
-    '~> 3.0',
-    '!= 3.7.0.rc.2',
-    '!= 3.7.0.rc.3',
-    '!= 3.7.0',
-    '!= 3.7.1',
-    '!= 3.8.0.rc.1'
-  ]
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4')
-    gem 'google-protobuf', *google_protobuf_versions
-  else
-    # Bundler resolves incorrect version (too new, incompatible with Ruby <= 2.3)
-    gem 'google-protobuf', *google_protobuf_versions, '< 3.19.2'
-  end
-
-  # Development
-  gem 'pry-byebug'
-  # gem 'pry-stack_explorer', platform: :ruby
-  # gem 'rbtrace'
-  # gem 'ruby-prof'
-  gem 'rspec'
-  gem 'rspec-wait'
-  gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick
+# Needed for ddtrace profiling
+google_protobuf_versions = [
+  '~> 3.0',
+  '!= 3.7.0.rc.2',
+  '!= 3.7.0.rc.3',
+  '!= 3.7.0',
+  '!= 3.7.1',
+  '!= 3.8.0.rc.1'
+]
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4')
+  gem 'google-protobuf', *google_protobuf_versions
+else
+  # Bundler resolves incorrect version (too new, incompatible with Ruby <= 2.3)
+  gem 'google-protobuf', *google_protobuf_versions, '< 3.19.2'
 end
+
+# Development
+gem 'pry-byebug'
+# gem 'pry-stack_explorer', platform: :ruby
+# gem 'rbtrace'
+# gem 'ruby-prof'
+gem 'rspec'
+gem 'rspec-wait'
+gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick


### PR DESCRIPTION
**What does this PR do?**

Set global source in Gemfile

**Motivation**

Fix flaky spec and follow the hint

```
[DEPRECATED] This Gemfile does not include an explicit global source. Not using an explicit global source may result in a different lockfile being generated depending on the gems you have installed locally before bundler is run. Instead, define a global source in your Gemfile like this: source "https://rubygems.org".
```

https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/6826/workflows/06fa256e-a72e-4ef9-854f-ded000e353e8/jobs/252886

```
Fetching gem metadata from https://rubygems.org/............
Resolving dependencies...
Your bundle is locked to google-protobuf (3.21.4-x86_64-linux) from rubygems
repository https://rubygems.org/ or installed locally, but that version can no
longer be found in that source. That means the author of google-protobuf
(3.21.4-x86_64-linux) has removed it. You'll need to update your bundle to a
version other than google-protobuf (3.21.4-x86_64-linux) that hasn't been
removed in order to install.
The command '/bin/sh -c bundle install' returned a non-zero code: 7
ERROR: Service 'sidekiq' failed to build : Build failed

Exited with code exit status 1
```