### PR TITLE
Avoid using problematic rspec-mocks 3.11.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,9 @@ end
 gem 'rake', '>= 10.5'
 gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
-gem 'rspec', '~> 3.10'
+gem 'rspec', '~> 3.11'
 gem 'rspec-collection_matchers', '~> 1.1'
+gem 'rspec-mocks', '!= 3.11.2'
 if RUBY_VERSION >= '2.3.0'
   gem 'rspec_junit_formatter', '>= 0.5.1'
 else

--- a/integration/apps/rack/Gemfile
+++ b/integration/apps/rack/Gemfile
@@ -42,7 +42,8 @@ else
 end
 
 # Development
-gem 'pry-byebug'
+gem 'pry-byebug' if RUBY_VERSION >= '2.3.0' && RUBY_ENGINE != 'truffleruby' && RUBY_VERSION < '3.2.0'
+gem 'pry-nav' if RUBY_VERSION < '2.3.0'
 # gem 'pry-stack_explorer', platform: :ruby
 # gem 'rbtrace'
 # gem 'ruby-prof'

--- a/integration/apps/rack/spec/spec_helper.rb
+++ b/integration/apps/rack/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'byebug'
 require 'support/integration_helper'
 
 RSpec.configure do |config|


### PR DESCRIPTION
**What does this PR do?**

Adds a restriction on our `Gemfile` (only used for testing) to not use `rspec-mocks` 3.11.2.

**Motivation**

This version of rspec-mocks breaks CI for Ruby 2.7, 3.0 and 3.1 on the following tests:

* ./spec/datadog/core/configuration_spec.rb:377 (Ruby 2.7)
* ./spec/datadog/core_spec.rb:35 (Ruby 2.7)
* ./spec/ddtrace/transport/http/builder_spec.rb:250 (Ruby 3.0, 3.1)

References:

* <https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/7560/workflows/24205733-d9fb-4781-962c-87499bad162d/jobs/280394>
* <https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/7560/workflows/24205733-d9fb-4781-962c-87499bad162d/jobs/280387>
* <https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/7560/workflows/24205733-d9fb-4781-962c-87499bad162d/jobs/280396>

**Additional Notes**

I have not yet reported this upstream, but wanted to first unblock our CI.

**How to test the change?**

Validate that CI is green.