### PR TITLE
Set TraceOperation to sampled=true by default

### DIFF
--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -74,7 +74,7 @@ module Datadog
         @id = id || Core::Utils.next_id
         @max_length = max_length || DEFAULT_MAX_LENGTH
         @parent_span_id = parent_span_id
-        @sampled = sampled.nil? ? false : sampled
+        @sampled = sampled.nil? ? true : sampled
 
         # Tags
         @agent_sample_rate = agent_sample_rate

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -648,4 +648,41 @@ RSpec.describe 'Tracer integration tests' do
       end
     end
   end
+
+  describe 'distributed tracing' do
+    include_context 'agent-based test'
+
+    [
+      Datadog::Tracing::Sampling::Ext::Priority::USER_REJECT,
+      Datadog::Tracing::Sampling::Ext::Priority::AUTO_REJECT,
+      Datadog::Tracing::Sampling::Ext::Priority::AUTO_KEEP,
+      Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP,
+    ].each do |priority|
+      context "with sampling priority #{priority}" do
+        let(:env) do
+          {
+            'HTTP_X_DATADOG_TRACE_ID' => '123',
+            'HTTP_X_DATADOG_PARENT_ID' => '456',
+            'HTTP_X_DATADOG_SAMPLING_PRIORITY' => priority.to_s,
+            'HTTP_X_DATADOG_ORIGIN' => 'ci',
+          }
+        end
+
+        it 'ensures trace is flushed' do
+          trace_digest = Datadog::Tracing::Propagation::HTTP.extract(env)
+          Datadog::Tracing.continue_trace!(trace_digest)
+
+          tracer.trace('name') {}
+
+          try_wait_until(attempts: 20) { tracer.writer.stats[:traces_flushed] >= 1 }
+
+          stats = tracer.writer.stats
+          expect(stats[:traces_flushed]).to eq(1)
+          expect(stats[:transport].client_error).to eq(0)
+          expect(stats[:transport].server_error).to eq(0)
+          expect(stats[:transport].internal_error).to eq(0)
+        end
+      end
+    end
+  end
 end

--- a/spec/datadog/tracing/trace_operation_spec.rb
+++ b/spec/datadog/tracing/trace_operation_spec.rb
@@ -650,34 +650,42 @@ RSpec.describe Datadog::Tracing::TraceOperation do
   describe '#sampled?' do
     subject(:sampled?) { trace_op.sampled? }
 
-    it { is_expected.to be false }
-
-    context 'when :sampled is set' do
-      let(:options) { { sampled: true } }
-      it { is_expected.to be true }
+    it 'traces are sampled by default' do
+      is_expected.to be true
     end
 
-    context 'when :sampling_priority is set to' do
-      let(:options) { { sampling_priority: sampling_priority } }
+    context 'when :sampled is set in initializer' do
+      let(:options) { { sampled: false } }
+      it { is_expected.to be false }
+    end
 
-      context 'AUTO_KEEP' do
-        let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::AUTO_KEEP }
-        it { is_expected.to be true }
-      end
+    [true, false].each do |sampled|
+      context "when :sampled is set to #{sampled}" do
+        let(:options) { { sampled: sampled } }
 
-      context 'AUTO_REJECT' do
-        let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::AUTO_REJECT }
-        it { is_expected.to be false }
-      end
+        context 'when :sampling_priority is set to' do
+          let(:options) { super().merge(sampling_priority: sampling_priority) }
 
-      context 'USER_KEEP' do
-        let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP }
-        it { is_expected.to be true }
-      end
+          context 'AUTO_KEEP' do
+            let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::AUTO_KEEP }
+            it { is_expected.to be true }
+          end
 
-      context 'USER_REJECT' do
-        let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::USER_REJECT }
-        it { is_expected.to be false }
+          context 'AUTO_REJECT' do
+            let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::AUTO_REJECT }
+            it { is_expected.to be sampled }
+          end
+
+          context 'USER_KEEP' do
+            let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP }
+            it { is_expected.to be true }
+          end
+
+          context 'USER_REJECT' do
+            let(:sampling_priority) { Datadog::Tracing::Sampling::Ext::Priority::USER_REJECT }
+            it { is_expected.to be sampled }
+          end
+        end
       end
     end
 
@@ -736,9 +744,8 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
     it do
       expect { keep! }
-        .to change { trace_op.sampled? }
-        .from(false)
-        .to(true)
+        .to_not change { trace_op.sampled? }
+        .from(true)
     end
 
     context 'when #sampled was true' do
@@ -775,8 +782,8 @@ RSpec.describe Datadog::Tracing::TraceOperation do
 
     it do
       expect { reject! }
-        .to_not change { trace_op.sampled? }
-        .from(false)
+        .to change { trace_op.sampled? }
+        .from(true).to(false)
     end
 
     context 'when #sampled was true' do


### PR DESCRIPTION
Fixes #2101

**Motivation**

In v0.x of `ddtrace`, the currently active trace, represented by the `Context` class, would always have a `sampled == true` by default, as it inherited its value from `Span#sampled`: https://github.com/DataDog/dd-trace-rb/blob/9fd04441f91f4668c6d31dcff2af2115b38318c0/lib/ddtrace/context.rb#L299

And `Span#sampled` defaults to `true`: https://github.com/DataDog/dd-trace-rb/blob/9fd04441f91f4668c6d31dcff2af2115b38318c0/lib/ddtrace/span.rb#L94

In v1.x, the currently active trace is now represented by a `TraceOperation`.
`TraceOperation#sampled` defaults to `false`: https://github.com/DataDog/dd-trace-rb/blob/4f646ea8f3b926715e3a7bbe4a5a1195ef4b7223/lib/datadog/tracing/trace_operation.rb#L77
And there's no mechanism to inherit sampling from the active span in v1.x.

This doesn't normally affect traces, as the `PrioritySampler`, which is the default sampler, always sets `sampled = true`: https://github.com/DataDog/dd-trace-rb/blob/4f646ea8f3b926715e3a7bbe4a5a1195ef4b7223/lib/datadog/tracing/sampling/priority_sampler.rb#L92-L98

But, sampling checks are completely skipped if the sampling decision was made in an upstream service. We only check the sampler if the current span is a root span (`parent_id == 0`): https://github.com/DataDog/dd-trace-rb/blob/4f646ea8f3b926715e3a7bbe4a5a1195ef4b7223/lib/datadog/tracing/tracer.rb#L345

Because distributed traces won't have any spans with `parent_id == 0`, as the local root span inherits the `parent_id` from the upstream distributed span, we never invoked the `PrioritySampler`.

**What does this PR do?**

This PR sets `TraceOperation#sampled` to `true` by default, as having traces being sampled by default was the desired intent in first place.