### PR TITLE
Unified tagging `span.kind` as `server` and `client`

### DIFF
--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor/server.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor/server.rb
@@ -59,6 +59,8 @@ module Datadog
                 span.set_tag(header, value)
               end
 
+              span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_SERVER)
+
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_SERVICE)
 

--- a/lib/datadog/tracing/contrib/mongodb/subscribers.rb
+++ b/lib/datadog/tracing/contrib/mongodb/subscribers.rb
@@ -33,6 +33,8 @@ module Datadog
 
             span.set_tag(Contrib::Ext::DB::TAG_SYSTEM, Ext::TAG_SYSTEM)
 
+            span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
+
             span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
             span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_COMMAND)
 

--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -45,6 +45,8 @@ module Datadog
             # Tag this span as belonging to Rack
             frontend_span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
             frontend_span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_HTTP_SERVER_QUEUE)
+            frontend_span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_SERVER)
+
 
             # Set peer service (so its not believed to belong to this app)
             frontend_span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, configuration[:web_service_name])
@@ -157,6 +159,8 @@ module Datadog
 
             request_span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
             request_span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_REQUEST)
+            request_span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_SERVER)
+
 
             # Set analytics sample rate
             if Contrib::Analytics.enabled?(configuration[:analytics_enabled])

--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -47,7 +47,6 @@ module Datadog
             frontend_span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_HTTP_SERVER_QUEUE)
             frontend_span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_SERVER)
 
-
             # Set peer service (so its not believed to belong to this app)
             frontend_span.set_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE, configuration[:web_service_name])
 
@@ -160,7 +159,6 @@ module Datadog
             request_span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
             request_span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_REQUEST)
             request_span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_SERVER)
-
 
             # Set analytics sample rate
             if Contrib::Analytics.enabled?(configuration[:analytics_enabled])

--- a/spec/datadog/tracing/contrib/grpc/datadog_interceptor/server_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/datadog_interceptor/server_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe 'tracing on the server connection' do
     it { expect(span.get_tag('rpc.system')).to eq 'grpc' }
     it { expect(span.get_tag('rpc.service')).to eq 'My::Server' }
     it { expect(span.get_tag('rpc.method')).to eq 'endpoint' }
+    it { expect(span.get_tag('span.kind')).to eq('server') }
+
 
     it 'has component and operation tags' do
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('grpc')

--- a/spec/datadog/tracing/contrib/grpc/datadog_interceptor/server_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/datadog_interceptor/server_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe 'tracing on the server connection' do
     it { expect(span.get_tag('rpc.method')).to eq 'endpoint' }
     it { expect(span.get_tag('span.kind')).to eq('server') }
 
-
     it 'has component and operation tags' do
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('grpc')
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('service')

--- a/spec/datadog/tracing/contrib/grpc/datadog_interceptor/server_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/datadog_interceptor/server_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe 'tracing on the server connection' do
           expect(span).to have_error_type('TestError')
           expect(span).to have_error_stack(include('server_spec.rb'))
           expect(span.get_tag('rpc.system')).to eq 'grpc'
+          expect(span.get_tag('span.kind')).to eq('server')
         end
       end
 
@@ -98,6 +99,7 @@ RSpec.describe 'tracing on the server connection' do
           expect(span).to_not have_error
           expect(span.get_tag('custom.handler')).to eq('Got error test error, but ignored it')
           expect(span.get_tag('rpc.system')).to eq('grpc')
+          expect(span.get_tag('span.kind')).to eq('server')
         end
       end
     end

--- a/spec/datadog/tracing/contrib/mongodb/client_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/client_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
         expect(span.get_tag('out.port')).to eq(port)
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('mongodb')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('command')
-        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('client')
+        expect(span.get_tag('span.kind')).to eq('client')
       end
 
       it_behaves_like 'analytics for integration' do

--- a/spec/datadog/tracing/contrib/mongodb/client_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/client_spec.rb
@@ -154,6 +154,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
         expect(span.get_tag('out.port')).to eq(port)
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('mongodb')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('command')
+        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('client')
       end
 
       it_behaves_like 'analytics for integration' do

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe 'Rack integration tests' do
       expect(span.status).to eq(0)
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('rack')
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
+      expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('server')
+
     end
   end
 
@@ -77,6 +79,8 @@ RSpec.describe 'Rack integration tests' do
             .to eq('rack')
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
             .to eq('request')
