### PR TITLE
Fix using legacy C definitions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,6 +194,7 @@ services:
       - TEST_REDIS_HOST=redis
       - TEST_REDIS_OLD_HOST=redis_old
       - TEST_REDIS_OLD_PORT=6379
+      - DDTRACE_CI=true
     stdin_open: true
     tty: true
     volumes:

--- a/ext/ddtrace_profiling_loader/extconf.rb
+++ b/ext/ddtrace_profiling_loader/extconf.rb
@@ -34,7 +34,7 @@ add_compiler_flag '-Werror' if ENV['DDTRACE_CI'] == 'true'
 #   (https://github.com/msgpack/msgpack-ruby/blob/18ce08f6d612fe973843c366ac9a0b74c4e50599/ext/msgpack/extconf.rb#L8)
 add_compiler_flag '-std=gnu99'
 
-# Gets really noisy when we include the MJIT header, let's omit it
+# Gets really noisy when we include the MJIT header, let's omit it (TODO: Use #pragma GCC diagnostic instead?)
 add_compiler_flag '-Wno-unused-function'
 
 # Allow defining variables at any point in a function
@@ -54,6 +54,9 @@ add_compiler_flag '-Wunused-parameter'
 # By setting this compiler flag, we tell it to assume that everything is private unless explicitly stated.
 # For more details see https://gcc.gnu.org/wiki/Visibility
 add_compiler_flag '-fvisibility=hidden'
+
+# Avoid legacy C definitions
+add_compiler_flag '-Wold-style-definition'
 
 # Enable all other compiler warnings
 add_compiler_flag '-Wall'

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -87,7 +87,7 @@ add_compiler_flag '-Werror' if ENV['DDTRACE_CI'] == 'true'
 #   (https://github.com/msgpack/msgpack-ruby/blob/18ce08f6d612fe973843c366ac9a0b74c4e50599/ext/msgpack/extconf.rb#L8)
 add_compiler_flag '-std=gnu99'
 
-# Gets really noisy when we include the MJIT header, let's omit it
+# Gets really noisy when we include the MJIT header, let's omit it (TODO: Use #pragma GCC diagnostic instead?)
 add_compiler_flag '-Wno-unused-function'
 
 # Allow defining variables at any point in a function
@@ -107,6 +107,9 @@ add_compiler_flag '-Wunused-parameter'
 # By setting this compiler flag, we tell it to assume that everything is private unless explicitly stated.
 # For more details see https://gcc.gnu.org/wiki/Visibility
 add_compiler_flag '-fvisibility=hidden'
+
+# Avoid legacy C definitions
+add_compiler_flag '-Wold-style-definition'
 
 # Enable all other compiler warnings
 add_compiler_flag '-Wall'

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -175,7 +175,7 @@ static VALUE _native_active_slot(DDTRACE_UNUSED VALUE _self, VALUE recorder_inst
 static VALUE _native_is_slot_one_mutex_locked(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE _native_is_slot_two_mutex_locked(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE test_slot_mutex_state(VALUE recorder_instance, int slot);
-static ddog_Timespec time_now();
+static ddog_Timespec time_now(void);
 static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE recorder_instance);
 static void serializer_set_start_timestamp_for_next_profile(struct stack_recorder_state *state, ddog_Timespec timestamp);
 static VALUE _native_record_endpoint(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE local_root_span_id, VALUE endpoint);
@@ -449,7 +449,7 @@ static VALUE test_slot_mutex_state(VALUE recorder_instance, int slot) {
 }
 
 // Note that this is using CLOCK_REALTIME (e.g. actual time since unix epoch) and not the CLOCK_MONOTONIC as we use in other parts of the codebase
-static ddog_Timespec time_now() {
+static ddog_Timespec time_now(void) {
   struct timespec current_time;
 
   if (clock_gettime(CLOCK_REALTIME, &current_time) != 0) rb_sys_fail("Failed to read CLOCK_REALTIME");


### PR DESCRIPTION
**What does this PR do?**:

This PR fixes one case where we were using a legacy style for defining a C function + explicitly enables compiler warnings for these kinds of legacy definitions.

**Motivation**:

We want to avoid the use of legacy definitions, to avoid issues moving to future compilers and/or future C language versions (C11 I'm looking at you).

**Additional Notes**:

For some reason `-Wall -Wextra` did not enable these compiler warnings. I'll be on the look out for more warnings that we can also enable.

**How to test the change?**:

Validate that CI is still green.