### PR TITLE
Unified tagging `span.kind` as `client`

### DIFF
--- a/lib/datadog/tracing/contrib/aws/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/aws/instrumentation.rb
@@ -33,6 +33,8 @@ module Datadog
             span.name = Ext::SPAN_COMMAND
             span.resource = context.safely(:resource)
 
+            span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
+
             span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
             span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_COMMAND)
 

--- a/lib/datadog/tracing/contrib/ethon/easy_patch.rb
+++ b/lib/datadog/tracing/contrib/ethon/easy_patch.rb
@@ -131,6 +131,8 @@ module Datadog
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_REQUEST)
 
+              span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
+
               uri = try_parse_uri
               return unless uri
 

--- a/lib/datadog/tracing/contrib/ethon/multi_patch.rb
+++ b/lib/datadog/tracing/contrib/ethon/multi_patch.rb
@@ -67,6 +67,8 @@ module Datadog
               @datadog_multi_span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               @datadog_multi_span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_MULTI_REQUEST)
 
+              @datadog_multi_span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
+
               # Tag as an external peer service
               @datadog_multi_span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, @datadog_multi_span.service)
 

--- a/lib/datadog/tracing/contrib/excon/middleware.rb
+++ b/lib/datadog/tracing/contrib/excon/middleware.rb
@@ -116,6 +116,8 @@ module Datadog
             span.service = service_name(datum[:host], @options)
             span.span_type = Tracing::Metadata::Ext::HTTP::TYPE_OUTBOUND
 
+            span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
+
             span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
             span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_REQUEST)
 

--- a/lib/datadog/tracing/contrib/faraday/middleware.rb
+++ b/lib/datadog/tracing/contrib/faraday/middleware.rb
@@ -42,6 +42,8 @@ module Datadog
             span.service = service_name(env[:url].host, options)
             span.span_type = Tracing::Metadata::Ext::HTTP::TYPE_OUTBOUND
 
+            span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
+
             span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
             span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_REQUEST)
 

--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
@@ -39,6 +39,8 @@ module Datadog
 
               span.set_tag(Contrib::Ext::RPC::TAG_SYSTEM, Ext::TAG_SYSTEM)
 
+              span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
+
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_CLIENT)
 

--- a/lib/datadog/tracing/contrib/http/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/http/instrumentation.rb
@@ -70,6 +70,8 @@ module Datadog
             end
 
             def annotate_span_with_request!(span, request, request_options)
+              span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
+
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_REQUEST)
 

--- a/lib/datadog/tracing/contrib/httpclient/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/httpclient/instrumentation.rb
@@ -51,6 +51,8 @@ module Datadog
             private
 
             def annotate_span_with_request!(span, req, req_options)
+              span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
+
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_REQUEST)
 

--- a/lib/datadog/tracing/contrib/httprb/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/httprb/instrumentation.rb
@@ -51,6 +51,8 @@ module Datadog
             private
 
             def annotate_span_with_request!(span, req, req_options)
+              span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
+
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_REQUEST)
 

--- a/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
@@ -27,6 +27,7 @@ module Datadog
                 span.span_type = Tracing::Metadata::Ext::SQL::TYPE
 
                 span.set_tag(Contrib::Ext::DB::TAG_SYSTEM, Ext::TAG_SYSTEM)
+                span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
 
                 span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
                 span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_QUERY)

--- a/lib/datadog/tracing/contrib/rest_client/request_patch.rb
+++ b/lib/datadog/tracing/contrib/rest_client/request_patch.rb
@@ -34,6 +34,8 @@ module Datadog
             def datadog_tag_request(uri, span)
               span.resource = method.to_s.upcase
 
+              span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
+
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_REQUEST)
 

--- a/spec/datadog/tracing/contrib/aws/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/aws/instrumentation_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe 'AWS instrumentation' do
         expect(span.get_tag('host')).to eq('sts.us-stubbed-1.amazonaws.com')
         expect(span.get_tag('http.method')).to eq('POST')
         expect(span.get_tag('http.status_code')).to eq('200')
+        expect(span.get_tag('span.kind')).to eq('client')
 
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('aws')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
@@ -103,6 +104,7 @@ RSpec.describe 'AWS instrumentation' do
         expect(span.get_tag('host')).to eq('s3.us-stubbed-1.amazonaws.com')
         expect(span.get_tag('http.method')).to eq('GET')
         expect(span.get_tag('http.status_code')).to eq('200')
+        expect(span.get_tag('span.kind')).to eq('client')
 
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('aws')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))

