### PR TITLE
Add profiler helper for detecting if we're on the main Ractor

### DIFF
--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -125,6 +125,9 @@ $defs << '-DNO_RB_NATIVE_THREAD' if RUBY_VERSION < '3.2'
 # On older Rubies, we need to use a backported version of this function. See private_vm_api_access.h for details.
 $defs << '-DUSE_BACKPORTED_RB_PROFILE_FRAME_METHOD_NAME' if RUBY_VERSION < '3'
 
+# On older Rubies, there are no Ractors
+$defs << '-DNO_RACTORS' if RUBY_VERSION < '3'
+
 # On older Rubies, we need to use rb_thread_t instead of rb_execution_context_t
 $defs << '-DUSE_THREAD_INSTEAD_OF_EXECUTION_CONTEXT' if RUBY_VERSION < '2.5'
 

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.h
@@ -18,6 +18,8 @@ bool is_thread_alive(VALUE thread);
 VALUE thread_name_for(VALUE thread);
 
 int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines, bool* is_ruby_frame);
+// Returns true if the current thread belongs to the main Ractor or if Ruby has no Ractor support
+bool ddtrace_rb_ractor_main_p(void);
 
 // Ruby 3.0 finally added support for showing CFUNC frames (frames for methods written using native code)
 // in stack traces gathered via `rb_profile_frames` (https://github.com/ruby/ruby/pull/3299).

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -178,6 +178,17 @@ RSpec.describe Datadog::Profiling::NativeExtension do
       end
 
       context 'on a background Ractor' do
+        # @ivoanjo: When we initially added this test, our test suite kept deadlocking in CI in a later test (not on
+        # this one).
+        #
+        # It turns out that Ruby 3.0 Ractors seem to have some bug that even running `Ractor.new { 'hello' }.take` will
+        # cause a later spec to fail, usually with a (native C) stack with `gc_finalize_deferred`.
+        #
+        # I was able to see this even on both Linux with 3.0.3 and macOS with 3.0.4. Thus, I decided to skip this
+        # spec on Ruby 3.0. We can always run it manually if we change something around this helper; and we have
+        # coverage on 3.1+ anyway.
+        before { skip 'Ruby 3.0 Ractors are too buggy to run this spec' if RUBY_VERSION.start_with?('3.0.') }
+
         subject(:ddtrace_rb_ractor_main_p) do
           Ractor.new { Datadog::Profiling::NativeExtension::Testing._native_ddtrace_rb_ractor_main_p }.take
         end

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require 'datadog/profiling/spec_helper'
 
@@ -157,6 +157,32 @@ RSpec.describe Datadog::Profiling::NativeExtension do
 
       it 'always returns nil' do
         is_expected.to be nil
+      end
+    end
+  end
+
+  describe 'ddtrace_rb_ractor_main_p' do
+    subject(:ddtrace_rb_ractor_main_p) { Datadog::Profiling::NativeExtension::Testing._native_ddtrace_rb_ractor_main_p }
+
+    context 'when Ruby has no support for Ractors' do
+      before { skip 'Behavior does not apply to current Ruby version' if RUBY_VERSION >= '3' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when Ruby has support for Ractors' do
+      before { skip 'Behavior does not apply to current Ruby version' if RUBY_VERSION < '3' }
+
+      context 'on the main Ractor' do
+        it { is_expected.to be true }
+      end
+
+      context 'on a background Ractor' do
+        subject(:ddtrace_rb_ractor_main_p) do
+          Ractor.new { Datadog::Profiling::NativeExtension::Testing._native_ddtrace_rb_ractor_main_p }.take
+        end
+
+        it { is_expected.to be false }
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**:

Add a new helper to `private_vm_access.c` that allows the caller thread to ask if it's running as part of the main Ractor.

On Rubies without Ractor support, as a simplification, we always return `true` so that callers don't need to probe for Ractor support.

**Motivation**:

This helper will be used to make sure the profiler code does not run on the wrong Ractor, since the profiler code is currently not built to be called in parallel from multiple Ractors.

**Additional Notes**:

Hey, I added the first spec that uses Ractors to our test suite!

**How to test the change?**:

Test coverage included.