### PR TITLE
Opentracing propagation with TraceDigest

### DIFF
--- a/lib/datadog/opentracer/rack_propagator.rb
+++ b/lib/datadog/opentracer/rack_propagator.rb
@@ -23,10 +23,14 @@ module Datadog
         # @param span_context [SpanContext]
         # @param carrier [Carrier] A carrier object of Rack type
         def inject(span_context, carrier)
-          active_trace = span_context.datadog_context.active_trace
+          digest = if span_context.datadog_context && span_context.datadog_context.active_trace
+                     span_context.datadog_context.active_trace.to_digest
+                   else
+                     span_context.datadog_trace_digest
+                   end
 
           # Inject Datadog trace properties
-          Tracing::Propagation::HTTP.inject!(active_trace, carrier)
+          Tracing::Propagation::HTTP.inject!(digest, carrier)
 
           # Inject baggage
           span_context.baggage.each do |key, value|

--- a/lib/datadog/opentracer/text_map_propagator.rb
+++ b/lib/datadog/opentracer/text_map_propagator.rb
@@ -27,8 +27,11 @@ module Datadog
           end
 
           # Inject Datadog trace properties
-          active_trace = span_context.datadog_context.active_trace
-          digest = active_trace.to_digest if active_trace
+          digest = if span_context.datadog_context && span_context.datadog_context.active_trace
+                     span_context.datadog_context.active_trace.to_digest
+                   else
+                     span_context.datadog_trace_digest
+                   end
           return unless digest
 
           carrier[HTTP_HEADER_ORIGIN] = digest.trace_origin

--- a/spec/datadog/opentracer/propagation_integration_spec.rb
+++ b/spec/datadog/opentracer/propagation_integration_spec.rb
@@ -186,7 +186,6 @@ RSpec.describe 'OpenTracer context propagation' do
           'ot-baggage-account_name' => 'acme'
         )
       end
-
     end
   end
 
@@ -340,6 +339,7 @@ RSpec.describe 'OpenTracer context propagation' do
       it { expect(receiver_datadog_span.trace_id).to eq(sender_datadog_span.trace_id) }
       it { expect(receiver_datadog_span.parent_id).to eq(sender_datadog_span.span_id) }
       it { expect(@receiver_scope.span.context.baggage).to include(baggage) }
+
       it do
         expect(@carrier).to include(
           Datadog::OpenTracer::RackPropagator::HTTP_HEADER_TRACE_ID => a_kind_of(String),
@@ -349,6 +349,7 @@ RSpec.describe 'OpenTracer context propagation' do
           'ot-baggage-account_name' => 'acme'
         )
       end
+
       it do
         expect(@another_carrier).to include(
           Datadog::OpenTracer::RackPropagator::HTTP_HEADER_TRACE_ID => a_kind_of(String),

--- a/spec/datadog/opentracer/rack_propagator_spec.rb
+++ b/spec/datadog/opentracer/rack_propagator_spec.rb
@@ -13,30 +13,6 @@ RSpec.describe Datadog::OpenTracer::RackPropagator do
   describe '#inject' do
     subject { described_class.inject(span_context, carrier) }
 
-    let(:span_context) do
-      instance_double(
-        Datadog::OpenTracer::SpanContext,
-        datadog_context: datadog_context,
-        baggage: baggage
-      )
-    end
-
-    let(:datadog_context) do
-      instance_double(
-        Datadog::Tracing::Context,
-        active_trace: datadog_trace
-      )
-    end
-
-    let(:datadog_trace) do
-      Datadog::Tracing::TraceOperation.new(
-        id: trace_id,
-        parent_span_id: span_id,
-        sampling_priority: sampling_priority,
-        origin: origin
-      )
-    end
-
     let(:trace_id) { double('trace ID') }
     let(:span_id) { double('span ID') }
     let(:sampling_priority) { double('sampling priority') }
@@ -46,8 +22,8 @@ RSpec.describe Datadog::OpenTracer::RackPropagator do
 
     let(:carrier) { instance_double(Datadog::OpenTracer::Carrier) }
 
-    # Expect carrier to be set with Datadog trace properties
     before do
+      # Expect carrier to be set with Datadog trace properties
       expect(carrier).to receive(:[]=)
         .with(Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID, trace_id.to_s)
       expect(carrier).to receive(:[]=)
@@ -56,17 +32,63 @@ RSpec.describe Datadog::OpenTracer::RackPropagator do
         .with(Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_SAMPLING_PRIORITY, sampling_priority.to_s)
       expect(carrier).to receive(:[]=)
         .with(Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_ORIGIN, origin.to_s)
-    end
 
-    # Expect carrier to be set with OpenTracing baggage
-    before do
+      # Expect carrier to be set with OpenTracing baggage
       baggage.each do |key, value|
         expect(carrier).to receive(:[]=)
           .with(described_class::BAGGAGE_PREFIX + key, value)
       end
     end
 
-    it { is_expected.to be nil }
+    context 'when given span context with datadog context' do
+      let(:span_context) do
+        instance_double(
+          Datadog::OpenTracer::SpanContext,
+          datadog_context: datadog_context,
+          baggage: baggage
+        )
+      end
+
+      let(:datadog_context) do
+        instance_double(
+          Datadog::Tracing::Context,
+          active_trace: datadog_trace
+        )
+      end
+
+      let(:datadog_trace) do
+        Datadog::Tracing::TraceOperation.new(
+          id: trace_id,
+          parent_span_id: span_id,
+          sampling_priority: sampling_priority,
+          origin: origin
+        )
+      end
+
+      it { is_expected.to be nil }
+    end
+
+    context 'when given span context with datadog trace digest' do
+      let(:span_context) do
+        instance_double(
+          Datadog::OpenTracer::SpanContext,
+          datadog_context: nil,
+          datadog_trace_digest: datadog_trace_digest,
+          baggage: baggage
+        )
+      end
+
+      let(:datadog_trace_digest) do
+        instance_double(
+          Datadog::Tracing::TraceDigest,
+          span_id: span_id,
+          trace_id: trace_id,
+          trace_origin: origin,
+          trace_sampling_priority: sampling_priority
+        )
+      end
+      it { is_expected.to be nil }
+    end
   end
 
   describe '#extract' do


### PR DESCRIPTION
**What does this PR do?**

During `1.x` upgrade, we introduce the `TraceDigest` for distributed tracing. 

The `inject` method takes an active trace from span context before converting to `TraceDigest` and propagate to the carrier. The `extract` method returns a span context with `TraceDigest` but not active trace, hence when the result of `extract` is provided to `inject`, an error occurs.

This PR changes the `inject` method to take trace digest when given a span context without an active trace.

**Motivation**

https://github.com/DataDog/dd-trace-rb/issues/2191

Users are using `OpenTracing#inject` and `OpenTracing#extract` for manual instrumentation and distributed tracing. The propagation chain breaks when `inject` after `extract`.