### PR TITLE
Support sidekiq 7

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -304,7 +304,7 @@ elsif ruby_version?('2.2')
     gem 'semantic_logger', '~> 4.0'
     gem 'sequel'
     gem 'shoryuken'
-    gem 'sidekiq'
+    gem 'sidekiq', '~> 5.2.9'
     gem 'sneakers', '>= 2.12.0'
     gem 'sqlite3', '~> 1.3.6'
     gem 'sucker_punch'
@@ -499,7 +499,7 @@ elsif ruby_version?('2.3')
     gem 'semantic_logger', '~> 4.0'
     gem 'sequel'
     gem 'shoryuken'
-    gem 'sidekiq'
+    gem 'sidekiq', '~> 5.2.9'
     gem 'sneakers', '>= 2.12.0'
     gem 'sqlite3', '~> 1.3.6'
     gem 'sucker_punch'
@@ -628,7 +628,7 @@ elsif ruby_version?('2.4')
     gem 'semantic_logger', '~> 4.0'
     gem 'sequel'
     gem 'shoryuken'
-    gem 'sidekiq'
+    gem 'sidekiq', '~> 5.2.9'
     gem 'sneakers', '>= 2.12.0'
     gem 'sqlite3', '~> 1.3.6'
     gem 'sucker_punch'
@@ -887,7 +887,7 @@ elsif ruby_version?('2.5')
     gem 'semantic_logger', '~> 4.0'
     gem 'sequel'
     gem 'shoryuken'
-    gem 'sidekiq'
+    gem 'sidekiq', '~> 5.2.9'
     gem 'sneakers', '>= 2.12.0'
     gem 'sqlite3', '~> 1.4.1', platform: :ruby
     gem 'jdbc-sqlite3', '>= 3.28', platform: :jruby
@@ -1122,7 +1122,7 @@ elsif ruby_version?('2.6')
       gem 'semantic_logger', '~> 4.0'
       gem 'sequel'
       gem 'shoryuken'
-      gem 'sidekiq'
+      gem 'sidekiq', '~> 5.2.9'
       gem 'sneakers', '>= 2.12.0'
       gem 'sqlite3', '~> 1.4.1', platform: :ruby
       gem 'jdbc-sqlite3', '>= 3.28', platform: :jruby

--- a/gemfiles/ruby_3.0.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib.gemfile.lock
@@ -1297,7 +1297,7 @@ GEM
     coderay (1.1.3)
     colorize (0.8.1)
     concurrent-ruby (1.1.10)
-    connection_pool (2.2.5)
+    connection_pool (2.3.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -1521,7 +1521,7 @@ GEM
       vegas (~> 0.1.11)
     que (1.4.0)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-contrib (2.3.0)
@@ -1542,6 +1542,8 @@ GEM
     rbtree (0.4.5)
     redcarpet (3.5.1)
     redis (3.3.5)
+    redis-client (0.11.1)
+      connection_pool
     redis-namespace (1.8.2)
       redis (>= 3.0.4)
     regexp_parser (2.2.1)
@@ -1612,11 +1614,11 @@ GEM
       aws-sdk-core (>= 2)
       concurrent-ruby
       thor
-    sidekiq (5.2.9)
-      connection_pool (~> 2.2, >= 2.2.2)
-      rack (~> 2.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 4.2)
+    sidekiq (7.0.1)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.9.0)
     sigdump (0.2.4)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
@@ -1747,7 +1749,6 @@ DEPENDENCIES
   shoryuken
   sidekiq
   simplecov!
-  sinatra
   sneakers (>= 2.12.0)
   sorbet (= 0.5.9672)
   spoom (~> 1.1)

--- a/gemfiles/ruby_3.0.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.3_contrib.gemfile.lock
@@ -1542,7 +1542,7 @@ GEM
     rbtree (0.4.5)
     redcarpet (3.5.1)
     redis (3.3.5)
-    redis-client (0.11.1)
+    redis-client (0.11.2)
       connection_pool
     redis-namespace (1.8.2)
       redis (>= 3.0.4)

