### PR TITLE
Unified tagging `db.mongodb.collection`

### DIFF
--- a/lib/datadog/tracing/contrib/mongodb/ext.rb
+++ b/lib/datadog/tracing/contrib/mongodb/ext.rb
@@ -20,6 +20,12 @@ module Datadog
           TAG_ROWS = 'mongodb.rows'.freeze
           TAG_COMPONENT = 'mongodb'.freeze
           TAG_OPERATION_COMMAND = 'command'.freeze
+
+          # Temporary namespace to accommodate unified tags which has naming collision, before
+          # making breaking changes
+          module DB
+            TAG_COLLECTION = 'db.mongodb.collection'.freeze
+          end
         end
       end
     end

--- a/lib/datadog/tracing/contrib/mongodb/subscribers.rb
+++ b/lib/datadog/tracing/contrib/mongodb/subscribers.rb
@@ -44,7 +44,7 @@ module Datadog
             # since it has been quantized and reduced
             span.set_tag(Ext::TAG_DB, query['database'])
             span.set_tag(Ext::TAG_COLLECTION, query['collection'])
-            span.set_tag(['db', Ext::TAG_COLLECTION].join('.'), query['collection'])
+            span.set_tag(Ext::DB::TAG_COLLECTION, query['collection'])
             span.set_tag(Ext::TAG_OPERATION, query['operation'])
             span.set_tag(Ext::TAG_QUERY, serialized_query)
             span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, event.address.host)

--- a/lib/datadog/tracing/contrib/mongodb/subscribers.rb
+++ b/lib/datadog/tracing/contrib/mongodb/subscribers.rb
@@ -44,6 +44,7 @@ module Datadog
             # since it has been quantized and reduced
             span.set_tag(Ext::TAG_DB, query['database'])
             span.set_tag(Ext::TAG_COLLECTION, query['collection'])
+            span.set_tag(['db', Ext::TAG_COLLECTION].join('.'), query['collection'])
             span.set_tag(Ext::TAG_OPERATION, query['operation'])
             span.set_tag(Ext::TAG_QUERY, serialized_query)
             span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, event.address.host)

--- a/spec/datadog/tracing/contrib/mongodb/client_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/client_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
         expect(span.get_tag('mongodb.db')).to eq(database)
         collection_value = collection.is_a?(Numeric) ? collection : collection.to_s
         expect(span.get_tag('mongodb.collection')).to eq(collection_value)
+        expect(span.get_tag('db.mongodb.collection')).to eq(collection_value)
         expect(span.get_tag('out.host')).to eq(host)
         expect(span.get_tag('out.port')).to eq(port)
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('mongodb')

--- a/spec/datadog/tracing/contrib/mongodb/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/integration_spec.rb
@@ -1,8 +1,7 @@
 # typed: ignore
 
 require 'datadog/tracing/contrib/support/spec_helper'
-
-require 'datadog/tracing/contrib/action_pack/integration'
+require 'datadog/tracing/contrib/mongodb/integration'
 
 RSpec.describe Datadog::Tracing::Contrib::MongoDB::Integration do
   extend ConfigurationHelpers


### PR DESCRIPTION
**What does this PR do?**

Add tag `db.mongodb.collection` for `mongodb` integration