### PR TITLE
WIP:Bullet error reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,9 @@ if RUBY_VERSION >= '2.4.0' && (RUBY_PLATFORM =~ /^x86_64-(darwin|linux)/)
   gem 'sorbet', '= 0.5.9672'
   gem 'spoom', '~> 1.1'
 end
+
+
+gem 'activerecord'
+gem 'bullet'
+gem 'sqlite3'
+gem 'mysql2'

--- a/lib/datadog/tracing/contrib/active_record/bullet.rb
+++ b/lib/datadog/tracing/contrib/active_record/bullet.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Tracing
+    module Contrib
+      module ActiveRecord
+        # N+1 query detection reporting
+        module Bullet
+          # Bullet's offending stack finder utility.
+          # Used to backfill the missing stack trace in Bullet::Detector::CounterCache errors.
+          StackFilter = Class.new { extend ::Bullet::StackTraceFilter }
+
+          # Bullet's NotificationCollector receives every bullet error at the offending site.
+          # This allows us to attribute the error to the closest enclosing span.
+          module NotificationCollector
+            def add(value)
+              return super unless Datadog.configuration.tracing[:active_record][:report_bullet]
+
+              active_span = Datadog::Tracing.active_span
+              if active_span && !active_span.has_error? # Do not override an application error, if present
+                callers = value.instance_variable_get(:@callers) || StackFilter.caller_in_project
+
+                # Try to match the original Bullet error reporting as much as possible.
+                # Users will be immediately familiar with the output.
+                active_span.set_error(['Bullet::Notification::UnoptimizedQueryError',
+                                       "#{value.title}\n#{value.body}",
+                                       callers])
+              end
+
+              super
+            end
+          end
+
+          def self.patch!
+            ::Bullet::NotificationCollector.prepend(NotificationCollector)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/tracing/contrib/active_record/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/active_record/configuration/settings.rb
@@ -27,6 +27,8 @@ module Datadog
               o.lazy
             end
 
+            option :report_bullet, default: false
+
             option :service_name do |o|
               o.default { Utils.adapter_name }
               o.lazy

--- a/lib/datadog/tracing/contrib/active_record/patcher.rb
+++ b/lib/datadog/tracing/contrib/active_record/patcher.rb
@@ -1,7 +1,6 @@
 # typed: true
 
 require_relative '../patcher'
-require_relative 'events'
 
 module Datadog
   module Tracing
@@ -18,7 +17,11 @@ module Datadog
           end
 
           def patch
+            require_relative 'events'
+            require_relative 'bullet'
+
             Events.subscribe!
+            Bullet.patch!
           end
         end
       end

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -273,6 +273,10 @@ module Datadog
         super
       end
 
+      def has_error?
+        @status == Metadata::Ext::Errors::STATUS
+      end
+
       # Return a string representation of the span.
       def to_s
         "SpanOperation(name:#{@name},sid:#{@id},tid:#{@trace_id},pid:#{@parent_id})"

--- a/spec/datadog/tracing/contrib/active_record/app.rb
+++ b/spec/datadog/tracing/contrib/active_record/app.rb
@@ -12,17 +12,23 @@ logger = Logger.new($stdout)
 logger.level = Logger::INFO
 
 # connecting to any kind of database is enough to test the integration
-root_pw = ENV.fetch('TEST_MYSQL_ROOT_PASSWORD', 'root')
-host = ENV.fetch('TEST_MYSQL_HOST', '127.0.0.1')
-port = ENV.fetch('TEST_MYSQL_PORT', '3306')
-db = ENV.fetch('TEST_MYSQL_DB', 'mysql')
-ActiveRecord::Base.establish_connection("mysql2://root:#{root_pw}@#{host}:#{port}/#{db}")
+# root_pw = ENV.fetch('TEST_MYSQL_ROOT_PASSWORD', 'root')
+# host = ENV.fetch('TEST_MYSQL_HOST', '127.0.0.1')
+# port = ENV.fetch('TEST_MYSQL_PORT', '3306')
+# db = ENV.fetch('TEST_MYSQL_DB', 'mysql')
+# ActiveRecord::Base.establish_connection("mysql2://root:#{root_pw}@#{host}:#{port}/#{db}")
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end
 
+class User < ApplicationRecord
+  has_many :articles
+end
+
 class Article < ApplicationRecord
+  belongs_to :user
 end
 
 # check if the migration has been executed
@@ -33,10 +39,28 @@ begin
 rescue ActiveRecord::StatementInvalid
   logger.info 'Executing database migrations'
   ActiveRecord::Schema.define(version: 20161003090450) do
+    create_table "users", force: true do |t|
+      t.string   "name"
+
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+    end
+
     create_table 'articles', force: :cascade do |t|
       t.string   'title'
+      t.references :user, index: true, foreign_key: true, on_delete: :cascade
+
       t.datetime 'created_at', null: false
       t.datetime 'updated_at', null: false
+    end
+  end
+
+  # Seed database
+  2.times do |i|
+    user = User.create!(name: "user_#{i}")
+
+    3.times do|j|
+      Article.create!(title: "article_#{i}_#{j}", user: user)
     end
   end
 else
@@ -45,3 +69,4 @@ end
 
 # force an access to prevent extra spans during tests
 Article.count
+User.count