--- a/lib/datadog/tracing/contrib/sidekiq/integration.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/integration.rb
@@ -14,6 +14,7 @@ module Datadog
 
           MINIMUM_VERSION = Gem::Version.new('3.5.4')
           MINIMUM_SERVER_INTERNAL_TRACING_VERSION = Gem::Version.new('5.2.4')
+          MINIMUM_CAPSULE_VERSION = Gem::Version.new('7.0.0')
 
           # @public_api Changing the integration name or integration options can cause breaking changes
           register_as :sidekiq
@@ -37,6 +38,13 @@ module Datadog
           # initialization order), we are limiting this tracing to v5.2.4+.
           def self.compatible_with_server_internal_tracing?
             version >= MINIMUM_SERVER_INTERNAL_TRACING_VERSION
+          end
+
+          # Capsules are a new way of configuring Sidekiq that was introduced in version 7
+          # that change the way some of the configuration data is exposed. Certain patches
+          # are applied differently for versions of Sidekiq that support capsules.
+          def self.supports_capsules?
+            version >= MINIMUM_CAPSULE_VERSION
           end
 
           def new_configuration

--- a/lib/datadog/tracing/contrib/sidekiq/patcher.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/patcher.rb
@@ -70,7 +70,7 @@ module Datadog
             require_relative 'server_internal_tracer/redis_info'
 
             if Integration.supports_capsules?
-               ::Sidekiq::Config.prepend(ServerInternalTracer::RedisInfo)
+              ::Sidekiq::Config.prepend(ServerInternalTracer::RedisInfo)
             else
               ::Sidekiq.singleton_class.prepend(ServerInternalTracer::RedisInfo)
             end

--- a/lib/datadog/tracing/contrib/sidekiq/patcher.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/patcher.rb
@@ -69,7 +69,11 @@ module Datadog
           def patch_redis_info
             require_relative 'server_internal_tracer/redis_info'
 
-            ::Sidekiq.singleton_class.prepend(ServerInternalTracer::RedisInfo)
+            if Integration.supports_capsules?
+               ::Sidekiq::Config.prepend(ServerInternalTracer::RedisInfo)
+            else
+              ::Sidekiq.singleton_class.prepend(ServerInternalTracer::RedisInfo)
+            end
           end
         end
       end

--- a/lib/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat.rb
@@ -44,6 +44,11 @@ module Datadog
                 super
               end
             end
+
+            # Sidekiq v7.0.1 changes the functionality of the Sidekiq::Launcher#heartbeat method
+            # and introduces the Sidekiq::Launcher#beat method, which does the same thing as the
+            # Sidekiq::Launcher#heartbeat method in versions of Sidekiq prior to v7.0.1
+            alias beat heartbeat
           end
         end
       end

--- a/lib/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat.rb
@@ -27,7 +27,7 @@ module Datadog
 
             private
 
-            def heartbeat
+            def beat
               configuration = Datadog.configuration.tracing[:sidekiq]
 
               Datadog::Tracing.trace(Ext::SPAN_HEARTBEAT, service: configuration[:service_name]) do |span|
@@ -45,10 +45,9 @@ module Datadog
               end
             end
 
-            # Sidekiq v7.0.1 changes the functionality of the Sidekiq::Launcher#heartbeat method
-            # and introduces the Sidekiq::Launcher#beat method, which does the same thing as the
-            # Sidekiq::Launcher#heartbeat method in versions of Sidekiq prior to v7.0.1
-            alias beat heartbeat
+            # Provides an alias for the pre-v7.0.1 heartbeat method, which does the same thing as
+            # the current Sidekiq::Launcher#beat method.
+            alias heartbeat beat
           end
         end
       end

--- a/spec/datadog/tracing/contrib/sidekiq/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/patcher_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Datadog::Tracing::Contrib::Sidekiq::Patcher do
     # actually a server, so we just have to skip them.
     skip if Gem.loaded_specs['sidekiq'].version < Gem::Version.new('4.0')
 
-    Sidekiq.default_configuration.client_middleware.clear
-    Sidekiq.default_configuration.server_middleware.clear
+    config.client_middleware.clear
+    config.server_middleware.clear
 
     allow(Sidekiq).to receive(:server?).and_return(server)
 
