### PR TITLE
Sampling-Propagation:Extract/Inject distributed headers

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -687,6 +687,19 @@ module Datadog
               o.lazy
             end
           end
+
+          # Maximum size for the `x-datadog-tags` distributed trace tags header.
+          #
+          # If the serialized size of distributed trace tags is larger than this value, it will
+          # not be parsed if incoming, nor exported if outgoing. An error message will be logged
+          # in this case.
+          #
+          # @default `DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH` environment variable, otherwise `512`
+          # @return [Integer]
+          option :x_datadog_tags_max_length do |o|
+            o.default { env_to_int(Tracing::Configuration::Ext::Distributed::ENV_X_DATADOG_TAGS_MAX_LENGTH, 512) }
+            o.lazy
+          end
         end
 
         # The `version` tag in Datadog. Use it to enable [Deployment Tracking](https://docs.datadoghq.com/tracing/deployment_tracking/).

--- a/lib/datadog/tracing/configuration/ext.rb
+++ b/lib/datadog/tracing/configuration/ext.rb
@@ -21,6 +21,7 @@ module Datadog
           PROPAGATION_STYLE_B3_SINGLE_HEADER = 'B3 single header'.freeze
           ENV_PROPAGATION_STYLE_INJECT = 'DD_PROPAGATION_STYLE_INJECT'.freeze
           ENV_PROPAGATION_STYLE_EXTRACT = 'DD_PROPAGATION_STYLE_EXTRACT'.freeze
+          ENV_X_DATADOG_TAGS_MAX_LENGTH = 'DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH'.freeze
         end
 
         # @public_api

--- a/lib/datadog/tracing/distributed/headers/datadog.rb
+++ b/lib/datadog/tracing/distributed/headers/datadog.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
 # typed: true
 
 require_relative 'parser'
 require_relative 'ext'
 require_relative '../../trace_digest'
+require_relative '../datadog_tags_codec'
 
 module Datadog
   module Tracing
@@ -10,40 +12,119 @@ module Datadog
       module Headers
         # Datadog provides helpers to inject or extract headers for Datadog style headers
         module Datadog
-          include Ext
+          class << self
+            include Ext
 
-          def self.inject!(digest, env)
-            return if digest.nil?
+            def inject!(digest, env)
+              return if digest.nil?
 
-            env[HTTP_HEADER_TRACE_ID] = digest.trace_id.to_s
-            env[HTTP_HEADER_PARENT_ID] = digest.span_id.to_s
-            env[HTTP_HEADER_SAMPLING_PRIORITY] = digest.trace_sampling_priority.to_s if digest.trace_sampling_priority
-            env[HTTP_HEADER_ORIGIN] = digest.trace_origin.to_s unless digest.trace_origin.nil?
+              env[HTTP_HEADER_TRACE_ID] = digest.trace_id.to_s
+              env[HTTP_HEADER_PARENT_ID] = digest.span_id.to_s
+              env[HTTP_HEADER_SAMPLING_PRIORITY] = digest.trace_sampling_priority.to_s if digest.trace_sampling_priority
+              env[HTTP_HEADER_ORIGIN] = digest.trace_origin.to_s unless digest.trace_origin.nil?
 
-            env
-          end
+              inject_tags(digest, env)
 
-          def self.extract(env)
-            # Extract values from headers
-            headers = Parser.new(env)
-            trace_id = headers.id(HTTP_HEADER_TRACE_ID)
-            parent_id = headers.id(HTTP_HEADER_PARENT_ID)
-            origin = headers.header(HTTP_HEADER_ORIGIN)
-            sampling_priority = headers.number(HTTP_HEADER_SAMPLING_PRIORITY)
+              env
+            end
 
-            # Return early if this propagation is not valid
-            # DEV: To be valid we need to have a trace id and a parent id
-            #      or when it is a synthetics trace, just the trace id.
-            # DEV: `Parser#id` will not return 0
-            return unless (trace_id && parent_id) || (origin && trace_id)
+            def extract(env)
+              # Extract values from headers
+              headers = Parser.new(env)
+              trace_id = headers.id(HTTP_HEADER_TRACE_ID)
+              parent_id = headers.id(HTTP_HEADER_PARENT_ID)
+              origin = headers.header(HTTP_HEADER_ORIGIN)
+              sampling_priority = headers.number(HTTP_HEADER_SAMPLING_PRIORITY)
 
