### PR TITLE
Debug:Print trace as it is about to be flushed

### DIFF
--- a/lib/ddtrace/transport/traces.rb
+++ b/lib/ddtrace/transport/traces.rb
@@ -101,6 +101,8 @@ module Datadog
           # Make the trace serializable
           serializable_trace = SerializableTrace.new(trace)
 
+          Datadog.logger.debug { "Flushing trace: #{JSON.dump(serializable_trace)}" }
+
           # Encode the trace
           encoder.encode(serializable_trace)
         end


### PR DESCRIPTION
When enabling diagnostic logging, we can see all traces that are sent to the writer.

This is very helpful, but does not capture the complete story of a trace.

The trace will be modified by **TraceFormatter**, which does quiet a bit of work applying tags to the root span: the root span that we see today in diagnostic logs will be much different when actually flushed.

There's also the Processing Pipeline that can modify or drop traces.

This PR adds a debug-level log as late as possible: right before we mush our trace into unintelligible bytes.

The log line looks like this:
```
Flushing trace: [{"error":0,"meta":{"env":"test-env","language":"ruby","runtime-id":"24c8dbaf-bd09-407d-812d-a8737f4bcaf0"},"metrics":{"_dd.top_level":1.0,"_dd.agent_psr":1.0,"system.pid":70439.0,"_sampling_priority_v1":1.0},"name":"a","parent_id":0,"resource":"a","service":"test-app","span_id":1472066385686673140,"trace_id":3514006046188043380,"type":null,"start":1663889528517354000,"duration":4000}]
```

I did not remove the existing pre-writer logger because if the trace fails to serialize due to being too large, or is dropped by the Processing Pipeline, we won't get any signals with the log introduced in this PR.

I think we should perform an overhaul in our debug logs: we should be able to enable it and have virtually everything needed to debug any issues we are used to encountering, without asking user to add ad-hoc logging when issues arise.