### PR TITLE
Fix CI instrumentation configuration 

### DIFF
--- a/lib/datadog/ci/contrib/cucumber/integration.rb
+++ b/lib/datadog/ci/contrib/cucumber/integration.rb
@@ -35,7 +35,7 @@ module Datadog
             false
           end
 
-          def default_configuration
+          def new_configuration
             Configuration::Settings.new
           end
 

--- a/lib/datadog/ci/contrib/rspec/integration.rb
+++ b/lib/datadog/ci/contrib/rspec/integration.rb
@@ -36,7 +36,7 @@ module Datadog
             false
           end
 
-          def default_configuration
+          def new_configuration
             Configuration::Settings.new
           end
 

--- a/spec/datadog/ci/contrib/cucumber/formatter_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/formatter_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe 'Cucumber formatter' do
 
   include_context 'CI mode activated'
 
-  let(:configuration_options) { {} }
   # Cucumber runtime setup
   let(:existing_runtime) { Cucumber::Runtime.new(runtime_options) }
   let(:runtime_options)  { {} }
@@ -27,7 +26,7 @@ RSpec.describe 'Cucumber formatter' do
 
   before do
     Datadog.configure do |c|
-      c.ci.instrument :cucumber, configuration_options
+      c.ci.instrument :cucumber, service_name: 'jalapenos'
     end
   end
 
@@ -47,7 +46,7 @@ RSpec.describe 'Cucumber formatter' do
       step_span = spans.find { |s| s.resource == 'datadog' }
 
       expect(scenario_span.resource).to eq('cucumber scenario')
-      expect(scenario_span.service).to eq(Datadog::CI::Contrib::Cucumber::Ext::SERVICE_NAME)
+      expect(scenario_span.service).to eq('jalapenos')
       expect(scenario_span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
       expect(scenario_span.name).to eq(Datadog::CI::Contrib::Cucumber::Ext::OPERATION_NAME)
       expect(step_span.resource).to eq('datadog')

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -11,11 +11,9 @@ require 'datadog/ci/contrib/rspec/integration'
 RSpec.describe 'RSpec hooks' do
   include_context 'CI mode activated'
 
-  let(:configuration_options) { {} }
-
   before do
     Datadog.configure do |c|
-      c.ci.instrument :rspec, configuration_options
+      c.ci.instrument :rspec, service_name: 'lspec'
     end
   end
 
@@ -43,6 +41,7 @@ RSpec.describe 'RSpec hooks' do
     expect(span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
     expect(span.name).to eq(Datadog::CI::Contrib::RSpec::Ext::OPERATION_NAME)
     expect(span.resource).to eq('some test foo')
+    expect(span.service).to eq('lspec')
     expect(span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq('some test foo')
     expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(spec.file_path)
     expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SPAN_KIND)).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)


### PR DESCRIPTION
**Motivation**

The CI instrumentation configuration is broken, cannot be customized(for example, `service_name`)

**What does this PR do?**

Fix the integration by implementing `new_configuration` and remove `default_configuration`