### PR TITLE
Workaround issue with rspec-mocks 3.12.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
 gem 'rspec', '~> 3.11'
 gem 'rspec-collection_matchers', '~> 1.1'
-gem 'rspec-mocks', '!= 3.11.2'
+gem 'rspec-mocks', ['!= 3.11.2', '!= 3.12.0'] # Temporary workaround for #2327
 if RUBY_VERSION >= '2.3.0'
   gem 'rspec_junit_formatter', '>= 0.5.1'
 else


### PR DESCRIPTION
**What does this PR do?**

The same issue we ran into in #2327 is present on the newly-released rspec-mocks 3.12.0.

This PR adds a restriction on our `Gemfile` (only used for testing) to not use `rspec-mocks` 3.12.2.

**Motivation**

This version of rspec-mocks breaks CI for Ruby 2.7, 3.0 and 3.1 on the following tests:

* ./spec/datadog/core/configuration_spec.rb:377 (Ruby 2.7)
* ./spec/datadog/core_spec.rb:35 (Ruby 2.7)
* ./spec/ddtrace/transport/http/builder_spec.rb:250 (Ruby 3.0, 3.1)

References:

* <https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/7611/workflows/dfae185d-fb67-44c6-bef3-1d0aad44d652/jobs/282330>
* <https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/7611/workflows/dfae185d-fb67-44c6-bef3-1d0aad44d652/jobs/282324>
* <https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/7611/workflows/dfae185d-fb67-44c6-bef3-1d0aad44d652/jobs/282333>

**Additional Notes**

I have not yet reported this upstream, but wanted to first unblock our CI.

**How to test the change?**

Validate that CI is green.