### PR TITLE
chore:Satisfy new Rack linter middleware

### DIFF
--- a/integration/apps/rack/Gemfile
+++ b/integration/apps/rack/Gemfile
@@ -5,6 +5,8 @@ source "https://rubygems.org"
 gem 'puma'
 gem 'unicorn'
 gem 'rack'
+gem 'rackup' if RUBY_VERSION >= '2.4'  # The `rackup` is its own gem since Rack 3.0
+
 if RUBY_VERSION < '2.3'
   gem 'redis', '< 4.1.1' # 4.1.1 "claims" to support 2.2 but is actually broken
 else

--- a/integration/apps/rack/app/acme.rb
+++ b/integration/apps/rack/app/acme.rb
@@ -54,11 +54,11 @@ module Acme
     end
 
     def not_found(request)
-      [404, { 'Content-Type' => 'text/plain' }, ["404 Not Found: #{request.path}"]]
+      [404, { 'content-type' => 'text/plain' }, ["404 Not Found: #{request.path}"]]
     end
 
     def application_error(request, error)
-      [500, { 'Content-Type' => 'text/plain' }, ["500 Application Error: #{error.class.name} #{error.message} Location: #{error.backtrace.first(3)}"]]
+      [500, { 'content-type' => 'text/plain' }, ["500 Application Error: #{error.class.name} #{error.message} Location: #{error.backtrace.first(3)}"]]
     end
   end
 
@@ -67,11 +67,11 @@ module Acme
       def fibonacci(request)
         n = rand(25..35)
         result = fib(n)
-        [200, { 'Content-Type' => 'text/plain' }, ["Basic: Fibonacci(#{n}): #{result}"]]
+        [200, { 'content-type' => 'text/plain' }, ["Basic: Fibonacci(#{n}): #{result}"]]
       end
 
       def default(request)
-        [200, { 'Content-Type' => 'text/plain' }, ["Basic: Default", "\nWebserver process: #{$PROGRAM_NAME}"]]
+        [200, { 'content-type' => 'text/plain' }, ["Basic: Default", "\nWebserver process: #{$PROGRAM_NAME}"]]
       end
 
       private
@@ -87,7 +87,7 @@ module Acme
       end
 
       def detailed_check(request)
