### PR TITLE
Add new integration apps also to edge workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -635,8 +635,9 @@ workflows:
           integration_apps: 'rack rails-six rails-seven sinatra2-classic sinatra2-modular'
           ruby_version: '3.2'
           <<: *filters_all_branches_and_tags
+      # ⬆️ **Note**: If add/remove test apps above, remember to also copy-paste the changes to the "edge" workflow further down the file.
+      #
       # ADD NEW RUBIES HERE
-      # MRI
       - orb/build:
           <<: *config-2_1
           name: build-2.1
@@ -841,31 +842,30 @@ workflows:
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.6
-          integration_apps: 'rack rails-five rails-six'
+          integration_apps: 'rack rails-five rails-six sinatra2-classic sinatra2-modular'
           ruby_version: '2.6'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-2.7
-          integration_apps: 'rack rails-five rails-six rails-seven'
+          integration_apps: 'rack rails-five rails-six rails-seven sinatra2-classic sinatra2-modular'
           ruby_version: '2.7'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-3.0
-          integration_apps: 'rack rails-six rails-seven'
+          integration_apps: 'rack rails-six rails-seven sinatra2-classic sinatra2-modular'
           ruby_version: '3.0'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-3.1
-          integration_apps: 'rack rails-six rails-seven'
+          integration_apps: 'rack rails-six rails-seven sinatra2-classic sinatra2-modular'
           ruby_version: '3.1'
           <<: *filters_all_branches_and_tags
       - orb/build_and_test_integration:
           name: build_and_test_integration-3.2
-          integration_apps: 'rack rails-six rails-seven'
+          integration_apps: 'rack rails-six rails-seven sinatra2-classic sinatra2-modular'
           ruby_version: '3.2'
           <<: *filters_all_branches_and_tags
       # ADD NEW RUBIES HERE
-      # MRI
       - orb/build:
           <<: *config-2_1
           name: build-2.1


### PR DESCRIPTION
**What does this PR do?**:

We recently added the sinatra2 integration apps, but forgot to also update the edge workflow to run them.

**Motivation**:

Make sure edge workflow matches the workflow we use for PRs/branches.

**How to test the change?**:

Not sure how to test before merging. To test the change after merging, we need to wait until the next "edge" workflow [on CircleCI](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb?branch=master) (runs once a day) and validate that the new sinatra apps are correctly running.