### PR TITLE
Minor improvement to timeout documentation

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2523,7 +2523,7 @@ The `Net` adapter submits traces using `Net::HTTP` over TCP. It is the default t
 Datadog.configure do |c|
   c.tracing.transport_options = proc { |t|
     # Hostname, port, and additional options. :timeout is in seconds.
-    t.adapter :net_http, '127.0.0.1', 8126, { timeout: 1 }
+    t.adapter :net_http, '127.0.0.1', 8126, timeout: 30
   }
 end
 ```

--- a/lib/ddtrace/transport/ext.rb
+++ b/lib/ddtrace/transport/ext.rb
@@ -9,7 +9,6 @@ module Datadog
         ADAPTER = :net_http # DEV: Rename to simply `:http`, as Net::HTTP is an implementation detail.
         DEFAULT_HOST = '127.0.0.1'.freeze
         DEFAULT_PORT = 8126
-        DEFAULT_TIMEOUT_SECONDS = 1
 
         HEADER_CONTAINER_ID = 'Datadog-Container-ID'.freeze
         HEADER_DD_API_KEY = 'DD-API-KEY'.freeze

--- a/lib/ddtrace/transport/http/adapters/net.rb
+++ b/lib/ddtrace/transport/http/adapters/net.rb
@@ -15,6 +15,7 @@ module Datadog
             :timeout,
             :ssl
 
+          # in seconds
           DEFAULT_TIMEOUT = 30
 
           # @deprecated Positional parameters are deprecated. Use named parameters instead.


### PR DESCRIPTION
**What does this PR do?**:

Improve the timeout example in the documentation with a reasonable value (which is the same as we currently use as a default).

Also remove an unused and misleading "default timeout" constant.

**Motivation**:

As raised in #818, the default `timeout` example is rather far away from the actual default being used, which may lead customers that copy-paste the example to have a bad experience.

I also discovered we had an incorrect constant with the default timeout which was not even being used anywhere (you can grep for it  to confirm!).

Thanks @benjaminwood for the awesome suggestion!

**How to test the change?**:

Validate that no tests are impacted by the removed constant.
