### PR TITLE
Support placeholder Garbage Collection frames in Collectors::Stack

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -163,8 +163,6 @@ void sample_thread(VALUE thread, sampling_buffer* buffer, VALUE recorder_instanc
       },
       .line = line,
     };
-
-    buffer->locations[i] = (ddog_Location) {.lines = (ddog_Slice_line) {.ptr = &buffer->lines[i], .len = 1}};
   }
 
   // Used below; since we want to stack-allocate this, we must do it here rather than in maybe_add_placeholder_frames_omitted
@@ -264,6 +262,12 @@ sampling_buffer *sampling_buffer_new(unsigned int max_frames) {
   buffer->is_ruby_frame = ruby_xcalloc(max_frames, sizeof(bool));
   buffer->locations     = ruby_xcalloc(max_frames, sizeof(ddog_Location));
   buffer->lines         = ruby_xcalloc(max_frames, sizeof(ddog_Line));
+
+  // Currently we have a 1-to-1 correspondence between lines and locations, so we just initialize the locations once
+  // here and then only mutate the contents of the lines.
+  for (unsigned int i = 0; i < max_frames; i++) {
+    buffer->locations[i] = (ddog_Location) {.lines = (ddog_Slice_line) {.ptr = &buffer->lines[i], .len = 1}};
+  }
 
   return buffer;
 }

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -112,7 +112,7 @@ static VALUE _native_sample(
 
   sampling_buffer *buffer = sampling_buffer_new(max_frames_requested);
 
-  if (in_gc == Qnil || in_gc == Qfalse) {
+  if (!RB_TEST(in_gc)) {
     sample_thread(
       thread,
       buffer,

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -112,7 +112,7 @@ static VALUE _native_sample(
 
   sampling_buffer *buffer = sampling_buffer_new(max_frames_requested);
 
-  if (!RB_TEST(in_gc)) {
+  if (!RTEST(in_gc)) {
     sample_thread(
       thread,
       buffer,

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.h
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.h
@@ -5,5 +5,6 @@
 typedef struct sampling_buffer sampling_buffer;
 
 void sample_thread(VALUE thread, sampling_buffer* buffer, VALUE recorder_instance, ddog_Slice_i64 metric_values, ddog_Slice_label labels);
+void sample_thread_in_gc(VALUE thread, sampling_buffer* buffer, VALUE recorder_instance, ddog_Slice_i64 metric_values, ddog_Slice_label labels);
 sampling_buffer *sampling_buffer_new(unsigned int max_frames);
 void sampling_buffer_free(sampling_buffer *buffer);

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
       before do
         Datadog::Profiling::Collectors::Stack::Testing
-          ._native_sample(Thread.current, stack_recorder, metric_values, labels, 400)
+          ._native_sample(Thread.current, stack_recorder, metric_values, labels, 400, false)
         expect(samples.size).to be 1
       end
 


### PR DESCRIPTION
**What does this PR do?**:

This PR adds a new feature to the `Collectors::Stack`: being able to include, at the top of the sampled stack, a placeholder frame saying "Garbage Collection".

**Motivation**:

The "Garbage Collection" placeholder is part of a new feature to show on the flamegraph the CPU and wall-clock time spent in garbage collection.

Right now we are not yet collecting this information, but I will follow up with a later PR to add this feature to `Collectors::CpuAndWallTime`.

**Additional Notes**:

~~I'm opening this PR as a draft because:~~
* ~~it's on top of #2302 to avoid a later rebase~~
* ~~libdatadog 0.9 has not been released yet, so CI fails~~

~~Thus, once libdatadog 0.9 is released and #2302 is merged, I'll re-trigger CI and mark this PR as non-draft when CI is back to green. I don't expect to need any code changes for that.~~

**How to test the change?**:

The changes to `Collectors::Stack` include code coverage. I plan to add later integration tests for the whole "gather GC time" feature.
