### PR TITLE
Lock protobuf dependency with cucumber

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -20,7 +20,23 @@ end
 
 def self.gem_cucumber(version)
   appraise "cucumber#{version}" do
-    gem 'cucumber', ">=#{version}.0.0", "<#{version + 1}.0.0"
+    gem 'cucumber', "~>#{version}"
+
+    # Locks the profiler's protobuf dependency to avoid conflict with cucumber.
+    # Without this, we can get this error:
+    # > TypeError:
+    # >   superclass mismatch for class FileDescriptorSet
+    # This happens because cucumber has its own Protobuf gem (`protobuf-cucumber`)
+    # that conflicts with `google-protobuf`: the load slightly different version of the same classes.
+    # Locking them together ensures they don't have conflicting class declaration.
+    # This only affects: 4.0.0 >= cucumber > 7.0.0.
+    #
+    # DEV: Ideally, the profiler would not be loaded when running cucumber tests as it is unrelated.
+    if Gem::Version.new(version) >= Gem::Version.new('4.0.0') &&
+      Gem::Version.new(version) < Gem::Version.new('7.0.0')
+      gem 'google-protobuf', '3.10.1' if RUBY_PLATFORM != 'java'
+      gem 'protobuf-cucumber', '3.10.8'
+    end
   end
 end
 

--- a/gemfiles/jruby_9.2.21.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_cucumber3.gemfile.lock
@@ -156,7 +156,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 3.0.0, < 4.0.0)
+  cucumber (~> 3)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   json-schema (< 3)

--- a/gemfiles/jruby_9.2.21.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_cucumber4.gemfile.lock
@@ -189,7 +189,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 4.0.0, < 5.0.0)
+  cucumber (~> 4)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   json-schema (< 3)
@@ -197,6 +197,7 @@ DEPENDENCIES
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-debugger-jruby
   rake (>= 10.5)

--- a/gemfiles/jruby_9.2.21.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_cucumber5.gemfile.lock
@@ -189,7 +189,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 5.0.0, < 6.0.0)
+  cucumber (~> 5)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   json-schema (< 3)
@@ -197,6 +197,7 @@ DEPENDENCIES
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-debugger-jruby
   rake (>= 10.5)

--- a/gemfiles/jruby_9.2.8.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber3.gemfile.lock
@@ -156,7 +156,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 3.0.0, < 4.0.0)
+  cucumber (~> 3)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   json-schema (< 3)
@@ -182,4 +182,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber4.gemfile.lock
@@ -189,7 +189,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 4.0.0, < 5.0.0)
+  cucumber (~> 4)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   json-schema (< 3)
@@ -197,6 +197,7 @@ DEPENDENCIES
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-debugger-jruby
   rake (>= 10.5)
@@ -215,4 +216,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber5.gemfile.lock
@@ -189,7 +189,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 5.0.0, < 6.0.0)
+  cucumber (~> 5)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   json-schema (< 3)
@@ -197,6 +197,7 @@ DEPENDENCIES
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-debugger-jruby
   rake (>= 10.5)
@@ -215,4 +216,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.3.9.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_cucumber3.gemfile.lock
@@ -156,7 +156,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 3.0.0, < 4.0.0)
+  cucumber (~> 3)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   json-schema (< 3)

--- a/gemfiles/jruby_9.3.9.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_cucumber4.gemfile.lock
@@ -189,7 +189,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 4.0.0, < 5.0.0)
+  cucumber (~> 4)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   json-schema (< 3)
@@ -197,6 +197,7 @@ DEPENDENCIES
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-debugger-jruby
   rake (>= 10.5)

--- a/gemfiles/jruby_9.3.9.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_cucumber5.gemfile.lock
@@ -189,7 +189,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 5.0.0, < 6.0.0)
+  cucumber (~> 5)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   json-schema (< 3)
@@ -197,6 +197,7 @@ DEPENDENCIES
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-debugger-jruby
   rake (>= 10.5)

--- a/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
@@ -122,7 +122,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 3.0.0, < 4.0.0)
+  cucumber (~> 3)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)

--- a/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
@@ -69,7 +69,7 @@ GEM
     dogstatsd-ruby (5.4.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.19.1)
+    google-protobuf (3.10.1)
     hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
@@ -153,16 +153,17 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 4.0.0, < 5.0.0)
+  cucumber (~> 4)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
-  google-protobuf (~> 3.0, < 3.19.2, != 3.7.1, != 3.7.0)
+  google-protobuf (= 3.10.1)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-nav
   pry-stack_explorer

--- a/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
@@ -166,7 +166,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 3.0.0, < 4.0.0)
+  cucumber (~> 3)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)

--- a/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
@@ -72,8 +72,8 @@ GEM
     dogstatsd-ruby (5.4.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.19.1)
