### PR TITLE
Support que 2

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -309,7 +309,7 @@ elsif ruby_version?('2.2')
     gem 'sqlite3', '~> 1.3.6'
     gem 'sucker_punch'
     gem 'typhoeus'
-    gem 'que', '>= 1.0.0'
+    gem 'que', '>= 1.0.0', '< 2.0.0'
   end
 
   appraise 'sinatra' do
@@ -504,7 +504,7 @@ elsif ruby_version?('2.3')
     gem 'sqlite3', '~> 1.3.6'
     gem 'sucker_punch'
     gem 'typhoeus'
-    gem 'que', '>= 1.0.0'
+    gem 'que', '>= 1.0.0', '< 2.0.0'
   end
 
   appraise 'sinatra' do
@@ -633,7 +633,7 @@ elsif ruby_version?('2.4')
     gem 'sqlite3', '~> 1.3.6'
     gem 'sucker_punch'
     gem 'typhoeus'
-    gem 'que', '>= 1.0.0'
+    gem 'que', '>= 1.0.0', '< 2.0.0'
   end
 
   appraise 'sinatra' do
@@ -893,7 +893,7 @@ elsif ruby_version?('2.5')
     gem 'jdbc-sqlite3', '>= 3.28', platform: :jruby
     gem 'sucker_punch'
     gem 'typhoeus'
-    gem 'que', '>= 1.0.0'
+    gem 'que', '>= 1.0.0', '< 2.0.0'
   end
 
   appraise 'sinatra' do
@@ -1128,7 +1128,7 @@ elsif ruby_version?('2.6')
       gem 'jdbc-sqlite3', '>= 3.28', platform: :jruby
       gem 'sucker_punch'
       gem 'typhoeus'
-      gem 'que', '>= 1.0.0'
+      gem 'que', '>= 1.0.0', '< 2.0.0'
     end
 
     appraise 'sinatra' do

--- a/gemfiles/ruby_3.0.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib.gemfile.lock
@@ -1519,7 +1519,7 @@ GEM
       thin (~> 1.6)
       thor (~> 0.19.1)
       vegas (~> 0.1.11)
-    que (1.4.0)
+    que (2.2.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-accept (0.4.5)


### PR DESCRIPTION
**What does this PR do?**
Updates the `contrib` appraisal group and associated specs to support `que` version 2.
