### PR TITLE
Improve clearing of profile data after Ruby app forks

### DIFF
--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -445,6 +445,10 @@ static VALUE _native_clear(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) 
 
   ddog_Timespec finish_timestamp = time_now();
 
+  // Why flip the slots as part of clearing? This makes clear behave exactly like serialize in terms of concurrency
+  // properties, even though right now there probably won't be any concurrency between calling clear and adding samples
+  // to the profile because we do not release the global VM lock while clearing.
+  // See also https://github.com/DataDog/dd-trace-rb/pull/2362/files#r1019659427 for more details.
   ddog_Profile *profile = serializer_flip_active_and_inactive_slots(state, finish_timestamp);
   if (!ddog_Profile_reset(profile, NULL /* start_time is optional */ )) {
     return rb_ary_new_from_args(2, error_symbol, rb_str_new_cstr("Failed to reset profile"));

--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -70,6 +70,13 @@ module Datadog
         !duration_below_threshold?(last_flush_finish_at || created_at, time_provider.now.utc)
       end
 
+      def clear
+        # TODO: This is a really heavy-handed way of clearing the buffer
+        flush
+
+        nil
+      end
+
       private
 
       def duration_below_threshold?(start, finish)

--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -71,9 +71,12 @@ module Datadog
       end
 
       def clear
-        # TODO: This is a really heavy-handed way of clearing the buffer
-        _, finish, _ = pprof_recorder.serialize
-        @last_flush_finish_at = finish
+        if pprof_recorder.respond_to?(:clear)
+          @last_flush_finish_at = pprof_recorder.clear
+        else # TODO: Remove this when the OldRecorder is retired and we can assume all recorders implement #clear
+          _, finish, = pprof_recorder.serialize
+          @last_flush_finish_at = finish
+        end
 
         nil
       end

--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -72,7 +72,8 @@ module Datadog
 
       def clear
         # TODO: This is a really heavy-handed way of clearing the buffer
-        flush
+        _, finish, _ = pprof_recorder.serialize
+        @last_flush_finish_at = finish
 
         nil
       end

--- a/lib/datadog/profiling/scheduler.rb
+++ b/lib/datadog/profiling/scheduler.rb
@@ -70,7 +70,7 @@ module Datadog
         # Clear any existing profiling state.
         # We don't want the child process to report profiling data from its parent.
         Datadog.logger.debug('Flushing exporter in child process #after_fork and discarding data')
-        exporter.flush
+        exporter.clear
       end
 
       # Configure Workers::IntervalLoop to not report immediately when scheduler starts

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -34,6 +34,24 @@ module Datadog
         end
       end
 
+      def clear
+        status, result = @no_concurrent_synchronize_mutex.synchronize { self.class._native_clear(self) }
+
+        if status == :ok
+          finish_timestamp = result
+
+          Datadog.logger.debug { "Cleared profile at #{finish_timestamp}" }
+
+          finish_timestamp
+        else
+          error_message = result
+
+          Datadog.logger.error("Failed to clear profiling data: #{error_message}")
+
+          nil
+        end
+      end
+
       # Used only for Ruby 2.2 which doesn't have the native `rb_time_timespec_new` API; called from native code
       def self.ruby_time_from(timespec_seconds, timespec_nanoseconds)
         Time.at(0).utc + timespec_seconds + (timespec_nanoseconds.to_r / 1_000_000_000)

--- a/spec/datadog/profiling/exporter_spec.rb
+++ b/spec/datadog/profiling/exporter_spec.rb
@@ -79,10 +79,36 @@ RSpec.describe Datadog::Profiling::Exporter do
 
     it { is_expected.to be nil }
 
-    it 'triggers pprof_recorder serialization' do
-      expect(pprof_recorder).to receive(:serialize)
+    context 'when pprof_recorder does not support clear' do
+      let(:pprof_recorder) { instance_double(Datadog::Profiling::OldRecorder, serialize: pprof_recorder_serialize) }
 
-      clear
+      it 'triggers pprof_recorder serialization' do
+        expect(pprof_recorder).to receive(:serialize)
+
+        clear
+      end
+
+      it 'sets the last_flush_finish_at to the result of serialize' do
+        clear
+
+        expect(exporter.send(:last_flush_finish_at)).to be finish
+      end
+    end
+
+    context 'when pprof_recorder supports clear' do
+      let(:pprof_recorder) { instance_double(Datadog::Profiling::StackRecorder, clear: finish) }
+
+      it 'triggers pprof_recorder clear' do
+        expect(pprof_recorder).to receive(:clear)
+
+        clear
+      end
+
+      it 'sets the last_flush_finish_at to the result of clear' do
+        clear
+
+        expect(exporter.send(:last_flush_finish_at)).to be finish
+      end
     end
   end
 

--- a/spec/datadog/profiling/scheduler_spec.rb
+++ b/spec/datadog/profiling/scheduler_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Datadog::Profiling::Scheduler do
     subject(:after_fork) { scheduler.after_fork }
 
     it 'clears the buffer' do
-      expect(exporter).to receive(:flush)
+      expect(exporter).to receive(:clear)
       after_fork
     end
   end

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         expect { stack_recorder.public_send(operation) }.to change { active_slot }.from(1).to(2)
       end
 
-      it 'locks the slot one mutex and keeps it locked' do
+      it 'locks the slot one mutex' do
         expect { stack_recorder.public_send(operation) }.to change { slot_one_mutex_locked? }.from(false).to(true)
       end
 
-      it 'unlocks the slot two mutex and keeps it unlocked' do
+      it 'unlocks the slot two mutex' do
         expect { stack_recorder.public_send(operation) }.to change { slot_two_mutex_locked? }.from(true).to(false)
       end
     end
@@ -64,11 +64,11 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         expect { stack_recorder.public_send(operation) }.to change { active_slot }.from(2).to(1)
       end
 
-      it 'unlocks the slot one mutex and keeps it unlocked' do
+      it 'unlocks the slot one mutex' do
         expect { stack_recorder.public_send(operation) }.to change { slot_one_mutex_locked? }.from(true).to(false)
       end
 
-      it 'locks the slow two mutex and keeps it locked' do
+      it 'locks the slot two mutex' do
         expect { stack_recorder.public_send(operation) }.to change { slot_two_mutex_locked? }.from(false).to(true)
       end
     end

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -39,6 +39,41 @@ RSpec.describe Datadog::Profiling::StackRecorder do
     end
   end
 
+  shared_examples_for 'locking behavior' do |operation|
+    context 'when slot one was the active slot' do
+      it 'sets slot two as the active slot' do
+        expect { stack_recorder.public_send(operation) }.to change { active_slot }.from(1).to(2)
+      end
+
+      it 'locks the slot one mutex and keeps it locked' do
+        expect { stack_recorder.public_send(operation) }.to change { slot_one_mutex_locked? }.from(false).to(true)
+      end
+
+      it 'unlocks the slot two mutex and keeps it unlocked' do
+        expect { stack_recorder.public_send(operation) }.to change { slot_two_mutex_locked? }.from(true).to(false)
+      end
+    end
+
+    context 'when slot two was the active slot' do
+      before do
+        # Trigger operation once, so that active slots get flipped
+        stack_recorder.public_send(operation)
+      end
+
+      it 'sets slot one as the active slot' do
+        expect { stack_recorder.public_send(operation) }.to change { active_slot }.from(2).to(1)
+      end
+
+      it 'unlocks the slot one mutex and keeps it unlocked' do
+        expect { stack_recorder.public_send(operation) }.to change { slot_one_mutex_locked? }.from(true).to(false)
+      end
+
+      it 'locks the slow two mutex and keeps it locked' do
+        expect { stack_recorder.public_send(operation) }.to change { slot_two_mutex_locked? }.from(false).to(true)
+      end
+    end
+  end
+
   describe '#serialize' do
     subject(:serialize) { stack_recorder.serialize }
 
@@ -61,40 +96,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       expect(message).to include finish.iso8601
     end
 
-    describe 'locking behavior' do
-      context 'when slot one was the active slot' do
-        it 'sets slot two as the active slot' do
-          expect { serialize }.to change { active_slot }.from(1).to(2)
-        end
-
-        it 'locks the slot one mutex and keeps it locked' do
-          expect { serialize }.to change { slot_one_mutex_locked? }.from(false).to(true)
-        end
-
-        it 'unlocks the slot two mutex and keeps it unlocked' do
-          expect { serialize }.to change { slot_two_mutex_locked? }.from(true).to(false)
-        end
-      end
-
-      context 'when slot two was the active slot' do
-        before do
-          # Trigger serialization once, so that active slots get flipped
-          stack_recorder.serialize
-        end
-
-        it 'sets slot one as the active slot' do
-          expect { serialize }.to change { active_slot }.from(2).to(1)
-        end
-
-        it 'unlocks the slot one mutex and keeps it unlocked' do
-          expect { serialize }.to change { slot_one_mutex_locked? }.from(true).to(false)
-        end
-
-        it 'locks the slow two mutex and keeps it locked' do
-          expect { serialize }.to change { slot_two_mutex_locked? }.from(false).to(true)
-        end
-      end
-    end
+    include_examples 'locking behavior', :serialize
 
     context 'when the profile is empty' do
       it 'uses the current time as the start and finish time' do
@@ -216,6 +218,76 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         start, = stack_recorder.serialize
 
         expect(start).to be >= before_serialize
+      end
+    end
+  end
+
+  describe '#clear' do
+    subject(:clear) { stack_recorder.clear }
+
+    it 'debug logs that clear was invoked' do
+      message = nil
+
+      expect(Datadog.logger).to receive(:debug) do |&message_block|
+        message = message_block.call
+      end
+
+      clear
+
+      expect(message).to match(/Cleared profile/)
+    end
+
+    include_examples 'locking behavior', :clear
+
+    it 'uses the current time as the finish time' do
+      before_clear = Time.now.utc
+      finish = clear
+      after_clear = Time.now.utc
+
+      expect(finish).to be_between(before_clear, after_clear)
+    end
+
+    context 'when profile has a sample' do
+      let(:collectors_stack) { Datadog::Profiling::Collectors::Stack.new }
+
+      let(:metric_values) { { 'cpu-time' => 123, 'cpu-samples' => 456, 'wall-time' => 789 } }
+      let(:labels) { { 'label_a' => 'value_a', 'label_b' => 'value_b' }.to_a }
+
+      it 'makes the next calls to serialize return no data' do
+        # Add some data
+        Datadog::Profiling::Collectors::Stack::Testing
+          ._native_sample(Thread.current, stack_recorder, metric_values, labels, 400, false)
+
+        # Sanity check: validate that data is there, to avoid the test passing because of other issues
+        sanity_check_samples = samples_from_pprof(stack_recorder.serialize.last)
+        expect(sanity_check_samples.size).to be 1
+
+        # Add some data, again
+        Datadog::Profiling::Collectors::Stack::Testing
+          ._native_sample(Thread.current, stack_recorder, metric_values, labels, 400, false)
+
+        clear
+
+        # Test twice in a row to validate that both profile slots are empty
+        expect(samples_from_pprof(stack_recorder.serialize.last)).to be_empty
+        expect(samples_from_pprof(stack_recorder.serialize.last)).to be_empty
+      end
+    end
+
+    context 'when there is a failure during serialization' do
+      before do
+        allow(Datadog.logger).to receive(:error)
+
+        # Real failures in serialization are hard to trigger, so we're using a mock failure instead
+        expect(described_class).to receive(:_native_clear).and_return([:error, 'test error message'])
+      end
+
+      it { is_expected.to be nil }
+
+      it 'logs an error message' do
+        expect(Datadog.logger).to receive(:error).with(/test error message/)
+
+        clear
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**:

When a Ruby app forks, we automatically restart the profiler in the child process as well. This ensures that in apps such as forking webservers we still provide full profiling coverage.

As part of automatically restarting the profiler in the child process, we want to clear any profiling data that has accumulated from the parent, as otherwise both the parent as well as the child process would report that data.

This "clearing of profiling data" happens in `Scheduler#after_fork`. Previously, this method would "clear data" by asking the exporter for the latest profile and then throwing this away.

This worked but it was rather heavy handed -- it did some useless work, as well as generated a few slightly-confusing debug logs:

```
DEBUG (dd-trace-rb/lib/datadog/profiling/scheduler.rb:73:in `after_fork') Flushing exporter in child process #after_fork and discarding data
DEBUG (dd-trace-rb/lib/datadog/profiling/stack_recorder.rb:25:in `serialize') Encoded profile covering 2022-11-10T09:42:22Z to 2022-11-10T09:42:22Z
DEBUG (dd-trace-rb/lib/datadog/profiling/exporter.rb:52:in `flush') Skipped exporting profiling events as profile duration is below minimum
```

To improve this for the new Ruby profiler, I've decided to implement a `StackRecorder#clear`, and then refactor the `Scheduler` and `Exporter` to use it instead.

For the old Ruby profiler (still the default, in-use by customers), I chose not to implement a `#clear`, and thus the old approach of serializing a profile and throwing it away is still used.

**Motivation**:

I've wanted to improve this for some time, but chose not to because I didn't want to invest on improving the old profiler just to then throw it away. Now that the new profiler is getting in better shape, I finally decided to implement this.

**Additional Notes**:

This PR is on top of #2359 just for my development convenience; it has no explicit dependencies on it.

**How to test the change?**:

Validate that profiles from the child process of a Ruby app that forks do not contain any profiling data from the parent process by looking at the profiler UX.