### PR TITLE
Fix incorrect start time for profiles

### DIFF
--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -372,7 +372,7 @@ static ddog_Profile *serializer_flip_active_and_inactive_slots(struct stack_reco
   pthread_mutex_t *previously_inactive = (previously_active_slot == 1) ? &state->slot_two_mutex : &state->slot_one_mutex;
 
   // Before making this profile active, we reset it so that it uses the correct timestamp for its start
-  ddog_Profile *previously_inactive_profile = (previously_active_slot == 1) ? state -> slot_two_profile : state->slot_one_profile;
+  ddog_Profile *previously_inactive_profile = (previously_active_slot == 1) ? state->slot_two_profile : state->slot_one_profile;
   if (!ddog_Profile_reset(previously_inactive_profile, &start_timestamp_for_next_profile)) rb_raise(rb_eRuntimeError, "Failed to reset profile");
 
   // Release the lock, thus making this slot active

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -98,9 +98,9 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
     context 'when the profile is empty' do
       it 'uses the current time as the start and finish time' do
-        before_serialize = Time.now
+        before_serialize = Time.now.utc
         serialize
-        after_serialize = Time.now
+        after_serialize = Time.now.utc
 
         expect(start).to be_between(before_serialize, after_serialize)
         expect(finish).to be_between(before_serialize, after_serialize)

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -192,5 +192,31 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         serialize
       end
     end
+
+    context 'when serializing multiple times in a row' do
+      it 'sets the start time of a profile to be >= the finish time of the previous profile' do
+        start1, finish1, = stack_recorder.serialize
+        start2, finish2, = stack_recorder.serialize
+        start3, finish3, = stack_recorder.serialize
+        start4, finish4, = stack_recorder.serialize
+
+        expect(start1).to be <= finish1
+        expect(finish1).to be <= start2
+        expect(finish2).to be <= start3
+        expect(finish3).to be <= start4
+        expect(start4).to be <= finish4
+      end
+
+      it 'sets the start time of the next profile to be >= the previous serialization call' do
+        stack_recorder
+
+        before_serialize = Time.now.utc
+
+        stack_recorder.serialize
+        start, = stack_recorder.serialize
+
+        expect(start).to be >= before_serialize
+      end
+    end
   end
 end


### PR DESCRIPTION
**What does this PR do?**:

(Important note: This fix only affects the new CPU Profiling 2.0 profiler which is still in **alpha**, see #2209)

In #2181 we added a concurrency-safe mechanism for `StackRecorder`. Key to how it works, is that we keep two `ddog_Profile` instances at every point in time, and we alternate between using them.

But this alternation introduced a bug with the `start_time` of profiles. Previously, the `start_time` got set whenever a profile got created or reset, and we used the current time for it.

That caused the following effect:

```
t=0
  created slot_one_profile (start_time=0)
  created slow_two_profile (start_time=0)
  make_active slot_one_profile

t=60
  serialized slot_one_profile (start_time=0, finish_time=60)
  reset slot_one_profile (start_time=60)
  make_active slot_two_profile

t=120
  serialized slot_two_profile (start_time=0, finish_time=120)
  reset slot_two_profile (start_time=120)
  make_active slot_one_profile

t=180
  serialized slot_one_profile (start_time=60, finish_time=180)
  reset slow_one_profile (start_time=180)
  make_active slot_two_profile
```

That is, other than the first profile (which is why we previously missed this bug), every profile got double the duration as intended, because we reset it after serialization, but that profile would not be used for the next period.

To fix this issue, we additionally change the "make_active" step above (actually implemented in `serializer_flip_active_and_inactive_slots`) to set the correct `start_time` on the profile that becomes active.

Thus, we get the correct behavior:

```
t=0
  created slot_one_profile (start_time=0)
  created slow_two_profile (start_time=0) # Ignored, will be changed later
  make_active slot_one_profile (start_time=0)

t=60
  serialized slot_one_profile (start_time=0, finish_time=60)
  reset slot_one_profile (start_time=60) # Ignored, will be changed later
  make_active slot_two_profile (start_time=60) # Correct start_time

t=120
  serialized slot_two_profile (start_time=60, finish_time=120)
  reset slot_two_profile (start_time=120) # Ignored, will be changed later
  make_active slot_one_profile (start_time=120) # Correct start_time

t=180
  serialized slot_one_profile (start_time=120, finish_time=180)
  reset slow_one_profile (start_time=180)
  make_active slot_two_profile (start_time=180)
```

**Motivation**:

Having profiles with the wrong duration breaks profile aggregation.

**Additional notes**:

As I mentioned above, this only affects the new CPU Profiling 2.0 profiler codepath, so I don't expect any customers to have ever ran into this issue.

**How to test the change?**:

Change includes coverage. Furthermore, running the profiler with `DD_TRACE_DEBUG` prints the start/finish timestamps after  serialization, which can be used to confirm they are correct.

Finally, comparing profiles before/after in the profiler UX will also show the difference.