### PR TITLE
[PROF-6260] Add support for tracking time spent in GC to CpuAndWallTime collector

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -224,7 +224,8 @@ VALUE cpu_and_wall_time_collector_sample(VALUE self_instance) {
       state->sampling_buffer,
       state->recorder_instance,
       (ddog_Slice_i64) {.ptr = metric_values, .len = ENABLED_VALUE_TYPES_COUNT},
-      (ddog_Slice_label) {.ptr = labels, .len = label_count}
+      (ddog_Slice_label) {.ptr = labels, .len = label_count},
+      SAMPLE_REGULAR
     );
   }
 

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.h
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.h
@@ -3,4 +3,6 @@
 #include <ruby.h>
 
 VALUE cpu_and_wall_time_collector_sample(VALUE self_instance);
+VALUE cpu_and_wall_time_collector_on_gc_start(VALUE self_instance);
+VALUE cpu_and_wall_time_collector_on_gc_finish(VALUE self_instance);
 VALUE enforce_cpu_and_wall_time_collector_instance(VALUE object);

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.h
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.h
@@ -4,7 +4,15 @@
 
 typedef struct sampling_buffer sampling_buffer;
 
-void sample_thread(VALUE thread, sampling_buffer* buffer, VALUE recorder_instance, ddog_Slice_i64 metric_values, ddog_Slice_label labels);
-void sample_thread_in_gc(VALUE thread, sampling_buffer* buffer, VALUE recorder_instance, ddog_Slice_i64 metric_values, ddog_Slice_label labels);
+typedef enum { SAMPLE_REGULAR, SAMPLE_IN_GC } sample_type;
+
+void sample_thread(
+  VALUE thread,
+  sampling_buffer* buffer,
+  VALUE recorder_instance,
+  ddog_Slice_i64 metric_values,
+  ddog_Slice_label labels,
+  sample_type type
+);
 sampling_buffer *sampling_buffer_new(unsigned int max_frames);
 void sampling_buffer_free(sampling_buffer *buffer);


### PR DESCRIPTION
**What does this PR do?**:

This PR builds on top of #2304 to deliver the new "showing time spent in GC in the flamegraph feature". It does not yet offer the full solution: it is still missing the part where we integrate with the Ruby VM to automatically track the in-gc/not-in-gc state for threads. This final bit will come in a follow-up PR.

Specifically, this PR modifies the cpu and wall-time tracking in the `CpuAndWallTime` collector to introduce a new implicit state that a thread can be in: doing garbage collection.

The way it works is: two new functions were introduced -- `cpu_and_wall_time_collector_on_gc_start` and `cpu_and_wall_time_collector_on_gc_finish`.

When `cpu_and_wall_time_collector_on_gc_start` gets called, the current cpu and wall-time get recorded to the thread context: `cpu_time_at_gc_start_ns` and `wall_time_at_gc_start_ns`.

While these fields are set, regular samples (if any) do not account for any time that passes after these two timestamps.

(Regular samples can still account for the time between the previous sample and the start of GC. I do not expect that currently samples during GC will be triggered BUT as the profiler develops this can change so I decided to code this anyway so it does not become a complication in the future).

Then, when `cpu_and_wall_time_collector_on_gc_finish` gets called, the following happens:

1. A sample gets taken, using the special `SAMPLE_IN_GC` sample type, which produces a stack with a placeholder `Garbage Collection` frame as the latest frame. This sample gets assigned the cpu and wall-time that elapsed since `on_gc_start` was called.

2. The thread is no longer marked as being in gc (the `cpu_time_at_gc_start_ns`  and `wall_time_at_gc_start_ns` get reset back to `INVALID_TIME`).

3. The `cpu_time_at_previous_sample_ns` and `wall_time_at_previous_sample_ns` get updated with the elapsed time in GC, so that all time is accounted for -- e.g. the next sample will not get "blamed" by time spent in GC.

**Motivation**:

This work will enable us to show the time spent in garbage collection in the flamegraph.

This time would previously be invisible, and accounted for as time for the unlucky Ruby method that was running when GC happened.

**Additional Notes**:

As discussed above, this PR is only a piece of the puzzle, and is still missing changes to the `CpuAndWallTimeWorker´ to integrate with the Ruby VM.

**How to test the change?**:

The change includes code coverage.

[PROF-6260]: https://datadoghq.atlassian.net/browse/PROF-6260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