### PR TITLE
Add a Traceable module and some macros

### DIFF
--- a/lib/datadog/tracing/traceable.rb
+++ b/lib/datadog/tracing/traceable.rb
@@ -1,0 +1,155 @@
+# typed: true
+
+require_relative './tracer'
+
+module Datadog
+  module Tracing
+    # A class may include {Datadog::Tracing::Traceable} to bring in some handy helpers to aid in creating
+    # traces around its own methods, or use values from its methods as tags on the current span.
+    module Traceable
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      module ClassMethods
+        # Wrap `method` in a {Datadog::Tracing#trace} block, with an operation name. Any extra kwargs will be
+        # passed to {Datadog::Tracing::Tracer#trace}.
+        #
+        # ```
+        # class MyClass
+        #   include Datadog::Tracing::Traceable
+        #
+        #   datadog_trace_method :load_data, operation_name: "my_class.load_data", tags: { my_tag: "value" }
+        #
+        #   def load_data
+        #     File.read("")
+        #   end
+        # end
+        # ```
+        #
+        # @param method [Symbol, String, Method] the method that should be wrapped in a {Datadog::Tracing#trace} block
+        # @param operation_name [String] the name of the operation for the new span (the first argument to {Datadog::Tracing#trace})
+        # @public_api
+        def datadog_trace_method(method, operation_name:, **trace_options)
+          method = method.name if method.is_a? Method
+          unless method_defined?(method) || private_method_defined?(method)
+            raise ArgumentError, "Could not find method '#{method}' on #{self.inspect} to trace"
+          end
+
+          return unless Tracing.enabled?
+
+          mod = module_to_prepend method, :datadog_trace_method do
+            define_method method do |*args, &block|
+              Tracing.trace operation_name, **trace_options do
+                super(*args, &block)
+              end
+            end
+          end
+
+          mod.send(method_scope(method), method)
+          prepend(mod)
+        end
+
+        # Intercept calls to the named `method` and use its return value as the value of a tag on the span active
+        # when the method is called. The tag name is the method name, but can be overridden using the `tag` param.
+        # The tag is added lazily, the tag will not be added if the method is not called by other code in your app.
+        #
+        # To add a span tag based on the value of the method, include the module and call `datadog_span_tag_from`:
+        # ```
+        # class MyClass
+        #   include Datadog::Tracing::Traceable
+        #
+        #   datadog_span_tag :name
+        #
+        #   private
+        #
+        #   def name
+        #     "this will be the tag value"
+        #   end
+        # end
+        # ```
+        #
+        # To add a tag with a custom tag name:
+        # ```
+        # class AdminController
+        #   include Datadog::Tracing::Traceable
+        #
+        #   datadog_span_tag :user_name, tag: "user.name"
+        #
+        #   private
+        #
+        #   def user_name
+        #     current_admin_user.name
+        #   end
+        # end
+        # ```
+        #
+        # To add a tag extracted from a complex object returned by a method:
+        # ```
+        # class UsersController
+        #   include Datadog::Tracing::Traceable
+        #
+        #   datadog_span_tag :current_user, tag: "user.id" { |user| user.id }
+        #
+        #   private
+        #
+        #   def current_user
+        #     User.find(session[:user_id])
+        #   end
+        # end
+        # ```
+        #
+        # @param method [Symbol, String, Method] the method whose value should be used for the new span tag
+        # @param tag_name [String] the name of the tag to set on the active span
+        # @yield optional block that receives the value returned from the method, whose return value will be used as the
+        #        value of the tag
+        # @yieldparam [Object] the value returned from the method
+        # @public_api
+        def datadog_span_tag(method, tag: nil, &block)
+          method = method.name if method.is_a? Method
+          unless method_defined?(method) || private_method_defined?(method)
+            raise ArgumentError, "Could not find method '#{method}' on #{self.inspect} to add as a span tag"
+          end
+
+          return unless Tracing.enabled?
+
+          tag = method.to_s unless tag
+
+          mod = module_to_prepend(method, :datadog_span_tag) do
+            define_method method do |*args, &method_block|
+              super(*args, &block).tap do |value|
+                value = block.call(value) unless block.nil?
+                Tracing.active_span&.set_tag(tag, value)
+              end
+            end
+          end
+
+          mod.send(method_scope(method), method)
+          prepend(mod)
+        end
+
+        private
+
+        def method_scope(method)
+          if private_method_defined?(method)
+            :private
+          elsif protected_method_defined?(method)
+            :protected
+          else
+            :public
+          end
+        end
+
+        def module_to_prepend(method, traceable, &block)
+          Module.new do
+            define_singleton_method(:inspect) do
+              "Datadog::Tracing::Traceable (for method=#{method.inspect} traceable=#{traceable.inspect})"
+            end
+
+            module_eval &block
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/traceable_spec.rb
+++ b/spec/datadog/tracing/traceable_spec.rb
@@ -1,0 +1,222 @@
+# typed: ignore
+
+require 'spec_helper'
+
+require 'datadog/tracing/traceable'
+
+RSpec.describe Datadog::Tracing::Traceable do
+  class TraceableClass
+    include Datadog::Tracing::Traceable
+
+    STRING_VALUE = "return value"
+
+    def an_object
+      OpenStruct.new something: "expected!", something_else: "unexpected"
+    end
+
+    def string_value
+      STRING_VALUE
+    end
+
+    def method_returning_arg(first)
+      first
+    end
+
+    protected
+    def protected_string_value
+      STRING_VALUE
+    end
+
+    private
+    def private_string_value
+      STRING_VALUE
+    end
+  end
+
+  before do
+    allow(Datadog::Tracing).to receive(:trace) do |*args, &block|
+      tracer.trace(*args, &block)
+    end
+
+    allow(Datadog::Tracing).to receive(:tracer).and_return(tracer)
+  end
+
+  after { tracer.shutdown! }
+
+  let(:tracer) { Datadog::Tracing::Tracer.new(writer: writer) }
+  let(:writer) { FauxWriter.new }
+
+  subject(:anonymous_traceable_class) do |example|
+    TraceableClass.dup.class_eval do # dup the class so it's clean for every test
+      define_singleton_method(:inspect) do
+        "TraceableClass (for #{example.example_group})" # give the anonymous class an intelligible inspect value
+      end
+
+      def inspect
+        "#<#{self.class.inspect}:#{super.split(":").last}" # give the instance an intelligible inspect value
+      end
+
+      self # Return the class as the subject
+    end
+  end
+
+  shared_examples "non-existent method" do
+    it "raises an ArgumentError referencing the method" do
+      expect { subject }.to raise_error(ArgumentError, /a_nonexistent_method/)
+    end
+
+    it "raises an ArgumentError referencing the class missing the method" do
+      expect { subject }.to raise_error(ArgumentError, /TraceableClass/)
+    end
+  end
+
+  shared_examples "return value" do
+    it "returns same object as the original method" do
+      expect(subject.string_value).to be(TraceableClass::STRING_VALUE)
+    end
+  end
+
+  shared_examples "method access" do
+    context "when the method is protected" do
+      it "raises a NoMethodError" do
+        expect { subject.protected_string_value }.to raise_error(NoMethodError, /protected method/)
+      end
+
+      it "exists as a protected method" do
+        expect(subject.protected_methods).to include(:protected_string_value)
+      end
+    end
+
+    context "when the method is private" do
+      it "raises a NoMethodError" do
+        expect { subject.private_string_value }.to raise_error(NoMethodError, /private method/)
+      end
+
+      it "exists as a private method" do
+        expect(subject.private_methods).to include(:private_string_value)
+      end
+    end
+  end
+
+  describe "prepended module" do
+    subject do
+      anonymous_traceable_class.class_eval do
+        datadog_span_tag :string_value
+      end
+
+      anonymous_traceable_class.ancestors.first
+    end
+
+    it "has a helpful inspect value" do
+      expect(subject.inspect).to match(/traceable=:datadog_span_tag/)
+      expect(subject.inspect).to match(/method=:string_value/)
+      expect(subject.inspect).to match(/Datadog::Tracing::Traceable/)
+    end
+
+    it "overrides the instance method specified" do
+      expect(subject.instance_methods).to include(:string_value)
+    end
+  end
+
+  describe "overridden method with arguments" do
+    subject do
+      anonymous_traceable_class.class_eval do
+        datadog_span_tag :method_returning_arg
+      end
+
+      anonymous_traceable_class.new.method_returning_arg(arg)
+    end
+
+    let(:arg) { "an argument" }
+
+    it "forwards the arguments to the original method" do
+      is_expected.to be arg
+    end
+  end
+
+  describe ".datadog_trace_method" do
+    subject do
+      anonymous_traceable_class.class_eval do
+        datadog_trace_method :string_value, operation_name: "class.string_value"
+        datadog_trace_method :protected_string_value, operation_name: "class.protected_string_value"
+        datadog_trace_method :private_string_value, operation_name: "class.private_string_value"
+      end
+
+      anonymous_traceable_class.new
+    end
+
+    it "traces the named method when it is called" do
+      subject.string_value
+
+      expect(spans.first.name).to eq "class.string_value"
+    end
+
+    context "when the named method doesn't exist" do
+      include_examples "non-existent method" do
+        subject do
+          anonymous_traceable_class.class_eval do
+            datadog_trace_method :a_nonexistent_method, operation_name: "my.operation"
+          end
+        end
+      end
+    end
+
+    include_examples "return value"
+    include_examples "method access"
+  end
+
+  describe ".datadog_span_tag" do
+    subject do
+      anonymous_traceable_class.class_eval do
+        datadog_span_tag :string_value
+        datadog_span_tag :protected_string_value
+        datadog_span_tag :private_string_value
+      end
+
+      anonymous_traceable_class.new
+    end
+
+    context "with a block" do
+      subject! do
+        anonymous_traceable_class.class_eval do
+          datadog_span_tag :an_object do |object|
+            object.something
+          end
+        end
+
+        tracer.trace 'my_operation' do
+          anonymous_traceable_class.new.an_object
+        end
+      end
+
+      let(:traces) { tracer.writer.traces }
+      let(:spans) { traces.first.spans }
+
+      it "uses the return value of the block as the tag value" do
+        expect(spans.first.meta).to include("an_object")
+        expect(spans.first.meta["an_object"]).to eq "expected!"
+      end
+    end
+
+    context "with a custom tag name" do
+      subject do
+        anonymous_traceable_class.class_eval do
+          datadog_span_tag :string_value, tag_name:
+        end
+      end
+    end
+
+    context "when the named method doesn't exist" do
+      include_examples "non-existent method" do
+        subject do
+          anonymous_traceable_class.class_eval do
+            datadog_trace_method :a_nonexistent_method, operation_name: "my.operation"
+          end
+        end
+      end
+    end
+
+    include_examples "return value"
+    include_examples "method access"
+  end
+end


