### PR TITLE
Bump minimum libdatadog version allowed

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -67,7 +67,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'libddwaf', '~> 1.3.0.2.0'
 
   # Used by profiling (and possibly others in the future)
-  spec.add_dependency 'libdatadog', '~> 0.7.0.1.0'
+  spec.add_dependency 'libdatadog', '~> 0.7.0.1.1'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb', 'ext/ddtrace_profiling_loader/extconf.rb']
 end

--- a/gemfiles/ruby_2.1.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -126,7 +126,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     makara (0.4.1)

--- a/gemfiles/ruby_2.1.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -37,7 +37,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -74,7 +74,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -70,7 +70,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -70,7 +70,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.2.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1268,7 +1268,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -37,7 +37,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -74,7 +74,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -70,7 +70,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -70,7 +70,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.3.8_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1364,7 +1364,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -37,7 +37,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -55,7 +55,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -75,7 +75,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -74,7 +74,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -70,7 +70,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -70,7 +70,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -37,7 +37,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -37,7 +37,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.4.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1430,7 +1430,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -52,7 +52,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.4.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -57,7 +57,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -77,7 +77,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.5.9_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1436,7 +1436,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -63,7 +63,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.5.9_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.6.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1437,7 +1437,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -64,7 +64,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.6.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.6.7_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -68,7 +68,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.6.7_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -89,7 +89,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.6.7_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -89,7 +89,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.6.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.6.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.6.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.6.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.6.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1437,7 +1437,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -64,7 +64,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.3_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -68,7 +68,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.3_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.3_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.7.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0)
+    libdatadog (0.7.0.1.1)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1447,8 +1447,8 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
-    libdatadog (0.7.0.1.0-aarch64-linux)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-aarch64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.3.0.2.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -65,8 +65,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-aarch64-linux)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-aarch64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.3.0.2.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-aarch64-linux)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-aarch64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.3.0.2.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.3_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -69,8 +69,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-aarch64-linux)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-aarch64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.3.0.2.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.3_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -89,8 +89,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-aarch64-linux)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-aarch64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.3.0.2.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.3_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -89,8 +89,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-aarch64-linux)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-aarch64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.3.0.2.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-aarch64-linux)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-aarch64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.3.0.2.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-aarch64-linux)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-aarch64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.3.0.2.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-aarch64-linux)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-aarch64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.3.0.2.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -119,8 +119,8 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-aarch64-linux)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-aarch64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.3.0.2.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-aarch64-linux)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-aarch64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.3.0.2.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-aarch64-linux)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-aarch64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.3.0.2.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -51,8 +51,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-aarch64-linux)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-aarch64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.3.0.2.0-x86_64-linux)

--- a/gemfiles/ruby_3.1.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1443,7 +1443,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_3.1.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -64,7 +64,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.1_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -68,7 +68,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.1_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.1_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_3.1.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_3.1.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_3.1.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_3.1.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_3.1.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1445,7 +1445,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.16.0)

--- a/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -63,7 +63,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.16.0)

--- a/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.3.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.0)
+      libdatadog (~> 0.7.0.1.1)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.0-x86_64-linux)
+    libdatadog (0.7.0.1.1-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)


### PR DESCRIPTION
**What does this PR do?**:

Bump the minimum libdatadog version allowed to 0.7.0.1.1 (the latest available version).

**Motivation**:

"Force" the latest libdatadog version to be used, for customers that are upgrading from an older version of ddtrace to a newer one.

**How to test the change?**:

Validate that profiling still works fine, and that libdatadog 0.7.0.1.1 is used when installing profiler.