### PR TITLE
Fix `service_nam` typo to `service_name`

### DIFF
--- a/lib/datadog/tracing/contrib/graphql/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/graphql/configuration/settings.rb
@@ -27,7 +27,7 @@ module Datadog
             end
 
             option :schemas
-            option :service_nam
+            option :service_name
           end
         end
       end


### PR DESCRIPTION
Just a simple typo fix in the configuration file of the Graphql integration. I don't know if this is the source of some of my recent issues, but if the option is going to be there... it should be right.