### PR TITLE
fix: AppSec Rails should check for railties instead of rails meta gem

### DIFF
--- a/lib/datadog/appsec/contrib/rails/integration.rb
+++ b/lib/datadog/appsec/contrib/rails/integration.rb
@@ -19,7 +19,7 @@ module Datadog
           register_as :rails, auto_patch: false
 
           def self.version
-            Gem.loaded_specs['rails'] && Gem.loaded_specs['rails'].version
+            Gem.loaded_specs['railties'] && Gem.loaded_specs['railties'].version
           end
 
           def self.loaded?


### PR DESCRIPTION
As discussed in slack. 
rails gem is a meta gem and should not be used to detect the presence of the rails framework.

If an application is running with stripped gem-set , the AppSec Extension fail to load with a comparison  error `nil >= MINIMUM_VERSION`