### PR TITLE
Implement method tracing API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,5 @@ if RUBY_VERSION >= '2.4.0' && (RUBY_PLATFORM =~ /^x86_64-(darwin|linux)/)
   gem 'sorbet', '= 0.5.9672'
   gem 'spoom', '~> 1.1'
 end
+
+gem 'datadog-instrumentation', git: 'https://github.com/DataDog/datadog-instrumentation-ruby', branch: 'master'

--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -69,5 +69,8 @@ Gem::Specification.new do |spec|
   # Used by profiling (and possibly others in the future)
   spec.add_dependency 'libdatadog', '~> 0.7.0.1.1'
 
+  # Used by method tracing API
+  spec.add_dependency 'datadog-instrumentation'
+
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb', 'ext/ddtrace_profiling_loader/extconf.rb']
 end

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -356,6 +356,7 @@ Where `name` should be a `String` that describes the generic kind of operation b
 
 And `options` are the following optional keyword arguments:
 
+### Options
 | Key | Type | Description | Default |
 | --------------- | ----------------------- | --- | --- |
 | `autostart`     | `Bool`                  | Whether the time measurement should be started automatically. If `false`, user must call `span.start`. | `true` |
@@ -446,6 +447,63 @@ You can also get the current active trace using the `active_trace` method. This 
 # e.g. accessing active trace
 
 current_trace = Datadog::Tracing.active_trace
+```
+
+## Method Tracing API
+Another option for manual instrumentation is to use the method tracing API to trace your own code or code from a library/framework we do not yet support.
+
+To generate traces, use the `Datadog::Tracing.trace_method` method:
+```ruby
+Datadog::Tracing.trace_method(name, target, span_options).around do |env, span, trace, &block|
+  # You can modify the span here.
+  # e.g. Change the resource name, set tags, etc.
+  block.call
+end
+```
+This method does not need to be called at the same location where the target is declared, providing you with more flexibility to separate business and tracing logic.
+
+The `trace_method` method accepts the following parameters:
+| Parameter | Type | Description | Example |
+| ---- | ------- | --------- | --- |
+| `name` | `String` | The generic kind of operation being done. | `pg.exec` |
+| `target` | `String` | The class and method you wish to instrument. The convention for this API is to use `#` for denoting an instance method, and `.` for a class method.| `PG::Connection#exec` |
+| `span_options` | `Hash`| An optional `Hash` that accepts the same keyword arguments as the [manual instrumentation options](#options). | `{ type: 'sql' }`|
+
+Calling `Datadog::Tracing.trace_method` returns an instance of `Dataodg::Tracing::Contrib::Hook`.
+
+To modify the trace that is produced, you can call `around` on the hook object. This provides you with the following parameters:
+| Parameter | Type | Description | Example |
+| --- | --- | ------ | --- |
+| `env` | `Dataodg::Tracing::Contrib::Hook::Env` | The `env` object provides access to the environment used to call the target method. You can call `.self`, `.args` or `.kwargs`.| `env.self` |
+| `span` | `Datadog::Tracing::SpanOperation` | The span object that you can modify. | `span.resource = env.args.first` |
+| `trace` | `Datadog::Tracing::TraceOperation` | The trace object that you can modify. | `trace.resource = env.args.first` |
+| `block` | `Proc` | This allows you to call the target method and manipulate the result. The result should be returned at the end of the block passed to `.around`. | `result = block.call` |
+
+You can also call `disable!` and `enable!` on the hook object to selectively trace the target. By default, tracing is enabled.
+
+Example of the method tracing API in action:
+```ruby
+hook = Datadog::Tracing.trace_method(
+  'pg.exec',
+  'PG::Connection#exec',
+  { type: 'sql' }
+).around do |env, span, _trace, &block|
+  span.service = 'pg'
+  span.resource = env.args.first
+  span.set_tag('db.instance', env.self.db)
+  span.set_tag('db.user', env.self.user)
+  span.set_tag('db.system', 'postgresql')
+  span.set_tag('out.host', env.self.host)
+  span.set_tag('out.port', env.self.port)
+  result = block.call
+  span.set_tag('db.row_count', result.ntuples)
+  result
+end
+
+hook.disabled? # false
+hook.disable!
+hook.disabled? # true
+hook.enable!
 ```
 
 ## Integration instrumentation

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -34,6 +34,7 @@ To contribute, check out the [contribution guidelines][contribution docs] and [d
         - [Configuring OpenTelemetry](#configuring-opentelemetry)
      - [Connect your application to the Datadog Agent](#connect-your-application-to-the-datadog-agent)
  - [Manual instrumentation](#manual-instrumentation)
+ - [Method tracing API](#method-tracing-api)
  - [Integration instrumentation](#integration-instrumentation)
      - [Action Cable](#action-cable)
      - [Action Mailer](#action-mailer)

--- a/gemfiles/ruby_3.0.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -1690,6 +1697,7 @@ DEPENDENCIES
   concurrent-ruby
   cucumber
   dalli (>= 3.0.0)
+  datadog-instrumentation!
   ddtrace!
   delayed_job
   delayed_job_active_record

--- a/gemfiles/ruby_3.0.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib_old.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -176,6 +183,7 @@ DEPENDENCIES
   climate_control (~> 0.2.0)
   concurrent-ruby
   dalli (< 3.0.0)
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   elasticsearch (< 8.0.0)

--- a/gemfiles/ruby_3.0.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_core_old.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -155,6 +162,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (~> 4)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)

--- a/gemfiles/ruby_3.0.3_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber3.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -176,6 +183,7 @@ DEPENDENCIES
   climate_control (~> 0.2.0)
   concurrent-ruby
   cucumber (>= 3.0.0, < 4.0.0)
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)

--- a/gemfiles/ruby_3.0.3_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber4.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -207,6 +214,7 @@ DEPENDENCIES
   climate_control (~> 0.2.0)
   concurrent-ruby
   cucumber (>= 4.0.0, < 5.0.0)
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)

--- a/gemfiles/ruby_3.0.3_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber5.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -207,6 +214,7 @@ DEPENDENCIES
   climate_control (~> 0.2.0)
   concurrent-ruby
   cucumber (>= 5.0.0, < 6.0.0)
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)

--- a/gemfiles/ruby_3.0.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_mysql2.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -294,6 +301,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)

--- a/gemfiles/ruby_3.0.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -294,6 +301,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)

--- a/gemfiles/ruby_3.0.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres_redis.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -295,6 +302,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)

--- a/gemfiles/ruby_3.0.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres_sidekiq.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -306,6 +313,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)

--- a/gemfiles/ruby_3.0.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_semantic_logger.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -293,6 +300,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)

