### PR TITLE
Sampling-Propagation:Consume distributed tags in TraceOperation

### DIFF
--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -160,13 +160,6 @@ module Datadog
         @service || (root_span && root_span.service)
       end
 
-      # Returns tracer tags that will be propagated if this span's context
-      # is exported through {.to_digest}.
-      # @return [Hash] key value pairs of distributed tags
-      def distributed_tags
-        meta.select { |name, _| name.start_with?(Metadata::Ext::Distributed::TAGS_PREFIX) }
-      end
-
       def measure(
         op_name,
         events: nil,
@@ -460,6 +453,13 @@ module Datadog
           metrics: metrics,
           root_span_id: !partial ? root_span && root_span.id : nil
         )
+      end
+
+      # Returns tracer tags that will be propagated if this span's context
+      # is exported through {.to_digest}.
+      # @return [Hash] key value pairs of distributed tags
+      def distributed_tags
+        meta.select { |name, _| name.start_with?(Metadata::Ext::Distributed::TAGS_PREFIX) }
       end
     end
     # rubocop:enable Metrics/ClassLength

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -160,6 +160,13 @@ module Datadog
         @service || (root_span && root_span.service)
       end
 
+      # Returns tracer tags that will be propagated if this span's context
+      # is exported through {.to_digest}.
+      # @return [Hash] key value pairs of distributed tags
+      def distributed_tags
+        meta.select { |name, _| name.start_with?(Metadata::Ext::Distributed::TAGS_PREFIX) }
+      end
+
       def measure(
         op_name,
         events: nil,
@@ -279,6 +286,7 @@ module Datadog
           span_resource: (@active_span && @active_span.resource),
           span_service: (@active_span && @active_span.service),
           span_type: (@active_span && @active_span.type),
+          trace_distributed_tags: distributed_tags,
           trace_hostname: @hostname,
           trace_id: @id,
           trace_name: name,

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -327,7 +327,9 @@ module Datadog
             id: digest.trace_id,
             origin: digest.trace_origin,
             parent_span_id: digest.span_id,
-            sampling_priority: digest.trace_sampling_priority
+            sampling_priority: digest.trace_sampling_priority,
+            # Distributed tags are just regular trace tags with special meaning to Datadog
+            tags: digest.trace_distributed_tags,
           )
         else
           TraceOperation.new(

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -48,8 +48,10 @@ RSpec.describe Datadog::Tracing::TraceOperation do
     let(:sampled) { true }
     let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP }
     let(:service) { 'billing-api' }
-    let(:tags) { { 'foo' => 'bar' } }
+    let(:tags) { { 'foo' => 'bar' }.merge(distributed_tags) }
     let(:metrics) { { 'baz' => 42.0 } }
+
+    let(:distributed_tags) { { '_dd.p.test' => 'value' } }
   end
 
   shared_examples 'a span with default events' do
@@ -1738,6 +1740,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               span_resource: nil,
               span_service: nil,
               span_type: nil,
+              trace_distributed_tags: {},
               trace_hostname: nil,
               trace_id: trace_op.id,
               trace_name: nil,
@@ -1761,6 +1764,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               span_resource: nil,
               span_service: nil,
               span_type: nil,
+              trace_distributed_tags: distributed_tags,
               trace_hostname: be_a_frozen_copy_of(hostname),
               trace_id: trace_op.id,
               trace_name: be_a_frozen_copy_of(name),
@@ -1795,8 +1799,9 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               service: 'foo',
               resource: 'bar',
               type: 'baz'
-            ) do |parent|
+            ) do |parent, trace|
               @parent = parent
+              trace.set_tag('_dd.p.test', 'value')
               to_digest
             end
           end
@@ -1809,6 +1814,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
             span_resource: 'bar',
             span_service: 'foo',
             span_type: 'baz',
+            trace_distributed_tags: { '_dd.p.test' => 'value' },
             trace_hostname: nil,
             trace_id: trace_op.id,
             trace_name: 'grandparent',
