### PR TITLE
Action:Upgrade ruby/setup-ruby action version

### DIFF
--- a/.github/workflows/test-head.yaml
+++ b/.github/workflows/test-head.yaml
@@ -17,7 +17,7 @@ jobs:
       # want the former only. relax the constraint to allow any version for
       # head rubies
       - run: sed -i~ -e '/spec\.required_ruby_version/d' ddtrace.gemspec
-      - uses: ruby/setup-ruby@77ca66ce2792fb05b8b204a203328e12593a64f3 # v1.72.1
+      - uses: ruby/setup-ruby@6148f408d35df04b0189be5e64c1458377b8ae13 # v1.114.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -18,7 +18,7 @@ jobs:
       # head rubies
       - if: ${{ matrix.ruby == 'head' }}
         run: sed -i~ -e '/spec\.required_ruby_version/d' ddtrace.gemspec
-      - uses: ruby/setup-ruby@f20f1eae726df008313d2e0d78c5e602562a1bcf # v1.86.0
+      - uses: ruby/setup-ruby@6148f408d35df04b0189be5e64c1458377b8ae13 # v1.114.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
This PR fixes a recent CI issue with MacOS builds not being able to fetch a proper Ruby 3.1 build:
https://github.com/DataDog/dd-trace-rb/runs/7754285255?check_suite_focus=true

```
Downloading Ruby
  https://github.com/ruby/ruby-builder/releases/download/toolcache/ruby-3.1.0-preview1-macos-latest.tar.gz
  Took   0.16 seconds
Error: Unexpected HTTP response: 404
```

The action is mysteriously trying to fetch `ruby-3.1.0-preview1-macos` for the `3.1` configuration, even though 3.1 is already out.

Upgrading the Action version did the trick.