### PR TITLE
[PROF-6556] Refactor profiling global variables

### DIFF
--- a/spec/datadog/profiling/integration_spec.rb
+++ b/spec/datadog/profiling/integration_spec.rb
@@ -120,8 +120,9 @@ RSpec.describe 'profiling integration test' do
           @current_span = span
           @current_root_span = trace.send(:root_span)
           example.run
+
+          Datadog::Tracing.shutdown!
         end
-        Datadog::Tracing.shutdown!
       end
 
       let(:tracer) { Datadog::Tracing.send(:tracer) }

--- a/spec/datadog/profiling/tasks/setup_spec.rb
+++ b/spec/datadog/profiling/tasks/setup_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Datadog::Profiling::Tasks::Setup do
 
     before do
       described_class::ACTIVATE_EXTENSIONS_ONLY_ONCE.send(:reset_ran_once_state_for_tests)
+
+      allow(task).to receive(:check_if_cpu_time_profiling_is_supported)
     end
 
     it 'actives the forking extension before setting up the at_fork hooks' do


### PR DESCRIPTION
**What does this PR do?**:

This PR adds a new global variable, `active_sampler_instance_state`, that is easier and cheaper to access during profiling to look up and record information. It then changes previous usages of `active_sampler_instance` to use this new one directly.

Finally, the `active_sampler_owner_thread` global variable was removed, and it was moved inside the state.

**Motivation**:

When the profiler is enabled, it keeps a reference to its state on a global variable. This is needed because in some contexts (e.g. signal handling) we don't have a good way to pass in the current state as an argument.

Up until now, we were only storing the `active_sampler_instance`, e.g. the Ruby `VALUE` from which we can extract the `CpuAndWallTimeWorker` state.

But... this got really awkward, and potentially more expensive, as in a bunch of places on the `CpuAndWallTimeWorker` we keep needing to do `rb_typeddata_is_kind_of` and `TypedData_Get_struct`.

To simplify this, we now store a direct pointer to the `CpuAndWallTimeWorker` state.

**Additional Notes**:

This PR also includes a few unrelated spec tweaks that I've extracted from my branch. See individual commits for details.

This PR is on top of #2436 to avoid merge conflicts. It is otherwise independent.

**How to test the change?**:

This refactor did not change any behavior, so the existing tests being green signal it's working correctly.