-            # Return new trace headers
-            TraceDigest.new(
-              span_id: parent_id,
-              trace_id: trace_id,
-              trace_origin: origin,
-              trace_sampling_priority: sampling_priority
-            )
+              # Return early if this propagation is not valid
+              # DEV: To be valid we need to have a trace id and a parent id
+              #      or when it is a synthetics trace, just the trace id.
+              # DEV: `Parser#id` will not return 0
+              return unless (trace_id && parent_id) || (origin && trace_id)
+
+              trace_distributed_tags = extract_tags(headers)
+
+              # Return new trace headers
+              TraceDigest.new(
+                span_id: parent_id,
+                trace_id: trace_id,
+                trace_origin: origin,
+                trace_sampling_priority: sampling_priority,
+                trace_distributed_tags: trace_distributed_tags,
+              )
+            end
+
+            private
+
+            # Export trace distributed tags through the `x-datadog-tags` header.
+            def inject_tags(digest, env)
+              return if digest.trace_distributed_tags.nil? || digest.trace_distributed_tags.empty?
+
+              if ::Datadog.configuration.tracing.x_datadog_tags_max_length <= 0
+                active_trace = Tracing.active_trace
+                active_trace.set_tag('_dd.propagation_error', 'disabled') if active_trace
+                return
+              end
+
+              encoded_tags = DatadogTagsCodec.encode(digest.trace_distributed_tags)
+
+              if encoded_tags.size > ::Datadog.configuration.tracing.x_datadog_tags_max_length
+                active_trace = Tracing.active_trace
+                active_trace.set_tag('_dd.propagation_error', 'inject_max_size') if active_trace
+
+                ::Datadog.logger.warn(
+                  "Failed to inject x-datadog-tags: tags are too large (size:#{encoded_tags.size} " \
+                  "limit:#{::Datadog.configuration.tracing.x_datadog_tags_max_length}). This limit can be configured " \
+                  'through the DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH environment variable.'
+                )
+                return
+              end
+
+              env[HTTP_HEADER_TAGS] = encoded_tags
+            rescue => e
+              active_trace = Tracing.active_trace
+              active_trace.set_tag('_dd.propagation_error', 'encoding_error') if active_trace
+              ::Datadog.logger.warn(
+                "Failed to inject x-datadog-tags: #{e.class.name} #{e.message} at #{Array(e.backtrace).first}"
+              )
+            end
+
+            # Import `x-datadog-tags` header tags as trace distributed tags.
+            def extract_tags(headers)
+              tags_header = headers.header(HTTP_HEADER_TAGS)
+              return unless tags_header
+
+              if ::Datadog.configuration.tracing.x_datadog_tags_max_length <= 0
+                active_trace = Tracing.active_trace
+                active_trace.set_tag('_dd.propagation_error', 'disabled') if active_trace
+                return
+              end
+
+              if tags_header.size > ::Datadog.configuration.tracing.x_datadog_tags_max_length
+                active_trace = Tracing.active_trace
+                active_trace.set_tag('_dd.propagation_error', 'extract_max_size') if active_trace
+
+                ::Datadog.logger.warn(
+                  "Failed to extract x-datadog-tags: tags are too large (size:#{tags_header.size} " \
+                  "limit:#{::Datadog.configuration.tracing.x_datadog_tags_max_length}). This limit can be configured " \
+                  'through the DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH environment variable.'
+                )
+                return
+              end
+
+              tags = DatadogTagsCodec.decode(tags_header)
+              tags.select! { |key, _| key.start_with?(VALID_TAGS_KEY_PREFIX) }
+              tags
+            rescue => e
+              active_trace = Tracing.active_trace
+              active_trace.set_tag('_dd.propagation_error', 'decoding_error') if active_trace
+              ::Datadog.logger.warn(
+                "Failed to extract x-datadog-tags: #{e.class.name} #{e.message} at #{Array(e.backtrace).first}"
+              )
+            end
+
+            # Only extract keys with the expected Datadog prefix
+            VALID_TAGS_KEY_PREFIX = '_dd.p.'
           end
         end
       end

--- a/lib/datadog/tracing/distributed/headers/datadog.rb
+++ b/lib/datadog/tracing/distributed/headers/datadog.rb
@@ -3,6 +3,7 @@
 
 require_relative 'parser'
 require_relative 'ext'
+require_relative '../../metadata/ext'
 require_relative '../../trace_digest'
 require_relative '../datadog_tags_codec'
 
