### PR TITLE
[PROF-5943] Clear leftover state on new profiler after Ruby VM forks

### DIFF
--- a/lib/datadog/profiling/collectors/cpu_and_wall_time.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time.rb
@@ -23,6 +23,10 @@ module Datadog
           result
         end
 
+        def reset_after_fork
+          self.class._native_reset_after_fork(self)
+        end
+
         private
 
         def safely_extract_context_key_from(tracer)

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -70,6 +70,10 @@ module Datadog
             @failure_exception = nil
           end
         end
+
+        def reset_after_fork
+          self.class._native_reset_after_fork(self)
+        end
       end
     end
   end

--- a/lib/datadog/profiling/collectors/old_stack.rb
+++ b/lib/datadog/profiling/collectors/old_stack.rb
@@ -218,6 +218,13 @@ module Datadog
           )
         end
 
+        def reset_after_fork
+          recorder.reset_after_fork
+
+          # NOTE: We could perhaps also call #reset_cpu_time_tracking here, although it's not needed because we always
+          # call in in #start.
+        end
+
         private
 
         # If the profiler is started for a while, stopped and then restarted OR whenever the process forks, we need to

--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -70,14 +70,8 @@ module Datadog
         !duration_below_threshold?(last_flush_finish_at || created_at, time_provider.now.utc)
       end
 
-      def clear
-        if pprof_recorder.respond_to?(:clear)
-          @last_flush_finish_at = pprof_recorder.clear
-        else # TODO: Remove this when the OldRecorder is retired and we can assume all recorders implement #clear
-          _, finish, = pprof_recorder.serialize
-          @last_flush_finish_at = finish
-        end
-
+      def reset_after_fork
+        @last_flush_finish_at = time_provider.now.utc
         nil
       end
 

--- a/lib/datadog/profiling/old_recorder.rb
+++ b/lib/datadog/profiling/old_recorder.rb
@@ -73,6 +73,14 @@ module Datadog
         [start, finish, encoded_pprof]
       end
 
+      def reset_after_fork
+        Datadog.logger.debug('Resetting OldRecorder in child process after fork')
+
+        # NOTE: A bit of a heavy-handed approach, but it doesn't happen often and this class will be removed soon anyway
+        serialize
+        nil
+      end
+
       # Error when event of an unknown type is used with the OldRecorder
       class UnknownEventError < StandardError
         attr_reader :event_class

--- a/lib/datadog/profiling/profiler.rb
+++ b/lib/datadog/profiling/profiler.rb
@@ -4,6 +4,8 @@ module Datadog
   module Profiling
     # Profiling entry point, which coordinates collectors and a scheduler
     class Profiler
+      include Datadog::Core::Utils::Forking
+
       attr_reader \
         :collectors,
         :scheduler
@@ -14,6 +16,11 @@ module Datadog
       end
 
       def start
+        after_fork! do
+          collectors.each(&:reset_after_fork)
+          scheduler.reset_after_fork
+        end
+
         collectors.each(&:start)
         scheduler.start
       end

--- a/lib/datadog/profiling/scheduler.rb
+++ b/lib/datadog/profiling/scheduler.rb
@@ -66,13 +66,6 @@ module Datadog
         end
       end
 
-      def after_fork
-        # Clear any existing profiling state.
-        # We don't want the child process to report profiling data from its parent.
-        Datadog.logger.debug('Flushing exporter in child process #after_fork and discarding data')
-        exporter.clear
-      end
-
       # Configure Workers::IntervalLoop to not report immediately when scheduler starts
       #
       # When a scheduler gets created (or reset), we don't want it to immediately try to flush; we want it to wait for
@@ -84,6 +77,10 @@ module Datadog
 
       def work_pending?
         exporter.can_flush?
+      end
+
+      def reset_after_fork
+        exporter.reset_after_fork
       end
 
       private

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -56,6 +56,10 @@ module Datadog
       def self.ruby_time_from(timespec_seconds, timespec_nanoseconds)
         Time.at(0).utc + timespec_seconds + (timespec_nanoseconds.to_r / 1_000_000_000)
       end
+
+      def reset_after_fork
+        self.class._native_reset_after_fork(self)
+      end
     end
   end
 end

--- a/lib/datadog/profiling/tasks/setup.rb
+++ b/lib/datadog/profiling/tasks/setup.rb
@@ -55,13 +55,6 @@ module Datadog
           if Process.respond_to?(:at_fork)
             Process.at_fork(:child) do
               begin
