### PR TITLE
Fix outdated references to `use` instead of `instrument` in docs

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1063,7 +1063,7 @@ end
 YourSchema.execute(query, variables: {}, context: {}, operation_name: nil)
 ```
 
-The `use :graphql` method accepts the following parameters. Additional options can be substituted in for `options`:
+The `instrument :graphql` method accepts the following parameters. Additional options can be substituted in for `options`:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
@@ -1116,7 +1116,7 @@ YourSchema.define do
 end
 ```
 
-Do *NOT* `use :graphql` in `Datadog.configure` if you choose to configure manually, as to avoid double tracing. These two means of configuring GraphQL tracing are considered mutually exclusive.
+Do *NOT* `instrument :graphql` in `Datadog.configure` if you choose to configure manually, as to avoid double tracing. These two means of configuring GraphQL tracing are considered mutually exclusive.
 
 ### gRPC
 


### PR DESCRIPTION
**What does this PR do?**:

This PR fixes the two leftover mentions of `use` in the docs that I found that should be replaced by `instrument`. I did not change the sinatra docs to avoid a conflict with #2217.

**Motivation**:

While reviewing #2217 where we fixed the sinatra documentation not to mention the outdated `use`, I decided to make a quick check if we had any more such leftovers, and it turns out we did.

**How to test the change?**:

Check that the documentation is actually correct now / build an example app and check that `instrument` correctly instruments it.