### PR TITLE
Tweak the upgrade guide banner in README/Getting Started to mention 1.x instead of 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-***Version 1.0.0 has recently been released. Check out our [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md#from-0x-to-10) for more details.***
+**We've recently released the 1.x version series. If you're upgrading from a 0.x version, check out our [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md#from-0x-to-10).**
 
 # Datadog Trace Client
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,4 +1,4 @@
-***Version 1.0.0 has been released. Check out our [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md#from-0x-to-10) for more details.***
+**We've recently released the 1.x version series. If you're upgrading from a 0.x version, check out our [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md#from-0x-to-10).**
 
 # Datadog Ruby Trace Client
 


### PR DESCRIPTION
**What does this PR do?**:

Tweak the language of the note we added at the top of the README.md and GettingStarted.md documents to refer to the 1.x series, and not just to 1.0.0.

**Motivation**:

It seemed a bit weird/confusing to me that the wording was presenting 1.0.0 as if it was the latest release, whereas customers should be on 1.3.0 (or whatever comes after).

**How to test the change?**:

This does not affect code, so looking at the diff and the GitHub markdown preview is enough.
