### PR TITLE
[PROF-6556] Fix profiler issue due to Ruby native thread reuse

### DIFF
--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -112,6 +112,7 @@ static VALUE _native_trigger_holding_the_gvl_signal_handler_on(DDTRACE_UNUSED VA
 
   pthread_mutex_lock(&holding_the_gvl_signal_handler_mutex);
 
+  // We keep trying for ~5 seconds (500 x 10ms) to try to avoid any flakiness if the test machine is a bit slow
   for (int tries = 0; holding_the_gvl_signal_handler_result[0] == Qfalse && tries < 500; tries++) {
     pthread_kill(thread, SIGPROF);
 

--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -1,5 +1,6 @@
 #include <ruby.h>
 #include <ruby/thread.h>
+#include <errno.h>
 
 #include "clock_id.h"
 #include "helpers.h"
@@ -111,14 +112,28 @@ static VALUE _native_trigger_holding_the_gvl_signal_handler_on(DDTRACE_UNUSED VA
 
   pthread_mutex_lock(&holding_the_gvl_signal_handler_mutex);
 
-  for (int tries = 0; holding_the_gvl_signal_handler_result[0] == Qfalse && tries < 100; tries++) {
+  for (int tries = 0; holding_the_gvl_signal_handler_result[0] == Qfalse && tries < 500; tries++) {
     pthread_kill(thread, SIGPROF);
 
+    // pthread_cond_timedwait is simply awful -- the deadline is based on wall-clock using a struct timespec, so we need
+    // all of the below complexity just to tell it "timeout is 10ms". The % limit dance below is needed because the
+    // `tv_nsec` part of a timespec can't go over the limit.
     struct timespec deadline;
     clock_gettime(CLOCK_REALTIME, &deadline);
-    deadline.tv_nsec += 10 * 1000 * 1000 /* 10ms */;
 
-    pthread_cond_timedwait(&holding_the_gvl_signal_handler_executed, &holding_the_gvl_signal_handler_mutex, &deadline);
+    unsigned int timeout_ns = 10 * 1000 * 1000 /* 10ms */;
+    unsigned int tv_nsec_limit = 1000 * 1000 * 1000 /* 1s */;
+    if ((deadline.tv_nsec + timeout_ns) < tv_nsec_limit) {
+      deadline.tv_nsec += timeout_ns;
+    } else {
+      deadline.tv_nsec = (deadline.tv_nsec + timeout_ns) % tv_nsec_limit;
+      deadline.tv_sec++;
+    }
+
+    int error = pthread_cond_timedwait(&holding_the_gvl_signal_handler_executed, &holding_the_gvl_signal_handler_mutex, &deadline);
+    if (error && error != ETIMEDOUT) {
+      rb_exc_raise(rb_syserr_new_str(error, rb_sprintf("Unexpected failure in _native_trigger_holding_the_gvl_signal_handler_on")));
+    }
   }
 
   pthread_mutex_unlock(&holding_the_gvl_signal_handler_mutex);

--- a/ext/ddtrace_profiling_native_extension/setup_signal_handler.c
+++ b/ext/ddtrace_profiling_native_extension/setup_signal_handler.c
@@ -93,7 +93,7 @@ static void toggle_sigprof_signal_handler_for_current_thread(int action) {
   sigemptyset(&signals_to_toggle);
   sigaddset(&signals_to_toggle, SIGPROF);
   int error = pthread_sigmask(action, &signals_to_toggle, NULL);
-  if (error) rb_exc_raise(rb_syserr_new_str(errno, rb_sprintf("Unexpected failure in pthread_sigmask, action=%d", action)));
+  if (error) rb_exc_raise(rb_syserr_new_str(error, rb_sprintf("Unexpected failure in pthread_sigmask, action=%d", action)));
 }
 
 void block_sigprof_signal_handler_from_running_in_current_thread(void) {
@@ -108,6 +108,6 @@ VALUE is_sigprof_blocked_in_current_thread(void) {
   sigset_t current_signals;
   sigemptyset(&current_signals);
   int error = pthread_sigmask(0, NULL, &current_signals);
-  if (error) rb_exc_raise(rb_syserr_new_str(errno, rb_sprintf("Unexpected failure in is_sigprof_blocked_in_current_thread")));
+  if (error) rb_exc_raise(rb_syserr_new_str(error, rb_sprintf("Unexpected failure in is_sigprof_blocked_in_current_thread")));
   return sigismember(&current_signals, SIGPROF) ? Qtrue : Qfalse;
 }

--- a/ext/ddtrace_profiling_native_extension/setup_signal_handler.h
+++ b/ext/ddtrace_profiling_native_extension/setup_signal_handler.h
@@ -7,3 +7,5 @@ void install_sigprof_signal_handler(void (*signal_handler_function)(int, siginfo
 void replace_sigprof_signal_handler_with_empty_handler(void (*expected_existing_handler)(int, siginfo_t *, void *));
 void remove_sigprof_signal_handler(void);
 void block_sigprof_signal_handler_from_running_in_current_thread(void);
+void unblock_sigprof_signal_handler_from_running_in_current_thread(void);
+VALUE is_sigprof_blocked_in_current_thread(void);

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -62,7 +62,6 @@ module Datadog
 
             return unless @worker_thread
 
-            @worker_thread.kill
             self.class._native_stop(self)
 
             @worker_thread.join

--- a/spec/datadog/profiling/collectors/interesting_backtrace_helper.rb
+++ b/spec/datadog/profiling/collectors/interesting_backtrace_helper.rb
@@ -135,6 +135,7 @@ module IbhMoreGlobals
 end
 
 def ibh_method_with_complex_parameters(a, b = nil, *c, (d), f:, g: nil, **h, &i)
+  d.to_s
   $ibh_anonymous_module.hello
 end
 


### PR DESCRIPTION
[PROF-6556] Fix profiler issue due to Ruby native thread reuse

**What does this PR do?**:

This PR fixes an issue that caused Ruby threads to inherit SIGPROF blocking from the `CpuAndWallTimeWorker` worker thread.

The issue is caused by an interaction with Ruby's native thread cache. When a Ruby `Thread` dies, Ruby does not immediately kill the underlying OS native thread.

Instead, it keeps it around for some time, and if another Ruby `Thread` starts in the meanwhile, it reuses the OS native thread, rather than getting a new one.

This can be observed easily starting on Ruby 3.1+ which actually added a method to observe the native thread id:

```ruby
puts RUBY_DESCRIPTION

puts Thread.new { Thread.current.native_thread_id }.value
puts Thread.new { Thread.current.native_thread_id }.value
puts Thread.new { Thread.current.native_thread_id }.value

puts "Sleeping for a bit..."
sleep 6

puts Thread.new { Thread.current.native_thread_id }.value
```

result:

```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-darwin20]
293997
293997
293997
Sleeping for a bit...
294151
```

(Note that this behavior is much older than Ruby 3.1, but  `#native_thread_id` was only introduced on that version).

The issue fixed by this PR was that the profiler blocked all SIGPROF signal delivery on its worker thread, because SIGPROF signals should never land on it.

After the profiler was stopped, its worker `Thread` died, but Ruby could decide to reuse the OS native thread, which meant that a random `Thread` instance created shortly after stopping the profiler could "inherit" the SIGPROF blocking.

This is definitely not intended and actually caused a recently-introduced spec to become flaky, because the test created a new `Thread` and that thread was inheriting the SIGPROF blocking.

```
Run options: include {:focus=>true, :ids=>{"./spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb"=>["1:2:7:1"], "./spec/datadog/profiling/native_extension_spec.rb"=>["1:5:3:1"]}}

Randomized with seed 19584

Datadog::Profiling::Collectors::CpuAndWallTimeWorker
  #start
    when a previous signal handler existed
      does not start the sampling loop

Datadog::Profiling::NativeExtension
  is_current_thread_holding_the_gvl
    correctness
      returns accurate results when compared to ruby_thread_has_gvl_p (FAILED - 1)

Failures:

  1) Datadog::Profiling::NativeExtension is_current_thread_holding_the_gvl correctness returns accurate results when compared to ruby_thread_has_gvl_p
     Failure/Error:
       result = Datadog::Profiling::NativeExtension::Testing
         ._native_trigger_holding_the_gvl_signal_handler_on(background_thread)

     RuntimeError:
       Could not signal background_thread
     # ./spec/datadog/profiling/native_extension_spec.rb:255:in `_native_trigger_holding_the_gvl_signal_handler_on'
     # ./spec/datadog/profiling/native_extension_spec.rb:255:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:216:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:108:in `block (2 levels) in <top (required)>'
     # /Users/ivo.anjo/.rvm/gems/ruby-2.7.6/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'

```

To fix this issue, I've refactored the setup and teardown of the `CpuAndWallTimeWorker` to make sure all clean up code runs correctly AND added a new clean up step to re-enable SIGPROF signal delivery on the worker `Thread` before it dies.

**Motivation**:

Beyond fixing the flaky test, this issue could cause the profiler to not be able to take samples, if e.g. a customer app was doing all its work on a `Thread` that happened to get SIGPROF signal delivery blocked.

**Additional Notes**:

The native thread reuse mechanism is interesting, but I wonder how many native gems have bugs hidden where they store things per-native-thread and forget that this can happen.

This PR is on top of #2415 (and the flaky test is introduced on that PR).

GitHub seems to be having issues with their container hosting, so CircleCI is not able to run CI. I'll re-trigger CI later.

**How to test the change?**:

Change includes test coverage.

[PROF-6556]: https://datadoghq.atlassian.net/browse/PROF-6556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