### PR TITLE
Setup ruby 3.2.0-preview2 image for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -630,12 +630,11 @@ workflows:
           integration_apps: 'rack rails-six rails-seven sinatra2-classic sinatra2-modular'
           ruby_version: '3.1'
           <<: *filters_all_branches_and_tags
-      # TODO: Re-enable once 3.2 testing is green!
-      # - orb/build_and_test_integration:
-      #     name: build_and_test_integration-3.2
-      #     integration_apps: 'rack rails-six rails-seven'
-      #     ruby_version: '3.2'
-      #     <<: *filters_all_branches_and_tags
+      - orb/build_and_test_integration:
+          name: build_and_test_integration-3.2
+          integration_apps: 'rack rails-six rails-seven sinatra2-classic sinatra2-modular'
+          ruby_version: '3.2'
+          <<: *filters_all_branches_and_tags
       # ADD NEW RUBIES HERE
       # MRI
       - orb/build:
@@ -860,12 +859,11 @@ workflows:
           integration_apps: 'rack rails-six rails-seven'
           ruby_version: '3.1'
           <<: *filters_all_branches_and_tags
-      # TODO: Re-enable once 3.2 testing is green!
-      # - orb/build_and_test_integration:
-      #     name: build_and_test_integration-3.2
-      #     integration_apps: 'rack rails-six rails-seven'
-      #     ruby_version: '3.2'
-      #     <<: *filters_all_branches_and_tags
+      - orb/build_and_test_integration:
+          name: build_and_test_integration-3.2
+          integration_apps: 'rack rails-six rails-seven'
+          ruby_version: '3.2'
+          <<: *filters_all_branches_and_tags
       # ADD NEW RUBIES HERE
       # MRI
       - orb/build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,7 +518,7 @@ job_configuration:
   - &config-3_2
     <<: *filters_all_branches_and_tags
     ruby_version: '3.2'
-    image: ivoanjo/docker-library:ddtrace_rb_3_2_0_preview1
+    image: ivoanjo/docker-library:ddtrace_rb_3_2_0_preview2
     resource_class_to_use: medium+
     # ADD NEW RUBIES HERE
   - &config-jruby-9_2_8_0 # Test with older 9.2 release because 9.2.9.0 changed behavior, see https://github.com/DataDog/dd-trace-rb/pull/1409

--- a/.circleci/images/primary/Dockerfile-3.2.0-preview2
+++ b/.circleci/images/primary/Dockerfile-3.2.0-preview2
@@ -1,6 +1,6 @@
 # This image supports multiple platforms, see README for build instructions
 
-FROM ruby:3.2.0-preview1-bullseye
+FROM ruby:3.2.0-preview2-bullseye
 
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -351,7 +351,7 @@ services:
       - bundle-3.1-arm64:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-3.2:
-    image: ivoanjo/docker-library:ddtrace_rb_3_2_0_preview1
+    image: ivoanjo/docker-library:ddtrace_rb_3_2_0_preview2
     platform: linux/x86_64
     command: /bin/bash
     depends_on:
@@ -381,7 +381,7 @@ services:
       - bundle-3.2:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-3.2-arm64:
-    image: ivoanjo/docker-library:ddtrace_rb_3_2_0_preview1_arm64
+    image: ivoanjo/docker-library:ddtrace_rb_3_2_0_preview2_arm64
     command: /bin/bash
     depends_on:
       - ddagent

--- a/integration/apps/rails-seven/Gemfile
+++ b/integration/apps/rails-seven/Gemfile
@@ -63,6 +63,7 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+  gem 'byebug', platform: :ruby
 end
 
 group :test do


### PR DESCRIPTION
**What does this PR do?**:

Setup the newly-released ruby 3.2.0-preview2 for use in development and testing. This includes testing with the integration apps BUT DOES NOT include running the main+integration test suites (see below).

**Motivation**:

Make sure we're compatible with the upcoming Ruby 3.2 release.

**Additional Notes**:

The main+integration test suites are broken on 3.2, see [this run](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/7254/workflows/5ee2a9c4-f04b-4444-ba20-501bbaf3516a/jobs/268577/parallel-runs/9?filterBy=FAILED). To allow us to still merge this PR to master, I've kept them disabled for now.

**How to test the change?**:

1. Validate that `build_and_test_integration-3.2-1` is green on CircleCI.
2. Validate that the `tracer-3.2` can be used for local development