@@ -31,12 +31,20 @@ RSpec.describe Datadog::Tracing::Contrib::Sidekiq::Patcher do
   # executes after the allows are setup.
   include_context 'Sidekiq testing'
 
+  let(:config) do
+    if Sidekiq.respond_to? :default_configuration
+      Sidekiq.default_configuration
+    else
+      Sidekiq
+    end
+  end
+
   context 'for a client' do
     let(:server) { false }
 
     it 'correctly patches' do
-      expect(Sidekiq.default_configuration.client_middleware.entries.map(&:klass)).to eq([Datadog::Tracing::Contrib::Sidekiq::ClientTracer])
-      expect(Sidekiq.default_configuration.server_middleware.entries.map(&:klass)).to eq([])
+      expect(config.client_middleware.entries.map(&:klass)).to eq([Datadog::Tracing::Contrib::Sidekiq::ClientTracer])
+      expect(config.server_middleware.entries.map(&:klass)).to eq([])
     end
   end
 
@@ -44,8 +52,8 @@ RSpec.describe Datadog::Tracing::Contrib::Sidekiq::Patcher do
     let(:server) { true }
 
     it 'correctly patches' do
-      expect(Sidekiq.default_configuration.client_middleware.entries.map(&:klass)).to eq([Datadog::Tracing::Contrib::Sidekiq::ClientTracer])
-      expect(Sidekiq.default_configuration.server_middleware.entries.map(&:klass)).to eq([Datadog::Tracing::Contrib::Sidekiq::ServerTracer])
+      expect(config.client_middleware.entries.map(&:klass)).to eq([Datadog::Tracing::Contrib::Sidekiq::ClientTracer])
+      expect(config.server_middleware.entries.map(&:klass)).to eq([Datadog::Tracing::Contrib::Sidekiq::ServerTracer])
     end
   end
 end

--- a/spec/datadog/tracing/contrib/sidekiq/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/patcher_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Datadog::Tracing::Contrib::Sidekiq::Patcher do
     # actually a server, so we just have to skip them.
     skip if Gem.loaded_specs['sidekiq'].version < Gem::Version.new('4.0')
 
-    Sidekiq.client_middleware.clear
-    Sidekiq.server_middleware.clear
+    Sidekiq.default_configuration.client_middleware.clear
+    Sidekiq.default_configuration.server_middleware.clear
 
     allow(Sidekiq).to receive(:server?).and_return(server)
 
@@ -35,8 +35,8 @@ RSpec.describe Datadog::Tracing::Contrib::Sidekiq::Patcher do
     let(:server) { false }
 
     it 'correctly patches' do
-      expect(Sidekiq.client_middleware.entries.map(&:klass)).to eq([Datadog::Tracing::Contrib::Sidekiq::ClientTracer])
-      expect(Sidekiq.server_middleware.entries.map(&:klass)).to eq([])
+      expect(Sidekiq.default_configuration.client_middleware.entries.map(&:klass)).to eq([Datadog::Tracing::Contrib::Sidekiq::ClientTracer])
+      expect(Sidekiq.default_configuration.server_middleware.entries.map(&:klass)).to eq([])
     end
   end
 
@@ -44,8 +44,8 @@ RSpec.describe Datadog::Tracing::Contrib::Sidekiq::Patcher do
     let(:server) { true }
 
     it 'correctly patches' do
-      expect(Sidekiq.client_middleware.entries.map(&:klass)).to eq([Datadog::Tracing::Contrib::Sidekiq::ClientTracer])
-      expect(Sidekiq.server_middleware.entries.map(&:klass)).to eq([Datadog::Tracing::Contrib::Sidekiq::ServerTracer])
+      expect(Sidekiq.default_configuration.client_middleware.entries.map(&:klass)).to eq([Datadog::Tracing::Contrib::Sidekiq::ClientTracer])
+      expect(Sidekiq.default_configuration.server_middleware.entries.map(&:klass)).to eq([Datadog::Tracing::Contrib::Sidekiq::ServerTracer])
     end
   end
 end

--- a/spec/datadog/tracing/contrib/sidekiq/server_tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/server_tracer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Server tracer' do
       chain.add(Datadog::Tracing::Contrib::Sidekiq::ServerTracer)
     end
 
