### PR TITLE
Action:Automatic pull request labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,38 @@
+# Configuration for GitHub Action `.github/workflows/pull-request-labeler.yml`.
+# See https://github.com/marketplace/actions/labeler for more information.
+
+# Only documentation changes
+docs:
+  - all: [ '**/*.md' ]
+
+# Only test changes
+dev/testing:
+  - all: [ '{spec/**,integration/**}' ]
+
+# Changes to Profiling
+profiling:
+  - any: [ 'lib/datadog/profiling/**' ]
+
+# Changes to CI-App
+ci-app:
+  - any: [ 'lib/datadog/ci/**' ]
+
+# Changes to ASM
+appsec:
+  - any: [ 'lib/datadog/appsec/**' ]
+
+# Changes to Tracing integrations
+integrations:
+  - any: [ 'lib/datadog/tracing/contrib/**' ]
+
+# Only repository GitHub changes
+dev/github:
+  - all: [ '.github/**' ]
+
+# Only repository CI changes
+dev/ci:
+  - all: [ '{.circleci/**,.gitlab-ci.yml}' ]
+
+# Version bump pull request
+release:
+  - all: [ '{CHANGELOG.md,lib/ddtrace/version.rb,gemfiles/**}' ]

--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -1,0 +1,16 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kachkaev/labeler@d89797c51d07680aec17049cc6790e9d323d9a93 # actions/labeler@v4 + https://github.com/actions/labeler/pull/316
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler.yml
+          dot: true # From https://github.com/actions/labeler/pull/316


### PR DESCRIPTION
This PR automatically adds GitHub labels to PRs where it's safe to assume their intent.

Some examples are PRs that:
* Only change documentation files. 
* Only change test files.
* Only change release-related files.
* Changes files in a specific product directory (e.g. ci, profiling).