-                # When Ruby forks, clock IDs for each of the threads
-                # will change. We can only update these IDs from the
-                # execution context of the thread that owns it.
-                # This hook will update the IDs for the main thread
-                # after a fork occurs.
-                Thread.current.send(:update_native_ids) if Thread.current.respond_to?(:update_native_ids, true)
-
                 # Restart profiler, if enabled
                 Profiling.start_if_enabled
               rescue StandardError => e

--- a/spec/datadog/profiling/collectors/old_stack_spec.rb
+++ b/spec/datadog/profiling/collectors/old_stack_spec.rb
@@ -764,4 +764,14 @@ RSpec.describe Datadog::Profiling::Collectors::OldStack do
       end
     end
   end
+
+  describe '#reset_after_fork' do
+    subject(:reset_after_fork) { collector.reset_after_fork }
+
+    it 'resets the recorder' do
+      expect(recorder).to receive(:reset_after_fork)
+
+      reset_after_fork
+    end
+  end
 end

--- a/spec/datadog/profiling/old_recorder_spec.rb
+++ b/spec/datadog/profiling/old_recorder_spec.rb
@@ -175,4 +175,27 @@ RSpec.describe Datadog::Profiling::OldRecorder do
       it { is_expected.to be nil }
     end
   end
+
+  describe '#reset_after_fork' do
+    subject(:reset_after_fork) { recorder.reset_after_fork }
+
+    before do
+      allow(Datadog.logger).to receive(:debug)
+    end
+
+    it { is_expected.to be nil }
+
+    it 'debug logs the reset event' do
+      expect(Datadog.logger).to receive(:debug).with(/Resetting/)
+
+      reset_after_fork
+    end
+
+    # NOTE: This again is a bit of a heavy-handed way of testing this method, but we plan to remove it soon anyway
+    it 'triggers a serialize call' do
+      expect(recorder).to receive(:serialize)
+
+      reset_after_fork
+    end
+  end
 end

--- a/spec/datadog/profiling/profiler_spec.rb
+++ b/spec/datadog/profiling/profiler_spec.rb
@@ -26,7 +26,24 @@ RSpec.describe Datadog::Profiling::Profiler do
     it 'signals collectors and scheduler to start' do
       expect(collectors).to all(receive(:start))
       expect(scheduler).to receive(:start)
+
       start
+    end
+
+    context 'when called after a fork' do
+      it 'resets the collectors and the scheduler before starting them' do
+        profiler # make sure instance is created in parent, so it detects the forking
+
+        expect_in_fork do
+          expect(collectors).to all(receive(:reset_after_fork).ordered)
+          expect(scheduler).to receive(:reset_after_fork).ordered
+
+          expect(collectors).to all(receive(:start).ordered)
+          expect(scheduler).to receive(:start).ordered
+
+          start
+        end
+      end
     end
   end
 

--- a/spec/datadog/profiling/profiler_spec.rb
+++ b/spec/datadog/profiling/profiler_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 
 require 'datadog/profiling'
 require 'datadog/profiling/profiler'
+require 'datadog/profiling/collectors/old_stack'
+require 'datadog/profiling/scheduler'
 
 RSpec.describe Datadog::Profiling::Profiler do
   subject(:profiler) { described_class.new(collectors, scheduler) }
@@ -31,6 +33,8 @@ RSpec.describe Datadog::Profiling::Profiler do
     end
 
     context 'when called after a fork' do
+      before { skip('Spec requires Ruby VM supporting fork') unless PlatformHelpers.supports_fork? }
+
       it 'resets the collectors and the scheduler before starting them' do
         profiler # make sure instance is created in parent, so it detects the forking
 

--- a/spec/datadog/profiling/scheduler_spec.rb
+++ b/spec/datadog/profiling/scheduler_spec.rb
@@ -86,15 +86,6 @@ RSpec.describe Datadog::Profiling::Scheduler do
     end
   end
 
-  describe '#after_fork' do
-    subject(:after_fork) { scheduler.after_fork }
-
-    it 'clears the buffer' do
-      expect(exporter).to receive(:clear)
-      after_fork
-    end
-  end
-
   describe '#flush_and_wait' do
     subject(:flush_and_wait) { scheduler.send(:flush_and_wait) }
 
@@ -209,6 +200,16 @@ RSpec.describe Datadog::Profiling::Scheduler do
       before { expect(exporter).to receive(:can_flush?).and_return(false) }
 
       it { is_expected.to be false }
