### PR TITLE
[PROF-5942] Disallow sampling ractors in profiler

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -323,6 +323,7 @@ static VALUE _native_sample_after_gc(DDTRACE_UNUSED VALUE self, VALUE collector_
 // Assumption 2: This function is allowed to raise exceptions. Caller is responsible for handling them, if needed.
 // Assumption 3: This function IS NOT called from a signal handler. This function is not async-signal-safe.
 // Assumption 4: This function IS NOT called in a reentrant way.
+// Assumption 5: This function is called from the main Ractor (if Ruby has support for Ractors).
 VALUE cpu_and_wall_time_collector_sample(VALUE self_instance) {
   struct cpu_and_wall_time_collector_state *state;
   TypedData_Get_Struct(self_instance, struct cpu_and_wall_time_collector_state, &cpu_and_wall_time_collector_typed_data, state);
@@ -384,6 +385,7 @@ VALUE cpu_and_wall_time_collector_sample(VALUE self_instance) {
 // This includes exceptions and use of ruby_xcalloc (because xcalloc can trigger GC)!
 //
 // Assumption 1: This function is called in a thread that is holding the Global VM Lock. Caller is responsible for enforcing this.
+// Assumption 2: This function is called from the main Ractor (if Ruby has support for Ractors).
 void cpu_and_wall_time_collector_on_gc_start(VALUE self_instance) {
   struct cpu_and_wall_time_collector_state *state;
   if (!rb_typeddata_is_kind_of(self_instance, &cpu_and_wall_time_collector_typed_data)) return;
@@ -428,6 +430,7 @@ void cpu_and_wall_time_collector_on_gc_start(VALUE self_instance) {
 // This includes exceptions and use of ruby_xcalloc (because xcalloc can trigger GC)!
 //
 // Assumption 1: This function is called in a thread that is holding the Global VM Lock. Caller is responsible for enforcing this.
+// Assumption 2: This function is called from the main Ractor (if Ruby has support for Ractors).
 void cpu_and_wall_time_collector_on_gc_finish(VALUE self_instance) {
   struct cpu_and_wall_time_collector_state *state;
   if (!rb_typeddata_is_kind_of(self_instance, &cpu_and_wall_time_collector_typed_data)) return;
@@ -464,6 +467,7 @@ void cpu_and_wall_time_collector_on_gc_finish(VALUE self_instance) {
 // Assumption 1: This function is called in a thread that is holding the Global VM Lock. Caller is responsible for enforcing this.
 // Assumption 2: This function is allowed to raise exceptions. Caller is responsible for handling them, if needed.
 // Assumption 3: Unlike `on_gc_start` and `on_gc_finish`, this method is allowed to allocate memory as needed.
+// Assumption 4: This function is called from the main Ractor (if Ruby has support for Ractors).
 VALUE cpu_and_wall_time_collector_sample_after_gc(VALUE self_instance) {
   struct cpu_and_wall_time_collector_state *state;
   TypedData_Get_Struct(self_instance, struct cpu_and_wall_time_collector_state, &cpu_and_wall_time_collector_typed_data, state);

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -263,8 +263,8 @@ module Datadog
             # being automatically enabled in the future.
             #
             # This toggle was added because, although this feature is safe and enabled by default on Ruby 2.x,
-            # on Ruby 3.x it can break in applications that make use of Ractors due to a Ruby VM bug
-            # (https://bugs.ruby-lang.org/issues/19112).
+            # on Ruby 3.x it can break in applications that make use of Ractors due to two Ruby VM bugs:
+            # https://bugs.ruby-lang.org/issues/19112 AND https://bugs.ruby-lang.org/issues/18464.
             #
             # If you use Ruby 3.x and your application does not use Ractors (or if your Ruby has been patched), the
             # feature is fully safe to enable and this toggle can be used to do so.

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -180,6 +180,65 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
     end
   end
 
+  describe 'Ractor safety' do
+    before do
+      skip 'Behavior does not apply to current Ruby version' if RUBY_VERSION < '3.'
+
+      # See native_extension_spec.rb for more details on the issues we saw on 3.0
+      skip 'Ruby 3.0 Ractors are too buggy to run this spec' if RUBY_VERSION.start_with?('3.0.')
+    end
+
+    shared_examples_for 'does not trigger a sample' do |run_ractor|
+      it 'does not trigger a sample' do
+        cpu_and_wall_time_worker.start
+        wait_until_running
+
+        run_ractor.call
+
+        cpu_and_wall_time_worker.stop
+
+        serialization_result = recorder.serialize
+        raise 'Unexpected: Serialization failed' unless serialization_result
+
+        samples_from_ractor =
+          samples_from_pprof(serialization_result.last)
+            .select { |it| it.fetch(:labels)[:'thread name'] == 'background ractor' }
+
+        expect(samples_from_ractor).to be_empty
+      end
+    end
+
+    context 'when called from a background ractor' do
+      describe 'handle_sampling_signal' do
+        include_examples 'does not trigger a sample',
+          (
+            proc do
+              Ractor.new do
+                Thread.current.name = 'background ractor'
+                Datadog::Profiling::Collectors::CpuAndWallTimeWorker::Testing._native_simulate_handle_sampling_signal
+              end.take
+            end
+          )
+      end
+
+      describe 'sample_from_postponed_job' do
+        include_examples 'does not trigger a sample',
+          (
+            proc do
+              Ractor.new do
+                Thread.current.name = 'background ractor'
+                Datadog::Profiling::Collectors::CpuAndWallTimeWorker::Testing._native_simulate_sample_from_postponed_job
+              end.take
+            end
+          )
+      end
+
+      # @ivoanjo: I initially tried to also test the GC callbacks, but it gets a bit hacky to force the thread
+      # context creation for the ractors, and then simulate a GC. (For instance -- how to prevent against the context
+      # creation running in parallel with a regular sample?)
+    end
+  end
+
   describe '#stop' do
     subject(:stop) { cpu_and_wall_time_worker.stop }
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -209,6 +209,11 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
     end
 
     context 'when called from a background ractor' do
+      # Even though we're not testing it explicitly, the GC profiling hooks can sometimes be called when running these
+      # specs. Unfortunately, there's a VM crash in that case as well -- https://bugs.ruby-lang.org/issues/18464 --
+      # so this must be disabled when interacting with Ractors.
+      let(:gc_profiling_enabled) { false }
+
       describe 'handle_sampling_signal' do
         include_examples 'does not trigger a sample',
           (


### PR DESCRIPTION
**What does this PR do?**:

This PR builds on top of #2350 and changes the `Collectors::CpuAndWallTimeWorker` to never trigger sampling if any of its methods get called from outside the main ractor.

This means that the profiler will not have visibility beyond the main ractor. Building support for that will come later, as we'll need to deal with the complexity of the profiler potentially being called from multiple ractors.

**Motivation**:

We don't yet support Ractors, but on an application using Ractors the profiler should not fail or misbehave. The expected behavior is that it just won't profile Ractors beyond the main one.

**Additional Notes**:

(Nothing)

**How to test the change?**:

I've included partial coverage, but testing the GC-related behavior was harder than I expected (also because of #2354), so for now I didn't add it.

To test this feature, you can enable profiling on a Ruby app using ractors and confirm that no samples appear from Ractors, but otherwise profiling works correctly (for threads in the main Ractor).

Here's a test app I've been using:

```ruby
puts RUBY_DESCRIPTION

def fib(n)
  return n if n <= 1
  fib(n-1) + fib(n-2)
end

Thread.current.name = "#{Thread.current.object_id} main"

ractor1 = Ractor.new do
  Thread.current.name = "#{Thread.current.object_id} ractor1 main"

  Thread.new do
    Thread.current.name = "#{Thread.current.object_id} ractor1 background"

    loop { fib(40) }
  end

  sleep 1
  puts "ractor1 => #{Thread.list}"

  loop { fib(40) }
end

ractor2 = Ractor.new do
  Thread.current.name = "#{Thread.current.object_id} ractor2 main"

  Thread.new do
    Thread.current.name = "#{Thread.current.object_id} ractor2 background"

    loop { fib(40) }
  end

  sleep 1
  puts "ractor2 => #{Thread.list}"

  loop { fib(40) }
end

puts "main => #{Thread.list}"

sleep
```