### PR TITLE
[PROF-6556] Leave SIGPROF signal handler after disabling profiling

### DIFF
--- a/ext/ddtrace_profiling_native_extension/setup_signal_handler.c
+++ b/ext/ddtrace_profiling_native_extension/setup_signal_handler.c
@@ -1,10 +1,32 @@
 #include <ruby.h>
 #include <signal.h>
 #include <errno.h>
+#include <stdbool.h>
 
+#include "helpers.h"
 #include "setup_signal_handler.h"
 
+static void install_sigprof_signal_handler_internal(
+  void (*signal_handler_function)(int, siginfo_t *, void *),
+  const char *handler_pretty_name,
+  void (*signal_handler_to_replace)(int, siginfo_t *, void *)
+);
+
+void empty_signal_handler(DDTRACE_UNUSED int _signal, DDTRACE_UNUSED siginfo_t *_info, DDTRACE_UNUSED void *_ucontext) { }
+
 void install_sigprof_signal_handler(void (*signal_handler_function)(int, siginfo_t *, void *), const char *handler_pretty_name) {
+  install_sigprof_signal_handler_internal(signal_handler_function, handler_pretty_name, NULL);
+}
+
+void replace_sigprof_signal_handler_with_empty_handler(void (*expected_existing_handler)(int, siginfo_t *, void *)) {
+  install_sigprof_signal_handler_internal(empty_signal_handler, "empty_signal_handler", expected_existing_handler);
+}
+
+static void install_sigprof_signal_handler_internal(
+  void (*signal_handler_function)(int, siginfo_t *, void *),
+  const char *handler_pretty_name,
+  void (*signal_handler_to_replace)(int, siginfo_t *, void *)
+) {
   struct sigaction existing_signal_handler_config = {.sa_sigaction = NULL};
   struct sigaction signal_handler_config = {
     .sa_flags = SA_RESTART | SA_SIGINFO,
@@ -16,11 +38,18 @@ void install_sigprof_signal_handler(void (*signal_handler_function)(int, siginfo
     rb_exc_raise(rb_syserr_new_str(errno, rb_sprintf("Could not install profiling signal handler (%s)", handler_pretty_name)));
   }
 
+  // Because signal handler functions are global, let's check if we're not stepping on someone else's toes.
+
+  // If the existing signal handler was our empty one, that's ok as well
+  if (existing_signal_handler_config.sa_sigaction == empty_signal_handler ||
   // In some corner cases (e.g. after a fork), our signal handler may still be around, and that's ok
-  if (existing_signal_handler_config.sa_sigaction == signal_handler_function) return;
+    existing_signal_handler_config.sa_sigaction == signal_handler_function ||
+  // Are we replacing a known handler with another one?
+    (signal_handler_to_replace != NULL && existing_signal_handler_config.sa_sigaction == signal_handler_to_replace)
+  ) { return; }
 
   if (existing_signal_handler_config.sa_handler != NULL || existing_signal_handler_config.sa_sigaction != NULL) {
-    // A previous signal handler already existed. Currently we don't support this situation, so let's just back out
+    // An unexpected/unknown signal handler already existed. Currently we don't support this situation, so let's just back out
     // of the installation.
 
     if (sigaction(SIGPROF, &existing_signal_handler_config, NULL) != 0) {
@@ -47,6 +76,8 @@ void install_sigprof_signal_handler(void (*signal_handler_function)(int, siginfo
   }
 }
 
+// Note: Be careful when using this; you probably want to use `replace_sigprof_signal_handler_with_empty_handler` instead.
+// (See comments on `collectors_cpu_and_wall_time_worker.c` for details)
 void remove_sigprof_signal_handler(void) {
   struct sigaction signal_handler_config = {
     .sa_handler = SIG_DFL, // Reset back to default

--- a/ext/ddtrace_profiling_native_extension/setup_signal_handler.h
+++ b/ext/ddtrace_profiling_native_extension/setup_signal_handler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+void empty_signal_handler(DDTRACE_UNUSED int _signal, DDTRACE_UNUSED siginfo_t *_info, DDTRACE_UNUSED void *_ucontext);
 void install_sigprof_signal_handler(void (*signal_handler_function)(int, siginfo_t *, void *), const char *handler_pretty_name);
+void replace_sigprof_signal_handler_with_empty_handler(void (*expected_existing_handler)(int, siginfo_t *, void *));
 void remove_sigprof_signal_handler(void);
 void block_sigprof_signal_handler_from_running_in_current_thread(void);


### PR DESCRIPTION
**What does this PR do?**:

This PR changes the teardown behavior of the `CpuAndWallTimeWorker` collector to NOT remove its SIGPROF signal handler, and instead leave behind an empty one.

**Motivation**:

While doing other experiments with signal handling, I discovered that if the Ruby VM receives a SIGPROF signal without having a signal handler setup, it defaults to the awful UNIX/POSIX behavior of instantly dieing with a confusing "Profiling timer expired" message (that has nothing to do with our profiler).

I reasoned that because signal handling is asynchronous, the following theoretical situation may happen:
1. `CpuAndWallTimeWorker` sends SIGPROF signal
2. `CpuAndWallTimeWorker` notices request to shut down
3. `CpuAndWallTimeWorker` removes SIGPROF signal handler during teardown
4. Process receives SIGPROF, causing it to die.

I strongly suspect this may never happen in practice, but as documented in the comment I added, the cost of my suspicion being wrong is really high, so just-in-case I decided to instead leave behind an empty signal handler.

**How to test the change?**:

Change includes test coverage. Additionally, you can doublecheck the change in behavior by doing something like:

```
$ DD_TRACE_DEBUG=true DD_PROFILING_ENABLED=true DD_PROFILING_FORCE_ENABLE_NEW=true bundle exec ddtracerb exec pry
D, [2022-11-23T09:31:54.278186 #22975] DEBUG -- ddtrace: [ddtrace] (components.rb:384:in `startup!') Profiling started
[1] pry(main)> Datadog.configure { |c| c.profiling.enabled = false };;
D, [2022-11-23T09:32:08.580276 #22975] DEBUG -- ddtrace: [ddtrace] (profiler.rb:29:in `shutdown!') Shutting down profiler
[3] pry(main)> Process.kill("SIGPROF", Process.pid)
```

and you'll see that the Ruby process stays alive. If you do the same thing to a process with no profiler, you'll see the process die when you send it the SIGPROF signal.
