### PR TITLE
[PROF-5860] Refactor profiling components and components spec in preparation for new components

### DIFF
--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -240,13 +240,14 @@ module Datadog
               endpoint_collection_enabled: settings.profiling.advanced.endpoint.collection.enabled
             )
 
-            old_recorder = build_profiler_old_recorder(settings)
-            exporter = build_profiler_exporter(settings, old_recorder)
-            collectors = build_profiler_collectors(settings, old_recorder, trace_identifiers_helper)
-            transport = build_profiler_transport(settings, agent_settings)
-            scheduler = build_profiler_scheduler(settings, exporter, transport)
+            recorder = build_profiler_old_recorder(settings)
+            collector = build_profiler_oldstack_collector(settings, recorder, trace_identifiers_helper)
 
-            Profiling::Profiler.new(collectors, scheduler)
+            exporter = build_profiler_exporter(settings, recorder)
+            transport = build_profiler_transport(settings, agent_settings)
+            scheduler = Profiling::Scheduler.new(exporter: exporter, transport: transport)
+
+            Profiling::Profiler.new([collector], scheduler)
           end
 
           private
@@ -279,34 +280,22 @@ module Datadog
           end
 
           def build_profiler_old_recorder(settings)
-            event_classes = [Profiling::Events::StackSample]
-
-            Profiling::OldRecorder.new(
-              event_classes,
-              settings.profiling.advanced.max_events,
-            )
+            Profiling::OldRecorder.new([Profiling::Events::StackSample], settings.profiling.advanced.max_events)
           end
 
-          def build_profiler_exporter(settings, old_recorder)
+          def build_profiler_exporter(settings, recorder)
             code_provenance_collector =
               (Profiling::Collectors::CodeProvenance.new if settings.profiling.advanced.code_provenance_enabled)
 
-            Profiling::Exporter.new(
-              # NOTE: Using the OldRecorder as a pprof_recorder is temporary and will be removed once libpprof is
-              # being used for aggregation
-              pprof_recorder: old_recorder,
-              code_provenance_collector: code_provenance_collector,
-            )
+            Profiling::Exporter.new(pprof_recorder: recorder, code_provenance_collector: code_provenance_collector)
           end
 
-          def build_profiler_collectors(settings, old_recorder, trace_identifiers_helper)
-            [
-              Profiling::Collectors::OldStack.new(
-                old_recorder,
-                trace_identifiers_helper: trace_identifiers_helper,
-                max_frames: settings.profiling.advanced.max_frames
-              )
-            ]
+          def build_profiler_oldstack_collector(settings, old_recorder, trace_identifiers_helper)
+            Profiling::Collectors::OldStack.new(
+              old_recorder,
+              trace_identifiers_helper: trace_identifiers_helper,
+              max_frames: settings.profiling.advanced.max_frames
+            )
           end
 
           def build_profiler_transport(settings, agent_settings)
@@ -329,10 +318,6 @@ module Datadog
                 api_key: settings.api_key,
                 upload_timeout_seconds: settings.profiling.upload.timeout_seconds,
               )
-          end
-
-          def build_profiler_scheduler(_settings, exporter, transport)
-            Profiling::Scheduler.new(exporter: exporter, transport: transport)
           end
         end
 

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
   subject(:components) { described_class.new(settings) }
 
   let(:settings) { Datadog::Core::Configuration::Settings.new }
+  let(:agent_settings) { Datadog::Core::Configuration::AgentSettingsResolver.call(settings, logger: nil) }
 
   let(:profiler_setup_task) { Datadog::Profiling.supported? ? instance_double(Datadog::Profiling::Tasks::Setup) : nil }
 
@@ -344,8 +345,6 @@ RSpec.describe Datadog::Core::Configuration::Components do
   end
 
   describe '::build_tracer' do
-    let(:agent_settings) { Datadog::Core::Configuration::AgentSettingsResolver.call(settings, logger: nil) }
-
     subject(:build_tracer) { described_class.build_tracer(settings, agent_settings) }
 
     context 'given an instance' do
@@ -880,7 +879,6 @@ RSpec.describe Datadog::Core::Configuration::Components do
   end
 
   describe '::build_profiler' do
-    let(:agent_settings) { Datadog::Core::Configuration::AgentSettingsResolver.call(settings, logger: nil) }
     let(:profiler) { build_profiler }
     let(:tracer) { instance_double(Datadog::Tracing::Tracer) }
 

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -893,15 +893,6 @@ RSpec.describe Datadog::Core::Configuration::Components do
     context 'given settings' do
       before { skip_if_profiling_not_supported(self) }
 
