### PR TITLE
Allow DD_TAGS values to have the colon character

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -323,8 +323,8 @@ module Datadog
 
             # Parse tags from environment
             env_to_list(Core::Environment::Ext::ENV_TAGS, comma_separated_only: false).each do |tag|
-              pair = tag.split(':')
-              tags[pair.first] = pair.last if pair.length == 2
+              key, value = tag.split(':', 2)
+              tags[key] = value if value && !value.empty?
             end
 
             # Override tags if defined

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -735,6 +735,14 @@ RSpec.describe Datadog::Core::Configuration::Settings do
           end
         end
 
+        context 'with multiple colons' do
+          let(:env_tags) { 'key:va:lue' }
+
+          it 'allows for colons in value' do
+            is_expected.to eq('key' => 'va:lue')
+          end
+        end
+
         context 'and when #env' do
           let(:options) { { **super(), env: env } }
 


### PR DESCRIPTION
Colons are allowed in Datadog tags: they are considered part of the key's "value".

From: https://docs.datadoghq.com/getting_started/tagging/#define-tags

> <p> The key always precedes the first colon of the global tag definition, for example:</p>
> 
> Tag | Key | Value
> -- | -- | --
> env:staging:east | env | staging:east

This PR allows for DD_TAGS to contain colons in the tag "value" component.