### PR TITLE
[PROF-5953] Ruby VM forking fixes for new profiler

### DIFF
--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -30,7 +30,7 @@ module Datadog
 
         def start
           @start_stop_mutex.synchronize do
-            return if @worker_thread
+            return if @worker_thread && @worker_thread.alive?
 
             Datadog.logger.debug { "Starting thread for: #{self}" }
             @worker_thread = Thread.new do

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -220,6 +220,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           try_wait_until(backoff: 0.01) { described_class::Testing._native_is_running?(another_instance) }
 
           expect(described_class::Testing._native_gc_tracepoint(cpu_and_wall_time_worker)).to_not be_enabled
+          expect(described_class::Testing._native_gc_tracepoint(another_instance)).to be_enabled
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?**:

This PR collects fixes for two issues related to the new profiler and Ruby apps that employ fork. See individual commits for details.

**Motivation**:

We fully support Ruby applications that use fork, so I've been spending time making sure the new profiler is correct for these applications as well.

**Additional Notes**:

I suspect there may be a few more fixes needed before the new profiler is solid on Ruby apps that use fork, so expect more PRs on this subject.

**This PR is on top of #2358 as I wanted to avoid any conflicts, but is independent of it**

**How to test the change?**:

Both changes include test coverage. Additionally, the first change can be easily observed by checking that the profiler restarts successfully after a fork in a Ruby app that uses forking.