### PR TITLE
[PROF-6566] Fix ddtrace installation issue when users have CI=true

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ test_containers:
     GRPC_RUBY_BUILD_PROCS: 6
     DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
     TEST_REDIS_OLD_HOST: redis_old
+    DD_PROFILING_CI: true
   - &container_parameters_environment
     - *container_base_environment
     - TEST_DATADOG_INTEGRATION: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ test_containers:
     GRPC_RUBY_BUILD_PROCS: 6
     DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
     TEST_REDIS_OLD_HOST: redis_old
-    DD_PROFILING_CI: true
+    DDTRACE_CI: true
   - &container_parameters_environment
     - *container_base_environment
     - TEST_DATADOG_INTEGRATION: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
+    environment: &common-environment
       - BUNDLE_GEMFILE=/app/Gemfile
       - DD_AGENT_HOST=ddagent
       - TEST_DATADOG_INTEGRATION=1
@@ -52,20 +52,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
-      - DD_AGENT_HOST=ddagent
-      - TEST_DATADOG_INTEGRATION=1
-      - TEST_ELASTICSEARCH_HOST=elasticsearch
-      - TEST_MEMCACHED_HOST=memcached
-      - TEST_MONGODB_HOST=mongodb
-      - TEST_MYSQL_HOST=mysql
-      - TEST_POSTGRES_HOST=postgres
-      - TEST_PRESTO_HOST=presto
-      - TEST_PRESTO_PORT=8080
-      - TEST_REDIS_HOST=redis
-      - TEST_REDIS_OLD_HOST=redis_old
-      - TEST_REDIS_OLD_PORT=6379
+    environment: *common-environment
     stdin_open: true
     tty: true
     volumes:
@@ -88,20 +75,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
-      - DD_AGENT_HOST=ddagent
-      - TEST_DATADOG_INTEGRATION=1
-      - TEST_ELASTICSEARCH_HOST=elasticsearch
-      - TEST_MEMCACHED_HOST=memcached
-      - TEST_MONGODB_HOST=mongodb
-      - TEST_MYSQL_HOST=mysql
-      - TEST_POSTGRES_HOST=postgres
-      - TEST_PRESTO_HOST=presto
-      - TEST_PRESTO_PORT=8080
-      - TEST_REDIS_HOST=redis
-      - TEST_REDIS_OLD_HOST=redis_old
-      - TEST_REDIS_OLD_PORT=6379
+    environment: *common-environment
     stdin_open: true
     tty: true
     volumes:
@@ -124,20 +98,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
-      - DD_AGENT_HOST=ddagent
-      - TEST_DATADOG_INTEGRATION=1
-      - TEST_ELASTICSEARCH_HOST=elasticsearch
-      - TEST_MEMCACHED_HOST=memcached
-      - TEST_MONGODB_HOST=mongodb
-      - TEST_MYSQL_HOST=mysql
-      - TEST_POSTGRES_HOST=postgres
-      - TEST_PRESTO_HOST=presto
-      - TEST_PRESTO_PORT=8080
-      - TEST_REDIS_HOST=redis
-      - TEST_REDIS_OLD_HOST=redis_old
-      - TEST_REDIS_OLD_PORT=6379
+    environment: *common-environment
     stdin_open: true
     tty: true
     volumes:
@@ -160,20 +121,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
-      - DD_AGENT_HOST=ddagent
-      - TEST_DATADOG_INTEGRATION=1
-      - TEST_ELASTICSEARCH_HOST=elasticsearch
-      - TEST_MEMCACHED_HOST=memcached
-      - TEST_MONGODB_HOST=mongodb
-      - TEST_MYSQL_HOST=mysql
-      - TEST_POSTGRES_HOST=postgres
-      - TEST_PRESTO_HOST=presto
-      - TEST_PRESTO_PORT=8080
-      - TEST_REDIS_HOST=redis
-      - TEST_REDIS_OLD_HOST=redis_old
-      - TEST_REDIS_OLD_PORT=6379
+    environment: *common-environment
     stdin_open: true
     tty: true
     volumes:
