### PR TITLE
Fix `URI::InvalidURIError`

### DIFF
--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -271,7 +271,7 @@ module Datadog
                          request_uri
                        end
 
-            base_url + fullpath
+            ::URI.join(base_url, fullpath).to_s
           end
 
           def parse_user_agent_header(headers)

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe 'Rack integration tests' do
           end
         end
 
-        context 'with REQUEST_URI' do
+        context 'with REQUEST_URI being a path' do
           subject(:response) { get '/success?foo=bar', {}, 'REQUEST_URI' => '/success?foo=bar' }
 
           context 'and default quantization' do
@@ -183,6 +183,21 @@ RSpec.describe 'Rack integration tests' do
               # The query string will not be quantized, per the option.
               expect(span.get_tag('http.url')).to eq('/success?foo=bar')
               expect(span.get_tag('http.base_url')).to eq('http://example.org')
+              expect(span).to be_root_span
+            end
+          end
+
+          context 'and quantization activated for base' do
+            let(:rack_options) { { quantize: { base: :show } } }
+
+            it_behaves_like 'a rack GET 200 span'
+
+            it do
+              # Since REQUEST_URI is set (usually provided by WEBrick/Puma)
+              # it uses REQUEST_URI, which has query string parameters.
+              # The query string will not be quantized, per the option.
+              expect(span.get_tag('http.url')).to eq('http://example.org/success?foo')
+              expect(span.get_tag('http.base_url')).to be_nil
               expect(span).to be_root_span
             end
           end
@@ -217,6 +232,21 @@ RSpec.describe 'Rack integration tests' do
               # The query string will not be quantized, per the option.
               expect(span.get_tag('http.url')).to eq('/success?foo=bar')
               expect(span.get_tag('http.base_url')).to eq('http://example.org')
+              expect(span).to be_root_span
+            end
+          end
+
+          context 'and quantization activated for base' do
+            let(:rack_options) { { quantize: { base: :show } } }
+
+            it_behaves_like 'a rack GET 200 span'
+
+            it do
+              # Since REQUEST_URI is set (usually provided by WEBrick/Puma)
+              # it uses REQUEST_URI, which has query string parameters.
+              # The query string will not be quantized, per the option.
+              expect(span.get_tag('http.url')).to eq('http://example.org/success?foo')
+              expect(span.get_tag('http.base_url')).to be_nil
               expect(span).to be_root_span
             end
           end

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -188,6 +188,40 @@ RSpec.describe 'Rack integration tests' do
           end
         end
 
+        context 'with REQUEST_URI containing base URI' do
+          subject(:response) { get '/success?foo=bar', {}, 'REQUEST_URI' => 'http://example.org/success?foo=bar' }
+
+          context 'and default quantization' do
+            let(:rack_options) { { quantize: {} } }
+
+            it_behaves_like 'a rack GET 200 span'
+
+            it do
+              # Since REQUEST_URI is set (usually provided by WEBrick/Puma)
+              # it uses REQUEST_URI, which has query string parameters.
+              # However, that query string will be quantized.
+              expect(span.get_tag('http.url')).to eq('/success?foo')
+              expect(span.get_tag('http.base_url')).to eq('http://example.org')
+              expect(span).to be_root_span
+            end
+          end
+
+          context 'and quantization activated for the query' do
+            let(:rack_options) { { quantize: { query: { show: ['foo'] } } } }
+
+            it_behaves_like 'a rack GET 200 span'
+
+            it do
+              # Since REQUEST_URI is set (usually provided by WEBrick/Puma)
+              # it uses REQUEST_URI, which has query string parameters.
+              # The query string will not be quantized, per the option.
+              expect(span.get_tag('http.url')).to eq('/success?foo=bar')
+              expect(span.get_tag('http.base_url')).to eq('http://example.org')
+              expect(span).to be_root_span
+            end
+          end
+        end
+
         context 'with sub-route' do
           let(:route) { '/success/100' }
 


### PR DESCRIPTION


<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

This fixes `URI::InvalidURIError` when it runs on WEBrick.
This error introduced in v1.5.0 (#2265).

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

`env['REQUEST_URI']` is often only path, but in some environments (e.g. WEBrick) it contains the base url (e.g. `http://localhost:3000/foo/bar`).
https://github.com/ruby/webrick/blob/v1.7.0/lib/webrick/httprequest.rb#L423
https://github.com/ruby/webrick/blob/v1.7.0/lib/webrick/httprequest.rb#L218
https://github.com/ruby/webrick/blob/v1.7.0/lib/webrick/httprequest.rb#L484-L505

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Start rails server on WEBrick and access app via web browser (e.g. `http://localhost:300/foo`).

My environment is below:
* Ruby 2.7.5
* ddtrace 1.5.0
* rack 2.2.4
* webrick 1.7.0
* rails 5.2.8.1