### PR TITLE
[PROF-5860] Allow new CPU Profiling 2.0 **alpha** profiler to be enabled

### DIFF
--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -240,13 +240,21 @@ module Datadog
 
             # NOTE: Please update the Initialization section of ProfilingDevelopment.md with any changes to this method
 
-            trace_identifiers_helper = Profiling::TraceIdentifiers::Helper.new(
-              tracer: tracer,
-              endpoint_collection_enabled: settings.profiling.advanced.endpoint.collection.enabled
-            )
+            if settings.profiling.advanced.force_enable_new_profiler
+              recorder = Datadog::Profiling::StackRecorder.new
+              collector = Datadog::Profiling::Collectors::CpuAndWallTimeWorker.new(
+                recorder: recorder,
+                max_frames: settings.profiling.advanced.max_frames
+              )
+            else
+              trace_identifiers_helper = Profiling::TraceIdentifiers::Helper.new(
+                tracer: tracer,
+                endpoint_collection_enabled: settings.profiling.advanced.endpoint.collection.enabled
+              )
 
-            recorder = build_profiler_old_recorder(settings)
-            collector = build_profiler_oldstack_collector(settings, recorder, trace_identifiers_helper)
+              recorder = build_profiler_old_recorder(settings)
+              collector = build_profiler_oldstack_collector(settings, recorder, trace_identifiers_helper)
+            end
 
             exporter = build_profiler_exporter(settings, recorder)
             transport = build_profiler_transport(settings, agent_settings)

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -241,6 +241,16 @@ module Datadog
               o.default { env_to_bool('DD_PROFILING_LEGACY_TRANSPORT_ENABLED', false) }
               o.lazy
             end
+
+            # Forces enabling the new profiler. We do not yet recommend turning on this option.
+            #
+            # Note that setting this to "false" (or not setting it) will not prevent the new profiler from
+            # being automatically used in the future.
+            # This option will be deprecated for removal once the new profiler gets enabled by default for all customers.
+            option :force_enable_new_profiler do |o|
+              o.default { env_to_bool('DD_PROFILING_FORCE_ENABLE_NEW', false) }
+              o.lazy
+            end
           end
 
           # @public_api

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -430,6 +430,41 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             .to(false)
         end
       end
+
+      describe '#force_enable_new_profiler' do
+        subject(:force_enable_new_profiler) { settings.profiling.advanced.force_enable_new_profiler }
+
+        context 'when DD_PROFILING_FORCE_ENABLE_NEW' do
+          around do |example|
+            ClimateControl.modify('DD_PROFILING_FORCE_ENABLE_NEW' => environment) do
+              example.run
+            end
+          end
+
+          context 'is not defined' do
+            let(:environment) { nil }
+
+            it { is_expected.to be false }
+          end
+
+          { 'true' => true, 'false' => false }.each do |string, value|
+            context "is defined as #{string}" do
+              let(:environment) { string }
+
+              it { is_expected.to be value }
+            end
+          end
+        end
+      end
+
+      describe '#force_enable_new_profiler=' do
+        it 'updates the #force_enable_new_profiler setting' do
+          expect { settings.profiling.advanced.force_enable_new_profiler = true }
+            .to change { settings.profiling.advanced.force_enable_new_profiler }
+            .from(false)
+            .to(true)
+        end
+      end
     end
 
     describe '#upload' do


### PR DESCRIPTION
# The new Ruby profiler, aka "CPU Profiling 2.0", is considered to be alpha state. We do not recommend turning it on.

But! We actually can turn it on now -- by using `DD_PROFILING_FORCE_ENABLE_NEW=true`.

The rest of the pieces have been put into place in previous PRs.

**What does this PR do?**:

Add a setting that allows choosing between the "old" profiler codepath, and the new "CPU Profiling 2.0" codepath.

**Motivation**:

Making it possible to test the new profiler.

**Additional Notes**

This PR sits atop #2208 because without the component in #2208 the profiler would not be able to be turned on. It is otherwise independent from that change.

**How to test the change?**:

Here's a simple run of the new profiler:

```
$ DD_TRACE_DEBUG=true DD_PROFILING_ENABLED=true DD_SERVICE=ivoanjo-testing DD_ENV=staging DD_PROFILING_FORCE_ENABLE_NEW=true bundle exec ddtracerb exec ruby -e sleep
I, [2022-08-05T14:40:38.715368 #24783]  INFO -- ddtrace: [ddtrace] (dd-trace-rb/lib/datadog/profiling/tasks/setup.rb:47:in `check_if_cpu_time_profiling_is_supported') CPU time profiling skipped because native CPU time is not supported: Feature requires Linux; macOS is not supported. Profiles containing 'Wall time' data will still be reported.
D, [2022-08-05T14:40:38.727312 #24783] DEBUG -- ddtrace: [ddtrace] (dd-trace-rb/lib/datadog/core/workers/async.rb:133:in `start_worker') Starting thread for: #<Datadog::Core::Telemetry::Heartbeat:0x00007f825b982080>
D, [2022-08-05T14:40:38.727510 #24783] DEBUG -- ddtrace: [ddtrace] (dd-trace-rb/lib/datadog/core/configuration/components.rb:371:in `startup!') Profiling started
D, [2022-08-05T14:40:38.727647 #24783] DEBUG -- ddtrace: [ddtrace] (dd-trace-rb/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb:33:in `block in start') Starting thread for: #<Datadog::Profiling::Collectors::CpuAndWallTimeWorker:0x00007f827b91b950>
D, [2022-08-05T14:40:38.727712 #24783] DEBUG -- ddtrace: [ddtrace] (dd-trace-rb/lib/datadog/core/workers/async.rb:133:in `start_worker') Starting thread for: #<Datadog::Profiling::Scheduler:0x00007f826c07bb60>
D, [2022-08-05T14:41:38.735153 #24783] DEBUG -- ddtrace: [ddtrace] (dd-trace-rb/lib/datadog/profiling/stack_recorder.rb:25:in `serialize') Encoded profile covering 2022-08-05T13:40:38Z to 2022-08-05T13:41:38Z
D, [2022-08-05T14:41:40.534027 #24783] DEBUG -- ddtrace: [ddtrace] (dd-trace-rb/lib/datadog/profiling/http_transport.rb:49:in `export') Successfully reported profiling data
```
