### PR TITLE
Backport "Fix `URI::InvalidURIError`"

### DIFF
--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -271,7 +271,7 @@ module Datadog
                          request_uri
                        end
 
-            base_url + fullpath
+            ::URI.join(base_url, fullpath).to_s
           end
 
           def parse_user_agent_header(headers)

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe 'Rack integration tests' do
           end
         end
 
-        context 'with REQUEST_URI' do
+        context 'with REQUEST_URI being a path' do
           subject(:response) { get '/success?foo=bar', {}, 'REQUEST_URI' => '/success?foo=bar' }
 
           context 'and default quantization' do
@@ -183,6 +183,21 @@ RSpec.describe 'Rack integration tests' do
               # The query string will not be quantized, per the option.
               expect(span.get_tag('http.url')).to eq('/success?foo=bar')
               expect(span.get_tag('http.base_url')).to eq('http://example.org')
+              expect(span).to be_root_span
+            end
+          end
+
+          context 'and quantization activated for base' do
+            let(:rack_options) { { quantize: { base: :show } } }
+
+            it_behaves_like 'a rack GET 200 span'
+
+            it do
+              # Since REQUEST_URI is set (usually provided by WEBrick/Puma)
+              # it uses REQUEST_URI, which has query string parameters.
+              # The query string will not be quantized, per the option.
+              expect(span.get_tag('http.url')).to eq('http://example.org/success?foo')
+              expect(span.get_tag('http.base_url')).to be_nil
               expect(span).to be_root_span
             end
           end
@@ -217,6 +232,21 @@ RSpec.describe 'Rack integration tests' do
               # The query string will not be quantized, per the option.
               expect(span.get_tag('http.url')).to eq('/success?foo=bar')
               expect(span.get_tag('http.base_url')).to eq('http://example.org')
+              expect(span).to be_root_span
+            end
+          end
+
+          context 'and quantization activated for base' do
+            let(:rack_options) { { quantize: { base: :show } } }
+
+            it_behaves_like 'a rack GET 200 span'
+
+            it do
+              # Since REQUEST_URI is set (usually provided by WEBrick/Puma)
+              # it uses REQUEST_URI, which has query string parameters.
+              # The query string will not be quantized, per the option.
+              expect(span.get_tag('http.url')).to eq('http://example.org/success?foo')
+              expect(span.get_tag('http.base_url')).to be_nil
               expect(span).to be_root_span
             end
           end

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -188,6 +188,40 @@ RSpec.describe 'Rack integration tests' do
           end
         end
 
+        context 'with REQUEST_URI containing base URI' do
+          subject(:response) { get '/success?foo=bar', {}, 'REQUEST_URI' => 'http://example.org/success?foo=bar' }
+
+          context 'and default quantization' do
+            let(:rack_options) { { quantize: {} } }
+
+            it_behaves_like 'a rack GET 200 span'
+
+            it do
+              # Since REQUEST_URI is set (usually provided by WEBrick/Puma)
+              # it uses REQUEST_URI, which has query string parameters.
+              # However, that query string will be quantized.
+              expect(span.get_tag('http.url')).to eq('/success?foo')
+              expect(span.get_tag('http.base_url')).to eq('http://example.org')
+              expect(span).to be_root_span
+            end
+          end
+
+          context 'and quantization activated for the query' do
+            let(:rack_options) { { quantize: { query: { show: ['foo'] } } } }
+
+            it_behaves_like 'a rack GET 200 span'
+
+            it do
+              # Since REQUEST_URI is set (usually provided by WEBrick/Puma)
+              # it uses REQUEST_URI, which has query string parameters.
+              # The query string will not be quantized, per the option.
+              expect(span.get_tag('http.url')).to eq('/success?foo=bar')
+              expect(span.get_tag('http.base_url')).to eq('http://example.org')
+              expect(span).to be_root_span
+            end
+          end
+        end
+
         context 'with sub-route' do
           let(:route) { '/success/100' }
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Backport of #2310 to `1.5-stable`

**Motivation**

Without this fix there's a possibility of crash.
