### PR TITLE
Benchmark SQL comment propagation with `mysql2`

### DIFF
--- a/lib/datadog/tracing/contrib/propagation/sql_comment.rb
+++ b/lib/datadog/tracing/contrib/propagation/sql_comment.rb
@@ -13,7 +13,7 @@ module Datadog
             return unless mode.enabled?
 
             # PENDING: Until `traceparent`` implementation in `full` mode
-            span_op.set_tag(Ext::TAG_DBM_TRACE_INJECTED, true) if mode.full?
+            # span_op.set_tag(Ext::TAG_DBM_TRACE_INJECTED, true) if mode.full?
           end
 
           def self.prepend_comment(sql, span_op, mode)
@@ -27,7 +27,7 @@ module Datadog
             }
 
             # PENDING: Until `traceparent`` implementation in `full` mode
-            tags.merge!(trace_context(span_op)) if mode.full?
+            # tags.merge!(trace_context(span_op)) if mode.full?
 
             "#{Comment.new(tags)} #{sql}"
           end
@@ -39,8 +39,7 @@ module Datadog
           # TODO: Derive from trace
           def self.trace_context(_)
             {
-              # Mock Randomness
-              traceparent: SecureRandom.uuid
+              # traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
             }.freeze
           end
         end

--- a/lib/datadog/tracing/contrib/propagation/sql_comment.rb
+++ b/lib/datadog/tracing/contrib/propagation/sql_comment.rb
@@ -13,7 +13,7 @@ module Datadog
             return unless mode.enabled?
 
             # PENDING: Until `traceparent`` implementation in `full` mode
-            # span_op.set_tag(Ext::TAG_DBM_TRACE_INJECTED, true) if mode.full?
+            span_op.set_tag(Ext::TAG_DBM_TRACE_INJECTED, true) if mode.full?
           end
 
           def self.prepend_comment(sql, span_op, mode)
@@ -27,7 +27,7 @@ module Datadog
             }
 
             # PENDING: Until `traceparent`` implementation in `full` mode
-            # tags.merge!(trace_context(span_op)) if mode.full?
+            tags.merge!(trace_context(span_op)) if mode.full?
 
             "#{Comment.new(tags)} #{sql}"
           end
@@ -39,7 +39,8 @@ module Datadog
           # TODO: Derive from trace
           def self.trace_context(_)
             {
-              # traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+              # Mock Randomness
+              traceparent: SecureRandom.uuid
             }.freeze
           end
         end

--- a/spec/ddtrace/benchmark/sql_comment_propagation_spec.rb
+++ b/spec/ddtrace/benchmark/sql_comment_propagation_spec.rb
@@ -1,0 +1,142 @@
+# typed: ignore
+
+require 'spec_helper'
+
+require 'benchmark/ips'
+require 'ddtrace'
+require 'mysql2'
+
+RSpec.describe '`mysql2` Tracing Integration', :order => :defined do
+
+  let(:host) { ENV.fetch('TEST_MYSQL_HOST') { '127.0.0.1' } }
+  let(:port) { ENV.fetch('TEST_MYSQL_PORT') { '3306' } }
+  let(:database) { ENV.fetch('TEST_MYSQL_DB') { 'mysql' } }
+  let(:username) { ENV.fetch('TEST_MYSQL_USER') { 'root' } }
+  let(:password) { ENV.fetch('TEST_MYSQL_PASSWORD') { 'root' } }
+
+  context 'timing' do
+    before { skip('Benchmark results not currently captured in CI') if ENV.key?('CI') }
+
+    before do
+      Datadog.configure do |c|
+        c.env = 'production'
+        c.service = 'myservice'
+        c.version = '1.0.0'
+        c.tracing.instrument :mysql2
+      end
+    end
+
+    let(:hash) do
+      {
+        host: host,
+        port: port,
+        database: database,
+        username: username,
+        password: password
+      }
+    end
+    let(:sql_statement) { 'SELECT 1;' }
+
+    context 'without db' do
+      context 'SELECT 1' do
+        it do
+          class MockClient
+            include Datadog::Tracing::Contrib::Mysql2::Instrumentation
+            attr_reader :query_options
+            def initialize(query_options)
+              @query_options = query_options
+            end
+
+            def query(sql, options = {})
+              nil
+            end
+          end
+
+          class MockDisabledClient < MockClient
+            def comment_propagation
+              'disabled'
+            end
+          end
+
+          class MockServiceClient < MockClient
+            def comment_propagation
+              'service'
+            end
+          end
+
+          class MockFullClient < MockClient
+            def comment_propagation
+              'full'
+            end
+          end
+
+          client_1 = MockDisabledClient.new(hash)
+          client_2 = MockServiceClient.new(hash)
+          client_3 = MockFullClient.new(hash)
+
+          client_1.query(sql_statement)
+          client_2.query(sql_statement)
+          client_3.query(sql_statement)
+
+          sleep 1
+
+          Benchmark.ips do |x|
+            x.report('disabled') { client_1.query(sql_statement) }
+            x.report('service') { client_2.query(sql_statement) }
+            x.report('full') { client_3.query(sql_statement) }
+
+            x.compare!
+          end
+        end
+      end
+    end
+
+    context 'with db' do
+      context 'SELECT 1' do
+        it do
+          class TestClient < Mysql2::Client
+            def query(sql, options = {})
+              super(sql, options)
+            end
+          end
+
+          class TestDisabledClient < TestClient
+            def comment_propagation
+              'disabled'
+            end
+          end
+
+          class TestServiceClient < TestClient
+            def comment_propagation
+              'service'
+            end
+          end
+
+          class TestFullClient < TestClient
+            def comment_propagation
+              'full'
+            end
+          end
+
+          client_1 = TestDisabledClient.new(hash)
+          client_2 = TestServiceClient.new(hash)
+          client_3 = TestFullClient.new(hash)
+
+          client_1.query(sql_statement)
+          client_2.query(sql_statement)
+          client_3.query(sql_statement)
+
+          sleep 1
+
+          Benchmark.ips do |x|
+            x.report('disabled') { client_1.query(sql_statement) }
+            x.report('service') { client_2.query(sql_statement) }
+            x.report('full') { client_3.query(sql_statement) }
+
+            x.compare!
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

Benchmark `mysql2` with sql comment propagation

**Without DB connection**

```
Warming up --------------------------------------
            disabled     2.051k i/100ms
             service     1.819k i/100ms
                full     1.542k i/100ms
Calculating -------------------------------------
            disabled     20.420k (±13.2%) i/s -    100.499k in   5.014070s
             service     18.319k (±12.5%) i/s -     90.950k in   5.050858s
                full     16.038k (±12.4%) i/s -     80.184k in   5.083800s

Comparison:
            disabled:    20420.2 i/s
             service:    18319.0 i/s - same-ish: difference falls within error
                full:    16038.1 i/s - same-ish: difference falls within error
```

-----------------

**Without DB connection**

```    
Warming up --------------------------------------
            disabled   557.000  i/100ms
             service   534.000  i/100ms
                full   503.000  i/100ms
Calculating -------------------------------------
            disabled      5.785k (± 9.3%) i/s -     28.964k in   5.058834s
             service      5.375k (±10.4%) i/s -     26.700k in   5.033094s
                full      5.112k (± 8.8%) i/s -     25.653k in   5.061620s

Comparison:
            disabled:     5785.5 i/s
             service:     5374.7 i/s - same-ish: difference falls within error
                full:     5111.8 i/s - same-ish: difference falls within error
```