--- a/gemfiles/ruby_3.0.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_resque2_redis3.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -177,6 +184,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)

--- a/gemfiles/ruby_3.0.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_resque2_redis4.gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/DataDog/datadog-instrumentation-ruby
+  revision: 8a009f7246072f69c44b4692b75c6fd2e3334eb9
+  branch: master
+  specs:
+    datadog-instrumentation (0.0.1)
+
+GIT
   remote: https://github.com/DataDog/simplecov
   revision: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
   ref: 3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db
@@ -177,6 +184,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
+  datadog-instrumentation!
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)

--- a/integration/apps/rack/Gemfile
+++ b/integration/apps/rack/Gemfile
@@ -47,3 +47,5 @@ gem 'pry-byebug'
 gem 'rspec'
 gem 'rspec-wait'
 gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick
+
+gem 'datadog-instrumentation', git: 'https://github.com/DataDog/datadog-instrumentation-ruby', branch: 'master'

--- a/integration/apps/rails-five/Gemfile
+++ b/integration/apps/rails-five/Gemfile
@@ -103,3 +103,5 @@ group :test, :development do
 
   gem 'listen'
 end
+
+gem 'datadog-instrumentation', git: 'https://github.com/DataDog/datadog-instrumentation-ruby', branch: 'master'

--- a/integration/apps/rails-seven/Gemfile
+++ b/integration/apps/rails-seven/Gemfile
@@ -104,3 +104,5 @@ google_protobuf_versions = [
   '!= 3.8.0.rc.1'
 ]
 gem 'google-protobuf', *google_protobuf_versions
+
+gem 'datadog-instrumentation', git: 'https://github.com/DataDog/datadog-instrumentation-ruby', branch: 'master'

--- a/integration/apps/rails-six/Gemfile
+++ b/integration/apps/rails-six/Gemfile
@@ -105,3 +105,5 @@ group :test, :development do
 
   gem 'listen'
 end
+
+gem 'datadog-instrumentation', git: 'https://github.com/DataDog/datadog-instrumentation-ruby', branch: 'master'

--- a/integration/apps/rspec/Gemfile
+++ b/integration/apps/rspec/Gemfile
@@ -12,3 +12,5 @@ gem 'byebug'
 
 # Testing/CI
 gem 'rspec'
+
+gem 'datadog-instrumentation', git: 'https://github.com/DataDog/datadog-instrumentation-ruby', branch: 'master'

--- a/integration/apps/ruby/Gemfile
+++ b/integration/apps/ruby/Gemfile
@@ -9,3 +9,5 @@ gem 'google-protobuf'
 gem 'ddtrace', *Datadog::DemoEnv.gem_spec('ddtrace')
 
 gem 'byebug'
