### PR TITLE
Include native thread id as part of thread id label for profiling

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -59,7 +59,7 @@
 // ---
 
 #define INVALID_TIME -1
-#define THREAD_ID_LIMIT_CHARS 20
+#define THREAD_ID_LIMIT_CHARS 44 // Why 44? "#{2**64} (#{2**64})".size + 1 for \0
 #define RAISE_ON_FAILURE true
 #define DO_NOT_RAISE_ON_FAILURE false
 #define IS_WALL_TIME true
@@ -625,7 +625,7 @@ static struct per_thread_context *get_context_for(VALUE thread, struct cpu_and_w
 }
 
 static void initialize_context(VALUE thread, struct per_thread_context *thread_context) {
-  snprintf(thread_context->thread_id, THREAD_ID_LIMIT_CHARS, "%ld", thread_id_for(thread));
+  snprintf(thread_context->thread_id, THREAD_ID_LIMIT_CHARS, "%"PRIu64" (%lu)", native_thread_id_for(thread), (unsigned long) thread_id_for(thread));
   thread_context->thread_id_char_slice = (ddog_CharSlice) {.ptr = thread_context->thread_id, .len = strlen(thread_context->thread_id)};
 
   thread_context->thread_cpu_time_id = thread_cpu_time_id_for(thread);

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -122,6 +122,9 @@ end
 # On older Rubies, there was no struct rb_native_thread. See private_vm_api_acccess.c for details.
 $defs << '-DNO_RB_NATIVE_THREAD' if RUBY_VERSION < '3.2'
 
+# On older Rubies, there was no tid member in the internal thread structure
+$defs << '-DNO_THREAD_TID' if RUBY_VERSION < '3.1'
+
 # On older Rubies, we need to use a backported version of this function. See private_vm_api_access.h for details.
 $defs << '-DUSE_BACKPORTED_RB_PROFILE_FRAME_METHOD_NAME' if RUBY_VERSION < '3'
 

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -12,6 +12,7 @@
 #include "extconf.h"
 
 rb_nativethread_id_t pthread_id_for(VALUE thread);
+uint64_t native_thread_id_for(VALUE thread);
 ptrdiff_t stack_depth_for(VALUE thread);
 VALUE ddtrace_thread_list(void);
 bool is_thread_alive(VALUE thread);

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -434,5 +434,5 @@ static ddog_Timespec time_now() {
 
   if (clock_gettime(CLOCK_REALTIME, &current_time) != 0) rb_sys_fail("Failed to read CLOCK_REALTIME");
 
-  return (ddog_Timespec) {.seconds = current_time.tv_sec, .nanoseconds = current_time.tv_nsec};
+  return (ddog_Timespec) {.seconds = current_time.tv_sec, .nanoseconds = (uint32_t) current_time.tv_nsec};
 }

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -110,8 +110,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       end
 
       current_thread_gc_samples =
-        all_samples
-          .select { |it| it.fetch(:labels).fetch(:'thread id') == Thread.current.object_id.to_s }
+        samples_for_thread(all_samples, Thread.current)
           .reject { |it| it.fetch(:locations).first.fetch(:path) == 'Garbage Collection' } # Separate test for GC below
 
       expect(current_thread_gc_samples).to_not be_empty
@@ -137,8 +136,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       all_samples = samples_from_pprof(serialization_result.last)
 
       current_thread_gc_samples =
-        all_samples
-          .select { |it| it.fetch(:labels).fetch(:'thread id') == Thread.current.object_id.to_s }
+        samples_for_thread(all_samples, Thread.current)
           .select { |it| it.fetch(:locations).first.fetch(:path) == 'Garbage Collection' }
 
       # NOTE: In some cases, Ruby may actually call two GC's back-to-back without us having the possibility to take

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -82,6 +82,14 @@ module ProfileHelpers
 
     { base_label: strings[function.name], path: strings[function.filename], lineno: line_entry.line }
   end
+
+  def object_id_from(thread_id)
+    Integer(thread_id.match(/\d+ \((?<object_id>\d+)\)/)[:object_id])
+  end
+
+  def samples_for_thread(samples, thread)
+    samples.select { |sample| object_id_from(sample.fetch(:labels).fetch(:'thread id')) == thread.object_id }
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
**What does this PR do?**:

This PR extends the `thread id` label that is attached to profiling samples to include the thread's "native thread id".

Up until now, the `thread id` that we attached was the result of calling `Thread#object_id`. That approach allows us to easily match what we see inside the Ruby process (because we can log the `Thread#object_id` where something happens) with the profile.

BUT if we wanted to match the profile with what the operating system's tooling showed, it was quite hard, because threads shown in the OS task manager tools show an OS-level thread identifier, which is not the same as the `Thread#object_id`.

To enable this matching, this PR changes the format of the `thread id` from `"#{thread.object_id}"` to `"#{thread.native_object_id} (#{thread.object_id})"` thus providing both identifers. (This is OK with the profiling backend).

Because `Thread#native_object_id` is a Ruby 3.1+ feature, on older Rubies we use a fallback identifier instead (`pthread_t`). This identifier isn't as useful as the native identifier; in the future we may want to explore a better fallback.

**Motivation**:

I found this helpful during development and when correlating data from profiler with other tools.

**Additional Notes**:

This includes full support for macOS, even though we don't officially support macOS.

This feature is only available on the new CPU Profiling 2.0 profiler which is still in alpha, see #2209.

**How to test the change?**:

This is easiest to test by profiling a Ruby app, and then checking that the native ids for threads match up with what shows up on `/proc`. (Remember, only for >= 3.1, for older Rubies it won't match.)