### PR TITLE
[PROF-5859] Introduce `CpuAndWallTimeWorker` to trigger profiling samples

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -178,6 +178,8 @@ static VALUE _native_sample(DDTRACE_UNUSED VALUE _self, VALUE collector_instance
 //
 // Assumption 1: This function is called in a thread that is holding the Global VM Lock. Caller is responsible for enforcing this.
 // Assumption 2: This function is allowed to raise exceptions. Caller is responsible for handling them, if needed.
+// Assumption 3: This function IS NOT called from a signal handler. This function is not async-signal-safe.
+// Assumption 4: This function IS NOT called in a reentrant way.
 VALUE cpu_and_wall_time_collector_sample(VALUE self_instance) {
   struct cpu_and_wall_time_collector_state *state;
   TypedData_Get_Struct(self_instance, struct cpu_and_wall_time_collector_state, &cpu_and_wall_time_collector_typed_data, state);

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -153,8 +153,6 @@ static VALUE _native_new(VALUE klass) {
 }
 
 static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE collector_instance, VALUE recorder_instance, VALUE max_frames) {
-  enforce_recorder_instance(recorder_instance);
-
   struct cpu_and_wall_time_collector_state *state;
   TypedData_Get_Struct(collector_instance, struct cpu_and_wall_time_collector_state, &cpu_and_wall_time_collector_typed_data, state);
 
@@ -164,7 +162,7 @@ static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE collector_inst
   // Update this when modifying state struct
   state->sampling_buffer = sampling_buffer_new(max_frames_requested);
   // hash_map_per_thread_context is already initialized, nothing to do here
-  state->recorder_instance = recorder_instance;
+  state->recorder_instance = enforce_recorder_instance(recorder_instance);
 
   return Qtrue;
 }
@@ -384,6 +382,7 @@ static long thread_id_for(VALUE thread) {
   return FIXNUM_P(object_id) ? FIX2LONG(object_id) : -1;
 }
 
-void enforce_cpu_and_wall_time_collector_instance(VALUE object) {
+VALUE enforce_cpu_and_wall_time_collector_instance(VALUE object) {
   Check_TypedStruct(object, &cpu_and_wall_time_collector_typed_data);
+  return object;
 }

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.h
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.h
@@ -3,4 +3,4 @@
 #include <ruby.h>
 
 VALUE cpu_and_wall_time_collector_sample(VALUE self_instance);
-void enforce_cpu_and_wall_time_collector_instance(VALUE object);
+VALUE enforce_cpu_and_wall_time_collector_instance(VALUE object);

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -265,7 +265,7 @@ static void block_sigprof_signal_handler_from_running_in_current_thread(void) {
 }
 
 static void handle_sampling_signal(DDTRACE_UNUSED int _signal, DDTRACE_UNUSED siginfo_t *_info, DDTRACE_UNUSED void *_ucontext) {
-  if (!ruby_native_thread_p() || !ruby_thread_has_gvl_p()) {
+  if (!ruby_thread_has_gvl_p()) {
     return; // Not safe to enqueue a sample from this thread
   }
 

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -25,7 +25,7 @@
 // Currently, sampling Ruby threads requires calling Ruby VM APIs that are only safe to call while holding on to the
 // global VM lock (and are not async-signal safe -- cannot be called from a signal handler).
 //
-// @ivoanjo: As a note, I don't we should think of this constraint as set in stone. Since can reach into the Ruby
+// @ivoanjo: As a note, I don't think we should think of this constraint as set in stone. Since can reach into the Ruby
 // internals, we may be able to figure out a way of overcoming it. But it's definitely going to be hard so for now
 // we're considering it as a given.
 //

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -1,0 +1,391 @@
+#include <ruby.h>
+#include <ruby/thread.h>
+#include <ruby/thread_native.h>
+#include <ruby/debug.h>
+#include <stdbool.h>
+#include <signal.h>
+#include "helpers.h"
+#include "ruby_helpers.h"
+#include "collectors_cpu_and_wall_time.h"
+#include "private_vm_api_access.h"
+
+// Used to trigger the periodic execution of Collectors::CpuAndWallTime, which implements all of the sampling logic
+// itself; this class only implements the "doing it periodically" part.
+//
+// This file implements the native bits of the Datadog::Profiling::Collectors::CpuAndWallTimeWorker class
+
+// ---
+// Here be dragons: This component is quite fiddly and probably one of the more complex in the profiler as it deals with
+// multiple threads, signal handlers, global state, etc.
+//
+// ## Design notes for this class:
+//
+// ### Constraints
+//
+// Currently, sampling Ruby threads requires calling Ruby VM APIs that are only safe to call while holding on to the
+// global VM lock (and are not async-signal safe -- cannot be called from a signal handler).
+//
+// @ivoanjo: As a note, I don't we should think of this constraint as set in stone. Since can reach into the Ruby
+// internals, we may be able to figure out a way of overcoming it. But it's definitely going to be hard so for now
+// we're considering it as a given.
+//
+// ### Flow for triggering samples
+//
+// The flow for triggering samples is as follows:
+//
+// 1. Inside the `run_sampling_trigger_loop` function (running in the `CpuAndWallTimeWorker` background thread),
+// a `SIGPROF` signal gets sent to the current process.
+//
+// 2. The `handle_sampling_signal` signal handler function gets called to handle the `SIGPROF` signal.
+//
+//   Which thread the signal handler function gets called on by the operating system is quite important. We need to perform
+// an operation -- calling the `rb_postponed_job_register_one` API -- that can only be called from the thread that
+// is holding on to the global VM lock. So this is the thread we're "hoping" our signal lands on.
+//
+//   The signal never lands on the `CpuAndWallTimeWorker` background thread because we explicitly block it off from that
+// thread in `block_sigprof_signal_handler_from_running_in_current_thread`.
+//
+//   If the signal lands on a thread that is not holding onto the global VM lock, we can't proceed to the next step,
+// and we need to restart the sampling flow from step 1. (There's still quite a few improvements we can make here,
+// but this is the current state of the implementation).
+//
+// 3. Inside `handle_sampling_signal`, if it's getting executed by the Ruby thread that is holding the global VM lock,
+// we can call `rb_postponed_job_register_one` to ask the Ruby VM to call our `sample_from_postponed_job` function
+// "as soon as it can".
+//
+// 4. The Ruby VM calls our `sample_from_postponed_job` from a thread holding the global VM lock. A sample is recorded by
+// calling `cpu_and_wall_time_collector_sample`.
+//
+// ---
+
+// Contains state for a single CpuAndWallTimeWorker instance
+struct cpu_and_wall_time_worker_state {
+  // Important: This is not atomic nor is it guaranteed to replace memory barriers and the like. Aka this works for
+  // telling the sampling trigger loop to stop, but if we ever need to communicate more, we should move to actual
+  // atomic operations. stdatomic.h seems a nice thing to reach out for.
+  volatile bool should_run;
+
+  VALUE cpu_and_wall_time_collector_instance;
+  // When something goes wrong during sampling, we record the Ruby exception here, so that it can be "re-raised" on
+  // the CpuAndWallTimeWorker thread
+  VALUE failure_exception;
+};
+
+static VALUE _native_new(VALUE klass);
+static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE self_instance, VALUE cpu_and_wall_time_collector_instance);
+static void cpu_and_wall_time_worker_typed_data_mark(void *state_ptr);
+static VALUE _native_sampling_loop(VALUE self, VALUE instance);
+static VALUE _native_stop(DDTRACE_UNUSED VALUE _self, VALUE self_instance);
+static void install_sigprof_signal_handler(void (*signal_handler_function)(int, siginfo_t *, void *));
+static void remove_sigprof_signal_handler(void);
+static void block_sigprof_signal_handler_from_running_in_current_thread(void);
+static void handle_sampling_signal(DDTRACE_UNUSED int _signal, DDTRACE_UNUSED siginfo_t *_info, DDTRACE_UNUSED void *_ucontext);
+static void *run_sampling_trigger_loop(void *state_ptr);
+static void interrupt_sampling_trigger_loop(void *state_ptr);
+static void sample_from_postponed_job(DDTRACE_UNUSED void *_unused);
+static VALUE handle_sampling_failure(VALUE self_instance, VALUE exception);
+static VALUE _native_current_sigprof_signal_handler(DDTRACE_UNUSED VALUE self);
+static VALUE release_gvl_and_run_sampling_trigger_loop(VALUE instance);
+static VALUE _native_is_running(DDTRACE_UNUSED VALUE self, VALUE instance);
+static void testing_signal_handler(DDTRACE_UNUSED int _signal, DDTRACE_UNUSED siginfo_t *_info, DDTRACE_UNUSED void *_ucontext);
+static VALUE _native_install_testing_signal_handler(DDTRACE_UNUSED VALUE self);
+static VALUE _native_remove_testing_signal_handler(DDTRACE_UNUSED VALUE self);
+
+// Global state -- be very careful when accessing or modifying it
+
+// Note: Global state must only be mutated while holding the global VM lock (we piggy back on it to ensure correctness).
+// The active_sampler_instance needs to be global because we access it from the signal handler.
+static VALUE active_sampler_instance = Qnil;
+// ...We also store active_sampler_owner_thread to be able to tell who the active_sampler_instance belongs to (and also
+// to detect when it is outdated)
+static VALUE active_sampler_owner_thread = Qnil;
+
+void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module) {
+  rb_global_variable(&active_sampler_instance);
+  rb_global_variable(&active_sampler_owner_thread);
+
+  VALUE collectors_module = rb_define_module_under(profiling_module, "Collectors");
+  VALUE collectors_cpu_and_wall_time_worker_class = rb_define_class_under(collectors_module, "CpuAndWallTimeWorker", rb_cObject);
+  // Hosts methods used for testing the native code using RSpec
+  VALUE testing_module = rb_define_module_under(collectors_cpu_and_wall_time_worker_class, "Testing");
+
+  // Instances of the CpuAndWallTimeWorker class are "TypedData" objects.
+  // "TypedData" objects are special objects in the Ruby VM that can wrap C structs.
+  // In this case, it wraps the cpu_and_wall_time_worker_state.
+  //
+  // Because Ruby doesn't know how to initialize native-level structs, we MUST override the allocation function for objects
+  // of this class so that we can manage this part. Not overriding or disabling the allocation function is a common
+  // gotcha for "TypedData" objects that can very easily lead to VM crashes, see for instance
+  // https://bugs.ruby-lang.org/issues/18007 for a discussion around this.
+  rb_define_alloc_func(collectors_cpu_and_wall_time_worker_class, _native_new);
+
+  rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_initialize", _native_initialize, 2);
+  rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_sampling_loop", _native_sampling_loop, 1);
+  rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_stop", _native_stop, 1);
+  rb_define_singleton_method(testing_module, "_native_current_sigprof_signal_handler", _native_current_sigprof_signal_handler, 0);
+  rb_define_singleton_method(testing_module, "_native_is_running?", _native_is_running, 1);
+  rb_define_singleton_method(testing_module, "_native_install_testing_signal_handler", _native_install_testing_signal_handler, 0);
+  rb_define_singleton_method(testing_module, "_native_remove_testing_signal_handler", _native_remove_testing_signal_handler, 0);
+}
+
+// This structure is used to define a Ruby object that stores a pointer to a struct cpu_and_wall_time_worker_state
+// See also https://github.com/ruby/ruby/blob/master/doc/extension.rdoc for how this works
+static const rb_data_type_t cpu_and_wall_time_worker_typed_data = {
+  .wrap_struct_name = "Datadog::Profiling::Collectors::CpuAndWallTimeWorker",
+  .function = {
+    .dmark = cpu_and_wall_time_worker_typed_data_mark,
+    .dfree = RUBY_DEFAULT_FREE,
+    .dsize = NULL, // We don't track profile memory usage (although it'd be cool if we did!)
+    //.dcompact = NULL, // FIXME: Add support for compaction
+  },
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+static VALUE _native_new(VALUE klass) {
+  struct cpu_and_wall_time_worker_state *state = ruby_xcalloc(1, sizeof(struct cpu_and_wall_time_worker_state));
+
+  state->should_run = false;
+  state->cpu_and_wall_time_collector_instance = Qnil;
+  state->failure_exception = Qnil;
+
+  return TypedData_Wrap_Struct(klass, &cpu_and_wall_time_worker_typed_data, state);
+}
+
+static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE self_instance, VALUE cpu_and_wall_time_collector_instance) {
+  struct cpu_and_wall_time_worker_state *state;
+  TypedData_Get_Struct(self_instance, struct cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);
+
+  state->cpu_and_wall_time_collector_instance = enforce_cpu_and_wall_time_collector_instance(cpu_and_wall_time_collector_instance);
+
+  return Qtrue;
+}
+
+// Since our state contains references to Ruby objects, we need to tell the Ruby GC about them
+static void cpu_and_wall_time_worker_typed_data_mark(void *state_ptr) {
+  struct cpu_and_wall_time_worker_state *state = (struct cpu_and_wall_time_worker_state *) state_ptr;
+
+  rb_gc_mark(state->cpu_and_wall_time_collector_instance);
+  rb_gc_mark(state->failure_exception);
+}
+
+// Called in a background thread created in CpuAndWallTimeWorker#start
+static VALUE _native_sampling_loop(DDTRACE_UNUSED VALUE _self, VALUE instance) {
+  struct cpu_and_wall_time_worker_state *state;
+  TypedData_Get_Struct(instance, struct cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);
+
+  if (active_sampler_owner_thread != Qnil && is_thread_alive(active_sampler_owner_thread)) {
+    rb_raise(
+      rb_eRuntimeError,
+      "Could not start CpuAndWallTimeWorker: There's already another instance of CpuAndWallTimeWorker active in a different thread"
+    );
+  }
+
+  // This write to a global is thread-safe BECAUSE we're still holding on to the global VM lock at this point
+  active_sampler_instance = instance;
+  active_sampler_owner_thread = rb_thread_current();
+
+  state->should_run = true;
+
+  block_sigprof_signal_handler_from_running_in_current_thread(); // We want to interrupt the thread with the global VM lock, never this one
+
+  install_sigprof_signal_handler(handle_sampling_signal);
+
+  // Release GVL, get to the actual work!
+  int exception_state;
+  rb_protect(release_gvl_and_run_sampling_trigger_loop, instance, &exception_state);
+
+  // The sample trigger loop finished (either cleanly or with an error); let's clean up
+
+  remove_sigprof_signal_handler();
+  active_sampler_instance = Qnil;
+  active_sampler_owner_thread = Qnil;
+
+  // Ensure that instance is not garbage collected while the native sampling loop is running; this is probably not needed, but just in case
+  RB_GC_GUARD(instance);
+
+  if (exception_state) rb_jump_tag(exception_state); // Re-raise any exception that happened
+
+  return Qnil;
+}
+
+static VALUE _native_stop(DDTRACE_UNUSED VALUE _self, VALUE self_instance) {
+  struct cpu_and_wall_time_worker_state *state;
+  TypedData_Get_Struct(self_instance, struct cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);
+
+  state->should_run = false;
+
+  return Qtrue;
+}
+
+static void install_sigprof_signal_handler(void (*signal_handler_function)(int, siginfo_t *, void *)) {
+  struct sigaction existing_signal_handler_config = {.sa_sigaction = NULL};
+  struct sigaction signal_handler_config = {
+    .sa_flags = SA_RESTART | SA_SIGINFO,
+    .sa_sigaction = signal_handler_function
+  };
+  sigemptyset(&signal_handler_config.sa_mask);
+
+  if (sigaction(SIGPROF, &signal_handler_config, &existing_signal_handler_config) != 0) {
+    rb_sys_fail("Could not start CpuAndWallTimeWorker: Could not install signal handler");
+  }
+
+  // In some corner cases (e.g. after a fork), our signal handler may still be around, and that's ok
+  if (existing_signal_handler_config.sa_sigaction == handle_sampling_signal) return;
+
+  if (existing_signal_handler_config.sa_handler != NULL || existing_signal_handler_config.sa_sigaction != NULL) {
+    // A previous signal handler already existed. Currently we don't support this situation, so let's just back out
+    // of the installation.
+
+    if (sigaction(SIGPROF, &existing_signal_handler_config, NULL) != 0) {
+      rb_sys_fail(
+        "Could not start CpuAndWallTimeWorker: Could not re-install pre-existing SIGPROF signal handler. " \
+        "This may break the component had installed it."
+      );
+    }
+
+    rb_raise(rb_eRuntimeError, "Could not start CpuAndWallTimeWorker: There's a pre-existing SIGPROF signal handler");
+  }
+}
+
+static void remove_sigprof_signal_handler(void) {
+  struct sigaction signal_handler_config = {
+    .sa_handler = SIG_DFL, // Reset back to default
+    .sa_flags = SA_RESTART // TODO: Unclear if this is actually needed/does anything at all
+  };
+  sigemptyset(&signal_handler_config.sa_mask);
+
+  if (sigaction(SIGPROF, &signal_handler_config, NULL) != 0) rb_sys_fail("Failure while removing the signal handler");
+}
+
+static void block_sigprof_signal_handler_from_running_in_current_thread(void) {
+  sigset_t signals_to_block;
+  sigemptyset(&signals_to_block);
+  sigaddset(&signals_to_block, SIGPROF);
+  pthread_sigmask(SIG_BLOCK, &signals_to_block, NULL);
+}
+
+static void handle_sampling_signal(DDTRACE_UNUSED int _signal, DDTRACE_UNUSED siginfo_t *_info, DDTRACE_UNUSED void *_ucontext) {
+  if (!ruby_native_thread_p() || !ruby_thread_has_gvl_p()) {
+    return; // Not safe to enqueue a sample from this thread
+  }
+
+  // We implicitly assume there can be no concurrent nor nested calls to handle_sampling_signal because
+  // a) we get triggered using SIGPROF, and the docs state second SIGPROF will not interrupt an existing one
+  // b) we validate we are in the thread that has the global VM lock; if a different thread gets a signal, it will return early
+  //    because it will not have the global VM lock
+  // TODO: Validate that this does not impact Ractors
+
+  // Note: rb_postponed_job_register_one ensures that if there's a previous sample_from_postponed_job queued for execution
+  // then we will not queue a second one. It does this by doing a linear scan on the existing jobs; in the future we
+  // may want to implement that check ourselves.
+
+  // TODO: Do something with result (potentially update tracking counters?)
+  /*int result =*/ rb_postponed_job_register_one(0, sample_from_postponed_job, NULL);
+}
+
+// The actual sampling trigger loop always runs **without** the global vm lock.
+static void *run_sampling_trigger_loop(void *state_ptr) {
+  struct cpu_and_wall_time_worker_state *state = (struct cpu_and_wall_time_worker_state *) state_ptr;
+
+  struct timespec time_between_signals = {.tv_nsec = 10 * 1000 * 1000 /* 10ms */};
+
+  while (state->should_run) {
+    // TODO: This is still a placeholder for a more complex mechanism. In particular:
+    // * We want to signal a particular thread or threads, not the process in general
+    // * We want to track if a signal landed on the thread holding the global VM lock and do something about it
+    // * We want to do more than having a fixed sampling rate
+
+    kill(getpid(), SIGPROF);
+    nanosleep(&time_between_signals, NULL);
+  }
+
+  return NULL; // Unused
+}
+
+// This is called by the Ruby VM when it wants to shut down the background thread
+static void interrupt_sampling_trigger_loop(void *state_ptr) {
+  struct cpu_and_wall_time_worker_state *state = (struct cpu_and_wall_time_worker_state *) state_ptr;
+
+  state->should_run = false;
+}
+
+static void sample_from_postponed_job(DDTRACE_UNUSED void *_unused) {
+  VALUE instance = active_sampler_instance; // Read from global variable
+
+  // This can potentially happen if the CpuAndWallTimeWorker was stopped while the postponed job was waiting to be executed; nothing to do
+  if (instance == Qnil) return;
+
+  struct cpu_and_wall_time_worker_state *state;
+  TypedData_Get_Struct(instance, struct cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);
+
+  // Trigger sampling using the Collectors::CpuAndWallTime; rescue against any exceptions that happen during sampling
+  VALUE (*function_to_call_safely)(VALUE) = cpu_and_wall_time_collector_sample;
+  VALUE function_to_call_safely_arg = state->cpu_and_wall_time_collector_instance;
+  VALUE (*exception_handler_function)(VALUE, VALUE) = handle_sampling_failure;
+  VALUE exception_handler_function_arg = instance;
+  rb_rescue2(
+    function_to_call_safely,
+    function_to_call_safely_arg,
+    exception_handler_function,
+    exception_handler_function_arg,
+    rb_eException, // rb_eException is the base class of all Ruby exceptions
+    0 // Required by API to be the last argument
+  );
+}
+
+static VALUE handle_sampling_failure(VALUE self_instance, VALUE exception) {
+  struct cpu_and_wall_time_worker_state *state;
+  TypedData_Get_Struct(self_instance, struct cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);
+
+  state->should_run = false;
+  state->failure_exception = exception;
+
+  return Qnil;
+}
+
+static VALUE _native_current_sigprof_signal_handler(DDTRACE_UNUSED VALUE self) {
+  struct sigaction existing_signal_handler_config = {.sa_sigaction = NULL};
+  if (sigaction(SIGPROF, NULL, &existing_signal_handler_config) != 0) {
+    rb_sys_fail("Failed to probe existing handler");
+  }
+
+  if (existing_signal_handler_config.sa_sigaction == handle_sampling_signal) {
+    return ID2SYM(rb_intern("profiling"));
+  } else if (existing_signal_handler_config.sa_sigaction != NULL) {
+    return ID2SYM(rb_intern("other"));
+  } else {
+    return Qnil;
+  }
+}
+
+static VALUE release_gvl_and_run_sampling_trigger_loop(VALUE instance) {
+  struct cpu_and_wall_time_worker_state *state;
+  TypedData_Get_Struct(instance, struct cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);
+
+  rb_thread_call_without_gvl(run_sampling_trigger_loop, state, interrupt_sampling_trigger_loop, state);
+
+  // If we stopped sampling due to an exception, re-raise it (now in the worker thread)
+  if (state->failure_exception != Qnil) rb_exc_raise(state->failure_exception);
+
+  return Qnil;
+}
+
+static VALUE _native_is_running(DDTRACE_UNUSED VALUE self, VALUE instance) {
+  return \
+    (active_sampler_owner_thread != Qnil && is_thread_alive(active_sampler_owner_thread) && active_sampler_instance == instance) ?
+    Qtrue : Qfalse;
+}
+
+static void testing_signal_handler(DDTRACE_UNUSED int _signal, DDTRACE_UNUSED siginfo_t *_info, DDTRACE_UNUSED void *_ucontext) {
+  /* Does nothing on purpose */
+}
+
+static VALUE _native_install_testing_signal_handler(DDTRACE_UNUSED VALUE self) {
+  install_sigprof_signal_handler(testing_signal_handler);
+  return Qtrue;
+}
+
+static VALUE _native_remove_testing_signal_handler(DDTRACE_UNUSED VALUE self) {
+  remove_sigprof_signal_handler();
+  return Qtrue;
+}

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -144,6 +144,8 @@ if RUBY_VERSION < '2.3'
   $defs << '-DUSE_LEGACY_RB_PROFILE_FRAMES'
   # ... you couldn't name threads
   $defs << '-DNO_THREAD_NAMES'
+  # ...the ruby_thread_has_gvl_p function was not exposed to users outside of the VM
+  $defs << '-DNO_THREAD_HAS_GVL'
 end
 
 # If we got here, libdatadog is available and loaded

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -681,3 +681,12 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, i
 }
 
 #endif // USE_LEGACY_RB_PROFILE_FRAMES
+
+#ifdef NO_THREAD_HAS_GVL
+int ruby_thread_has_gvl_p(void) {
+  // TODO: The CpuAndWallTimeWorker needs this function, but Ruby 2.2 doesn't expose it... For now this placeholder
+  // will enable the profiling native extension to continue to compile on Ruby 2.2, but the CpuAndWallTimeWorker will
+  // not work properly on 2.2. Will be addressed later.
+  return 0;
+}
+#endif // NO_THREAD_HAS_GVL

--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -5,6 +5,7 @@
 
 // Each class/module here is implemented in their separate file
 void collectors_cpu_and_wall_time_init(VALUE profiling_module);
+void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module);
 void collectors_stack_init(VALUE profiling_module);
 void http_transport_init(VALUE profiling_module);
 void stack_recorder_init(VALUE profiling_module);
