### PR TITLE
Restrain redis 5 version for known compatibility issue

### DIFF
--- a/integration/apps/rack/Gemfile
+++ b/integration/apps/rack/Gemfile
@@ -8,7 +8,8 @@ gem 'rack'
 if RUBY_VERSION < '2.3'
   gem 'redis', '< 4.1.1' # 4.1.1 "claims" to support 2.2 but is actually broken
 else
-  gem 'redis'
+  # Known compatibility issue: https://github.com/redis/redis-rb/issues/1142
+  gem 'redis', '< 5'
 end
 if RUBY_VERSION < '2.2'
   gem 'sidekiq', '< 5' # 5.0.3 checks for older Rubies and breaks, but does not declare it on the gemspec :(

--- a/integration/apps/rails-five/Gemfile
+++ b/integration/apps/rails-five/Gemfile
@@ -68,7 +68,8 @@ gem 'ipaddress'
 gem 'rabl', platform: :ruby
 gem 'rack-cors'
 gem 'rake'
-gem 'redis'
+# Known compatibility issue: https://github.com/redis/redis-rb/issues/1142
+gem 'redis', '< 5'
 gem 'resque'
 # gem 'resque-pool' # Incompatible with Redis 4.0+
 gem 'resque-scheduler'

--- a/integration/apps/rails-seven/Gemfile
+++ b/integration/apps/rails-seven/Gemfile
@@ -86,7 +86,8 @@ gem 'aws-sdk'
 gem 'devise'
 gem 'httparty'
 gem 'mysql2'
-gem 'redis'
+# Known compatibility issue: https://github.com/redis/redis-rb/issues/1142
+gem 'redis', '< 5'
 gem 'resque'
 gem 'unicorn'
 

--- a/integration/apps/rails-six/Gemfile
+++ b/integration/apps/rails-six/Gemfile
@@ -63,7 +63,8 @@ gem 'ipaddress'
 gem 'rabl', platform: :ruby
 gem 'rack-cors'
 gem 'rake'
-gem 'redis'
+# Known compatibility issue: https://github.com/redis/redis-rb/issues/1142
+gem 'redis', '< 5'
 gem 'resque'
 # gem 'resque-pool' # Incompatible with Redis 4.0+
 gem 'resque-scheduler'


### PR DESCRIPTION
**What does this PR do?**

Do not use redis 5 for integration test

**Motivation**

Fix CI breaking version on redis 5

https://github.com/redis/redis-rb/issues/1142#issue-1354572770
https://github.com/resque/resque/issues/1821
https://github.com/resque/resque/pull/1823