### PR TITLE
Add deprecation warning to rails instrumentation option to rack

### DIFF
--- a/lib/datadog/tracing/contrib/rails/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rails/configuration/settings.rb
@@ -48,6 +48,10 @@ module Datadog
 
             option :exception_controller do |o|
               o.on_set do |value|
+                Datadog.logger.warn(
+                  '[Deprecated] Using #exception_controller for configuration is deprecated and will ' \
+                  'be removed on a future ddtrace release. Please configure the option on action_pack instrumentation instead.'
+                )
                 # Update ActionPack exception controller too
                 Datadog.configuration.tracing[:action_pack][:exception_controller] = value
               end
@@ -58,6 +62,10 @@ module Datadog
             option :template_base_path do |o|
               o.default 'views/'
               o.on_set do |value|
+                Datadog.logger.warn(
+                  '[Deprecated] Using #template_base_path for configuration is deprecated and will ' \
+                  'be removed on a future ddtrace release. Please configure the option on action_view instrumentation instead.'
+                )
                 # Update ActionView template base path too
                 Datadog.configuration.tracing[:action_view][:template_base_path] = value
               end

--- a/lib/datadog/tracing/contrib/rails/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/rails/configuration/settings.rb
@@ -46,10 +46,6 @@ module Datadog
               end
             end
 
-            option :distributed_tracing, default: true
-
-            option :request_queuing, default: false
-
             option :exception_controller do |o|
               o.on_set do |value|
                 # Update ActionPack exception controller too
@@ -58,12 +54,46 @@ module Datadog
             end
 
             option :middleware, default: true
-            option :middleware_names, default: false
+
             option :template_base_path do |o|
               o.default 'views/'
               o.on_set do |value|
                 # Update ActionView template base path too
                 Datadog.configuration.tracing[:action_view][:template_base_path] = value
+              end
+            end
+
+            # Rack
+            option :distributed_tracing do |o|
+              o.default true
+              o.on_set do |value|
+                Datadog.logger.warn(
+                  '[Deprecated] Using #distributed_tracing for configuration is deprecated and will ' \
+                  'be removed on a future ddtrace release. Please configure the option on rack instrumentation instead.'
+                )
+                Datadog.configuration.tracing[:rack][:distributed_tracing] = value
+              end
+            end
+
+            option :request_queuing do |o|
+              o.default false
+              o.on_set do |value|
+                Datadog.logger.warn(
+                  '[Deprecated] Using #request_queuing for configuration is deprecated and will ' \
+                  'be removed on a future ddtrace release. Please configure the option on rack instrumentation instead.'
+                )
+                Datadog.configuration.tracing[:rack][:request_queuing] = value
+              end
+            end
+
+            option :middleware_names do |o|
+              o.default false
+              o.on_set do |value|
+                Datadog.logger.warn(
+                  '[Deprecated] Using #middleware_names for configuration is deprecated and will ' \
+                  'be removed on a future ddtrace release. Please configure the option on rack instrumentation instead.'
+                )
+                Datadog.configuration.tracing[:rack][:middleware_names] = value
               end
             end
           end

--- a/lib/datadog/tracing/contrib/rails/framework.rb
+++ b/lib/datadog/tracing/contrib/rails/framework.rb
@@ -45,15 +45,16 @@ module Datadog
               end
 
               activate_rack!(datadog_config, rails_config)
-              activate_action_cable!(datadog_config, rails_config)
-              activate_action_mailer!(datadog_config, rails_config)
-              activate_active_support!(datadog_config, rails_config)
-              activate_action_pack!(datadog_config, rails_config)
-              activate_action_view!(datadog_config, rails_config)
-              activate_active_job!(datadog_config, rails_config)
-              activate_active_record!(datadog_config, rails_config)
-              activate_lograge!(datadog_config, rails_config)
-              activate_semantic_logger!(datadog_config, rails_config)
+
+              activate_action_cable!(datadog_config)
+              activate_action_mailer!(datadog_config)
+              activate_active_support!(datadog_config)
+              activate_action_pack!(datadog_config)
+              activate_action_view!(datadog_config)
+              activate_active_job!(datadog_config)
+              activate_active_record!(datadog_config)
+              activate_lograge!(datadog_config)
+              activate_semantic_logger!(datadog_config)
             end
           end
 
@@ -68,61 +69,49 @@ module Datadog
             )
           end
 
-          def self.activate_active_support!(datadog_config, rails_config)
+          def self.activate_active_support!(datadog_config)
             return unless defined?(::ActiveSupport)
 
             datadog_config.tracing.instrument(:active_support)
           end
 
-          def self.activate_action_cable!(datadog_config, rails_config)
+          def self.activate_action_cable!(datadog_config)
             return unless defined?(::ActionCable)
 
             datadog_config.tracing.instrument(:action_cable)
           end
 
-          def self.activate_action_mailer!(datadog_config, rails_config)
+          def self.activate_action_mailer!(datadog_config)
             return unless defined?(::ActionMailer)
 
-            datadog_config.tracing.instrument(
-              :action_mailer,
-              service_name: rails_config[:service_name]
-            )
+            datadog_config.tracing.instrument(:action_mailer)
           end
 
-          def self.activate_action_pack!(datadog_config, rails_config)
+          def self.activate_action_pack!(datadog_config)
             return unless defined?(::ActionPack)
 
-            datadog_config.tracing.instrument(
-              :action_pack,
-              service_name: rails_config[:service_name]
-            )
+            datadog_config.tracing.instrument(:action_pack)
           end
 
-          def self.activate_action_view!(datadog_config, rails_config)
+          def self.activate_action_view!(datadog_config)
             return unless defined?(::ActionView)
 
-            datadog_config.tracing.instrument(
-              :action_view,
-              service_name: rails_config[:service_name]
-            )
+            datadog_config.tracing.instrument(:action_view)
           end
 
-          def self.activate_active_job!(datadog_config, rails_config)
+          def self.activate_active_job!(datadog_config)
             return unless defined?(::ActiveJob)
 
-            datadog_config.tracing.instrument(
-              :active_job,
-              service_name: rails_config[:service_name]
-            )
+            datadog_config.tracing.instrument(:active_job)
           end
 
-          def self.activate_active_record!(datadog_config, rails_config)
+          def self.activate_active_record!(datadog_config)
             return unless defined?(::ActiveRecord)
 
             datadog_config.tracing.instrument(:active_record)
           end
 
-          def self.activate_lograge!(datadog_config, rails_config)
+          def self.activate_lograge!(datadog_config)
             return unless defined?(::Lograge)
 
             if datadog_config.tracing.log_injection
@@ -132,7 +121,7 @@ module Datadog
             end
           end
 
-          def self.activate_semantic_logger!(datadog_config, rails_config)
+          def self.activate_semantic_logger!(datadog_config)
             return unless defined?(::SemanticLogger)
 
             if datadog_config.tracing.log_injection


### PR DESCRIPTION
**What does this PR do?**

In the future, we want rails only activating other instrumentations, further configuration requires explicit definition. such as 

```
Datadog.configure do |c|
  c.tracing.instrument :rails 
  c.tracing.instrument :rack, request_queuing: true 
end
```

1. Avoid passing `service_name` to `ActionMailer`, `ActionPack`, `ActionView`, `ActiveJob` 
2. Emit deprecation warning for rails instrumentation option to rack  



