### PR TITLE
Remove analytics docs for actionmailer and graphql

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -567,7 +567,6 @@ end
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `email_data` | Whether or not to append additional email payload metadata to `action_mailer.deliver` spans. Fields include `['subject', 'to', 'from', 'bcc', 'cc', 'date', 'perform_deliveries']`. | `false` |
 
 ### Action Pack
@@ -1069,8 +1068,6 @@ The `use :graphql` method accepts the following parameters. Additional options c
 | --- | ----------- | ------- |
 | `schemas` | Required. Array of `GraphQL::Schema` objects which to trace. Tracing will be added to all the schemas listed, using the options provided to this configuration. If you do not provide any, then tracing will not be activated. | `[]` |
 | `service_name` | Service name used for graphql instrumentation | `'ruby-graphql'` |
-| `analytics_enabled` | Enable analytics for spans. `true` for on, `nil` to defer to Datadog global setting, `false` for off. | `false` |
-| `analytics_sample_rate` | Rate which tracing data should be sampled for Datadog analytics. Must be a float between `0` and `1.0`. | `1.0` |
 
 **Manually configuring GraphQL schemas**
 


### PR DESCRIPTION
**What does this PR do?**

Remove the analytics related documentation

**Motivation**

Integration analytics options are deprecated. We recently added some back from our community, which was meant to be removed.

https://github.com/DataDog/dd-trace-rb/pull/2195