### PR TITLE
Use require_relative and proper line breaks for telemetry

### DIFF
--- a/lib/datadog/core/telemetry/client.rb
+++ b/lib/datadog/core/telemetry/client.rb
@@ -1,8 +1,8 @@
 # typed: true
 
-require 'datadog/core/telemetry/emitter'
-require 'datadog/core/telemetry/heartbeat'
-require 'datadog/core/utils/forking'
+require_relative 'emitter'
+require_relative 'heartbeat'
+require_relative '../utils/forking'
 
 module Datadog
   module Core

--- a/lib/datadog/core/telemetry/collector.rb
+++ b/lib/datadog/core/telemetry/collector.rb
@@ -4,15 +4,15 @@
 
 require 'etc'
 
-require 'datadog/core/configuration/agent_settings_resolver'
-require 'datadog/core/environment/ext'
-require 'datadog/core/environment/platform'
-require 'datadog/core/telemetry/v1/application'
-require 'datadog/core/telemetry/v1/dependency'
-require 'datadog/core/telemetry/v1/host'
-require 'datadog/core/telemetry/v1/integration'
-require 'datadog/core/telemetry/v1/product'
-require 'ddtrace/transport/ext'
+require_relative '../configuration/agent_settings_resolver'
+require_relative '../environment/ext'
+require_relative '../environment/platform'
+require_relative 'v1/application'
+require_relative 'v1/dependency'
+require_relative 'v1/host'
+require_relative 'v1/integration'
+require_relative 'v1/product'
+require_relative '../../../ddtrace/transport/ext'
 
 module Datadog
   module Core

--- a/lib/datadog/core/telemetry/emitter.rb
+++ b/lib/datadog/core/telemetry/emitter.rb
@@ -1,9 +1,9 @@
 # typed: true
 
-require 'datadog/core/telemetry/event'
-require 'datadog/core/telemetry/http/transport'
-require 'datadog/core/utils/sequence'
-require 'datadog/core/utils/forking'
+require_relative 'event'
+require_relative 'http/transport'
+require_relative '../utils/sequence'
+require_relative '../utils/forking'
 
 module Datadog
   module Core

--- a/lib/datadog/core/telemetry/emitter.rb
+++ b/lib/datadog/core/telemetry/emitter.rb
@@ -25,8 +25,10 @@ module Datadog
         # @param request_type [String] the type of telemetry request to collect data for
         def request(request_type)
           begin
-            request = Datadog::Core::Telemetry::Event.new.telemetry_request(request_type: request_type,
-                                                                            seq_id: self.class.sequence.next).to_h
+            request = Datadog::Core::Telemetry::Event.new.telemetry_request(
+              request_type: request_type,
+              seq_id: self.class.sequence.next
+            ).to_h
             @http_transport.request(request_type: request_type.to_s, payload: request.to_json)
           rescue StandardError => e
             Datadog.logger.debug("Unable to send telemetry request for event `#{request_type}`: #{e}")

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -1,8 +1,8 @@
 # typed: true
 
-require 'datadog/core/telemetry/collector'
-require 'datadog/core/telemetry/v1/app_event'
-require 'datadog/core/telemetry/v1/telemetry_request'
+require_relative 'collector'
+require_relative 'v1/app_event'
+require_relative 'v1/telemetry_request'
 
 module Datadog
   module Core

--- a/lib/datadog/core/telemetry/heartbeat.rb
+++ b/lib/datadog/core/telemetry/heartbeat.rb
@@ -1,7 +1,7 @@
 # typed: false
 
-require 'datadog/core/worker'
-require 'datadog/core/workers/polling'
+require_relative '../worker'
+require_relative '../workers/polling'
 
 module Datadog
   module Core

--- a/lib/datadog/core/telemetry/http/adapters/net.rb
+++ b/lib/datadog/core/telemetry/http/adapters/net.rb
@@ -1,6 +1,6 @@
 # typed: true
 
-require 'datadog/core/telemetry/http/response'
+require_relative '../response'
 
 module Datadog
   module Core

--- a/lib/datadog/core/telemetry/http/transport.rb
+++ b/lib/datadog/core/telemetry/http/transport.rb
@@ -1,9 +1,9 @@
 # typed: true
 
-require 'datadog/core/configuration/settings'
-require 'datadog/core/telemetry/http/env'
-require 'datadog/core/telemetry/http/ext'
-require 'datadog/core/telemetry/http/adapters/net'
+require_relative '../../configuration/settings'
+require_relative 'env'
+require_relative 'ext'
+require_relative 'adapters/net'
 
 module Datadog
   module Core

--- a/lib/datadog/core/telemetry/v1/application.rb
+++ b/lib/datadog/core/telemetry/v1/application.rb
@@ -31,10 +31,16 @@ module Datadog
           # @param service_name [String] Service’s name (DD_SERVICE)
           # @param service_version [String] Service’s version (DD_VERSION)
           # @param tracer_version [String] Version of the used tracer
