### PR TITLE
Remove ruby platform check for sorbet dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,8 +88,8 @@ end
 # Sorbet releases almost daily, with new checks introduced that can make a
 # previously-passing codebase start failing. Thus, we need to lock to a specific
 # version and bump it from time to time.
-# Also, there's no support for windows
-if RUBY_VERSION >= '2.4.0' && (RUBY_PLATFORM =~ /^x86_64-(darwin|linux)/)
+# Also, there's no support for windows, but M1 Mac with `arm64-darwin21` architecture is doing fine
+if RUBY_VERSION >= '2.4.0'
   gem 'sorbet', '= 0.5.9672'
   gem 'spoom', '~> 1.1'
 end


### PR DESCRIPTION
**What does this PR do?**

With the ruby platform check, the appraisal lockfile would always end up with difference. However, currently we are using a compatible version that could be installed on `x86` or `arm64-darwin21` from M1 Mac. So we could remove this conditional 

**How to test this**

With M1 Mac, `bundle install && bundle exec rake typecheck` 