### PR TITLE
[PROF-6556] Directly send SIGPROF signals to thread holding Global VM Lock

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -368,6 +368,9 @@ static void *run_sampling_trigger_loop(void *state_ptr) {
 
     current_gvl_owner owner = gvl_owner();
     if (owner.valid) {
+      // Note that reading the GVL owner and sending them a signal is a race -- the Ruby VM keeps on executing while
+      // we're doing this, so we may still not signal the correct thread from time to time, but our signal handler
+      // includes a check to see if it got called in the right thread
       pthread_kill(owner.owner, SIGPROF);
     } else {
       // TODO: This is not a great "plan B", will be improved on a later PR


### PR DESCRIPTION
**What does this PR do?**:

This PR changes the `CpuAndWallTimeWorker` so that it triggers sampling by sending a SIGPROF signal directly to the thread that is holding the Global VM Lock.

Previously, we would instead send a SIGPROF to the entire Ruby process.

Note that reading the GVL owner and sending them a signal is a race -- the Ruby VM keeps on executing while we're doing this, so we may still not signal the correct thread from time to time, but the profiler is built to handle this correctly.

**Motivation**:

The previous "send a SIGPROF to the entire process" approach could cause the profiler to miss a lot of samples, because the signal handler would not be called on the right thread.

I observed that at least on my local development machine, the signals tended to land on the Ruby main thread, and if that thread was sleeping, then the profiler would not sample (or not sample as often as expected), even if some other background thread was very busy working.

Furthermore, because signal delivery can interrupt system calls, targetting the right thread will hopefully mean less system calls interrupted needlessly.

**Additional Notes**:

This PR is atop #2437 because it uses the newly-added stats for testing, and atop #2415 because it needs `gvl_owner`.

**How to test the change?**:

Testing this change is non-trivial. I decided to use the `CpuAndWallTimeWorker` stats to validate that for a known-problematic situation (background thread busy + main thread idle) that we took enough samples and targetted the right thread most of the time.