### PR TITLE
Unified tagging for graphql

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1368,7 +1368,8 @@ elsif ruby_version?('3.0') || ruby_version?('3.1')
     gem 'ethon'
     gem 'excon'
     gem 'grape'
-    gem 'graphql', '>= 2.0'
+    # gem 'graphql', '>= 2.0'
+    gem 'graphql', git: 'https://github.com/TonyCTHsu/graphql-ruby.git', branch: 'datadog/unified-tagging'
     gem 'grpc', '>= 1.38.0' # Minimum version with Ruby 3.0 support
     gem 'hiredis'
     gem 'http'

--- a/spec/datadog/tracing/contrib/graphql/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/graphql/tracer_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'GraphQL patcher' do
       let(:supports_component_operation_tag?) { Gem::Version.new(GraphQL::VERSION) > Gem::Version.new('2.0.6') }
       # Update this when released
       let(:supports_unified_tagging?) do
-        Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new("2.0.14")
+        Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new('2.0.14')
       end
 
       it do
@@ -109,8 +109,8 @@ RSpec.describe 'GraphQL patcher' do
           end
         end
 
-        validate_span = spans.find {|s| s.name == 'validate.graphql' }
-        parse_span = spans.find {|s| s.name == 'parse.graphql' }
+        validate_span = spans.find { |s| s.name == 'validate.graphql' }
+        parse_span = spans.find { |s| s.name == 'parse.graphql' }
         execute_spans = spans.select do |s|
           s.name == 'execute.graphql' &&
             s.resource == 'execute.graphql' &&


### PR DESCRIPTION
**What does this PR do?**

Add unified tagging `graphql.source`, `graphql.operation.type`,  `graphql.operation.name`

https://github.com/rmosolgo/graphql-ruby/pull/4196
