### PR TITLE
Unified tagging `db.redis.database_index`

### DIFF
--- a/lib/datadog/tracing/contrib/redis/ext.rb
+++ b/lib/datadog/tracing/contrib/redis/ext.rb
@@ -19,6 +19,7 @@ module Datadog
           TYPE = 'redis'.freeze
           TAG_COMPONENT = 'redis'.freeze
           TAG_OPERATION_COMMAND = 'command'.freeze
+          TAG_DATABASE_INDEX = 'db.redis.database_index'.freeze
         end
       end
     end

--- a/lib/datadog/tracing/contrib/redis/tags.rb
+++ b/lib/datadog/tracing/contrib/redis/tags.rb
@@ -24,6 +24,8 @@ module Datadog
 
               span.set_tag Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, client.host
               span.set_tag Tracing::Metadata::Ext::NET::TAG_TARGET_PORT, client.port
+
+              span.set_tag Ext::TAG_DATABASE_INDEX, client.db.to_s
               span.set_tag Ext::TAG_DB, client.db
               span.set_tag Ext::TAG_RAW_COMMAND, span.resource if show_command_args?
             end

--- a/spec/datadog/tracing/contrib/redis/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/instrumentation_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe 'Redis instrumentation test' do
   let(:test_host) { ENV.fetch('TEST_REDIS_HOST', '127.0.0.1') }
   let(:test_port) { ENV.fetch('TEST_REDIS_PORT', 6379).to_i }
 
-  let(:client) { Redis.new(host: test_host, port: test_port) }
-  let(:configuration_options) { {} }
+  # Redis instance supports 16 databases,
+  # the default is 0 but can be changed to any number from 0-15,
+  # to configure support more databases, check `redis.conf`
+  let(:test_database) { (0..15).to_a.sample }
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.
@@ -24,10 +26,38 @@ RSpec.describe 'Redis instrumentation test' do
     skip unless ENV['TEST_DATADOG_INTEGRATION']
   end
 
+  RSpec::Matchers.define :be_a_redis_span do
+    match(notify_expectation_failures: true) do |span|
+      expect(span.name).to eq('redis.command')
+      expect(span.span_type).to eq('redis')
+
+      expect(span.resource).to eq(@resource)
+      expect(span.service).to eq(@service)
+
+      expect(span).to_not have_error
+      expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('redis')
+      expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('command')
+
+      expect(span.get_tag('out.host')).to eq(@host)
+      expect(span.get_tag('out.port')).to eq(@port.to_f)
+      expect(span.get_tag('redis.raw_command')).to eq(@raw_command)
+      expect(span.get_tag('db.redis.database_index')).to eq(@db.to_s)
+    end
+
+    chain :with do |opts|
+      @resource = opts.fetch(:resource)
+      @service = opts.fetch(:service)
+      @raw_command = opts.fetch(:raw_command)
+      @host = opts.fetch(:host)
+      @port = opts.fetch(:port)
+      @db = opts.fetch(:db)
+    end
+  end
+
   describe 'when multiplexed configuration is provided via url' do
     let(:default_service_name) { 'default-service' }
     let(:service_name) { 'multiplex-service' }
-    let(:redis_url) { "redis://#{test_host}:#{test_port}/0" }
+    let(:redis_url) { "redis://#{test_host}:#{test_port}/#{test_database}" }
     let(:client) { Redis.new(url: redis_url) }
 
     before do
@@ -44,17 +74,28 @@ RSpec.describe 'Redis instrumentation test' do
       end
 
       it 'calls instrumentation' do
-        expect(spans.size).to eq(1)
-        expect(span.service).to eq(service_name)
-        expect(span.name).to eq('redis.command')
-        expect(span.span_type).to eq('redis')
-        expect(span.resource).to eq('SET abc 123')
-        expect(span.get_tag('redis.raw_command')).to eq('SET abc 123')
-        expect(span.get_tag('out.host')).to eq(test_host)
-        expect(span.get_tag('out.port')).to eq(test_port.to_f)
+        expect(spans.size).to eq(2)
 
-        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('redis')
-        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('command')
+        select_db_span, span = spans
+
+        # Select the designated database first
+        expect(select_db_span).to be_a_redis_span.with(
+          resource: "SELECT #{test_database}",
+          service: 'multiplex-service',
+          raw_command: "SELECT #{test_database}",
+          host: test_host,
+          port: test_port,
+          db: test_database
+        )
+
+        expect(span).to be_a_redis_span.with(
+          resource: 'SET abc 123',
+          service: 'multiplex-service',
+          raw_command: 'SET abc 123',
+          host: test_host,
+          port: test_port,
+          db: test_database
+        )
       end
     end
   end
@@ -62,12 +103,14 @@ RSpec.describe 'Redis instrumentation test' do
   describe 'when multiplexed configuration is provided via hash' do
     let(:default_service_name) { 'default-service' }
     let(:service_name) { 'multiplex-service' }
-    let(:client) { Redis.new(host: test_host, port: test_port) }
+    let(:client) { Redis.new(host: test_host, port: test_port, db: test_database) }
 
     before do
       Datadog.configure do |c|
         c.tracing.instrument :redis, service_name: default_service_name
-        c.tracing.instrument :redis, describes: { host: test_host, port: test_port }, service_name: service_name
+        c.tracing.instrument :redis,
+          describes: { host: test_host, port: test_port, db: test_database },
+          service_name: service_name
       end
     end
 
@@ -78,17 +121,28 @@ RSpec.describe 'Redis instrumentation test' do
       end
 
       it 'calls instrumentation' do
-        expect(spans.size).to eq(1)
-        expect(span.service).to eq(service_name)
-        expect(span.name).to eq('redis.command')
-        expect(span.span_type).to eq('redis')
-        expect(span.resource).to eq('SET abc 123')
-        expect(span.get_tag('redis.raw_command')).to eq('SET abc 123')
-        expect(span.get_tag('out.host')).to eq(test_host)
-        expect(span.get_tag('out.port')).to eq(test_port.to_f)
+        expect(spans.size).to eq(2)
 
-        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('redis')
-        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('command')
+        select_db_span, span = spans
+
+        # Select the designated database first
+        expect(select_db_span).to be_a_redis_span.with(
+          resource: "SELECT #{test_database}",
+          service: 'multiplex-service',
+          raw_command: "SELECT #{test_database}",
+          host: test_host,
+          port: test_port,
+          db: test_database
+        )
+
+        expect(span).to be_a_redis_span.with(
+          resource: 'SET abc 123',
+          service: 'multiplex-service',
+          raw_command: 'SET abc 123',
+          host: test_host,
+          port: test_port,
+          db: test_database
+        )
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**

Add tag `db.redis.database_index` for `redis` integration