--- a/spec/datadog/tracing/contrib/ethon/multi_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/multi_patch_spec.rb
@@ -93,6 +93,11 @@ RSpec.describe Datadog::Tracing::Contrib::Ethon::MultiPatch do
           expect(multi_span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('multi.request')
         end
 
+        it 'have `client` as `span.kind`' do
+          expect(multi_span.get_tag('span.kind')).to eq('client')
+          expect(easy_span.get_tag('span.kind')).to eq('client')
+        end
+
         it 'makes multi span a parent for easy span' do
           expect(easy_span.parent_id).to eq(multi_span.span_id)
         end

--- a/spec/datadog/tracing/contrib/ethon/shared_examples.rb
+++ b/spec/datadog/tracing/contrib/ethon/shared_examples.rb
@@ -55,6 +55,10 @@ RSpec.shared_examples_for 'span' do
     expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
   end
 
+  it 'has `client` as `span.kind`' do
+    expect(span.get_tag('span.kind')).to eq('client')
+  end
+
   it_behaves_like 'a peer service span' do
     let(:peer_hostname) { host }
   end

--- a/spec/datadog/tracing/contrib/excon/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/excon/instrumentation_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
 
       expect(request_span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('excon')
       expect(request_span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
+      expect(request_span.get_tag('span.kind')).to eq('client')
     end
 
     it_behaves_like 'a peer service span' do
@@ -121,6 +122,7 @@ RSpec.describe Datadog::Tracing::Contrib::Excon::Middleware do
       expect(request_span.get_tag(Datadog::Tracing::Metadata::Ext::HTTP::TAG_STATUS_CODE)).to eq('500')
       expect(request_span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_HOST)).to eq('example.com')
       expect(request_span.get_tag(Datadog::Tracing::Metadata::Ext::NET::TAG_TARGET_PORT)).to eq(80)
+      expect(request_span.get_tag('span.kind')).to eq('client')
       expect(request_span.span_type).to eq(Datadog::Tracing::Metadata::Ext::HTTP::TYPE_OUTBOUND)
       expect(request_span).to have_error
       expect(request_span).to have_error_type('Error 500')

--- a/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/faraday/middleware_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe 'Faraday middleware' do
 
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('faraday')
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
+      expect(span.get_tag('span.kind')).to eq('client')
     end
 
     it_behaves_like 'a peer service span' do
@@ -102,6 +103,7 @@ RSpec.describe 'Faraday middleware' do
 
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('faraday')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
+        expect(span.get_tag('span.kind')).to eq('client')
       end
 
       it 'executes without warnings' do
@@ -145,6 +147,7 @@ RSpec.describe 'Faraday middleware' do
 
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('faraday')
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
+      expect(span.get_tag('span.kind')).to eq('client')
     end
 
     it_behaves_like 'a peer service span' do
@@ -171,6 +174,7 @@ RSpec.describe 'Faraday middleware' do
 
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('faraday')
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
+      expect(span.get_tag('span.kind')).to eq('client')
     end
 
     it_behaves_like 'a peer service span' do
@@ -198,6 +202,7 @@ RSpec.describe 'Faraday middleware' do
 
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('faraday')
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
+      expect(span.get_tag('span.kind')).to eq('client')
     end
 
     it_behaves_like 'a peer service span' do

--- a/spec/datadog/tracing/contrib/grpc/datadog_interceptor/client_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/datadog_interceptor/client_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe 'tracing on the client connection' do
     it { expect(span.get_tag('error.stack')).to be_nil }
     it { expect(span.get_tag('some')).to eq 'datum' }
     it { expect(span.get_tag('rpc.system')).to eq('grpc') }
+    it { expect(span.get_tag('span.kind')).to eq('client') }
 
     it 'has component and operation tags' do
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('grpc')

--- a/spec/datadog/tracing/contrib/http/miniapp_spec.rb
+++ b/spec/datadog/tracing/contrib/http/miniapp_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe 'net/http miniapp tests' do
           expect(span.get_tag('http.url')).to eq('/my/path')
           expect(span.get_tag('http.method')).to eq('GET')
           expect(span.get_tag('http.status_code')).to eq('200')
+          expect(span.get_tag('span.kind')).to eq('client')
           expect(span.parent_id).to eq(parent_span.span_id)
           expect(span.trace_id).to eq(trace_id)
 

--- a/spec/datadog/tracing/contrib/http/request_spec.rb
+++ b/spec/datadog/tracing/contrib/http/request_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe 'net/http requests' do
         expect(span.get_tag('http.status_code')).to eq('200')
         expect(span.get_tag('out.host')).to eq(host)
         expect(span.get_tag('out.port')).to eq(port.to_s)
+        expect(span.get_tag('span.kind')).to eq('client')
         expect(span.status).to eq(0)
       end
 
@@ -91,6 +92,7 @@ RSpec.describe 'net/http requests' do
         expect(span.get_tag('http.status_code')).to eq('404')
         expect(span.get_tag('out.host')).to eq(host)
         expect(span.get_tag('out.port')).to eq(port.to_s)
+        expect(span.get_tag('span.kind')).to eq('client')
         expect(span.status).to eq(1)
         expect(span.get_tag('error.type')).to eq('Net::HTTPNotFound')
         expect(span.get_tag('error.msg')).to be nil
@@ -161,6 +163,7 @@ RSpec.describe 'net/http requests' do
         expect(span.get_tag('http.status_code')).to eq('201')
         expect(span.get_tag('out.host')).to eq(host)
         expect(span.get_tag('out.port')).to eq(port.to_s)
+        expect(span.get_tag('span.kind')).to eq('client')
         expect(span.status).to eq(0)
       end
 
@@ -193,6 +196,7 @@ RSpec.describe 'net/http requests' do
         expect(span.get_tag('http.status_code')).to eq('200')
         expect(span.get_tag('out.host')).to eq(host)
         expect(span.get_tag('out.port')).to eq(port.to_s)
+        expect(span.get_tag('span.kind')).to eq('client')
         expect(span.status).to eq(0)
       end
 
@@ -219,6 +223,7 @@ RSpec.describe 'net/http requests' do
         expect(spans).to have(1).items
         expect(span.name).to eq('http.request')
         expect(span.service).to eq(service_name)
+        expect(span.get_tag('span.kind')).to eq('client')
       end
 
       it_behaves_like 'a peer service span' do
@@ -240,6 +245,7 @@ RSpec.describe 'net/http requests' do
       expect(span.name).to eq(Datadog::Tracing::Contrib::HTTP::Ext::SPAN_REQUEST)
       expect(span.service).to eq(host)
       expect(span.resource).to eq('GET')
+      expect(span.get_tag('span.kind')).to eq('client')
     end
 
     context 'and the host matches a specific configuration' do
@@ -261,6 +267,7 @@ RSpec.describe 'net/http requests' do
       it 'uses the configured service name over the domain name and the correct describes block' do
         response
         expect(span.service).to eq('bar')
+        expect(span.get_tag('span.kind')).to eq('client')
       end
     end
   end
@@ -425,6 +432,7 @@ RSpec.describe 'net/http requests' do
         expect(span.get_tag('http.method')).to eq('GET')
         expect(span.get_tag('out.host')).to eq(host)
         expect(span.get_tag('out.port')).to eq(port.to_s)
+        expect(span.get_tag('span.kind')).to eq('client')
         expect(span).to have_error
         expect(span).to have_error_type(timeout_error.class.to_s)
         expect(span).to have_error_message(timeout_error.message)
@@ -447,6 +455,7 @@ RSpec.describe 'net/http requests' do
         expect(span.get_tag('http.method')).to eq('GET')
         expect(span.get_tag('out.host')).to eq(host)
         expect(span.get_tag('out.port')).to eq(port.to_s)
+        expect(span.get_tag('span.kind')).to eq('client')
         expect(span).to have_error
         expect(span).to have_error_type(custom_error.class.to_s)
         expect(span).to have_error_message(custom_error.message)

--- a/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
@@ -129,6 +129,10 @@ RSpec.describe Datadog::Tracing::Contrib::Httpclient::Instrumentation do
             expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
           end
 
+          it 'has `client` as `span.kind`' do
+            expect(span.get_tag('span.kind')).to eq('client')
+          end
+
           it_behaves_like 'a peer service span' do
             let(:peer_hostname) { host }
           end

--- a/spec/datadog/tracing/contrib/httprb/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httprb/instrumentation_spec.rb
@@ -134,6 +134,10 @@ RSpec.describe Datadog::Tracing::Contrib::Httprb::Instrumentation do
             expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
           end
 
+          it 'has `client` as `span.kind`' do
+            expect(span.get_tag('span.kind')).to eq('client')
+          end
+
           it_behaves_like 'a peer service span' do
             let(:peer_hostname) { host }
           end

--- a/spec/datadog/tracing/contrib/mysql2/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/mysql2/patcher_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe 'Mysql2::Client patcher' do
 
           expect(spans.count).to eq(1)
           expect(span.service).to eq(service_name)
+          expect(span.get_tag('span.kind')).to eq('client')
           expect(span.get_tag('db.system')).to eq('mysql')
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_PEER_SERVICE)).to eq(service_name)
         end