--- a/spec/datadog/tracing/contrib/active_record/n_plus_one_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/n_plus_one_spec.rb
@@ -1,0 +1,107 @@
+require 'datadog/tracing/contrib/support/spec_helper'
+
+require 'ddtrace'
+require 'active_record'
+
+require_relative 'app'
+
+require 'bullet'
+
+RSpec.describe "N+1 detection reporting" do
+  before do
+    Datadog.configure do |c|
+      c.tracing.instrument :active_record, configuration_options
+    end
+
+    Bullet.enable = true
+  end
+
+  after do
+    Bullet.enable = false
+    Datadog.registry[:active_record].reset_configuration!
+  end
+
+  context 'with report_bullet: true' do
+    let(:configuration_options) { { report_bullet: true } } # TODO: better naming for this option?
+
+    def with_traced_bullet
+      def named_method # A named method that we can assert as part of the stack trace
+        yield
+      end
+
+      named_method do
+        tracer.trace('test') do
+          Bullet.profile do
+            yield
+          end
+        end
+      rescue
+      end
+    end
+
+    context 'with a n+1 query' do
+      it 'captures bullet error in the active span' do
+        with_traced_bullet do
+          Article.all.each { |article| article.user }
+        end
+
+        expect(root_span).to have_error
+        expect(root_span).to have_error_type(Bullet::Notification::UnoptimizedQueryError.to_s)
+        expect(root_span).to have_error_message(include("USE eager loading detected"))
+        expect(root_span).to have_error_message(include("Article => [:user]"))
+        expect(root_span).to have_error_message(include("Add to your query: .includes([:user])"))
+        expect(root_span).to have_error_stack(/in.*named_method/)
+      end
+
+      context 'with application error' do
+        it 'does not override application error with bullet error' do
+          with_traced_bullet do
+            Article.all.each { |article| article.user }
+            raise ArgumentError, 'app error'
+          end
+
+          expect(root_span).to have_error_type(ArgumentError.to_s)
+          expect(root_span).to have_error_message('app error')
+        end
+      end
+    end
+
+    context 'with an unused eager loading' do
+      it 'captures bullet error in the active span' do
+        with_traced_bullet do
+          Article.preload(:user).load
+        end
+
+        expect(root_span).to have_error
+        expect(root_span).to have_error_type(Bullet::Notification::UnoptimizedQueryError.to_s)
+        expect(root_span).to have_error_message(include("AVOID eager loading detected"))
+        expect(root_span).to have_error_message(include("Article => [:user]"))
+        expect(root_span).to have_error_message(include("Remove from your query: .includes([:user])"))
+        expect(root_span).to have_error_stack(/in.*named_method/)
+      end
+    end
+
+    context 'with a counter cache needed' do
+      it 'captures bullet error in the active span' do
+        with_traced_bullet do
+          User.all.each do |user|
+            user.articles.reset.size
+          end
+        end
+
+        Class.new { extend Bullet::StackTraceFilter }.caller_in_project
+
+        expect(root_span).to have_error
+        expect(root_span).to have_error_type(Bullet::Notification::UnoptimizedQueryError.to_s)
+        expect(root_span).to have_error_message(include("Need Counter Cache"))
+        expect(root_span).to have_error_message(include("User => [:articles]"))
+        expect(root_span).to have_error_stack(/in.*named_method/)
+      end
+    end
+  end
+
+  # DEV: [Prosopite](https://rubygems.org/gems/prosopite) also detects N+1, but is less popular then Bullet.
+  # DEV: This is likely a `community/help-wanted` feature request.
+  # context 'with report_prosopite: true' do
+  # end
+end

--- a/spec/datadog/tracing/contrib/support/tracer_helpers.rb
+++ b/spec/datadog/tracing/contrib/support/tracer_helpers.rb
@@ -25,6 +25,17 @@ module Contrib
       @spans ||= fetch_spans
     end
 
+    def root_span
+      @root_span ||= begin
+        roots = spans.select { |s| s.parent_id == 0 }
+        if roots.size == 1
+          roots[0]
+        else
+          raise "More than one root span present! #{roots.inspect}"
+        end
+      end
+    end
+
     # Retrieves all traces in the current tracer instance.
     # This method does not cache its results.
     def fetch_traces(tracer = self.tracer)

--- a/spec/support/span_helpers.rb
+++ b/spec/support/span_helpers.rb
@@ -22,10 +22,10 @@ module SpanHelpers
         @tag_name = tag_name
         @actual = span.get_tag(tag)
 
-        if args.empty? && @actual
+        if args.empty?
           # This condition enables the default matcher:
           # expect(foo).to have_error_tag
-          return true
+          return !@actual.nil?
         end
 
         values_match? expected, @actual
@@ -37,10 +37,10 @@ module SpanHelpers
         @tag_name = tag_name
         @actual = span.get_tag(tag)
 
-        if args.empty? && @actual.nil?
+        if args.empty?
           # This condition enables the default matcher:
           # expect(foo).to_not have_error_tag
-          return true
+          return @actual.nil?
         end
 
         values_match? expected, @actual


### PR DESCRIPTION
<img width="918" alt="Screen Shot 2022-08-18 at 6 24 36 PM" src="https://user-images.githubusercontent.com/583503/185445961-80630b74-7bd2-4d43-94d9-11ad4ae4ad5a.png">

### Caveats

* Error does not propagate all the way to the root span: this means this request is not considered an error span, thus not displayed in aggregated trace dashboards.
  * This can be seen as an upside, given it won't trigger any alerts that might be monitoring the affected trace path.