### PR TITLE
Handle REQUEST_URI with base url

### DIFF
--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -272,10 +272,12 @@ module Datadog
 
                          query_string.empty? ? path : "#{path}?#{query_string}"
                        else
-                         request_uri
+                         # normally REQUEST_URI starts at the path, but it
+                         # might contain the full URL in some cases (e.g WEBrick)
+                         request_uri.sub(/^#{base_url}/, '')
                        end
 
-            ::URI.join(base_url, fullpath).to_s
+            base_url + fullpath
           end
 
           def parse_user_agent_header(headers)

--- a/spec/datadog/tracing/contrib/rack/middlewares_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/middlewares_spec.rb
@@ -44,4 +44,27 @@ RSpec.describe Datadog::Tracing::Contrib::Rack::TraceMiddleware do
       end
     end
   end
+
+  # Non-ASCII URLs cannot be tested with `rack-test` as of v2.0.2.
+  # It would be ideal if that was possible, as we could create integration tests
+  # for such cases.
+  #
+  # As an alternative, we test the parsing method directly.
+  describe '#parse_url' do
+    subject(:parse_url) { middleware.send(:parse_url, env, original_env) }
+    let(:env) { { 'REQUEST_URI' => uri, 'HTTP_HOST' => 'localhost:443', 'rack.url_scheme' => 'https' } }
+    let(:original_env) { {} }
+
+    context 'with Unicode characters' do
+      let(:uri) { 'https://localhost/success/?繋がってて' }
+
+      it { is_expected.to eq(uri) }
+    end
+
+    context 'with unencoded ASCII characters' do
+      let(:uri) { 'https://localhost/success/|' }
+
+      it { is_expected.to eq(uri) }
+    end
+  end
 end


### PR DESCRIPTION
This has been reported to happen on WEBrick, it may happen in other ways depending on how the variable is set.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Handle #2310 differently, preventing an exception for invalid URLs as found in #2309

**Motivation**

#2310 causes #2309 again because of the introduction of URI parsing via `URI.join` at a stage to early.

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**

Start an app like so (with tracing enabled of course):

```
bundle exec puma -w 0 -p 9292
bundle exec rackup -s webrick -p 9292
```

Then `curl` it:

```
curl -vvv 'http://user:pass@127.0.0.1:9292/foo/bar|'
```

On Puma this should return a `HTTP/1.1 404 Not Found` and in the `rack.request` span tags the path should be replaced by a `?` placeholder by quantization:

```
// with quantization: base: :show
      "http.url": "http://127.0.0.1:9292/?",
// with quantization: base: :exclude (default)
      "http.url": "?",
      "http.base_url": "http://127.0.0.1:9292",
```

On WEBrick, which attempts to parse the URI by itself, this should return an early `HTTP/1.1 400 Bad Request`:

```
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
<HTML>
  <HEAD><TITLE>Bad Request</TITLE></HEAD>
  <BODY>
    <H1>Bad Request</H1>
    bad URI `/foo/bar|'.
    <HR>
    <ADDRESS>
     WEBrick/1.7.0 (Ruby/3.0.4/2022-04-12) at
     Cassini.local:9292
    </ADDRESS>
  </BODY>
</HTML>
```

Unfortunately I could not introduce proper non-regression spec examples like this:

```diff
diff --git a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
index 69416eef1..9f3049128 100644
--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -126,6 +126,28 @@ RSpec.describe 'Rack integration tests' do
           it { expect(trace.resource).to eq('GET 200') }
         end
 
+        context 'with Unicode characters' do
+          let(:route) { '/success/?繋がってて' }
+
+          it_behaves_like 'a rack GET 200 span'
+
+          it do
+            expect(span.get_tag('http.url')).to eq('?')
+            expect(span.get_tag('http.base_url')).to eq('http://example.org')
+          end
+        end
+
+        context 'with unencoded ASCII characters' do
+          let(:route) { '/success/|' }
+
+          it_behaves_like 'a rack GET 200 span'
+
+          it do
+            expect(span.get_tag('http.url')).to eq('?')
+            expect(span.get_tag('http.base_url')).to eq('http://example.org')
+          end
+        end
+
         context 'with query string parameters' do
           let(:route) { '/success?foo=bar' }
 
```

Indeed `Rack::Test` tries to parse the route very early when its `get` is called, therefore triggers the exception way before anything happens:

```
   URI::InvalidURIError:
       bad URI(is not URI?): "/success/|"
     Shared Example Group: "a rack GET 200 span" called from ./spec/datadog/tracing/contrib/rack/integration_test_spec.rb:143
     # /usr/local/bundle/gems/rack-test-1.1.0/lib/rack/test.rb:214:in `parse_uri'
     # /usr/local/bundle/gems/rack-test-1.1.0/lib/rack/test.rb:127:in `custom_request'
     # /usr/local/bundle/gems/rack-test-1.1.0/lib/rack/test.rb:58:in `get'
     # ./spec/datadog/tracing/contrib/rack/integration_test_spec.rb:99:in `block (5 levels) in <top (required)>'
```

So, short of hacking `Rack::Test` to death I skipped adding these.