### PR TITLE
[PROF-5859] Preparation to add the new `CpuAndWallTimeWorker` component

### DIFF
--- a/docs/ProfilingDevelopment.md
+++ b/docs/ProfilingDevelopment.md
@@ -6,11 +6,18 @@ For a more practical view of getting started with development of `ddtrace`, see 
 
 ## Profiling components high-level view
 
+Some of the profiling components referenced below are implemented using C code. As much as possible, that C code is still
+assigned to Ruby classes and Ruby methods, and the Ruby classes are still created in `.rb` files.
+
 Components below live inside <../lib/datadog/profiling>:
 
 * (Deprecated) `Collectors::OldStack`: Collects stack trace samples from Ruby threads for both CPU-time (if available) and wall-clock.
   Runs on its own background thread.
 * `Collectors::CodeProvenance`: Collects library metadata to power grouping and categorization of stack traces (e.g. to help distinguish user code, from libraries, from the standard library, etc).
+* `Collectors::CpuAndWallTime`: Collects samples of living Ruby threads, recording elapsed CPU and Wall-clock time, and
+tagging them with thread id and thread name. Relies on the `Collectors::Stack` for the actual stack sampling.
+* `Collectors::Stack`: Used to gather a stack trace from a given Ruby thread. Stores its output on a `StackRecorder`.
+
 * (Deprecated) `Encoding::Profile::Protobuf`: Encodes gathered data into the pprof format.
 * (Deprecated) `Events::Stack`, `Events::StackSample`: Entity classes used to represent stacks.
 * `Ext::Forking`: Monkey patches `Kernel#fork`, adding a `Kernel#at_fork` callback mechanism which is used to restore
@@ -22,15 +29,13 @@ Components below live inside <../lib/datadog/profiling>:
 * (Deprecated) `TraceIdentifiers::*`: Used to retrieve trace id and span id from tracers, to be used to connect traces to profiles.
 * (Deprecated) `BacktraceLocation`: Entity class used to represent an entry in a stack trace.
 * (Deprecated) `Buffer`: Bounded buffer used to store profiling events.
+* (Deprecated) `Event`
 * `Flush`: Entity class used to represent the payload to be reported for a given profile.
 * `Profiler`: Profiling entry point, which coordinates collectors and a scheduler.
 * (Deprecated) `OldRecorder`: Stores profiling events gathered by the `Collector::OldStack`. (To be removed after migration to libddprof aggregation)
 * `Exporter`: Gathers data from `OldRecorder` and `Collectors::CodeProvenance` to be reported as a profile.
 * `Scheduler`: Periodically (every 1 minute) takes data from the `Exporter` and pushes them to the configured transport.
   Runs on its own background thread.
-* `Collectors::CpuAndWallTime`: TODO
-* `Collectors::Stack`: Used to gather a stack trace from a given Ruby thread. Used to gather a stack trace from a given Ruby thread.
-  Stores its output on a `StackRecorder`.
 * `StackRecorder`: Stores stack samples in a native libdatadog data structure and exposes Ruby-level serialization APIs.
 * `TagBuilder`: Builds a hash of default plus user tags to be included in a profile
 

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -5,6 +5,7 @@
 #include "libdatadog_helpers.h"
 #include "private_vm_api_access.h"
 #include "stack_recorder.h"
+#include "collectors_cpu_and_wall_time.h"
 
 // Used to periodically (time-based) sample threads, recording elapsed CPU-time and Wall-time between samples.
 // This file implements the native bits of the Datadog::Profiling::Collectors::CpuAndWallTime class
