### PR TITLE
RFC: Refactor how native extension testing methods are exposed

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -61,6 +61,8 @@ static long thread_id_for(VALUE thread);
 void collectors_cpu_and_wall_time_init(VALUE profiling_module) {
   VALUE collectors_module = rb_define_module_under(profiling_module, "Collectors");
   VALUE collectors_cpu_and_wall_time_class = rb_define_class_under(collectors_module, "CpuAndWallTime", rb_cObject);
+  // Hosts methods used for testing the native code using RSpec
+  VALUE testing_module = rb_define_module_under(collectors_cpu_and_wall_time_class, "Testing");
 
   // Instances of the CpuAndWallTime class are "TypedData" objects.
   // "TypedData" objects are special objects in the Ruby VM that can wrap C structs.
@@ -73,10 +75,10 @@ void collectors_cpu_and_wall_time_init(VALUE profiling_module) {
   rb_define_alloc_func(collectors_cpu_and_wall_time_class, _native_new);
 
   rb_define_singleton_method(collectors_cpu_and_wall_time_class, "_native_initialize", _native_initialize, 3);
-  rb_define_singleton_method(collectors_cpu_and_wall_time_class, "_native_sample", _native_sample, 1);
-  rb_define_singleton_method(collectors_cpu_and_wall_time_class, "_native_thread_list", _native_thread_list, 0);
   rb_define_singleton_method(collectors_cpu_and_wall_time_class, "_native_inspect", _native_inspect, 1);
-  rb_define_singleton_method(collectors_cpu_and_wall_time_class, "_native_per_thread_context", _native_per_thread_context, 1);
+  rb_define_singleton_method(testing_module, "_native_sample", _native_sample, 1);
+  rb_define_singleton_method(testing_module, "_native_thread_list", _native_thread_list, 0);
+  rb_define_singleton_method(testing_module, "_native_per_thread_context", _native_per_thread_context, 1);
 }
 
 // This structure is used to define a Ruby object that stores a pointer to a struct cpu_and_wall_time_collector_state
@@ -313,7 +315,10 @@ static int remove_if_dead_thread(st_data_t key_thread, st_data_t value_context, 
   return ST_DELETE;
 }
 
-// Returns the whole contents of the per_thread_context structs being tracked, for debugging/testing
+// This method exists only to enable testing Datadog::Profiling::Collectors::CpuAndWallTime behavior using RSpec.
+// It SHOULD NOT be used for other purposes.
+//
+// Returns the whole contents of the per_thread_context structs being tracked.
 static VALUE _native_per_thread_context(DDTRACE_UNUSED VALUE _self, VALUE collector_instance) {
   struct cpu_and_wall_time_collector_state *state;
   TypedData_Get_Struct(collector_instance, struct cpu_and_wall_time_collector_state, &cpu_and_wall_time_collector_typed_data, state);

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -33,8 +33,10 @@ static void record_placeholder_stack_in_native_code(VALUE recorder_instance, ddp
 void collectors_stack_init(VALUE profiling_module) {
   VALUE collectors_module = rb_define_module_under(profiling_module, "Collectors");
   VALUE collectors_stack_class = rb_define_class_under(collectors_module, "Stack", rb_cObject);
+  // Hosts methods used for testing the native code using RSpec
+  VALUE testing_module = rb_define_module_under(collectors_stack_class, "Testing");
 
-  rb_define_singleton_method(collectors_stack_class, "_native_sample", _native_sample, 5);
+  rb_define_singleton_method(testing_module, "_native_sample", _native_sample, 5);
 
   missing_string = rb_str_new2("");
   rb_global_variable(&missing_string);

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -176,6 +176,8 @@ static VALUE test_slot_mutex_state(VALUE recorder_instance, int slot);
 
 void stack_recorder_init(VALUE profiling_module) {
   stack_recorder_class = rb_define_class_under(profiling_module, "StackRecorder", rb_cObject);
+  // Hosts methods used for testing the native code using RSpec
+  VALUE testing_module = rb_define_module_under(stack_recorder_class, "Testing");
 
   // Instances of the StackRecorder class are "TypedData" objects.
   // "TypedData" objects are special objects in the Ruby VM that can wrap C structs.
@@ -188,9 +190,9 @@ void stack_recorder_init(VALUE profiling_module) {
   rb_define_alloc_func(stack_recorder_class, _native_new);
 
   rb_define_singleton_method(stack_recorder_class, "_native_serialize",  _native_serialize, 1);
-  rb_define_singleton_method(stack_recorder_class, "_native_active_slot", _native_active_slot, 1);
-  rb_define_singleton_method(stack_recorder_class, "_native_slot_one_mutex_locked?", _native_is_slot_one_mutex_locked, 1);
-  rb_define_singleton_method(stack_recorder_class, "_native_slot_two_mutex_locked?", _native_is_slot_two_mutex_locked, 1);
+  rb_define_singleton_method(testing_module, "_native_active_slot", _native_active_slot, 1);
+  rb_define_singleton_method(testing_module, "_native_slot_one_mutex_locked?", _native_is_slot_one_mutex_locked, 1);
+  rb_define_singleton_method(testing_module, "_native_slot_two_mutex_locked?", _native_is_slot_two_mutex_locked, 1);
 
   ok_symbol = ID2SYM(rb_intern_const("ok"));
   error_symbol = ID2SYM(rb_intern_const("error"));

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time.rb
@@ -12,24 +12,6 @@ module Datadog
           self.class._native_initialize(self, recorder, max_frames)
         end
 
-        # This method exists only to enable testing Datadog::Profiling::Collectors::CpuAndWallTime behavior using RSpec.
-        # It SHOULD NOT be used for other purposes.
-        def sample
-          self.class._native_sample(self)
-        end
-
-        # This method exists only to enable testing Datadog::Profiling::Collectors::CpuAndWallTime behavior using RSpec.
-        # It SHOULD NOT be used for other purposes.
-        def thread_list
-          self.class._native_thread_list
-        end
-
-        # This method exists only to enable testing Datadog::Profiling::Collectors::CpuAndWallTime behavior using RSpec.
-        # It SHOULD NOT be used for other purposes.
-        def per_thread_context
-          self.class._native_per_thread_context(self)
-        end
-
         def inspect
           # Compose Ruby's default inspect with our custom inspect for the native parts
           result = super()

--- a/lib/datadog/profiling/collectors/stack.rb
+++ b/lib/datadog/profiling/collectors/stack.rb
@@ -4,15 +4,9 @@ module Datadog
   module Profiling
     module Collectors
       # Used to gather a stack trace from a given Ruby thread. Stores its output on a `StackRecorder`.
-      # Almost all of this class is implemented as native code.
       #
-      # Methods prefixed with _native_ are implemented in `collectors_stack.c`
-      class Stack
-        # This method exists only to enable testing Datadog::Profiling::Collectors::Stack behavior using RSpec.
-        # It SHOULD NOT be used for other purposes.
-        def sample(thread, recorder_instance, metric_values_hash, labels_array, max_frames: 400)
-          self.class._native_sample(thread, recorder_instance, metric_values_hash, labels_array, max_frames)
-        end
+      # This class is not empty; all of this class is implemented as native code.
+      class Stack # rubocop:disable Lint/EmptyClass
       end
     end
   end

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -38,24 +38,6 @@ module Datadog
       def self.ruby_time_from(timespec_seconds, timespec_nanoseconds)
         Time.at(0).utc + timespec_seconds + (timespec_nanoseconds.to_r / 1_000_000_000)
       end
-
-      # This method exists only to enable testing Datadog::Profiling::StackRecorder behavior using RSpec.
-      # It SHOULD NOT be used for other purposes.
-      def active_slot
-        self.class._native_active_slot(self)
-      end
-
-      # This method exists only to enable testing Datadog::Profiling::StackRecorder behavior using RSpec.
-      # It SHOULD NOT be used for other purposes.
-      def slot_one_mutex_locked?
-        self.class._native_slot_one_mutex_locked?(self)
-      end
-
-      # This method exists only to enable testing Datadog::Profiling::StackRecorder behavior using RSpec.
-      # It SHOULD NOT be used for other purposes.
-      def slot_two_mutex_locked?
-        self.class._native_slot_two_mutex_locked?(self)
-      end
     end
   end
 end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
@@ -42,6 +42,18 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
     end
   end
 
+  def sample
+    described_class::Testing._native_sample(cpu_and_wall_time_collector)
+  end
+
+  def thread_list
+    described_class::Testing._native_thread_list
+  end
+
+  def per_thread_context
+    described_class::Testing._native_per_thread_context(cpu_and_wall_time_collector)
+  end
+
   describe '#sample' do
     let(:pprof_result) do
       serialization_result = recorder.serialize
@@ -54,14 +66,14 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
     it 'samples all threads' do
       all_threads = Thread.list
 
-      cpu_and_wall_time_collector.sample
+      sample
 
       expect(Thread.list).to eq(all_threads), 'Threads finished during this spec, causing flakiness!'
       expect(samples.size).to be all_threads.size
     end
 
     it 'tags the samples with the object ids of the Threads they belong to' do
-      cpu_and_wall_time_collector.sample
+      sample
 
       expect(samples.map { |it| it.fetch(:labels).fetch(:'thread id') })
         .to include(*[Thread.main, t1, t2, t3].map(&:object_id).map(&:to_s))
@@ -74,7 +86,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
       t2.name = nil
       t3.name = 'thread t3'
 
-      cpu_and_wall_time_collector.sample
+      sample
 
       t1_sample = samples.find { |it| it.fetch(:labels).fetch(:'thread id') == t1.object_id.to_s }
       t2_sample = samples.find { |it| it.fetch(:labels).fetch(:'thread id') == t2.object_id.to_s }
@@ -92,13 +104,13 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
     end
 
     it 'includes the wall time elapsed between samples' do
-      cpu_and_wall_time_collector.sample
+      sample
       wall_time_at_first_sample =
-        cpu_and_wall_time_collector.per_thread_context.fetch(t1).fetch(:wall_time_at_previous_sample_ns)
+        per_thread_context.fetch(t1).fetch(:wall_time_at_previous_sample_ns)
 
-      cpu_and_wall_time_collector.sample
+      sample
       wall_time_at_second_sample =
-        cpu_and_wall_time_collector.per_thread_context.fetch(t1).fetch(:wall_time_at_previous_sample_ns)
+        per_thread_context.fetch(t1).fetch(:wall_time_at_previous_sample_ns)
 
       t1_samples = samples.select { |it| it.fetch(:labels).fetch(:'thread id') == t1.object_id.to_s }
       wall_time = t1_samples.first.fetch(:values).fetch(:'wall-time')
@@ -110,7 +122,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
     end
 
     it 'tags samples with how many times they were seen' do
-      5.times { cpu_and_wall_time_collector.sample }
+      5.times { sample }
 
       t1_sample = samples.find { |it| it.fetch(:labels).fetch(:'thread id') == t1.object_id.to_s }
 
@@ -124,7 +136,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
         end
 
         it 'sets the cpu-time on every sample to zero' do
-          5.times { cpu_and_wall_time_collector.sample }
+          5.times { sample }
 
           expect(samples).to all include(values: include(:'cpu-time' => 0))
         end
@@ -137,7 +149,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
 
         it 'includes the cpu-time for the samples' do
           rspec_thread_spent_time = Datadog::Core::Utils::Time.measure(:nanosecond) do
-            5.times { cpu_and_wall_time_collector.sample }
+            5.times { sample }
             samples # to trigger serialization
           end
 
@@ -160,36 +172,36 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
 
   describe '#thread_list' do
     it "returns the same as Ruby's Thread.list" do
-      expect(cpu_and_wall_time_collector.thread_list).to eq Thread.list
+      expect(thread_list).to eq Thread.list
     end
   end
 
   describe '#per_thread_context' do
     context 'before sampling' do
       it do
-        expect(cpu_and_wall_time_collector.per_thread_context).to be_empty
+        expect(per_thread_context).to be_empty
       end
     end
 
     context 'after sampling' do
       before do
         @wall_time_before_sample_ns = Datadog::Core::Utils::Time.get_time(:nanosecond)
-        cpu_and_wall_time_collector.sample
+        sample
         @wall_time_after_sample_ns = Datadog::Core::Utils::Time.get_time(:nanosecond)
       end
 
       it 'contains all the sampled threads' do
-        expect(cpu_and_wall_time_collector.per_thread_context.keys).to include(Thread.main, t1, t2, t3)
+        expect(per_thread_context.keys).to include(Thread.main, t1, t2, t3)
       end
 
       it 'contains the thread ids (object_ids) of all sampled threads' do
-        cpu_and_wall_time_collector.per_thread_context.each do |thread, context|
+        per_thread_context.each do |thread, context|
           expect(context.fetch(:thread_id)).to eq thread.object_id.to_s
         end
       end
 
       it 'sets the wall_time_at_previous_sample_ns to the current wall clock value' do
-        expect(cpu_and_wall_time_collector.per_thread_context.values).to all(
+        expect(per_thread_context.values).to all(
           include(wall_time_at_previous_sample_ns: be_between(@wall_time_before_sample_ns, @wall_time_after_sample_ns))
         )
       end
@@ -201,13 +213,13 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
           end
 
           it 'sets the cpu_time_at_previous_sample_ns to zero' do
-            expect(cpu_and_wall_time_collector.per_thread_context.values).to all(
+            expect(per_thread_context.values).to all(
               include(cpu_time_at_previous_sample_ns: 0)
             )
           end
 
           it 'marks the thread_cpu_time_ids as not valid' do
-            expect(cpu_and_wall_time_collector.per_thread_context.values).to all(
+            expect(per_thread_context.values).to all(
               include(thread_cpu_time_id_valid?: false)
             )
           end
@@ -221,7 +233,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
           it 'sets the cpu_time_at_previous_sample_ns to the current cpu clock value' do
             # It's somewhat difficult to validate the actual value since this is an operating system-specific value
             # which should only be assessed in relation to other values for the same thread, not in absolute
-            expect(cpu_and_wall_time_collector.per_thread_context.values).to all(
+            expect(per_thread_context.values).to all(
               include(cpu_time_at_previous_sample_ns: not_be(0))
             )
           end
@@ -230,10 +242,10 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
             sample_values = []
 
             3.times do
-              cpu_and_wall_time_collector.sample
+              sample
 
               sample_values <<
-                cpu_and_wall_time_collector.per_thread_context[Thread.main].fetch(:cpu_time_at_previous_sample_ns)
+                per_thread_context[Thread.main].fetch(:cpu_time_at_previous_sample_ns)
             end
 
             expect(sample_values.uniq.size).to be(3), 'Every sample is expected to have a differ cpu time value'
@@ -241,7 +253,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
           end
 
           it 'marks the thread_cpu_time_ids as valid' do
-            expect(cpu_and_wall_time_collector.per_thread_context.values).to all(
+            expect(per_thread_context.values).to all(
               include(thread_cpu_time_id_valid?: true)
             )
           end
@@ -251,10 +263,10 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
 
     context 'after sampling multiple times' do
       it 'contains only the threads still alive' do
-        cpu_and_wall_time_collector.sample
+        sample
 
         # All alive threads still in there
-        expect(cpu_and_wall_time_collector.per_thread_context.keys).to include(Thread.main, t1, t2, t3)
+        expect(per_thread_context.keys).to include(Thread.main, t1, t2, t3)
 
         # Get rid of t2
         t2.kill
@@ -262,10 +274,10 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
 
         # Currently the clean-up gets triggered only every 100th sample, so we need to do this to trigger the
         # clean-up. This can probably be improved (see TODO on the actual implementation)
-        100.times { cpu_and_wall_time_collector.sample }
+        100.times { sample }
 
-        expect(cpu_and_wall_time_collector.per_thread_context.keys).to_not include(t2)
-        expect(cpu_and_wall_time_collector.per_thread_context.keys).to include(Thread.main, t1, t3)
+        expect(per_thread_context.keys).to_not include(t2)
+        expect(per_thread_context.keys).to include(Thread.main, t1, t3)
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**:

This change follows from [this discussion thread](https://github.com/DataDog/dd-trace-rb/pull/2181#discussion_r929383004) on improving how testing-only methods are exposed from the native extension.

Here's what I came up with:

* All methods exposed only for testing are scoped inside `Testing` modules; e.g. testing methods for `StackRecorder` are inside `StackRecorder::Testing`

* Removed the "middlemen" methods on the classes themselves. They existed only for documentation of the existence and objective of those methods, but now that they are scoped under `Testing` the "middlemen" methods seem less interesting to have.

* Changed any specs using those methods to directly call the native methods in the `Testing` modules.

* Still kept the `_native_` prefix for all native methods that get exposed to Ruby. I'm open to discussing this, but I really like being extremely explicit on when the Ruby/C boundary is being crossed.

This doesn't change anything for production code, it only shuffles test code around. I'm opening it as an RFC to make it clear this is an option that seems nice but I'm open to changing it further.

**Motivation**:

Improve the structure of native extension methods that get exposed for RSpec testing.

**How to test the change?**:

Check that specs are still green. All this affects is testing code, so if the tests still pass, things are still 👌 