### PR TITLE
Align Ruby CI cache keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -481,37 +481,37 @@ job_configuration:
   # MRI
   - &config-2_1
     <<: *filters_all_branches_and_tags
-    ruby_version: '2.1'
+    ruby_version: 'ruby-2.1.10'
     image: ghcr.io/datadog/dd-trace-rb/ruby:2.1.10-dd
     resource_class_to_use: medium+
   - &config-2_2
     <<: *filters_all_branches_and_tags
-    ruby_version: '2.2'
+    ruby_version: 'ruby-2.2.10'
     image: ghcr.io/datadog/dd-trace-rb/ruby:2.2.10-dd
     resource_class_to_use: medium+
   - &config-2_3
     <<: *filters_all_branches_and_tags
-    ruby_version: '2.3'
+    ruby_version: 'ruby-2.3.8'
     image: ghcr.io/datadog/dd-trace-rb/ruby:2.3.8-dd
     resource_class_to_use: medium+
   - &config-2_4
     <<: *filters_all_branches_and_tags
-    ruby_version: '2.4.10'
+    ruby_version: 'ruby-2.4.10'
     image: ghcr.io/datadog/dd-trace-rb/ruby:2.4.10-dd
     resource_class_to_use: medium+
   - &config-2_5
     <<: *filters_all_branches_and_tags
-    ruby_version: '2.5'
+    ruby_version: 'ruby-2.5.9'
     image: ghcr.io/datadog/dd-trace-rb/ruby:2.5.9-dd
     resource_class_to_use: medium+
   - &config-2_6
     <<: *filters_all_branches_and_tags
-    ruby_version: '2.6.10'
+    ruby_version: 'ruby-2.6.10'
     image: ghcr.io/datadog/dd-trace-rb/ruby:2.6.10-dd
     resource_class_to_use: medium+
   - &config-2_7
     <<: *filters_all_branches_and_tags
-    ruby_version: '2.7'
+    ruby_version: 'ruby-2.7.3'
     image: ghcr.io/datadog/dd-trace-rb/ruby:2.7.3-dd
     resource_class_to_use: medium+
   - &config-2_7-small
@@ -519,17 +519,17 @@ job_configuration:
     resource_class_to_use: small
   - &config-3_0
     <<: *filters_all_branches_and_tags
-    ruby_version: '3.0.4'
+    ruby_version: 'ruby-3.0.4'
     image: ghcr.io/datadog/dd-trace-rb/ruby:3.0.4-dd
     resource_class_to_use: medium+
   - &config-3_1
     <<: *filters_all_branches_and_tags
-    ruby_version: '3.1.2'
+    ruby_version: 'ruby-3.1.2'
     image: ghcr.io/datadog/dd-trace-rb/ruby:3.1.2-dd
     resource_class_to_use: medium+
   - &config-3_2
     <<: *filters_all_branches_and_tags
-    ruby_version: '3.2'
+    ruby_version: 'ruby-3.2.0-preview3'
     image: ghcr.io/datadog/dd-trace-rb/ruby:3.2.0-preview3-dd
     resource_class_to_use: medium+
     # ADD NEW RUBIES HERE
@@ -540,17 +540,17 @@ job_configuration:
     resource_class_to_use: medium+
   - &config-jruby-9_2-latest # More recent release of 9.2
     <<: *filters_all_branches_and_tags
-    ruby_version: 'jruby-9.2-latest'
+    ruby_version: 'jruby-9.2.18.0'
     image: ghcr.io/datadog/dd-trace-rb/jruby:9.2.18.0-dd
     resource_class_to_use: medium+
   - &config-jruby-9_3-latest
     <<: *filters_all_branches_and_tags
-    ruby_version: 'jruby-9.3-latest'
+    ruby_version: 'jruby-9.3.4.0'
     image: ghcr.io/datadog/dd-trace-rb/jruby:9.3.4.0-dd
     resource_class_to_use: medium+
-  - &config-truffleruby-22_0_0
+  - &config-truffleruby-22_3_0
     <<: *filters_all_branches_and_tags
-    ruby_version: 'truffleruby-22.0.0'
+    ruby_version: 'truffleruby-22.3.0'
     image: ghcr.io/datadog/dd-trace-rb/truffleruby:22.3.0-dd
     resource_class_to_use: medium+
 
@@ -587,7 +587,7 @@ workflows:
             - test-jruby-9.2.8.0
             - test-jruby-9.2-latest
             - test-jruby-9.3-latest
-            # soon™️ - test-truffleruby-22.0.0
+            # soon™️ - test-truffleruby-22.3.0
       - orb/changelog:
           <<: *config-2_7-small
           name: changelog
@@ -764,13 +764,13 @@ workflows:
       # TruffleRuby
       # soon™️
       # - orb/build:
-      #     <<: *config-truffleruby-22_0_0
-      #     name: build-truffleruby-22.0.0
+      #     <<: *config-truffleruby-22_3_0
+      #     name: build-truffleruby-22.3.0
       # - orb/test:
-      #     <<: *config-truffleruby-22_0_0
-      #     name: test-truffleruby-22.0.0
+      #     <<: *config-truffleruby-22_3_0
+      #     name: test-truffleruby-22.3.0
       #     requires:
-      #       - build-truffleruby-22.0.0
+      #       - build-truffleruby-22.3.0
       # Release jobs
       - "deploy prerelease Gem":
           <<: *filters_all_branches_and_tags
@@ -792,7 +792,7 @@ workflows:
             - test-jruby-9.2.8.0
             - test-jruby-9.2-latest
             - test-jruby-9.3-latest
-            # soon™️ - test-truffleruby-22.0.0
+            # soon™️ - test-truffleruby-22.3.0
       - "deploy release":
           <<: *filters_only_release_tags
           requires:
@@ -813,7 +813,7 @@ workflows:
             - test-jruby-9.2.8.0
             - test-jruby-9.2-latest
             - test-jruby-9.3-latest
-            # soon™️ - test-truffleruby-22.0.0
+            # soon™️ - test-truffleruby-22.3.0
   # This workflow runs the same `build` and `test` jobs as above on a schedule.
   # Tasks related to housekeeping (e.g. prerelease) are not relevant
   # to this daily check, as they are not expected to be impacted here.
@@ -1005,11 +1005,11 @@ workflows:
       # TruffleRuby
       # soon™️
       # - orb/build:
-      #     <<: *config-truffleruby-22_0_0
-      #     name: build-truffleruby-22.0.0
+      #     <<: *config-truffleruby-22_3_0
+      #     name: build-truffleruby-22.3.0
       #     edge: true
       # - orb/test:
-      #     <<: *config-truffleruby-22_0_0
-      #     name: test-truffleruby-22.0.0
+      #     <<: *config-truffleruby-22_3_0
+      #     name: test-truffleruby-22.3.0
       #     requires:
-      #       - build-truffleruby-22.0.0
+      #       - build-truffleruby-22.3.0


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Making sure to use a dedicated cache per patch version

**Motivation**

Changing versions (even patch) sometimes comes with userland changes as well (e.g glibc gets bumped) as the base image gets updated.

This has caused some issues in the past, either directly or via cache pollution from an updated branch saving a new cache then an earlier non-updated branch picking that cache up.

So making sure to use a dedicated cache per patch version reduces potential for breakage.

**Additional Notes**

This also adds a `ruby-` prefix, materialising the ruby engine in use, making it consistent with other non-MRI engines. It shoudl probably apply to job names as well, but I punted on that because of the GitHub PR merge enforcement on job names.

**How to test the change?**

CI should be green.