### PR TITLE
Update to Ruby 2.7.6

### DIFF
--- a/.circleci/images/primary/Dockerfile-2.7.6
+++ b/.circleci/images/primary/Dockerfile-2.7.6
@@ -1,4 +1,4 @@
-FROM ruby:2.7.3
+FROM ruby:2.7.6
 
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
@@ -48,12 +48,11 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
 RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
 
 # Install RubyGems
-# RUN gem update --system # Upgrading disabled until https://github.com/thoughtbot/appraisal/issues/162 is fixed
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Upgrade RubyGems and Bundler # Upgrading disabled until https://github.com/thoughtbot/appraisal/issues/162 is fixed
-# RUN gem update --system
-# RUN gem install bundler
+RUN gem update --system
+RUN gem install bundler
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -40,8 +40,8 @@ jobs:
             version: 2.6.7
             dockerfile: Dockerfile-2.6.7
           - engine: ruby
-            version: 2.7.3
-            dockerfile: Dockerfile-2.7.3
+            version: 2.7.6
+            dockerfile: Dockerfile-2.7.6
           - engine: ruby
             version: 3.0.3
             dockerfile: Dockerfile-3.0.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,7 +148,7 @@ services:
       - bundle-2.6:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-2.7:
-    image: ghcr.io/datadog/dd-trace-rb/ruby:2.7.3-dd
+    image: ghcr.io/datadog/dd-trace-rb/ruby:2.7.6-dd
     command: /bin/bash
     depends_on:
       - ddagent


### PR DESCRIPTION
Allows nokogiri 1.13+ binary gems to be installed otherwise they fail on `aarch64` with:

    version `GLIBC_2.29' not found

Indeed ruby:2.7.3 has libc6 2.28 and ruby:2.7.6 has libc6 2.31

Also, bundler and rubygems can now be updated as this is fixed:

https://github.com/thoughtbot/appraisal/issues/162

Needed for: https://github.com/DataDog/system-tests-apps-ruby/pull/7