### PR TITLE
Fix Non-GET request method with rails exception controller

### DIFF
--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -885,7 +885,7 @@ RSpec.describe 'Rack integration tests' do
         expect(span.name).to eq('rack.request')
         expect(span.span_type).to eq('web')
         expect(span.service).to eq(tracer.default_service)
-        expect(span.resource).to eq('GET 200')
+        expect(span.resource).to eq('POST 200')
         expect(span.get_tag('http.method')).to eq('POST')
         expect(span.get_tag('http.status_code')).to eq('200')
         expect(span.status).to eq(0)

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -863,5 +863,35 @@ RSpec.describe 'Rack integration tests' do
         end
       end
     end
+
+    context 'with a route that mutates request method' do
+      let(:routes) do
+        proc do
+          map '/change_request_method' do
+            run(
+              proc do |env|
+                env['REQUEST_METHOD'] = 'GET'
+                [200, { 'Content-Type' => 'text/html' }, ['OK']]
+              end
+            )
+          end
+        end
+      end
+
+      it do
+        post '/change_request_method'
+
+        expect(span).to be_root_span
+        expect(span.name).to eq('rack.request')
+        expect(span.span_type).to eq('web')
+        expect(span.service).to eq(tracer.default_service)
+        expect(span.resource).to eq('GET 200')
+        expect(span.get_tag('http.method')).to eq('POST')
+        expect(span.get_tag('http.status_code')).to eq('200')
+        expect(span.status).to eq(0)
+        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('rack')
+        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
+      end
+    end
   end
 end


### PR DESCRIPTION
**What does this PR do?**

https://github.com/DataDog/dd-trace-rb/issues/2315

When instrumenting a non-GET request, a Rails app with [exceptions_app](https://guides.rubyonrails.org/configuring.html#config-exceptions-app) configured would mutated the request method to `GET` before dispatching to the exception handling app. 

https://github.com/rails/rails/blob/8015c2c2cf5c8718449677570f372ceb01318a32/actionpack/lib/action_dispatch/middleware/show_exceptions.rb#L45

Hence, it would be more accurate to fetch the value from the original rack env(prior to the mutation).