### PR TITLE
test:Fix flaky time in test

### DIFF
--- a/spec/datadog/core/telemetry/collector_spec.rb
+++ b/spec/datadog/core/telemetry/collector_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe Datadog::Core::Telemetry::Collector do
     subject(:tracer_time) { dummy_class.tracer_time }
 
     before do
-      allow(Time).to receive(:now).and_return(Time.new(2020))
+      allow(Time).to receive(:now).and_return(Time.utc(1577836800))
     end
 
     it { is_expected.to be_a_kind_of(Integer) }

--- a/spec/datadog/core/telemetry/collector_spec.rb
+++ b/spec/datadog/core/telemetry/collector_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe Datadog::Core::Telemetry::Collector do
     subject(:tracer_time) { dummy_class.tracer_time }
 
     before do
-      allow(Time).to receive(:now).and_return(Time.utc(1577836800))
+      allow(Time).to receive(:now).and_return(Time.at(1577836800))
     end
 
     it { is_expected.to be_a_kind_of(Integer) }


### PR DESCRIPTION
`Time.new(2020).to_i` returns different values depending on the local time zone. This breaks the assertion `is_expected.to eq(1577836800)`.

This PR makes it return the same epoch on regardless of the system timezone.