@@ -196,20 +144,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
-      - DD_AGENT_HOST=ddagent
-      - TEST_DATADOG_INTEGRATION=1
-      - TEST_ELASTICSEARCH_HOST=elasticsearch
-      - TEST_MEMCACHED_HOST=memcached
-      - TEST_MONGODB_HOST=mongodb
-      - TEST_MYSQL_HOST=mysql
-      - TEST_POSTGRES_HOST=postgres
-      - TEST_PRESTO_HOST=presto
-      - TEST_PRESTO_PORT=8080
-      - TEST_REDIS_HOST=redis
-      - TEST_REDIS_OLD_HOST=redis_old
-      - TEST_REDIS_OLD_PORT=6379
+    environment: *common-environment
     stdin_open: true
     tty: true
     volumes:
@@ -232,20 +167,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
-      - DD_AGENT_HOST=ddagent
-      - TEST_DATADOG_INTEGRATION=1
-      - TEST_ELASTICSEARCH_HOST=elasticsearch
-      - TEST_MEMCACHED_HOST=memcached
-      - TEST_MONGODB_HOST=mongodb
-      - TEST_MYSQL_HOST=mysql
-      - TEST_POSTGRES_HOST=postgres
-      - TEST_PRESTO_HOST=presto
-      - TEST_PRESTO_PORT=8080
-      - TEST_REDIS_HOST=redis
-      - TEST_REDIS_OLD_HOST=redis_old
-      - TEST_REDIS_OLD_PORT=6379
+    environment: *common-environment
     stdin_open: true
     tty: true
     volumes:
@@ -267,7 +189,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
+    environment: &common-environment-3x
       - BUNDLE_GEMFILE=/app/Gemfile
       - DD_AGENT_HOST=ddagent
       - TEST_DATADOG_INTEGRATION=1
@@ -299,18 +221,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
-      - DD_AGENT_HOST=ddagent
-      - TEST_DATADOG_INTEGRATION=1
-      - TEST_ELASTICSEARCH_HOST=elasticsearch
-      - TEST_MEMCACHED_HOST=memcached
-      - TEST_MONGODB_HOST=mongodb
-      - TEST_MYSQL_HOST=mysql
-      - TEST_POSTGRES_HOST=postgres
-      - TEST_REDIS_HOST=redis
-      - TEST_REDIS_OLD_HOST=redis_old
-      - TEST_REDIS_OLD_PORT=6379
+    environment: *common-environment-3x
     stdin_open: true
     tty: true
     volumes:
@@ -332,18 +243,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
-      - DD_AGENT_HOST=ddagent
-      - TEST_DATADOG_INTEGRATION=1
-      - TEST_ELASTICSEARCH_HOST=elasticsearch
-      - TEST_MEMCACHED_HOST=memcached
-      - TEST_MONGODB_HOST=mongodb
-      - TEST_MYSQL_HOST=mysql
-      - TEST_POSTGRES_HOST=postgres
-      - TEST_REDIS_HOST=redis
-      - TEST_REDIS_OLD_HOST=redis_old
-      - TEST_REDIS_OLD_PORT=6379
+    environment: *common-environment-3x
     stdin_open: true
     tty: true
     volumes:
@@ -364,18 +264,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
-      - DD_AGENT_HOST=ddagent
-      - TEST_DATADOG_INTEGRATION=1
-      - TEST_ELASTICSEARCH_HOST=elasticsearch
-      - TEST_MEMCACHED_HOST=memcached
-      - TEST_MONGODB_HOST=mongodb
-      - TEST_MYSQL_HOST=mysql
-      - TEST_POSTGRES_HOST=postgres
-      - TEST_REDIS_HOST=redis
-      - TEST_REDIS_OLD_HOST=redis_old
-      - TEST_REDIS_OLD_PORT=6379
+    environment: *common-environment-3x
     stdin_open: true
     tty: true
     volumes:
@@ -397,18 +286,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
-      - DD_AGENT_HOST=ddagent
-      - TEST_DATADOG_INTEGRATION=1
-      - TEST_ELASTICSEARCH_HOST=elasticsearch
-      - TEST_MEMCACHED_HOST=memcached
-      - TEST_MONGODB_HOST=mongodb
-      - TEST_MYSQL_HOST=mysql
-      - TEST_POSTGRES_HOST=postgres
-      - TEST_REDIS_HOST=redis
-      - TEST_REDIS_OLD_HOST=redis_old
-      - TEST_REDIS_OLD_PORT=6379
+    environment: *common-environment-3x
     stdin_open: true
     tty: true
     volumes:
