### PR TITLE
Move contrib-specific database span tags

### DIFF
--- a/lib/datadog/tracing/contrib/ext.rb
+++ b/lib/datadog/tracing/contrib/ext.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Tracing
+    module Contrib
+      # Contrib specific constants
+      module Ext
+        # @public_api
+        module DB
+          TAG_INSTANCE = 'db.instance'
+          TAG_USER = 'db.user'
+          TAG_SYSTEM = 'db.system'
+          TAG_STATEMENT = 'db.statement'
+          TAG_ROW_COUNT = 'db.row_count'
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/tracing/contrib/pg/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/pg/instrumentation.rb
@@ -2,6 +2,7 @@
 
 require_relative '../../metadata/ext'
 require_relative '../analytics'
+require_relative '../ext'
 require_relative 'ext'
 
 module Datadog
@@ -95,9 +96,9 @@ module Datadog
               span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, service)
               span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, host)
 
-              span.set_tag(Tracing::Metadata::Ext::DB::TAG_INSTANCE, db)
-              span.set_tag(Tracing::Metadata::Ext::DB::TAG_USER, user)
-              span.set_tag(Tracing::Metadata::Ext::DB::TAG_SYSTEM, Ext::SPAN_SYSTEM)
+              span.set_tag(Contrib::Ext::DB::TAG_INSTANCE, db)
+              span.set_tag(Contrib::Ext::DB::TAG_USER, user)
+              span.set_tag(Contrib::Ext::DB::TAG_SYSTEM, Ext::SPAN_SYSTEM)
 
               span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, host)
               span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_PORT, port)
@@ -106,7 +107,7 @@ module Datadog
             end
 
             def annotate_span_with_result!(span, result)
-              span.set_tag(Tracing::Metadata::Ext::DB::TAG_ROW_COUNT, result.ntuples)
+              span.set_tag(Contrib::Ext::DB::TAG_ROW_COUNT, result.ntuples)
             end
 
             def datadog_configuration

--- a/lib/datadog/tracing/metadata/ext.rb
+++ b/lib/datadog/tracing/metadata/ext.rb
@@ -157,15 +157,6 @@ module Datadog
         end
 
         # @public_api
-        module DB
-          TAG_INSTANCE = 'db.instance'
-          TAG_USER = 'db.user'
-          TAG_SYSTEM = 'db.system'
-          TAG_STATEMENT = 'db.statement'
-          TAG_ROW_COUNT = 'db.row_count'
-        end
-
-        # @public_api
         module SpanKind
           TAG_SERVER = 'server'
           TAG_CLIENT = 'client'

--- a/spec/datadog/tracing/contrib/pg/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/pg/patcher_spec.rb
@@ -89,15 +89,15 @@ RSpec.describe 'PG::Connection patcher' do
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_SERVICE))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::DEFAULT_PEER_SERVICE_NAME)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_HOSTNAME)).to eq(host)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_INSTANCE)).to eq(dbname)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_USER)).to eq(user)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_SYSTEM))
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_INSTANCE)).to eq(dbname)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_USER)).to eq(user)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_SYSTEM))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::SPAN_SYSTEM)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_HOST)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_PORT)).to eq(port.to_i)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_PORT)).to eq(port.to_i)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_ROW_COUNT)).to eq(1)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_ROW_COUNT)).to eq(1)
         end
 
         it_behaves_like 'analytics for integration' do
@@ -171,15 +171,15 @@ RSpec.describe 'PG::Connection patcher' do
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_SERVICE))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::DEFAULT_PEER_SERVICE_NAME)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_HOSTNAME)).to eq(host)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_INSTANCE)).to eq(dbname)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_USER)).to eq(user)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_SYSTEM))
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_INSTANCE)).to eq(dbname)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_USER)).to eq(user)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_SYSTEM))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::SPAN_SYSTEM)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_HOST)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_PORT)).to eq(port.to_i)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_PORT)).to eq(port.to_i)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_ROW_COUNT)).to eq(1)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_ROW_COUNT)).to eq(1)
         end
 
         it_behaves_like 'analytics for integration' do
@@ -253,15 +253,15 @@ RSpec.describe 'PG::Connection patcher' do
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_SERVICE))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::DEFAULT_PEER_SERVICE_NAME)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_HOSTNAME)).to eq(host)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_INSTANCE)).to eq(dbname)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_USER)).to eq(user)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_SYSTEM))
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_INSTANCE)).to eq(dbname)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_USER)).to eq(user)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_SYSTEM))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::SPAN_SYSTEM)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_HOST)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_PORT)).to eq(port.to_i)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_PORT)).to eq(port.to_i)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_ROW_COUNT)).to eq(1)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_ROW_COUNT)).to eq(1)
         end
 
         it_behaves_like 'analytics for integration' do