-    google-protobuf (3.19.1-x86_64-linux)
+    google-protobuf (3.10.1)
+    google-protobuf (3.10.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
@@ -197,16 +197,17 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 4.0.0, < 5.0.0)
+  cucumber (~> 4)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
-  google-protobuf (~> 3.0, < 3.19.2, != 3.7.1, != 3.7.0)
+  google-protobuf (= 3.10.1)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-nav
   pry-stack_explorer

--- a/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
@@ -174,7 +174,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 3.0.0, < 4.0.0)
+  cucumber (~> 3)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)

--- a/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
@@ -83,8 +83,8 @@ GEM
     dogstatsd-ruby (5.4.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.19.4)
-    google-protobuf (3.19.4-x86_64-linux)
+    google-protobuf (3.10.1)
+    google-protobuf (3.10.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
@@ -207,16 +207,17 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 4.0.0, < 5.0.0)
+  cucumber (~> 4)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
-  google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
+  google-protobuf (= 3.10.1)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-nav
   pry-stack_explorer

--- a/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
@@ -83,8 +83,8 @@ GEM
     dogstatsd-ruby (5.4.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.19.4)
-    google-protobuf (3.19.4-x86_64-linux)
+    google-protobuf (3.10.1)
+    google-protobuf (3.10.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
@@ -207,16 +207,17 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 5.0.0, < 6.0.0)
+  cucumber (~> 5)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
-  google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
+  google-protobuf (= 3.10.1)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-nav
   pry-stack_explorer

--- a/gemfiles/ruby_2.6.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_cucumber3.gemfile.lock
@@ -178,7 +178,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 3.0.0, < 4.0.0)
+  cucumber (~> 3)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)

--- a/gemfiles/ruby_2.6.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_cucumber4.gemfile.lock
@@ -84,8 +84,8 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.9)
-    google-protobuf (3.21.9-x86_64-linux)
+    google-protobuf (3.10.1)
+    google-protobuf (3.10.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -211,16 +211,17 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 4.0.0, < 5.0.0)
+  cucumber (~> 4)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
-  google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
+  google-protobuf (= 3.10.1)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-byebug
   pry-stack_explorer

--- a/gemfiles/ruby_2.6.10_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_cucumber5.gemfile.lock
@@ -84,8 +84,8 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.9)
-    google-protobuf (3.21.9-x86_64-linux)
+    google-protobuf (3.10.1)
+    google-protobuf (3.10.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -211,16 +211,17 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 5.0.0, < 6.0.0)
+  cucumber (~> 5)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
-  google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
+  google-protobuf (= 3.10.1)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-byebug
   pry-stack_explorer

--- a/gemfiles/ruby_2.7.6_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber3.gemfile.lock
@@ -178,7 +178,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 3.0.0, < 4.0.0)
+  cucumber (~> 3)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)

--- a/gemfiles/ruby_2.7.6_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber4.gemfile.lock
@@ -83,8 +83,8 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.9)
-    google-protobuf (3.21.9-x86_64-linux)
+    google-protobuf (3.10.1)
+    google-protobuf (3.10.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -209,16 +209,17 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 4.0.0, < 5.0.0)
+  cucumber (~> 4)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
-  google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
+  google-protobuf (= 3.10.1)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-byebug
   pry-stack_explorer

--- a/gemfiles/ruby_2.7.6_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber5.gemfile.lock
@@ -83,8 +83,8 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.9)
-    google-protobuf (3.21.9-x86_64-linux)
+    google-protobuf (3.10.1)
+    google-protobuf (3.10.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -209,16 +209,17 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 5.0.0, < 6.0.0)
+  cucumber (~> 5)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
-  google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
+  google-protobuf (= 3.10.1)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-byebug
   pry-stack_explorer

--- a/gemfiles/ruby_3.0.4_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber3.gemfile.lock
@@ -178,7 +178,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 3.0.0, < 4.0.0)
+  cucumber (~> 3)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)

--- a/gemfiles/ruby_3.0.4_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber4.gemfile.lock
@@ -83,8 +83,8 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.9)
-    google-protobuf (3.21.9-x86_64-linux)
+    google-protobuf (3.10.1)
+    google-protobuf (3.10.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -209,16 +209,17 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 4.0.0, < 5.0.0)
+  cucumber (~> 4)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
-  google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
+  google-protobuf (= 3.10.1)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-byebug
   pry-stack_explorer

--- a/gemfiles/ruby_3.0.4_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber5.gemfile.lock
@@ -83,8 +83,8 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.9)
-    google-protobuf (3.21.9-x86_64-linux)
+    google-protobuf (3.10.1)
+    google-protobuf (3.10.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -209,16 +209,17 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 5.0.0, < 6.0.0)
+  cucumber (~> 5)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
-  google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
+  google-protobuf (= 3.10.1)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-byebug
   pry-stack_explorer

--- a/gemfiles/ruby_3.1.2_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber3.gemfile.lock
@@ -175,7 +175,7 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 3.0.0, < 4.0.0)
+  cucumber (~> 3)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)

