### PR TITLE
test:Reduce wait time on RuntimeMetrics tests

### DIFF
--- a/lib/datadog/core/workers/interval_loop.rb
+++ b/lib/datadog/core/workers/interval_loop.rb
@@ -89,6 +89,8 @@ module Datadog
 
         def perform_loop
           mutex.synchronize do
+            return unless run_loop? # Return if thread was stopped before it even started
+
             @run_loop = true
 
             shutdown.wait(mutex, loop_wait_time) if loop_wait_before_first_iteration?

--- a/lib/datadog/core/workers/interval_loop.rb
+++ b/lib/datadog/core/workers/interval_loop.rb
@@ -23,11 +23,9 @@ module Datadog
 
         def stop_loop
           mutex.synchronize do
-            run_loop = run_loop?
-            @run_loop = false # Always mark loop as stopped, in case worker thread hasn't started yet
+            return false unless run_loop?
 
-            return false unless run_loop
-
+            @run_loop = false
             shutdown.signal
           end
 
@@ -91,9 +89,6 @@ module Datadog
 
         def perform_loop
           mutex.synchronize do
-            # Check if thread was explicitly stopped before it even started
-            return if instance_variable_defined?(:@run_loop) && !run_loop?
-
             @run_loop = true
 
             shutdown.wait(mutex, loop_wait_time) if loop_wait_before_first_iteration?

--- a/lib/datadog/core/workers/interval_loop.rb
+++ b/lib/datadog/core/workers/interval_loop.rb
@@ -23,9 +23,11 @@ module Datadog
 
         def stop_loop
           mutex.synchronize do
-            return false unless run_loop?
+            run_loop = run_loop?
+            @run_loop = false # Always mark loop as stopped, in case worker thread hasn't started yet
 
-            @run_loop = false
+            return false unless run_loop
+
             shutdown.signal
           end
 
@@ -89,7 +91,8 @@ module Datadog
 
         def perform_loop
           mutex.synchronize do
-            return unless run_loop? # Return if thread was stopped before it even started
+            # Check if thread was explicitly stopped before it even started
+            return if instance_variable_defined?(:@run_loop) && !run_loop?
 
             @run_loop = true
 

--- a/spec/datadog/core/workers/runtime_metrics_spec.rb
+++ b/spec/datadog/core/workers/runtime_metrics_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe Datadog::Core::Workers::RuntimeMetrics do
 
   describe 'integration tests', :integration do
     describe 'interval' do
-      let(:default_flush_interval) { 0.5 }
+      let(:default_flush_interval) { 0.1 }
 
       before do
         stub_const(
@@ -282,7 +282,11 @@ RSpec.describe Datadog::Core::Workers::RuntimeMetrics do
       it 'produces metrics every interval' do
         worker.perform
 
-        sleep(default_flush_interval + 0.2)
+        Thread.pass # Let the background thread start
+
+        sleep(default_flush_interval * 1.1)
+
+        Thread.pass # Let the background thread run, if it hasn't during the sleep above
 
         # Metrics are produced once right away
         # and again after an interval.

--- a/spec/datadog/core/workers/runtime_metrics_spec.rb
+++ b/spec/datadog/core/workers/runtime_metrics_spec.rb
@@ -282,11 +282,7 @@ RSpec.describe Datadog::Core::Workers::RuntimeMetrics do
       it 'produces metrics every interval' do
         worker.perform
 
-        Thread.pass # Let the background thread start
-
         sleep(default_flush_interval * 1.1)
-
-        Thread.pass # Let the background thread run, if it hasn't during the sleep above
 
         # Metrics are produced once right away
         # and again after an interval.

--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -70,10 +70,9 @@ module SynchronizationHelpers
       else
         sleep(backoff)
       end
-      attempts -= 1
-
-      raise('Wait time exhausted!') if attempts <= 0
     end
+
+    raise('Wait time exhausted!')
   end
 
   def test_repeat

--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -53,11 +53,23 @@ module SynchronizationHelpers
 
   # Defaults to 5 second timeout
   def try_wait_until(attempts: 50, backoff: 0.1)
-    loop do
+    # It's common for tests to want to run simple tasks in a background thread
+    # but call this method without the thread having even time to start.
+    #
+    # We add an extra attempt, interleaved by `Thread.pass`, in order to allow for
+    # those simple cases to quickly succeed without a timed `sleep` call. This will
+    # save simple test one `backoff` seconds sleep cycle.
+    #
+    # The total configured timeout is not reduced.
+    (attempts + 1).times do |i|
       result = yield(attempts)
       return result if result
 
-      sleep(backoff)
+      if i == 0
+        Thread.pass
+      else
+        sleep(backoff)
+      end
       attempts -= 1
 
       raise('Wait time exhausted!') if attempts <= 0


### PR DESCRIPTION
I don't like slow tests: they waste our finite time in this beautiful world.

Runtime metric is one of the slowest test files we have, sometimes have one test case that takes 5 seconds to run ("Datadog::Core::Workers::RuntimeMetrics#perform when #enabled? is true starts a worker thread"): https://app.circleci.com/insights/github/DataDog/dd-trace-rb/workflows/build-and-test/tests?branch=master&reporting-window=last-30-days

There are other, slower tests but some are pretty tricky to solve and this one was a low-hanging fruit.