### PR TITLE
Removes unnecessary peer.service check for language

### DIFF
--- a/lib/ddtrace/transport/trace_formatter.rb
+++ b/lib/ddtrace/transport/trace_formatter.rb
@@ -94,7 +94,7 @@ module Datadog
       end
 
       def tag_lang!
-        return if trace.lang.nil? || root_span.get_tag(Tracing::Metadata::Ext::TAG_PEER_SERVICE)
+        return if trace.lang.nil?
 
         root_span.set_tag(
           Core::Runtime::Ext::TAG_LANG,

--- a/spec/ddtrace/transport/trace_formatter_spec.rb
+++ b/spec/ddtrace/transport/trace_formatter_spec.rb
@@ -146,15 +146,6 @@ RSpec.describe Datadog::Transport::TraceFormatter do
             Datadog::Tracing::Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY => sampling_priority,
           )
         end
-
-        context 'but peer.service is set' do
-          before do
-            allow(root_span).to receive(:get_tag).and_call_original
-            allow(root_span).to receive(:get_tag)
-              .with(Datadog::Tracing::Metadata::Ext::TAG_PEER_SERVICE)
-              .and_return('a-peer-service')
-          end
-        end
       end
 
       shared_examples 'root span with generic tags' do

--- a/spec/ddtrace/transport/trace_formatter_spec.rb
+++ b/spec/ddtrace/transport/trace_formatter_spec.rb
@@ -154,11 +154,6 @@ RSpec.describe Datadog::Transport::TraceFormatter do
               .with(Datadog::Tracing::Metadata::Ext::TAG_PEER_SERVICE)
               .and_return('a-peer-service')
           end
-
-          it 'does not set language tag' do
-            format!
-            expect(root_span).to have_metadata(Datadog::Core::Runtime::Ext::TAG_LANG => nil)
-          end
         end
       end
 


### PR DESCRIPTION


**What does this PR do?**
Removes unnecessary `peer.service` check when setting `lang` tags to ensure `lang` tags are set on all spans 

**Additional Notes**
The trace-agent currently reads the language headers from the trace and extracts into the payload which the backend then expands on a span-by-span basis accordingly. Thus to have consistency, in older versions where the trace-agent does not read headers, the `lang` tag should just be set on all spans anyway. 


