### PR TITLE
WIP:Report correct ActiveSupport cache backend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,11 @@ if RUBY_VERSION >= '2.4.0' && (RUBY_PLATFORM =~ /^x86_64-(darwin|linux)/)
   gem 'sorbet', '= 0.5.9672'
   gem 'spoom', '~> 1.1'
 end
+
+gem 'rails', '~> 6.1.0'
+gem 'pg', '>= 1.1', platform: :ruby
+gem 'activerecord-jdbcpostgresql-adapter', '>= 61', platform: :jruby
+gem 'sidekiq', '>= 6.1.2'
+gem 'sprockets', '< 4'
+gem 'lograge', '~> 0.11'
+gem 'i18n', '1.8.7', platform: :jruby # Removal pending: https://github.com/ruby-i18n/i18n/issues/555#issuecomment-772112169

--- a/lib/datadog/core/utils.rb
+++ b/lib/datadog/core/utils.rb
@@ -110,6 +110,36 @@ module Datadog
 
         [match[1], match[2].to_i]
       end
+
+      # Remove the prefixed module names from `Class#name` or `Module#name`.
+      # @example
+      #  `App::Api::User` returns `User`.
+      # @param [String] class_name the result from a `Class#name` or `Module#name` call
+      # @return [String] the class or module name without its enclosing modules
+      def self.extract_class_name(class_name)
+        if idx = class_name.rindex("::")
+          class_name[(idx + 2)..-1]
+        else
+          class_name
+        end
+      end
+
+      # Converts CamelCase strings to snake_case.
+      # @example
+      #  `MyClass` returns `my_class`.
+      # @param [String] string a CamelCase string
+      # @return [String] the snake_case version of the provided string
+      def self.camel_to_snake_case(string)
+        first_letter = true
+        string.gsub(/[A-Z]/) { |upcase_char|
+          if first_letter # Don't add `_` at the beginning of the string.
+            first_letter = false
+            upcase_char.downcase
+          else
+            "_#{upcase_char.downcase}"
+          end
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
Solves #1252

We currently report the globally configured `Rails.configuration.cache_store` as the cache backend tag (`rails.cache.backend`) regardless if the instrumented ActiveSupport cache object is actually the global `cache_store`.

This causes applications with multiple caching backends to incorrectly always report `Rails.configuration.cache_store` as the backend of all cache clients.

This PR now reports the respective client for the instrument ActiveSupport cache object. Current users should see no change, as the tag value is kept backwards compatible for Rails applications using only the global `cache_store` object.

Users with multiple cache backends will now see them correctly reported in the `rails.cache.backend` span tag.