+    end
+  end
+
+  describe '#reset_after_fork' do
+    subject(:reset_after_fork) { scheduler.reset_after_fork }
+
+    it 'resets the exporter' do
+      expect(exporter).to receive(:reset_after_fork)
+
+      reset_after_fork
     end
   end
 end

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -39,41 +39,6 @@ RSpec.describe Datadog::Profiling::StackRecorder do
     end
   end
 
-  shared_examples_for 'locking behavior' do |operation|
-    context 'when slot one was the active slot' do
-      it 'sets slot two as the active slot' do
-        expect { stack_recorder.public_send(operation) }.to change { active_slot }.from(1).to(2)
-      end
-
-      it 'locks the slot one mutex' do
-        expect { stack_recorder.public_send(operation) }.to change { slot_one_mutex_locked? }.from(false).to(true)
-      end
-
-      it 'unlocks the slot two mutex' do
-        expect { stack_recorder.public_send(operation) }.to change { slot_two_mutex_locked? }.from(true).to(false)
-      end
-    end
-
-    context 'when slot two was the active slot' do
-      before do
-        # Trigger operation once, so that active slots get flipped
-        stack_recorder.public_send(operation)
-      end
-
-      it 'sets slot one as the active slot' do
-        expect { stack_recorder.public_send(operation) }.to change { active_slot }.from(2).to(1)
-      end
-
-      it 'unlocks the slot one mutex' do
-        expect { stack_recorder.public_send(operation) }.to change { slot_one_mutex_locked? }.from(true).to(false)
-      end
-
-      it 'locks the slot two mutex' do
-        expect { stack_recorder.public_send(operation) }.to change { slot_two_mutex_locked? }.from(false).to(true)
-      end
-    end
-  end
-
   describe '#serialize' do
     subject(:serialize) { stack_recorder.serialize }
 
@@ -96,7 +61,40 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       expect(message).to include finish.iso8601
     end
 
-    include_examples 'locking behavior', :serialize
+    describe 'locking behavior' do
+      context 'when slot one was the active slot' do
+        it 'sets slot two as the active slot' do
+          expect { serialize }.to change { active_slot }.from(1).to(2)
+        end
+
+        it 'locks the slot one mutex' do
+          expect { serialize }.to change { slot_one_mutex_locked? }.from(false).to(true)
+        end
+
+        it 'unlocks the slot two mutex' do
+          expect { serialize }.to change { slot_two_mutex_locked? }.from(true).to(false)
+        end
+      end
+
+      context 'when slot two was the active slot' do
+        before do
+          # Trigger serialization once, so that active slots get flipped
+          stack_recorder.serialize
+        end
+
+        it 'sets slot one as the active slot' do
+          expect { serialize }.to change { active_slot }.from(2).to(1)
+        end
+
+        it 'unlocks the slot one mutex' do
+          expect { serialize }.to change { slot_one_mutex_locked? }.from(true).to(false)
+        end
+
+        it 'locks the slot two mutex' do
+          expect { serialize }.to change { slot_two_mutex_locked? }.from(false).to(true)
+        end
+      end
+    end
 
     context 'when the profile is empty' do
       it 'uses the current time as the start and finish time' do
@@ -139,8 +137,6 @@ RSpec.describe Datadog::Profiling::StackRecorder do
     end
 
     context 'when profile has a sample' do
-      let(:collectors_stack) { Datadog::Profiling::Collectors::Stack.new }
-
       let(:metric_values) { { 'cpu-time' => 123, 'cpu-samples' => 456, 'wall-time' => 789 } }
       let(:labels) { { 'label_a' => 'value_a', 'label_b' => 'value_b' }.to_a }
 
@@ -222,34 +218,40 @@ RSpec.describe Datadog::Profiling::StackRecorder do
     end
   end
 
-  describe '#clear' do
-    subject(:clear) { stack_recorder.clear }
+  describe '#reset_after_fork' do
+    subject(:reset_after_fork) { stack_recorder.reset_after_fork }
 
-    it 'debug logs that clear was invoked' do
-      message = nil
-
-      expect(Datadog.logger).to receive(:debug) do |&message_block|
-        message = message_block.call
+    context 'when slot one was the active slot' do
+      it 'keeps slot one as the active slot' do
+        expect(active_slot).to be 1
       end
 
-      clear
+      it 'keeps the slot one mutex unlocked' do
+        expect(slot_one_mutex_locked?).to be false
+      end
 
-      expect(message).to match(/Cleared profile/)
+      it 'keeps the slot two mutex locked' do
+        expect(slot_two_mutex_locked?).to be true
+      end
     end
 
-    include_examples 'locking behavior', :clear
+    context 'when slot two was the active slot' do
+      before { stack_recorder.serialize }
 
