### PR TITLE
Update to JRuby 9.2.21.0 and 9.3.9.0

### DIFF
--- a/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
@@ -1,3 +1,12 @@
+# Note:
+#
+# There is an incompatibility between ethon and httprb on debian 11 bullseye.
+# This is why this image is based on debian 10 buster.
+#
+# See:
+# - https://github.com/jruby/jruby/issues/7033
+# - https://github.com/DataDog/dd-trace-rb/pull/2380#issuecomment-1320994823
+#
 # openjdk:8-jre image is from https://github.com/docker-library/openjdk/blob/a0c4da867ddd1a11408b7ec5032f12130bdc5476/8/jre/buster/Dockerfile
 # note: docker-library/openjdk is deprecated, there is a later move to https://hub.docker.com/_/eclipse-temurin
 FROM openjdk:8-jre-buster AS jruby-9.2.21.0-jre8

--- a/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
@@ -1,24 +1,11 @@
-# NOTE BEFORE YOU UPGRADE TO A LATER JRUBY 9.2 VERSION:
-# There's an incompatibility in JRuby 9.2.19.0+ when run on Java 8 (jre8) with the ethon gem, see
-# https://github.com/jruby/jruby/issues/7033 .
-# The issue goes away if we run on Java 11, but we probably want to test on 8.
-# So, as of this writing (January 2022) we cannot have it all: latest ethon, ethon testing enable, latest JRuby 9.2,
-# and Java 8. One always has to give.
-#
-# since next one is 9.2.19.0 at https://github.com/jruby/docker-jruby/blob/d083a9c13640eba8c135caeefbff3b89350bbede/9.2/jre8/Dockerfile
-# we took the following from this one which is 9.2.11 as default but AFAICT was used to build 9.2.18
-# https://github.com/jruby/docker-jruby/blob/f94681bb26c3da5159e8c0ba9842005a011a76de/9000/jre8/Dockerfile
-#
-# a more recent one would be https://github.com/jruby/docker-jruby/blob/9881bee2d7510aa17dba6b1d7ae5ff711fddd624/9.2/jre8/Dockerfile
-#
-# openjdk:8-jre image is from https://github.com/docker-library/openjdk/blob/a0c4da867ddd1a11408b7ec5032f12130bdc5476/8/jre/bullseye/Dockerfile
+# openjdk:8-jre image is from https://github.com/docker-library/openjdk/blob/a0c4da867ddd1a11408b7ec5032f12130bdc5476/8/jre/buster/Dockerfile
 # note: docker-library/openjdk is deprecated, there is a later move to https://hub.docker.com/_/eclipse-temurin
-FROM openjdk:8-jre-buster AS jruby-9.2.18.0-jre8
+FROM openjdk:8-jre-buster AS jruby-9.2.21.0-jre8
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV JRUBY_VERSION 9.2.18.0
-ENV JRUBY_SHA256 425a5c970a6d918ae531275850634d12169e3557754b2b817fbfb7987a32c1a7
+ENV JRUBY_VERSION 9.2.21.0
+ENV JRUBY_SHA256 dbf05fca4f61bd7d5131d9b83c5f4d1a249213c474b82def37e82013969c8b8a
 RUN mkdir /opt/jruby \
   && curl -fSL https://repo1.maven.org/maven2/org/jruby/jruby-dist/${JRUBY_VERSION}/jruby-dist-${JRUBY_VERSION}-bin.tar.gz -o /tmp/jruby.tar.gz \
   && echo "$JRUBY_SHA256 /tmp/jruby.tar.gz" | sha256sum -c - \
@@ -49,8 +36,7 @@ RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
 
 CMD [ "irb" ]
 
-# See note at the top before updating to a later version!
-FROM jruby-9.2.18.0-jre8
+FROM jruby-9.2.21.0-jre8
 
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
@@ -102,12 +88,11 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
 RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
 
 # Install RubyGems
-RUN gem update --system
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Upgrade RubyGems and Bundler
-RUN gem uninstall -i /opt/jruby/lib/ruby/gems/shared bundler -v 2.1.4 # Remove when https://github.com/thoughtbot/appraisal/issues/162 is fixed
-RUN gem install bundler -v 2.1.2 # Remove when https://github.com/thoughtbot/appraisal/issues/162 is fixed
+RUN gem update --system
+RUN gem install bundler
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 # Ensure JRuby is available when running "bash --login"

--- a/.circleci/images/primary/Dockerfile-jruby-9.2.8.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.8.0
@@ -89,8 +89,11 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
 RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
 
 # Install RubyGems
-RUN gem update --system
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
+
+# Upgrade RubyGems and Bundler
+RUN gem update --system
+RUN gem install bundler
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 # Ensure JRuby is available when running "bash --login"

--- a/.circleci/images/primary/Dockerfile-jruby-9.2.8.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.8.0
@@ -1,3 +1,12 @@
+# Note:
+#
+# There is an incompatibility between ethon and httprb on debian 11 bullseye.
+# This is why this image is based on debian 10 buster.
+#
+# See:
+# - https://github.com/jruby/jruby/issues/7033
+# - https://github.com/DataDog/dd-trace-rb/pull/2380#issuecomment-1320994823
+#
 # taken from https://github.com/jruby/docker-jruby/blob/5de2f8fd4c518cfb621be236fe7e9732c77b6129/9000/jre/Dockerfile
 #
 # openjdk:8-jre image is from https://github.com/docker-library/openjdk/blob/a0c4da867ddd1a11408b7ec5032f12130bdc5476/8/jre/bullseye/Dockerfile