+
+gem 'datadog-instrumentation', git: 'https://github.com/DataDog/datadog-instrumentation-ruby', branch: 'master'

--- a/integration/apps/sinatra2-classic/Gemfile
+++ b/integration/apps/sinatra2-classic/Gemfile
@@ -34,3 +34,5 @@ gem 'pry-byebug'
 gem 'rspec'
 gem 'rspec-wait'
 gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick
+
+gem 'datadog-instrumentation', git: 'https://github.com/DataDog/datadog-instrumentation-ruby', branch: 'master'

--- a/integration/apps/sinatra2-modular/Gemfile
+++ b/integration/apps/sinatra2-modular/Gemfile
@@ -35,3 +35,5 @@ gem 'pry-byebug'
 gem 'rspec'
 gem 'rspec-wait'
 gem 'webrick' if RUBY_VERSION >= '2.3' # Older Rubies can just use the built-in version of webrick
+
+gem 'datadog-instrumentation', git: 'https://github.com/DataDog/datadog-instrumentation-ruby', branch: 'master'

--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -129,8 +129,8 @@ module Datadog
 
       # (see Datadog::Tracing::Tracer#trace_method)
       # @public_api
-      def trace_method(name, target, span_options = {})
-        tracer.trace_method(name, target, span_options)
+      def trace_method(target, name, span_options = {})
+        tracer.trace_method(target, name, span_options)
       end
 
       private

--- a/lib/datadog/tracing.rb
+++ b/lib/datadog/tracing.rb
@@ -127,6 +127,12 @@ module Datadog
         current_tracer.enabled
       end
 
+      # (see Datadog::Tracing::Tracer#trace_method)
+      # @public_api
+      def trace_method(name, target, span_options = {})
+        tracer.trace_method(name, target, span_options)
+      end
+
       private
 
       # DEV: components hosts both tracing and profiling inner objects today

--- a/lib/datadog/tracing/contrib/hook.rb
+++ b/lib/datadog/tracing/contrib/hook.rb
@@ -38,8 +38,8 @@ module Datadog
 
         def invoke(stack, env)
           Datadog::Tracing.trace(name, **span_options) do |span, trace|
-            env_obj = Env.new(env)
             if around_block
+              env_obj = Env.new(env)
               around_block.call(env_obj, span, trace) do
                 stack.call(env)[:return]
               end

--- a/lib/datadog/tracing/contrib/hook.rb
+++ b/lib/datadog/tracing/contrib/hook.rb
@@ -1,0 +1,60 @@
+# typed: true
+
+require 'datadog/instrumentation'
+
+module Datadog
+  module Tracing
+    module Contrib
+      # Class defining hook used to implement method tracing
+      class Hook
+        def initialize(name, target, span_options = {})
+          @name = name
+          @target = target
+          @span_options = span_options
+        end
+
+        def inject!
+          trace_hook = self
+          @hook = Datadog::Instrumentation::Hook[@target].add do
+            append do |stack, env|
+              trace_hook.invoke(stack, env)
+            end
+          end
+
+          @hook.install
+        end
+
+        def around(&block)
+          @around = block
+          self
+        end
+
+        def invoke(stack, env)
+          Datadog::Tracing.trace(@name, **@span_options) do |span, trace|
+            env_obj = Env.new(env)
+            if @around
+              @around.call(env_obj, span, trace) do
+                stack.call(env)[:return]
+              end
+            else
+              stack.call(env)[:return]
+            end
+          end
+        end
+
+        class Env
+          attr_accessor \
+            :self,
+            :args,
+            :kwargs
+
+          def initialize(env)
+            @self = env[:self]
+            @args = env[:args]
+            @kwargs = env[:kwargs]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/tracing/contrib/hook.rb
+++ b/lib/datadog/tracing/contrib/hook.rb
@@ -14,9 +14,9 @@ module Datadog
           :span_options,
           :target
 
-        def initialize(name, target, span_options = {})
-          @name = name
+        def initialize(target, name, span_options = {})
           @target = target
+          @name = name
           @span_options = span_options
         end
 

--- a/lib/datadog/tracing/contrib/hook.rb
+++ b/lib/datadog/tracing/contrib/hook.rb
@@ -49,6 +49,18 @@ module Datadog
           end
         end
 
+        def disable!
+          hook.disable
+        end
+
+        def enable!
+          hook.enable
+        end
+
+        def disabled?
+          hook.disabled?
+        end
+
         # Class defining the Env object that can be used to extract information passed to the method to be traced
         class Env
           attr_accessor \

--- a/lib/datadog/tracing/contrib/hook.rb
+++ b/lib/datadog/tracing/contrib/hook.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 require 'datadog/instrumentation'
 

