### PR TITLE
Merge v1.5.2 changes back to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [1.5.2] - 2022-10-27
+
+### Deprecation notice
+
+- `DD_TRACE_CLIENT_IP_HEADER_DISABLED` was changed to `DD_TRACE_CLIENT_IP_ENABLED`. Although the former still works we encourage usage of the latter instead.
+
+### Changed
+
+- `http.client_ip` tag collection is made opt-in for APM. Note that `http.client_ip` is always collected when ASM is enabled as part of the security service provided ([#2321][], [#2331][])
+
+### Fixed
+
+- Handle REQUEST_URI with base url ([#2328][], [#2330][])
+
 ## [1.5.1] - 2022-10-19
 
 ### Changed
@@ -2145,7 +2159,8 @@ Release notes: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.3.1
 
 Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 
-[Unreleased]: https://github.com/DataDog/dd-trace-rb/compare/v1.5.1...master
+[Unreleased]: https://github.com/DataDog/dd-trace-rb/compare/v1.5.2...master
+[1.5.2]: https://github.com/DataDog/dd-trace-rb/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/DataDog/dd-trace-rb/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/DataDog/dd-trace-rb/compare/v1.4.2...v1.5.0
 [1.4.1]: https://github.com/DataDog/dd-trace-rb/compare/v1.4.1...v1.4.2
@@ -3052,6 +3067,10 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#2311]: https://github.com/DataDog/dd-trace-rb/issues/2311
 [#2318]: https://github.com/DataDog/dd-trace-rb/issues/2318
 [#2319]: https://github.com/DataDog/dd-trace-rb/issues/2319
+[#2321]: https://github.com/DataDog/dd-trace-rb/issues/2321
+[#2328]: https://github.com/DataDog/dd-trace-rb/issues/2328
+[#2330]: https://github.com/DataDog/dd-trace-rb/issues/2330
+[#2331]: https://github.com/DataDog/dd-trace-rb/issues/2331
 [@AdrianLC]: https://github.com/AdrianLC
 [@Azure7111]: https://github.com/Azure7111
 [@BabyGroot]: https://github.com/BabyGroot

--- a/gemfiles/jruby_9.2.18.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.18.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.18.0_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.4.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3.4.0_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.4.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.4.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.6.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6.7_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.7.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7.3_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.0.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.0.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.0.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.0.3_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.0.3_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.0.3_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.0.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.0.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.0.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.0.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.0.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.0.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.0.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.1.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.1.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.1.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.1.1_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.1.1_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.1.1_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.1.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.1.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.1.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.1.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.1.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.1.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.1.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1.1_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.2.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.2.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.5.1)
+    ddtrace (1.5.2)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -4,7 +4,7 @@ module DDTrace
   module VERSION
     MAJOR = 1
     MINOR = 5
-    PATCH = 1
+    PATCH = 2
     PRE = nil
 
     STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.')


### PR DESCRIPTION
**What does this PR do?**

Merge the `v1.5.2` tag back to `master`.

**Motivation**

This ensures that `master` has all the latest changes.

**Additional Notes**

The commit list is a bit big, since there were a few backports from master to the `1.5-stable` branch.

BUT, if you look at the diff, all of the changes were already in master anyway, so in the end the only difference between `v1.5.2` and `master` was the version bump + changelog + appraisals.

**How to test the change?**

Validate thatt CI is still green.