--- a/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
@@ -1,3 +1,12 @@
+# Note:
+#
+# There is an incompatibility between ethon and httprb on debian 11 bullseye.
+# This is why this image is based on debian 10 buster.
+#
+# See:
+# - https://github.com/jruby/jruby/issues/7033
+# - https://github.com/DataDog/dd-trace-rb/pull/2380#issuecomment-1320994823
+#
 # openjdk:11-jre image is from https://github.com/docker-library/openjdk/blob/8dfb0c5645098b8c330c4811c8228cae52f18388/11/jre/buster/Dockerfile
 # note: docker-library/openjdk is deprecated, there is a later move to https://hub.docker.com/_/eclipse-temurin
 FROM openjdk:11-jre-buster AS jruby-9.3.9.0-jre11

--- a/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
@@ -1,4 +1,42 @@
-FROM jruby:9.3.4-jre11
+# openjdk:11-jre image is from https://github.com/docker-library/openjdk/blob/8dfb0c5645098b8c330c4811c8228cae52f18388/11/jre/buster/Dockerfile
+# note: docker-library/openjdk is deprecated, there is a later move to https://hub.docker.com/_/eclipse-temurin
+FROM openjdk:11-jre-buster AS jruby-9.3.9.0-jre11
+
+RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV JRUBY_VERSION 9.3.9.0
+ENV JRUBY_SHA256 251e6dd8d1d2f82922c8c778d7857e1bef82fe5ca2cf77bc09356421d0b05ab8
+RUN mkdir /opt/jruby \
+  && curl -fSL https://repo1.maven.org/maven2/org/jruby/jruby-dist/${JRUBY_VERSION}/jruby-dist-${JRUBY_VERSION}-bin.tar.gz -o /tmp/jruby.tar.gz \
+  && echo "$JRUBY_SHA256 /tmp/jruby.tar.gz" | sha256sum -c - \
+  && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
+  && rm /tmp/jruby.tar.gz \
+  && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
+ENV PATH /opt/jruby/bin:$PATH
+
+# skip installing gem documentation
+RUN mkdir -p /opt/jruby/etc \
+  && { \
+    echo 'install: --no-document'; \
+    echo 'update: --no-document'; \
+  } >> /opt/jruby/etc/gemrc
+
+RUN gem install bundler rake net-telnet xmlrpc
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+    BUNDLE_BIN="$GEM_HOME/bin" \
+    BUNDLE_SILENCE_ROOT_WARNING=1 \
+    BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+  && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+
+CMD [ "irb" ]
+
+FROM jruby-9.3.9.0-jre11
 
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
@@ -50,7 +88,6 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
 RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
 
 # Install RubyGems
-RUN gem update --system
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Upgrade RubyGems and Bundler

--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -52,14 +52,14 @@ jobs:
             version: 3.2.0-preview3
             dockerfile: Dockerfile-3.2.0-preview3
           - engine: jruby
-            version: 9.2.18.0
-            dockerfile: Dockerfile-jruby-9.2-latest
+            version: 9.2.21.0
+            dockerfile: Dockerfile-jruby-9.2.21.0
           - engine: jruby
             version: 9.2.8.0
             dockerfile: Dockerfile-jruby-9.2.8.0
           - engine: jruby
-            version: 9.3.4.0
-            dockerfile: Dockerfile-jruby-9.3-latest
+            version: 9.3.9.0
+            dockerfile: Dockerfile-jruby-9.3.9.0
           - engine: truffleruby
             version: 22.3.0
             dockerfile: Dockerfile-truffleruby-22.3.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -266,8 +266,8 @@ services:
       - .:/app
       - bundle-jruby-9.2.8.0:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
-  tracer-jruby-9.2-latest:
-    image: ghcr.io/datadog/dd-trace-rb/jruby:9.2.18.0-dd
+  tracer-jruby-9.2:
+    image: ghcr.io/datadog/dd-trace-rb/jruby:9.2.21.0-dd
     command: /bin/bash
     depends_on:
       - ddagent
@@ -285,10 +285,10 @@ services:
     tty: true
     volumes:
       - .:/app
-      - bundle-jruby-9.2-latest:/usr/local/bundle
+      - bundle-jruby-9.2:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
-  tracer-jruby-9.3-latest:
-    image: ghcr.io/datadog/dd-trace-rb/jruby:9.3.4.0-dd
+  tracer-jruby-9.3:
+    image: ghcr.io/datadog/dd-trace-rb/jruby:9.3.9.0-dd
     command: /bin/bash
     depends_on:
       - ddagent
@@ -306,7 +306,7 @@ services:
     tty: true
     volumes:
       - .:/app
-      - bundle-jruby-9.3-latest:/usr/local/bundle
+      - bundle-jruby-9.3:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   # TruffleRuby
   tracer-truffleruby-22.3.0:
@@ -427,8 +427,8 @@ volumes:
   bundle-3.2:
   # ADD NEW RUBIES HERE
   bundle-jruby-9.2.8.0:
-  bundle-jruby-9.2-latest:
-  bundle-jruby-9.3-latest:
+  bundle-jruby-9.2:
+  bundle-jruby-9.3:
   bundle-truffleruby-22.3.0:
   ddagent_var_run:
   # Temporary folder used while compiling the profiling native extension. We place this in a volume to avoid the


### PR DESCRIPTION
Built 9.3 from a buster base, vendored in to attempt to avoid any issues with bullseye.

Also, a bit of alignment on 9.2.8.0.

And removed the `-latest` suffixes as they don't mean much.