### PR TITLE
Adds `span.kind` tag for `que`, `shoryuken`, `sneakers`, and `resque`

### DIFF
--- a/lib/datadog/tracing/contrib/que/tracer.rb
+++ b/lib/datadog/tracing/contrib/que/tracer.rb
@@ -33,6 +33,8 @@ module Datadog
               request_span.set_tag(Ext::TAG_JOB_ARGS, job.que_attrs[:args]) if configuration[:tag_args]
               request_span.set_tag(Ext::TAG_JOB_DATA, job.que_attrs[:data]) if configuration[:tag_data]
 
+              request_span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CONSUMER)
+
               set_sample_rate(request_span)
               Contrib::Analytics.set_measured(request_span)
 

--- a/lib/datadog/tracing/contrib/resque/resque_job.rb
+++ b/lib/datadog/tracing/contrib/resque/resque_job.rb
@@ -41,6 +41,8 @@ module Datadog
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_JOB)
 
+              span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CONSUMER)
+
               # Set analytics sample rate
               if Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])
                 Contrib::Analytics.set_sample_rate(span, datadog_configuration[:analytics_sample_rate])

--- a/lib/datadog/tracing/contrib/shoryuken/tracer.rb
+++ b/lib/datadog/tracing/contrib/shoryuken/tracer.rb
@@ -37,6 +37,8 @@ module Datadog
               span.set_tag(Ext::TAG_JOB_ATTRIBUTES, sqs_msg.attributes) if sqs_msg.respond_to?(:attributes)
               span.set_tag(Ext::TAG_JOB_BODY, body) if configuration[:tag_body]
 
+              span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CONSUMER)
+
               yield
             end
           end

--- a/lib/datadog/tracing/contrib/sneakers/tracer.rb
+++ b/lib/datadog/tracing/contrib/sneakers/tracer.rb
@@ -41,6 +41,8 @@ module Datadog
 
               request_span.set_tag(Ext::TAG_JOB_BODY, deserialized_msg) if configuration[:tag_body]
 
+              request_span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CONSUMER)
+
               @app.call(deserialized_msg, delivery_info, metadata, handler)
             end
           end

--- a/spec/datadog/tracing/contrib/que/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/que/tracer_spec.rb
@@ -81,6 +81,12 @@ RSpec.describe Datadog::Tracing::Contrib::Que::Tracer do
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::Errors::TAG_TYPE)).to eq('StandardError')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::Errors::TAG_STACK)).not_to be_nil
       end
+
+      it 'has span.kind tag with value consumer' do
+        enqueue
+
+        expect(span.get_tag('span.kind')).to eq('consumer')
+      end
     end
 
     context 'with tag_args enabled' do

--- a/spec/datadog/tracing/contrib/resque/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/resque/instrumentation_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe 'Resque instrumentation' do
         expect(span).to_not have_error
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('resque')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('job')
+        expect(span.get_tag('span.kind')).to eq('consumer')
       end
 
       it_behaves_like 'analytics for integration' do
@@ -119,6 +120,7 @@ RSpec.describe 'Resque instrumentation' do
         expect(span).to have_error_type(error_class_name)
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('resque')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('job')
+        expect(span.get_tag('span.kind')).to eq('consumer')
       end
 
       context 'with custom error handler' do

--- a/spec/datadog/tracing/contrib/shoryuken/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/shoryuken/tracer_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe Datadog::Tracing::Contrib::Shoryuken::Tracer do
       expect(span.get_tag(Datadog::Tracing::Contrib::Shoryuken::Ext::TAG_JOB_ATTRIBUTES)).to eq(attributes.to_s)
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('shoryuken')
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('job')
+      expect(span.get_tag('span.kind')).to eq('consumer')
     end
 
     it_behaves_like 'analytics for integration' do

--- a/spec/datadog/tracing/contrib/sneakers/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sneakers/tracer_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe Datadog::Tracing::Contrib::Sneakers::Tracer do
       expect(span.get_tag(Datadog::Tracing::Contrib::Sneakers::Ext::TAG_JOB_QUEUE)).to eq(queue_name)
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('sneakers')
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('job')
+      expect(span.get_tag('span.kind')).to eq('consumer')
     end
 
     context 'when the tag_body is true' do


### PR DESCRIPTION
**What does this PR do?**
Adds `span.kind` tag for integrations `que`, `shoryuken`, `sneakers`, and `resque`

Refer to [Opentelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/9fa7c656b26647b27e485a6af7e38dc716eba98a/specification/trace/api.md#spankind) for definitions of consumer

These integrations uniquely only have `consumer` tags and the corresponding `producer` functions are not traced thus no span within the integration has an opposing `producer` tag.

`que`, `shoryuken`, and `sneakers` integrations have the `span.kind` tag set within the `call` function that runs jobs
`resque` has `span.kind` tag set within the `perform` function that runs jobs