@@ -120,7 +121,7 @@ module Datadog
 
               tags = DatadogTagsCodec.decode(tags_header)
               # Only extract keys with the expected Datadog prefix
-              tags.select! { |key, _| key.start_with?(Metadata::Ext::Distributed::TAGS_PREFIX) }
+              tags.select! { |key, _| key.start_with?(Tracing::Metadata::Ext::Distributed::TAGS_PREFIX) }
               tags
             rescue => e
               active_trace = Tracing.active_trace

--- a/lib/datadog/tracing/distributed/headers/datadog.rb
+++ b/lib/datadog/tracing/distributed/headers/datadog.rb
@@ -57,6 +57,11 @@ module Datadog
             private
 
             # Export trace distributed tags through the `x-datadog-tags` header.
+            #
+            # DEV: This method accesses global state (the active trace) to record its error state as a trace tag.
+            # DEV: This means errors cannot be reported if there's not active span.
+            # DEV: Ideally, we'd have a dedicated error reporting stream for all of ddtrace.
+            # DEV: The same comment applies to the {.extract_tags}.
             def inject_tags(digest, env)
               return if digest.trace_distributed_tags.nil? || digest.trace_distributed_tags.empty?
 

--- a/lib/datadog/tracing/distributed/headers/datadog.rb
+++ b/lib/datadog/tracing/distributed/headers/datadog.rb
@@ -120,7 +120,7 @@ module Datadog
 
               tags = DatadogTagsCodec.decode(tags_header)
               # Only extract keys with the expected Datadog prefix
-              tags.select! { |key, _| key.start_with?(Ext::TAGS_PREFIX) }
+              tags.select! { |key, _| key.start_with?(Metadata::Ext::Distributed::TAGS_PREFIX) }
               tags
             rescue => e
               active_trace = Tracing.active_trace

--- a/lib/datadog/tracing/distributed/headers/datadog.rb
+++ b/lib/datadog/tracing/distributed/headers/datadog.rb
@@ -95,6 +95,7 @@ module Datadog
             end
 
             # Import `x-datadog-tags` header tags as trace distributed tags.
+            # Only tags that have the `_dd.p.` prefix are processed.
             def extract_tags(headers)
               tags_header = headers.header(HTTP_HEADER_TAGS)
               return unless tags_header
@@ -118,7 +119,8 @@ module Datadog
               end
 
               tags = DatadogTagsCodec.decode(tags_header)
-              tags.select! { |key, _| key.start_with?(VALID_TAGS_KEY_PREFIX) }
+              # Only extract keys with the expected Datadog prefix
+              tags.select! { |key, _| key.start_with?(Ext::TAGS_PREFIX) }
               tags
             rescue => e
               active_trace = Tracing.active_trace
@@ -127,9 +129,6 @@ module Datadog
                 "Failed to extract x-datadog-tags: #{e.class.name} #{e.message} at #{Array(e.backtrace).first}"
               )
             end
-
-            # Only extract keys with the expected Datadog prefix
-            VALID_TAGS_KEY_PREFIX = '_dd.p.'
           end
         end
       end

--- a/lib/datadog/tracing/distributed/headers/ext.rb
+++ b/lib/datadog/tracing/distributed/headers/ext.rb
@@ -12,6 +12,8 @@ module Datadog
           HTTP_HEADER_PARENT_ID = 'x-datadog-parent-id'.freeze
           HTTP_HEADER_SAMPLING_PRIORITY = 'x-datadog-sampling-priority'.freeze
           HTTP_HEADER_ORIGIN = 'x-datadog-origin'.freeze
+          # Distributed trace-level tags
+          HTTP_HEADER_TAGS = 'x-datadog-tags'.freeze
 
           # B3 headers used for distributed tracing
           B3_HEADER_TRACE_ID = 'x-b3-traceid'.freeze

--- a/lib/datadog/tracing/metadata/ext.rb
+++ b/lib/datadog/tracing/metadata/ext.rb
@@ -47,6 +47,10 @@ module Datadog
         module Distributed
           TAG_ORIGIN = '_dd.origin'
           TAG_SAMPLING_PRIORITY = '_sampling_priority_v1'
+
+          # Trace tags with this prefix will propagate from a trace through distributed tracing.
+          # Distributed headers tags with this prefix will be injected into the active trace.
+          TAGS_PREFIX = '_dd.p.'
         end
 
         # @public_api

