### PR TITLE
Update actions/checkout and actions/*-artifact to Node 16

### DIFF
--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -70,7 +70,7 @@ jobs:
     name: Build (${{ matrix.engine }} ${{ matrix.version }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Using docker-container engine enables advanced buildx features
       - name: Set up Docker container engine

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -49,12 +49,12 @@ jobs:
     name: System Tests (${{ matrix.weblog-variant }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
 
       - name: Checkout dd-trace-rb
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: 'binaries/dd-trace-rb'
 
@@ -76,7 +76,7 @@ jobs:
           DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
 
       - name: Archive logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: system-tests-${{ matrix.library }}-${{ matrix.weblog-variant }}-logs-${{ github.run_id }}-${{ github.sha }}

--- a/.github/workflows/test-head.yaml
+++ b/.github/workflows/test-head.yaml
@@ -12,7 +12,7 @@ jobs:
       JRUBY_OPTS: --dev
       DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # bundler appears to match both prerelease and release rubies when we
       # want the former only. relax the constraint to allow any version for
       # head rubies

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -12,7 +12,7 @@ jobs:
       SKIP_SIMPLECOV: 1
       DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # bundler appears to match both prerelease and release rubies when we
       # want the former only. relax the constraint to allow any version for
       # head rubies


### PR DESCRIPTION
**What does this PR do?**

Update actions to use Node 16-based ones.

**Motivation**

Node 12 actions are deprecated.

**How to test the change?**

GHA CI should stay green, no deprecation notice should be shown in summaries.