### PR TITLE
Adds `span.kind` with values `producer` and `consumer` for `delayed_job`

### DIFF
--- a/lib/datadog/tracing/contrib/delayed_job/plugin.rb
+++ b/lib/datadog/tracing/contrib/delayed_job/plugin.rb
@@ -35,6 +35,8 @@ module Datadog
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_JOB)
 
+              span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CONSUMER)
+
               yield job
             end
           end
@@ -58,6 +60,8 @@ module Datadog
 
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_ENQUEUE)
+
+              span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_PRODUCER)
 
               yield job
             end

--- a/lib/datadog/tracing/contrib/redis/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/redis/instrumentation.rb
@@ -26,6 +26,7 @@ module Datadog
                 span.span_type = Contrib::Redis::Ext::TYPE
                 span.resource = get_command(args)
                 Contrib::Redis::Tags.set_common_tags(self, span)
+                span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
 
                 response = super
               end
@@ -43,6 +44,7 @@ module Datadog
                 span.resource = commands.any? ? commands.join("\n") : '(none)'
                 span.set_metric Contrib::Redis::Ext::METRIC_PIPELINE_LEN, commands.length
                 Contrib::Redis::Tags.set_common_tags(self, span)
+                span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
 
                 response = super
               end

--- a/spec/datadog/tracing/contrib/delayed_job/plugin_spec.rb
+++ b/spec/datadog/tracing/contrib/delayed_job/plugin_spec.rb
@@ -184,6 +184,10 @@ RSpec.describe Datadog::Tracing::Contrib::DelayedJob::Plugin, :delayed_job_activ
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
           .to eq(Datadog::Tracing::Contrib::DelayedJob::Ext::TAG_OPERATION_JOB)
       end
+
+      it 'has span.kind tag with value consumer' do
+        expect(span.get_tag('span.kind')).to eq('consumer')
+      end
     end
 
     describe 'enqueue span' do
@@ -210,6 +214,10 @@ RSpec.describe Datadog::Tracing::Contrib::DelayedJob::Plugin, :delayed_job_activ
 
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
           .to eq(Datadog::Tracing::Contrib::DelayedJob::Ext::TAG_OPERATION_ENQUEUE)
+      end
+
+      it 'has span.kind tag with value producer' do
+        expect(span.get_tag('span.kind')).to eq('producer')
       end
     end
 

--- a/spec/datadog/tracing/contrib/redis/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/instrumentation_spec.rb
@@ -99,6 +99,8 @@ RSpec.describe 'Redis instrumentation test' do
           port: test_port,
           db: test_database
         )
+
+        expect(span.get_tag('span.kind')).to eq('client')
       end
     end
   end
@@ -147,6 +149,8 @@ RSpec.describe 'Redis instrumentation test' do
           port: test_port,
           db: test_database
         )
+
+        expect(span.get_tag('span.kind')).to eq('client')
       end
     end
   end

--- a/spec/datadog/tracing/contrib/redis/miniapp_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/miniapp_spec.rb
@@ -82,12 +82,14 @@ RSpec.describe 'Redis mini app test' do
         expect(redis_cmd1_span.parent_id).to eq(process_span.span_id)
         expect(redis_cmd1_span.trace_id).to eq(publish_span.trace_id)
         expect(redis_cmd1_span.get_tag('db.system')).to eq('redis')
+        expect(redis_cmd2_span.get_tag('span.kind')).to eq('client')
 
         expect(redis_cmd2_span.name).to eq('redis.command')
         expect(redis_cmd2_span.service).to eq('test-service')
         expect(redis_cmd2_span.parent_id).to eq(process_span.span_id)
         expect(redis_cmd2_span.trace_id).to eq(publish_span.trace_id)
         expect(redis_cmd2_span.get_tag('db.system')).to eq('redis')
+        expect(redis_cmd2_span.get_tag('span.kind')).to eq('client')
       end
 
       it_behaves_like 'a peer service span' do

--- a/spec/datadog/tracing/contrib/redis/redis_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/redis_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe 'Redis test' do
           expect(span.resource).to eq('SET FOO bar')
           expect(span.get_tag('redis.raw_command')).to eq('SET FOO bar')
           expect(span.get_tag('db.system')).to eq('redis')
+          expect(span.get_tag('span.kind')).to eq('client')
         end
 
         it_behaves_like 'a span with common tags'
