### PR TITLE
Bump allowed version of debase-ruby_core_source to include v0.10.17

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -60,8 +60,8 @@ Gem::Specification.new do |spec|
   # (https://github.com/ruby-debug/debase-ruby_core_source/pull/6) so we should keep that as a lower bound going
   # forward.
   #
-  # we're pinning it at the latest available version and will manually bump the dependency as needed.
-  spec.add_dependency 'debase-ruby_core_source', '= 0.10.16'
+  # We're pinning it at the latest available version and will manually bump the dependency as needed.
+  spec.add_dependency 'debase-ruby_core_source', '>= 0.10.16', '<= 0.10.17'
 
   # Used by appsec
   spec.add_dependency 'libddwaf', '~> 1.3.0.2.0'


### PR DESCRIPTION
**What does this PR do?**:

Bump allowed version of debase-ruby_core_source to include the latest v0.10.17.

**Motivation**:

In the past, we decided to manually opt-in to debase-ruby_core_source releases; but we also don't want to force customers to stay on an older version.

**Additional Notes**:

I validated this release is ok by looking through:

* https://github.com/ruby-debug/debase-ruby_core_source/releases/tag/v0.10.17
* https://my.diffend.io/gems/debase-ruby_core_source/0.10.16/0.10.17

**How to test the change?**:

Check that profiling continues to compile and work on Ruby <= 2.5 (later versions do not use this dependency).