@@ -82,6 +83,7 @@ RSpec.describe 'Mysql2::Client patcher' do
           query
 
           expect(spans.count).to eq(1)
+          expect(span.get_tag('span.kind')).to eq('client')
           expect(span.get_tag('mysql2.db.name')).to eq(database)
           expect(span.get_tag('out.host')).to eq(host)
           expect(span.get_tag('out.port')).to eq(port)
@@ -116,6 +118,7 @@ RSpec.describe 'Mysql2::Client patcher' do
 
           expect(spans.count).to eq(1)
           expect(span.status).to eq(1)
+          expect(span.get_tag('span.kind')).to eq('client')
           expect(span.get_tag('db.system')).to eq('mysql')
           expect(span.get_tag('error.msg'))
             .to eq("Unknown column 'INVALID' in 'field list'")

--- a/spec/datadog/tracing/contrib/rest_client/request_patch_spec.rb
+++ b/spec/datadog/tracing/contrib/rest_client/request_patch_spec.rb
@@ -100,6 +100,10 @@ RSpec.describe Datadog::Tracing::Contrib::RestClient::RequestPatch do
             expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
           end
 
+          it 'has `client` as `span.kind`' do
+            expect(span.get_tag('span.kind')).to eq('client')
+          end
+
           it_behaves_like 'a peer service span' do
             let(:peer_hostname) { host }
           end


### PR DESCRIPTION
**What does this PR do?**

Unified tagging `span.kind` as `client`, inspired by [Opentelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/9fa7c656b26647b27e485a6af7e38dc716eba98a/specification/trace/api.md#spankind
) 