@@ -336,15 +336,15 @@ RSpec.describe 'PG::Connection patcher' do
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_SERVICE))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::DEFAULT_PEER_SERVICE_NAME)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_HOSTNAME)).to eq(host)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_INSTANCE)).to eq(dbname)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_USER)).to eq(user)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_SYSTEM))
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_INSTANCE)).to eq(dbname)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_USER)).to eq(user)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_SYSTEM))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::SPAN_SYSTEM)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_HOST)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_PORT)).to eq(port.to_i)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_PORT)).to eq(port.to_i)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_ROW_COUNT)).to eq(1)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_ROW_COUNT)).to eq(1)
         end
 
         it_behaves_like 'analytics for integration' do
@@ -420,15 +420,15 @@ RSpec.describe 'PG::Connection patcher' do
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_SERVICE))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::DEFAULT_PEER_SERVICE_NAME)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_HOSTNAME)).to eq(host)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_INSTANCE)).to eq(dbname)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_USER)).to eq(user)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_SYSTEM))
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_INSTANCE)).to eq(dbname)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_USER)).to eq(user)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_SYSTEM))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::SPAN_SYSTEM)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_HOST)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_PORT)).to eq(port.to_i)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_PORT)).to eq(port.to_i)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_ROW_COUNT)).to eq(1)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_ROW_COUNT)).to eq(1)
         end
 
         it_behaves_like 'analytics for integration' do
@@ -507,15 +507,15 @@ RSpec.describe 'PG::Connection patcher' do
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_SERVICE))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::DEFAULT_PEER_SERVICE_NAME)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_HOSTNAME)).to eq(host)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_INSTANCE)).to eq(dbname)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_USER)).to eq(user)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_SYSTEM))
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_INSTANCE)).to eq(dbname)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_USER)).to eq(user)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_SYSTEM))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::SPAN_SYSTEM)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_HOST)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_PORT)).to eq(port.to_i)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_PORT)).to eq(port.to_i)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_ROW_COUNT)).to eq(1)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_ROW_COUNT)).to eq(1)
         end
 
         it_behaves_like 'analytics for integration' do
@@ -595,15 +595,15 @@ RSpec.describe 'PG::Connection patcher' do
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_SERVICE))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::DEFAULT_PEER_SERVICE_NAME)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_HOSTNAME)).to eq(host)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_INSTANCE)).to eq(dbname)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_USER)).to eq(user)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_SYSTEM))
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_INSTANCE)).to eq(dbname)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_USER)).to eq(user)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_SYSTEM))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::SPAN_SYSTEM)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_HOST)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_PORT)).to eq(port.to_i)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_PORT)).to eq(port.to_i)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_ROW_COUNT)).to eq(1)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_ROW_COUNT)).to eq(1)
         end
 
         it_behaves_like 'analytics for integration' do
@@ -679,15 +679,15 @@ RSpec.describe 'PG::Connection patcher' do
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_SERVICE))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::DEFAULT_PEER_SERVICE_NAME)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_HOSTNAME)).to eq(host)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_INSTANCE)).to eq(dbname)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_USER)).to eq(user)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_SYSTEM))
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_INSTANCE)).to eq(dbname)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_USER)).to eq(user)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_SYSTEM))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::SPAN_SYSTEM)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_HOST)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_PORT)).to eq(port.to_i)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_PORT)).to eq(port.to_i)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_ROW_COUNT)).to eq(1)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_ROW_COUNT)).to eq(1)
         end
 
         it_behaves_like 'analytics for integration' do
@@ -764,15 +764,15 @@ RSpec.describe 'PG::Connection patcher' do
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_SERVICE))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::DEFAULT_PEER_SERVICE_NAME)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_HOSTNAME)).to eq(host)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_INSTANCE)).to eq(dbname)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_USER)).to eq(user)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_SYSTEM))
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_INSTANCE)).to eq(dbname)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_USER)).to eq(user)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_SYSTEM))
             .to eq(Datadog::Tracing::Contrib::Pg::Ext::SPAN_SYSTEM)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_HOST)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_PORT)).to eq(port.to_i)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_NAME)).to eq(host)
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_DESTINATION_PORT)).to eq(port.to_i)
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::DB::TAG_ROW_COUNT)).to eq(1)
+          expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_ROW_COUNT)).to eq(1)
         end
 
         it_behaves_like 'analytics for integration' do


### PR DESCRIPTION
This PR moves database-specific contrib fields to inside the `contrib` folder: before it was under the more general `metadata` folder.

This changes aligns these tags more with our isolated contrib goals.