### PR TITLE
fix namespace typos in docs

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -406,7 +406,7 @@ def db_query(start, finish, query)
 end
 ```
 
-Calling `Datadog::Tracing.trace` without a block will cause the function to return a `Datadog::SpanOperation` that is started, but not finished. You can then modify this span however you wish, then close it `finish`.
+Calling `Datadog::Tracing.trace` without a block will cause the function to return a `Datadog::Tracing::SpanOperation` that is started, but not finished. You can then modify this span however you wish, then close it `finish`.
 
 *You must not leave any unfinished spans.* If any spans are left open when the trace completes, the trace will be discarded. You can [activate debug mode](#tracer-settings) to check for warnings if you suspect this might be happening.
 

--- a/docs/UpgradeGuide.md
+++ b/docs/UpgradeGuide.md
@@ -363,7 +363,7 @@ Direct usage of `Datadog::Context` has been removed. Previously, it was used to 
 
 Manual tracing is now done through the [public API](https://www.rubydoc.info/gems/ddtrace/).
 
-Whereas in 0.x, the block would provide a `Datadog::Span` as `span`, in 1.0, the block provides a `Datadog::SpanOperation` as `span` and `Datadog::TraceOperation` as `trace`.
+Whereas in 0.x, the block would provide a `Datadog::Span` as `span`, in 1.0, the block provides a `Datadog::Tracing::SpanOperation` as `span` and `Datadog::Tracing::TraceOperation` as `trace`.
 
 ```ruby
 ### Old 0.x ###
@@ -723,7 +723,7 @@ end
 | Tracing API                           | Removed  | `Pipeline.before_flush`                                                                                             | Use `Datadog::Tracing.before_flush` instead.                                                                                                                              |
 | Tracing API                           | Removed  | `SpanOperation#context`                                                                                             | Use `Datadog::Tracing.active_trace` instead.                                                                                                                              |
 | Tracing API                           | Removed  | `SpanOperation#parent`/`SpanOperation#parent=`                                                                      | Not supported.                                                                                                                                                            |
-| Tracing API                           | Removed  | `SpanOperation#sampled`                                                                                             | Use `Datadog::TraceOperation#sampled?` instead.                                                                                                                           |
+| Tracing API                           | Removed  | `SpanOperation#sampled`                                                                                             | Use `Datadog::Tracing::TraceOperation#sampled?` instead.                                                                                                                           |
 | Tracing API                           | Removed  | `Tracer#active_correlation.to_log_format`                                                                           | Use `Datadog::Tracing.log_correlation` instead.                                                                                                                           |
 | Tracing API                           | Removed  | `Tracer#active_correlation`                                                                                         | Use `Datadog::Tracing.correlation` instead.                                                                                                                               |
 | Tracing API                           | Removed  | `Tracer#active_root_span`                                                                                           | Use `Datadog::Tracing.active_trace` instead.                                                                                                                              |

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -1009,7 +1009,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           it_behaves_like 'a span with default events'
         end
 
-        context 'as Datadog::SpanOperation::Events' do
+        context 'as Datadog::Tracing::SpanOperation::Events' do
           let(:events) { Datadog::Tracing::SpanOperation::Events.new }
 
           it_behaves_like 'a span with default events' do
@@ -1027,7 +1027,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           it_behaves_like 'a span with default events'
         end
 
-        context 'as Datadog::SpanOperation::Events' do
+        context 'as Datadog::Tracing::SpanOperation::Events' do
           it_behaves_like 'a span with default events' do
             let(:on_error) { proc { |*args| callback_spy.call(*args) } }
             let(:callback_spy) { spy('callback spy') }


### PR DESCRIPTION
* Fix `Datadog::SpanOperation` -> `Datadog::Tracing::SpanOperation`
* Fix `Datadog::TraceOperation` -> `Datadog::Tracing::TraceOperation`


**What does this PR do?**

Fix typos in documentation

**Motivation**

While upgrading code to the 1.x API (we were using `ddtrace` 0.52), we ran into a few minor problems.

**Additional Notes**

**How to test the change?**

There shouldn't be any occurrences of the incorrect class names in the codebase:

```bash
[ -z "$(git grep -E 'Datadog::(Span|Trace)Operation')" ] && echo success
```