@@ -429,18 +307,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
-      - DD_AGENT_HOST=ddagent
-      - TEST_DATADOG_INTEGRATION=1
-      - TEST_ELASTICSEARCH_HOST=elasticsearch
-      - TEST_MEMCACHED_HOST=memcached
-      - TEST_MONGODB_HOST=mongodb
-      - TEST_MYSQL_HOST=mysql
-      - TEST_POSTGRES_HOST=postgres
-      - TEST_REDIS_HOST=redis
-      - TEST_REDIS_OLD_HOST=redis_old
-      - TEST_REDIS_OLD_PORT=6379
+    environment: *common-environment-3x
     stdin_open: true
     tty: true
     volumes:
@@ -465,20 +332,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
-      - DD_AGENT_HOST=ddagent
-      - TEST_DATADOG_INTEGRATION=1
-      - TEST_ELASTICSEARCH_HOST=elasticsearch
-      - TEST_MEMCACHED_HOST=memcached
-      - TEST_MONGODB_HOST=mongodb
-      - TEST_MYSQL_HOST=mysql
-      - TEST_POSTGRES_HOST=postgres
-      - TEST_PRESTO_HOST=presto
-      - TEST_PRESTO_PORT=8080
-      - TEST_REDIS_HOST=redis
-      - TEST_REDIS_OLD_HOST=redis_old
-      - TEST_REDIS_OLD_PORT=6379
+    environment: *common-environment
     stdin_open: true
     tty: true
     volumes:
@@ -500,20 +354,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
-      - DD_AGENT_HOST=ddagent
-      - TEST_DATADOG_INTEGRATION=1
-      - TEST_ELASTICSEARCH_HOST=elasticsearch
-      - TEST_MEMCACHED_HOST=memcached
-      - TEST_MONGODB_HOST=mongodb
-      - TEST_MYSQL_HOST=mysql
-      - TEST_POSTGRES_HOST=postgres
-      - TEST_PRESTO_HOST=presto
-      - TEST_PRESTO_PORT=8080
-      - TEST_REDIS_HOST=redis
-      - TEST_REDIS_OLD_HOST=redis_old
-      - TEST_REDIS_OLD_PORT=6379
+    environment: *common-environment
     stdin_open: true
     tty: true
     volumes:
@@ -535,20 +376,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
-      - DD_AGENT_HOST=ddagent
-      - TEST_DATADOG_INTEGRATION=1
-      - TEST_ELASTICSEARCH_HOST=elasticsearch
-      - TEST_MEMCACHED_HOST=memcached
-      - TEST_MONGODB_HOST=mongodb
-      - TEST_MYSQL_HOST=mysql
-      - TEST_POSTGRES_HOST=postgres
-      - TEST_PRESTO_HOST=presto
-      - TEST_PRESTO_PORT=8080
-      - TEST_REDIS_HOST=redis
-      - TEST_REDIS_OLD_HOST=redis_old
-      - TEST_REDIS_OLD_PORT=6379
+    environment: *common-environment
     stdin_open: true
     tty: true
     volumes:
@@ -571,20 +399,7 @@ services:
       - redis
       - redis_old
     env_file: ./.env
-    environment:
-      - BUNDLE_GEMFILE=/app/Gemfile
-      - DD_AGENT_HOST=ddagent
-      - TEST_DATADOG_INTEGRATION=1
-      - TEST_ELASTICSEARCH_HOST=elasticsearch
-      - TEST_MEMCACHED_HOST=memcached
-      - TEST_MONGODB_HOST=mongodb
-      - TEST_MYSQL_HOST=mysql
-      - TEST_POSTGRES_HOST=postgres
-      - TEST_PRESTO_HOST=presto
-      - TEST_PRESTO_PORT=8080
-      - TEST_REDIS_HOST=redis
-      - TEST_REDIS_OLD_HOST=redis_old
-      - TEST_REDIS_OLD_PORT=6379
+    environment: *common-environment
     stdin_open: true
     tty: true
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - TEST_REDIS_HOST=redis
       - TEST_REDIS_OLD_HOST=redis_old
       - TEST_REDIS_OLD_PORT=6379
