### PR TITLE
Add required hostname value to Datadog agent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ test_containers:
       - DD_APM_ENABLED=true
       - DD_BIND_HOST=0.0.0.0
       - DD_API_KEY=00000000000000000000000000000000
+      - DD_HOSTNAME=dd-trace-rb-ci
   - &agent_port 8126
 
 check_exact_bundle_cache_hit: &check_exact_bundle_cache_hit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -546,6 +546,7 @@ services:
       - DD_APM_ENABLED=true
       - DD_BIND_HOST=0.0.0.0
       - "DD_API_KEY=${DD_API_KEY}"
+      - DD_HOSTNAME=dd-trace-rb-ci
       - DD_APM_RECEIVER_SOCKET=/var/run/datadog/apm.socket
     expose:
       - "8125/udp"


### PR DESCRIPTION
The Datadog agent now requires a meaningful hostname in order to start (https://github.com/DataDog/datadog-agent/issues/14152)

The CircleCI environment is not really a fully fledged production environment, thus the agent fails to find a suitable hostname.

This PR adds a hostname explicitly to the agent.