-    it 'uses the current time as the finish time' do
-      before_clear = Time.now.utc
-      finish = clear
-      after_clear = Time.now.utc
+      it 'sets slot one as the active slot' do
+        expect { reset_after_fork }.to change { active_slot }.from(2).to(1)
+      end
 
-      expect(finish).to be_between(before_clear, after_clear)
+      it 'unlocks the slot one mutex' do
+        expect { reset_after_fork }.to change { slot_one_mutex_locked? }.from(true).to(false)
+      end
+
+      it 'locks the slot two mutex' do
+        expect { reset_after_fork }.to change { slot_two_mutex_locked? }.from(false).to(true)
+      end
     end
 
     context 'when profile has a sample' do
-      let(:collectors_stack) { Datadog::Profiling::Collectors::Stack.new }
-
       let(:metric_values) { { 'cpu-time' => 123, 'cpu-samples' => 456, 'wall-time' => 789 } }
       let(:labels) { { 'label_a' => 'value_a', 'label_b' => 'value_b' }.to_a }
 
@@ -266,7 +268,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         Datadog::Profiling::Collectors::Stack::Testing
           ._native_sample(Thread.current, stack_recorder, metric_values, labels, 400, false)
 
-        clear
+        reset_after_fork
 
         # Test twice in a row to validate that both profile slots are empty
         expect(samples_from_pprof(stack_recorder.serialize.last)).to be_empty
@@ -274,21 +276,13 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       end
     end
 
-    context 'when there is a failure during serialization' do
-      before do
-        allow(Datadog.logger).to receive(:error)
+    it 'sets the start_time of the active profile to the time of the reset_after_fork' do
+      stack_recorder # Initialize instance
 
-        # Real failures in serialization are hard to trigger, so we're using a mock failure instead
-        expect(described_class).to receive(:_native_clear).and_return([:error, 'test error message'])
-      end
+      now = Time.now
+      reset_after_fork
 
-      it { is_expected.to be nil }
-
-      it 'logs an error message' do
-        expect(Datadog.logger).to receive(:error).with(/test error message/)
-
-        clear
-      end
+      expect(stack_recorder.serialize.first).to be >= now
     end
   end
 end

--- a/spec/datadog/profiling/tasks/setup_spec.rb
+++ b/spec/datadog/profiling/tasks/setup_spec.rb
@@ -197,35 +197,6 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
           at_fork_hook.call
         end
       end
-
-      it 'sets up an at_fork hook that updates the native id of the current thread' do
-        without_partial_double_verification do
-          expect(Thread.current).to receive(:update_native_ids)
-        end
-
-        at_fork_hook.call
-      end
-
-      context 'when there is an issue updating the native id of the current thread' do
-        before do
-          without_partial_double_verification do
-            expect(Thread.current).to receive(:update_native_ids).and_raise('Dummy exception')
-          end
-          allow(Datadog.logger).to receive(:warn) # Silence logging during tests
-        end
-
-        it 'does not raise any error' do
-          at_fork_hook.call
-        end
-
-        it 'logs an exception' do
-          expect(Datadog.logger).to receive(:warn) do |&message|
-            expect(message.call).to include('Dummy exception')
-          end
-
-          at_fork_hook.call
-        end
-      end
     end
 
     context 'when #at_fork is not available' do


### PR DESCRIPTION
**What does this PR do?**:

This PR is a follow-up from work started in #2359 and continued in #2362 for fixing and improving support for Ruby VM forks in the new profiler.

When a Ruby application forks (such as the puma webserver in multiprocess mode), we automatically restart the profiler in the child processes.

But, as part of restarting we should also make sure to reset any state that is leftover from the parent process.

This PR makes sure that, for the new profiler:
1. Resetting the state is done in a safe way (e.g. without concurrency issues). This required a refactoring of how we do it.
2. There is no leftover state from the parent.

While the old profiler codepath was also affected by the refactoring in this PR, it was already doing the two steps above correctly; the changes in this PR are just to make it easier to support the feature in the new profiler.

**Motivation**:

It's common for Ruby apps to make use of fork, and this is a configuration we expect to continue to support in the new Ruby profiler.

**Additional Notes**:

This PR is easier to review commit-by-commit.

**How to test the change?**:

Besides the included test coverage, this can be manually seen in action by validating that the profiler (both on the old codepath and [the new codepath](https://github.com/DataDog/dd-trace-rb/pull/2209)) restarts correctly on child processes after a fork and that profiles reported by those child processes are correct and do not contain left-over state from the parent.