@@ -1849,6 +1855,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               span_resource: nil,
               span_service: nil,
               span_type: nil,
+              trace_distributed_tags: {},
               trace_hostname: nil,
               trace_id: trace_op.id,
               trace_name: nil,
@@ -1881,6 +1888,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               span_resource: 'bar',
               span_service: 'foo',
               span_type: 'baz',
+              trace_distributed_tags: {},
               trace_hostname: nil,
               trace_id: trace_op.id,
               trace_name: 'parent',
@@ -1913,6 +1921,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
               span_resource: nil,
               span_service: nil,
               span_type: nil,
+              trace_distributed_tags: {},
               trace_hostname: nil,
               trace_id: trace_op.id,
               trace_name: 'parent',
@@ -1953,6 +1962,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
             span_resource: nil,
             span_service: nil,
             span_type: nil,
+            trace_distributed_tags: {},
             trace_hostname: nil,
             trace_id: trace_op.id,
             trace_name: 'grandparent',
@@ -2005,7 +2015,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           end
 
           it 'maintains the same tags' do
-            expect(new_trace_op.send(:meta)).to eq({ 'foo' => 'bar' })
+            expect(new_trace_op.send(:meta)).to eq(tags)
           end
 
           it 'maintains the same metrics' do
@@ -2075,7 +2085,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
         end
 
         it 'maintains the same tags' do
-          expect(new_trace_op.send(:meta)).to eq({ 'foo' => 'bar' })
+          expect(new_trace_op.send(:meta)).to eq(tags)
         end
 
         it 'maintains the same metrics' do
@@ -2124,7 +2134,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           end
 
           it 'maintains the same tags' do
-            expect(new_trace_op.send(:meta)).to eq({ 'foo' => 'bar' })
+            expect(new_trace_op.send(:meta)).to eq(tags)
           end
 
           it 'maintains the same metrics' do
@@ -2163,7 +2173,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           end
 
           it 'maintains the same tags' do
-            expect(new_trace_op.send(:meta)).to eq({ 'foo' => 'bar' })
+            expect(new_trace_op.send(:meta)).to eq(tags)
           end
 
           it 'maintains the same metrics' do
@@ -2202,7 +2212,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
           end
 
           it 'maintains the same tags' do
-            expect(new_trace_op.send(:meta)).to eq({ 'foo' => 'bar' })
+            expect(new_trace_op.send(:meta)).to eq(tags)
           end
 
           it 'maintains the same metrics' do
@@ -2251,7 +2261,7 @@ RSpec.describe Datadog::Tracing::TraceOperation do
         end
 
         it 'maintains the same tags' do
-          expect(new_trace_op.send(:meta)).to eq({ 'foo' => 'bar' })
+          expect(new_trace_op.send(:meta)).to eq(tags)
         end
 
         it 'maintains the same metrics' do

--- a/spec/datadog/tracing/tracer_integration_spec.rb
+++ b/spec/datadog/tracing/tracer_integration_spec.rb
@@ -304,4 +304,62 @@ RSpec.describe Datadog::Tracing::Tracer do
       end
     end
   end
