### PR TITLE
[PROF-6556] Profiler signal handler setup improvements

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -245,7 +245,7 @@ static VALUE _native_sampling_loop(DDTRACE_UNUSED VALUE _self, VALUE instance) {
 
   block_sigprof_signal_handler_from_running_in_current_thread(); // We want to interrupt the thread with the global VM lock, never this one
 
-  install_sigprof_signal_handler(handle_sampling_signal);
+  install_sigprof_signal_handler(handle_sampling_signal, "handle_sampling_signal");
   if (state->gc_profiling_enabled) rb_tracepoint_enable(state->gc_tracepoint);
 
   // Release GVL, get to the actual work!
@@ -405,7 +405,7 @@ static void testing_signal_handler(DDTRACE_UNUSED int _signal, DDTRACE_UNUSED si
 // This method exists only to enable testing Datadog::Profiling::Collectors::CpuAndWallTimeWorker behavior using RSpec.
 // It SHOULD NOT be used for other purposes.
 static VALUE _native_install_testing_signal_handler(DDTRACE_UNUSED VALUE self) {
-  install_sigprof_signal_handler(testing_signal_handler);
+  install_sigprof_signal_handler(testing_signal_handler, "testing_signal_handler");
   return Qtrue;
 }
 

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -8,6 +8,7 @@
 #include "ruby_helpers.h"
 #include "collectors_cpu_and_wall_time.h"
 #include "private_vm_api_access.h"
+#include "setup_signal_handler.h"
 
 // Used to trigger the periodic execution of Collectors::CpuAndWallTime, which implements all of the sampling logic
 // itself; this class only implements the "doing it periodically" part.
@@ -96,9 +97,6 @@ static void cpu_and_wall_time_worker_typed_data_mark(void *state_ptr);
 static VALUE _native_sampling_loop(VALUE self, VALUE instance);
 static VALUE _native_stop(DDTRACE_UNUSED VALUE _self, VALUE self_instance);
 static VALUE stop(VALUE self_instance, VALUE optional_exception);
-static void install_sigprof_signal_handler(void (*signal_handler_function)(int, siginfo_t *, void *));
-static void remove_sigprof_signal_handler(void);
-static void block_sigprof_signal_handler_from_running_in_current_thread(void);
 static void handle_sampling_signal(DDTRACE_UNUSED int _signal, DDTRACE_UNUSED siginfo_t *_info, DDTRACE_UNUSED void *_ucontext);
 static void *run_sampling_trigger_loop(void *state_ptr);
 static void interrupt_sampling_trigger_loop(void *state_ptr);
@@ -286,52 +284,10 @@ static VALUE stop(VALUE self_instance, VALUE optional_exception) {
   return Qtrue;
 }
 
-static void install_sigprof_signal_handler(void (*signal_handler_function)(int, siginfo_t *, void *)) {
-  struct sigaction existing_signal_handler_config = {.sa_sigaction = NULL};
-  struct sigaction signal_handler_config = {
-    .sa_flags = SA_RESTART | SA_SIGINFO,
-    .sa_sigaction = signal_handler_function
-  };
-  sigemptyset(&signal_handler_config.sa_mask);
 
-  if (sigaction(SIGPROF, &signal_handler_config, &existing_signal_handler_config) != 0) {
-    rb_sys_fail("Could not start CpuAndWallTimeWorker: Could not install signal handler");
-  }
 
-  // In some corner cases (e.g. after a fork), our signal handler may still be around, and that's ok
-  if (existing_signal_handler_config.sa_sigaction == handle_sampling_signal) return;
 
-  if (existing_signal_handler_config.sa_handler != NULL || existing_signal_handler_config.sa_sigaction != NULL) {
-    // A previous signal handler already existed. Currently we don't support this situation, so let's just back out
-    // of the installation.
 
-    if (sigaction(SIGPROF, &existing_signal_handler_config, NULL) != 0) {
-      rb_sys_fail(
-        "Could not start CpuAndWallTimeWorker: Could not re-install pre-existing SIGPROF signal handler. " \
-        "This may break the component had installed it."
-      );
-    }
-
-    rb_raise(rb_eRuntimeError, "Could not start CpuAndWallTimeWorker: There's a pre-existing SIGPROF signal handler");
-  }
-}
-
-static void remove_sigprof_signal_handler(void) {
-  struct sigaction signal_handler_config = {
-    .sa_handler = SIG_DFL, // Reset back to default
-    .sa_flags = SA_RESTART // TODO: Unclear if this is actually needed/does anything at all
-  };
-  sigemptyset(&signal_handler_config.sa_mask);
-
-  if (sigaction(SIGPROF, &signal_handler_config, NULL) != 0) rb_sys_fail("Failure while removing the signal handler");
-}
-
-static void block_sigprof_signal_handler_from_running_in_current_thread(void) {
-  sigset_t signals_to_block;
-  sigemptyset(&signals_to_block);
-  sigaddset(&signals_to_block, SIGPROF);
-  pthread_sigmask(SIG_BLOCK, &signals_to_block, NULL);
-}
 
 // NOTE: Remember that this will run in the thread and within the scope of user code, including user C code.
 // We need to be careful not to change any state that may be observed OR to restore it if we do. For instance, if anything

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -35,7 +35,7 @@
 // if the argument passed in is not actually a `Thread` instance.
 static inline rb_thread_t *thread_struct_from_object(VALUE thread) {
   static const rb_data_type_t *thread_data_type = NULL;
-  if (thread_data_type == NULL) thread_data_type = RTYPEDDATA_TYPE(rb_thread_current());
+  if (UNLIKELY(thread_data_type == NULL)) thread_data_type = RTYPEDDATA_TYPE(rb_thread_current());
 
   return (rb_thread_t *) rb_check_typeddata(thread, thread_data_type);
 }

--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -14,7 +14,7 @@
 #else
   // On older Rubies, use a copy of the VM internal headers shipped in the debase-ruby_core_source gem
 
-  // We can't do anything about warnings in VM headers, so we just use this technique to surpress them.
+  // We can't do anything about warnings in VM headers, so we just use this technique to suppress them.
   // See https://nelkinda.com/blog/suppress-warnings-in-gcc-and-clang/#d11e364 for details.
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wunused-parameter"

--- a/ext/ddtrace_profiling_native_extension/setup_signal_handler.c
+++ b/ext/ddtrace_profiling_native_extension/setup_signal_handler.c
@@ -1,0 +1,51 @@
+#include <ruby.h>
+#include <signal.h>
+
+#include "setup_signal_handler.h"
+
+void install_sigprof_signal_handler(void (*signal_handler_function)(int, siginfo_t *, void *)) {
+  struct sigaction existing_signal_handler_config = {.sa_sigaction = NULL};
+  struct sigaction signal_handler_config = {
+    .sa_flags = SA_RESTART | SA_SIGINFO,
+    .sa_sigaction = signal_handler_function
+  };
+  sigemptyset(&signal_handler_config.sa_mask);
+
+  if (sigaction(SIGPROF, &signal_handler_config, &existing_signal_handler_config) != 0) {
+    rb_sys_fail("Could not install signal handler");
+  }
+
+  // In some corner cases (e.g. after a fork), our signal handler may still be around, and that's ok
+  if (existing_signal_handler_config.sa_sigaction == signal_handler_function) return;
+
+  if (existing_signal_handler_config.sa_handler != NULL || existing_signal_handler_config.sa_sigaction != NULL) {
+    // A previous signal handler already existed. Currently we don't support this situation, so let's just back out
+    // of the installation.
+
+    if (sigaction(SIGPROF, &existing_signal_handler_config, NULL) != 0) {
+      rb_sys_fail(
+        "Could not re-install pre-existing SIGPROF signal handler. " \
+        "This may break the library/gem had installed it."
+      );
+    }
+
+    rb_raise(rb_eRuntimeError, "Could not install profiling signal handler: There's a pre-existing SIGPROF signal handler");
+  }
+}
+
+void remove_sigprof_signal_handler(void) {
+  struct sigaction signal_handler_config = {
+    .sa_handler = SIG_DFL, // Reset back to default
+    .sa_flags = SA_RESTART // TODO: Unclear if this is actually needed/does anything at all
+  };
+  sigemptyset(&signal_handler_config.sa_mask);
+
+  if (sigaction(SIGPROF, &signal_handler_config, NULL) != 0) rb_sys_fail("Failure while removing the signal handler");
+}
+
+void block_sigprof_signal_handler_from_running_in_current_thread(void) {
+  sigset_t signals_to_block;
+  sigemptyset(&signals_to_block);
+  sigaddset(&signals_to_block, SIGPROF);
+  pthread_sigmask(SIG_BLOCK, &signals_to_block, NULL);
+}

--- a/ext/ddtrace_profiling_native_extension/setup_signal_handler.h
+++ b/ext/ddtrace_profiling_native_extension/setup_signal_handler.h
@@ -1,0 +1,5 @@
+#pragma once
+
+void install_sigprof_signal_handler(void (*signal_handler_function)(int, siginfo_t *, void *));
+void remove_sigprof_signal_handler(void);
+void block_sigprof_signal_handler_from_running_in_current_thread(void);

--- a/ext/ddtrace_profiling_native_extension/setup_signal_handler.h
+++ b/ext/ddtrace_profiling_native_extension/setup_signal_handler.h
@@ -1,5 +1,5 @@
 #pragma once
 
-void install_sigprof_signal_handler(void (*signal_handler_function)(int, siginfo_t *, void *));
+void install_sigprof_signal_handler(void (*signal_handler_function)(int, siginfo_t *, void *), const char *handler_pretty_name);
 void remove_sigprof_signal_handler(void);
 void block_sigprof_signal_handler_from_running_in_current_thread(void);

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         exception = try_wait_until(backoff: 0.01) { cpu_and_wall_time_worker.send(:failure_exception) }
 
         expect(exception.message).to include 'pre-existing SIGPROF'
+        expect(exception.message).to include 'handle_sampling_signal' # validate that handler name is included
       end
 
       it 'leaves the existing signal handler in place' do


### PR DESCRIPTION
**What does this PR do?**:

This PR:
* Refactors the signal handler installation/removal/blocking code from the `CpuAndWallTimeWorker` implementation to a separate file
* Modifies the `install_sigprof_signal_handler` to receive the name of the handler being setup, so that exception messages can also include this information.

**Motivation**:

I'm working on two other signal-related changes, and extracted these commits from my branch to enable smaller reviews :)

**Additional Notes**:

The signal handler code has test coverage via the `CpuAndWallTimeWorker` specs. I decided to leave the tests there for now, rather than separating them out.

This is because some of these low-level behaviors are hard to test in isolation.

**How to test the change?**:

Existing tests already cover this change.
