### PR TITLE
Disable GC profiling on Ruby 3 by default due to Ruby VM Ractor-related bug

### DIFF
--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.c
@@ -2,7 +2,6 @@
 
 void raise_unexpected_type(
   VALUE value,
-  DDTRACE_UNUSED enum ruby_value_type _type,
   const char *value_name,
   const char *type_name,
   const char *file,

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.h
@@ -45,12 +45,14 @@ static inline int check_if_pending_exception(void) {
 // Ruby has a Check_Type(value, type) that is roughly equivalent to this BUT Ruby's version is rather cryptic when it fails
 // e.g. "wrong argument type nil (expected String)". This is a replacement that prints more information to help debugging.
 #define ENFORCE_TYPE(value, type) \
-  { if (RB_UNLIKELY(!RB_TYPE_P(value, type))) raise_unexpected_type(value, type, ADD_QUOTES(value), ADD_QUOTES(type), __FILE__, __LINE__, __func__); }
+  { if (RB_UNLIKELY(!RB_TYPE_P(value, type))) raise_unexpected_type(value, ADD_QUOTES(value), ADD_QUOTES(type), __FILE__, __LINE__, __func__); }
+
+#define ENFORCE_BOOLEAN(value) \
+  { if (RB_UNLIKELY(value != Qtrue && value != Qfalse)) raise_unexpected_type(value, ADD_QUOTES(value), "true or false", __FILE__, __LINE__, __func__); }
 
 // Called by ENFORCE_TYPE; should not be used directly
 NORETURN(void raise_unexpected_type(
   VALUE value,
-  enum ruby_value_type type,
   const char *value_name,
   const char *type_name,
   const char *file,

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -253,6 +253,7 @@ module Datadog
                 recorder: recorder,
                 max_frames: settings.profiling.advanced.max_frames,
                 tracer: tracer,
+                gc_profiling_enabled: should_enable_gc_profiling?(settings)
               )
             else
               trace_identifiers_helper = Profiling::TraceIdentifiers::Helper.new(
@@ -327,6 +328,22 @@ module Datadog
                 api_key: settings.api_key,
                 upload_timeout_seconds: settings.profiling.upload.timeout_seconds,
               )
+          end
+
+          def should_enable_gc_profiling?(settings)
+            return true if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3')
+
+            # See comments on the setting definition for more context on why it exists.
+            if settings.profiling.advanced.force_enable_gc_profiling
+              Datadog.logger.debug(
+                'Profiling time/resources spent in Garbage Collection force enabled. Do not use Ractors in combination ' \
+                'with this option as profiles will be incomplete.'
+              )
+
+              true
+            else
+              false
+            end
           end
         end
 

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -256,6 +256,25 @@ module Datadog
               o.default { env_to_bool('DD_PROFILING_FORCE_ENABLE_NEW', false) }
               o.lazy
             end
+
+            # Forces enabling of profiling of time/resources spent in Garbage Collection.
+            #
+            # Note that setting this to "false" (or not setting it) will not prevent the feature from being
+            # being automatically enabled in the future.
+            #
+            # This toggle was added because, although this feature is safe and enabled by default on Ruby 2.x,
+            # on Ruby 3.x it can break in applications that make use of Ractors due to a Ruby VM bug
+            # (https://bugs.ruby-lang.org/issues/19112).
+            #
+            # If you use Ruby 3.x and your application does not use Ractors (or if your Ruby has been patched), the
+            # feature is fully safe to enable and this toggle can be used to do so.
+            #
+            # We expect that once the above issue is patched, we'll automatically re-enable the feature on fixed Ruby
+            # versions.
+            option :force_enable_gc_profiling do |o|
+              o.default { env_to_bool('DD_PROFILING_FORCE_ENABLE_GC', false) }
+              o.lazy
+            end
           end
 
           # @public_api

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -19,9 +19,10 @@ module Datadog
           recorder:,
           max_frames:,
           tracer:,
+          gc_profiling_enabled:,
           cpu_and_wall_time_collector: CpuAndWallTime.new(recorder: recorder, max_frames: max_frames, tracer: tracer)
         )
-          self.class._native_initialize(self, cpu_and_wall_time_collector)
+          self.class._native_initialize(self, cpu_and_wall_time_collector, gc_profiling_enabled)
           @worker_thread = nil
           @failure_exception = nil
           @start_stop_mutex = Mutex.new

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -465,6 +465,41 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             .to(true)
         end
       end
+
+      describe '#force_enable_gc_profiling' do
+        subject(:force_enable_gc_profiling) { settings.profiling.advanced.force_enable_gc_profiling }
+
+        context 'when DD_PROFILING_FORCE_ENABLE_GC' do
+          around do |example|
+            ClimateControl.modify('DD_PROFILING_FORCE_ENABLE_GC' => environment) do
+              example.run
+            end
+          end
+
+          context 'is not defined' do
+            let(:environment) { nil }
+
+            it { is_expected.to be false }
+          end
+
+          { 'true' => true, 'false' => false }.each do |string, value|
+            context "is defined as #{string}" do
+              let(:environment) { string }
+
+              it { is_expected.to be value }
+            end
+          end
+        end
+      end
+
+      describe '#force_enable_gc_profiling=' do
+        it 'updates the #force_enable_gc_profiling setting' do
+          expect { settings.profiling.advanced.force_enable_gc_profiling = true }
+            .to change { settings.profiling.advanced.force_enable_gc_profiling }
+            .from(false)
+            .to(true)
+        end
+      end
     end
 
     describe '#upload' do


### PR DESCRIPTION
**What does this PR do?**:

This PR:

* Adds a toggle that can be used to enable/disable the GC profiling feature added in #2336
* Enables the GC profiling feature by default on Ruby 2.x and disables the feature by default on Ruby 3.x
* Exposes a new `DD_PROFILING_FORCE_ENABLE_GC` / `settings.profiling.advanced.force_enable_gc_profiling` setting to allow customers that don't use Ractors to manually re-enable the GC profiling feature.

**Motivation**:

While validating that the new profiler correctly works with Ractors, I discovered that adding specs that invoked Ractors caused the previously-built GC profiling feature (and attached specs) to start failing.

I was able to track this down to an actual VM bug, which I've reported upstream as <https://bugs.ruby-lang.org/issues/19112>.

To avoid impacting any customers (specifically, they would potentially observe profiles with incomplete data), I decided to disable GC profiling for Ruby 3.x customers for now.

I am hoping that the Ruby core team can be convinced to fix this issue and backport it to existing Ruby 3.x stable releases, so that we can again re-enable this feature for these users.

As an alternative, if this issue sticks around for a long time and we really want this feature to be on by default for Ruby 3.x customers, there are probably are ways for us to automatically detect if Ractors are in use or not. I chose not to pursue such a mechanism for now.

**Additional Notes**:

(None)

**How to test the change?**:

The change includes test coverage. You can also observe this feature by profiling a Ruby application:

* On Ruby 2.x you will see garbage collection frames
* On Ruby 3.x you will not see garbage collection frames unless you force enable the feature.