+
+  describe 'distributed trace' do
+    context 'with distributed datadog headers' do
+      let(:extract) { Datadog::Tracing::Propagation::HTTP.extract(rack_headers) }
+      let(:trace) { Datadog::Tracing.continue_trace!(extract) }
+      let(:inject) { {}.tap { |env| Datadog::Tracing::Propagation::HTTP.inject!(trace.to_digest, env) } }
+
+      let(:headers) do
+        {
+          Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TRACE_ID => trace_id.to_s,
+          Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_PARENT_ID => parent_id.to_s,
+          Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_ORIGIN => origin,
+          Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_SAMPLING_PRIORITY => sampling_priority.to_s,
+          Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TAGS => distributed_tags,
+        }
+      end
+      let(:rack_headers) do
+        headers.map { |key, value| [rack_header(key), value] }.to_h
+      end
+
+      let(:trace_id) { 123 }
+      let(:parent_id) { 456 }
+      let(:origin) { 'outer-space' }
+      let(:sampling_priority) { 1 }
+      let(:distributed_tags) { '_dd.p.test=value' }
+
+      after { Datadog::Tracing.continue_trace!(nil) }
+
+      # TODO: Consolidate all `rack_header`s in a single place
+      def rack_header(header)
+        "http-#{header}".upcase!.tr('-', '_')
+      end
+
+      it 'populates active trace' do
+        expect(trace.id).to eq(trace_id)
+        expect(trace.parent_span_id).to eq(parent_id)
+        expect(trace.origin).to eq(origin)
+        expect(trace.sampling_priority).to eq(sampling_priority)
+        expect(trace.distributed_tags).to eq('_dd.p.test' => 'value')
+      end
+
+      it 'populates injected request headers' do
+        expect(inject).to include(headers)
+      end
+
+      it 'populates injected request headers when values are modified' do
+        trace.origin = 'other-origin'
+        trace.sampling_priority = 9
+        trace.set_tag('_dd.p.test', 'changed')
+
+        expect(inject).to include(
+          Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_ORIGIN => 'other-origin',
+          Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_SAMPLING_PRIORITY => '9',
+          Datadog::Tracing::Distributed::Headers::Ext::HTTP_HEADER_TAGS => '_dd.p.test=changed',
+        )
+      end
+    end
+  end
 end

--- a/spec/datadog/tracing/tracer_integration_spec.rb
+++ b/spec/datadog/tracing/tracer_integration_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe Datadog::Tracing::Tracer do
         expect(trace.parent_span_id).to eq(parent_id)
         expect(trace.origin).to eq(origin)
         expect(trace.sampling_priority).to eq(sampling_priority)
-        expect(trace.distributed_tags).to eq('_dd.p.test' => 'value')
+        expect(trace.send(:distributed_tags)).to eq('_dd.p.test' => 'value')
       end
 
       it 'populates injected request headers' do

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -812,10 +812,11 @@ RSpec.describe Datadog::Tracing::Tracer do
       it 'causes next #trace to continue the trace' do
         tracer.trace('operation') do |span, trace|
           expect(trace).to have_attributes(
-            distributed_tags: { '_dd.p.test' => 'value' },
             origin: digest.trace_origin,
             sampling_priority: digest.trace_sampling_priority,
           )
+
+          expect(trace.send(:distributed_tags)).to eq('_dd.p.test' => 'value')
 
           expect(span).to have_attributes(
             parent_id: digest.span_id,

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -800,9 +800,10 @@ RSpec.describe Datadog::Tracing::Tracer do
       let(:digest) do
         Datadog::Tracing::TraceDigest.new(
           span_id: Datadog::Core::Utils.next_id,
+          trace_distributed_tags: { '_dd.p.test' => 'value' },
           trace_id: Datadog::Core::Utils.next_id,
           trace_origin: 'synthetics',
-          trace_sampling_priority: Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP
+          trace_sampling_priority: Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP,
         )
       end
 
@@ -811,8 +812,9 @@ RSpec.describe Datadog::Tracing::Tracer do
       it 'causes next #trace to continue the trace' do
         tracer.trace('operation') do |span, trace|
           expect(trace).to have_attributes(
+            distributed_tags: { '_dd.p.test' => 'value' },
             origin: digest.trace_origin,
-            sampling_priority: digest.trace_sampling_priority
+            sampling_priority: digest.trace_sampling_priority,
           )
 
           expect(span).to have_attributes(


### PR DESCRIPTION
Follow up from #2264

This PR consumes the `TraceDigest#trace_distributed_tags` field in `Tracing.continue_trace!`.

Incoming distributed tags become regular trace-level tags of the active trace.

This means that they will make it to the backend through the regular agent payload, as well as be propagated to downstream services on `Tracing::Propagation::HTTP.inject!`.