### PR TITLE
Upgrade to libdatadog 0.8.0.1.0

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -67,7 +67,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'libddwaf', '~> 1.3.0.2.0'
 
   # Used by profiling (and possibly others in the future)
-  spec.add_dependency 'libdatadog', '~> 0.7.0.1.1'
+  spec.add_dependency 'libdatadog', '~> 0.8.0.1.0'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb', 'ext/ddtrace_profiling_loader/extconf.rb']
 end

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -34,7 +34,7 @@ struct cpu_and_wall_time_collector_state {
 // Tracks per-thread state
 struct per_thread_context {
   char thread_id[THREAD_ID_LIMIT_CHARS];
-  ddprof_ffi_CharSlice thread_id_char_slice;
+  ddog_CharSlice thread_id_char_slice;
   thread_cpu_time_id thread_cpu_time_id;
   long cpu_time_at_previous_sample_ns;  // Can be INVALID_TIME until initialized or if getting it fails for another reason
   long wall_time_at_previous_sample_ns; // Can be INVALID_TIME until initialized
@@ -209,12 +209,12 @@ VALUE cpu_and_wall_time_collector_sample(VALUE self_instance) {
     bool have_thread_name = thread_name != Qnil;
 
     int label_count = 1 + (have_thread_name ? 1 : 0);
-    ddprof_ffi_Label labels[label_count];
+    ddog_Label labels[label_count];
 
-    labels[0] = (ddprof_ffi_Label) {.key = DDPROF_FFI_CHARSLICE_C("thread id"), .str = thread_context->thread_id_char_slice};
+    labels[0] = (ddog_Label) {.key = DDOG_CHARSLICE_C("thread id"), .str = thread_context->thread_id_char_slice};
     if (have_thread_name) {
-      labels[1] = (ddprof_ffi_Label) {
-        .key = DDPROF_FFI_CHARSLICE_C("thread name"),
+      labels[1] = (ddog_Label) {
+        .key = DDOG_CHARSLICE_C("thread name"),
         .str = char_slice_from_ruby_string(thread_name)
       };
     }
@@ -223,8 +223,8 @@ VALUE cpu_and_wall_time_collector_sample(VALUE self_instance) {
       thread,
       state->sampling_buffer,
       state->recorder_instance,
-      (ddprof_ffi_Slice_i64) {.ptr = metric_values, .len = ENABLED_VALUE_TYPES_COUNT},
-      (ddprof_ffi_Slice_label) {.ptr = labels, .len = label_count}
+      (ddog_Slice_i64) {.ptr = metric_values, .len = ENABLED_VALUE_TYPES_COUNT},
+      (ddog_Slice_label) {.ptr = labels, .len = label_count}
     );
   }
 
@@ -261,7 +261,7 @@ static struct per_thread_context *get_or_create_context_for(VALUE thread, struct
 
 static void initialize_context(VALUE thread, struct per_thread_context *thread_context) {
   snprintf(thread_context->thread_id, THREAD_ID_LIMIT_CHARS, "%ld", thread_id_for(thread));
-  thread_context->thread_id_char_slice = (ddprof_ffi_CharSlice) {.ptr = thread_context->thread_id, .len = strlen(thread_context->thread_id)};
+  thread_context->thread_id_char_slice = (ddog_CharSlice) {.ptr = thread_context->thread_id, .len = strlen(thread_context->thread_id)};
 
   thread_context->thread_cpu_time_id = thread_cpu_time_id_for(thread);
 

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.h
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <ddprof/ffi.h>
+#include <datadog/profiling.h>
 
 typedef struct sampling_buffer sampling_buffer;
 
-void sample_thread(VALUE thread, sampling_buffer* buffer, VALUE recorder_instance, ddprof_ffi_Slice_i64 metric_values, ddprof_ffi_Slice_label labels);
+void sample_thread(VALUE thread, sampling_buffer* buffer, VALUE recorder_instance, ddog_Slice_i64 metric_values, ddog_Slice_label labels);
 sampling_buffer *sampling_buffer_new(unsigned int max_frames);
 void sampling_buffer_free(sampling_buffer *buffer);

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -152,7 +152,7 @@ end
 ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libdatadog.pkgconfig_folder}"
 Logging.message(" [ddtrace] PKG_CONFIG_PATH set to #{ENV['PKG_CONFIG_PATH'].inspect}\n")
 
-unless pkg_config('ddprof_ffi_with_rpath')
+unless pkg_config('datadog_profiling_with_rpath')
   skip_building_extension!(
     if Datadog::Profiling::NativeExtensionHelpers::Supported.pkg_config_missing?
       Datadog::Profiling::NativeExtensionHelpers::Supported::PKG_CONFIG_IS_MISSING

--- a/ext/ddtrace_profiling_native_extension/http_transport.c
+++ b/ext/ddtrace_profiling_native_extension/http_transport.c
@@ -1,6 +1,6 @@
 #include <ruby.h>
 #include <ruby/thread.h>
-#include <ddprof/ffi.h>
+#include <datadog/profiling.h>
 #include "helpers.h"
 #include "libdatadog_helpers.h"
 #include "ruby_helpers.h"
@@ -19,20 +19,20 @@ static ID log_failure_to_process_tag_id; // id of :log_failure_to_process_tag in
 static VALUE http_transport_class = Qnil;
 
 struct call_exporter_without_gvl_arguments {
-  ddprof_ffi_ProfileExporterV3 *exporter;
-  ddprof_ffi_Request *request;
-  ddprof_ffi_CancellationToken *cancel_token;
-  ddprof_ffi_SendResult result;
+  ddog_ProfileExporter *exporter;
+  ddog_Request *request;
+  ddog_CancellationToken *cancel_token;
+  ddog_SendResult result;
   bool send_ran;
 };
 
-inline static ddprof_ffi_ByteSlice byte_slice_from_ruby_string(VALUE string);
+inline static ddog_ByteSlice byte_slice_from_ruby_string(VALUE string);
 static VALUE _native_validate_exporter(VALUE self, VALUE exporter_configuration);
-static ddprof_ffi_NewProfileExporterV3Result create_exporter(VALUE exporter_configuration, VALUE tags_as_array);
-static VALUE handle_exporter_failure(ddprof_ffi_NewProfileExporterV3Result exporter_result);
-static ddprof_ffi_EndpointV3 endpoint_from(VALUE exporter_configuration);
-static ddprof_ffi_Vec_tag convert_tags(VALUE tags_as_array);
-static void safely_log_failure_to_process_tag(ddprof_ffi_Vec_tag tags, VALUE err_details);
+static ddog_NewProfileExporterResult create_exporter(VALUE exporter_configuration, VALUE tags_as_array);
+static VALUE handle_exporter_failure(ddog_NewProfileExporterResult exporter_result);
+static ddog_Endpoint endpoint_from(VALUE exporter_configuration);
+static ddog_Vec_tag convert_tags(VALUE tags_as_array);
+static void safely_log_failure_to_process_tag(ddog_Vec_tag tags, VALUE err_details);
 static VALUE _native_do_export(
   VALUE self,
   VALUE exporter_configuration,
@@ -63,55 +63,55 @@ void http_transport_init(VALUE profiling_module) {
   log_failure_to_process_tag_id = rb_intern_const("log_failure_to_process_tag");
 }
 
-inline static ddprof_ffi_ByteSlice byte_slice_from_ruby_string(VALUE string) {
+inline static ddog_ByteSlice byte_slice_from_ruby_string(VALUE string) {
   ENFORCE_TYPE(string, T_STRING);
-  ddprof_ffi_ByteSlice byte_slice = {.ptr = (uint8_t *) StringValuePtr(string), .len = RSTRING_LEN(string)};
+  ddog_ByteSlice byte_slice = {.ptr = (uint8_t *) StringValuePtr(string), .len = RSTRING_LEN(string)};
   return byte_slice;
 }
 
 static VALUE _native_validate_exporter(DDTRACE_UNUSED VALUE _self, VALUE exporter_configuration) {
   ENFORCE_TYPE(exporter_configuration, T_ARRAY);
-  ddprof_ffi_NewProfileExporterV3Result exporter_result = create_exporter(exporter_configuration, rb_ary_new());
+  ddog_NewProfileExporterResult exporter_result = create_exporter(exporter_configuration, rb_ary_new());
 
   VALUE failure_tuple = handle_exporter_failure(exporter_result);
   if (!NIL_P(failure_tuple)) return failure_tuple;
 
   // We don't actually need the exporter for now -- we just wanted to validate that we could create it with the
   // settings we were given
-  ddprof_ffi_NewProfileExporterV3Result_drop(exporter_result);
+  ddog_NewProfileExporterResult_drop(exporter_result);
 
   return rb_ary_new_from_args(2, ok_symbol, Qnil);
 }
 
-static ddprof_ffi_NewProfileExporterV3Result create_exporter(VALUE exporter_configuration, VALUE tags_as_array) {
+static ddog_NewProfileExporterResult create_exporter(VALUE exporter_configuration, VALUE tags_as_array) {
   ENFORCE_TYPE(exporter_configuration, T_ARRAY);
   ENFORCE_TYPE(tags_as_array, T_ARRAY);
 
-  // This needs to be called BEFORE convert_tags since it can raise an exception and thus cause the ddprof_ffi_Vec_tag
+  // This needs to be called BEFORE convert_tags since it can raise an exception and thus cause the ddog_Vec_tag
   // to be leaked.
-  ddprof_ffi_EndpointV3 endpoint = endpoint_from(exporter_configuration);
+  ddog_Endpoint endpoint = endpoint_from(exporter_configuration);
 
-  ddprof_ffi_Vec_tag tags = convert_tags(tags_as_array);
+  ddog_Vec_tag tags = convert_tags(tags_as_array);
 
-  ddprof_ffi_NewProfileExporterV3Result exporter_result =
-    ddprof_ffi_ProfileExporterV3_new(DDPROF_FFI_CHARSLICE_C("ruby"), &tags, endpoint);
+  ddog_NewProfileExporterResult exporter_result =
+    ddog_ProfileExporter_new(DDOG_CHARSLICE_C("ruby"), &tags, endpoint);
 
-  ddprof_ffi_Vec_tag_drop(tags);
+  ddog_Vec_tag_drop(tags);
 
   return exporter_result;
 }
 
-static VALUE handle_exporter_failure(ddprof_ffi_NewProfileExporterV3Result exporter_result) {
-  if (exporter_result.tag == DDPROF_FFI_NEW_PROFILE_EXPORTER_V3_RESULT_OK) return Qnil;
+static VALUE handle_exporter_failure(ddog_NewProfileExporterResult exporter_result) {
+  if (exporter_result.tag == DDOG_NEW_PROFILE_EXPORTER_RESULT_OK) return Qnil;
 
   VALUE err_details = ruby_string_from_vec_u8(exporter_result.err);
 
-  ddprof_ffi_NewProfileExporterV3Result_drop(exporter_result);
+  ddog_NewProfileExporterResult_drop(exporter_result);
 
   return rb_ary_new_from_args(2, error_symbol, err_details);
 }
 
-static ddprof_ffi_EndpointV3 endpoint_from(VALUE exporter_configuration) {
+static ddog_Endpoint endpoint_from(VALUE exporter_configuration) {
   ENFORCE_TYPE(exporter_configuration, T_ARRAY);
 
   ID working_mode = SYM2ID(rb_ary_entry(exporter_configuration, 0)); // SYM2ID verifies its input so we can do this safely
@@ -126,27 +126,27 @@ static ddprof_ffi_EndpointV3 endpoint_from(VALUE exporter_configuration) {
     ENFORCE_TYPE(site, T_STRING);
     ENFORCE_TYPE(api_key, T_STRING);
 
-    return ddprof_ffi_EndpointV3_agentless(char_slice_from_ruby_string(site), char_slice_from_ruby_string(api_key));
+    return ddog_Endpoint_agentless(char_slice_from_ruby_string(site), char_slice_from_ruby_string(api_key));
   } else { // agent_id
     VALUE base_url = rb_ary_entry(exporter_configuration, 1);
     ENFORCE_TYPE(base_url, T_STRING);
 
-    return ddprof_ffi_EndpointV3_agent(char_slice_from_ruby_string(base_url));
+    return ddog_Endpoint_agent(char_slice_from_ruby_string(base_url));
   }
 }
 
 __attribute__((warn_unused_result))
-static ddprof_ffi_Vec_tag convert_tags(VALUE tags_as_array) {
+static ddog_Vec_tag convert_tags(VALUE tags_as_array) {
   ENFORCE_TYPE(tags_as_array, T_ARRAY);
 
   long tags_count = RARRAY_LEN(tags_as_array);
-  ddprof_ffi_Vec_tag tags = ddprof_ffi_Vec_tag_new();
+  ddog_Vec_tag tags = ddog_Vec_tag_new();
 
   for (long i = 0; i < tags_count; i++) {
     VALUE name_value_pair = rb_ary_entry(tags_as_array, i);
 
     if (!RB_TYPE_P(name_value_pair, T_ARRAY)) {
-      ddprof_ffi_Vec_tag_drop(tags);
+      ddog_Vec_tag_drop(tags);
       ENFORCE_TYPE(name_value_pair, T_ARRAY);
     }
 
@@ -155,23 +155,23 @@ static ddprof_ffi_Vec_tag convert_tags(VALUE tags_as_array) {
     VALUE tag_value = rb_ary_entry(name_value_pair, 1);
 
     if (!(RB_TYPE_P(tag_name, T_STRING) && RB_TYPE_P(tag_value, T_STRING))) {
-      ddprof_ffi_Vec_tag_drop(tags);
+      ddog_Vec_tag_drop(tags);
       ENFORCE_TYPE(tag_name, T_STRING);
       ENFORCE_TYPE(tag_value, T_STRING);
     }
 
-    ddprof_ffi_PushTagResult push_result =
-      ddprof_ffi_Vec_tag_push(&tags, char_slice_from_ruby_string(tag_name), char_slice_from_ruby_string(tag_value));
+    ddog_PushTagResult push_result =
+      ddog_Vec_tag_push(&tags, char_slice_from_ruby_string(tag_name), char_slice_from_ruby_string(tag_value));
 
-    if (push_result.tag == DDPROF_FFI_PUSH_TAG_RESULT_ERR) {
+    if (push_result.tag == DDOG_PUSH_TAG_RESULT_ERR) {
       VALUE err_details = ruby_string_from_vec_u8(push_result.err);
-      ddprof_ffi_PushTagResult_drop(push_result);
+      ddog_PushTagResult_drop(push_result);
 
       // libdatadog validates tags and may catch invalid tags that ddtrace didn't actually catch.
       // We warn users about such tags, and then just ignore them.
       safely_log_failure_to_process_tag(tags, err_details);
     } else {
-      ddprof_ffi_PushTagResult_drop(push_result);
+      ddog_PushTagResult_drop(push_result);
     }
   }
 
@@ -184,12 +184,12 @@ static VALUE log_failure_to_process_tag(VALUE err_details) {
 
 // Since we are calling into Ruby code, it may raise an exception. This method ensure that dynamically-allocated tags
 // get cleaned before propagating the exception.
-static void safely_log_failure_to_process_tag(ddprof_ffi_Vec_tag tags, VALUE err_details) {
+static void safely_log_failure_to_process_tag(ddog_Vec_tag tags, VALUE err_details) {
   int exception_state;
   rb_protect(log_failure_to_process_tag, err_details, &exception_state);
 
   if (exception_state) {           // An exception was raised
-    ddprof_ffi_Vec_tag_drop(tags); // clean up
+    ddog_Vec_tag_drop(tags); // clean up
     rb_jump_tag(exception_state);  // "Re-raise" exception
   }
 }
@@ -197,17 +197,17 @@ static void safely_log_failure_to_process_tag(ddprof_ffi_Vec_tag tags, VALUE err
 // Note: This function handles a bunch of libdatadog dynamically-allocated objects, so it MUST not use any Ruby APIs
 // which can raise exceptions, otherwise the objects will be leaked.
 static VALUE perform_export(
-  ddprof_ffi_NewProfileExporterV3Result valid_exporter_result, // Must be called with a valid exporter result
-  ddprof_ffi_Timespec start,
-  ddprof_ffi_Timespec finish,
-  ddprof_ffi_Slice_file slice_files,
-  ddprof_ffi_Vec_tag *additional_tags,
+  ddog_NewProfileExporterResult valid_exporter_result, // Must be called with a valid exporter result
+  ddog_Timespec start,
+  ddog_Timespec finish,
+  ddog_Slice_file slice_files,
+  ddog_Vec_tag *additional_tags,
   uint64_t timeout_milliseconds
 ) {
-  ddprof_ffi_ProfileExporterV3 *exporter = valid_exporter_result.ok;
-  ddprof_ffi_CancellationToken *cancel_token = ddprof_ffi_CancellationToken_new();
-  ddprof_ffi_Request *request =
-    ddprof_ffi_ProfileExporterV3_build(exporter, start, finish, slice_files, additional_tags, timeout_milliseconds);
+  ddog_ProfileExporter *exporter = valid_exporter_result.ok;
+  ddog_CancellationToken *cancel_token = ddog_CancellationToken_new();
+  ddog_Request *request =
+    ddog_ProfileExporter_build(exporter, start, finish, slice_files, additional_tags, timeout_milliseconds);
 
   // We'll release the Global VM Lock while we're calling send, so that the Ruby VM can continue to work while this
   // is pending
@@ -236,24 +236,24 @@ static VALUE perform_export(
   }
 
   // Cleanup exporter and token, no longer needed
-  ddprof_ffi_CancellationToken_drop(cancel_token);
-  ddprof_ffi_NewProfileExporterV3Result_drop(valid_exporter_result);
+  ddog_CancellationToken_drop(cancel_token);
+  ddog_NewProfileExporterResult_drop(valid_exporter_result);
 
   if (pending_exception) {
     // If we got here send did not run, so we need to explicitly dispose of the request
-    ddprof_ffi_Request_drop(request);
+    ddog_Request_drop(request);
 
     // Let Ruby propagate the exception. This will not return.
     rb_jump_tag(pending_exception);
   }
 
-  ddprof_ffi_SendResult result = args.result;
-  bool success = result.tag == DDPROF_FFI_SEND_RESULT_HTTP_RESPONSE;
+  ddog_SendResult result = args.result;
+  bool success = result.tag == DDOG_SEND_RESULT_HTTP_RESPONSE;
 
   VALUE ruby_status = success ? ok_symbol : error_symbol;
   VALUE ruby_result = success ? UINT2NUM(result.http_response.code) : ruby_string_from_vec_u8(result.err);
 
-  ddprof_ffi_SendResult_drop(args.result);
+  ddog_SendResult_drop(args.result);
   // The request itself does not need to be freed as libdatadog takes care of it as part of sending.
 
   return rb_ary_new_from_args(2, ruby_status, ruby_result);
@@ -288,29 +288,29 @@ static VALUE _native_do_export(
 
   uint64_t timeout_milliseconds = NUM2ULONG(upload_timeout_milliseconds);
 
-  ddprof_ffi_Timespec start =
+  ddog_Timespec start =
     {.seconds = NUM2LONG(start_timespec_seconds), .nanoseconds = NUM2UINT(start_timespec_nanoseconds)};
-  ddprof_ffi_Timespec finish =
+  ddog_Timespec finish =
     {.seconds = NUM2LONG(finish_timespec_seconds), .nanoseconds = NUM2UINT(finish_timespec_nanoseconds)};
 
   int files_to_report = 1 + (have_code_provenance ? 1 : 0);
-  ddprof_ffi_File files[files_to_report];
-  ddprof_ffi_Slice_file slice_files = {.ptr = files, .len = files_to_report};
+  ddog_File files[files_to_report];
+  ddog_Slice_file slice_files = {.ptr = files, .len = files_to_report};
 
-  files[0] = (ddprof_ffi_File) {
+  files[0] = (ddog_File) {
     .name = char_slice_from_ruby_string(pprof_file_name),
     .file = byte_slice_from_ruby_string(pprof_data)
   };
   if (have_code_provenance) {
-    files[1] = (ddprof_ffi_File) {
+    files[1] = (ddog_File) {
       .name = char_slice_from_ruby_string(code_provenance_file_name),
       .file = byte_slice_from_ruby_string(code_provenance_data)
     };
   }
 
-  ddprof_ffi_Vec_tag *null_additional_tags = NULL;
+  ddog_Vec_tag *null_additional_tags = NULL;
 
-  ddprof_ffi_NewProfileExporterV3Result exporter_result = create_exporter(exporter_configuration, tags_as_array);
+  ddog_NewProfileExporterResult exporter_result = create_exporter(exporter_configuration, tags_as_array);
   // Note: Do not add anything that can raise exceptions after this line, as otherwise the exporter memory will leak
 
   VALUE failure_tuple = handle_exporter_failure(exporter_result);
@@ -322,7 +322,7 @@ static VALUE _native_do_export(
 static void *call_exporter_without_gvl(void *call_args) {
   struct call_exporter_without_gvl_arguments *args = (struct call_exporter_without_gvl_arguments*) call_args;
 
-  args->result = ddprof_ffi_ProfileExporterV3_send(args->exporter, args->request, args->cancel_token);
+  args->result = ddog_ProfileExporter_send(args->exporter, args->request, args->cancel_token);
   args->send_ran = true;
 
   return NULL; // Unused
@@ -330,5 +330,5 @@ static void *call_exporter_without_gvl(void *call_args) {
 
 // Called by Ruby when it wants to interrupt call_exporter_without_gvl above, e.g. when the app wants to exit cleanly
 static void interrupt_exporter_call(void *cancel_token) {
-  ddprof_ffi_CancellationToken_cancel((ddprof_ffi_CancellationToken *) cancel_token);
+  ddog_CancellationToken_cancel((ddog_CancellationToken *) cancel_token);
 }

--- a/ext/ddtrace_profiling_native_extension/libdatadog_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/libdatadog_helpers.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <ddprof/ffi.h>
+#include <datadog/profiling.h>
 #include "ruby_helpers.h"
 
-inline static ddprof_ffi_CharSlice char_slice_from_ruby_string(VALUE string) {
+inline static ddog_CharSlice char_slice_from_ruby_string(VALUE string) {
   ENFORCE_TYPE(string, T_STRING);
-  ddprof_ffi_CharSlice char_slice = {.ptr = StringValuePtr(string), .len = RSTRING_LEN(string)};
+  ddog_CharSlice char_slice = {.ptr = StringValuePtr(string), .len = RSTRING_LEN(string)};
   return char_slice;
 }
 
-inline static VALUE ruby_string_from_vec_u8(ddprof_ffi_Vec_u8 string) {
+inline static VALUE ruby_string_from_vec_u8(ddog_Vec_u8 string) {
   return rb_str_new((char *) string.ptr, string.len);
 }

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -31,8 +31,9 @@ module Datadog
       # This runpath gets hardcoded at native library linking time. You can look at it using the `readelf` tool in
       # Linux: e.g. `readelf -d ddtrace_profiling_native_extension.2.7.3_x86_64-linux.so`.
       #
-      # In ddtrace 1.1.0, we only set as runpath an absolute path to libdatadog. (This gets set automatically by the call
-      # to `pkg_config('ddprof_ffi_with_rpath')` in `extconf.rb`). This worked fine as long as libdatadog was **NOT**
+      # In older versions of ddtrace, we only set as runpath an absolute path to libdatadog.
+      # (This gets set automatically by the call
+      # to `pkg_config('datadog_profiling_with_rpath')` in `extconf.rb`). This worked fine as long as libdatadog was **NOT**
       # moved from the folder it was present at ddtrace installation/linking time.
       #
       # Unfortunately, environments such as Heroku and AWS Elastic Beanstalk move gems around in the filesystem after

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -7,7 +7,7 @@
 #include "libdatadog_helpers.h"
 #include "ruby_helpers.h"
 
-// Used to wrap a ddprof_ffi_Profile in a Ruby object and expose Ruby-level serialization APIs
+// Used to wrap a ddog_Profile in a Ruby object and expose Ruby-level serialization APIs
 // This file implements the native bits of the Datadog::Profiling::StackRecorder class
 
 // ---
@@ -24,7 +24,7 @@
 // 2. The thread that serializes and reports profiles, let's call it the **serializer thread**. We enforce that there
 // cannot be more than one thread attempting to serialize profiles at a time.
 //
-// If both the sampler and serializer threads are trying to access the same `ddprof_ffi_Profile` in parallel, we will
+// If both the sampler and serializer threads are trying to access the same `ddog_Profile` in parallel, we will
 // have a concurrency issue. Thus, the StackRecorder has an added mechanism to avoid this.
 //
 // As an additional constraint, the **sampler thread** has absolute priority and must never block while
@@ -32,7 +32,7 @@
 //
 // ### The solution: Keep two profiles at the same time
 //
-// To solve for the constraints above, the StackRecorder keeps two `ddprof_ffi_Profile` profile instances inside itself.
+// To solve for the constraints above, the StackRecorder keeps two `ddog_Profile` profile instances inside itself.
 // They are called the `slot_one_profile` and `slot_two_profile`.
 //
 // Each profile is paired with its own mutex. `slot_one_profile` is protected by `slot_one_mutex` and `slot_two_profile`
@@ -135,10 +135,10 @@ static VALUE stack_recorder_class = Qnil;
 // Contains native state for each instance
 struct stack_recorder_state {
   pthread_mutex_t slot_one_mutex;
-  ddprof_ffi_Profile *slot_one_profile;
+  ddog_Profile *slot_one_profile;
 
   pthread_mutex_t slot_two_mutex;
-  ddprof_ffi_Profile *slot_two_profile;
+  ddog_Profile *slot_two_profile;
 
   short active_slot; // MUST NEVER BE ACCESSED FROM record_sample; this is NOT for the sampler thread to use.
 };
@@ -146,7 +146,7 @@ struct stack_recorder_state {
 // Used to return a pair of values from sampler_lock_active_profile()
 struct active_slot_pair {
   pthread_mutex_t *mutex;
-  ddprof_ffi_Profile *profile;
+  ddog_Profile *profile;
 };
 
 struct call_serialize_without_gvl_arguments {
@@ -154,8 +154,8 @@ struct call_serialize_without_gvl_arguments {
   struct stack_recorder_state *state;
 
   // Set by callee
-  ddprof_ffi_Profile *profile;
-  ddprof_ffi_SerializeResult result;
+  ddog_Profile *profile;
+  ddog_SerializeResult result;
 
   // Set by both
   bool serialize_ran;
@@ -164,11 +164,11 @@ struct call_serialize_without_gvl_arguments {
 static VALUE _native_new(VALUE klass);
 static void stack_recorder_typed_data_free(void *data);
 static VALUE _native_serialize(VALUE self, VALUE recorder_instance);
-static VALUE ruby_time_from(ddprof_ffi_Timespec ddprof_time);
+static VALUE ruby_time_from(ddog_Timespec ddprof_time);
 static void *call_serialize_without_gvl(void *call_args);
 static struct active_slot_pair sampler_lock_active_profile();
 static void sampler_unlock_active_profile(struct active_slot_pair active_slot);
-static ddprof_ffi_Profile *serializer_flip_active_and_inactive_slots(struct stack_recorder_state *state);
+static ddog_Profile *serializer_flip_active_and_inactive_slots(struct stack_recorder_state *state);
 static VALUE _native_active_slot(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE _native_is_slot_one_mutex_locked(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE _native_is_slot_two_mutex_locked(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
@@ -199,7 +199,7 @@ void stack_recorder_init(VALUE profiling_module) {
   ruby_time_from_id = rb_intern_const("ruby_time_from");
 }
 
-// This structure is used to define a Ruby object that stores a pointer to a ddprof_ffi_Profile instance
+// This structure is used to define a Ruby object that stores a pointer to a ddog_Profile instance
 // See also https://github.com/ruby/ruby/blob/master/doc/extension.rdoc for how this works
 static const rb_data_type_t stack_recorder_typed_data = {
   .wrap_struct_name = "Datadog::Profiling::StackRecorder",
@@ -214,7 +214,7 @@ static const rb_data_type_t stack_recorder_typed_data = {
 static VALUE _native_new(VALUE klass) {
   struct stack_recorder_state *state = ruby_xcalloc(1, sizeof(struct stack_recorder_state));
 
-  ddprof_ffi_Slice_value_type sample_types = {.ptr = enabled_value_types, .len = ENABLED_VALUE_TYPES_COUNT};
+  ddog_Slice_value_type sample_types = {.ptr = enabled_value_types, .len = ENABLED_VALUE_TYPES_COUNT};
 
   state->slot_one_mutex = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
   state->slot_two_mutex = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
@@ -227,8 +227,8 @@ static VALUE _native_new(VALUE klass) {
 
   // Note: Don't raise exceptions after this point, since it'll lead to libdatadog memory leaking!
 
-  state->slot_one_profile = ddprof_ffi_Profile_new(sample_types, NULL /* period is optional */, NULL /* start_time is optional */);
-  state->slot_two_profile = ddprof_ffi_Profile_new(sample_types, NULL /* period is optional */, NULL /* start_time is optional */);
+  state->slot_one_profile = ddog_Profile_new(sample_types, NULL /* period is optional */, NULL /* start_time is optional */);
+  state->slot_two_profile = ddog_Profile_new(sample_types, NULL /* period is optional */, NULL /* start_time is optional */);
 
   return TypedData_Wrap_Struct(klass, &stack_recorder_typed_data, state);
 }
@@ -237,10 +237,10 @@ static void stack_recorder_typed_data_free(void *state_ptr) {
   struct stack_recorder_state *state = (struct stack_recorder_state *) state_ptr;
 
   pthread_mutex_destroy(&state->slot_one_mutex);
-  ddprof_ffi_Profile_free(state->slot_one_profile);
+  ddog_Profile_free(state->slot_one_profile);
 
   pthread_mutex_destroy(&state->slot_two_mutex);
-  ddprof_ffi_Profile_free(state->slot_two_profile);
+  ddog_Profile_free(state->slot_two_profile);
 
   ruby_xfree(state);
 }
@@ -267,33 +267,33 @@ static VALUE _native_serialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instan
     rb_thread_call_without_gvl2(call_serialize_without_gvl, &args, NULL /* No interruption function needed in this case */, NULL /* Not needed */);
   }
 
-  ddprof_ffi_SerializeResult serialized_profile = args.result;
+  ddog_SerializeResult serialized_profile = args.result;
 
-  if (serialized_profile.tag == DDPROF_FFI_SERIALIZE_RESULT_ERR) {
+  if (serialized_profile.tag == DDOG_SERIALIZE_RESULT_ERR) {
     VALUE err_details = ruby_string_from_vec_u8(serialized_profile.err);
-    ddprof_ffi_SerializeResult_drop(serialized_profile);
+    ddog_SerializeResult_drop(serialized_profile);
     return rb_ary_new_from_args(2, error_symbol, err_details);
   }
 
   VALUE encoded_pprof = ruby_string_from_vec_u8(serialized_profile.ok.buffer);
 
-  ddprof_ffi_Timespec ddprof_start = serialized_profile.ok.start;
-  ddprof_ffi_Timespec ddprof_finish = serialized_profile.ok.end;
+  ddog_Timespec ddprof_start = serialized_profile.ok.start;
+  ddog_Timespec ddprof_finish = serialized_profile.ok.end;
 
   // Clean up libdatadog object to avoid leaking in case ruby_time_from raises an exception
-  ddprof_ffi_SerializeResult_drop(serialized_profile);
+  ddog_SerializeResult_drop(serialized_profile);
 
   VALUE start = ruby_time_from(ddprof_start);
   VALUE finish = ruby_time_from(ddprof_finish);
 
-  if (!ddprof_ffi_Profile_reset(args.profile, NULL /* start_time is optional */ )) {
+  if (!ddog_Profile_reset(args.profile, NULL /* start_time is optional */ )) {
     return rb_ary_new_from_args(2, error_symbol, rb_str_new_cstr("Failed to reset profile"));
   }
 
   return rb_ary_new_from_args(2, ok_symbol, rb_ary_new_from_args(3, start, finish, encoded_pprof));
 }
 
-static VALUE ruby_time_from(ddprof_ffi_Timespec ddprof_time) {
+static VALUE ruby_time_from(ddog_Timespec ddprof_time) {
   #ifndef NO_RB_TIME_TIMESPEC_NEW // Modern Rubies
     const int utc = INT_MAX - 1; // From Ruby sources
     struct timespec time = {.tv_sec = ddprof_time.seconds, .tv_nsec = ddprof_time.nanoseconds};
@@ -303,13 +303,13 @@ static VALUE ruby_time_from(ddprof_ffi_Timespec ddprof_time) {
   #endif
 }
 
-void record_sample(VALUE recorder_instance, ddprof_ffi_Sample sample) {
+void record_sample(VALUE recorder_instance, ddog_Sample sample) {
   struct stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, struct stack_recorder_state, &stack_recorder_typed_data, state);
 
   struct active_slot_pair active_slot = sampler_lock_active_profile(state);
 
-  ddprof_ffi_Profile_add(active_slot.profile, sample);
+  ddog_Profile_add(active_slot.profile, sample);
 
   sampler_unlock_active_profile(active_slot);
 }
@@ -318,7 +318,7 @@ static void *call_serialize_without_gvl(void *call_args) {
   struct call_serialize_without_gvl_arguments *args = (struct call_serialize_without_gvl_arguments *) call_args;
 
   args->profile = serializer_flip_active_and_inactive_slots(args->state);
-  args->result = ddprof_ffi_Profile_serialize(args->profile, NULL /* end_time is optional */, NULL /* duration_nanos is optional */);
+  args->result = ddog_Profile_serialize(args->profile, NULL /* end_time is optional */, NULL /* duration_nanos is optional */);
   args->serialize_ran = true;
 
   return NULL; // Unused
@@ -357,7 +357,7 @@ static void sampler_unlock_active_profile(struct active_slot_pair active_slot) {
   if (error != 0) rb_syserr_fail(error, "Unexpected failure in sampler_unlock_active_profile");
 }
 
-static ddprof_ffi_Profile *serializer_flip_active_and_inactive_slots(struct stack_recorder_state *state) {
+static ddog_Profile *serializer_flip_active_and_inactive_slots(struct stack_recorder_state *state) {
   int error;
   int previously_active_slot = state->active_slot;
 

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.h
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <ddprof/ffi.h>
+#include <datadog/profiling.h>
 
-// Note: Please DO NOT use `VALUE_STRING` anywhere else, instead use `DDPROF_FFI_CHARSLICE_C`.
+// Note: Please DO NOT use `VALUE_STRING` anywhere else, instead use `DDOG_CHARSLICE_C`.
 // `VALUE_STRING` is only needed because older versions of gcc (4.9.2, used in our Ruby 2.2 CI test images)
 // tripped when compiling `enabled_value_types` using `-std=gnu99` due to the extra cast that is included in
-// `DDPROF_FFI_CHARSLICE_C` with the following error:
+// `DDOG_CHARSLICE_C` with the following error:
 //
 // ```
 // compiling ../../../../ext/ddtrace_profiling_native_extension/stack_recorder.c
 // ../../../../ext/ddtrace_profiling_native_extension/stack_recorder.c:23:1: error: initializer element is not constant
-// static const ddprof_ffi_ValueType enabled_value_types[] = {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE};
+// static const ddog_ValueType enabled_value_types[] = {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE};
 // ^
 // ```
 #define VALUE_STRING(string) {.ptr = "" string, .len = sizeof(string) - 1}
@@ -23,7 +23,7 @@
 #define HEAP_LIVE_SIZE_VALUE    {.type_ = VALUE_STRING("heap-live-size"),    .unit = VALUE_STRING("bytes")}
 #define HEAP_LIVE_SAMPLES_VALUE {.type_ = VALUE_STRING("heap-live-samples"), .unit = VALUE_STRING("count")}
 
-static const ddprof_ffi_ValueType enabled_value_types[] = {
+static const ddog_ValueType enabled_value_types[] = {
   #define CPU_TIME_VALUE_POS 0
   CPU_TIME_VALUE,
   #define CPU_SAMPLES_VALUE_POS 1
@@ -32,7 +32,7 @@ static const ddprof_ffi_ValueType enabled_value_types[] = {
   WALL_TIME_VALUE
 };
 
-#define ENABLED_VALUE_TYPES_COUNT (sizeof(enabled_value_types) / sizeof(ddprof_ffi_ValueType))
+#define ENABLED_VALUE_TYPES_COUNT (sizeof(enabled_value_types) / sizeof(ddog_ValueType))
 
-void record_sample(VALUE recorder_instance, ddprof_ffi_Sample sample);
+void record_sample(VALUE recorder_instance, ddog_Sample sample);
 VALUE enforce_recorder_instance(VALUE object);

--- a/gemfiles/jruby_9.2.18.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1438,7 +1438,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.18.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -59,7 +59,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.18.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.18.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -63,7 +63,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.18.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.18.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.18.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -100,7 +100,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.18.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.2.18.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.18.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.2.18.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.18.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.2.18.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.18.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1438,7 +1438,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -59,7 +59,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -63,7 +63,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -100,7 +100,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.2.8.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.2.8.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.2.8.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.4.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1438,7 +1438,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.4.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -59,7 +59,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.4.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.4.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -63,7 +63,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.4.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.4.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.4.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.4.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.4.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.4.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.4.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -100,7 +100,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.4.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.3.4.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.4.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.4.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.4.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.4.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.3.4.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.4.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.4.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.4.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.4.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.4.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.3.4.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.4.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1)
+    libdatadog (0.8.0.1.0)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.1.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -126,7 +126,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     makara (0.4.1)

--- a/gemfiles/ruby_2.1.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -37,7 +37,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -74,7 +74,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -70,7 +70,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -70,7 +70,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.2.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1268,7 +1268,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -37,7 +37,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -74,7 +74,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -70,7 +70,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -70,7 +70,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.3.8_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1364,7 +1364,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -37,7 +37,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -55,7 +55,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -75,7 +75,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -74,7 +74,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -70,7 +70,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -70,7 +70,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -78,7 +78,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -85,7 +85,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -37,7 +37,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -37,7 +37,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.4.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1430,7 +1430,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -52,7 +52,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.4.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -57,7 +57,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -77,7 +77,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -39,7 +39,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.5.9_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1436,7 +1436,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -63,7 +63,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.5.9_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -97,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -114,7 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -110,7 +110,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.6.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1437,7 +1437,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -64,7 +64,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.6.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.6.7_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -68,7 +68,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.6.7_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -89,7 +89,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.6.7_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -89,7 +89,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.6.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.6.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.6.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.6.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.6.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.6.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1436,7 +1436,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -64,7 +64,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.3_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -68,7 +68,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.3_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.3_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -111,7 +111,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.7.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.7.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1447,7 +1447,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_3.0.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -65,7 +65,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -51,7 +51,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0.3_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -69,7 +69,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0.3_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -89,7 +89,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0.3_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -89,7 +89,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -118,8 +118,8 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-aarch64-linux)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-aarch64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.3.0.2.0-x86_64-linux)

--- a/gemfiles/ruby_3.0.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_3.0.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_3.0.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -119,7 +119,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_3.0.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_3.0.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -51,7 +51,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.0.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -51,7 +51,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1443,7 +1443,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_3.1.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -64,7 +64,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.1_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -68,7 +68,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.1_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.1_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -88,7 +88,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_3.1.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_3.1.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_3.1.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_3.1.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     io-wait (0.2.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_3.1.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.1.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -1445,7 +1445,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.16.0)

--- a/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -63,7 +63,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -67,7 +67,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -115,7 +115,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.16.0)

--- a/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.4.0)
       debase-ruby_core_source (= 0.10.16)
-      libdatadog (~> 0.7.0.1.1)
+      libdatadog (~> 0.8.0.1.0)
       libddwaf (~> 1.3.0.2.0)
       msgpack
 
@@ -49,7 +49,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.7.0.1.1-x86_64-linux)
+    libdatadog (0.8.0.1.0-x86_64-linux)
     libddwaf (1.3.0.2.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/lib/datadog/profiling/http_transport.rb
+++ b/lib/datadog/profiling/http_transport.rb
@@ -58,7 +58,7 @@ module Datadog
         end
       end
 
-      # Used to log soft failures in `ddprof_ffi_Vec_tag_push` (e.g. we still report the profile in these cases)
+      # Used to log soft failures in `ddog_Vec_tag_push` (e.g. we still report the profile in these cases)
       # Called from native code
       def self.log_failure_to_process_tag(failure_details)
         Datadog.logger.warn("Failed to add tag to profiling request: #{failure_details}")

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -468,10 +468,10 @@ RSpec.describe Datadog::Profiling::HttpTransport do
       end
 
       # As the describe above says, here we're testing the cancellation behavior. If cancellation is not correctly
-      # implemented, then `ddprof_ffi_ProfileExporterV3_send` will block until `upload_timeout_seconds` is hit and
+      # implemented, then `ddog_ProfileExporter_send` will block until `upload_timeout_seconds` is hit and
       # nothing we could do on the Ruby VM side will interrupt it.
       # If it is correctly implemented, then the `exporter_thread.kill` will cause
-      # `ddprof_ffi_ProfileExporterV3_send` to return immediately and this test will quickly finish.
+      # `ddog_ProfileExporter_send` to return immediately and this test will quickly finish.
       it 'can be interrupted' do
         exporter_thread = Thread.new { http_transport.export(flush) }
         request_received_queue.pop

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers do
           raise('Missing SOEXT for current platform')
 
         gem_lib_folder = "#{Gem.loaded_specs['ddtrace'].gem_dir}/lib"
-        full_libdatadog_path = "#{gem_lib_folder}/#{relative_path}/libddprof_ffi.#{libdatadog_extension}"
+        full_libdatadog_path = "#{gem_lib_folder}/#{relative_path}/libdatadog_profiling.#{libdatadog_extension}"
 
         expect(relative_path).to start_with('../')
         expect(File.exist?(full_libdatadog_path))


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**:

Upgrade dd-trace-rb to use the latest libdatadog release.

This latest version brings a lot of renames to clean up the last
remnants of the library being called libddprof instead of libdatadog.

This PR only updates our code to use the new names, and otherwise
behavior is unchanged (and all specs are still passing).

**Motivation**:

The 0.8.0 includes at least one new feature that will be needed in the new Ruby profiler.

**Additional Notes**:

I am opening this as a draft PR until libdatadog 0.8.0 gets released on Rubygems.org.
This can already be tested locally as described in https://github.com/DataDog/libdatadog/pull/44.

**Also, we may want to wait until after the dd-trace-rb 1.4.0 release goes out to merge this PR.**

**How to test the change?**:

Because this PR doesn't really change any behavior, our existing test suite should be enough to validate that things remain working (and it's green for me locally -- it should become green in CI once libdatadog gets released on rubygems.org).