### PR TITLE
Add http.useragent tag

### DIFF
--- a/lib/datadog/tracing/metadata/ext.rb
+++ b/lib/datadog/tracing/metadata/ext.rb
@@ -63,12 +63,14 @@ module Datadog
           TAG_BASE_URL = 'http.base_url'
           TAG_METHOD = 'http.method'
           TAG_STATUS_CODE = 'http.status_code'
+          TAG_USER_AGENT = 'http.useragent'
           TAG_URL = 'http.url'
           TYPE_INBOUND = AppTypes::TYPE_WEB.freeze
           TYPE_OUTBOUND = 'http'
           TYPE_PROXY = 'proxy'
           TYPE_TEMPLATE = 'template'
           TAG_CLIENT_IP = 'http.client_ip'
+          HEADER_USER_AGENT = 'User-Agent'
 
           # General header functionality
           module Headers

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -685,6 +685,48 @@ RSpec.describe 'Rack integration tests' do
         end
 
         describe 'GET request' do
+          context 'that does not sent user agent' do
+            subject(:response) { get '/headers/', {}, headers }
+
+            let(:headers) do
+              {}
+            end
+
+            before do
+              is_expected.to be_ok
+              expect(spans).to have(1).items
+            end
+
+            it_behaves_like 'a rack GET 200 span'
+
+            it do
+              expect(span.get_tag('http.useragent')).to be nil
+              expect(span.get_tag('http.request.headers.user-agent')).to be nil
+            end
+          end
+
+          context 'that sends user agent' do
+            subject(:response) { get '/headers/', {}, headers }
+
+            let(:headers) do
+              {
+                'HTTP_USER_AGENT' => 'SuperUserAgent',
+              }
+            end
+
+            before do
+              is_expected.to be_ok
+              expect(spans).to have(1).items
+            end
+
+            it_behaves_like 'a rack GET 200 span'
+
+            it do
+              expect(span.get_tag('http.useragent')).to eq('SuperUserAgent')
+              expect(span.get_tag('http.request.headers.user-agent')).to be nil
+            end
+          end
+
           context 'that sends headers' do
             subject(:response) { get '/headers/', {}, headers }
 


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Add `http.useragent` tag to capture and report the user agent that made an HTTP request to Rack-based applications.

**Motivation**

While User-Agent is a header and can be included in the http.request_headers tag, it is not by default, and even if it were it could be removed from the list by the user.

This unconditionally obtains the request header value and stores it in a dedicated tag.

**Additional Notes**

This is a requirement for server-side ASM and is part of the APM tag standardization project. 

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