+      - DD_PROFILING_CI=true
     stdin_open: true
     tty: true
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - TEST_REDIS_HOST=redis
       - TEST_REDIS_OLD_HOST=redis_old
       - TEST_REDIS_OLD_PORT=6379
-      - DD_PROFILING_CI=true
+      - DDTRACE_CI=true
     stdin_open: true
     tty: true
     volumes:

--- a/ext/ddtrace_profiling_loader/extconf.rb
+++ b/ext/ddtrace_profiling_loader/extconf.rb
@@ -26,7 +26,7 @@ end
 
 # Because we can't control what compiler versions our customers use, shipping with -Werror by default is a no-go.
 # But we can enable it in CI, so that we quickly spot any new warnings that just got introduced.
-add_compiler_flag '-Werror' if ENV['CI'] == 'true'
+add_compiler_flag '-Werror' if ENV['DD_PROFILING_CI'] == 'true'
 
 # Older gcc releases may not default to C99 and we need to ask for this. This is also used:
 # * by upstream Ruby -- search for gnu99 in the codebase

--- a/ext/ddtrace_profiling_loader/extconf.rb
+++ b/ext/ddtrace_profiling_loader/extconf.rb
@@ -26,7 +26,7 @@ end
 
 # Because we can't control what compiler versions our customers use, shipping with -Werror by default is a no-go.
 # But we can enable it in CI, so that we quickly spot any new warnings that just got introduced.
-add_compiler_flag '-Werror' if ENV['DD_PROFILING_CI'] == 'true'
+add_compiler_flag '-Werror' if ENV['DDTRACE_CI'] == 'true'
 
 # Older gcc releases may not default to C99 and we need to ask for this. This is also used:
 # * by upstream Ruby -- search for gnu99 in the codebase

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -79,7 +79,7 @@ end
 
 # Because we can't control what compiler versions our customers use, shipping with -Werror by default is a no-go.
 # But we can enable it in CI, so that we quickly spot any new warnings that just got introduced.
-add_compiler_flag '-Werror' if ENV['CI'] == 'true'
+add_compiler_flag '-Werror' if ENV['DD_PROFILING_CI'] == 'true'
 
 # Older gcc releases may not default to C99 and we need to ask for this. This is also used:
 # * by upstream Ruby -- search for gnu99 in the codebase

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -79,7 +79,7 @@ end
 
 # Because we can't control what compiler versions our customers use, shipping with -Werror by default is a no-go.
 # But we can enable it in CI, so that we quickly spot any new warnings that just got introduced.
-add_compiler_flag '-Werror' if ENV['DD_PROFILING_CI'] == 'true'
+add_compiler_flag '-Werror' if ENV['DDTRACE_CI'] == 'true'
 
 # Older gcc releases may not default to C99 and we need to ask for this. This is also used:
 # * by upstream Ruby -- search for gnu99 in the codebase


### PR DESCRIPTION
**What does this PR do?**:

In #2358 we changed how the profiling native extension is built in CI by adding the `-Werror` compiler option to turn warnings into errors.

We did this automatically by checking if the `CI` environment variable was set to `true`.

Unfortunately, this broke at least one user, see <https://github.com/DataDog/datadog-api-client-ruby/pull/1137>. The warning that was triggered in that case was actually not relevant, see my investigation in <https://github.com/DataDog/dd-trace-rb/issues/2377>.

The `CI=true` was never meant to trigger outside of our CI, but clearly it's too generic of a name for us to rely on that.

To fix this, I've gone ahead and changed the configuration so that `-Werror` only gets added when `DD_PROFILING_CI=true`. I also changed our docker and CircleCI configurations to set this by default.

**Motivation**:

This issue affected one Datadog internal customer -- <https://github.com/DataDog/datadog-api-client-ruby/pull/1137>.

This should never happen -- we don't want any issues when compiling the profiling bits to affect ddtrace installation.

**Additional Notes**:

(Nothing)

**How to test the change?**:

Validate that `-Werror` only gets added when `DD_PROFILING_CI=true`.

To trigger a warning for testing, try removing `DDTRACE_UNUSED` from function argument declarations, and you should see that the compiler starts failing due to that.

---

Fixes #2377