-    Sidekiq::Extensions.enable_delay! if Sidekiq::VERSION > '5.0.0'
+    Sidekiq::Extensions.enable_delay! if Sidekiq::VERSION > '5.0.0' && Sidekiq::VERSION < '7.0.0'
   end
 
   it 'traces async job run' do
@@ -170,27 +170,29 @@ RSpec.describe 'Server tracer' do
     end
   end
 
-  context 'with delayed extensions' do
-    subject(:do_work) { DelayableClass.delay.do_work }
+  if Sidekiq::VERSION > '5.0.0' && Sidekiq::VERSION < '7.0.0'
+    context 'with delayed extensions' do
+      subject(:do_work) { DelayableClass.delay.do_work }
 
-    before do
-      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
-        pending 'Broken in Ruby 3.1.0-preview1, see https://github.com/mperham/sidekiq/issues/5064'
+      before do
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+          pending 'Broken in Ruby 3.1.0-preview1, see https://github.com/mperham/sidekiq/issues/5064'
+        end
+
+        stub_const(
+          'DelayableClass',
+          Class.new do
+            def self.do_work
+              puts 'a'
+            end
+          end
+        )
       end
 
-      stub_const(
-        'DelayableClass',
-        Class.new do
-          def self.do_work
-            puts 'a'
-          end
-        end
-      )
-    end
-
-    it 'traces with correct resource' do
-      do_work
-      expect(spans.first.resource).to eq('DelayableClass.do_work')
+      it 'traces with correct resource' do
+        do_work
+        expect(spans.first.resource).to eq('DelayableClass.do_work')
+      end
     end
   end
 end

--- a/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
@@ -6,8 +6,6 @@ require 'datadog/tracing/contrib/sidekiq/client_tracer'
 require 'datadog/tracing/contrib/sidekiq/server_tracer'
 require 'sidekiq/testing'
 
-$TESTING = false  # sidekiq uses this global internally to alter its behavior for its test suite
-
 RSpec.shared_context 'Sidekiq testing' do
   include SidekiqTestingConfiguration
 

--- a/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
@@ -102,7 +102,7 @@ module SidekiqServerExpectations
 
     cli = Sidekiq::CLI.instance
     cli.parse(['--require', app_tempfile.path]) # boot the "app"
-    launcher = Sidekiq::Launcher.new(cli.send(:options))
+    launcher = Sidekiq::Launcher.new(cli.config)
     launcher.stop
     exit
   ensure

--- a/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
@@ -6,6 +6,8 @@ require 'datadog/tracing/contrib/sidekiq/client_tracer'
 require 'datadog/tracing/contrib/sidekiq/server_tracer'
 require 'sidekiq/testing'
 
+$TESTING = false  # sidekiq uses this global internally to alter its behavior for its test suite
+
 RSpec.shared_context 'Sidekiq testing' do
   include SidekiqTestingConfiguration
 

--- a/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
@@ -104,7 +104,13 @@ module SidekiqServerExpectations
 
     cli = Sidekiq::CLI.instance
     cli.parse(['--require', app_tempfile.path]) # boot the "app"
-    launcher = Sidekiq::Launcher.new(cli.config)
+    opts =
+      if cli.respond_to? :config
+        cli.config
+      else
+        cli.send(:options)
+      end
+    launcher = Sidekiq::Launcher.new(opts)
     launcher.stop
     exit
   ensure

--- a/spec/datadog/tracing/contrib/sidekiq/tracer_configure_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/tracer_configure_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Tracer configuration' do
       end
 
       it 'uses custom error handler' do
-        expect { perform_async }.to raise_error
+        expect { perform_async }.to raise_error(ZeroDivisionError)
         expect(@error_handler_called).to be_truthy
       end
     end


### PR DESCRIPTION
**What does this PR do?**
* Updates the `contrib` appraisal group to use the latest version of the `sidekiq` gem (v7)
* Updates specs to work with the `sidekiq` version 7 API
* Updates the tracer code to work with `sidekiq` version 7 while continuing to work with prior supported versions