@@ -43,7 +44,6 @@ static int hash_map_per_thread_context_free_values(st_data_t _thread, st_data_t 
 static VALUE _native_new(VALUE klass);
 static VALUE _native_initialize(VALUE self, VALUE collector_instance, VALUE recorder_instance, VALUE max_frames);
 static VALUE _native_sample(VALUE self, VALUE collector_instance);
-static void sample(VALUE collector_instance);
 static VALUE _native_thread_list(VALUE self);
 static struct per_thread_context *get_or_create_context_for(VALUE thread, struct cpu_and_wall_time_collector_state *state);
 static void initialize_context(VALUE thread, struct per_thread_context *thread_context);
@@ -167,13 +167,17 @@ static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE collector_inst
 // This method exists only to enable testing Datadog::Profiling::Collectors::CpuAndWallTime behavior using RSpec.
 // It SHOULD NOT be used for other purposes.
 static VALUE _native_sample(DDTRACE_UNUSED VALUE _self, VALUE collector_instance) {
-  sample(collector_instance);
+  cpu_and_wall_time_collector_sample(collector_instance);
   return Qtrue;
 }
 
-static void sample(VALUE collector_instance) {
+// This function gets called from the Collectors::CpuAndWallTimeWorker to trigger the actual sampling.
+//
+// Assumption 1: This function is called in a thread that is holding the Global VM Lock. Caller is responsible for enforcing this.
+// Assumption 2: This function is allowed to raise exceptions. Caller is responsible for handling them, if needed.
+VALUE cpu_and_wall_time_collector_sample(VALUE self_instance) {
   struct cpu_and_wall_time_collector_state *state;
-  TypedData_Get_Struct(collector_instance, struct cpu_and_wall_time_collector_state, &cpu_and_wall_time_collector_typed_data, state);
+  TypedData_Get_Struct(self_instance, struct cpu_and_wall_time_collector_state, &cpu_and_wall_time_collector_typed_data, state);
 
   VALUE threads = ddtrace_thread_list();
   long current_wall_time_ns = wall_time_now_ns();
@@ -224,6 +228,9 @@ static void sample(VALUE collector_instance) {
   // TODO: This seems somewhat overkill and inefficient to do often; right now we just doing every few samples
   // but there's probably a better way to do this if we actually track when threads finish
   if (state->sample_count % 100 == 0) remove_context_for_dead_threads(state);
+
+  // Return a VALUE to make it easier to call this function from Ruby APIs that expect a return value (such as rb_rescue2)
+  return Qnil;
 }
 
 // This method exists only to enable testing Datadog::Profiling::Collectors::CpuAndWallTime behavior using RSpec.
@@ -367,4 +374,8 @@ static long thread_id_for(VALUE thread) {
   // So, for now, let's simplify: we only support FIXNUMs, and we won't break if we get a BIGNUM; we just won't
   // record the thread_id (but samples will still be collected).
   return FIXNUM_P(object_id) ? FIX2LONG(object_id) : -1;
+}
+
+void enforce_cpu_and_wall_time_collector_instance(VALUE object) {
+  Check_TypedStruct(object, &cpu_and_wall_time_collector_typed_data);
 }

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -7,8 +7,11 @@
 #include "stack_recorder.h"
 #include "collectors_cpu_and_wall_time.h"
 
-// Used to periodically (time-based) sample threads, recording elapsed CPU-time and Wall-time between samples.
+// Used to periodically sample threads, recording elapsed CPU-time and Wall-time between samples.
+//
 // This file implements the native bits of the Datadog::Profiling::Collectors::CpuAndWallTime class
+//
+// Triggering of this component (e.g. deciding when to take a sample) is implemented in Collectors::CpuAndWallTimeWorker.
 
 #define INVALID_TIME -1
 #define THREAD_ID_LIMIT_CHARS 20

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.h
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <ruby.h>
+
+VALUE cpu_and_wall_time_collector_sample(VALUE self_instance);
+void enforce_cpu_and_wall_time_collector_instance(VALUE object);

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.h
@@ -57,3 +57,9 @@ NORETURN(void raise_unexpected_type(
   int line,
   const char* function_name
 ));
+
+// This API is exported as a public symbol by the VM BUT the function header is not defined in any public header, so we
+// repeat it here to be able to use in our code.
+//
+// Queries if the current thread is the owner of the global VM lock.
+int ruby_thread_has_gvl_p(void);

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time.rb
@@ -3,8 +3,11 @@
 module Datadog
   module Profiling
     module Collectors
-      # Used to periodically (time-based) sample threads, recording elapsed CPU-time and Wall-time between samples.
+      # Used to periodically sample threads, recording elapsed CPU-time and Wall-time between samples.
+      # Triggering of this component (e.g. deciding when to take a sample) is implemented in
+      # Collectors::CpuAndWallTimeWorker.
       # The stack collection itself is handled using the Datadog::Profiling::Collectors::Stack.
+      # Almost all of this class is implemented as native code.
       #
       # Methods prefixed with _native_ are implemented in `collectors_cpu_and_wall_time.c`
       class CpuAndWallTime


### PR DESCRIPTION
**What does this PR do?**:

This PR includes 3 small changes I've extracted from a bigger branch that adds the final component needed for the new Ruby profiler: the `CpuAndWallTimeWorker`.

This component will take care of triggering samples, e.g. making them happen periodically, which is the big missing part from the new Ruby profiler. (Up until know, we could only manually take samples)

**Motivation**: 

I like to submit small PRs, and the `CpuAndWallTimeWorker` will by itself contain a bit of complexity, so this way I'll reduce the size of that upcoming PR.

I also like to do at least one PR per day, and I was missing my daily PR :)

**How to test the change?**:

None of the changes in this PR actually change any observable behavior yet; they'll only come into action in future PRs.