--- a/lib/datadog/tracing/contrib/hook.rb
+++ b/lib/datadog/tracing/contrib/hook.rb
@@ -27,6 +27,7 @@ module Datadog
               trace_hook.invoke(stack, env)
             end
           end
+          # binding.pry
 
           hook.install
         end
@@ -36,6 +37,7 @@ module Datadog
           self
         end
 
+        # Class defining the Env object that can be used to extract information passed to the method to be traced
         class Env
           attr_accessor \
             :self,

--- a/lib/datadog/tracing/contrib/mysql2/patcher.rb
+++ b/lib/datadog/tracing/contrib/mysql2/patcher.rb
@@ -24,7 +24,7 @@ module Datadog
           def patch_mysql2_client
             # ::Mysql2::Client.include(Instrumentation)
 
-            Datadog::Tracing.trace_method(Ext::SPAN_QUERY, 'Mysql2::Client#query').around do |env, span, _trace, &block|
+            Datadog::Tracing.trace_method('Mysql2::Client#query', Ext::SPAN_QUERY).around do |env, span, _trace, &block|
               sql = env.args[0]
               query_options = env.self.query_options
 

--- a/lib/datadog/tracing/contrib/mysql2/patcher.rb
+++ b/lib/datadog/tracing/contrib/mysql2/patcher.rb
@@ -22,7 +22,46 @@ module Datadog
           end
 
           def patch_mysql2_client
-            ::Mysql2::Client.include(Instrumentation)
+            # ::Mysql2::Client.include(Instrumentation)
+
+            Datadog::Tracing.trace_method(Ext::SPAN_QUERY, 'Mysql2::Client#query').around do |env, span, _trace, &block|
+              sql = env.args[0]
+              query_options = env.self.query_options
+
+              service = Datadog.configuration_for(env.self, :service_name) || datadog_configuration[:service_name]
+              span.service = service
+
+              span.resource = sql
+              span.span_type = Tracing::Metadata::Ext::SQL::TYPE
+
+              span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
+              span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_QUERY)
+
+              # Tag as an external peer service
+              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, service)
+              span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, query_options[:host])
+
+              # Set analytics sample rate
+              Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
+
+              span.set_tag(Ext::TAG_DB_NAME, query_options[:database])
+              span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, query_options[:host])
+              span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_PORT, query_options[:port])
+
+              block.call
+            end
+          end
+
+          def datadog_configuration
+            Datadog.configuration.tracing[:mysql2]
+          end
+
+          def analytics_enabled?
+            datadog_configuration[:analytics_enabled]
+          end
+
+          def analytics_sample_rate
+            datadog_configuration[:analytics_sample_rate]
           end
         end
       end

--- a/lib/datadog/tracing/contrib/pg/patcher.rb
+++ b/lib/datadog/tracing/contrib/pg/patcher.rb
@@ -1,7 +1,6 @@
 # typed: ignore
 
 require_relative '../patcher'
-# require_relative 'instrumentation'
 
 module Datadog
   module Tracing

--- a/lib/datadog/tracing/contrib/pg/patcher.rb
+++ b/lib/datadog/tracing/contrib/pg/patcher.rb
@@ -1,7 +1,7 @@
 # typed: ignore
 
 require_relative '../patcher'
-require_relative 'instrumentation'
+# require_relative 'instrumentation'
 
 module Datadog
   module Tracing
@@ -22,7 +22,119 @@ module Datadog
           end
 
           def patch_pg_connection