-        [200, { 'Content-Type' => 'application/json'}, [JSON.pretty_generate(
+        [200, { 'content-type' => 'application/json'}, [JSON.pretty_generate(
           webserver_process: $PROGRAM_NAME,
           profiler_available: Datadog::Profiling.start_if_enabled,
           # NOTE: Threads can't be named on Ruby 2.1 and 2.2
@@ -98,7 +98,7 @@ module Acme
 
     class BackgroundJobs
       def read_sidekiq(request)
-        [200, { 'Content-Type' => 'application/json' }, [SidekiqBackgroundJob.read(request.params.fetch('key')).to_s, "\n"]]
+        [200, { 'content-type' => 'application/json' }, [SidekiqBackgroundJob.read(request.params.fetch('key')).to_s, "\n"]]
       end
 
       def write_sidekiq(request)
@@ -108,7 +108,7 @@ module Acme
       end
 
       def read_resque(request)
-        [200, { 'Content-Type' => 'application/json' }, [ResqueBackgroundJob.read(request.params.fetch('key')).to_s, "\n"]]
+        [200, { 'content-type' => 'application/json' }, [ResqueBackgroundJob.read(request.params.fetch('key')).to_s, "\n"]]
       end
 
       def write_resque(request)

--- a/integration/apps/rack/app/acme.rb
+++ b/integration/apps/rack/app/acme.rb
@@ -67,11 +67,11 @@ module Acme
       def fibonacci(request)
         n = rand(25..35)
         result = fib(n)
-        ['200', { 'Content-Type' => 'text/plain' }, ["Basic: Fibonacci(#{n}): #{result}"]]
+        [200, { 'Content-Type' => 'text/plain' }, ["Basic: Fibonacci(#{n}): #{result}"]]
       end
 
       def default(request)
-        ['200', { 'Content-Type' => 'text/plain' }, ["Basic: Default", "\nWebserver process: #{$PROGRAM_NAME}"]]
+        [200, { 'Content-Type' => 'text/plain' }, ["Basic: Default", "\nWebserver process: #{$PROGRAM_NAME}"]]
       end
 
       private
@@ -83,11 +83,11 @@ module Acme
 
     class Health
       def check(request)
-        ['204', {}, []]
+        [204, {}, []]
       end
 
       def detailed_check(request)
-        ['200', { 'Content-Type' => 'application/json'}, [JSON.pretty_generate(
+        [200, { 'Content-Type' => 'application/json'}, [JSON.pretty_generate(
           webserver_process: $PROGRAM_NAME,
           profiler_available: Datadog::Profiling.start_if_enabled,
           # NOTE: Threads can't be named on Ruby 2.1 and 2.2
@@ -98,23 +98,23 @@ module Acme
 
     class BackgroundJobs
       def read_sidekiq(request)
-        ['200', { 'Content-Type' => 'application/json' }, [SidekiqBackgroundJob.read(request.params.fetch('key')).to_s, "\n"]]
+        [200, { 'Content-Type' => 'application/json' }, [SidekiqBackgroundJob.read(request.params.fetch('key')).to_s, "\n"]]
       end
 
       def write_sidekiq(request)
         SidekiqBackgroundJob.async_write(request.params.fetch('key'), request.params.fetch('value'))
 
-        ['202', {}, []]
+        [202, {}, []]
       end
 
       def read_resque(request)
-        ['200', { 'Content-Type' => 'application/json' }, [ResqueBackgroundJob.read(request.params.fetch('key')).to_s, "\n"]]
+        [200, { 'Content-Type' => 'application/json' }, [ResqueBackgroundJob.read(request.params.fetch('key')).to_s, "\n"]]
       end
 
       def write_resque(request)
         ResqueBackgroundJob.async_write(request.params.fetch('key'), request.params.fetch('value'))
 
-        ['202', {}, []]
+        [202, {}, []]
       end
     end
   end

--- a/integration/apps/sinatra2-classic/app/acme.rb
+++ b/integration/apps/sinatra2-classic/app/acme.rb
@@ -33,7 +33,7 @@ end
 get '/health/detailed' do
   [
     200,
-    { 'Content-Type' => 'application/json' },
+    { 'content-type' => 'application/json' },
     JSON.generate(
       webserver_process: $PROGRAM_NAME,
       profiler_available: Datadog::Profiling.start_if_enabled,
@@ -57,7 +57,7 @@ get '/basic/fibonacci' do
 
   [
     200,
-    { 'Content-Type' => 'text/plain' },
+    { 'content-type' => 'text/plain' },
     ["Basic: Fibonacci(#{n}): #{result}"]
   ]
 end

--- a/integration/apps/sinatra2-modular/app/basic.rb
+++ b/integration/apps/sinatra2-modular/app/basic.rb
@@ -14,7 +14,7 @@ class Basic < Sinatra::Base
 
     [
       200,
-      { 'Content-Type' => 'text/plain' },
+      { 'content-type' => 'text/plain' },
       ["Basic: Fibonacci(#{n}): #{result}"]
     ]
   end

--- a/integration/apps/sinatra2-modular/app/health.rb
+++ b/integration/apps/sinatra2-modular/app/health.rb
@@ -11,7 +11,7 @@ class Health < Sinatra::Base
   get '/health/detailed' do
     [
       200,
-      { 'Content-Type' => 'application/json' },
+      { 'content-type' => 'application/json' },
       JSON.generate(
         webserver_process: $PROGRAM_NAME,
         profiler_available: Datadog::Profiling.start_if_enabled,


### PR DESCRIPTION
We've started getting this issue in CI:
```
Rack::Lint::LintError: Status must be an Integer >=100
```

And that's because we've been returning the status code in Rack apps as strings, not integers. A new version of Rack now checks for that, a few more things in the `Lint` middleware: https://github.com/rack/rack/blob/main/lib/rack/lint.rb

This PR solves that.