### PR TITLE
Correctly extract commit message from AppVeyor

### DIFF
--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -97,6 +97,14 @@ module Datadog
             tag = env['APPVEYOR_REPO_TAG_NAME']
           end
 
+          commit_message = env['APPVEYOR_REPO_COMMIT_MESSAGE']
+          if commit_message
+            extended = env['APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED']
+            if extended
+              commit_message += "\n" + extended
+            end
+          end
+
           {
             TAG_PROVIDER_NAME => 'appveyor',
             Core::Git::Ext::TAG_REPOSITORY_URL => repository,
@@ -111,7 +119,7 @@ module Datadog
             Core::Git::Ext::TAG_TAG => tag,
             Core::Git::Ext::TAG_COMMIT_AUTHOR_NAME => env['APPVEYOR_REPO_COMMIT_AUTHOR'],
             Core::Git::Ext::TAG_COMMIT_AUTHOR_EMAIL => env['APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL'],
-            Core::Git::Ext::TAG_COMMIT_MESSAGE => env['APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED']
+            Core::Git::Ext::TAG_COMMIT_MESSAGE => commit_message
           }
         end
 

--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -100,9 +100,7 @@ module Datadog
           commit_message = env['APPVEYOR_REPO_COMMIT_MESSAGE']
           if commit_message
             extended = env['APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED']
-            if extended
-              commit_message += "\n" + extended
-            end
+            commit_message = "#{commit_message}\n#{extended}" if extended
           end
 
           {

--- a/spec/datadog/ci/ext/fixtures/ci/appveyor.json
+++ b/spec/datadog/ci/ext/fixtures/ci/appveyor.json
@@ -9,7 +9,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -24,7 +25,7 @@
       "git.branch": "master",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message",
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
       "git.commit.sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
@@ -39,7 +40,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -69,7 +70,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -99,7 +100,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -129,7 +130,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github",
       "HOME": "/not-my-home",
@@ -161,7 +162,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -191,7 +192,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github",
       "HOME": "/not-my-home",
@@ -223,7 +224,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name"
     },
     {
@@ -249,7 +250,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -279,7 +280,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -309,7 +310,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -340,7 +341,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -371,7 +372,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -401,7 +402,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github",
       "APPVEYOR_REPO_TAG_NAME": "origin/tags/0.1.0"
@@ -432,7 +433,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github",
       "APPVEYOR_REPO_TAG_NAME": "refs/heads/tags/0.1.0"
@@ -461,7 +462,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "DD_GIT_BRANCH": "user-supplied-branch",
       "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
@@ -501,7 +502,7 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
       "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",


### PR DESCRIPTION
**What does this PR do?**
Fixes getting the full commit message when running on the AppVeyor CI.

**Motivation**
Previously we were only checking `APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED` which, [as per the docs](https://www.appveyor.com/docs/environment-variables/) only contains the "rest" of the commit message. The first line of the commit message is in `APPVEYOR_REPO_COMMIT_MESSAGE`.

**How to test the change?**
Updated appveyor fixture.