### PR TITLE
Use full URL in `http.url` tag

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,7 +61,7 @@ Style/NumericLiterals:
   Enabled: false
 
 Metrics/ClassLength:
-  Max: 140
+  Enabled: false
 
 Metrics/BlockLength:
   Max: 42

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -5,7 +5,6 @@ module Datadog
     module Configuration
       # Configuration settings, acting as an integration registry
       # TODO: as with Configuration, this is a trivial implementation
-      # rubocop:disable Metrics/ClassLength
       class Settings
         class << self
           def boolean
@@ -188,7 +187,6 @@ module Datadog
           initialize
         end
       end
-      # rubocop:enable Metrics/ClassLength
     end
   end
 end

--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -18,8 +18,6 @@ module Datadog
       #
       # Whenever there is a conflict (different configurations are provided in different orders), it MUST warn the users
       # about it and pick a value based on the following priority: code > environment variable > defaults.
-      #
-      # rubocop:disable Metrics/ClassLength
       class AgentSettingsResolver
         AgentSettings = \
           Struct.new(
@@ -359,7 +357,6 @@ module Datadog
           end
         end
       end
-      # rubocop:enable Metrics/ClassLength
     end
   end
 end

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -18,7 +18,6 @@ module Datadog
   module Core
     module Configuration
       # Global components for the trace library.
-      # rubocop:disable Metrics/ClassLength
       class Components
         class << self
           def build_health_metrics(settings)
@@ -431,7 +430,6 @@ module Datadog
           telemetry.emit_closing! unless replacement
         end
       end
-      # rubocop:enable Metrics/ClassLength
     end
   end
 end

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -15,7 +15,6 @@ module Datadog
       # Global configuration settings for the trace library.
       # @public_api
       # rubocop:disable Metrics/BlockLength
-      # rubocop:disable Metrics/ClassLength
       # rubocop:disable Layout/LineLength
       class Settings
         include Base
@@ -713,9 +712,7 @@ module Datadog
           end
         end
       end
-
       # rubocop:enable Metrics/BlockLength
-      # rubocop:enable Metrics/ClassLength
       # rubocop:enable Layout/LineLength
     end
   end

--- a/lib/datadog/profiling/collectors/old_stack.rb
+++ b/lib/datadog/profiling/collectors/old_stack.rb
@@ -15,7 +15,7 @@ module Datadog
       # Runs on its own background thread.
       #
       # This class has the prefix "Old" because it will be deprecated by the new native CPU Profiler
-      class OldStack < Core::Worker # rubocop:disable Metrics/ClassLength
+      class OldStack < Core::Worker
         include Core::Workers::Polling
 
         DEFAULT_MAX_TIME_USAGE_PCT = 2.0

--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -23,6 +23,8 @@ module Datadog
         # in the Rack environment so that it can be retrieved by the underlying
         # application. If request tags are not set by the app, they will be set using
         # information available at the Rack level.
+        #
+        # rubocop:disable Metrics/ClassLength
         class TraceMiddleware
           def initialize(app)
             @app = app
@@ -304,6 +306,7 @@ module Datadog
             end
           end
         end
+        # rubocop:enable Metrics/ClassLength
       end
     end
   end

--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -169,7 +169,10 @@ module Datadog
             url = parse_url(env, original_env)
 
             if request_span.get_tag(Tracing::Metadata::Ext::HTTP::TAG_URL).nil?
-              options = configuration[:quantize]
+              options = configuration[:quantize] || {}
+
+              # Quantization::HTTP.url base defaults to :show, but we are transitioning
+              options[:base] ||= :exclude
 
               request_span.set_tag(
                 Tracing::Metadata::Ext::HTTP::TAG_URL,

--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -23,8 +23,6 @@ module Datadog
         # in the Rack environment so that it can be retrieved by the underlying
         # application. If request tags are not set by the app, they will be set using
         # information available at the Rack level.
-        #
-        # rubocop:disable Metrics/ClassLength
         class TraceMiddleware
           def initialize(app)
             @app = app
@@ -309,7 +307,6 @@ module Datadog
             end
           end
         end
-        # rubocop:enable Metrics/ClassLength
       end
     end
   end

--- a/lib/datadog/tracing/contrib/utils/quantization/http.rb
+++ b/lib/datadog/tracing/contrib/utils/quantization/http.rb
@@ -43,7 +43,7 @@ module Datadog
                 # Remove any URI fragments
                 uri.fragment = nil unless options[:fragment] == :show
 
-                unless options[:base] == :show
+                if options[:base] == :exclude
                   uri.host = nil
                   uri.port = nil
                   uri.scheme = nil

--- a/lib/datadog/tracing/contrib/utils/quantization/http.rb
+++ b/lib/datadog/tracing/contrib/utils/quantization/http.rb
@@ -22,6 +22,14 @@ module Datadog
               options[:placeholder] || PLACEHOLDER
             end
 
+            def base_url(url, options = {})
+              URI.parse(url).tap do |uri|
+                uri.path = ''
+                uri.query = nil
+                uri.fragment = nil
+              end.to_s
+            end
+
             def url!(url, options = {})
               options ||= {}
 
@@ -32,8 +40,14 @@ module Datadog
                   uri.query = (!query.nil? && query.empty? ? nil : query)
                 end
 
-                # Remove any URI framents
+                # Remove any URI fragments
                 uri.fragment = nil unless options[:fragment] == :show
+
+                unless options[:base] == :show
+                  uri.host = nil
+                  uri.port = nil
+                  uri.scheme = nil
+                end
               end.to_s
             end
 

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -18,7 +18,6 @@ module Datadog
     # It gives a Span a context which can be used to
     # build a Span. When completed, it yields the Span.
     #
-    # rubocop:disable Metrics/ClassLength
     # @public_api
     class SpanOperation
       include Metadata
@@ -516,6 +515,5 @@ module Datadog
       alias :span_type :type
       alias :span_type= :type=
     end
-    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -22,7 +22,6 @@ module Datadog
     # For async support, a {Datadog::Tracing::TraceOperation} should be employed
     # per execution context (e.g. Thread, etc.)
     #
-    # rubocop:disable Metrics/ClassLength
     # @public_api
     class TraceOperation
       include Metadata::Tagging
@@ -454,6 +453,5 @@ module Datadog
         )
       end
     end
-    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/datadog/tracing/trace_segment.rb
+++ b/lib/datadog/tracing/trace_segment.rb
@@ -11,7 +11,6 @@ module Datadog
   module Tracing
     # Serializable construct representing a trace
     # @public_api
-    # rubocop:disable Metrics/ClassLength
     class TraceSegment
       TAG_NAME = 'name'.freeze
       TAG_RESOURCE = 'resource'.freeze
@@ -203,6 +202,5 @@ module Datadog
         meta[TAG_SERVICE]
       end
     end
-    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -23,7 +23,6 @@ module Datadog
     # example, a trace can be used to track the entire time spent processing a complicated web request.
     # Even though the request may require multiple resources and machines to handle the request, all
     # of these function calls and sub-requests would be encapsulated within a single trace.
-    # rubocop:disable Metrics/ClassLength
     class Tracer
       attr_reader \
         :trace_flush,
@@ -528,6 +527,5 @@ module Datadog
         end
       end
     end
-    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'Rack integration tests' do
           it_behaves_like 'a rack GET 200 span'
 
           context 'and default quantization' do
-            let(:rack_options) { super().merge(quantize: {}) }
+            let(:rack_options) { { quantize: {} } }
 
             it do
               expect(span.get_tag('http.url')).to eq('/success/')
@@ -114,7 +114,7 @@ RSpec.describe 'Rack integration tests' do
           end
 
           context 'and quantization activated for URL base' do
-            let(:rack_options) { super().merge(quantize: { base: :show }) }
+            let(:rack_options) { { quantize: { base: :show } } }
 
             it do
               expect(span.get_tag('http.url')).to eq('http://example.org/success/')
@@ -130,7 +130,7 @@ RSpec.describe 'Rack integration tests' do
           let(:route) { '/success?foo=bar' }
 
           context 'and default quantization' do
-            let(:rack_options) { super().merge(quantize: {}) }
+            let(:rack_options) { { quantize: {} } }
 
             it_behaves_like 'a rack GET 200 span'
 
@@ -142,7 +142,7 @@ RSpec.describe 'Rack integration tests' do
           end
 
           context 'and quantization activated for the query' do
-            let(:rack_options) { super().merge(quantize: { query: { show: ['foo'] } }) }
+            let(:rack_options) { { quantize: { query: { show: ['foo'] } } } }
 
             it_behaves_like 'a rack GET 200 span'
 
@@ -158,7 +158,7 @@ RSpec.describe 'Rack integration tests' do
           subject(:response) { get '/success?foo=bar', {}, 'REQUEST_URI' => '/success?foo=bar' }
 
           context 'and default quantization' do
-            let(:rack_options) { super().merge(quantize: {}) }
+            let(:rack_options) { { quantize: {} } }
 
             it_behaves_like 'a rack GET 200 span'
 
@@ -173,7 +173,7 @@ RSpec.describe 'Rack integration tests' do
           end
 
           context 'and quantization activated for the query' do
-            let(:rack_options) { super().merge(quantize: { query: { show: ['foo'] } }) }
+            let(:rack_options) { { quantize: { query: { show: ['foo'] } } } }
 
             it_behaves_like 'a rack GET 200 span'
 

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'Rack integration tests' do
     end
   end
 
+  after { Datadog.registry[:rack].reset_configuration! }
+
   context 'for an application' do
     let(:app) do
       app_routes = routes

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe 'Rack integration tests' do
           it do
             # Since REQUEST_URI isn't available in Rack::Test by default (comes from WEBrick/Puma)
             # it reverts to PATH_INFO, which doesn't have query string parameters.
-            expect(span.get_tag('http.url')).to eq('/success')
+            expect(span.get_tag('http.url')).to eq('/success?foo')
             expect(span.get_tag('http.base_url')).to eq('http://example.org')
             expect(span).to be_root_span
           end

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -101,10 +101,24 @@ RSpec.describe 'Rack integration tests' do
 
           it_behaves_like 'a rack GET 200 span'
 
-          it do
-            expect(span.get_tag('http.url')).to eq('/success/')
-            expect(span.get_tag('http.base_url')).to eq('http://example.org')
-            expect(span).to be_root_span
+          context 'and default quantization' do
+            let(:rack_options) { super().merge(quantize: {}) }
+
+            it do
+              expect(span.get_tag('http.url')).to eq('/success/')
+              expect(span.get_tag('http.base_url')).to eq('http://example.org')
+              expect(span).to be_root_span
+            end
+          end
+
+          context 'and quantization activated for URL base' do
+            let(:rack_options) { super().merge(quantize: { base: :show }) }
+
+            it do
+              expect(span.get_tag('http.url')).to eq('http://example.org/success/')
+              expect(span.get_tag('http.base_url')).to be_nil
+              expect(span).to be_root_span
+            end
           end
 
           it { expect(trace.resource).to eq('GET 200') }

--- a/spec/datadog/tracing/contrib/sinatra/multi_app_spec.rb
+++ b/spec/datadog/tracing/contrib/sinatra/multi_app_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
           spans.each do |span|
             if span.name == Datadog::Tracing::Contrib::Rack::Ext::SPAN_REQUEST
               expect(span.resource).to eq('GET /endpoint')
-              expect(span.get_tag(Datadog::Tracing::Metadata::Ext::HTTP::TAG_URL)).to eq('/endpoint')
+              expect(span.get_tag(Datadog::Tracing::Metadata::Ext::HTTP::TAG_URL)).to eq('/one/endpoint')
 
               next
             end
@@ -95,7 +95,7 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
           spans.each do |span|
             if span.name == Datadog::Tracing::Contrib::Rack::Ext::SPAN_REQUEST
               expect(span.resource).to eq('GET /endpoint')
-              expect(span.get_tag(Datadog::Tracing::Metadata::Ext::HTTP::TAG_URL)).to eq('/endpoint')
+              expect(span.get_tag(Datadog::Tracing::Metadata::Ext::HTTP::TAG_URL)).to eq('/two/endpoint')
 
               next
             end
@@ -120,7 +120,7 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
           spans.each do |span|
             if span.name == Datadog::Tracing::Contrib::Rack::Ext::SPAN_REQUEST
               expect(span.resource).to eq('GET /one/endpoint')
-              expect(span.get_tag(Datadog::Tracing::Metadata::Ext::HTTP::TAG_URL)).to eq('/endpoint')
+              expect(span.get_tag(Datadog::Tracing::Metadata::Ext::HTTP::TAG_URL)).to eq('/one/endpoint')
 
               next
             end
@@ -141,7 +141,7 @@ RSpec.describe 'Sinatra instrumentation for multi-apps' do
           spans.each do |span|
             if span.name == Datadog::Tracing::Contrib::Rack::Ext::SPAN_REQUEST
               expect(span.resource).to eq('GET /two/endpoint')
-              expect(span.get_tag(Datadog::Tracing::Metadata::Ext::HTTP::TAG_URL)).to eq('/endpoint')
+              expect(span.get_tag(Datadog::Tracing::Metadata::Ext::HTTP::TAG_URL)).to eq('/two/endpoint')
 
               next
             end

--- a/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
+++ b/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe Datadog::Tracing::Contrib::Utils::Quantization::HTTP do
         it { is_expected.to eq('http://example.com/path?category_id&sort_by#featured') }
       end
 
+      context 'with base: :show' do
+        let(:options) { { base: :show } }
+
+        it { is_expected.to eq('http://example.com/path?category_id&sort_by') }
+      end
+
+      context 'with base: :exclude' do
+        let(:options) { { base: :exclude } }
+
+        it { is_expected.to eq('/path?category_id&sort_by') }
+      end
+
       context 'with Unicode characters' do
         # URLs do not permit unencoded non-ASCII characters in the URL.
         let(:url) { 'http://example.com/path?繋がってて' }

--- a/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
+++ b/spec/datadog/tracing/contrib/utils/quantization/http_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Datadog::Tracing::Contrib::Utils::Quantization::HTTP do
         it { is_expected.to eq('http://example.com/path') }
       end
 
-      context 'with show: :all' do
+      context 'with fragment: :show' do
         let(:options) { { fragment: :show } }
 
         it { is_expected.to eq('http://example.com/path?category_id&sort_by#featured') }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

*Adjust HTTP URL tags to comply with span tag unification RFC*

- align http.url with tag naming RFC (and Rack's #url) to include the
  complete request URL
- drop http.base_url, now unneeded
- preserve REQUEST_URI logic that differs from Rack's logic
- add SCRIPT_NAME which was previously unhandled for PATH_INFO
- append QUERY_STRING when using PATH_INFO to match REQUEST_URI

*Enable query string quantization by default*
    
This change is mandated by the unifying tag RFC.

**Motivation**

Compliance with internal RFC document.
