### PR TITLE
Faraday middleware uses HttpAnnotationHelper

### DIFF
--- a/lib/datadog/tracing/contrib/faraday/middleware.rb
+++ b/lib/datadog/tracing/contrib/faraday/middleware.rb
@@ -39,8 +39,7 @@ module Datadog
 
           def annotate!(span, env, options)
             span.resource = resource_name(env)
-            service_name(env[:url].host, options)
-            span.service = options[:split_by_domain] ? env[:url].host : options[:service_name]
+            span.service = service_name(env[:url].host, options)
             span.span_type = Tracing::Metadata::Ext::HTTP::TYPE_OUTBOUND
 
             span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)


### PR DESCRIPTION
`service_name(env[:url].host, options)` was called but the result was not used.

**What does this PR do?**

Fixes a bug where faraday middleware duplicates `HttpAnnotationHelper` logic.

**Motivation**

I have a patched version of `HttpAnnotationHelper` logic which allows combining `service_name` and `split_by_domain` together as currently they are exclusive. However, I noticed that this update logic is not applied automatically to requests made by faraday library.

**How to test the change?**

This change does not modify existing library behavior, it only removes duplication so that future changes to `HttpAnnotationHelper` are by automatically used across all http tracing libraries, including faraday.