### PR TITLE
Remove sidekiq version cap

### DIFF
--- a/integration/apps/rack/Gemfile
+++ b/integration/apps/rack/Gemfile
@@ -13,8 +13,7 @@ end
 if RUBY_VERSION < '2.2'
   gem 'sidekiq', '< 5' # 5.0.3 checks for older Rubies and breaks, but does not declare it on the gemspec :(
 else
-  # `6.5.3` and `6.5.2` contain broken dependency, https://github.com/mperham/sidekiq/issues/5456
-  gem 'sidekiq', ['!= 6.5.2', '!= 6.5.3']
+  gem 'sidekiq'
 end
 gem 'resque'
 gem 'rake'


### PR DESCRIPTION
This reverts commit 79b9138cee3e6cf0832fcbe6ad208f55b3e34e84.

**Motivation**

Sidekiq have already released a newer version which fixed the broken dependency.

https://github.com/mperham/sidekiq/blob/main/Changes.md#654