### PR TITLE
[PROF-6463] Implement support for endpoint profiling in CpuAndWallTime collector

### DIFF
--- a/lib/datadog/profiling/collectors/cpu_and_wall_time.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time.rb
@@ -30,10 +30,12 @@ module Datadog
         private
 
         def safely_extract_context_key_from(tracer)
-          tracer &&
-            tracer.respond_to?(:provider) &&
-            # NOTE: instance_variable_get always works, even on nil -- it just returns nil if the variable doesn't exist
-            tracer.provider.instance_variable_get(:@context).instance_variable_get(:@key)
+          provider = tracer && tracer.respond_to?(:provider) && tracer.provider
+
+          return unless provider
+
+          context = provider.instance_variable_get(:@context)
+          context && context.instance_variable_get(:@key)
         end
       end
     end

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -65,7 +65,7 @@ module ProfileHelpers
         labels: sample.label.map do |it|
           [
             string_table[it.key].to_sym,
-            it.str != 0 ? string_table[it.str] : raise('Unexpected: label encoded as number instead of string'),
+            it.num == 0 ? string_table[it.str] : raise('Unexpected: label encoded as number instead of string'),
           ]
         end.to_h,
       }


### PR DESCRIPTION
**What does this PR do?**:

This PR reimplements support for the profiling endpoint feature in the `CpuAndWallTime` collector.

Although the implementation is different, the approach is conceptually the same as provided by `Datadog::Profiling::TraceIdentifiers::Ddtrace` for the old profiler codepaths.

The constraints of this implementation are the same as the ones in #2342 and effectively this is only a small extension of the work done in that PR.

**Motivation**:

Endpoint profiling allows customers to filter down their profiles to individual endpoints (for web apps) that they may be interested in investigating.

**Additional Notes**:

Comparing a Ruby string with a `char *` is really annoying.

**How to test the change?**:

Beyond the code coverage included by the change, it can also be tested by enabling profiling and tracing for a Ruby web app, and then checking that the application's endpoints show up in the right sidebar in the profiling UX.