-            ::PG::Connection.include(Instrumentation)
+            # ::PG::Connection.include(Instrumentation)
+
+            Datadog::Tracing.trace_method(
+              Ext::SPAN_EXEC,
+              'PG::Connection#exec',
+              { type: Tracing::Metadata::Ext::SQL::TYPE }
+            ).around do |env, span, _trace, &block|
+              trace(env, span, env.args.first, block)
+            end
+            Datadog::Tracing.trace_method(
+              Ext::SPAN_EXEC_PARAMS,
+              'PG::Connection#exec_params',
+              { type: Tracing::Metadata::Ext::SQL::TYPE }
+            ).around do |env, span, _trace, &block|
+              trace(env, span, env.args.first, block)
+            end
+            Datadog::Tracing.trace_method(
+              Ext::SPAN_EXEC_PREPARED,
+              'PG::Connection#exec_prepared',
+              { type: Tracing::Metadata::Ext::SQL::TYPE }
+            ).around do |env, span, _trace, &block|
+              trace(env, span, env.args.first, block)
+            end
+            Datadog::Tracing.trace_method(
+              Ext::SPAN_ASYNC_EXEC,
+              'PG::Connection#async_exec',
+              { type: Tracing::Metadata::Ext::SQL::TYPE }
+            ).around do |env, span, _trace, &block|
+              trace(env, span, env.args.first, block)
+            end
+            Datadog::Tracing.trace_method(
+              Ext::SPAN_ASYNC_EXEC_PARAMS,
+              'PG::Connection#async_exec_params',
+              { type: Tracing::Metadata::Ext::SQL::TYPE }
+            ).around do |env, span, _trace, &block|
+              trace(env, span, env.args.first, block)
+            end
+            Datadog::Tracing.trace_method(
+              Ext::SPAN_ASYNC_EXEC_PREPARED,
+              'PG::Connection#async_exec_prepared',
+              { type: Tracing::Metadata::Ext::SQL::TYPE }
+            ).around do |env, span, _trace, &block|
+              trace(env, span, env.args.first, block)
+            end
+            Datadog::Tracing.trace_method(
+              Ext::SPAN_SYNC_EXEC,
+              'PG::Connection#sync_exec',
+              { type: Tracing::Metadata::Ext::SQL::TYPE }
+            ).around do |env, span, _trace, &block|
+              trace(env, span, env.args.first, block)
+            end
+            Datadog::Tracing.trace_method(
+              Ext::SPAN_SYNC_EXEC_PARAMS,
+              'PG::Connection#sync_exec_params',
+              { type: Tracing::Metadata::Ext::SQL::TYPE }
+            ).around do |env, span, _trace, &block|
+              trace(env, span, env.args.first, block)
+            end
+            Datadog::Tracing.trace_method(
+              Ext::SPAN_SYNC_EXEC_PREPARED,
+              'PG::Connection#sync_exec_prepared',
+              { type: Tracing::Metadata::Ext::SQL::TYPE }
+            ).around do |env, span, _trace, &block|
+              trace(env, span, env.args.first, block)
+            end
+          end
+
+          def trace(env, span, resource, block)
+            service = Datadog.configuration_for(env.self, :service_name) || datadog_configuration[:service_name]
+            Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
+            annotate_span_with_query!(span, env, service, resource)
+            result = block.call
+            annotate_span_with_result!(span, result)
+          end
+
+          def annotate_span_with_query!(span, env, service, resource)
+            span.service = service
+            span.resource = resource
+
+            span.set_tag(Ext::TAG_DB_NAME, env.self.db)
+
+            span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
+            span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_QUERY)
+            span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
+
+            # Tag as an external peer service
+            span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, service)
+            span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, env.self.host)
+
+            span.set_tag(Tracing::Metadata::Ext::DB::TAG_INSTANCE, env.self.db)
+            span.set_tag(Tracing::Metadata::Ext::DB::TAG_USER, env.self.user)
+            span.set_tag(Tracing::Metadata::Ext::DB::TAG_SYSTEM, Ext::SPAN_SYSTEM)
+
+            span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, env.self.host)
+            span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_PORT, env.self.port)
+            span.set_tag(Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME, env.self.host)
+            span.set_tag(Tracing::Metadata::Ext::NET::TAG_DESTINATION_PORT, env.self.port)
+          end
+
+          def annotate_span_with_result!(span, result)
+            span.set_tag(Tracing::Metadata::Ext::DB::TAG_ROW_COUNT, result.ntuples)
+          end
+
+          def datadog_configuration
+            Datadog.configuration.tracing[:pg]
+          end
+
+          def analytics_enabled?
+            datadog_configuration[:analytics_enabled]
+          end
+
+          def analytics_sample_rate
+            datadog_configuration[:analytics_sample_rate]
           end
         end
       end

--- a/lib/datadog/tracing/contrib/pg/patcher.rb
+++ b/lib/datadog/tracing/contrib/pg/patcher.rb
@@ -24,68 +24,26 @@ module Datadog
           def patch_pg_connection
             # ::PG::Connection.include(Instrumentation)
 
