### PR TITLE
Fix OpenTracing context propagation

### DIFF
--- a/lib/datadog/opentracer/tracer.rb
+++ b/lib/datadog/opentracer/tracer.rb
@@ -151,12 +151,10 @@ module Datadog
           tags: tags || {}
         )
 
-        # Build or extend the OpenTracer::SpanContext
-        span_context = if parent_span_context
-                         SpanContextFactory.clone(span_context: parent_span_context)
-                       else
-                         SpanContextFactory.build(datadog_context: datadog_context)
-                       end
+        span_context =  SpanContextFactory.build(
+                          datadog_context: datadog_context || datadog_tracer.send(:call_context),
+                          baggage: parent_span_context ? parent_span_context.baggage.dup : {}
+                        )
 
         # Wrap the Datadog span and OpenTracer::Span context in a OpenTracer::Span
         Span.new(datadog_span: datadog_span, span_context: span_context)

--- a/lib/datadog/opentracer/tracer.rb
+++ b/lib/datadog/opentracer/tracer.rb
@@ -151,10 +151,10 @@ module Datadog
           tags: tags || {}
         )
 
-        span_context =  SpanContextFactory.build(
-                          datadog_context: datadog_context || datadog_tracer.send(:call_context),
-                          baggage: parent_span_context ? parent_span_context.baggage.dup : {}
-                        )
+        span_context = SpanContextFactory.build(
+          datadog_context: datadog_context || datadog_tracer.send(:call_context),
+          baggage: parent_span_context ? parent_span_context.baggage.dup : {}
+        )
 
         # Wrap the Datadog span and OpenTracer::Span context in a OpenTracer::Span
         Span.new(datadog_span: datadog_span, span_context: span_context)

--- a/spec/datadog/opentracer/propagation_integration_spec.rb
+++ b/spec/datadog/opentracer/propagation_integration_spec.rb
@@ -182,19 +182,23 @@ RSpec.describe 'OpenTracer context propagation' do
       it { expect(@destination_scope.span.context.baggage).to include(baggage) }
 
       it do
-        expect(@origin_carrier[Datadog::OpenTracer::TextMapPropagator::HTTP_HEADER_TRACE_ID]).to eq origin_datadog_span.trace_id
-        expect(@origin_carrier[Datadog::OpenTracer::TextMapPropagator::HTTP_HEADER_PARENT_ID]).to eq origin_datadog_span.span_id
-        expect(@origin_carrier[Datadog::OpenTracer::TextMapPropagator::HTTP_HEADER_SAMPLING_PRIORITY]).to eq 1
-        expect(@origin_carrier[Datadog::OpenTracer::TextMapPropagator::HTTP_HEADER_ORIGIN]).to eq 'synthetics'
-        expect(@origin_carrier['ot-baggage-account_name']).to eq 'acme'
+        expect(@origin_carrier).to include(
+          Datadog::OpenTracer::TextMapPropagator::HTTP_HEADER_TRACE_ID => origin_datadog_span.trace_id,
+          Datadog::OpenTracer::TextMapPropagator::HTTP_HEADER_PARENT_ID => origin_datadog_span.span_id,
+          Datadog::OpenTracer::TextMapPropagator::HTTP_HEADER_SAMPLING_PRIORITY => 1,
+          Datadog::OpenTracer::TextMapPropagator::HTTP_HEADER_ORIGIN => 'synthetics',
+          'ot-baggage-account_name' => 'acme'
+        )
       end
 
       it do
-        expect(@intermediate_carrier[Datadog::OpenTracer::TextMapPropagator::HTTP_HEADER_TRACE_ID]).to eq intermediate_datadog_span.trace_id
-        expect(@intermediate_carrier[Datadog::OpenTracer::TextMapPropagator::HTTP_HEADER_PARENT_ID]).to eq intermediate_datadog_span.span_id
-        expect(@intermediate_carrier[Datadog::OpenTracer::TextMapPropagator::HTTP_HEADER_SAMPLING_PRIORITY]).to eq 1
-        expect(@intermediate_carrier[Datadog::OpenTracer::TextMapPropagator::HTTP_HEADER_ORIGIN]).to eq 'synthetics'
-        expect(@intermediate_carrier['ot-baggage-account_name']).to eq 'acme'
+        expect(@intermediate_carrier).to include(
+          Datadog::OpenTracer::TextMapPropagator::HTTP_HEADER_TRACE_ID => intermediate_datadog_span.trace_id,
+          Datadog::OpenTracer::TextMapPropagator::HTTP_HEADER_PARENT_ID => intermediate_datadog_span.span_id,
+          Datadog::OpenTracer::TextMapPropagator::HTTP_HEADER_SAMPLING_PRIORITY => 1,
+          Datadog::OpenTracer::TextMapPropagator::HTTP_HEADER_ORIGIN => 'synthetics',
+          'ot-baggage-account_name' => 'acme'
+        )
       end
     end
   end
