### PR TITLE
Suggest use of Ruby 3.0 in development guide

### DIFF
--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -27,8 +27,8 @@ To start a development environment, choose a target Ruby version then run the fo
 # In the root directory of the project...
 cd ~/dd-trace-rb
 
-# Create and start a Ruby 2.3 test environment with its dependencies
-docker-compose run --rm tracer-2.3 /bin/bash
+# Create and start a Ruby 3.0 test environment with its dependencies
+docker-compose run --rm tracer-3.0 /bin/bash
 
 # Then inside the container (e.g. `root@2a73c6d8673e:/app`)...
 # Install the library dependencies


### PR DESCRIPTION
**What does this PR do?**

Replace Ruby 2.3 with 3.0 in the development setup guide.

**Motivation**

Because we don't have arm64 Ruby 2.3 images (yet), our instructions aren't a great experience for developers on arm laptops (usually Apple M1/M2/...).

By using 3.0 as a default, since we have multiplatform images for that Ruby version, those contributors will have a better experience.

**Additional Notes**
(None)

**How to test the change?**

Run the instructions locally -- this is a development guide, after all!
