### PR TITLE
Fix agent_url in environment logger when io transport 

### DIFF
--- a/lib/datadog/core/diagnostics/environment_logger.rb
+++ b/lib/datadog/core/diagnostics/environment_logger.rb
@@ -106,13 +106,13 @@ module Datadog
           Datadog.configuration.version
         end
 
-        # @return [String] target agent URL for trace flushing
+        # @return [String, nil] target agent URL for trace flushing
         def agent_url
           # Retrieve the effect agent URL, regardless of how it was configured
           transport = Tracing.send(:tracer).writer.transport
 
-          # return '' with IO transport
-          return '' unless transport.respond_to?(:client)
+          # return `nil` with IO transport
+          return unless transport.respond_to?(:client)
 
           adapter = transport.client.api.adapter
           adapter.url

--- a/lib/datadog/core/diagnostics/environment_logger.rb
+++ b/lib/datadog/core/diagnostics/environment_logger.rb
@@ -110,6 +110,10 @@ module Datadog
         def agent_url
           # Retrieve the effect agent URL, regardless of how it was configured
           transport = Tracing.send(:tracer).writer.transport
+
+          # return '' with IO transport
+          return '' unless transport.respond_to?(:client)
+
           adapter = transport.client.api.adapter
           adapter.url
         end

--- a/spec/datadog/core/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/core/diagnostics/environment_logger_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 
 require 'datadog/core/diagnostics/environment_logger'
+require 'ddtrace/transport/io'
 
 RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
   subject(:env_logger) { described_class }
@@ -234,6 +235,20 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
 
         it { is_expected.to include agent_error: include('ZeroDivisionError') }
         it { is_expected.to include agent_error: include('msg') }
+      end
+
+      context 'with IO transport' do
+        before do
+          Datadog.configure do |c|
+            c.tracing.writer = Datadog::Tracing::SyncWriter.new(
+              transport: Datadog::Transport::IO.default
+            )
+          end
+        end
+
+        after { Datadog.configure { |c| c.tracing.writer = nil } }
+
+        it { is_expected.to include agent_url: '' }
       end
 
       context 'with unix socket transport' do

--- a/spec/datadog/core/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/core/diagnostics/environment_logger_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
 
         after { Datadog.configure { |c| c.tracing.writer = nil } }
 
-        it { is_expected.to include agent_url: '' }
+        it { is_expected.to include agent_url: nil }
       end
 
       context 'with unix socket transport' do


### PR DESCRIPTION
**What does this PR do?**

Mitigate the [error](https://github.com/DataDog/dd-trace-rb/issues/2312) from environment logger when IO transport is configured.

The environment logger, seems to be only working for HTTP transport, the object has client attribute, and api and adapter so on…, but not for IO transport