@@ -22,6 +23,7 @@ void DDTRACE_EXPORT Init_ddtrace_profiling_native_extension(void) {
   rb_define_singleton_method(native_extension_module, "clock_id_for", clock_id_for, 1); // from clock_id.h
 
   collectors_cpu_and_wall_time_init(profiling_module);
+  collectors_cpu_and_wall_time_worker_init(profiling_module);
   collectors_stack_init(profiling_module);
   http_transport_init(profiling_module);
   stack_recorder_init(profiling_module);

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -324,8 +324,9 @@ static void *call_serialize_without_gvl(void *call_args) {
   return NULL; // Unused
 }
 
-void enforce_recorder_instance(VALUE object) {
+VALUE enforce_recorder_instance(VALUE object) {
   Check_TypedStruct(object, &stack_recorder_typed_data);
+  return object;
 }
 
 static struct active_slot_pair sampler_lock_active_profile(struct stack_recorder_state *state) {

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.h
@@ -34,4 +34,4 @@ static const ddprof_ffi_ValueType enabled_value_types[] = {
 #define ENABLED_VALUE_TYPES_COUNT (sizeof(enabled_value_types) / sizeof(ddprof_ffi_ValueType))
 
 void record_sample(VALUE recorder_instance, ddprof_ffi_Sample sample);
-void enforce_recorder_instance(VALUE object);
+VALUE enforce_recorder_instance(VALUE object);

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -148,6 +148,7 @@ module Datadog
       require_relative 'profiling/ext/forking'
       require_relative 'profiling/collectors/code_provenance'
       require_relative 'profiling/collectors/cpu_and_wall_time'
+      require_relative 'profiling/collectors/cpu_and_wall_time_worker'
       require_relative 'profiling/collectors/old_stack'
       require_relative 'profiling/collectors/stack'
       require_relative 'profiling/stack_recorder'

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -1,0 +1,74 @@
+# typed: false
+
+module Datadog
+  module Profiling
+    module Collectors
+      # Used to trigger the periodic execution of Collectors::CpuAndWallTime, which implements all of the sampling logic
+      # itself; this class only implements the "doing it periodically" part.
+      # Almost all of this class is implemented as native code.
+      #
+      # Methods prefixed with _native_ are implemented in `collectors_cpu_and_wall_time_worker.c`
+      class CpuAndWallTimeWorker
+        private
+
+        attr_accessor :failure_exception
+
+        public
+
+        def initialize(
+          recorder:,
+          max_frames:,
+          cpu_and_wall_time_collector: CpuAndWallTime.new(recorder: recorder, max_frames: max_frames)
+        )
+          self.class._native_initialize(self, cpu_and_wall_time_collector)
+          @worker_thread = nil
+          @failure_exception = nil
+          @start_stop_mutex = Mutex.new
+        end
+
+        def start
+          @start_stop_mutex.synchronize do
+            return if @worker_thread
+
+            Datadog.logger.debug { "Starting thread for: #{self}" }
+            @worker_thread = Thread.new do
+              begin
+                Thread.current.name = self.class.name unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+
+                self.class._native_sampling_loop(self)
+
+                Datadog.logger.debug('CpuAndWallTimeWorker thread stopping cleanly')
+              rescue Exception => e # rubocop:disable Lint/RescueException
+                @failure_exception = e
+                Datadog.logger.warn(
+                  "Worker thread error. Cause: #{e.class.name} #{e.message} Location: #{Array(e.backtrace).first}"
+                )
+              end
+            end
+          end
+
+          true
+        end
+
+        # TODO: Provided only for compatibility with the API for Collectors::OldStack used in the Profiler class.
+        # Can be removed once we remove OldStack.
+        def enabled=(_); end
+
+        def stop(*_)
+          @start_stop_mutex.synchronize do
+            Datadog.logger.debug('Requesting CpuAndWallTimeWorker thread shut down')
+
+            return unless @worker_thread
+
+            @worker_thread.kill
+            self.class._native_stop(self)
+
+            @worker_thread.join
+            @worker_thread = nil
+            @failure_exception = nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -13,7 +13,7 @@ module Datadog
         # This isn't something we expect to happen normally, but because it would break the assumptions of the
         # C-level mutexes (that there is a single serializer thread), we add it here as an extra safeguard against it
         # accidentally happening.
-        @no_concurrent_synchronize_mutex = Thread::Mutex.new
+        @no_concurrent_synchronize_mutex = Mutex.new
       end
 
       def serialize

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1,6 +1,7 @@
 # typed: ignore
 
 require 'datadog/profiling/spec_helper'
+require 'datadog/profiling/collectors/cpu_and_wall_time_worker'
 
 RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   before { skip_if_profiling_not_supported(self) }

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1,0 +1,137 @@
+# typed: ignore
+
+require 'datadog/profiling/spec_helper'
+
+RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
+  before { skip_if_profiling_not_supported(self) }
+
+  let(:recorder) { Datadog::Profiling::StackRecorder.new }
+
+  subject(:cpu_and_wall_time_worker) { described_class.new(recorder: recorder, max_frames: 400) }
+
+  describe '#start' do
+    subject(:start) do
+      cpu_and_wall_time_worker.start
+      wait_until_running
+    end
+
+    after do
+      cpu_and_wall_time_worker.stop
+    end
+
+    it 'creates a new thread' do
+      skip 'Spec not compatible with Ruby 2.2' if RUBY_VERSION.start_with?('2.2.')
+
+      start
+
+      expect(Thread.list.map(&:name)).to include(described_class.name)
+    end
+
+    it 'does not create a second thread if start is called again' do
+      start
+
+      expect(Thread).to_not receive(:new)
+
+      cpu_and_wall_time_worker.start
+    end
+
+    it 'does not allow other instances of the CpuAndWallTimeWorker to start' do
+      start
+
+      allow(Datadog.logger).to receive(:warn)
+
+      another_instance = described_class.new(recorder: Datadog::Profiling::StackRecorder.new, max_frames: 400)
+      another_instance.start
+
+      exception = try_wait_until(backoff: 0.01) { another_instance.send(:failure_exception) }
+
+      expect(exception.message).to include 'another instance'
+    end
+
+    it 'installs the profiling SIGPROF signal handler' do
+      start
+
+      expect(described_class::Testing._native_current_sigprof_signal_handler).to be :profiling
+    end
+
+    context 'when a previous signal handler existed' do
+      before do
+        described_class::Testing._native_install_testing_signal_handler
+        expect(described_class::Testing._native_current_sigprof_signal_handler).to be :other
+
+        allow(Datadog.logger).to receive(:warn)
+      end
+
+      after do
+        described_class::Testing._native_remove_testing_signal_handler
+      end
+
+      it 'does not start the sampling loop' do
+        cpu_and_wall_time_worker.start
+
+        exception = try_wait_until(backoff: 0.01) { cpu_and_wall_time_worker.send(:failure_exception) }
+
+        expect(exception.message).to include 'pre-existing SIGPROF'
+      end
+
+      it 'leaves the existing signal handler in place' do
+        cpu_and_wall_time_worker.start
+
+        try_wait_until(backoff: 0.01) { cpu_and_wall_time_worker.send(:failure_exception) }
+
+        expect(described_class::Testing._native_current_sigprof_signal_handler).to be :other
+      end
+    end
+
+    it 'triggers sampling and records the results' do
+      start
+
+      all_samples = try_wait_until do
+        serialization_result = recorder.serialize
+        raise 'Unexpected: Serialization failed' unless serialization_result
+
+        samples = samples_from_pprof(serialization_result.last)
+        samples if samples.any?
+      end
+
+      current_thread_sample = all_samples.find do |it|
+        it.fetch(:labels).fetch(:'thread id') == Thread.current.object_id.to_s
+      end
+
+      expect(current_thread_sample).to_not be nil
+    end
+  end
+
+  describe '#stop' do
+    subject(:stop) { cpu_and_wall_time_worker.stop }
+
+    before do
+      cpu_and_wall_time_worker.start
+      wait_until_running
+    end
+
+    it 'shuts down the background thread' do
+      skip 'Spec not compatible with Ruby 2.2' if RUBY_VERSION.start_with?('2.2.')
+
+      stop
+
+      expect(Thread.list.map(&:name)).to_not include(described_class.name)
+    end
+
+    it 'removes the profiling sigprof signal handler' do
+      stop
+
+      expect(described_class::Testing._native_current_sigprof_signal_handler).to be nil
+    end
+  end
+
+  describe '#enabled=' do
+    it 'does nothing (provided only for API compatibility)' do
+      cpu_and_wall_time_worker.enabled = true
+    end
+  end
+
+  def wait_until_running
+    try_wait_until(backoff: 0.01) { described_class::Testing._native_is_running?(cpu_and_wall_time_worker) }
+  end
+end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -85,6 +85,8 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
     end
 
     it 'triggers sampling and records the results' do
+      pending 'Currently broken on Ruby 2.2 due to missing ruby_thread_has_gvl_p API' if RUBY_VERSION.start_with?('2.2.')
+
       start
 
       all_samples = try_wait_until do
@@ -112,9 +114,9 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
     end
 
     it 'shuts down the background thread' do
-      skip 'Spec not compatible with Ruby 2.2' if RUBY_VERSION.start_with?('2.2.')
-
       stop
+
+      skip 'Spec not compatible with Ruby 2.2' if RUBY_VERSION.start_with?('2.2.')
 
       expect(Thread.list.map(&:name)).to_not include(described_class.name)
     end

--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -54,12 +54,13 @@ module SynchronizationHelpers
   # Defaults to 5 second timeout
   def try_wait_until(attempts: 50, backoff: 0.1)
     loop do
-      break if yield(attempts)
+      result = yield(attempts)
+      return result if result
 
       sleep(backoff)
       attempts -= 1
 
-      raise StandardError, 'Wait time exhausted!' if attempts <= 0
+      raise('Wait time exhausted!') if attempts <= 0
     end
   end
 


### PR DESCRIPTION
**What does this PR do?**:

Adds the new `Profiling::Collectors::CpuAndWallTimeWorker`.

The `CpuAndWallTimeWorker` component takes care of automatically triggering the `CpuAndWallTime` collector.

In a single sentence, this component a) runs in a background thread, b) periodically uses a unix signal (SIGPROF) to interrupt a running Ruby thread, and c) gets the interrupted Ruby thread to call the `CpuAndWallTime` collector to take a sample.

Thus we achieve periodic sampling of Ruby threads. The `CpuAndWallTimeWorker` was the last big missing piece for the new Ruby profiler, and we can now turn it on and actually get samples.

**Motivation**:

This component has the important job of periodically triggering taking samples. In the old profiler, this behavior lived in `Collectors::OldStack`.

Without this component, the profiler would not be able to run in the background of customer applications.

**Additional Notes**:

The inner workings of the `CpuAndWallTimeWorker` are non-trivial, and hopefully the design description included, as well as the specs will help in documenting what it does and how it does it.

Finally, I would consider this component as not being complete yet, and I'll call the current state "alpha".

In particular, it's missing at least:

* Handling of forks (there's some work, but I'm not convinced it's enough)
* Validation / specs that show it's Ractor-safe
* Dynamic sampling rate/pacing mechanism
* Sending signals to specific threads, not to the whole process, to reduce bias and improve CPU profiling

I have notes for all of these things, and will continue working on them until we're confident on the implementation and on our validation, and can start asking customers to test it out.

**How to test the change?**:

Change includes test coverage. In a later PR, I'll add the ability to turn on the new profiler, which will enable us to test the full stack of new profiler components in real apps.