--- a/lib/datadog/tracing/propagation/http.rb
+++ b/lib/datadog/tracing/propagation/http.rb
@@ -23,7 +23,15 @@ module Datadog
           Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG => Distributed::Headers::Datadog
         }.freeze
 
-        # inject! popolates the env with span ID, trace ID and sampling priority
+        # inject! populates the env with span ID, trace ID and sampling priority
+        #
+        # DEV-2.0: inject! should work without arguments, injecting the active_trace's digest
+        # DEV-2.0: and returning a new Hash with the injected headers.
+        # DEV-2.0: inject! should also accept either a `trace` or a `digest`, as a `trace`
+        # DEV-2.0: argument is the common use case, but also allows us to set error tags in the `trace`
+        # DEV-2.0: if needed.
+        # DEV-2.0: Ideally, we'd have a separate stream to report tracer errors and never
+        # DEV-2.0: touch the active span.
         def self.inject!(digest, env)
           # Prevent propagation from being attempted if trace headers provided are nil.
           if digest.nil?

--- a/lib/datadog/tracing/trace_digest.rb
+++ b/lib/datadog/tracing/trace_digest.rb
@@ -12,6 +12,7 @@ module Datadog
         :span_resource,
         :span_service,
         :span_type,
+        :trace_distributed_tags,
         :trace_hostname,
         :trace_id,
         :trace_name,
@@ -28,6 +29,7 @@ module Datadog
         span_resource: nil,
         span_service: nil,
         span_type: nil,
+        trace_distributed_tags: nil,
         trace_hostname: nil,
         trace_id: nil,
         trace_name: nil,
@@ -43,6 +45,7 @@ module Datadog
         @span_resource = span_resource && span_resource.dup.freeze
         @span_service = span_service && span_service.dup.freeze
         @span_type = span_type && span_type.dup.freeze
+        @trace_distributed_tags = trace_distributed_tags && trace_distributed_tags.dup.freeze
         @trace_hostname = trace_hostname && trace_hostname.dup.freeze
         @trace_id = trace_id
         @trace_name = trace_name && trace_name.dup.freeze

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -1444,6 +1444,41 @@ RSpec.describe Datadog::Core::Configuration::Settings do
           .to(options)
       end
     end
+
+    describe '#x_datadog_tags_max_length' do
+      subject { settings.tracing.x_datadog_tags_max_length }
+
+      context "when #{Datadog::Tracing::Configuration::Ext::Distributed::ENV_X_DATADOG_TAGS_MAX_LENGTH}" do
+        around do |example|
+          ClimateControl.modify(
+            Datadog::Tracing::Configuration::Ext::Distributed::ENV_X_DATADOG_TAGS_MAX_LENGTH => env_var
+          ) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:env_var) { nil }
+
+          it { is_expected.to eq(512) }
+        end
+
+        context 'is defined' do
+          let(:env_var) { '123' }
+
+          it { is_expected.to eq(123) }
+        end
+      end
+    end
+
+    describe '#x_datadog_tags_max_length=' do
+      it 'updates the #x_datadog_tags_max_length setting' do
+        expect { settings.tracing.x_datadog_tags_max_length = 123 }
+          .to change { settings.tracing.x_datadog_tags_max_length }
+          .from(512)
+          .to(123)
+      end
+    end
   end
 
   describe '#version' do

--- a/spec/datadog/opentracer/rack_propagator_spec.rb
+++ b/spec/datadog/opentracer/rack_propagator_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Datadog::OpenTracer::RackPropagator do
     let(:span_id) { double('span ID') }
     let(:sampling_priority) { double('sampling priority') }
     let(:origin) { double('synthetics') }
+    let(:trace_distributed_tags) { { '_dd.p.key' => 'value' } }
 
     let(:baggage) { { 'account_name' => 'acme' } }
 
@@ -32,6 +33,8 @@ RSpec.describe Datadog::OpenTracer::RackPropagator do
         .with(Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_SAMPLING_PRIORITY, sampling_priority.to_s)
       expect(carrier).to receive(:[]=)
         .with(Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_ORIGIN, origin.to_s)
+      allow(carrier).to receive(:[]=) # TODO: Change to `expect` when TraceOperation starts consuming trace_distributed_tags
+        .with(Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TAGS, '_dd.p.key=value')
 
       # Expect carrier to be set with OpenTracing baggage
       baggage.each do |key, value|
@@ -61,7 +64,7 @@ RSpec.describe Datadog::OpenTracer::RackPropagator do
           id: trace_id,
           parent_span_id: span_id,
           sampling_priority: sampling_priority,