-          def initialize(language_name:, language_version:, service_name:, tracer_version:, env: nil, products: nil,
-                         runtime_name: nil, runtime_patches: nil, runtime_version: nil, service_version: nil)
-            validate(language_name: language_name, language_version: language_version, service_name: service_name,
-                     tracer_version: tracer_version)
+          def initialize(
+            language_name:, language_version:, service_name:, tracer_version:, env: nil, products: nil,
+            runtime_name: nil, runtime_patches: nil, runtime_version: nil, service_version: nil
+          )
+            validate(
+              language_name: language_name,
+              language_version: language_version,
+              service_name: service_name,
+              tracer_version: tracer_version
+            )
             @env = env
             @language_name = language_name
             @language_version = language_version

--- a/lib/datadog/core/telemetry/v1/host.rb
+++ b/lib/datadog/core/telemetry/v1/host.rb
@@ -20,8 +20,10 @@ module Datadog
           # @param kernel_version [String] uname -v
           # @param os [String] uname -o
           # @param os_version [String] Version of OS running
-          def initialize(container_id: nil, hostname: nil, kernel_name: nil, kernel_release: nil, kernel_version: nil,
-                         os_version: nil, os: nil)
+          def initialize(
+            container_id: nil, hostname: nil, kernel_name: nil, kernel_release: nil, kernel_version: nil,
+            os_version: nil, os: nil
+          )
             @container_id = container_id
             @hostname = hostname
             @kernel_name = kernel_name

--- a/lib/datadog/core/telemetry/v1/telemetry_request.rb
+++ b/lib/datadog/core/telemetry/v1/telemetry_request.rb
@@ -37,10 +37,20 @@ module Datadog
           # @param debug [Boolean] Flag that enables payload debug mode
           # @param session_id [String] V4 UUID that represents the session of the top level tracer process, often same\
           #   as runtime_id
-          def initialize(api_version:, application:, host:, payload:, request_type:, runtime_id:, seq_id:, tracer_time:,
-                         debug: nil, session_id: nil)
-            validate(api_version: api_version, application: application, host: host, payload: payload,
-                     request_type: request_type, runtime_id: runtime_id, seq_id: seq_id, tracer_time: tracer_time)
+          def initialize(
+            api_version:, application:, host:, payload:, request_type:, runtime_id:, seq_id:, tracer_time:,
+            debug: nil, session_id: nil
+          )
+            validate(
+              api_version: api_version,
+              application: application,
+              host: host,
+              payload: payload,
+              request_type: request_type,
+              runtime_id: runtime_id,
+              seq_id: seq_id,
+              tracer_time: tracer_time
+            )
             @api_version = api_version
             @application = application
             @debug = debug

--- a/spec/datadog/core/telemetry/v1/telemetry_request_spec.rb
+++ b/spec/datadog/core/telemetry/v1/telemetry_request_spec.rb
@@ -25,8 +25,12 @@ RSpec.describe Datadog::Core::Telemetry::V1::TelemetryRequest do
 
   let(:api_version) { 'v1' }
   let(:application) do
-    Datadog::Core::Telemetry::V1::Application.new(language_name: 'ruby', language_version: '3.0',
-                                                  service_name: 'myapp', tracer_version: '1.0')
+    Datadog::Core::Telemetry::V1::Application.new(
+      language_name: 'ruby',
+      language_version: '3.0',
+      service_name: 'myapp',
+      tracer_version: '1.0'
+    )
   end
   let(:debug) { false }
   let(:host) { Datadog::Core::Telemetry::V1::Host.new(container_id: 'd39b145254d1f9c337fdd2be132f6') }
@@ -95,8 +99,12 @@ RSpec.describe Datadog::Core::Telemetry::V1::TelemetryRequest do
 
       context 'is valid' do
         let(:application) do
-          Datadog::Core::Telemetry::V1::Application.new(language_name: 'ruby', language_version: '3.0',
-                                                        service_name: 'myapp', tracer_version: '1.0')
+          Datadog::Core::Telemetry::V1::Application.new(
+            language_name: 'ruby',
+            language_version: '3.0',
+            service_name: 'myapp',
+            tracer_version: '1.0'
+          )
         end
         it { is_expected.to be_a_kind_of(described_class) }
       end
@@ -170,8 +178,12 @@ RSpec.describe Datadog::Core::Telemetry::V1::TelemetryRequest do
 
     let(:api_version) { 'v1' }
     let(:application) do
-      Datadog::Core::Telemetry::V1::Application.new(language_name: 'ruby', language_version: '3.0',
-                                                    service_name: 'myapp', tracer_version: '1.0')
+      Datadog::Core::Telemetry::V1::Application.new(
+        language_name: 'ruby',
+        language_version: '3.0',
+        service_name: 'myapp',
+        tracer_version: '1.0'
+      )
     end
     let(:debug) { false }
     let(:host) { Datadog::Core::Telemetry::V1::Host.new(container_id: 'd39b145254d1f9c337fdd2be132f6') }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
The telemetry feature branch was branched off of `master` a while ago - this PR makes the necessary changes to ensure the telemetry code conforms with the new linting requirements (i.e. using `require_relative` and proper line breaks for method definitions with multi-line parameters).

**Motivation**
<!-- What inspired you to submit this pull request? -->
This will allow the CI checks to pass on the telemetry feature branch in preparation for merging

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Unit tests still pass + rubocop passes