@@ -312,7 +316,6 @@ RSpec.describe 'OpenTracer context propagation' do
       let(:destination_datadog_trace) { datadog_traces.find { |x| x.name == destination_span_name } }
       let(:destination_datadog_span) { datadog_spans.find { |x| x.name == destination_span_name } }
 
-
       # NOTE: If these baggage names include either dashes or uppercase characters
       #       they will not make a round-trip with the same key format. They will
       #       be converted to underscores and lowercase characters, because Rack
@@ -375,19 +378,23 @@ RSpec.describe 'OpenTracer context propagation' do
       it { expect(@destination_scope.span.context.baggage).to include(baggage) }
 
       it do
-        expect(@origin_carrier[Datadog::OpenTracer::RackPropagator::HTTP_HEADER_TRACE_ID]).to eq origin_datadog_span.trace_id.to_s
-        expect(@origin_carrier[Datadog::OpenTracer::RackPropagator::HTTP_HEADER_PARENT_ID]).to eq origin_datadog_span.span_id.to_s
-        expect(@origin_carrier[Datadog::OpenTracer::RackPropagator::HTTP_HEADER_SAMPLING_PRIORITY]).to eq '1'
-        expect(@origin_carrier[Datadog::OpenTracer::RackPropagator::HTTP_HEADER_ORIGIN]).to eq 'synthetics'
-        expect(@origin_carrier['ot-baggage-account_name']).to eq 'acme'
+        expect(@origin_carrier).to include(
+          Datadog::OpenTracer::RackPropagator::HTTP_HEADER_TRACE_ID => origin_datadog_span.trace_id.to_s,
+          Datadog::OpenTracer::RackPropagator::HTTP_HEADER_PARENT_ID => origin_datadog_span.span_id.to_s,
+          Datadog::OpenTracer::RackPropagator::HTTP_HEADER_SAMPLING_PRIORITY => '1',
+          Datadog::OpenTracer::RackPropagator::HTTP_HEADER_ORIGIN => 'synthetics',
+          'ot-baggage-account_name' => 'acme'
+        )
       end
 
       it do
-        expect(@intermediate_carrier[Datadog::OpenTracer::RackPropagator::HTTP_HEADER_TRACE_ID]).to eq intermediate_datadog_span.trace_id.to_s
-        expect(@intermediate_carrier[Datadog::OpenTracer::RackPropagator::HTTP_HEADER_PARENT_ID]).to eq intermediate_datadog_span.span_id.to_s
-        expect(@intermediate_carrier[Datadog::OpenTracer::RackPropagator::HTTP_HEADER_SAMPLING_PRIORITY]).to eq '1'
-        expect(@intermediate_carrier[Datadog::OpenTracer::RackPropagator::HTTP_HEADER_ORIGIN]).to eq 'synthetics'
-        expect(@intermediate_carrier['ot-baggage-account_name']).to eq 'acme'
+        expect(@intermediate_carrier).to include(
+          Datadog::OpenTracer::RackPropagator::HTTP_HEADER_TRACE_ID => intermediate_datadog_span.trace_id.to_s,
+          Datadog::OpenTracer::RackPropagator::HTTP_HEADER_PARENT_ID => intermediate_datadog_span.span_id.to_s,
+          Datadog::OpenTracer::RackPropagator::HTTP_HEADER_SAMPLING_PRIORITY => '1',
+          Datadog::OpenTracer::RackPropagator::HTTP_HEADER_ORIGIN => 'synthetics',
+          'ot-baggage-account_name' => 'acme'
+        )
       end
     end
   end


### PR DESCRIPTION
Fixes #2191 

Context propagation in OpenTracing was not working properly. Ordinarily, each new `Span` should get its own `SpanContext`, containing the relevant `Datadog::Tracing::Context` state. Instead, of building this `SpanContext` with the current state, it would build it with the previous state in inherited from its parent. This would case the child to inherit the grandparent's ID as its parent ID.

This change makes sure we build a new `SpanContext` per `Span`, and only propagate the relevant `Datadog::Tracing::Context`.