### PR TITLE
Adds 'span.kind' tag for 'kafka'

### DIFF
--- a/lib/datadog/tracing/contrib/kafka/consumer_event.rb
+++ b/lib/datadog/tracing/contrib/kafka/consumer_event.rb
@@ -10,6 +10,7 @@ module Datadog
             super
 
             span.set_tag(Ext::TAG_GROUP, payload[:group_id])
+            span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CONSUMER)
           end
         end
       end

--- a/lib/datadog/tracing/contrib/kafka/events/produce_operation/send_messages.rb
+++ b/lib/datadog/tracing/contrib/kafka/events/produce_operation/send_messages.rb
@@ -20,6 +20,7 @@ module Datadog
 
                 span.set_tag(Ext::TAG_MESSAGE_COUNT, payload[:message_count]) if payload.key?(:message_count)
                 span.set_tag(Ext::TAG_SENT_MESSAGE_COUNT, payload[:sent_message_count]) if payload.key?(:sent_message_count)
+                span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_PRODUCER)
               end
 
               module_function

--- a/lib/datadog/tracing/contrib/kafka/events/producer/deliver_messages.rb
+++ b/lib/datadog/tracing/contrib/kafka/events/producer/deliver_messages.rb
@@ -23,6 +23,7 @@ module Datadog
                 if payload.key?(:delivered_message_count)
                   span.set_tag(Ext::TAG_DELIVERED_MESSAGE_COUNT, payload[:delivered_message_count])
                 end
+                span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_PRODUCER)
               end
 
               module_function

--- a/spec/datadog/tracing/contrib/kafka/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/kafka/patcher_spec.rb
@@ -137,6 +137,7 @@ RSpec.describe 'Kafka patcher' do
           expect(span).to_not have_error
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('kafka')
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('consumer.process_batch')
+          expect(span.get_tag('span.kind')).to eq('consumer')
         end
       end
     end
@@ -167,6 +168,7 @@ RSpec.describe 'Kafka patcher' do
           expect(span.get_tag('kafka.highwater_mark_offset')).to eq(highwater_mark_offset)
           expect(span.get_tag('kafka.offset_lag')).to eq(offset_lag)
           expect(span).to have_error
+          expect(span.get_tag('span.kind')).to eq('consumer')
         end
       end
     end
@@ -222,6 +224,7 @@ RSpec.describe 'Kafka patcher' do
           expect(span).to_not have_error
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('kafka')
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('consumer.process_message')
+          expect(span.get_tag('span.kind')).to eq('consumer')
         end
       end
     end
@@ -252,6 +255,7 @@ RSpec.describe 'Kafka patcher' do
           expect(span.get_tag('kafka.offset')).to eq(offset)
           expect(span.get_tag('kafka.offset_lag')).to eq(offset_lag)
           expect(span).to have_error
+          expect(span.get_tag('span.kind')).to eq('consumer')
         end
       end
     end
@@ -566,6 +570,7 @@ RSpec.describe 'Kafka patcher' do
           expect(span).to_not have_error
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('kafka')
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('producer.send_messages')
+          expect(span.get_tag('span.kind')).to eq('producer')
         end
       end
     end
@@ -592,6 +597,7 @@ RSpec.describe 'Kafka patcher' do
           expect(span.get_tag('kafka.message_count')).to eq(message_count)
           expect(span.get_tag('kafka.sent_message_count')).to eq(sent_message_count)
           expect(span).to have_error
+          expect(span.get_tag('span.kind')).to eq('producer')
         end
       end
     end
@@ -638,6 +644,7 @@ RSpec.describe 'Kafka patcher' do
           expect(span).to_not have_error
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('kafka')
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('producer.deliver_messages')
+          expect(span.get_tag('span.kind')).to eq('producer')
         end
       end
     end
@@ -665,6 +672,7 @@ RSpec.describe 'Kafka patcher' do
           expect(span.get_tag('kafka.message_count')).to eq(message_count)
           expect(span.get_tag('kafka.delivered_message_count')).to eq(delivered_message_count)
           expect(span).to have_error
+          expect(span.get_tag('span.kind')).to eq('producer')
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?**
Adds `span.kind` tag for integrations `kafka`

Refer to [Opentelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/9fa7c656b26647b27e485a6af7e38dc716eba98a/specification/trace/api.md#spankind) for definitions of consumer and producer

The producer  and produce_operations files enqueues jobs in an asynchronous manner meaning that it gets the `producer` value for `span.kind`
The consumer_event super class completes jobs in an asynchronous manner meaning that it gets the `consumer` value for `span.kind`

Note that currently unable to distinguish between the spans of sending and receiving a message for kafka request under the connections folder. If that is ever more specific, we can add `span.kind` tags there


