### PR TITLE
CI:Test time limit with thread dump report

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -241,5 +241,32 @@ end
 
 Thread.prepend(DatadogThreadDebugger)
 
+# Enforce test time limit, to allow us to debug why some test runs get stuck in CI
+if ENV.key?('CI')
+  require 'spec/support/thread_helpers'
+
+  ThreadHelpers.with_leaky_thread_creation('Deadline thread') do
+    Thread.new do
+      sleep_time = 30 * 60 # 30 minutes
+      sleep(sleep_time)
+
+      warn "Test too longer than #{sleep_time}s to finish, aborting test run."
+      warn 'Stack trace of all running threads:'
+
+      Thread.list.select { |t| t.alive? && t != Thread.current }.each_with_index.map do |t, idx|
+        backtrace = t.backtrace
+        backtrace = '(Not available)' if backtrace.nil? || backtrace.empty?
+
+        warn "#{idx}: #{t} (#{t.class.name})",
+          'Thread Backtrace:',
+          backtrace.map { |l| "\t#{l}" }.join("\n"),
+          "\n"
+      end
+
+      Kernel.exit(1)
+    end
+  end
+end
+
 # Helper matchers
 RSpec::Matchers.define_negated_matcher :not_be, :be


### PR DESCRIPTION
In another attempt to debug [log writing failed. closed stream](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/6939/workflows/5a1363b8-007f-468a-a334-262ac35cd0d9/jobs/256791), I'm adding a test deadline monitor thread to our CI test runs. This specific run ran for 5 hours 😮 

This monitor will dump the stack track of all threads after 30 minutes and kill the RSpec process with a non-zero exit code.

None of our tests are close to taking 30 minutes (the slowest tests, for JRuby, take around 6 minutes).

Hopefully this will allow debugging not only this specific issue, but any other tests that happen to get stuck in the future.