+          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+            .to eq('server')
         end
       end
     end
@@ -286,6 +290,8 @@ RSpec.describe 'Rack integration tests' do
               .to eq('rack')
             expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
               .to eq('request')
+            expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+              .to eq('server')
           end
         end
       end
@@ -322,6 +328,8 @@ RSpec.describe 'Rack integration tests' do
           expect(web_server_span.get_tag('operation')).to eq('queue')
           expect(web_server_span.get_tag('peer.service')).to eq('web-server')
           expect(web_server_span.status).to eq(0)
+          expect(web_server_span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+            .to eq('server')
 
           expect(rack_span.span_type).to eq('web')
           expect(rack_span.service).to eq(tracer.default_service)
@@ -331,6 +339,8 @@ RSpec.describe 'Rack integration tests' do
           expect(rack_span.status).to eq(0)
           expect(rack_span.get_tag('component')).to eq('rack')
           expect(rack_span.get_tag('operation')).to eq('request')
+          expect(rack_span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+            .to eq('server')
         end
       end
     end
@@ -367,6 +377,8 @@ RSpec.describe 'Rack integration tests' do
             .to eq('rack')
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
             .to eq('request')
+          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+            .to eq('server')
         end
       end
     end
@@ -404,6 +416,8 @@ RSpec.describe 'Rack integration tests' do
             .to eq('rack')
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
             .to eq('request')
+          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+            .to eq('server')
         end
       end
     end
@@ -444,6 +458,8 @@ RSpec.describe 'Rack integration tests' do
               .to eq('rack')
             expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
               .to eq('request')
+            expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+              .to eq('server')
           end
         end
       end
@@ -483,6 +499,8 @@ RSpec.describe 'Rack integration tests' do
               .to eq('rack')
             expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
               .to eq('request')
+            expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+              .to eq('server')
           end
         end
       end
@@ -538,6 +556,8 @@ RSpec.describe 'Rack integration tests' do
                 .to eq('rack')
               expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
                 .to eq('request')
+              expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+                .to eq('server')
             end
           end
         end
@@ -582,6 +602,7 @@ RSpec.describe 'Rack integration tests' do
           expect(web_server_span.get_tag('operation')).to eq('queue')
           expect(web_server_span.get_tag('peer.service')).to eq('web-server')
           expect(web_server_span.status).to eq(0)
+          expect(web_server_span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('server')
 
           expect(rack_span.span_type).to eq('web')
           expect(rack_span.service).to eq(tracer.default_service)
@@ -591,6 +612,8 @@ RSpec.describe 'Rack integration tests' do
           expect(rack_span.status).to eq(0)
           expect(rack_span.get_tag('component')).to eq('rack')
           expect(rack_span.get_tag('operation')).to eq('request')
+          expect(rack_span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('server')
+
 
           expect(nested_app_span.resource).to eq('UserController#show')
         end
@@ -640,6 +663,8 @@ RSpec.describe 'Rack integration tests' do
                 .to eq('rack')
               expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
                 .to eq('request')
+              expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+                .to eq('server')
             end
           end
         end
@@ -681,6 +706,8 @@ RSpec.describe 'Rack integration tests' do
                 .to eq('rack')
               expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
                 .to eq('request')
+              expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+                .to eq('server')
             end
           end
         end
@@ -891,6 +918,8 @@ RSpec.describe 'Rack integration tests' do
         expect(span.status).to eq(0)
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('rack')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
+        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('server')
+
       end
     end
   end

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe 'Rack integration tests' do
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('rack')
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('server')
-
     end
   end
 
@@ -614,7 +613,6 @@ RSpec.describe 'Rack integration tests' do
           expect(rack_span.get_tag('operation')).to eq('request')
           expect(rack_span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('server')
 
-
           expect(nested_app_span.resource).to eq('UserController#show')
         end
       end
@@ -919,7 +917,6 @@ RSpec.describe 'Rack integration tests' do
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('rack')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('server')
-
       end
     end
   end

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Rack integration tests' do
       expect(span.status).to eq(0)
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('rack')
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
-      expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('server')
+      expect(span.get_tag('span.kind')).to eq('server')
     end
   end
 
@@ -78,7 +78,7 @@ RSpec.describe 'Rack integration tests' do
             .to eq('rack')
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
             .to eq('request')
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+          expect(span.get_tag('span.kind'))
             .to eq('server')
         end
       end
@@ -289,7 +289,7 @@ RSpec.describe 'Rack integration tests' do
               .to eq('rack')
             expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
               .to eq('request')
-            expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+            expect(span.get_tag('span.kind'))
               .to eq('server')
           end
         end
@@ -327,7 +327,7 @@ RSpec.describe 'Rack integration tests' do
           expect(web_server_span.get_tag('operation')).to eq('queue')
           expect(web_server_span.get_tag('peer.service')).to eq('web-server')
           expect(web_server_span.status).to eq(0)
-          expect(web_server_span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+          expect(web_server_span.get_tag('span.kind'))
             .to eq('server')
 
           expect(rack_span.span_type).to eq('web')
@@ -338,7 +338,7 @@ RSpec.describe 'Rack integration tests' do
           expect(rack_span.status).to eq(0)
           expect(rack_span.get_tag('component')).to eq('rack')
           expect(rack_span.get_tag('operation')).to eq('request')
-          expect(rack_span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+          expect(rack_span.get_tag('span.kind'))
             .to eq('server')
         end
       end
@@ -376,7 +376,7 @@ RSpec.describe 'Rack integration tests' do
             .to eq('rack')
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
             .to eq('request')
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+          expect(span.get_tag('span.kind'))
             .to eq('server')
         end
       end
@@ -415,7 +415,7 @@ RSpec.describe 'Rack integration tests' do
             .to eq('rack')
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
             .to eq('request')
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+          expect(span.get_tag('span.kind'))
             .to eq('server')
         end
       end
@@ -457,7 +457,7 @@ RSpec.describe 'Rack integration tests' do
               .to eq('rack')
             expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
               .to eq('request')
-            expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+            expect(span.get_tag('span.kind'))
               .to eq('server')
           end
         end
@@ -498,7 +498,7 @@ RSpec.describe 'Rack integration tests' do
               .to eq('rack')
             expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
               .to eq('request')
-            expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+            expect(span.get_tag('span.kind'))
               .to eq('server')
           end
         end
@@ -555,7 +555,7 @@ RSpec.describe 'Rack integration tests' do
                 .to eq('rack')
               expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
                 .to eq('request')
-              expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+              expect(span.get_tag('span.kind'))
                 .to eq('server')
             end
           end
@@ -601,7 +601,7 @@ RSpec.describe 'Rack integration tests' do
           expect(web_server_span.get_tag('operation')).to eq('queue')
           expect(web_server_span.get_tag('peer.service')).to eq('web-server')
           expect(web_server_span.status).to eq(0)
-          expect(web_server_span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('server')
+          expect(web_server_span.get_tag('span.kind')).to eq('server')
 
           expect(rack_span.span_type).to eq('web')
           expect(rack_span.service).to eq(tracer.default_service)
@@ -611,7 +611,7 @@ RSpec.describe 'Rack integration tests' do
           expect(rack_span.status).to eq(0)
           expect(rack_span.get_tag('component')).to eq('rack')
           expect(rack_span.get_tag('operation')).to eq('request')
-          expect(rack_span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('server')
+          expect(rack_span.get_tag('span.kind')).to eq('server')
 
           expect(nested_app_span.resource).to eq('UserController#show')
         end
@@ -661,7 +661,7 @@ RSpec.describe 'Rack integration tests' do
                 .to eq('rack')
               expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
                 .to eq('request')
-              expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+              expect(span.get_tag('span.kind'))
                 .to eq('server')
             end
           end
@@ -704,7 +704,7 @@ RSpec.describe 'Rack integration tests' do
                 .to eq('rack')
               expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
                 .to eq('request')
-              expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND))
+              expect(span.get_tag('span.kind'))
                 .to eq('server')
             end
           end
@@ -916,7 +916,7 @@ RSpec.describe 'Rack integration tests' do
         expect(span.status).to eq(0)
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('rack')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('request')
-        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('server')
+        expect(span.get_tag('span.kind')).to eq('server')
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**

Unified tagging `span.kind` as `server` and `client`, inspired by [Opentelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/9fa7c656b26647b27e485a6af7e38dc716eba98a/specification/trace/api.md#spankind
) 