-          origin: origin
+          origin: origin,
         )
       end
 
@@ -84,7 +87,8 @@ RSpec.describe Datadog::OpenTracer::RackPropagator do
           span_id: span_id,
           trace_id: trace_id,
           trace_origin: origin,
-          trace_sampling_priority: sampling_priority
+          trace_sampling_priority: sampling_priority,
+          trace_distributed_tags: trace_distributed_tags,
         )
       end
       it { is_expected.to be nil }
@@ -102,7 +106,8 @@ RSpec.describe Datadog::OpenTracer::RackPropagator do
         span_id: double('span ID'),
         trace_id: double('trace ID'),
         trace_origin: double('origin'),
-        trace_sampling_priority: double('sampling priority')
+        trace_sampling_priority: double('sampling priority'),
+        trace_distributed_tags: double('trace_distributed_tags'),
       )
     end
 

--- a/spec/datadog/tracing/distributed/headers/datadog_spec.rb
+++ b/spec/datadog/tracing/distributed/headers/datadog_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::Datadog do
   end
 
   describe '#inject!' do
-    subject!(:inject!) { described_class.inject!(digest, env) }
+    subject(:inject!) { described_class.inject!(digest, env) }
     let(:env) { {} }
 
     context 'with nil digest' do
@@ -30,7 +30,7 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::Datadog do
       end
 
       it do
