### PR TITLE
Ensure that Datadog::Tracing::TraceSegment can be reported correctly when they are dropped

### DIFF
--- a/lib/ddtrace/transport/traces.rb
+++ b/lib/ddtrace/transport/traces.rb
@@ -80,14 +80,7 @@ module Datadog
 
           if encoded.size > max_size
             # This single trace is too large, we can't flush it
-            span_output = if trace.respond_to?(:map)
-                            trace.map(&:to_hash)
-                          elsif trace.respond_to?(:spans)
-                            trace.spans.map(&:to_hash)
-                          else
-                            trace.inspect
-                          end
-            Datadog.logger.debug("Dropping trace. Payload too large: '#{span_output}'")
+            Datadog.logger.debug { "Dropping trace. Payload too large: '#{trace.inspect}'" }
             Datadog.health_metrics.transport_trace_too_large(1)
 
             return nil

--- a/lib/ddtrace/transport/traces.rb
+++ b/lib/ddtrace/transport/traces.rb
@@ -80,7 +80,14 @@ module Datadog
 
           if encoded.size > max_size
             # This single trace is too large, we can't flush it
-            Datadog.logger.debug { "Dropping trace. Payload too large: '#{trace.map(&:to_hash)}'" }
+            span_output = if trace.respond_to?(:map)
+                            trace.map(&:to_hash)
+                          elsif trace.respond_to?(:spans)
+                            trace.spans.map(&:to_hash)
+                          else
+                            trace.inspect
+                          end
+            Datadog.logger.debug("Dropping trace. Payload too large: '#{span_output}'")
             Datadog.health_metrics.transport_trace_too_large(1)
 
             return nil

--- a/spec/datadog/core/configuration_spec.rb
+++ b/spec/datadog/core/configuration_spec.rb
@@ -372,7 +372,7 @@ RSpec.describe Datadog::Core::Configuration do
       subject(:configure_onto) { test_class.configure_onto(object, **options) }
 
       let(:object) { Object.new }
-      let(:options) { {} }
+      let(:options) { { any: :thing } }
 
       it 'attaches a pin to the object' do
         expect(Datadog::Core::Pin)

--- a/spec/datadog/core_spec.rb
+++ b/spec/datadog/core_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Datadog do
         subject(:configure_onto) { datadog.configure_onto(object, **options) }
 
         let(:object) { Object.new }
-        let(:options) { {} }
+        let(:options) { { any: :thing } }
 
         it 'attaches a pin to the object' do
           expect(Datadog::Core::Pin)

--- a/spec/ddtrace/transport/http/builder_spec.rb
+++ b/spec/ddtrace/transport/http/builder_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe Datadog::Transport::HTTP::Builder do
 
         before do
           expect(builder.api_instance_class).to receive(:new)
-            .with(spec, adapter, foo: :bar, headers: {})
+            .with(spec, adapter, { foo: :bar, headers: {} })
             .and_call_original
         end
 

--- a/spec/ddtrace/transport/traces_spec.rb
+++ b/spec/ddtrace/transport/traces_spec.rb
@@ -102,6 +102,20 @@ RSpec.describe Datadog::Transport::Traces::Chunker do
           expect(health_metrics).to have_received(:transport_trace_too_large).with(1).twice
         end
       end
+
+      context 'with TraceSegment too large' do
+        include_context 'health metrics'
+
+        let(:max_size) { 0 }
+        let(:spans) { [Datadog::Tracing::Span.new('a', parent_id: 0), Datadog::Tracing::Span.new('b', parent_id: 0)] }
+        let(:traces) { [Datadog::Tracing::TraceSegment.new(spans, origin: 'ci-origin')] }
+
+        it 'drops all traces except the smallest for TraceSegment' do
+          expect(Datadog.logger).to receive(:debug).with(/Dropping trace. Payload too large/)
+          is_expected.to eq([])
+          expect(health_metrics).to have_received(:transport_trace_too_large).with(1).once
+        end
+      end
     end
 
     context 'with a lazy enumerator' do


### PR DESCRIPTION
**What does this PR do?**

This proposes a fix for https://github.com/DataDog/dd-trace-rb/issues/2334

TraceSegment doesn't respond to `map` but the spans inside it do, so it should provide usable debug information going forward.

I'm not confident that the test is the best it can be, I'm just focused on the issue I've encountered, I had to change the logger statement to actually render the log line to ensure it works appropriately.

**Motivation**

I found the bug

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
