### PR TITLE
Silence compiler warning in Ruby headers

### DIFF
--- a/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
+++ b/ext/ddtrace_profiling_native_extension/private_vm_api_access.c
@@ -18,6 +18,7 @@
   // See https://nelkinda.com/blog/suppress-warnings-in-gcc-and-clang/#d11e364 for details.
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wunused-parameter"
+  #pragma GCC diagnostic ignored "-Wattributes"
     #include <vm_core.h>
   #pragma GCC diagnostic pop
   #include <iseq.h>


### PR DESCRIPTION
**What does this PR do?**:

Silence a compiler warning that we can't do anything about (it's on the Ruby VM headers) and that is breaking CI (because we turn warnings into errors in CI).

**Motivation**:

We can't do anything about these warnings, so they are not interesting to see.

In particular, here's the warning I saw:

```
In file included from /usr/local/bundle/gems/debase-ruby_core_source-0.10.17/lib/debase/ruby_core_source/ruby-2.4.3-p205/method.h:14,
                 from /usr/local/bundle/gems/debase-ruby_core_source-0.10.17/lib/debase/ruby_core_source/ruby-2.4.3-p205/vm_core.h:67,
                 from ../../../../ext/ddtrace_profiling_native_extension/private_vm_api_access.c:22:
/usr/local/bundle/gems/debase-ruby_core_source-0.10.17/lib/debase/ruby_core_source/ruby-2.4.3-p205/internal.h:991:1: warning: 'const' attribute on function returning 'void' [-Wattributes]
 CONSTFUNC(void rb_gc_mark_encodings(void));
 ^~~~~~~~~
```

...this was with the `ghcr.io/datadog/dd-trace-rb/ruby:2.4.10-dd` docker image.

**Additional Notes**:
(Nothing)

**How to test the change?**:
Validate that Ruby 2.4 CI is green.