-      shared_context 'enabled profiler' do
-        before do
-          allow(settings.profiling)
-            .to receive(:enabled)
-            .and_return(true)
-          allow(profiler_setup_task).to receive(:run)
-        end
-      end
-
       shared_examples_for 'profiler with default collectors' do
         subject(:stack_collector) { profiler.collectors.first }
 
@@ -956,7 +947,10 @@ RSpec.describe Datadog::Core::Configuration::Components do
       end
 
       context 'with :enabled true' do
-        include_context 'enabled profiler'
+        before do
+          allow(settings.profiling).to receive(:enabled).and_return(true)
+          allow(profiler_setup_task).to receive(:run)
+        end
 
         context 'by default' do
           it_behaves_like 'profiler with default collectors'

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -989,7 +989,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
           it 'initializes the exporter with a code provenance collector' do
             expect(Datadog::Profiling::Exporter).to receive(:new) do |code_provenance_collector:, **_|
               expect(code_provenance_collector).to be_a_kind_of(Datadog::Profiling::Collectors::CodeProvenance)
-            end.and_call_original
+            end
 
             build_profiler
           end
@@ -1000,7 +1000,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
             it 'initializes the exporter with a nil code provenance collector' do
               expect(Datadog::Profiling::Exporter).to receive(:new) do |code_provenance_collector:, **_|
                 expect(code_provenance_collector).to be nil
-              end.and_call_original
+              end
 
               build_profiler
             end

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -964,13 +964,11 @@ RSpec.describe Datadog::Core::Configuration::Components do
           end
 
           it 'creates a scheduler with an HttpTransport' do
-            http_transport = instance_double(Datadog::Profiling::HttpTransport)
-
-            expect(Datadog::Profiling::HttpTransport).to receive(:new).and_return(http_transport)
+            expect(Datadog::Profiling::Scheduler).to receive(:new) do |transport:, **_|
+              expect(transport).to be_a_kind_of(Datadog::Profiling::HttpTransport)
+            end
 
             build_profiler
-
-            expect(profiler.scheduler.send(:transport)).to be http_transport
           end
 
           [true, false].each do |value|

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -893,10 +893,6 @@ RSpec.describe Datadog::Core::Configuration::Components do
     context 'given settings' do
       before { skip_if_profiling_not_supported(self) }
 
-      shared_examples_for 'disabled profiler' do
-        it { is_expected.to be nil }
-      end
-
       shared_context 'enabled profiler' do
         before do
           allow(settings.profiling)
@@ -944,17 +940,19 @@ RSpec.describe Datadog::Core::Configuration::Components do
       end
 
       context 'by default' do
-        it_behaves_like 'disabled profiler'
+        it 'does not build a profiler' do
+          is_expected.to be nil
+        end
       end
 
       context 'with :enabled false' do
         before do
-          allow(settings.profiling)
-            .to receive(:enabled)
-            .and_return(false)
+          allow(settings.profiling).to receive(:enabled).and_return(false)
         end
 
-        it_behaves_like 'disabled profiler'
+        it 'does not build a profiler' do
+          is_expected.to be nil
+        end
       end
 
       context 'with :enabled true' do

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -899,13 +899,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
         it 'has a Stack collector' do
           expect(profiler.collectors).to have(1).item
           expect(profiler.collectors).to include(kind_of(Datadog::Profiling::Collectors::OldStack))
-          is_expected.to have_attributes(
-            enabled?: true,
-            started?: false,
-            ignore_thread: nil,
-            max_frames: settings.profiling.advanced.max_frames,
-            max_time_usage_pct: 2.0
-          )
+          is_expected.to have_attributes(max_frames: settings.profiling.advanced.max_frames)
         end
       end
 
@@ -914,11 +908,6 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
         it do
           is_expected.to be_a_kind_of(Datadog::Profiling::Scheduler)
-          is_expected.to have_attributes(
-            enabled?: true,
-            started?: false,
-            loop_base_interval: 60.0
-          )
         end
       end
 


### PR DESCRIPTION
**What does this PR do?**:

This PR refactors the profiling components initialization, as well as the components specs to make it easier to add the new components (which are implemented in the native extension).

**Motivation**:

I'm getting ready to add a way to enable the new components (off by default), and this refactoring was extracted from my working branch.

**Additional Notes**:

This is one of those PRs where I recommend enabling the "hide whitespace" option while looking at the diff on github.

Furthermore, I recommend reviewing it commit-by-commit.

**How to test the change?**:

The changes to the components include test coverage; and if the components setup breaks the profiler will not work so every integration test and reliability environment test would break as well.