@@ -104,6 +105,7 @@ RSpec.describe 'Redis test' do
           expect(span.resource).to eq('GET FOO')
           expect(span.get_tag('redis.raw_command')).to eq('GET FOO')
           expect(span.get_tag('db.system')).to eq('redis')
+          expect(span.get_tag('span.kind')).to eq('client')
         end
 
         it_behaves_like 'a span with common tags'
@@ -127,6 +129,7 @@ RSpec.describe 'Redis test' do
           expect(span.resource).to eq('SET FOO bar')
           expect(span.get_tag('redis.raw_command')).to eq('SET FOO bar')
           expect(span.get_tag('db.system')).to eq('redis')
+          expect(span.get_tag('span.kind')).to eq('client')
         end
       end
     end
@@ -147,6 +150,7 @@ RSpec.describe 'Redis test' do
           expect(span.resource).to eq('SET')
           expect(span.get_tag('redis.raw_command')).to be_nil
           expect(span.get_tag('db.system')).to eq('redis')
+          expect(span.get_tag('span.kind')).to eq('client')
         end
       end
     end
@@ -179,6 +183,7 @@ RSpec.describe 'Redis test' do
           expect(span.resource).to eq("SET v1 0\nSET v2 0\nINCR v1\nINCR v2\nINCR v2")
           expect(span.get_tag('redis.raw_command')).to eq("SET v1 0\nSET v2 0\nINCR v1\nINCR v2\nINCR v2")
           expect(span.get_tag('db.system')).to eq('redis')
+          expect(span.get_tag('span.kind')).to eq('client')
         end
 
         it_behaves_like 'a span with common tags'
@@ -199,6 +204,7 @@ RSpec.describe 'Redis test' do
           expect(span.resource).to eq("SET\nSET\nINCR\nINCR\nINCR")
           expect(span.get_tag('redis.raw_command')).to be_nil
           expect(span.get_tag('db.system')).to eq('redis')
+          expect(span.get_tag('span.kind')).to eq('client')
         end
       end
     end
@@ -225,6 +231,7 @@ RSpec.describe 'Redis test' do
           expect(span.resource).to eq('(none)')
           expect(span.get_tag('redis.raw_command')).to eq('(none)')
           expect(span.get_tag('db.system')).to eq('redis')
+          expect(span.get_tag('span.kind')).to eq('client')
         end
 
         it_behaves_like 'a span with common tags'
@@ -257,6 +264,7 @@ RSpec.describe 'Redis test' do
           expect(span.get_tag('error.msg')).to match(/ERR unknown command/)
           expect(span.get_tag('error.type')).to eq('Redis::CommandError')
           expect(span.get_tag('error.stack').length).to be >= 3
+          expect(span.get_tag('span.kind')).to eq('client')
         end
 
         it_behaves_like 'a span with common tags'
@@ -276,6 +284,7 @@ RSpec.describe 'Redis test' do
           expect(span.resource).to eq("SET K #{'x' * 47}...")
           expect(span.get_tag('db.system')).to eq('redis')
           expect(span.get_tag('redis.raw_command')).to eq("SET K #{'x' * 47}...")
+          expect(span.get_tag('span.kind')).to eq('client')
         end
 
         it_behaves_like 'a span with common tags'
@@ -299,6 +308,7 @@ RSpec.describe 'Redis test' do
           expect(span.resource).to eq('GET K')
           expect(span.get_tag('redis.raw_command')).to eq('GET K')
           expect(span.get_tag('db.system')).to eq('redis')
+          expect(span.get_tag('span.kind')).to eq('client')
         end
 
         it_behaves_like 'a span with common tags'
@@ -318,6 +328,7 @@ RSpec.describe 'Redis test' do
           expect(span.resource).to eq('AUTH ?')
           expect(span.get_tag('redis.raw_command')).to eq('AUTH ?')
           expect(span.get_tag('db.system')).to eq('redis')
+          expect(span.get_tag('span.kind')).to eq('client')
         end
 
         it_behaves_like 'a peer service span' do


### PR DESCRIPTION
**What does this PR do?**

Adds `span.kind` tag for certain spans in delayed_job

Refer to [Opentelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/9fa7c656b26647b27e485a6af7e38dc716eba98a/specification/trace/api.md#spankind) for definitions of producer and consumer

The `instrument_invoke` method has been tagged with `consumer` for `span.kind`
The `instrument_enqueue` method has been tagged with `producer` for `span.kind`
