### PR TITLE
Fix flaky profiling spec

### DIFF
--- a/spec/datadog/profiling/encoding/profile_spec.rb
+++ b/spec/datadog/profiling/encoding/profile_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Datadog::Profiling::Encoding::Profile::Protobuf do
     let(:events) { double('events') }
     let(:event_count) { nil }
 
-    let(:template) { instance_double(Datadog::Profiling::Pprof::Template) }
+    let(:template) { instance_double(Datadog::Profiling::Pprof::Template, debug_statistics: 'template_debug_statistics') }
     let(:profile) { instance_double(Perftools::Profiles::Profile) }
     let(:payload) { instance_double(Datadog::Profiling::Pprof::Payload) }
     let(:start_time) { Time.utc(2020) }
@@ -45,6 +45,8 @@ RSpec.describe Datadog::Profiling::Encoding::Profile::Protobuf do
         .with(start: start_time, finish: finish_time)
         .and_return(payload)
         .ordered
+
+      allow(Datadog.logger).to receive(:debug)
     end
 
     it 'returns a pprof-encoded profile' do
@@ -53,8 +55,6 @@ RSpec.describe Datadog::Profiling::Encoding::Profile::Protobuf do
 
     describe 'debug logging' do
       let(:event_count) { 42 }
-
-      let(:template) { instance_double(Datadog::Profiling::Pprof::Template, debug_statistics: 'template_debug_statistics') }
 
       it 'debug logs profile information' do
         expect(Datadog.logger).to receive(:debug) do |&message_block|


### PR DESCRIPTION
**What does this PR do?**:

Fix a flaky spec.

The `template` double used in this test was missing the `debug_statistics` method which was used only for debug logging.

This caused the following error if debug logging was enabled:

```
$ DD_TRACE_DEBUG=true bundle exec rspec ./spec/datadog/profiling/encoding/profile_spec.rb

Failures:

  1) Datadog::Profiling::Encoding::Profile::Protobuf.encode returns a pprof-encoded profile
     Failure/Error: "events: #{event_count} (#{events_sampled}#{template.debug_statistics})"
       #<InstanceDouble(Datadog::Profiling::Pprof::Template) (anonymous)> received unexpected message :debug_statistics with (no args)
     # ./lib/datadog/profiling/encoding/profile.rb:33:in `block in encode'
     # ./lib/datadog/core/logger.rb:33:in `block in add'
     # ./lib/datadog/core/logger.rb:32:in `add'
     # ./lib/datadog/profiling/encoding/profile.rb:23:in `encode'
     # ./spec/datadog/profiling/encoding/profile_spec.rb:12:in `block (3 levels) in <top (required)>'
     # ./spec/datadog/profiling/encoding/profile_spec.rb:51:in `block (3 levels) in <top (required)>'
```

By default, the tests run with debug logging disabled, which means this should not be triggered but clearly there are some specs that enable debug logging and forget to reset it, as this issue was triggered in CI (<https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/7044/workflows/5e163ba5-3df6-4647-bef5-b1a50facd500/jobs/260574>)
with Ruby 2.4 when running `bundle exec appraisal ruby-2.4.10-core-old rake spec:main` with seed `52138`.

To avoid this issue at all, I've just made sure the spec still passes with debug logging enabled.

**Motivation**:

No flaky specs allowed!

**How to test the change?**:

Validate that spec passes even when `DD_TRACE_DEBUG` is set to `true`.