### PR TITLE
Fix flaky spec with redis database index

### DIFF
--- a/spec/datadog/tracing/contrib/redis/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/instrumentation_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe 'Redis instrumentation test' do
 
   # Redis instance supports 16 databases,
   # the default is 0 but can be changed to any number from 0-15,
-  # to configure support more databases, check `redis.conf`,
-  # since 0 is the default, the SELECT command would be skipped
-  let(:test_database) { (1..15).to_a.sample }
+  # to configure support more databases, check `redis.conf`
+  # since 0 is the default, the SELECT db command would be skipped
+  let(:test_database) { 15 }
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.

--- a/spec/datadog/tracing/contrib/redis/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/instrumentation_spec.rb
@@ -12,8 +12,9 @@ RSpec.describe 'Redis instrumentation test' do
 
   # Redis instance supports 16 databases,
   # the default is 0 but can be changed to any number from 0-15,
-  # to configure support more databases, check `redis.conf`
-  let(:test_database) { (0..15).to_a.sample }
+  # to configure support more databases, check `redis.conf`,
+  # since 0 is the default, the SELECT command would be skipped
+  let(:test_database) { (1..15).to_a.sample }
 
   around do |example|
     # Reset before and after each example; don't allow global state to linger.


### PR DESCRIPTION
**What does this PR do?**

Fix redis database index in spec

**Motivation**

The flaky spec in introduced from https://github.com/DataDog/dd-trace-rb/pull/2274

The redis connection would fire `select db` command when switching database, since `0` is the default database for redis, the db select span would be skipped, hence leading to flakiness.