### PR TITLE
Align profile value types with latest backend expectations

### DIFF
--- a/ext/ddtrace_profiling_native_extension/stack_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.h
@@ -15,12 +15,13 @@
 // ```
 #define VALUE_STRING(string) {.ptr = "" string, .len = sizeof(string) - 1}
 
-#define      CPU_TIME_VALUE {.type_ = VALUE_STRING("cpu-time"),      .unit = VALUE_STRING("nanoseconds")}
-#define   CPU_SAMPLES_VALUE {.type_ = VALUE_STRING("cpu-samples"),   .unit = VALUE_STRING("count")}
-#define     WALL_TIME_VALUE {.type_ = VALUE_STRING("wall-time"),     .unit = VALUE_STRING("nanoseconds")}
-#define ALLOC_SAMPLES_VALUE {.type_ = VALUE_STRING("alloc-samples"), .unit = VALUE_STRING("count")}
-#define   ALLOC_SPACE_VALUE {.type_ = VALUE_STRING("alloc-space"),   .unit = VALUE_STRING("bytes")}
-#define    HEAP_SPACE_VALUE {.type_ = VALUE_STRING("heap-space"),    .unit = VALUE_STRING("bytes")}
+#define CPU_TIME_VALUE          {.type_ = VALUE_STRING("cpu-time"),          .unit = VALUE_STRING("nanoseconds")}
+#define CPU_SAMPLES_VALUE       {.type_ = VALUE_STRING("cpu-samples"),       .unit = VALUE_STRING("count")}
+#define WALL_TIME_VALUE         {.type_ = VALUE_STRING("wall-time"),         .unit = VALUE_STRING("nanoseconds")}
+#define ALLOC_SIZE_VALUE        {.type_ = VALUE_STRING("alloc-size"),        .unit = VALUE_STRING("bytes")}
+#define ALLOC_SAMPLES_VALUE     {.type_ = VALUE_STRING("alloc-samples"),     .unit = VALUE_STRING("count")}
+#define HEAP_LIVE_SIZE_VALUE    {.type_ = VALUE_STRING("heap-live-size"),    .unit = VALUE_STRING("bytes")}
+#define HEAP_LIVE_SAMPLES_VALUE {.type_ = VALUE_STRING("heap-live-samples"), .unit = VALUE_STRING("count")}
 
 static const ddprof_ffi_ValueType enabled_value_types[] = {
   #define CPU_TIME_VALUE_POS 0


### PR DESCRIPTION
**What does this PR do?**:

The profiling backend team (cc @peterg17) has been working on aligning most runtimes on a standard set of profile value types.

To align with the standard set, the profile types used were changed as follows:

* `alloc-space` became `alloc-size`
* `heap-space` became `heap-live-size`

Additionally, the following two changes were made:

* Introduce a definition for `heap-live-samples`
* Reformat spacing to keep it consistent (sorry for the diff noise on this one -- hopefully it's worth the readability boost) (**You can use GitHub's "Hide whitespace" option to show a better diff**)

**Motivation**:

Aligning most runtimes on a standard set of profile value types.

**Additional Notes**:

I'll get someone from the profiling backend team to review this, since it makes a lot of sense :)

Note that in practice this does not impact anything right now, since the profile value types that were changed are not enabled -- they are not in the `enabled_value_types[]` so right now they are only placeholders for later enablement.

This also means that there's nothing to test (yet), since these definitions all disappear after compilation. They'll be tested once they start being actually used.

**How to test the change?**:

See additional notes on why this doesn't need to be tested yet.