### PR TITLE
Adds `span.kind` tag for `sidekiq`

### DIFF
--- a/lib/datadog/tracing/contrib/sidekiq/client_tracer.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/client_tracer.rb
@@ -28,6 +28,11 @@ module Datadog
               span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_PUSH)
 
+              span.set_tag(
+                Datadog::Tracing::Metadata::Ext::TAG_KIND,
+                Datadog::Tracing::Metadata::Ext::SpanKind::TAG_PRODUCER
+              )
+
               # Set analytics sample rate
               if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
                 Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])

--- a/lib/datadog/tracing/contrib/sidekiq/server_tracer.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/server_tracer.rb
@@ -40,6 +40,11 @@ module Datadog
               span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_JOB)
 
+              span.set_tag(
+                Datadog::Tracing::Metadata::Ext::TAG_KIND,
+                Datadog::Tracing::Metadata::Ext::SpanKind::TAG_CONSUMER
+              )
+
               # Set analytics sample rate
               if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
                 Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])

--- a/spec/datadog/tracing/contrib/sidekiq/client_tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/client_tracer_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe 'ClientTracerTest' do
     expect(span.get_metric('_dd.measured')).to be_nil
     expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('sidekiq')
     expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('push')
+    expect(span.get_tag('span.kind')).to eq('producer')
   end
 
   context 'with nested trace' do
@@ -55,6 +56,7 @@ RSpec.describe 'ClientTracerTest' do
       expect(child_span.status).to eq(0)
       expect(child_span.parent_id).to eq(parent_span.span_id)
       expect(child_span.get_metric('_dd.measured')).to be_nil
+      expect(child_span.get_tag('span.kind')).to eq('producer')
     end
   end
 

--- a/spec/datadog/tracing/contrib/sidekiq/server_tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/server_tracer_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe 'Server tracer' do
     expect(span.get_metric('_dd.measured')).to eq(1.0)
     expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('sidekiq')
     expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('job')
+    expect(span.get_tag('span.kind')).to eq('consumer')
   end
 
   context 'with job run failing' do
@@ -69,6 +70,7 @@ RSpec.describe 'Server tracer' do
       expect(span).to be_root_span
       expect(span.get_tag('sidekiq.job.args')).to be_nil
       expect(span.get_metric('_dd.measured')).to eq(1.0)
+      expect(span.get_tag('span.kind')).to eq('consumer')
     end
   end
 
@@ -101,6 +103,7 @@ RSpec.describe 'Server tracer' do
       expect(empty.status).to eq(0)
       expect(empty).to be_root_span
       expect(empty.get_metric('_dd.measured')).to eq(1.0)
+      expect(empty.get_tag('span.kind')).to eq('consumer')
 
       expect(custom.service).to eq(tracer.default_service)
       expect(custom.resource).to eq('CustomWorker')
@@ -109,6 +112,7 @@ RSpec.describe 'Server tracer' do
       expect(custom).to be_root_span
       expect(custom.get_tag('sidekiq.job.args')).to eq(['?'].to_s)
       expect(custom.get_metric('_dd.measured')).to eq(1.0)
+      expect(custom.get_tag('span.kind')).to eq('consumer')
     end
 
     context 'with tag_args' do
@@ -158,6 +162,7 @@ RSpec.describe 'Server tracer' do
         expect(empty.status).to eq(0)
         expect(empty).to be_root_span
         expect(empty.get_metric('_dd.measured')).to eq(1.0)
+        expect(empty.get_tag('span.kind')).to eq('consumer')
 
         expect(custom.service).to eq('sidekiq-slow')
         expect(custom.resource).to eq('CustomWorker')
@@ -166,6 +171,7 @@ RSpec.describe 'Server tracer' do
         expect(custom).to be_root_span
         expect(custom.get_tag('sidekiq.job.args')).to eq(['random_id'].to_s)
         expect(custom.get_metric('_dd.measured')).to eq(1.0)
+        expect(custom.get_tag('span.kind')).to eq('consumer')
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**
Adds `span.kind` tag for integrations `sidekiq`

Refer to [Opentelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/9fa7c656b26647b27e485a6af7e38dc716eba98a/specification/trace/api.md#spankind) for definitions of consumer and producer

The client_tracer enqueues jobs in an asynchronous manner meaning that it gets the `producer` value for `span.kind`
The server_tracer completes jobs in an asynchronous manner meaning that it gets the `consumer` value for `span.kind`

Note the internal spans are not marked with span.kind but because they are edge spans, there may need to be marked with `peer.service` down the line to match [Otel](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/7cc8a21f80eb77519de0612c718d7a2702692604/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/patches/poller.rb#L16) requirements


