### PR TITLE
Allow `debase-ruby_core_source` 0.10.18 to be used

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |spec|
   # forward.
   #
   # We're pinning it at the latest available version and will manually bump the dependency as needed.
-  spec.add_dependency 'debase-ruby_core_source', '>= 0.10.16', '<= 0.10.17'
+  spec.add_dependency 'debase-ruby_core_source', '>= 0.10.16', '<= 0.10.18'
 
   # Used by appsec
   spec.add_dependency 'libddwaf', '~> 1.5.1.0.0'


### PR DESCRIPTION
**What does this PR do?**:

Allow the latest `debase-ruby_core_source` version to be used by dd-trace-rb.

**Motivation**:

As discussed in #1740, we decided to pin the range of versions of `debase-ruby_core_source` we use, so that we can validate each version as it comes out.

The changes on 0.10.18
(<https://my.diffend.io/gems/debase-ruby_core_source/0.10.17/0.10.18>) don't impact dd-trace-rb, because they only affect Ruby 3.2-preview3 and we don't use `debase-ruby_core_source` on Ruby >= 2.6.

Nevertheless, it's important we keep our version up-to-date as customers may need the latest version of `debase-ruby_core_source` for other gems they use.

**Additional Notes**:

(None)

**How to test the change?**:

CI should still be green for all supported Ruby versions.