-            Datadog::Tracing.trace_method(
-              Ext::SPAN_EXEC,
-              'PG::Connection#exec',
-              { type: Tracing::Metadata::Ext::SQL::TYPE }
-            ).around do |env, span, _trace, &block|
-              trace(env, span, env.args.first, block)
-            end
-            Datadog::Tracing.trace_method(
-              Ext::SPAN_EXEC_PARAMS,
-              'PG::Connection#exec_params',
-              { type: Tracing::Metadata::Ext::SQL::TYPE }
-            ).around do |env, span, _trace, &block|
-              trace(env, span, env.args.first, block)
-            end
-            Datadog::Tracing.trace_method(
-              Ext::SPAN_EXEC_PREPARED,
-              'PG::Connection#exec_prepared',
-              { type: Tracing::Metadata::Ext::SQL::TYPE }
-            ).around do |env, span, _trace, &block|
-              trace(env, span, env.args.first, block)
-            end
-            Datadog::Tracing.trace_method(
-              Ext::SPAN_ASYNC_EXEC,
-              'PG::Connection#async_exec',
-              { type: Tracing::Metadata::Ext::SQL::TYPE }
-            ).around do |env, span, _trace, &block|
-              trace(env, span, env.args.first, block)
-            end
-            Datadog::Tracing.trace_method(
-              Ext::SPAN_ASYNC_EXEC_PARAMS,
-              'PG::Connection#async_exec_params',
-              { type: Tracing::Metadata::Ext::SQL::TYPE }
-            ).around do |env, span, _trace, &block|
-              trace(env, span, env.args.first, block)
-            end
-            Datadog::Tracing.trace_method(
-              Ext::SPAN_ASYNC_EXEC_PREPARED,
-              'PG::Connection#async_exec_prepared',
-              { type: Tracing::Metadata::Ext::SQL::TYPE }
-            ).around do |env, span, _trace, &block|
-              trace(env, span, env.args.first, block)
-            end
-            Datadog::Tracing.trace_method(
-              Ext::SPAN_SYNC_EXEC,
-              'PG::Connection#sync_exec',
-              { type: Tracing::Metadata::Ext::SQL::TYPE }
-            ).around do |env, span, _trace, &block|
-              trace(env, span, env.args.first, block)
-            end
-            Datadog::Tracing.trace_method(
-              Ext::SPAN_SYNC_EXEC_PARAMS,
-              'PG::Connection#sync_exec_params',
-              { type: Tracing::Metadata::Ext::SQL::TYPE }
-            ).around do |env, span, _trace, &block|
-              trace(env, span, env.args.first, block)
-            end
-            Datadog::Tracing.trace_method(
-              Ext::SPAN_SYNC_EXEC_PREPARED,
-              'PG::Connection#sync_exec_prepared',
-              { type: Tracing::Metadata::Ext::SQL::TYPE }
-            ).around do |env, span, _trace, &block|
-              trace(env, span, env.args.first, block)
+            instrumentation_points = [
+              [Ext::SPAN_EXEC, 'PG::Connection#exec'],
+              [Ext::SPAN_EXEC_PARAMS, 'PG::Connection#exec_params'],
+              [Ext::SPAN_EXEC_PREPARED, 'PG::Connection#exec_prepared'],
+              [Ext::SPAN_ASYNC_EXEC, 'PG::Connection#async_exec'],
+              [Ext::SPAN_ASYNC_EXEC_PARAMS, 'PG::Connection#async_exec_params'],
+              [Ext::SPAN_ASYNC_EXEC_PREPARED, 'PG::Connection#async_exec_prepared'],
+              [Ext::SPAN_SYNC_EXEC, 'PG::Connection#sync_exec'],
+              [Ext::SPAN_SYNC_EXEC_PARAMS, 'PG::Connection#sync_exec_params'],
+              [Ext::SPAN_SYNC_EXEC_PREPARED, 'PG::Connection#sync_exec_prepared']
+            ]
+
+            instrumentation_points.each do |name, target|
+              Datadog::Tracing.trace_method(
+                name,
+                target,
+                { type: Tracing::Metadata::Ext::SQL::TYPE }
+              ).around do |env, span, _trace, &block|
+                trace(env, span, env.args.first, block)
+              end
             end
           end
 

--- a/lib/datadog/tracing/contrib/pg/patcher.rb
+++ b/lib/datadog/tracing/contrib/pg/patcher.rb
@@ -37,8 +37,8 @@ module Datadog
 
             instrumentation_points.each do |name, target|
               Datadog::Tracing.trace_method(
-                name,
                 target,
+                name,
                 { type: Tracing::Metadata::Ext::SQL::TYPE }
               ).around do |env, span, _trace, &block|
                 service = Datadog.configuration_for(env.self, :service_name) || datadog_configuration[:service_name]

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -305,8 +305,8 @@ module Datadog
       # @param [String] target Defines the method to be traced
       # @param [Hash] span_options Optional value to be added to the produced span
       # @return [Datadog::Tracing::Contrib::Hook] The newly defined Datadog::Tracing::Contrib::Hook object
-      def trace_method(name, target, span_options = {})
-        trace_hook = Datadog::Tracing::Contrib::Hook.new(name, target, span_options)
+      def trace_method(target, name, span_options = {})
+        trace_hook = Datadog::Tracing::Contrib::Hook.new(target, name, span_options)
         trace_hook.inject!
         trace_hook
       end

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 require_relative '../core'
 require_relative '../core/environment/ext'

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -4,6 +4,7 @@ require_relative '../core'
 require_relative '../core/environment/ext'
 require_relative '../core/environment/socket'
 
