### PR TITLE
Replace `Exporter#empty?` with `Exporter#can_flush?`

### DIFF
--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -22,18 +22,18 @@ module Datadog
       attr_reader \
         :pprof_recorder,
         :code_provenance_collector, # The code provenance collector acts both as collector and as a recorder
-        :minimum_duration
+        :minimum_duration_seconds
 
       public
 
       def initialize(
         pprof_recorder:,
         code_provenance_collector:,
-        minimum_duration: PROFILE_DURATION_THRESHOLD_SECONDS
+        minimum_duration_seconds: PROFILE_DURATION_THRESHOLD_SECONDS
       )
         @pprof_recorder = pprof_recorder
         @code_provenance_collector = code_provenance_collector
-        @minimum_duration = minimum_duration
+        @minimum_duration_seconds = minimum_duration_seconds
       end
 
       def flush
@@ -67,7 +67,7 @@ module Datadog
       private
 
       def duration_below_threshold?(start, finish)
-        (finish - start) < @minimum_duration
+        (finish - start) < minimum_duration_seconds
       end
     end
   end

--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -22,22 +22,30 @@ module Datadog
       attr_reader \
         :pprof_recorder,
         :code_provenance_collector, # The code provenance collector acts both as collector and as a recorder
-        :minimum_duration_seconds
+        :minimum_duration_seconds,
+        :time_provider,
+        :last_flush_finish_at,
+        :created_at
 
       public
 
       def initialize(
         pprof_recorder:,
         code_provenance_collector:,
-        minimum_duration_seconds: PROFILE_DURATION_THRESHOLD_SECONDS
+        minimum_duration_seconds: PROFILE_DURATION_THRESHOLD_SECONDS,
+        time_provider: Time
       )
         @pprof_recorder = pprof_recorder
         @code_provenance_collector = code_provenance_collector
         @minimum_duration_seconds = minimum_duration_seconds
+        @time_provider = time_provider
+        @last_flush_finish_at = nil
+        @created_at = time_provider.now.utc
       end
 
       def flush
         start, finish, uncompressed_pprof = pprof_recorder.serialize
+        @last_flush_finish_at = finish
 
         return if uncompressed_pprof.nil? # We don't want to report empty profiles
 
@@ -60,8 +68,8 @@ module Datadog
         )
       end
 
-      def empty?
-        pprof_recorder.empty?
+      def can_flush?
+        !duration_below_threshold?(last_flush_finish_at || created_at, time_provider.now.utc)
       end
 
       private

--- a/lib/datadog/profiling/old_recorder.rb
+++ b/lib/datadog/profiling/old_recorder.rb
@@ -73,11 +73,6 @@ module Datadog
         [start, finish, encoded_pprof]
       end
 
-      # NOTE: Remember that if the recorder is being accessed by multiple threads, this is an inherently racy operation.
-      def empty?
-        @buffers.values.all?(&:empty?)
-      end
-
       # Error when event of an unknown type is used with the OldRecorder
       class UnknownEventError < StandardError
         attr_reader :event_class

--- a/lib/datadog/profiling/scheduler.rb
+++ b/lib/datadog/profiling/scheduler.rb
@@ -83,7 +83,7 @@ module Datadog
       end
 
       def work_pending?
-        !exporter.empty?
+        exporter.can_flush?
       end
 
       private

--- a/spec/datadog/profiling/old_recorder_spec.rb
+++ b/spec/datadog/profiling/old_recorder_spec.rb
@@ -175,21 +175,4 @@ RSpec.describe Datadog::Profiling::OldRecorder do
       it { is_expected.to be nil }
     end
   end
-
-  describe '#empty?' do
-    let(:event_classes) { [event_class] }
-    let(:event_class) { Class.new(Datadog::Profiling::Event) }
-
-    context 'when there are no events recorded' do
-      it { is_expected.to be_empty }
-    end
-
-    context 'when there are recorded events' do
-      before do
-        recorder.push(event_class.new)
-      end
-
-      it { is_expected.to_not be_empty }
-    end
-  end
 end

--- a/spec/datadog/profiling/scheduler_spec.rb
+++ b/spec/datadog/profiling/scheduler_spec.rb
@@ -199,16 +199,16 @@ RSpec.describe Datadog::Profiling::Scheduler do
   describe '#work_pending?' do
     subject(:work_pending?) { scheduler.work_pending? }
 
-    context 'when the exporter has no events' do
-      before { expect(exporter).to receive(:empty?).and_return(true) }
-
-      it { is_expected.to be false }
-    end
-
-    context 'when the exporter has events' do
-      before { expect(exporter).to receive(:empty?).and_return(false) }
+    context 'when the exporter can flush' do
+      before { expect(exporter).to receive(:can_flush?).and_return(true) }
 
       it { is_expected.to be true }
+    end
+
+    context 'when the exporter can not flush' do
+      before { expect(exporter).to receive(:can_flush?).and_return(false) }
+
+      it { is_expected.to be false }
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**:

Replace `Exporter#empty?` with `Exporter#can_flush?`.

**Motivation**:

The `#empty?` method was used by the `Scheduler` to determine if there was data to be flushed.

With the move to libdatadog to keep the data, it's somewhat awkward to implement an `#empty?` method, since that would entail looking at internal libdatadog state or tracking such a thing ourselves.

Instead, let's replace it with a time-based `#can_flush?` that uses the same `duration_below_threshold?` mechanism we had to decide if there was enough data on a flush. 
The resulting outcome is similar, but needs no extra tracking outside of the `Exporter` class.

**Additional Notes**:

`Scheduler#work_pending?` gets called from `Datadog::Core::Workers::IntervalLoop` which implements the reusable looping logic. It's somewhat complex for what the `Scheduler` needs; I may some day remove that dependency.

**How to test the change?**:

Change includes test coverage. Also, if everything is correct then profiles will be reported while the application is running, as well as a list profile at shut down time.