### PR TITLE
Upgrade Redis to 6.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -611,7 +611,7 @@ services:
     ports:
       - "${TEST_PRESTO_PORT}:8080"
   redis:
-    image: redis:3.2
+    image: redis:6.2
     expose:
       - "6379"
     ports:


### PR DESCRIPTION
**What does this PR do?**

Update Redis image to 6.2

**Motivation**

Currently, our test suite is testing Sidekiq 5.x, in order to put the later versions of Sidekiq into our automated test suite. The image for Redis need to be updated

* Sidekiq 6.x requires Redis 4+
* Sidekiq 7.x requires Redis 6.2+