+require_relative 'contrib/hook'
 require_relative 'correlation'
 require_relative 'event'
 require_relative 'flush'
@@ -296,6 +297,18 @@ module Datadog
         return unless @enabled
 
         @writer.stop if @writer
+      end
+
+      # Setup a Datadog::Tracing::Contrib::Hook object to trace a method.
+      #
+      # @param [String] name Defines the name of the span
+      # @param [String] target Defines the method to be traced
+      # @param [Hash] span_options Optional value to be added to the produced span
+      # @return [Datadog::Tracing::Contrib::Hook] The newly defined Datadog::Tracing::Contrib::Hook object
+      def trace_method(name, target, span_options = {})
+        trace_hook = Datadog::Tracing::Contrib::Hook.new(name, target, span_options)
+        trace_hook.inject!
+        trace_hook
       end
 
       private

--- a/spec/datadog/tracing/contrib/hook_spec.rb
+++ b/spec/datadog/tracing/contrib/hook_spec.rb
@@ -1,0 +1,68 @@
+# typed: false
+
+require 'datadog/tracing/contrib/hook'
+
+require 'ddtrace'
+
+RSpec.describe Datadog::Tracing::Contrib::Hook do
+  subject(:hook) { described_class.new(name, target, span_options) }
+
+  let(:name) { 'test_span' }
+  let(:target) { 'Target#method' }
+  let(:span_options) { {} }
+
+  describe '#initialize' do
+    it do
+      is_expected.to have_attributes(
+        name: name,
+        target: target,
+        span_options: span_options
+      )
+    end
+
+    context 'when span_options not provided' do
+      subject(:hook) { described_class.new(name, target) }
+      it do
+        is_expected.to have_attributes(
+          name: name,
+          target: target,
+          span_options: {}
+        )
+      end
+
+      it { is_expected.to be_a_kind_of(described_class) }
+    end
+  end
+
+  describe '#inject!' do
+    subject(:inject!) { hook.inject! }
+
+    it do
+      inject!
+
+      expect(hook).to have_attributes(hook: be_a_kind_of(Datadog::Instrumentation::Hook))
+    end
+  end
+
+  describe '#around' do
+    subject(:around) { hook.around(&block) }
+    let(:block) { nil }
+
+    it { is_expected.to be_a_kind_of(described_class) }
+
+    it do
+      around
+      expect(hook).to have_attributes(around_block: block)
+    end
+  end
+
+  describe '::Env' do
+    subject(:env) { Datadog::Tracing::Contrib::Hook::Env.new(env_hash) }
+    let(:env_hash) { { self: self_instance, args: args, kwargs: kwargs } }
+    let(:self_instance) { double('self') }
+    let(:args) { double('args') }
+    let(:kwargs) { double('kwargs') }
+
+    it { is_expected.to have_attributes(self: self_instance, args: args, kwargs: kwargs) }
+  end
+end

--- a/spec/datadog/tracing/contrib/hook_spec.rb
+++ b/spec/datadog/tracing/contrib/hook_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Datadog::Tracing::Contrib::Hook do
       inject!
 
       expect(hook).to have_attributes(hook: be_a_kind_of(Datadog::Instrumentation::Hook))
+      expect(hook.hook.point.to_s).to eq(target)
     end
   end
 

--- a/spec/datadog/tracing/contrib/hook_spec.rb
+++ b/spec/datadog/tracing/contrib/hook_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require 'datadog/tracing/contrib/hook'
 

--- a/spec/datadog/tracing/contrib/hook_spec.rb
+++ b/spec/datadog/tracing/contrib/hook_spec.rb
@@ -45,6 +45,40 @@ RSpec.describe Datadog::Tracing::Contrib::Hook do
     end
   end
 
+  describe '#invoke' do
+    subject(:invoke) { hook.invoke(stack, env) }
+    let(:stack) { double('stack') }
+    let(:env) { double('env') }
+    let(:return_object) { double('return') }
+
+    before do
+      allow(stack).to receive(:call).and_return({ return: return_object })
+      allow(env).to receive(:[]).and_return(double('attr'))
+    end
+
+    context 'when around block provided' do
+      let(:block) { proc { |_env, _span, _trace, &block| block.call } }
+
+      before do
+        hook.around(&block)
+      end
+
+      it do
+        res = invoke
+        expect(stack).to have_received(:call).with(env)
+        expect(res).to be(return_object)
+      end
+    end
+
+    context 'when around block not provided' do
+      it do
+        res = invoke
+        expect(stack).to have_received(:call).with(env)
+        expect(res).to be(return_object)
+      end
+    end
+  end
+
   describe '#around' do
     subject(:around) { hook.around(&block) }
     let(:block) { nil }

