### PR TITLE
Fix ruby 2.4 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,7 +494,7 @@ job_configuration:
     resource_class_to_use: medium+
   - &config-2_4
     <<: *filters_all_branches_and_tags
-    ruby_version: '2.4'
+    ruby_version: '2.4.10'
     image: ghcr.io/datadog/dd-trace-rb/ruby:2.4.10-dd
     resource_class_to_use: medium+
   - &config-2_5

--- a/gemfiles/ruby_2.4.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib.gemfile.lock
@@ -1390,6 +1390,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    google-protobuf (3.11.4)
     google-protobuf (3.11.4-x86_64-linux)
     googleapis-common-protos-types (1.0.5)
       google-protobuf (~> 3.11)
@@ -1401,6 +1402,9 @@ GEM
       rack (>= 1.3.0)
       rack-accept
     graphql (2.0.6)
+    grpc (1.28.0)
+      google-protobuf (~> 3.11)
+      googleapis-common-protos-types (~> 1.0)
     grpc (1.28.0-x86_64-linux)
       google-protobuf (~> 3.11)
       googleapis-common-protos-types (~> 1.0)
@@ -1425,7 +1429,10 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
+    libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
@@ -1607,17 +1614,9 @@ GEM
       rake (~> 12.3)
       serverengine (~> 2.1.0)
       thor
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sqlite3 (1.3.13)
     sucker_punch (3.0.1)
       concurrent-ruby (~> 1.0)
@@ -1643,6 +1642,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -1688,7 +1688,7 @@ DEPENDENCIES
   pry
   pry-nav
   pry-stack_explorer
-  que (>= 1.0.0)
+  que (>= 1.0.0, < 2.0.0)
   racecar (>= 0.3.5)
   rack
   rack-contrib
@@ -1715,8 +1715,6 @@ DEPENDENCIES
   sidekiq
   simplecov (~> 0.17)
   sneakers (>= 2.12.0)
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   sqlite3 (~> 1.3.6)
   sucker_punch
   typhoeus
@@ -1724,4 +1722,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.20
+   2.3.26

--- a/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
@@ -48,12 +48,16 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.15.5)
+    google-protobuf (3.19.1)
     google-protobuf (3.19.1-x86_64-linux)
     graphql (1.12.24)
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
@@ -131,14 +135,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.1.0)
     webmock (3.13.0)
@@ -150,6 +146,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -189,10 +186,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.20
+   2.3.26

--- a/gemfiles/ruby_2.4.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_core_old.gemfile.lock
@@ -36,11 +36,15 @@ GEM
     dogstatsd-ruby (4.8.3)
     extlz4 (0.3.3)
     ffi (1.15.5)
+    google-protobuf (3.19.1)
     google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
@@ -112,14 +116,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.1.0)
     webmock (3.13.0)
@@ -131,6 +127,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -166,10 +163,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.20
+   2.3.26

--- a/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
@@ -54,11 +54,15 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     gherkin (5.1.0)
+    google-protobuf (3.19.1)
     google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
@@ -132,14 +136,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.1.0)
     webmock (3.13.0)
@@ -151,6 +147,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -187,10 +184,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.20
+   2.3.26

--- a/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
@@ -72,13 +72,17 @@ GEM
     dogstatsd-ruby (5.4.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
+    google-protobuf (3.19.1)
     google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
@@ -158,14 +162,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.2.1)
@@ -182,6 +178,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -218,10 +215,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.20
+   2.3.26

--- a/gemfiles/ruby_2.4.10_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_hanami_1.gemfile.lock
@@ -66,6 +66,7 @@ GEM
       dry-types (~> 0.12.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
+    google-protobuf (3.19.1)
     google-protobuf (3.19.1-x86_64-linux)
     hanami (1.3.5)
       bundler (>= 1.6, < 3)
@@ -115,7 +116,10 @@ GEM
     inflecto (0.0.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     mail (2.7.1)
@@ -193,14 +197,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.10461)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.11)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     transproc (1.1.1)
@@ -216,6 +212,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -254,10 +251,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.2.19
+   2.3.26

--- a/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
@@ -82,13 +82,17 @@ GEM
     ffi (1.15.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    google-protobuf (3.19.1)
     google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
@@ -207,14 +211,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -239,6 +235,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -277,11 +274,9 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   sprockets (< 4)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.20
+   2.3.26

--- a/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
@@ -82,13 +82,17 @@ GEM
     ffi (1.15.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    google-protobuf (3.19.1)
     google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
@@ -207,14 +211,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -239,6 +235,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -277,11 +274,9 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   sprockets (< 4)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.20
+   2.3.26

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
@@ -82,13 +82,17 @@ GEM
     ffi (1.15.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    google-protobuf (3.19.1)
     google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
@@ -208,14 +212,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -240,6 +236,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -279,11 +276,9 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   sprockets (< 4)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.20
+   2.3.26

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -82,13 +82,17 @@ GEM
     ffi (1.15.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    google-protobuf (3.19.1)
     google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
@@ -224,14 +228,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -256,6 +252,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -296,11 +293,9 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   sprockets (< 4)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.20
+   2.3.26

--- a/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
@@ -83,13 +83,17 @@ GEM
     ffi (1.15.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    google-protobuf (3.19.1)
     google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     lograge (0.11.2)
@@ -216,14 +220,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -248,6 +244,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -288,11 +285,9 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   sidekiq
   simplecov (~> 0.17)
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   sprockets (< 4)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.20
+   2.3.26

--- a/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
@@ -82,13 +82,17 @@ GEM
     ffi (1.15.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    google-protobuf (3.19.1)
     google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     loofah (2.15.0)
@@ -206,14 +210,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -238,6 +234,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -276,11 +273,9 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   sprockets (< 4)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.20
+   2.3.26

--- a/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
@@ -36,11 +36,15 @@ GEM
     dogstatsd-ruby (5.4.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
+    google-protobuf (3.19.1)
     google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
@@ -134,14 +138,6 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.1.0)
       tilt (~> 2.0)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.10)
     unicode-display_width (2.1.0)
@@ -156,6 +152,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -193,10 +190,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.20
+   2.3.26

--- a/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
@@ -36,11 +36,15 @@ GEM
     dogstatsd-ruby (5.4.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
+    google-protobuf (3.19.1)
     google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
@@ -134,14 +138,6 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.1.0)
       tilt (~> 2.0)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.9807)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.9)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.10)
     unicode-display_width (2.1.0)
@@ -156,6 +152,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -193,10 +190,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.20
+   2.3.26

--- a/gemfiles/ruby_2.4.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_sinatra.gemfile.lock
@@ -36,11 +36,15 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
+    google-protobuf (3.19.1)
     google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
     libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
@@ -125,14 +129,6 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.1.0)
       tilt (~> 2.0)
-    sorbet (0.5.9672)
-      sorbet-static (= 0.5.9672)
-    sorbet-runtime (0.5.10461)
-    sorbet-static (0.5.9672-x86_64-linux)
-    spoom (1.1.11)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     unicode-display_width (2.3.0)
@@ -145,6 +141,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -182,10 +179,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
   sinatra
-  sorbet (= 0.5.9672)
-  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.2.19
+   2.3.26


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Ruby 2.4 image update to Debian Buster should have used a new cache, but a CI race condition on the `binary_version` file update may have caused cache pollution with Stretch-built gems, in turn making any later attempt to use this image fail.

**Motivation**

CircleCI `test-2.4` job failing all around.


**How to test the change?**

CircleCI `test-2.4` job should turn green.