### PR TITLE
Tweak profiler code to avoid triggering bug in compiler warnings

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -144,11 +144,10 @@ void sample_thread(
 
   // Samples thread into recorder, including as a top frame in the stack a frame named "Garbage Collection"
   if (type == SAMPLE_IN_GC) {
+    ddog_CharSlice function_name = DDOG_CHARSLICE_C("");
+    ddog_CharSlice function_filename = DDOG_CHARSLICE_C("Garbage Collection");
     buffer->lines[0] = (ddog_Line) {
-      .function = (ddog_Function) {
-        .name = DDOG_CHARSLICE_C(""),
-        .filename = DDOG_CHARSLICE_C("Garbage Collection")
-      },
+      .function = (ddog_Function) {.name = function_name, .filename = function_filename},
       .line = 0
     };
     // To avoid changing sample_thread_internal, we just prepare a new buffer struct that uses the same underlying storage as the
@@ -300,11 +299,10 @@ static void maybe_add_placeholder_frames_omitted(VALUE thread, sampling_buffer* 
 
   // Important note: `frames_omitted_message` MUST have a lifetime that is at least as long as the call to
   // `record_sample`. So be careful where it gets allocated. (We do have tests for this, at least!)
+  ddog_CharSlice function_name = DDOG_CHARSLICE_C("");
+  ddog_CharSlice function_filename = {.ptr = frames_omitted_message, .len = strlen(frames_omitted_message)};
   buffer->lines[buffer->max_frames - 1] = (ddog_Line) {
-    .function = (ddog_Function) {
-      .name = DDOG_CHARSLICE_C(""),
-      .filename = ((ddog_CharSlice) {.ptr = frames_omitted_message, .len = strlen(frames_omitted_message)})
-    },
+    .function = (ddog_Function) {.name = function_name, .filename = function_filename},
     .line = 0,
   };
 }
@@ -337,11 +335,10 @@ static void record_placeholder_stack_in_native_code(
   sampling_buffer *record_buffer,
   int extra_frames_in_record_buffer
 ) {
+  ddog_CharSlice function_name = DDOG_CHARSLICE_C("");
+  ddog_CharSlice function_filename = DDOG_CHARSLICE_C("In native code");
   buffer->lines[0] = (ddog_Line) {
-    .function = (ddog_Function) {
-      .name = DDOG_CHARSLICE_C(""),
-      .filename = DDOG_CHARSLICE_C("In native code")
-    },
+    .function = (ddog_Function) {.name = function_name, .filename = function_filename},
     .line = 0
   };
 
@@ -373,7 +370,8 @@ sampling_buffer *sampling_buffer_new(unsigned int max_frames) {
   // Currently we have a 1-to-1 correspondence between lines and locations, so we just initialize the locations once
   // here and then only mutate the contents of the lines.
   for (unsigned int i = 0; i < max_frames; i++) {
-    buffer->locations[i] = (ddog_Location) {.lines = (ddog_Slice_line) {.ptr = &buffer->lines[i], .len = 1}};
+    ddog_Slice_line lines = (ddog_Slice_line) {.ptr = &buffer->lines[i], .len = 1};
+    buffer->locations[i] = (ddog_Location) {.lines = lines};
   }
 
   return buffer;


### PR DESCRIPTION
**What does this PR do?**:

This PR slightly tweaks some of the profiler C code to avoid triggering an incorrect compiler warning, and thus breaking CI (because we turn all warnings into errors in CI).

**Motivation**:

In <https://github.com/DataDog/dd-trace-rb/issues/2377> I documented a set of compiler warnings that are incorrect. Usually having incorrect warnings is not an issue, but in CI we compile with `-Werror` to turn all warnings into errors, so we can't just ignore them.

In <https://github.com/DataDog/dd-trace-rb/pull/2408> while upgrading our Ruby images, we ran into this issue again on our own CI.

**Additional Notes**:

Can I go back to coding Ruby?

**How to test the change?**:

CI should remain green, even when using the 2.7 docker image from <https://github.com/DataDog/dd-trace-rb/pull/2408>.
