### PR TITLE
Fix failing spec

### DIFF
--- a/spec/datadog/tracing/contrib/rails/cache_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/cache_spec.rb
@@ -186,14 +186,14 @@ RSpec.describe 'Rails cache' do
 
     subject(:write_multi) { cache.write_multi(Hash[multi_keys.zip(values)], opt_name: :opt_value) }
 
-    it_behaves_like 'a no-op when instrumentation is disabled'
-
     context 'when the method is defined' do
       before do
         unless ::ActiveSupport::Cache::Store.public_method_defined?(:write_multi)
           skip 'Test is not applicable to this Rails version'
         end
       end
+
+      it_behaves_like 'a no-op when instrumentation is disabled'
 
       it_behaves_like 'measured span for integration', false do
         before { write_multi }
@@ -321,14 +321,14 @@ RSpec.describe 'Rails cache' do
   describe '#fetch_multi' do
     subject(:fetch_multi) { cache.fetch_multi(*multi_keys, expires_in: 42) { |key| 50 + key[-1].to_i } }
 
-    it_behaves_like 'a no-op when instrumentation is disabled'
-
     context 'when the method is defined' do
       before do
         unless ::ActiveSupport::Cache::Store.public_method_defined?(:fetch_multi)
           skip 'Test is not applicable to this Rails version'
         end
       end
+
+      it_behaves_like 'a no-op when instrumentation is disabled'
 
       it_behaves_like 'measured span for integration', false do
         before { fetch_multi }


### PR DESCRIPTION
**What does this PR do?**

Fix the specs by moving examples to the correct scope, which verified the methods are present, meaning it is a valid Ruby or Rails version that is meant to be tested. Otherwise, skipping the example.

**Motivation**

Testing suite is failing. The examples are acting assuming  `ActiveSupport::Cache` would respond to `write_multi` and `fetch_multi`. Both methods are introduced in later Ruby and Rails versions, hence it is breaking tests.