### PR TITLE
Adjust macOS testing

### DIFF
--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -1,12 +1,25 @@
-name: macOS testing
+name: Test macOS
 on: [push]
 jobs:
   test-macos:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
-        ruby: [2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1] # ADD NEW RUBIES HERE
+        os:
+          - macos-11
+          - macos-12
+        ruby:
+          - '2.1'
+          - '2.2'
+          - '2.3'
+          - '2.4'
+          - '2.5'
+          - '2.6'
+          - '2.7'
+          - '3.0'
+          - '3.1'
+          # ADD NEW RUBIES HERE
+    name: Test (${{ matrix.os }}, ${{ matrix.ruby }})
     runs-on: ${{ matrix.os }}
     env:
       SKIP_SIMPLECOV: 1


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Small adjustments to this GH workflow:

- lock macOS version 
- test on multiple macOS versions
- name jobs
- rename some stuff

**Motivation**

`macos-latest` is a moving target. In fact, some jobs pick it up as `macos-12` and some seem to pick it up as `macos-11` as we get a warning.

Native libraries (e.g libddwaf) may encounter issues on specific macOS versions.

Naming is for clarity, renaming is to follow the "{verb} {something}" pattern of GH Actions

**How to test the change?**

Take a peek at CI.