### PR DESCRIPTION
This is a draft PR because I don't consider the feature complete, but I'm requesting review to see if this kind of thing is in-line with the Datadog's vision for the library.

**What does this PR do?**
This adds a module, `Datadog::Tracing::Traceable` that can be included in a class in your app to simplify tracing of its methods or using method values as tags.

Documentation on its use is inline, but here's a quick sample:

```ruby
class MyClass
  include Datadog::Tracing::Traceable

  datadog_trace_method :load_data, operation_name: "my_class.load_data", tags: { my_tag: "value" }

  def load_data
    File.read("some large data file.csv")
  end
end
```

This creates a new `SpanOperation` around the `MyClass#load_data` method without changing the code of the method itself.

```ruby
class AdminController
  include Datadog::Tracing::Traceable

  datadog_span_tag :user_name, tag: "user.name"

  private

  def user_name
    current_admin_user.name
  end
end
```

This would attach the return value of `AdminController#user_name` as a tag to the active span _when (and only when) the method is called_, and does not trigger a call to the method itself.

**Motivation**
We recently wanted to be able to spy on things loaded by Rails controller `before_action` hooks, but only if those hooks were actually called and not disabled (ex: in a subclass of `ApplicationController`).

We've also been exploring how to more easily trace an entire method without needing to modify the code of the method itself.

Inspired by [Shopify/statsd-instrument](https://github.com/Shopify/statsd-instrument).

Things that could be added:

- Some helpful non-macro helper methods like
  - `Traceable#datadog_active_span`: a quick reference to the active span in the current trace
  - `Traceable#datadog_active_trace`: a quick reference to the current trace
  - `Traceable#datadog_track_error(exception)`: quickly call `set_error` on the active span with `exception`
- macro methods to change configuration around the execution of a method
- etc

Naming and stuff could all be different, I'm just spitballing here 😏 

**Additional Notes**
I'm opening this PR mostly to see if this is something the Datadog team would be interested in as a contribution, and to get some feedback on module name/hierarchy. It could also be done differently so all the instrumentation could be centrally located in one file (similar to `statsd-instrument`)

**How to test the change?**
Basic specs are included, this is a WIP.