-        expect(env).to eq(
+        is_expected.to eq(
           Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => '10000',
           Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '20000'
         )
@@ -46,7 +46,7 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::Datadog do
         end
 
         it do
-          expect(env).to eq(
+          is_expected.to eq(
             Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => '50000',
             Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '60000',
             Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_SAMPLING_PRIORITY => '1'
@@ -64,7 +64,7 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::Datadog do
           end
 
           it do
-            expect(env).to eq(
+            is_expected.to eq(
               Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => '70000',
               Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '80000',
               Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_SAMPLING_PRIORITY => '1',
@@ -84,11 +84,85 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::Datadog do
         end
 
         it do
-          expect(env).to eq(
+          is_expected.to eq(
             Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => '90000',
             Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => '100000',
             Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_ORIGIN => 'synthetics'
           )
+        end
+      end
+
+      context 'with trace_distributed_tags' do
+        let(:digest) { Datadog::Tracing::TraceDigest.new(trace_distributed_tags: tags) }
+
+        context 'nil' do
+          let(:tags) { nil }
+          it { is_expected.to_not include('x-datadog-tags') }
+        end
+
+        context '{}' do
+          let(:tags) { {} }
+          it { is_expected.to_not include('x-datadog-tags') }
+        end
+
+        context "{ key: 'value' }" do
+          let(:tags) { { key: 'value' } }
+          it { is_expected.to include('x-datadog-tags' => 'key=value') }
+        end
+
+        context 'within an active trace' do
+          before do
+            allow(Datadog::Tracing).to receive(:active_trace).and_return(active_trace)
+            allow(active_trace).to receive(:set_tag)
+          end
+
+          let(:active_trace) { double(Datadog::Tracing::TraceOperation) }
+
+          context 'with tags too large' do
+            let(:tags) { { key: 'very large value' * 32 } }
+
+            it { is_expected.to_not include('x-datadog-tags') }
+
+            it 'sets error tag' do
+              expect(active_trace).to receive(:set_tag).with('_dd.propagation_error', 'inject_max_size')
+              expect(Datadog.logger).to receive(:warn).with(/tags are too large/)
+              inject!
+            end
+          end
+
+          context 'with configuration x_datadog_tags_max_length zero' do
+            before do
+              Datadog.configure { |c| c.tracing.x_datadog_tags_max_length = 0 }
+            end
+
+            let(:tags) { { key: 'value' } }
+
+            it { is_expected.to_not include('x-datadog-tags') }
+
+            it 'sets error tag' do
+              expect(active_trace).to receive(:set_tag).with('_dd.propagation_error', 'disabled')
+              inject!
+            end
+
+            context 'and no tags' do
+              let(:tags) { {} }
+
+              it 'does not set error for empty tags' do
+                expect(active_trace).to_not receive(:set_tag)
+                inject!
+              end
+            end
+          end
+
+          context 'with invalid tags' do
+            let(:tags) { 'not_a_tag_hash' }
+
+            it 'sets error tag' do
+              expect(active_trace).to receive(:set_tag).with('_dd.propagation_error', 'encoding_error')
+              expect(Datadog.logger).to receive(:warn).with(/Failed to inject/)
+              inject!
+            end
+          end
         end
       end
     end
@@ -153,6 +227,81 @@ RSpec.describe Datadog::Tracing::Distributed::Headers::Datadog do
         it { expect(digest.trace_id).to eq(10000) }
         it { expect(digest.trace_origin).to eq('synthetics') }
         it { expect(digest.trace_sampling_priority).to be nil }
+      end
+
+      context 'with trace_distributed_tags' do
+        subject(:trace_distributed_tags) { extract.trace_distributed_tags }
+        let(:env) { super().merge(env_header('x-datadog-tags') => tags) }
+
+        context 'nil' do
+          let(:tags) { nil }
+          it { is_expected.to be_nil }
+        end
+
+        context 'an empty value' do
+          let(:tags) { '' }
+          it { is_expected.to be_nil }
+        end
+
+        context "{ _dd.p.key: 'value' }" do
+          let(:tags) { '_dd.p.key=value' }
+          it { is_expected.to eq('_dd.p.key' => 'value') }
+        end
+
+        context 'within an active trace' do
+          before do
+            allow(Datadog::Tracing).to receive(:active_trace).and_return(active_trace)
+            allow(active_trace).to receive(:set_tag)
+          end
+
+          let(:active_trace) { double(Datadog::Tracing::TraceOperation) }
+
+          context 'with tags too large' do
+            let(:tags) { 'key=very large value,' * 25 }
+
+            it { is_expected.to be_nil }
+
+            it 'sets error tag' do
+              expect(active_trace).to receive(:set_tag).with('_dd.propagation_error', 'extract_max_size')
+              expect(Datadog.logger).to receive(:warn).with(/tags are too large/)
+              extract
+            end
+          end
+
+          context 'with configuration x_datadog_tags_max_length zero' do
+            before do
+              Datadog.configure { |c| c.tracing.x_datadog_tags_max_length = 0 }
+            end
+
+            let(:tags) { 'key=value' }
+
+            it { is_expected.to be_nil }
+
+            it 'sets error tag' do
+              expect(active_trace).to receive(:set_tag).with('_dd.propagation_error', 'disabled')
+              extract
+            end
+
+            context 'and no tags' do
+              let(:tags) { '' }
+
+              it 'does not set error for empty tags' do
+                expect(active_trace).to_not receive(:set_tag)
+                extract
+              end
+            end
+          end
+
+          context 'with invalid tags' do
+            let(:tags) { 'not a valid tag header' }
+
+            it 'sets error tag' do
+              expect(active_trace).to receive(:set_tag).with('_dd.propagation_error', 'decoding_error')
+              expect(Datadog.logger).to receive(:warn).with(/Failed to extract/)
+              extract
+            end
+          end
+        end
       end
     end
 

--- a/spec/datadog/tracing/trace_digest_spec.rb
+++ b/spec/datadog/tracing/trace_digest_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Datadog::Tracing::TraceDigest do
           span_resource: nil,
           span_service: nil,
           span_type: nil,
+          trace_distributed_tags: nil,
           trace_hostname: nil,
           trace_id: nil,
           trace_name: nil,
@@ -69,6 +70,13 @@ RSpec.describe Datadog::Tracing::TraceDigest do
         let(:span_type) { 'worker' }
 
         it { is_expected.to have_attributes(span_type: be_a_frozen_copy_of(span_type)) }
+      end
+
+      context ':trace_distributed_tags' do
+        let(:options) { { trace_distributed_tags: trace_distributed_tags } }
+        let(:trace_distributed_tags) { { tag: 'value' } }
+
+        it { is_expected.to have_attributes(trace_distributed_tags: be_a_frozen_copy_of(trace_distributed_tags)) }
       end
 
       context ':trace_hostname' do


### PR DESCRIPTION
Follow up from #2216

_**I recommend reviewing this PR with "No Whitespace" enable, as I've indented most of the `lib/datadog/tracing/distributed/headers/datadog.rb` file.**_

This PR extracts and injects trace-level distribute tags through the HTTP header `x-datadog-tags`.

The tags are currently read and written to a `TraceDigest`, but not yet consumed by the rest of the application: this will be done in a later PR.

Most of the complexity is around error handling, which is defined in the feature's RFC.

One configuration was added: a max size to the `x-datadog-tags` (and respective environment variable `DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH`), as per RFC.