### PR TITLE
CI: Fetch committer and author in Bitrise

### DIFF
--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -330,6 +330,10 @@ module Datadog
           branch = (
             env['BITRISEIO_GIT_BRANCH_DEST'] || env['BITRISE_GIT_BRANCH']
           )
+          commiter_email = (
+            env['GIT_CLONE_COMMIT_COMMITER_EMAIL'] || env['GIT_CLONE_COMMIT_COMMITER_NAME']
+          )
+
           {
             TAG_PROVIDER_NAME => 'bitrise',
             TAG_PIPELINE_ID => env['BITRISE_BUILD_SLUG'],
@@ -341,7 +345,11 @@ module Datadog
             Core::Git::Ext::TAG_COMMIT_SHA => commit,
             Core::Git::Ext::TAG_BRANCH => branch,
             Core::Git::Ext::TAG_TAG => env['BITRISE_GIT_TAG'],
-            Core::Git::Ext::TAG_COMMIT_MESSAGE => env['BITRISE_GIT_MESSAGE']
+            Core::Git::Ext::TAG_COMMIT_MESSAGE => env['BITRISE_GIT_MESSAGE'],
+            Core::Git::Ext::TAG_COMMIT_AUTHOR_NAME => env['GIT_CLONE_COMMIT_AUTHOR_NAME'],
+            Core::Git::Ext::TAG_COMMIT_AUTHOR_EMAIL => env['GIT_CLONE_COMMIT_AUTHOR_EMAIL'],
+            Core::Git::Ext::TAG_COMMIT_COMMITTER_NAME => env['GIT_CLONE_COMMIT_COMMITER_NAME'],
+            Core::Git::Ext::TAG_COMMIT_COMMITTER_EMAIL => commiter_email
           }
         end
 


### PR DESCRIPTION
**What does this PR do?**
Reads committer and author info from the env vars set by the CI provider.

Other tracers always set `TAG_COMMIT_COMMITTER_EMAIL` to the committer name. However there's a committer email variable we can use. I assume this was a typo that propagated from the spec to all tracers, so I've changed the spec to say we should use the email and fallback to the name if not available (just in case the spec was intentional because the email is not always available).


**Motivation**
These are in the CI spec but were missing from this tracer.