--- a/gemfiles/ruby_3.1.2_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber4.gemfile.lock
@@ -83,7 +83,8 @@ GEM
     dogstatsd-ruby (5.4.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.19.4)
+    google-protobuf (3.10.1)
+    google-protobuf (3.10.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
@@ -206,16 +207,17 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 4.0.0, < 5.0.0)
+  cucumber (~> 4)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
-  google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
+  google-protobuf (= 3.10.1)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-byebug
   pry-stack_explorer

--- a/gemfiles/ruby_3.1.2_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber5.gemfile.lock
@@ -83,7 +83,8 @@ GEM
     dogstatsd-ruby (5.4.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.19.4)
+    google-protobuf (3.10.1)
+    google-protobuf (3.10.1-x86_64-linux)
     hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
@@ -206,16 +207,17 @@ DEPENDENCIES
   builder
   climate_control (~> 0.2.0)
   concurrent-ruby
-  cucumber (>= 5.0.0, < 6.0.0)
+  cucumber (~> 5)
   ddtrace!
   dogstatsd-ruby (>= 3.3.0, != 5.1.0, != 5.0.1, != 5.0.0)
   extlz4 (~> 0.3, >= 0.3.3)
-  google-protobuf (~> 3.0, != 3.7.1, != 3.7.0)
+  google-protobuf (= 3.10.1)
   json-schema (< 3)
   memory_profiler (~> 0.9)
   opentracing (>= 0.4.1)
   os (~> 1.1)
   pimpmychangelog (>= 0.1.2)
+  protobuf-cucumber (= 3.10.8)
   pry
   pry-byebug
   pry-stack_explorer


### PR DESCRIPTION
This PR fixes [this CI error](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/8141/workflows/590d3b00-0541-4b10-9469-262cffdcba34/jobs/302412) that surfaced recently:
```
TypeError:
  superclass mismatch for class FileDescriptorSet
# /usr/local/bundle/gems/protobuf-cucumber-3.10.8/lib/protobuf/descriptors/google/protobuf/descriptor.pb.rb:15:in `<module:Protobuf>'
# /usr/local/bundle/gems/protobuf-cucumber-3.10.8/lib/protobuf/descriptors/google/protobuf/descriptor.pb.rb:9:in `<module:Google>'
# /usr/local/bundle/gems/protobuf-cucumber-3.10.8/lib/protobuf/descriptors/google/protobuf/descriptor.pb.rb:8:in `<top (required)>'
# /usr/local/bundle/gems/protobuf-cucumber-3.10.8/lib/protobuf/descriptors.rb:2:in `require'
# /usr/local/bundle/gems/protobuf-cucumber-3.10.8/lib/protobuf/descriptors.rb:2:in `<top (required)>'
# /usr/local/bundle/gems/protobuf-cucumber-3.10.8/lib/protobuf.rb:44:in `require'
# /usr/local/bundle/gems/protobuf-cucumber-3.10.8/lib/protobuf.rb:44:in `<top (required)>'
# /usr/local/bundle/gems/cucumber-messages-13.2.1/lib/cucumber/messages.pb.rb:6:in `require'
# /usr/local/bundle/gems/cucumber-messages-13.2.1/lib/cucumber/messages.pb.rb:6:in `<top (required)>'
# /usr/local/bundle/gems/cucumber-messages-13.2.1/lib/cucumber/messages.rb:1:in `require'
# /usr/local/bundle/gems/cucumber-messages-13.2.1/lib/cucumber/messages.rb:1:in `<top (required)>'
# /usr/local/bundle/gems/cucumber-5.3.0/lib/cucumber/configuration.rb:6:in `require'
# /usr/local/bundle/gems/cucumber-5.3.0/lib/cucumber/configuration.rb:6:in `<top (required)>'
# /usr/local/bundle/gems/cucumber-5.3.0/lib/cucumber/runtime.rb:4:in `require'
# /usr/local/bundle/gems/cucumber-5.3.0/lib/cucumber/runtime.rb:4:in `<top (required)>'
# /usr/local/bundle/gems/cucumber-5.3.0/lib/cucumber.rb:6:in `require'
# /usr/local/bundle/gems/cucumber-5.3.0/lib/cucumber.rb:6:in `<top (required)>'
# ./spec/datadog/ci/contrib/cucumber/patcher_spec.rb:6:in `require'
# ./spec/datadog/ci/contrib/cucumber/patcher_spec.rb:6:in `<top (required)>'
```

This happens because some versions of `cucumber` have their own version of the protobuf gem: [`protobuf-cucumber`](https://rubygems.org/gems/protobuf-cucumber). This version can conflict with the official `google-protobuf` gem when both are installed.

This only affects: 4.0.0 >= `cucumber` > 7.0.0.

This PR locks both `google-protobuf` and `protobuf-cucumber` to compatible gem versions for affected versions of `cucumber`.