--- a/spec/datadog/tracing/contrib/hook_spec.rb
+++ b/spec/datadog/tracing/contrib/hook_spec.rb
@@ -91,6 +91,30 @@ RSpec.describe Datadog::Tracing::Contrib::Hook do
     end
   end
 
+  describe '#disable!' do
+    subject(:disable!) { hook.disable! }
+
+    before do
+      hook.inject!
+    end
+
+    it do
+      expect { disable! }.to change { hook.disabled? }.from(false).to(true)
+    end
+  end
+
+  describe '#enable!' do
+    subject(:enable!) { hook.enable! }
+
+    before do
+      hook.inject!
+    end
+
+    it do
+      expect { enable! }.to change { hook.disabled? }.to(false)
+    end
+  end
+
   describe '::Env' do
     subject(:env) { Datadog::Tracing::Contrib::Hook::Env.new(env_hash) }
     let(:env_hash) { { self: self_instance, args: args, kwargs: kwargs } }

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require 'spec_helper'
 

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -942,7 +942,7 @@ RSpec.describe Datadog::Tracing::Tracer do
   end
 
   describe '#trace_method' do
-    subject(:trace_method) { tracer.trace_method(name, target, span_options) }
+    subject(:trace_method) { tracer.trace_method(target, name, span_options) }
     let(:name) { 'test_span' }
     let(:target) { 'Target#method' }
     let(:span_options) { {} }

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -940,6 +940,29 @@ RSpec.describe Datadog::Tracing::Tracer do
       end
     end
   end
+
+  describe '#trace_method' do
+    subject(:trace_method) { tracer.trace_method(name, target, span_options) }
+    let(:name) { 'test_span' }
+    let(:target) { 'Target#method' }
+    let(:span_options) { {} }
+
+    it { is_expected.to be_a_kind_of(Datadog::Tracing::Contrib::Hook) }
+    it { is_expected.to have_attributes(name: name, target: target, span_options: span_options) }
+
+    context 'when called' do
+      let(:hook) { double('hook', :inject! => nil) }
+
+      before do
+        allow(Datadog::Tracing::Contrib::Hook).to receive(:new).and_return(hook)
+      end
+
+      it do
+        trace_method
+        expect(hook).to have_received(:inject!)
+      end
+    end
+  end
 end
 
 RSpec.describe Datadog::Tracing::Tracer::TraceCompleted do

--- a/spec/datadog/tracing_spec.rb
+++ b/spec/datadog/tracing_spec.rb
@@ -153,4 +153,17 @@ RSpec.describe Datadog::Tracing do
       enabled?
     end
   end
+
+  describe '.trace_method' do
+    subject(:trace_method) { described_class.trace_method(name, target, span_options) }
+    let(:name) { double('name') }
+    let(:target) { double('target') }
+    let(:span_options) { { resource: double('option') } }
+
+    it 'delegates to the tracer' do
+      expect(Datadog.send(:components).tracer).to receive(:trace_method)
+        .with(name, target, span_options).and_return(returned)
+      expect(trace_method).to eq(returned)
+    end
+  end
 end

--- a/spec/datadog/tracing_spec.rb
+++ b/spec/datadog/tracing_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Datadog::Tracing do
 
     it 'delegates to the tracer' do
       expect(Datadog.send(:components).tracer).to receive(:trace_method)
-        .with(name, target, span_options).and_return(returned)
+        .with(target, name, span_options).and_return(returned)
       expect(trace_method).to eq(returned)
     end
   end

--- a/spec/datadog/tracing_spec.rb
+++ b/spec/datadog/tracing_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Datadog::Tracing do
   end
 
   describe '.trace_method' do
-    subject(:trace_method) { described_class.trace_method(name, target, span_options) }
+    subject(:trace_method) { described_class.trace_method(target, name, span_options) }
     let(:name) { double('name') }
     let(:target) { double('target') }
     let(:span_options) { { resource: double('option') } }


### PR DESCRIPTION
WIP: still debugging why the system tests are failing on this branch. Instrumentation API also does not support ruby `3.2` at the moment.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR adds a method tracing API that can be used by:
1. Customers tracing their own code
2. Customers looking to trace code from gems we don't yet instrument
3. Us when developing new integrations

**Motivation**
<!-- What inspired you to submit this pull request? -->
Method tracing has been requested for a long time by the community. This implementation makes use of [the instrumentation API](https://github.com/DataDog/datadog-instrumentation-ruby) to provide users with an easy interface to implement custom instrumentation.

**Additional Notes**
<!-- Anything else we should know when reviewing? -->
The number of changed files is inflated because of the changes to the gemfile.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Unit tests have been added to test the changes. `pg` and `mysql2` instrumentation was modified as a POC that the API works (the original instrumentation code is not deleted in this branch).