### PR TITLE
Add static type checking via RBS + Steep

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,4 +10,4 @@ jobs:
         with:
           ruby-version: '3.1'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - run: bundle exec steep check || true
+      - run: bundle exec steep check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,13 @@
+name: Check
+on: [push]
+jobs:
+  check:
+    name: Check types
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@6148f408d35df04b0189be5e64c1458377b8ae13 # v1.114.0
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - run: bundle exec steep check || true

--- a/Appraisals
+++ b/Appraisals
@@ -1694,3 +1694,5 @@ ruby_runtime = if defined?(RUBY_ENGINE_VERSION)
 appraisals.each do |appraisal|
   appraisal.name.prepend("#{ruby_runtime}-")
 end
+
+# vim: ft=ruby

--- a/Gemfile
+++ b/Gemfile
@@ -84,18 +84,20 @@ if RUBY_PLATFORM != 'java'
   end
 end
 
-# For type checking
-# Sorbet releases almost daily, with new checks introduced that can make a
-# previously-passing codebase start failing. Thus, we need to lock to a specific
-# version and bump it from time to time.
-# Also, there's no support for windows
-if RUBY_VERSION >= '2.4.0' && (RUBY_PLATFORM =~ /^x86_64-(darwin|linux)/)
-  gem 'sorbet', '= 0.5.9672'
-  gem 'spoom', '~> 1.1'
-end
+group :check do
+  # For type checking
+  # Sorbet releases almost daily, with new checks introduced that can make a
+  # previously-passing codebase start failing. Thus, we need to lock to a specific
+  # version and bump it from time to time.
+  # Also, there's no support for windows
+  if RUBY_VERSION >= '2.4.0' && (RUBY_PLATFORM =~ /^x86_64-(darwin|linux)/)
+    gem 'sorbet', '= 0.5.9672'
+    gem 'spoom', '~> 1.1'
+  end
 
-# type checking with steep
-if RUBY_VERSION >= '2.6.0' && RUBY_PLATFORM != 'java'
-  gem 'rbs', '~> 2.8.1', require: false
-  gem 'steep', '~> 1.3.0', require: false
+  # type checking with steep
+  if RUBY_VERSION >= '2.6.0' && RUBY_PLATFORM != 'java'
+    gem 'rbs', '~> 2.8.1', require: false
+    gem 'steep', '~> 1.3.0', require: false
+  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -93,3 +93,9 @@ if RUBY_VERSION >= '2.4.0' && (RUBY_PLATFORM =~ /^x86_64-(darwin|linux)/)
   gem 'sorbet', '= 0.5.9672'
   gem 'spoom', '~> 1.1'
 end
+
+# type checking with steep
+if RUBY_VERSION >= '2.6.0' && RUBY_PLATFORM != 'java'
+  gem 'rbs', '~> 2.8.1', require: false
+  gem 'steep', '~> 1.3.0', require: false
+end

--- a/Steepfile
+++ b/Steepfile
@@ -1,0 +1,14 @@
+target :appsec do
+  signature "sig"
+
+  check "lib/datadog/appsec"
+  ignore "lib/datadog/appsec/contrib"
+
+  library "pathname", "set"
+  library "cgi"
+  library "logger", "monitor"
+  library "tsort"
+  library "json"
+
+  #gem 'libddwaf'
+end

--- a/Steepfile
+++ b/Steepfile
@@ -10,5 +10,12 @@ target :appsec do
   library "tsort"
   library "json"
 
-  #gem 'libddwaf'
+  # TODO: gem 'libddwaf'
+
+  repo_path "vendor/rbs"
+  library "ffi"
+  library "jruby"
+  library "gem"
+  library "rails"
+  library "sinatra"
 end

--- a/docs/StaticTypingGuide.md
+++ b/docs/StaticTypingGuide.md
@@ -1,0 +1,193 @@
+# Stating Typing Guide
+
+Static typing description is achieved via Ruby core [RBS](https://github.com/ruby/rbs).
+
+Static type checking is achieved via [Steep](https://github.com/soutaro/steep).
+
+## Quick start
+
+
+### Run the type check
+
+```
+bundle exec steep check [sources]
+```
+
+The `sources` arguments are optional and used to scope type checking to a smaller set of files or directories.
+
+### Generate type signature skeleton
+
+```
+bundle exec rbs prototype rb [source files]
+```
+
+Outputs `.rbs` content on stdout. The `source files` arguments lists the files from which the skeleton will be statically built from parsing. No evaluation occurs, therefore this has limited typing analysis capability, typically resulting in a lot of `untyped`.
+
+Note: Comments are reproduced as is which is useful for a visual check but should be manually removed when moving the skeleton to a `.rbs` file, because of the duplication and risk of comments getting desynced.
+
+## Layout
+
+Ruby code in `.rb` files are, as is customary for a gem, stored in `lib`.
+
+While RBS type annotations could be put inline, this creates a lot of noise, hampering "pure Ruby" readability. While the closeness with the code itself may look like an advantage, such annotations live in comments, which are harder to read and mix with other comments.
+
+RBS types can be described in any number of `.rbs` files, stored in `sig`. These files can be generated, syntax highlighted, checked, linted, and more. This is therefore the chosen approach.
+
+While the presence of `.rb` and `.rbs` files is entirely decoupled, here we choose to have one `.rbs` file per `.rb` file, mirroring the `lib` structure in `sig`. This has a number of advantages such as tracking typing progress, noticing stale files, generating new files without messing with existing type information, configuring IDEs and editors to jump from source to signature and back...
+
+Tools such as `rbs prototype` output comments. These should be removed, and only comments relevant to typing should end up in `.rbs` files.
+
+## Progressive typing
+
+Similar to many other Ruby tools, Steep reads project configuration from a DSL in `Steepfile`. We will use that to allow progressive typing.
+
+### Type checking vs signature loading
+
+Steep distinguishes between loading signatures and actually checking code for signatures. This is extremely useful to progressively type code, limiting check scope while still being able to provide signatures to code that can't be fully checked yet.
+
+```
+target :default do
+  signature "sig"           # ALL signatures from this directory will be loaded
+
+  check "lib/foo/bar"       # ONLY this source code folder will be checked against, using ALL signatures above
+  ignore "lib/foo/bar/baz"  # EXCEPT this subfolder
+end
+```
+
+### Dependency signatures
+
+Steep starts with a [minimal core](https://github.com/ruby/rbs/tree/master/core) loaded type signatures. Adding more [types from the Ruby stdlib](https://github.com/ruby/rbs/tree/master/stdlib) should be done progressively as required:
+
+```
+  library "set" # adds typing for Ruby stdlib's Set
+```
+
+Note: These signatures are part of [`rbs`](), which is included in Ruby releases since Ruby 3.0.
+
+Gems can embed a `sig` directory, which can be used directly:
+
+```
+  library "some_gem_with_a_sig_dir"
+```
+
+Some gems don't have typing information.
+
+In addition, a [vast collection of gems](https://github.com/ruby/gem_rbs_collection) have been typed. These can be fetched via a Rubygems/Bundler-like feature of RBS called [collections](https://github.com/ruby/rbs/blob/e91be7275f4005b1aeac8eadc2faa2b4ad5fdfef/docs/collection.md)
+
+```
+  collection_config "rbs_collection.steep.yaml"
+```
+
+This yaml file is akin to a Gemfile, describes the sources and gem signatures to fetch, and also has a lockfile mechanism. It can also integrate with `bundler` to match the signatures with the gem versions in use.
+
+Otherwise signatures can be vendored:
+
+```
+  repo_path "vendor/rbs"
+  library "subdir"
+```
+
+Typically these are be written as needed for gems entirely missing signatures, and ideally contributed back either upstream to the gem project itself or to the gem rbs collection project.
+
+### Measuring progress
+
+With the described layout and 1:1 match, it becomes easy to track coarse-grained coverage, additions, removals, changes through refactorings, in a similar way as is usually done with unit tests or specs.
+
+In addition, to output typing detailed coverage statistics:
+
+```
+bundle exec steep stats
+```
+
+## Typing a file
+
+### Basics
+
+To type a `.rb` file without a matching `.rbs` file, start with the skeleton:
+
+```
+mkdir -p sig/foo
+bundle exec rbs prototype rb lib/foo/bar.rb > sig/foo/bar.rbs
+```
+
+One can then proceed to [adjusting the signatures](https://github.com/ruby/rbs/blob/e91be7275f4005b1aeac8eadc2faa2b4ad5fdfef/docs/syntax.md) ([by example](https://github.com/ruby/rbs/blob/e91be7275f4005b1aeac8eadc2faa2b4ad5fdfef/docs/rbs_by_example.md)), removing as much `untyped` as possible.
+
+### Type profiling
+
+To discover types, one can leverage [`typeprof`](https://github.com/ruby/typeprof). Contrary to `rbs prototype rb` which relies solely on static parsing, `typeprof` is a Ruby interpreter, except it doesn't *execute* Ruby code, merely evaluates it to track types. Entry point calls to explore the various codepaths are required.
+
+With this file:
+
+```
+# test.rb
+def foo(x)
+  p x        # reveal type of x
+
+  if x > 10
+    x.to_s
+  else
+    nil
+  end
+end
+
+foo(42)      # this call is needed otherwise there's nothing evaluated!
+foo(3)       # make sure to explore as many codepaths as possible to get best coverage
+```
+
+The following is evaluated:
+
+```
+$ typeprof test.rb
+# TypeProf 0.21.2
+
+# Revealed types
+#  foo.rb:3 #=> Integer
+
+# Classes
+class Object
+  private
+  def foo: (Integer x) -> String?
+end
+```
+
+One quick hackish way to type a class is to add a bunch of calls all the way down the file defining that class and run `typeprof` on it exploring the most interesting codepaths. This can also be achieved with a separate file requiring the one we want to type and performing calls there. In theory typeprof could be run on unit test files having 100% coverage and output precise type information for the tested code.
+
+See the [demo doc](https://github.com/ruby/typeprof/blob/26ab9108860d9a4ce050acb3422ee7721d4d50b0/doc/demo.md) for more examples and features.
+
+## Useful commands
+
+### Match `.rbs` to `.rb`
+
+```
+find sig -type f -name '*.rbs' | while read -r sig; do tmp="${sig/%.rbs/}"; lib="${tmp/#sig/lib}.rb"; test -f "${lib}" && echo -n 'OK ' || echo -n 'NO '; echo "${lib}"; done
+```
+
+For each `.rbs` file in `sig` it outputs:
+
+- `OK` when a matching `.rb` file is found in `lib`
+- `NO` when no matching `.rb` file is found in `lib`
+
+Therefore with `| grep '^NO'` it becomes easy to list `.rbs` files that have no match, so, given the layout design, these files are stale.
+
+### Match `.rb` to `.rbs`
+
+```
+find lib -name \*.rb -print | while read -r lib; do tmp="${lib/%.rb/}"; sig="${tmp/#lib/sig}.rbs"; test -f "${sig}" && echo -n 'OK ' || echo -n 'NO '; echo "${sig}"; done
+```
+
+Adjust `find` to restrict scope.
+
+For each `.rb` file in `lib` it outputs:
+
+- `OK` when a matching `.rbs` file is found in `sig`
+- `NO` when no matching `.rbs` file is found in `sig`
+
+Therefore with `| grep '^NO'` it becomes easy to list `.rb` files that have no match, so, given the layout design, these files are missing typing information.
+
+### Mass-generate missing `.rbs` skeletons
+
+Warning: you probably want to adjust that `find` to a subset of `lib`, as incomplete typing information may end up forcing you to type more things than you initially wanted to!
+
+```
+find lib -name \*.rb -print | while read -r lib; do tmp="${lib/%.rb/}"; sig="${tmp/#lib/sig}.rbs"; test -f "${sig}" || { echo "${sig}"; mkdir -p "${sig/%.rbs}"; bundle exec rbs prototype rb "${lib}" | grep -v '^ *#' > "${sig}" } done
+```

--- a/docs/StaticTypingGuide.md
+++ b/docs/StaticTypingGuide.md
@@ -1,4 +1,4 @@
-# Stating Typing Guide
+# Static Typing Guide
 
 Static typing description is achieved via Ruby core [RBS](https://github.com/ruby/rbs).
 
@@ -150,7 +150,7 @@ class Object
 end
 ```
 
-One quick hackish way to type a class is to add a bunch of calls all the way down the file defining that class and run `typeprof` on it exploring the most interesting codepaths. This can also be achieved with a separate file requiring the one we want to type and performing calls there. In theory typeprof could be run on unit test files having 100% coverage and output precise type information for the tested code.
+One quick hackish way to type a class is to add a bunch of calls all the way down the file defining that class and run `typeprof` on it exploring the most interesting codepaths. This can also be achieved with a separate file requiring the one we want to type and performing calls there. In theory `typeprof` could be run on unit test files having 100% coverage and output precise type information for the tested code.
 
 See the [demo doc](https://github.com/ruby/typeprof/blob/26ab9108860d9a4ce050acb3422ee7721d4d50b0/doc/demo.md) for more examples and features.
 

--- a/lib/datadog/appsec.rb
+++ b/lib/datadog/appsec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require_relative 'appsec/configuration'
 require_relative 'appsec/extensions'

--- a/lib/datadog/appsec/assets.rb
+++ b/lib/datadog/appsec/assets.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require 'pathname'
 

--- a/lib/datadog/appsec/configuration.rb
+++ b/lib/datadog/appsec/configuration.rb
@@ -14,7 +14,9 @@ module Datadog
 
       # Configuration DSL implementation
       class DSL
-        Instrument = Struct.new(:name, :options)
+        # Struct constant whisker cast for Steep
+        Instrument = _ = Struct.new(:name, :options)
+
         def initialize
           @instruments = []
           @options = {}

--- a/lib/datadog/appsec/configuration.rb
+++ b/lib/datadog/appsec/configuration.rb
@@ -15,7 +15,7 @@ module Datadog
       # Configuration DSL implementation
       class DSL
         # Struct constant whisker cast for Steep
-        Instrument = _ = Struct.new(:name, :options)
+        Instrument = _ = Struct.new(:name, :options) # rubocop:disable Naming/ConstantName
 
         def initialize
           @instruments = []

--- a/lib/datadog/appsec/configuration.rb
+++ b/lib/datadog/appsec/configuration.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 require_relative 'configuration/settings'
 

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -126,37 +126,45 @@ module Datadog
         end
 
         def enabled
-          @options[:enabled]
+          # Cast for Steep
+          _ = @options[:enabled]
         end
 
         def ruleset
-          @options[:ruleset]
+          # Cast for Steep
+          _ = @options[:ruleset]
         end
 
         # EXPERIMENTAL: This configurable is not meant to be publicly used, but
         #               is very useful for testing. It may change at any point in time.
         def ip_denylist
-          @options[:ip_denylist]
+          # Cast for Steep
+          _ = @options[:ip_denylist]
         end
 
         def waf_timeout
-          @options[:waf_timeout]
+          # Cast for Steep
+          _ = @options[:waf_timeout]
         end
 
         def waf_debug
-          @options[:waf_debug]
+          # Cast for Steep
+          _ = @options[:waf_debug]
         end
 
         def trace_rate_limit
-          @options[:trace_rate_limit]
+          # Cast for Steep
+          _ = @options[:trace_rate_limit]
         end
 
         def obfuscator_key_regex
-          @options[:obfuscator_key_regex]
+          # Cast for Steep
+          _ = @options[:obfuscator_key_regex]
         end
 
         def obfuscator_value_regex
-          @options[:obfuscator_value_regex]
+          # Cast for Steep
+          _ = @options[:obfuscator_value_regex]
         end
 
         def [](integration_name)

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -9,7 +9,7 @@ module Datadog
         class << self
           def boolean
             # @type ^(::String) -> bool
-            ->(v) do
+            ->(v) do # rubocop:disable Style/Lambda
               case v
               when /(1|true)/i
                 true
@@ -29,10 +29,10 @@ module Datadog
 
           def integer
             # @type ^(::String) -> ::Integer
-            ->(v) do
+            ->(v) do # rubocop:disable Style/Lambda
               case v
               when /(\d+)/
-                Integer($1)
+                Regexp.last_match(1).to_i
               else
                 raise ArgumentError, "invalid integer: #{v.inspect}"
               end
@@ -42,7 +42,7 @@ module Datadog
           # rubocop:disable Metrics/MethodLength
           def duration(base = :ns, type = :integer)
             # @type ^(::String) -> ::Integer | ::Float
-            ->(v) do
+            ->(v) do # rubocop:disable Style/Lambda
               cast = case type
                      when :integer, Integer
                        method(:Integer)
@@ -67,19 +67,19 @@ module Datadog
 
               case v
               when /^(\d+)h$/
-                cast.call($1) * 1_000_000_000 * 60 * 60 / scale
+                cast.call(Regexp.last_match(1)) * 1_000_000_000 * 60 * 60 / scale
               when /^(\d+)m$/
-                cast.call($1) * 1_000_000_000 * 60 / scale
+                cast.call(Regexp.last_match(1)) * 1_000_000_000 * 60 / scale
               when /^(\d+)s$/
-                cast.call($1) * 1_000_000_000 / scale
+                cast.call(Regexp.last_match(1)) * 1_000_000_000 / scale
               when /^(\d+)ms$/
-                cast.call($1) * 1_000_000 / scale
+                cast.call(Regexp.last_match(1)) * 1_000_000 / scale
               when /^(\d+)us$/
-                cast.call($1) * 1_000 / scale
+                cast.call(Regexp.last_match(1)) * 1_000 / scale
               when /^(\d+)ns$/
-                cast.call($1) / scale
+                cast.call(Regexp.last_match(1)) / scale
               when /^(\d+)$/
-                cast.call($1)
+                cast.call(Regexp.last_match(1))
               else
                 raise ArgumentError, "invalid duration: #{v.inspect}"
               end
@@ -114,7 +114,7 @@ module Datadog
         }.freeze
 
         # Struct constant whisker cast for Steep
-        Integration = _ = Struct.new(:integration, :options)
+        Integration = _ = Struct.new(:integration, :options) # rubocop:disable Naming/ConstantName
 
         def initialize
           @integrations = []

--- a/lib/datadog/appsec/contrib/auto_instrument.rb
+++ b/lib/datadog/appsec/contrib/auto_instrument.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/contrib/configuration/settings.rb
+++ b/lib/datadog/appsec/contrib/configuration/settings.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require_relative '../../../core/configuration/base'
 

--- a/lib/datadog/appsec/contrib/integration.rb
+++ b/lib/datadog/appsec/contrib/integration.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/contrib/patcher.rb
+++ b/lib/datadog/appsec/contrib/patcher.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/contrib/rack/configuration/settings.rb
+++ b/lib/datadog/appsec/contrib/rack/configuration/settings.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require_relative '../../configuration/settings'
 require_relative '../ext'

--- a/lib/datadog/appsec/contrib/rack/ext.rb
+++ b/lib/datadog/appsec/contrib/rack/ext.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require_relative '../../../instrumentation/gateway'
 require_relative '../../../reactive/operation'

--- a/lib/datadog/appsec/contrib/rack/reactive/request.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/request.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 require_relative '../request'
 

--- a/lib/datadog/appsec/contrib/rack/reactive/request_body.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/request_body.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 require_relative '../request'
 

--- a/lib/datadog/appsec/contrib/rack/reactive/response.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/response.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 require_relative '../response'
 

--- a/lib/datadog/appsec/contrib/rack/request.rb
+++ b/lib/datadog/appsec/contrib/rack/request.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 require_relative '../../../tracing/client_ip'
 require_relative '../../../tracing/contrib/rack/header_collection'

--- a/lib/datadog/appsec/contrib/rack/response.rb
+++ b/lib/datadog/appsec/contrib/rack/response.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/contrib/rails/configuration/settings.rb
+++ b/lib/datadog/appsec/contrib/rails/configuration/settings.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require_relative '../../configuration/settings'
 require_relative '../ext'

--- a/lib/datadog/appsec/contrib/rails/ext.rb
+++ b/lib/datadog/appsec/contrib/rails/ext.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/contrib/rails/framework.rb
+++ b/lib/datadog/appsec/contrib/rails/framework.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require_relative '../../../instrumentation/gateway'
 require_relative '../../../reactive/operation'

--- a/lib/datadog/appsec/contrib/rails/reactive/action.rb
+++ b/lib/datadog/appsec/contrib/rails/reactive/action.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 require_relative '../request'
 

--- a/lib/datadog/appsec/contrib/rails/request.rb
+++ b/lib/datadog/appsec/contrib/rails/request.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/contrib/rails/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rails/request_middleware.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/contrib/sinatra/configuration/settings.rb
+++ b/lib/datadog/appsec/contrib/sinatra/configuration/settings.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require_relative '../../configuration/settings'
 require_relative '../ext'

--- a/lib/datadog/appsec/contrib/sinatra/ext.rb
+++ b/lib/datadog/appsec/contrib/sinatra/ext.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/contrib/sinatra/framework.rb
+++ b/lib/datadog/appsec/contrib/sinatra/framework.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require_relative '../../../instrumentation/gateway'
 require_relative '../../../reactive/operation'

--- a/lib/datadog/appsec/contrib/sinatra/reactive/routed.rb
+++ b/lib/datadog/appsec/contrib/sinatra/reactive/routed.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/contrib/sinatra/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/sinatra/request_middleware.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/event.rb
+++ b/lib/datadog/appsec/event.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require 'json'
 

--- a/lib/datadog/appsec/extensions.rb
+++ b/lib/datadog/appsec/extensions.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require_relative 'configuration'
 

--- a/lib/datadog/appsec/extensions.rb
+++ b/lib/datadog/appsec/extensions.rb
@@ -29,21 +29,16 @@ module Datadog
         end
 
         # Writer methods
-        def trace_rate_limit=(arg)
+
+        def instrument(name, options = {})
           dsl = AppSec::Configuration::DSL.new
-          dsl.trace_rate_limit = arg
+          dsl.instrument(name, options)
           @settings.merge(dsl)
         end
 
-        def options(arg)
+        def enabled=(arg)
           dsl = AppSec::Configuration::DSL.new
-          dsl.options arg
-          @settings.merge(dsl)
-        end
-
-        def instruments(arg)
-          dsl = AppSec::Configuration::DSL.new
-          dsl.instruments arg
+          dsl.enabled = arg
           @settings.merge(dsl)
         end
 
@@ -59,21 +54,9 @@ module Datadog
           @settings.merge(dsl)
         end
 
-        def instrument(*args)
-          dsl = AppSec::Configuration::DSL.new
-          dsl.instrument(*args)
-          @settings.merge(dsl)
-        end
-
         def waf_timeout=(arg)
           dsl = AppSec::Configuration::DSL.new
           dsl.waf_timeout = arg
-          @settings.merge(dsl)
-        end
-
-        def enabled=(arg)
-          dsl = AppSec::Configuration::DSL.new
-          dsl.enabled = arg
           @settings.merge(dsl)
         end
 
@@ -83,25 +66,44 @@ module Datadog
           @settings.merge(dsl)
         end
 
+        def trace_rate_limit=(arg)
+          dsl = AppSec::Configuration::DSL.new
+          dsl.trace_rate_limit = arg
+          @settings.merge(dsl)
+        end
+
+        def obfuscator_key_regex=(arg)
+          dsl = AppSec::Configuration::DSL.new
+          dsl.obfuscator_key_regex = arg
+          @settings.merge(dsl)
+        end
+
+        def obfuscator_value_regex=(arg)
+          dsl = AppSec::Configuration::DSL.new
+          dsl.obfuscator_value_regex = arg
+          @settings.merge(dsl)
+        end
+
         # Reader methods
-        def [](arg)
-          @settings[arg]
+
+        def [](key)
+          @settings[key]
+        end
+
+        def enabled
+          @settings.enabled
         end
 
         def ruleset
           @settings.ruleset
         end
 
-        def ruledata
-          @settings.ruledata
+        def ip_denylist
+          @settings.ip_denylist
         end
 
         def waf_timeout
           @settings.waf_timeout
-        end
-
-        def enabled
-          @settings.enabled
         end
 
         def waf_debug
@@ -110,6 +112,14 @@ module Datadog
 
         def trace_rate_limit
           @settings.trace_rate_limit
+        end
+
+        def obfuscator_key_regex
+          @settings.obfuscator_key_regex
+        end
+
+        def obfuscator_value_regex
+          @settings.obfuscator_key_regex
         end
 
         def merge(arg)

--- a/lib/datadog/appsec/instrumentation/gateway.rb
+++ b/lib/datadog/appsec/instrumentation/gateway.rb
@@ -15,8 +15,8 @@ module Datadog
             @block = block
           end
 
-          def call(*args, **kwargs, &block)
-            @block.call(*args, **kwargs, &block)
+          def call(stack, env)
+            @block.call(stack, env)
           end
         end
 

--- a/lib/datadog/appsec/instrumentation/gateway.rb
+++ b/lib/datadog/appsec/instrumentation/gateway.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/rate_limiter.rb
+++ b/lib/datadog/appsec/rate_limiter.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/reactive/address_hash.rb
+++ b/lib/datadog/appsec/reactive/address_hash.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/reactive/engine.rb
+++ b/lib/datadog/appsec/reactive/engine.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 require_relative 'address_hash'
 require_relative 'subscriber'

--- a/lib/datadog/appsec/reactive/operation.rb
+++ b/lib/datadog/appsec/reactive/operation.rb
@@ -15,7 +15,7 @@ module Datadog
           Datadog.logger.debug { "operation: #{name} initialize" }
           @name = name
           @parent = parent
-          @reactive = reactive_engine || parent && parent.reactive || Reactive::Engine.new
+          @reactive = reactive_engine || (parent.reactive unless parent.nil?) || Reactive::Engine.new
 
           # TODO: concurrent store
           # TODO: constant

--- a/lib/datadog/appsec/reactive/operation.rb
+++ b/lib/datadog/appsec/reactive/operation.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 require_relative 'engine'
 

--- a/lib/datadog/appsec/reactive/subscriber.rb
+++ b/lib/datadog/appsec/reactive/subscriber.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/response.rb
+++ b/lib/datadog/appsec/response.rb
@@ -38,26 +38,21 @@ module Datadog
 
         private
 
+        FORMAT_MAP = {
+          'text/html' => :html,
+          'application/json' => :json,
+          'text/plain' => :text,
+        }.freeze
+
         def format(env)
-          formats = ['text/html', 'application/json']
           accepted = env['HTTP_ACCEPT'].split(',').map { |m| Utils::HTTP::MediaRange.new(m) }.sort
 
-          format = nil
-          accepted.each do |range|
-            # @type break: nil
+          accepted.reduce(:text) do |default, range|
+            format = FORMAT_MAP.keys.find { |type, _format| range === type }
 
-            format = formats.find { |f| range === f }
+            return FORMAT_MAP[format] if format
 
-            break if format
-          end
-
-          case format
-          when 'text/html'
-            :html
-          when 'application/json'
-            :json
-          else
-            :text
+            default
           end
         end
       end

--- a/lib/datadog/appsec/response.rb
+++ b/lib/datadog/appsec/response.rb
@@ -44,15 +44,17 @@ module Datadog
           'text/plain' => :text,
         }.freeze
 
+        DEFAULT_FORMAT = :text
+
         def format(env)
+          return DEFAULT_FORMAT unless env.key?('HTTP_ACCEPT')
+
           accepted = env['HTTP_ACCEPT'].split(',').map { |m| Utils::HTTP::MediaRange.new(m) }.sort
 
-          accepted.reduce(:text) do |default, range|
+          accepted.each_with_object(DEFAULT_FORMAT) do |_default, range|
             format = FORMAT_MAP.keys.find { |type, _format| range === type }
 
             return FORMAT_MAP[format] if format
-
-            default
           end
         end
       end

--- a/lib/datadog/appsec/response.rb
+++ b/lib/datadog/appsec/response.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require_relative 'assets'
 require_relative 'utils/http/media_range'

--- a/lib/datadog/appsec/utils.rb
+++ b/lib/datadog/appsec/utils.rb
@@ -1,0 +1,6 @@
+module Datadog
+  module AppSec
+    module Utils
+    end
+  end
+end

--- a/lib/datadog/appsec/utils.rb
+++ b/lib/datadog/appsec/utils.rb
@@ -1,5 +1,6 @@
 module Datadog
   module AppSec
+    # Utilities for AppSec
     module Utils
     end
   end

--- a/lib/datadog/appsec/utils/http.rb
+++ b/lib/datadog/appsec/utils/http.rb
@@ -1,0 +1,8 @@
+module Datadog
+  module AppSec
+    module Utils
+      module HTTP
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/utils/http.rb
+++ b/lib/datadog/appsec/utils/http.rb
@@ -1,6 +1,7 @@
 module Datadog
   module AppSec
     module Utils
+      # HTTP utilities
       module HTTP
       end
     end

--- a/lib/datadog/appsec/utils/http/media_range.rb
+++ b/lib/datadog/appsec/utils/http/media_range.rb
@@ -1,0 +1,201 @@
+# typed: false
+
+require_relative 'media_type'
+
+module Datadog
+  module AppSec
+    module Utils
+      module HTTP
+        # Implementation of media range for content negotiation
+        class MediaRange
+          class ParseError < ::StandardError
+          end
+
+          WILDCARD = '*'.freeze
+          WILDCARD_RE = ::Regexp.escape(WILDCARD)
+
+          # See: https://www.rfc-editor.org/rfc/rfc7230#section-3.2.6
+          TOKEN_RE = /[-#$%&'*+.^_`|~A-Za-z0-9]+/.freeze
+
+          # See: https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1.1
+          PARAMETER_RE = %r{ # rubocop:disable Style/RegexpLiteral
+            (?:
+              (?<parameter_name>#{TOKEN_RE})
+              =
+              (?:
+                (?<parameter_value>#{TOKEN_RE})
+                |
+                "(?<parameter_value>[^"]+)"
+              )
+            )
+          }ix.freeze
+
+          # See: https://www.rfc-editor.org/rfc/rfc7231#section-5.3.2
+          ACCEPT_EXT_RE = %r{ # rubocop:disable Style/RegexpLiteral
+            (?:
+              (?<ext_name>#{TOKEN_RE})
+              =
+              (?:
+                (?<ext_value>#{TOKEN_RE})
+                |
+                "(?<ext_value>[^"]+)"
+              )
+            )
+          }ix.freeze
+
+          # See: https://www.rfc-editor.org/rfc/rfc7231#section-5.3.1
+          QVALUE_RE = %r{ # rubocop:disable Style/RegexpLiteral
+            0(?:\.\d{1,3})?
+            |
+            1(?:\.0{1,3})?
+          }ix.freeze
+
+          # See: https://www.rfc-editor.org/rfc/rfc7231#section-5.3.2
+          MEDIA_RANGE_RE = %r{
+            \A
+            (?:
+              (?<type>#{WILDCARD_RE})/(?<subtype>#{WILDCARD_RE})
+              |
+              (?<type>#{TOKEN_RE})/(?<subtype>#{WILDCARD_RE})
+              |
+              (?<type>#{TOKEN_RE})/(?<subtype>#{TOKEN_RE})
+            )
+            (?<parameters>
+              (?:
+                \s*;\s*
+                (?!q=)
+                #{PARAMETER_RE}
+              )*
+            )
+            (?<accept_params>
+              (?<weight>
+                \s*;\s*
+                (?:q=
+                  (?<quality>
+                    #{QVALUE_RE}
+                  )
+                )
+              )
+              (?<accept_exts>
+                (?<accept_ext>
+                  (?:
+                    \s*;\s*
+                    (?!q=)
+                    #{ACCEPT_EXT_RE}
+                  )*
+                )
+              )
+            )?
+            \Z
+          }ix.freeze
+
+          attr_reader :type, :subtype, :quality, :parameters, :accept_ext
+
+          def initialize(media_range) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+            media_range_match = MEDIA_RANGE_RE.match(media_range)
+
+            raise ParseError, media_range.inspect if media_range_match.nil?
+
+            @type = (media_range_match['type'] || WILDCARD).downcase
+            @subtype = (media_range_match['subtype'] || WILDCARD).downcase
+            @quality = (media_range_match['quality'] || 1.0).to_f
+            @parameters = {}
+            @accept_ext = {}
+
+            parameters = media_range_match['parameters']
+
+            return if parameters.nil?
+
+            parameters.split(';').map(&:strip).each do |parameter|
+              parameter_match = PARAMETER_RE.match(parameter)
+
+              next if parameter_match.nil?
+
+              parameter_name = parameter_match['parameter_name']
+              parameter_value = parameter_match['parameter_value']
+
+              next if parameter_name.nil? || parameter_value.nil?
+
+              @parameters[parameter_name.downcase] = parameter_value.downcase
+            end
+
+            accept_exts = media_range_match['accept_exts']
+
+            return if accept_exts.nil?
+
+            accept_exts.split(';').map(&:strip).each do |ext|
+              ext_match = ACCEPT_EXT_RE.match(ext)
+
+              next if ext_match.nil?
+
+              ext_name = ext_match['ext_name']
+              ext_value = ext_match['ext_value']
+
+              next if ext_name.nil? || ext_value.nil?
+
+              @accept_ext[ext_name.downcase] = ext_value.downcase
+            end
+          end
+
+          # Compare two MediaRange for ordering
+          def <=>(other)
+            unless (q = quality <=> other.quality) == 0 || q.nil?
+              return q
+            end
+
+            if (s = specificity <=> other.specificity) != 0
+              return s
+            end
+
+            unless wildcard?(:type)
+              if wildcard?(:subtype) && !other.wildcard?(:subtype)
+                return -1
+              elsif !wildcard?(:subtype) && other.wildcard?(:subtype)
+                return 1
+              end
+            end
+
+            if wildcard?(:type) && !other.wildcard?(:type)
+              return -1
+            elsif !wildcard?(:type) && other.wildcard?(:type)
+              return 1
+            end
+
+            0
+          end
+
+          # Compare with a MediaType for match
+          #
+          # returns true if the MediaType is accepted by this MediaRange
+          def ===(other)
+            return self === MediaType.new(other) if other.is_a?(::String)
+
+            type == other.type && subtype == other.subtype && other.parameters.all? { |k, v| parameters[k] == v } ||
+              type == other.type && wildcard?(:subtype) ||
+              wildcard?(:type) && wildcard?(:subtype)
+          end
+
+          def specificity
+            @parameters.count
+          end
+
+          def wildcard?(field = nil)
+            return wildcard?(:type) || wildcard?(:subtype) if field.nil?
+
+            instance_variable_get(:"@#{field}") == WILDCARD
+          end
+
+          def to_s
+            s = "#{@type}/#{@subtype}"
+
+            s << ';' << @parameters.map { |k, v| "#{k}=#{v}" }.join(';') if @parameters.count > 0
+            s << ";q=#{@quality}" if @quality < 1.0
+            s << ';' << @accept_ext.map { |k, v| "#{k}=#{v}" }.join(';') if @accept_ext.count > 0
+
+            s
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/utils/http/media_range.rb
+++ b/lib/datadog/appsec/utils/http/media_range.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require_relative 'media_type'
 

--- a/lib/datadog/appsec/utils/http/media_type.rb
+++ b/lib/datadog/appsec/utils/http/media_type.rb
@@ -1,0 +1,87 @@
+# typed: false
+
+module Datadog
+  module AppSec
+    module Utils
+      module HTTP
+        # Implementation of media type for content negotiation
+        #
+        # See:
+        # - https://www.rfc-editor.org/rfc/rfc7231#section-5.3.1
+        # - https://www.rfc-editor.org/rfc/rfc7231#section-5.3.2
+        class MediaType
+          class ParseError < ::StandardError
+          end
+
+          WILDCARD = '*'.freeze
+
+          # See: https://www.rfc-editor.org/rfc/rfc7230#section-3.2.6
+          TOKEN_RE = /[-#$%&'*+.^_`|~A-Za-z0-9]+/.freeze
+
+          # See: https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1.1
+          PARAMETER_RE = %r{ # rubocop:disable Style/RegexpLiteral
+            (?:
+              (?<parameter_name>#{TOKEN_RE})
+              =
+              (?:
+                (?<parameter_value>#{TOKEN_RE})
+                |
+                "(?<parameter_value>[^"]+)"
+              )
+            )
+          }ix.freeze
+
+          # See: https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1.1
+          MEDIA_TYPE_RE = %r{
+            \A
+            (?<type>#{TOKEN_RE})/(?<subtype>#{TOKEN_RE})
+            (?<parameters>
+              (?:
+                \s*;\s*
+                #{PARAMETER_RE}
+              )*
+            )
+            \Z
+          }ix.freeze
+
+          attr_reader :type, :subtype, :parameters
+
+          def initialize(media_type)
+            media_type_match = MEDIA_TYPE_RE.match(media_type)
+
+            raise ParseError, media_type.inspect if media_type_match.nil?
+
+            @type = (media_type_match['type'] || WILDCARD).downcase
+            @subtype = (media_type_match['subtype'] || WILDCARD).downcase
+            @parameters = {}
+
+            parameters = media_type_match['parameters']
+
+            return if parameters.nil?
+
+            parameters.split(';').map(&:strip).each do |parameter|
+              parameter_match = PARAMETER_RE.match(parameter)
+
+              next if parameter_match.nil?
+
+              parameter_name = parameter_match['parameter_name']
+              parameter_value = parameter_match['parameter_value']
+
+              next if parameter_name.nil? || parameter_value.nil?
+
+              @parameters[parameter_name.downcase] = parameter_value.downcase
+            end
+          end
+
+          def to_s
+            s = "#{@type}/#{@subtype}"
+
+            s << ';' << @parameters.map { |k, v| "#{k}=#{v}" }.join(';') if @parameters.count > 0
+
+            s
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/utils/http/media_type.rb
+++ b/lib/datadog/appsec/utils/http/media_type.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 module Datadog
   module AppSec

--- a/sig/datadog/appsec.rbs
+++ b/sig/datadog/appsec.rbs
@@ -1,0 +1,7 @@
+module Datadog
+  module AppSec
+    extend Configuration::ClassMethods
+  end
+end
+
+

--- a/sig/datadog/appsec/assets.rbs
+++ b/sig/datadog/appsec/assets.rbs
@@ -1,0 +1,19 @@
+module Datadog
+  module AppSec
+    module Assets
+      @blocked: ::Hash[::Symbol, ::String]
+
+      def self?.waf_rules: (?::Symbol kind) -> ::String
+
+      def self?.blocked: (?format: ::Symbol) -> ::String
+
+      def self?.path: () -> ::Pathname
+
+      def self?.filepath: (::String filename) -> ::Pathname
+
+      def self?.read: (::String filename, ?::String mode) -> ::String
+
+      def self?.dir: () -> ::String
+    end
+  end
+end

--- a/sig/datadog/appsec/configuration.rbs
+++ b/sig/datadog/appsec/configuration.rbs
@@ -4,8 +4,8 @@ module Datadog
       def self.included: (::Module base) -> void
 
       class DSL
-        type option_value = ::Integer | bool | ::Symbol | ::String | ::StringIO | ::Regexp | ::Hash[::Symbol, option_value] | ::Array[option_value]
-        type options = ::Hash[::Symbol, option_value]
+        type option = ::Integer | bool | ::Symbol | ::String | ::StringIO | ::File | ::Regexp | ::Hash[::Symbol | ::String, option] | ::Array[option]
+        type options = ::Hash[::Symbol, option]
 
         class Instrument < ::Struct[untyped]
           def initialize: (::Symbol name, options options) -> void
@@ -25,7 +25,7 @@ module Datadog
         def instruments: () -> ::Array[Instrument]
 
         def enabled=: (bool) -> void
-        def ruleset=: (::Symbol | ::String | ::StringIO) -> void
+        def ruleset=: (::Symbol | ::String | ::Hash[::String, untyped] | ::File | ::StringIO) -> void
         def ip_denylist=: (::Array[::String]) -> void
         def waf_timeout=: (::Integer) -> void
         def waf_debug=: (bool) -> void

--- a/sig/datadog/appsec/configuration.rbs
+++ b/sig/datadog/appsec/configuration.rbs
@@ -1,0 +1,46 @@
+module Datadog
+  module AppSec
+    module Configuration
+      def self.included: (::Module base) -> void
+
+      class DSL
+        type option_value = ::Integer | bool | ::Symbol | ::String | ::StringIO | ::Regexp | ::Hash[::Symbol, option_value] | ::Array[option_value]
+        type options = ::Hash[::Symbol, option_value]
+
+        class Instrument < ::Struct[untyped]
+          def initialize: (::Symbol name, options options) -> void
+          attr_accessor name: ::Symbol
+          attr_accessor options: options
+        end
+
+        @instruments: ::Array[Instrument]
+        @options: options
+
+        def options: () -> options
+
+        def initialize: () -> void
+
+        def instrument: (::Symbol name, ?options options) -> void
+
+        def instruments: () -> ::Array[Instrument]
+
+        def enabled=: (bool) -> void
+        def ruleset=: (::Symbol | ::String | ::StringIO) -> void
+        def ip_denylist=: (::Array[::String]) -> void
+        def waf_timeout=: (::Integer) -> void
+        def waf_debug=: (bool) -> void
+        def trace_rate_limit=: (::Integer) -> void
+        def obfuscator_key_regex=: (::String | ::Regexp) -> void
+        def obfuscator_value_regex=: (::String | ::Regexp) -> void
+      end
+
+      module ClassMethods
+        @settings: Settings
+
+        def configure: () { (DSL) -> void } -> void
+
+        def settings: () -> Settings
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/configuration/settings.rbs
+++ b/sig/datadog/appsec/configuration/settings.rbs
@@ -1,0 +1,48 @@
+module Datadog
+  module AppSec
+    module Configuration
+      class Settings
+        def initialize: () -> void
+
+        type duration = (::Integer | ::Float)
+        type options = Configuration::DSL::options
+
+        class Integration < ::Struct[untyped]
+          def initialize: (untyped integration, options options) -> void
+          attr_accessor integration: untyped
+          attr_accessor options: options
+        end
+
+        def self.boolean: () -> ^(::String) -> bool
+        def self.string: () -> ^(::String) -> ::String
+        def self.integer: () -> ^(::String) -> ::Integer
+        def self.duration: (?::Symbol base, ?::Symbol type) -> ^(::String, ::Symbol) -> duration
+
+        DEFAULTS: options
+        ENVS: Hash[::String, ::Array[untyped]]
+        DEFAULT_OBFUSCATOR_VALUE_REGEX: ::String
+        DEFAULT_OBFUSCATOR_KEY_REGEX: ::String
+
+        @options: options
+        @integrations: ::Array[Integration]
+
+        def enabled: () -> bool
+        def ruleset: () -> (::Symbol | ::String)
+        def ip_denylist: () -> ::Array[::String]
+        def waf_timeout: () -> ::Integer
+        def waf_debug: () -> bool
+        def trace_rate_limit: () -> ::Integer
+        def obfuscator_key_regex: () -> ::String
+        def obfuscator_value_regex: () -> ::String
+
+        def []: (::Symbol integration_name) -> options
+
+        def merge: (DSL) -> Settings
+
+        private
+
+        def reset!: () -> void
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/configuration/settings.rbs
+++ b/sig/datadog/appsec/configuration/settings.rbs
@@ -27,7 +27,7 @@ module Datadog
         @integrations: ::Array[Integration]
 
         def enabled: () -> bool
-        def ruleset: () -> (::Symbol | ::String)
+        def ruleset: () -> (::Symbol | ::String | ::Hash[::String, untyped] | ::File | ::StringIO)
         def ip_denylist: () -> ::Array[::String]
         def waf_timeout: () -> ::Integer
         def waf_debug: () -> bool

--- a/sig/datadog/appsec/contrib/auto_instrument.rbs
+++ b/sig/datadog/appsec/contrib/auto_instrument.rbs
@@ -1,8 +1,6 @@
 module Datadog
   module AppSec
     module Contrib
-      # Auto-instrumentation for security integrations
-      # TODO: this implementation is trivial, check for shareable code with tracer
       module AutoInstrument
         def self.patch_all: () -> untyped
       end

--- a/sig/datadog/appsec/contrib/auto_instrument.rbs
+++ b/sig/datadog/appsec/contrib/auto_instrument.rbs
@@ -1,0 +1,11 @@
+module Datadog
+  module AppSec
+    module Contrib
+      # Auto-instrumentation for security integrations
+      # TODO: this implementation is trivial, check for shareable code with tracer
+      module AutoInstrument
+        def self.patch_all: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/configuration/settings.rbs
+++ b/sig/datadog/appsec/contrib/configuration/settings.rbs
@@ -1,0 +1,16 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Configuration
+        class Settings
+          include Datadog::Core::Configuration::Base
+
+          # through Datadog::Configuration::Base
+          include Datadog::Core::Environment::VariableHelpers
+          extend Datadog::Core::Environment::VariableHelpers
+          extend Datadog::Core::Configuration::Options::ClassMethods
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/configuration/settings.rbs
+++ b/sig/datadog/appsec/contrib/configuration/settings.rbs
@@ -5,7 +5,6 @@ module Datadog
         class Settings
           include Datadog::Core::Configuration::Base
 
-          # through Datadog::Configuration::Base
           include Datadog::Core::Environment::VariableHelpers
           extend Datadog::Core::Environment::VariableHelpers
           extend Datadog::Core::Configuration::Options::ClassMethods

--- a/sig/datadog/appsec/contrib/integration.rbs
+++ b/sig/datadog/appsec/contrib/integration.rbs
@@ -1,0 +1,21 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Integration
+        RegisteredIntegration: untyped
+
+        def self.included: (untyped base) -> untyped
+
+        module ClassMethods
+          def register_as: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+          def compatible?: () -> bool
+        end
+
+        def self.register: (untyped integration, untyped name, untyped options) -> untyped
+
+        def self.registry: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/patcher.rbs
+++ b/sig/datadog/appsec/contrib/patcher.rbs
@@ -1,0 +1,8 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Patcher
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rack/configuration/settings.rbs
+++ b/sig/datadog/appsec/contrib/rack/configuration/settings.rbs
@@ -1,0 +1,12 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rack
+        module Configuration
+          class Settings < Datadog::AppSec::Contrib::Configuration::Settings
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rack/ext.rbs
+++ b/sig/datadog/appsec/contrib/rack/ext.rbs
@@ -1,0 +1,13 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rack
+        module Ext
+          APP: untyped
+
+          ENV_ENABLED: untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rack/gateway/watcher.rbs
+++ b/sig/datadog/appsec/contrib/rack/gateway/watcher.rbs
@@ -1,0 +1,24 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rack
+        module Gateway
+          # Watcher for Rack gateway events
+          module Watcher
+            # rubocop:disable Metrics/AbcSize
+            # rubocop:disable Metrics/MethodLength
+            # rubocop:disable Metrics/CyclomaticComplexity
+            # rubocop:disable Metrics/PerceivedComplexity
+            def self.watch: () -> untyped
+
+            private
+
+            def self.active_trace: () -> (nil | untyped)
+
+            def self.active_span: () -> (nil | untyped)
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rack/gateway/watcher.rbs
+++ b/sig/datadog/appsec/contrib/rack/gateway/watcher.rbs
@@ -3,12 +3,7 @@ module Datadog
     module Contrib
       module Rack
         module Gateway
-          # Watcher for Rack gateway events
           module Watcher
-            # rubocop:disable Metrics/AbcSize
-            # rubocop:disable Metrics/MethodLength
-            # rubocop:disable Metrics/CyclomaticComplexity
-            # rubocop:disable Metrics/PerceivedComplexity
             def self.watch: () -> untyped
 
             private

--- a/sig/datadog/appsec/contrib/rack/integration.rbs
+++ b/sig/datadog/appsec/contrib/rack/integration.rbs
@@ -5,7 +5,6 @@ module Datadog
         class Integration
           include Datadog::AppSec::Contrib::Integration
 
-          # through Datadog::AppSec::Contrib::Integration
           extend Datadog::AppSec::Contrib::Integration::ClassMethods
 
           MINIMUM_VERSION: untyped

--- a/sig/datadog/appsec/contrib/rack/integration.rbs
+++ b/sig/datadog/appsec/contrib/rack/integration.rbs
@@ -1,0 +1,28 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rack
+        class Integration
+          include Datadog::AppSec::Contrib::Integration
+
+          # through Datadog::AppSec::Contrib::Integration
+          extend Datadog::AppSec::Contrib::Integration::ClassMethods
+
+          MINIMUM_VERSION: untyped
+
+          def self.version: () -> untyped
+
+          def self.loaded?: () -> bool
+
+          def self.compatible?: () -> bool
+
+          def auto_instrument?: () -> bool
+
+          def default_configuration: () -> untyped
+
+          def patcher: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rack/patcher.rbs
+++ b/sig/datadog/appsec/contrib/rack/patcher.rbs
@@ -1,0 +1,19 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rack
+        module Patcher
+          include Datadog::AppSec::Contrib::Patcher
+
+          def self?.patched?: () -> bool
+
+          def self?.target_version: () -> untyped
+
+          def self?.logger: () -> untyped
+
+          def self?.patch: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rack/reactive/request.rbs
+++ b/sig/datadog/appsec/contrib/rack/reactive/request.rbs
@@ -1,0 +1,17 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rack
+        module Reactive
+          # Dispatch data from a Rack request to the WAF context
+          module Request
+            def self.publish: (untyped op, untyped request) -> untyped
+
+            # rubocop:disable Metrics/MethodLength
+            def self.subscribe: (untyped op, untyped waf_context) { (untyped) -> untyped } -> untyped
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rack/reactive/request.rbs
+++ b/sig/datadog/appsec/contrib/rack/reactive/request.rbs
@@ -3,11 +3,9 @@ module Datadog
     module Contrib
       module Rack
         module Reactive
-          # Dispatch data from a Rack request to the WAF context
           module Request
             def self.publish: (untyped op, untyped request) -> untyped
 
-            # rubocop:disable Metrics/MethodLength
             def self.subscribe: (untyped op, untyped waf_context) { (untyped) -> untyped } -> untyped
           end
         end

--- a/sig/datadog/appsec/contrib/rack/reactive/request_body.rbs
+++ b/sig/datadog/appsec/contrib/rack/reactive/request_body.rbs
@@ -1,0 +1,16 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rack
+        module Reactive
+          # Dispatch data from a Rack request to the WAF context
+          module RequestBody
+            def self.publish: (untyped op, untyped request) -> untyped
+
+            def self.subscribe: (untyped op, untyped waf_context) { (untyped) -> untyped } -> untyped
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rack/reactive/request_body.rbs
+++ b/sig/datadog/appsec/contrib/rack/reactive/request_body.rbs
@@ -3,7 +3,6 @@ module Datadog
     module Contrib
       module Rack
         module Reactive
-          # Dispatch data from a Rack request to the WAF context
           module RequestBody
             def self.publish: (untyped op, untyped request) -> untyped
 

--- a/sig/datadog/appsec/contrib/rack/reactive/response.rbs
+++ b/sig/datadog/appsec/contrib/rack/reactive/response.rbs
@@ -1,0 +1,16 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rack
+        module Reactive
+          # Dispatch data from a Rack response to the WAF context
+          module Response
+            def self.publish: (untyped op, untyped response) -> untyped
+
+            def self.subscribe: (untyped op, untyped waf_context) { (untyped) -> untyped } -> untyped
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rack/reactive/response.rbs
+++ b/sig/datadog/appsec/contrib/rack/reactive/response.rbs
@@ -3,7 +3,6 @@ module Datadog
     module Contrib
       module Rack
         module Reactive
-          # Dispatch data from a Rack response to the WAF context
           module Response
             def self.publish: (untyped op, untyped response) -> untyped
 

--- a/sig/datadog/appsec/contrib/rack/request.rbs
+++ b/sig/datadog/appsec/contrib/rack/request.rbs
@@ -1,0 +1,24 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rack
+        # Normalized extration of data from Rack::Request
+        module Request
+          def self.query: (untyped request) -> untyped
+
+          def self.headers: (untyped request) -> untyped
+
+          def self.body: (untyped request) -> untyped
+
+          def self.url: (untyped request) -> untyped
+
+          def self.cookies: (untyped request) -> untyped
+
+          def self.form_hash: (untyped request) -> untyped
+
+          def self.client_ip: (untyped request) -> (nil | untyped)
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rack/request.rbs
+++ b/sig/datadog/appsec/contrib/rack/request.rbs
@@ -2,7 +2,6 @@ module Datadog
   module AppSec
     module Contrib
       module Rack
-        # Normalized extration of data from Rack::Request
         module Request
           def self.query: (untyped request) -> untyped
 

--- a/sig/datadog/appsec/contrib/rack/request_body_middleware.rbs
+++ b/sig/datadog/appsec/contrib/rack/request_body_middleware.rbs
@@ -2,9 +2,6 @@ module Datadog
   module AppSec
     module Contrib
       module Rack
-        # Rack request body middleware for AppSec
-        # This should be inserted just below Rack::JSONBodyParser or
-        # legacy Rack::PostBodyContentTypeParser from rack-contrib
         class RequestBodyMiddleware
           def initialize: (untyped app, ?::Hash[untyped, untyped] opt) -> void
 

--- a/sig/datadog/appsec/contrib/rack/request_body_middleware.rbs
+++ b/sig/datadog/appsec/contrib/rack/request_body_middleware.rbs
@@ -1,0 +1,16 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rack
+        # Rack request body middleware for AppSec
+        # This should be inserted just below Rack::JSONBodyParser or
+        # legacy Rack::PostBodyContentTypeParser from rack-contrib
+        class RequestBodyMiddleware
+          def initialize: (untyped app, ?::Hash[untyped, untyped] opt) -> void
+
+          def call: (untyped env) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rack/request_middleware.rbs
+++ b/sig/datadog/appsec/contrib/rack/request_middleware.rbs
@@ -1,0 +1,15 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rack
+        class RequestMiddleware
+          def initialize: (untyped app, ?::Hash[untyped, untyped] opt) -> untyped
+
+          attr_reader logger: untyped
+
+          def call: (untyped env) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rack/response.rbs
+++ b/sig/datadog/appsec/contrib/rack/response.rbs
@@ -1,0 +1,16 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rack
+        # Normalized extration of data from Rack::Response
+        module Response
+          def self.headers: (untyped response) -> untyped
+
+          def self.cookies: (untyped response) -> untyped
+
+          def self.status: (untyped response) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rack/response.rbs
+++ b/sig/datadog/appsec/contrib/rack/response.rbs
@@ -2,7 +2,6 @@ module Datadog
   module AppSec
     module Contrib
       module Rack
-        # Normalized extration of data from Rack::Response
         module Response
           def self.headers: (untyped response) -> untyped
 

--- a/sig/datadog/appsec/contrib/rails/configuration/settings.rbs
+++ b/sig/datadog/appsec/contrib/rails/configuration/settings.rbs
@@ -1,0 +1,13 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rails
+        module Configuration
+          # Custom settings for the Rack integration
+          class Settings < Datadog::AppSec::Contrib::Configuration::Settings
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rails/configuration/settings.rbs
+++ b/sig/datadog/appsec/contrib/rails/configuration/settings.rbs
@@ -3,7 +3,6 @@ module Datadog
     module Contrib
       module Rails
         module Configuration
-          # Custom settings for the Rack integration
           class Settings < Datadog::AppSec::Contrib::Configuration::Settings
           end
         end

--- a/sig/datadog/appsec/contrib/rails/ext.rbs
+++ b/sig/datadog/appsec/contrib/rails/ext.rbs
@@ -1,0 +1,14 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rails
+        # Rack integration constants
+        module Ext
+          APP: "rails"
+
+          ENV_ENABLED: "DD_TRACE_RAILS_ENABLED"
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rails/ext.rbs
+++ b/sig/datadog/appsec/contrib/rails/ext.rbs
@@ -2,7 +2,6 @@ module Datadog
   module AppSec
     module Contrib
       module Rails
-        # Rack integration constants
         module Ext
           APP: "rails"
 

--- a/sig/datadog/appsec/contrib/rails/framework.rbs
+++ b/sig/datadog/appsec/contrib/rails/framework.rbs
@@ -2,13 +2,11 @@ module Datadog
   module AppSec
     module Contrib
       module Rails
-        # Rails specific framework tie
         module Framework
           def self.setup: () -> untyped
 
           def self.config_with_defaults: (untyped datadog_config) -> untyped
 
-          # Apply relevant configuration from Sinatra to Rack
           def self.activate_rack!: (untyped datadog_config, untyped sinatra_config) -> untyped
         end
       end

--- a/sig/datadog/appsec/contrib/rails/framework.rbs
+++ b/sig/datadog/appsec/contrib/rails/framework.rbs
@@ -1,0 +1,17 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rails
+        # Rails specific framework tie
+        module Framework
+          def self.setup: () -> untyped
+
+          def self.config_with_defaults: (untyped datadog_config) -> untyped
+
+          # Apply relevant configuration from Sinatra to Rack
+          def self.activate_rack!: (untyped datadog_config, untyped sinatra_config) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rails/gateway/watcher.rbs
+++ b/sig/datadog/appsec/contrib/rails/gateway/watcher.rbs
@@ -3,7 +3,6 @@ module Datadog
     module Contrib
       module Rails
         module Gateway
-          # Watcher for Rails gateway events
           module Watcher
             def self.watch: () -> untyped
 

--- a/sig/datadog/appsec/contrib/rails/gateway/watcher.rbs
+++ b/sig/datadog/appsec/contrib/rails/gateway/watcher.rbs
@@ -1,0 +1,20 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rails
+        module Gateway
+          # Watcher for Rails gateway events
+          module Watcher
+            def self.watch: () -> untyped
+
+            private
+
+            def self.active_trace: () -> (nil | untyped)
+
+            def self.active_span: () -> (nil | untyped)
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rails/integration.rbs
+++ b/sig/datadog/appsec/contrib/rails/integration.rbs
@@ -1,0 +1,25 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rails
+        class Integration
+          include Datadog::AppSec::Contrib::Integration
+
+          MINIMUM_VERSION: untyped
+
+          def self.version: () -> untyped
+
+          def self.loaded?: () -> untyped
+
+          def self.compatible?: () -> untyped
+
+          def self.auto_instrument?: () -> true
+
+          def default_configuration: () -> untyped
+
+          def patcher: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rails/patcher.rbs
+++ b/sig/datadog/appsec/contrib/rails/patcher.rbs
@@ -2,7 +2,6 @@ module Datadog
   module AppSec
     module Contrib
       module Rails
-        # Patcher for AppSec on Rails
         module Patcher
           include Datadog::AppSec::Contrib::Patcher
 
@@ -22,7 +21,6 @@ module Datadog
 
           def self?.add_middleware: (untyped app) -> untyped
 
-          # Hook into ActionController::Instrumentation#process_action, which encompasses action filters
           module ProcessActionPatch
             def process_action: (*untyped args) -> untyped
           end

--- a/sig/datadog/appsec/contrib/rails/patcher.rbs
+++ b/sig/datadog/appsec/contrib/rails/patcher.rbs
@@ -1,0 +1,45 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rails
+        # Patcher for AppSec on Rails
+        module Patcher
+          include Datadog::AppSec::Contrib::Patcher
+
+          BEFORE_INITIALIZE_ONLY_ONCE_PER_APP: untyped
+
+          AFTER_INITIALIZE_ONLY_ONCE_PER_APP: untyped
+
+          def self?.patched?: () -> untyped
+
+          def self?.target_version: () -> untyped
+
+          def self?.patch: () -> untyped
+
+          def self?.patch_before_intialize: () -> untyped
+
+          def self?.before_intialize: (untyped app) -> untyped
+
+          def self?.add_middleware: (untyped app) -> untyped
+
+          # Hook into ActionController::Instrumentation#process_action, which encompasses action filters
+          module ProcessActionPatch
+            def process_action: (*untyped args) -> untyped
+          end
+
+          def self?.patch_process_action: () -> untyped
+
+          def self?.include_middleware?: (untyped middleware, untyped app) -> untyped
+
+          def self?.inspect_middlewares: (untyped app) -> untyped
+
+          def self?.patch_after_intialize: () -> untyped
+
+          def self?.after_intialize: (untyped app) -> untyped
+
+          def self?.setup_security: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rails/reactive/action.rbs
+++ b/sig/datadog/appsec/contrib/rails/reactive/action.rbs
@@ -1,0 +1,16 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rails
+        module Reactive
+          # Dispatch data from a Rails request to the WAF context
+          module Action
+            def self.publish: (untyped op, untyped request) -> untyped
+
+            def self.subscribe: (untyped op, untyped waf_context) { (untyped) -> untyped } -> untyped
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rails/reactive/action.rbs
+++ b/sig/datadog/appsec/contrib/rails/reactive/action.rbs
@@ -3,7 +3,6 @@ module Datadog
     module Contrib
       module Rails
         module Reactive
-          # Dispatch data from a Rails request to the WAF context
           module Action
             def self.publish: (untyped op, untyped request) -> untyped
 

--- a/sig/datadog/appsec/contrib/rails/request.rbs
+++ b/sig/datadog/appsec/contrib/rails/request.rbs
@@ -1,0 +1,14 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rails
+        # Normalized extration of data from ActionDispatch::Request
+        module Request
+          def self.parsed_body: (untyped request) -> (nil | untyped)
+
+          def self.route_params: (untyped request) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rails/request.rbs
+++ b/sig/datadog/appsec/contrib/rails/request.rbs
@@ -2,7 +2,6 @@ module Datadog
   module AppSec
     module Contrib
       module Rails
-        # Normalized extration of data from ActionDispatch::Request
         module Request
           def self.parsed_body: (untyped request) -> (nil | untyped)
 

--- a/sig/datadog/appsec/contrib/rails/request_middleware.rbs
+++ b/sig/datadog/appsec/contrib/rails/request_middleware.rbs
@@ -1,0 +1,14 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Rails
+        # Rack middleware for AppSec on Rails
+        class RequestMiddleware
+          def initialize: (untyped app, ?::Hash[untyped, untyped] opt) -> void
+
+          def call: (untyped env) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/rails/request_middleware.rbs
+++ b/sig/datadog/appsec/contrib/rails/request_middleware.rbs
@@ -2,7 +2,6 @@ module Datadog
   module AppSec
     module Contrib
       module Rails
-        # Rack middleware for AppSec on Rails
         class RequestMiddleware
           def initialize: (untyped app, ?::Hash[untyped, untyped] opt) -> void
 

--- a/sig/datadog/appsec/contrib/sinatra/configuration/settings.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/configuration/settings.rbs
@@ -3,7 +3,6 @@ module Datadog
     module Contrib
       module Sinatra
         module Configuration
-          # Custom settings for the Rack integration
           class Settings < Datadog::AppSec::Contrib::Configuration::Settings
           end
         end

--- a/sig/datadog/appsec/contrib/sinatra/configuration/settings.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/configuration/settings.rbs
@@ -1,0 +1,13 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Sinatra
+        module Configuration
+          # Custom settings for the Rack integration
+          class Settings < Datadog::AppSec::Contrib::Configuration::Settings
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/sinatra/ext.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/ext.rbs
@@ -1,0 +1,16 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Sinatra
+        # Sinatra integration constants
+        module Ext
+          APP: "sinatra"
+
+          ENV_ENABLED: "DD_TRACE_SINATRA_ENABLED"
+
+          ROUTE_INTERRUPT: :datadog_appsec_contrib_sinatra_route_interrupt
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/sinatra/ext.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/ext.rbs
@@ -2,7 +2,6 @@ module Datadog
   module AppSec
     module Contrib
       module Sinatra
-        # Sinatra integration constants
         module Ext
           APP: "sinatra"
 

--- a/sig/datadog/appsec/contrib/sinatra/framework.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/framework.rbs
@@ -1,0 +1,21 @@
+module Datadog
+  module AppSec
+    module Contrib
+      # Instrument Sinatra.
+      module Sinatra
+        # Sinatra framework code, used to essentially:
+        # - handle configuration entries which are specific to Datadog tracing
+        # - instrument parts of the framework when needed
+        module Framework
+          # Configure Rack from Sinatra, but only if Rack has not been configured manually beforehand
+          def self.setup: () -> untyped
+
+          def self.config_with_defaults: (untyped datadog_config) -> untyped
+
+          # Apply relevant configuration from Sinatra to Rack
+          def self.activate_rack!: (untyped datadog_config, untyped sinatra_config) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/sinatra/framework.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/framework.rbs
@@ -1,18 +1,12 @@
 module Datadog
   module AppSec
     module Contrib
-      # Instrument Sinatra.
       module Sinatra
-        # Sinatra framework code, used to essentially:
-        # - handle configuration entries which are specific to Datadog tracing
-        # - instrument parts of the framework when needed
         module Framework
-          # Configure Rack from Sinatra, but only if Rack has not been configured manually beforehand
           def self.setup: () -> untyped
 
           def self.config_with_defaults: (untyped datadog_config) -> untyped
 
-          # Apply relevant configuration from Sinatra to Rack
           def self.activate_rack!: (untyped datadog_config, untyped sinatra_config) -> untyped
         end
       end

--- a/sig/datadog/appsec/contrib/sinatra/gateway/watcher.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/gateway/watcher.rbs
@@ -1,0 +1,21 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Sinatra
+        module Gateway
+          # Watcher for Sinatra gateway events
+          module Watcher
+            # rubocop:disable Metrics/MethodLength
+            def self.watch: () -> untyped
+
+            private
+
+            def self.active_trace: () -> (nil | untyped)
+
+            def self.active_span: () -> (nil | untyped)
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/sinatra/gateway/watcher.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/gateway/watcher.rbs
@@ -3,9 +3,7 @@ module Datadog
     module Contrib
       module Sinatra
         module Gateway
-          # Watcher for Sinatra gateway events
           module Watcher
-            # rubocop:disable Metrics/MethodLength
             def self.watch: () -> untyped
 
             private

--- a/sig/datadog/appsec/contrib/sinatra/integration.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/integration.rbs
@@ -1,0 +1,25 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Sinatra
+        class Integration
+          include Datadog::AppSec::Contrib::Integration
+
+          MINIMUM_VERSION: untyped
+
+          def self.version: () -> untyped
+
+          def self.loaded?: () -> untyped
+
+          def self.compatible?: () -> untyped
+
+          def self.auto_instrument?: () -> true
+
+          def default_configuration: () -> untyped
+
+          def patcher: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/sinatra/patcher.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/patcher.rbs
@@ -2,29 +2,22 @@ module Datadog
   module AppSec
     module Contrib
       module Sinatra
-        # Set tracer configuration at a late enough time
         module AppSecSetupPatch
           def setup_middleware: (*untyped args) ?{ () -> untyped } -> untyped
         end
 
-        # Hook into builder before the middleware list gets frozen
         module DefaultMiddlewarePatch
           def setup_middleware: (*untyped args) ?{ () -> untyped } -> untyped
         end
 
-        # Hook into Base#dispatch!, which encompasses route filters
         module DispatchPatch
           def dispatch!: () -> untyped
         end
 
-        # Hook into Base#route_eval, which
-        # path params are returned by pattern.params in process_route, then
-        # merged with normal params, so we get both
         module RoutePatch
           def process_route: () { (untyped) -> untyped } -> untyped
         end
 
-        # Patcher for AppSec on Sinatra
         module Patcher
           include Datadog::AppSec::Contrib::Patcher
 

--- a/sig/datadog/appsec/contrib/sinatra/patcher.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/patcher.rbs
@@ -1,0 +1,48 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Sinatra
+        # Set tracer configuration at a late enough time
+        module AppSecSetupPatch
+          def setup_middleware: (*untyped args) ?{ () -> untyped } -> untyped
+        end
+
+        # Hook into builder before the middleware list gets frozen
+        module DefaultMiddlewarePatch
+          def setup_middleware: (*untyped args) ?{ () -> untyped } -> untyped
+        end
+
+        # Hook into Base#dispatch!, which encompasses route filters
+        module DispatchPatch
+          def dispatch!: () -> untyped
+        end
+
+        # Hook into Base#route_eval, which
+        # path params are returned by pattern.params in process_route, then
+        # merged with normal params, so we get both
+        module RoutePatch
+          def process_route: () { (untyped) -> untyped } -> untyped
+        end
+
+        # Patcher for AppSec on Sinatra
+        module Patcher
+          include Datadog::AppSec::Contrib::Patcher
+
+          def self?.patched?: () -> untyped
+
+          def self?.target_version: () -> untyped
+
+          def self?.patch: () -> untyped
+
+          def self?.setup_security: () -> untyped
+
+          def self?.patch_default_middlewares: () -> untyped
+
+          def self?.patch_dispatch: () -> untyped
+
+          def self?.patch_route: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/sinatra/reactive/routed.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/reactive/routed.rbs
@@ -3,7 +3,6 @@ module Datadog
     module Contrib
       module Sinatra
         module Reactive
-          # Dispatch data from a Rack request to the WAF context
           module Routed
             def self.publish: (untyped op, untyped data) -> untyped
 

--- a/sig/datadog/appsec/contrib/sinatra/reactive/routed.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/reactive/routed.rbs
@@ -1,0 +1,16 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Sinatra
+        module Reactive
+          # Dispatch data from a Rack request to the WAF context
+          module Routed
+            def self.publish: (untyped op, untyped data) -> untyped
+
+            def self.subscribe: (untyped op, untyped waf_context) { (untyped) -> untyped } -> untyped
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/sinatra/request_middleware.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/request_middleware.rbs
@@ -1,0 +1,14 @@
+module Datadog
+  module AppSec
+    module Contrib
+      module Sinatra
+        # Rack middleware for AppSec on Sinatra
+        class RequestMiddleware
+          def initialize: (untyped app, ?::Hash[untyped, untyped] opt) -> void
+
+          def call: (untyped env) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/contrib/sinatra/request_middleware.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/request_middleware.rbs
@@ -2,7 +2,6 @@ module Datadog
   module AppSec
     module Contrib
       module Sinatra
-        # Rack middleware for AppSec on Sinatra
         class RequestMiddleware
           def initialize: (untyped app, ?::Hash[untyped, untyped] opt) -> void
 

--- a/sig/datadog/appsec/event.rbs
+++ b/sig/datadog/appsec/event.rbs
@@ -1,0 +1,19 @@
+module Datadog
+  module AppSec
+    # AppSec event
+    module Event
+      ALLOWED_REQUEST_HEADERS: untyped
+
+      ALLOWED_RESPONSE_HEADERS: untyped
+
+      # Record events for a trace
+      #
+      # This is expected to be called only once per trace for the rate limiter
+      # to properly apply
+      def self.record: (*untyped events) -> (nil | untyped)
+
+      # rubocop:disable Metrics/MethodLength
+      def self.record_via_span: (*untyped events) -> untyped
+    end
+  end
+end

--- a/sig/datadog/appsec/event.rbs
+++ b/sig/datadog/appsec/event.rbs
@@ -1,18 +1,12 @@
 module Datadog
   module AppSec
-    # AppSec event
     module Event
       ALLOWED_REQUEST_HEADERS: untyped
 
       ALLOWED_RESPONSE_HEADERS: untyped
 
-      # Record events for a trace
-      #
-      # This is expected to be called only once per trace for the rate limiter
-      # to properly apply
       def self.record: (*untyped events) -> (nil | untyped)
 
-      # rubocop:disable Metrics/MethodLength
       def self.record_via_span: (*untyped events) -> untyped
     end
   end

--- a/sig/datadog/appsec/extensions.rbs
+++ b/sig/datadog/appsec/extensions.rbs
@@ -16,19 +16,19 @@ module Datadog
 
         def instrument: (::Symbol name, ?Configuration::DSL::options options) -> void
 
-        def enabled=: (untyped arg) -> untyped
-        def ruleset=: (untyped arg) -> untyped
-        def ip_denylist=: (untyped arg) -> untyped
-        def waf_timeout=: (untyped arg) -> untyped
-        def waf_debug=: (untyped arg) -> untyped
-        def trace_rate_limit=: (untyped arg) -> untyped
+        def enabled=: (bool arg) -> untyped
+        def ruleset=: ((::Symbol | ::String | ::Hash[::String, untyped] | ::File | ::StringIO) arg) -> untyped
+        def ip_denylist=: (::Array[::String] arg) -> untyped
+        def waf_timeout=: (::Integer arg) -> untyped
+        def waf_debug=: (bool arg) -> untyped
+        def trace_rate_limit=: (::Integer arg) -> untyped
         def obfuscator_key_regex=: (::String | ::Regexp) -> void
         def obfuscator_value_regex=: (::String | ::Regexp) -> void
 
         def []: (::Symbol arg) -> Configuration::Settings::options
 
         def enabled: () -> bool
-        def ruleset: () -> (::Symbol | ::String)
+        def ruleset: () -> (::Symbol | ::String | ::Hash[::String, untyped] | ::File | ::StringIO)
         def ip_denylist: () -> ::Array[::String]
         def waf_timeout: () -> ::Integer
         def waf_debug: () -> bool

--- a/sig/datadog/appsec/extensions.rbs
+++ b/sig/datadog/appsec/extensions.rbs
@@ -1,0 +1,47 @@
+module Datadog
+  module AppSec
+    module Extensions
+      def self.activate!: () -> untyped
+
+      module Settings
+        @appsec: AppSecAdapter
+
+        def appsec: () -> AppSecAdapter
+      end
+
+      class AppSecAdapter
+        @settings: Configuration::Settings
+
+        def initialize: (Configuration::Settings settings) -> void
+
+        def instrument: (::Symbol name, ?Configuration::DSL::options options) -> void
+
+        def enabled=: (untyped arg) -> untyped
+        def ruleset=: (untyped arg) -> untyped
+        def ip_denylist=: (untyped arg) -> untyped
+        def waf_timeout=: (untyped arg) -> untyped
+        def waf_debug=: (untyped arg) -> untyped
+        def trace_rate_limit=: (untyped arg) -> untyped
+        def obfuscator_key_regex=: (::String | ::Regexp) -> void
+        def obfuscator_value_regex=: (::String | ::Regexp) -> void
+
+        def []: (::Symbol arg) -> Configuration::Settings::options
+
+        def enabled: () -> bool
+        def ruleset: () -> (::Symbol | ::String)
+        def ip_denylist: () -> ::Array[::String]
+        def waf_timeout: () -> ::Integer
+        def waf_debug: () -> bool
+        def trace_rate_limit: () -> ::Integer
+        def obfuscator_key_regex: () -> ::String
+        def obfuscator_value_regex: () -> ::String
+
+        def merge: (untyped arg) -> untyped
+
+        private
+
+        def reset!: () -> void
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/instrumentation/gateway.rbs
+++ b/sig/datadog/appsec/instrumentation/gateway.rbs
@@ -2,21 +2,31 @@ module Datadog
   module AppSec
     module Instrumentation
       class Gateway
+        type middleware_result = untyped
+        type final_call_result = untyped
+        type final_call = ^() -> final_call_result
+        type stack = ::Proc
+        type env = untyped
+
+        # TODO: this should be a struct
+        type stack_result = ::Array[nil | middleware_result | final_call_result]
+
         class Middleware
           attr_reader key: ::Symbol
           attr_reader block: ::Proc
 
-          def call: (*untyped args, **untyped kwargs) -> untyped
+          def initialize: (::Symbol key) { (stack next, env env) -> stack_result } -> void
+          def call: (stack next, env env) -> stack_result
         end
 
-        type data = untyped
+        @middlewares: ::Hash[::String, ::Array[Middleware]]
 
         def initialize: () -> void
-
-        def push: (::String event_name, data data) -> bool
-
-        def watch: (::String event_name) { (data data) -> void } -> void
+        def push: (::String name, env env) { () -> final_call_result } -> stack_result
+        def watch: (::String name, ::Symbol key) { (stack next, env env) -> stack_result } -> void
       end
+
+      self.@gateway: Gateway
 
       def self.gateway: () -> Gateway
     end

--- a/sig/datadog/appsec/instrumentation/gateway.rbs
+++ b/sig/datadog/appsec/instrumentation/gateway.rbs
@@ -1,0 +1,24 @@
+module Datadog
+  module AppSec
+    module Instrumentation
+      class Gateway
+        class Middleware
+          attr_reader key: ::Symbol
+          attr_reader block: ::Proc
+
+          def call: (*untyped args, **untyped kwargs) -> untyped
+        end
+
+        type data = untyped
+
+        def initialize: () -> void
+
+        def push: (::String event_name, data data) -> bool
+
+        def watch: (::String event_name) { (data data) -> void } -> void
+      end
+
+      def self.gateway: () -> Gateway
+    end
+  end
+end

--- a/sig/datadog/appsec/processor.rbs
+++ b/sig/datadog/appsec/processor.rbs
@@ -1,73 +1,50 @@
 module Datadog
   module AppSec
-    # Processor integrates libddwaf into datadog/appsec
     class Processor
-      # Interface object to check using case .. when
-      module IOLike
-        def read: () -> nil
-
-        def rewind: () -> nil
-
-        def self.===: (untyped other) -> untyped
-      end
-
-      # Context manages a sequence of runs
       class Context
-        attr_reader time_ns: untyped
+        type event = untyped
+        type data = WAF::data
 
-        attr_reader time_ext_ns: untyped
+        attr_reader time_ns: ::Float
+        attr_reader time_ext_ns: ::Float
+        attr_reader timeouts: ::Integer
+        attr_reader events: ::Array[event]
 
-        attr_reader timeouts: untyped
+        @context: WAF::Context
 
-        attr_reader events: untyped
-
-        def initialize: (untyped processor) -> void
-
-        def run: (*untyped args) -> untyped
-
-        def finalize: () -> untyped
+        def initialize: (Processor processor) -> void
+        def run: (data input, ?::Integer timeout) -> WAF::Result
+        def finalize: () -> void
       end
 
       attr_reader ruleset_info: untyped
-
       attr_reader addresses: untyped
 
+      @handle: WAF::Handle
+      @ruleset: ::Hash[::String, untyped]
+      @addresses: ::Array[::String]
+
       def initialize: () -> void
-
-      def ready?: () -> untyped
-
-      def new_context: () -> untyped
-
+      def ready?: () -> bool
+      def new_context: () -> Context
       def update_rule_data: (untyped data) -> untyped
-
       def toggle_rules: (untyped map) -> untyped
-
       def update_ip_denylist: (?untyped denylist, ?id: ::String) -> untyped
-
-      def finalize: () -> untyped
+      def finalize: () -> void
 
       attr_reader handle: untyped
 
       private
 
-      def load_libddwaf: () -> untyped
+      def load_libddwaf: () -> bool
+      def load_ruleset: () -> bool
+      def create_waf_handle: () -> bool
 
-      def load_ruleset: () -> untyped
-
-      def create_waf_handle: () -> untyped
-
-      # check whether libddwaf is required *and* able to provide the needed feature
-      def self.libddwaf_provides_waf?: () -> (true | false)
-
-      # libddwaf raises a LoadError on unsupported platforms; it may at some
-      # point succeed in being required yet not provide a specific needed feature.
-      def self.require_libddwaf: () -> untyped
-
-      def self.libddwaf_spec: () -> untyped
-
-      def self.libddwaf_platform: () -> (untyped | "unknown")
-
-      def self.ruby_platforms: () -> untyped
+      def self.libddwaf_provides_waf?: () -> bool
+      def self.require_libddwaf: () -> bool
+      def self.libddwaf_spec: () -> ::Gem::BasicSpecification
+      def self.libddwaf_platform: () -> ::String
+      def self.ruby_platforms: () -> ::Array[::String]
     end
   end
 end

--- a/sig/datadog/appsec/processor.rbs
+++ b/sig/datadog/appsec/processor.rbs
@@ -1,0 +1,73 @@
+module Datadog
+  module AppSec
+    # Processor integrates libddwaf into datadog/appsec
+    class Processor
+      # Interface object to check using case .. when
+      module IOLike
+        def read: () -> nil
+
+        def rewind: () -> nil
+
+        def self.===: (untyped other) -> untyped
+      end
+
+      # Context manages a sequence of runs
+      class Context
+        attr_reader time_ns: untyped
+
+        attr_reader time_ext_ns: untyped
+
+        attr_reader timeouts: untyped
+
+        attr_reader events: untyped
+
+        def initialize: (untyped processor) -> void
+
+        def run: (*untyped args) -> untyped
+
+        def finalize: () -> untyped
+      end
+
+      attr_reader ruleset_info: untyped
+
+      attr_reader addresses: untyped
+
+      def initialize: () -> void
+
+      def ready?: () -> untyped
+
+      def new_context: () -> untyped
+
+      def update_rule_data: (untyped data) -> untyped
+
+      def toggle_rules: (untyped map) -> untyped
+
+      def update_ip_denylist: (?untyped denylist, ?id: ::String) -> untyped
+
+      def finalize: () -> untyped
+
+      attr_reader handle: untyped
+
+      private
+
+      def load_libddwaf: () -> untyped
+
+      def load_ruleset: () -> untyped
+
+      def create_waf_handle: () -> untyped
+
+      # check whether libddwaf is required *and* able to provide the needed feature
+      def self.libddwaf_provides_waf?: () -> (true | false)
+
+      # libddwaf raises a LoadError on unsupported platforms; it may at some
+      # point succeed in being required yet not provide a specific needed feature.
+      def self.require_libddwaf: () -> untyped
+
+      def self.libddwaf_spec: () -> untyped
+
+      def self.libddwaf_platform: () -> (untyped | "unknown")
+
+      def self.ruby_platforms: () -> untyped
+    end
+  end
+end

--- a/sig/datadog/appsec/rate_limiter.rbs
+++ b/sig/datadog/appsec/rate_limiter.rbs
@@ -1,0 +1,24 @@
+module Datadog
+  module AppSec
+    class RateLimiter
+      type timestamp = ::Float
+      type rate = ::Integer
+
+      @rate: ::Integer
+      @timestamps: ::Array[timestamp]
+
+      def initialize: (rate rate) -> void
+
+      # TODO: return type of limit is return type of block
+      def limit: () { () -> untyped } -> untyped
+
+      def self.limit: (::Symbol name) { () -> untyped } -> untyped
+
+      def self.reset!: (::Symbol name) -> void
+
+      def self.rate_limiter: (::Symbol name) -> RateLimiter
+
+      def self.trace_rate_limit: () -> rate
+    end
+  end
+end

--- a/sig/datadog/appsec/reactive/address_hash.rbs
+++ b/sig/datadog/appsec/reactive/address_hash.rbs
@@ -1,12 +1,14 @@
 module Datadog
   module AppSec
     module Reactive
-      class AddressHash < Hash[String, untyped]
-        def []=: (String key, untyped value) -> untyped
+      class AddressHash < ::Hash[::Array[::String], ::Array[Subscriber]]
+        type key = ::Array[::String]
 
-        def addresses: () -> untyped
+        def []=: (key key, Subscriber value) -> Subscriber
 
-        def with: (untyped address) -> untyped
+        def addresses: () -> ::Array[::String]
+
+        def with: (::String address) -> ::Array[key]
       end
     end
   end

--- a/sig/datadog/appsec/reactive/address_hash.rbs
+++ b/sig/datadog/appsec/reactive/address_hash.rbs
@@ -1,0 +1,13 @@
+module Datadog
+  module AppSec
+    module Reactive
+      class AddressHash < Hash[String, untyped]
+        def []=: (String key, untyped value) -> untyped
+
+        def addresses: () -> untyped
+
+        def with: (untyped address) -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/reactive/engine.rbs
+++ b/sig/datadog/appsec/reactive/engine.rbs
@@ -7,10 +7,8 @@ module Datadog
         @children: ::Array[untyped]
 
         def initialize: () -> void
-
-        def subscribe: (*String addresses) { (*top values) -> void } -> void
-
-        def publish: (String address, top data) -> void
+        def subscribe: (*::String addresses) { (*untyped values) -> void } -> void
+        def publish: (::String address, top data) -> void
       end
     end
   end

--- a/sig/datadog/appsec/reactive/engine.rbs
+++ b/sig/datadog/appsec/reactive/engine.rbs
@@ -1,0 +1,17 @@
+module Datadog
+  module AppSec
+    module Reactive
+      class Engine
+        @data: ::Hash[::String, untyped]
+        @subscribers: AddressHash
+        @children: ::Array[untyped]
+
+        def initialize: () -> void
+
+        def subscribe: (*String addresses) { (*top values) -> void } -> void
+
+        def publish: (String address, top data) -> void
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/reactive/operation.rbs
+++ b/sig/datadog/appsec/reactive/operation.rbs
@@ -1,0 +1,25 @@
+module Datadog
+  module AppSec
+    module Reactive
+      class Operation
+        attr_reader reactive: untyped
+
+        attr_reader parent: untyped
+
+        attr_reader name: untyped
+
+        def logger: () -> untyped
+
+        def initialize: (untyped name, ?untyped? parent, ?untyped? reactive_engine) { (untyped) -> untyped } -> untyped
+
+        def subscribe: (*untyped addresses) { (untyped) -> untyped } -> untyped
+
+        def publish: (untyped address, untyped data) -> untyped
+
+        def finalize: () -> untyped
+
+        def self.active: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/reactive/operation.rbs
+++ b/sig/datadog/appsec/reactive/operation.rbs
@@ -6,7 +6,7 @@ module Datadog
         attr_reader parent: Operation?
         attr_reader name: ::String
 
-        def initialize: (::String name, ?Operation? parent, ?Engine? reactive_engine) { (untyped) -> untyped } -> untyped
+        def initialize: (::String name, ?Operation? parent, ?Engine? reactive_engine) ?{ (Operation) -> void } -> void
         def logger: () -> ::Logger
         def subscribe: (*::String addresses) { (*untyped values) -> void } -> void
         def publish: (::String address, untyped data) -> untyped

--- a/sig/datadog/appsec/reactive/operation.rbs
+++ b/sig/datadog/appsec/reactive/operation.rbs
@@ -2,23 +2,17 @@ module Datadog
   module AppSec
     module Reactive
       class Operation
-        attr_reader reactive: untyped
+        attr_reader reactive: Engine
+        attr_reader parent: Operation?
+        attr_reader name: ::String
 
-        attr_reader parent: untyped
+        def initialize: (::String name, ?Operation? parent, ?Engine? reactive_engine) { (untyped) -> untyped } -> untyped
+        def logger: () -> ::Logger
+        def subscribe: (*::String addresses) { (*untyped values) -> void } -> void
+        def publish: (::String address, untyped data) -> untyped
+        def finalize: () -> void
 
-        attr_reader name: untyped
-
-        def logger: () -> untyped
-
-        def initialize: (untyped name, ?untyped? parent, ?untyped? reactive_engine) { (untyped) -> untyped } -> untyped
-
-        def subscribe: (*untyped addresses) { (untyped) -> untyped } -> untyped
-
-        def publish: (untyped address, untyped data) -> untyped
-
-        def finalize: () -> untyped
-
-        def self.active: () -> untyped
+        def self.active: () -> Operation?
       end
     end
   end

--- a/sig/datadog/appsec/reactive/subscriber.rbs
+++ b/sig/datadog/appsec/reactive/subscriber.rbs
@@ -1,0 +1,11 @@
+module Datadog
+  module AppSec
+    module Reactive
+      class Subscriber
+        def initialize: () { () -> untyped } -> untyped
+
+        def call: (*untyped args) -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/reactive/subscriber.rbs
+++ b/sig/datadog/appsec/reactive/subscriber.rbs
@@ -2,8 +2,9 @@ module Datadog
   module AppSec
     module Reactive
       class Subscriber
-        def initialize: () { () -> untyped } -> untyped
+        @block: ::Proc
 
+        def initialize: () { () -> untyped } -> untyped
         def call: (*untyped args) -> untyped
       end
     end

--- a/sig/datadog/appsec/response.rbs
+++ b/sig/datadog/appsec/response.rbs
@@ -1,26 +1,20 @@
 module Datadog
   module AppSec
-    # AppSec response
     class Response
-      attr_reader status: untyped
+      attr_reader status: ::Integer
+      attr_reader headers: ::Hash[::String, ::String]
+      attr_reader body: ::Array[untyped]
 
-      attr_reader headers: untyped
-
-      attr_reader body: untyped
-
-      def initialize: (status: untyped, ?headers: ::Hash[untyped, untyped], ?body: untyped) -> void
-
+      def initialize: (status: ::Integer, ?headers: ::Hash[::String, ::String], ?body: ::Array[untyped]) -> void
       def to_rack: () -> ::Array[untyped]
+      def to_sinatra_response: () -> ::Sinatra::Response
+      def to_action_dispatch_response: () -> ::ActionDispatch::Response
 
-      def to_sinatra_response: () -> untyped
-
-      def to_action_dispatch_response: () -> untyped
-
-      def self.negotiate: (untyped env) -> untyped
+      def self.negotiate: (::Hash[untyped, untyped] env) -> Response
 
       private
 
-      def self.format: (untyped env) -> untyped
+      def self.format: (::Hash[untyped, untyped] env) -> ::Symbol
     end
   end
 end

--- a/sig/datadog/appsec/response.rbs
+++ b/sig/datadog/appsec/response.rbs
@@ -14,6 +14,8 @@ module Datadog
 
       private
 
+      FORMAT_MAP: ::Hash[::String, ::Symbol]
+
       def self.format: (::Hash[untyped, untyped] env) -> ::Symbol
     end
   end

--- a/sig/datadog/appsec/response.rbs
+++ b/sig/datadog/appsec/response.rbs
@@ -1,0 +1,26 @@
+module Datadog
+  module AppSec
+    # AppSec response
+    class Response
+      attr_reader status: untyped
+
+      attr_reader headers: untyped
+
+      attr_reader body: untyped
+
+      def initialize: (status: untyped, ?headers: ::Hash[untyped, untyped], ?body: untyped) -> void
+
+      def to_rack: () -> ::Array[untyped]
+
+      def to_sinatra_response: () -> untyped
+
+      def to_action_dispatch_response: () -> untyped
+
+      def self.negotiate: (untyped env) -> untyped
+
+      private
+
+      def self.format: (untyped env) -> untyped
+    end
+  end
+end

--- a/sig/datadog/appsec/response.rbs
+++ b/sig/datadog/appsec/response.rbs
@@ -15,6 +15,7 @@ module Datadog
       private
 
       FORMAT_MAP: ::Hash[::String, ::Symbol]
+      DEFAULT_FORMAT: ::Symbol
 
       def self.format: (::Hash[untyped, untyped] env) -> ::Symbol
     end

--- a/sig/datadog/appsec/utils/http/media_range.rbs
+++ b/sig/datadog/appsec/utils/http/media_range.rbs
@@ -1,0 +1,33 @@
+module Datadog
+  module AppSec
+    module Utils
+      module HTTP
+        class MediaRange
+          class ParseError < ::StandardError
+          end
+
+          WILDCARD: ::String
+          WILDCARD_RE: ::String
+          TOKEN_RE: ::Regexp
+          PARAMETER_RE: ::Regexp
+          ACCEPT_EXT_RE: ::Regexp
+          QVALUE_RE: ::Regexp
+          MEDIA_RANGE_RE: ::Regexp
+
+          attr_reader type: ::String
+          attr_reader subtype: ::String
+          attr_reader quality: ::Float
+          attr_reader parameters: ::Hash[::String, ::String]
+          attr_reader accept_ext: ::Hash[::String, ::String]
+
+          def initialize: (::String) -> void
+          def specificity: () -> ::Integer
+          def wildcard?: (?::Symbol?) -> bool
+          def <=>: (MediaRange) -> ::Integer
+          def ===: (MediaType | ::String) -> bool
+          def to_s: () -> ::String
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/utils/http/media_type.rbs
+++ b/sig/datadog/appsec/utils/http/media_type.rbs
@@ -1,0 +1,24 @@
+module Datadog
+  module AppSec
+    module Utils
+      module HTTP
+        class MediaType
+          class ParseError < ::StandardError
+          end
+
+          WILDCARD: ::String
+          TOKEN_RE: ::Regexp
+          PARAMETER_RE: ::Regexp
+          MEDIA_TYPE_RE: ::Regexp
+
+          attr_reader type: ::String
+          attr_reader subtype: ::String
+          attr_reader parameters: ::Hash[::String, ::String]
+
+          def initialize: (::String) -> void
+          def to_s: () -> ::String
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/waf.rbs
+++ b/sig/datadog/appsec/waf.rbs
@@ -1,19 +1,230 @@
 module Datadog
   module AppSec
     module WAF
-      class Args < Hash[String, untyped]
-        def self?.[]: (Hash[String, untyped]) -> Args
+      module LibDDWAF
+        class Error < StandardError
+          attr_reader ruleset_info: Hash[Symbol, untyped] | nil
+
+          def initialize: (::String msg, ?ruleset_info: Hash[Symbol, untyped]?) -> void
+        end
+
+        extend ::FFI::Library
+
+        def self.local_os: () -> ::String
+        def self.local_cpu: () -> ::String
+        def self.local_version: () -> (::String | nil)
+        def self.source_dir: () -> ::String
+        def self.vendor_dir: () -> ::String
+        def self.libddwaf_vendor_dir: () -> ::String
+        def self.shared_lib_triplet: (?version: ::String?) -> ::String
+        def self.libddwaf_dir: () -> ::String
+        def self.shared_lib_extname: () -> ::String
+        def self.shared_lib_path: () -> ::String
+
+        # version
+
+        def self.ddwaf_get_version: () -> ::String
+
+        # ddwaf::object data structure
+
+        DDWAF_OBJ_TYPE: ::FFI::Enum
+
+        class UInt32Ptr < ::FFI::Struct
+        end
+
+        class UInt64Ptr < ::FFI::Struct
+        end
+
+        class SizeTPtr < ::FFI::Struct
+        end
+
+        class ObjectValueUnion < ::FFI::Union
+        end
+
+        class Object < ::FFI::Struct
+        end
+
+        # setters
+
+        def self.ddwaf_object_invalid: (LibDDWAF::Object) -> ::FFI::Pointer
+        def self.ddwaf_object_string: (LibDDWAF::Object, ::String) -> ::FFI::Pointer
+        def self.ddwaf_object_stringl: (LibDDWAF::Object, ::String, ::Integer) -> ::FFI::Pointer
+        def self.ddwaf_object_stringl_nc: (LibDDWAF::Object, ::String, ::Integer) -> ::FFI::Pointer
+        def self.ddwaf_object_unsigned: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
+        def self.ddwaf_object_signed: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
+        def self.ddwaf_object_unsigned_force: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
+        def self.ddwaf_object_signed_force: (LibDDWAF::Object, ::Integer) -> ::FFI::Pointer
+        def self.ddwaf_object_bool: (LibDDWAF::Object, bool) -> ::FFI::Pointer
+
+        def self.ddwaf_object_array: (LibDDWAF::Object) -> ::FFI::Pointer
+        def self.ddwaf_object_array_add: (LibDDWAF::Object, LibDDWAF::Object) -> bool
+
+        def self.ddwaf_object_map: (LibDDWAF::Object) -> ::FFI::Pointer
+        def self.ddwaf_object_map_add: (LibDDWAF::Object, ::String, LibDDWAF::Object) -> bool
+        def self.ddwaf_object_map_addl: (LibDDWAF::Object, ::String, ::Integer, LibDDWAF::Object) -> bool
+        def self.ddwaf_object_map_addl_nc: (LibDDWAF::Object, ::String, ::Integer, LibDDWAF::Object) -> bool
+
+        # getters
+
+        def self.ddwaf_object_type: (LibDDWAF::Object) -> ::FFI::Enum
+        def self.ddwaf_object_size: (LibDDWAF::Object) -> ::Integer
+        def self.ddwaf_object_length: (LibDDWAF::Object) -> ::Integer
+        def self.ddwaf_object_get_key: (LibDDWAF::Object, SizeTPtr) -> ::String
+        def self.ddwaf_object_get_string: (LibDDWAF::Object, SizeTPtr) -> ::String
+        def self.ddwaf_object_get_unsigned: (LibDDWAF::Object, SizeTPtr) -> ::Integer
+        def self.ddwaf_object_get_signed: (LibDDWAF::Object, SizeTPtr) -> ::Integer
+        def self.ddwaf_object_get_index: (LibDDWAF::Object, ::Integer) -> LibDDWAF::Object
+
+        # freeers
+
+        def self.ddwaf_object_free: (LibDDWAF::Object) -> void
+
+        ObjectFree: ::FFI::Function
+        ObjectNoFree: ::FFI::Pointer
+
+        # main handle
+
+        class Config < ::FFI::Struct
+          class Limits < ::FFI::Struct
+          end
+
+          class Obfuscator < ::FFI::Struct
+          end
+        end
+
+        class RuleSetInfo < ::FFI::Struct
+        end
+
+        RuleSetInfoNone: ::Datadog::AppSec::WAF::LibDDWAF::RuleSetInfo
+
+        def self.ddwaf_ruleset_info_free: (RuleSetInfo) -> void
+
+        def self.ddwaf_init: (top, Config, RuleSetInfo) -> ::FFI::Pointer
+        def self.ddwaf_destroy: (::FFI::Pointer) -> void
+
+        def self.ddwaf_required_addresses: (::FFI::Pointer, UInt32Ptr) -> ::FFI::Pointer
+        def self.ddwaf_rule_data_ids: (::FFI::Pointer, UInt32Ptr) -> ::FFI::Pointer
+
+        # updating
+
+        DDWAF_RET_CODE: ::FFI::Enum
+
+        def self.ddwaf_update_rule_data: (::FFI::Pointer, LibDDWAF::Object) -> ::Symbol
+        def self.ddwaf_toggle_rules: (::FFI::Pointer, LibDDWAF::Object) -> ::Symbol
+
+        # running
+
+        def self.ddwaf_context_init: (::FFI::Pointer) -> ::FFI::Pointer
+        def self.ddwaf_context_destroy: (::FFI::Pointer) -> void
+
+        class ResultActions < ::FFI::Struct
+        end
+
+        class Result < ::FFI::Struct
+        end
+
+        def self.ddwaf_run: (::FFI::Pointer, Object, Result, ::Integer) -> ::Symbol
+        def self.ddwaf_result_free: (Result) -> void
+
+        # logging
+
+        DDWAF_LOG_LEVEL: ::FFI::Enum
+
+        type ddwaf_log_level = ::Symbol
+
+        # TODO: signature is as below but steep 1.1 does not yet support method/proc/block mapping
+        # type ddwaf_log_cb = ^(ddwaf_log_level, ::String, ::String, ::Integer, ::FFI::Pointer, ::Integer) -> void
+        type ddwaf_log_cb = ::Method | ::Proc
+        def self.ddwaf_set_log_cb: (ddwaf_log_cb, ddwaf_log_level) -> bool
+
+        DEFAULT_MAX_CONTAINER_SIZE: ::Integer
+        DEFAULT_MAX_CONTAINER_DEPTH: ::Integer
+        DEFAULT_MAX_STRING_LENGTH: ::Integer
+
+        DDWAF_MAX_CONTAINER_SIZE: ::Integer
+        DDWAF_MAX_CONTAINER_DEPTH: ::Integer
+        DDWAF_MAX_STRING_LENGTH: ::Integer
+
+        DDWAF_RUN_TIMEOUT: ::Integer
       end
 
-      def self?.logger: () -> ::Logger
+      def self.version: () -> ::String
 
-      def self?.rules: () -> ::String
+      type data = String | Symbol | Integer | Float | TrueClass | FalseClass | Array[data] | Hash[String | Symbol, data] | nil
 
-      def self?.name: () -> ::String
+      def self.ruby_to_object: (data val, ?max_container_size: ::Integer?, ?max_container_depth: ::Integer?, ?max_string_length: ::Integer?, ?coerce: bool?) -> ::Datadog::AppSec::WAF::LibDDWAF::Object
+      def self.object_to_ruby: (::Datadog::AppSec::WAF::LibDDWAF::Object obj) -> data
 
-      def self?.load_rules: () -> void
+      self.@logger: ::Logger
+      self.@log_callback: LibDDWAF::ddwaf_log_cb
 
-      def self?.run: (Args waf_args) -> bool
+      def self.log_callback: (LibDDWAF::ddwaf_log_level, ::String, ::String, ::Integer, ::FFI::Pointer, ::Integer) -> void
+      def self.logger: () -> ::Logger
+      def self.logger=: (::Logger logger) -> void
+
+      RESULT_CODE: ::Hash[::Symbol, ::Symbol]
+
+      class Handle
+        attr_reader handle_obj: ::FFI::Pointer
+        attr_reader ruleset_info: Hash[Symbol, untyped]
+
+        def initialize: (data rule, ?limits: ::Hash[::Symbol, ::Integer], ?obfuscator: ::Hash[::Symbol, ::String]) -> void
+        def finalize: () -> untyped
+        def required_addresses: () -> ::Array[::String]
+        def update_rule_data: (::Array[untyped]) -> ::Symbol
+        def toggle_rules: (::Hash[::String, bool]) -> ::Symbol
+
+        private
+
+        @valid: bool
+
+        def validate!: () -> void
+        def invalidate!: () -> void
+        def valid?: () -> (nil | bool)
+        def valid!: () -> void
+
+        @retained: Array[untyped]
+
+        def retained: () -> Array[untyped]
+        def retain: (top object) -> void
+        def release: (top object) -> void
+      end
+
+      type result_data = Array[untyped] | nil
+
+      class Result
+        attr_reader status: ::Symbol
+        attr_reader data: untyped
+        attr_reader total_runtime: ::Float
+        attr_reader timeout: bool
+        attr_reader actions: ::Array[::String]
+
+        def initialize: (::Symbol, result_data, ::Float, bool, ::Array[::String]) -> void
+      end
+
+      class Context
+        attr_reader context_obj: ::FFI::Pointer
+
+        def initialize: (Handle handle) -> void
+        def finalize: () -> void
+
+        def run: (data input, ?::Integer timeout) -> ::Array[top]
+
+        private
+
+        @valid: bool
+
+        def validate!: () -> void
+        def invalidate!: () -> void
+        def valid?: () -> (nil | bool)
+        def valid!: () -> void
+
+        @retained: Array[untyped]
+
+        def retained: () -> Array[untyped]
+        def retain: (top object) -> void
+        def release: (top object) -> void
+      end
     end
   end
 end

--- a/sig/datadog/appsec/waf.rbs
+++ b/sig/datadog/appsec/waf.rbs
@@ -1,0 +1,19 @@
+module Datadog
+  module AppSec
+    module WAF
+      class Args < Hash[String, untyped]
+        def self?.[]: (Hash[String, untyped]) -> Args
+      end
+
+      def self?.logger: () -> ::Logger
+
+      def self?.rules: () -> ::String
+
+      def self?.name: () -> ::String
+
+      def self?.load_rules: () -> void
+
+      def self?.run: (Args waf_args) -> bool
+    end
+  end
+end

--- a/sig/datadog/core.rbs
+++ b/sig/datadog/core.rbs
@@ -1,0 +1,6 @@
+module Datadog
+  module Core
+  end
+
+  extend Core::Configuration
+end

--- a/sig/datadog/core/configuration.rbs
+++ b/sig/datadog/core/configuration.rbs
@@ -1,0 +1,9 @@
+module Datadog
+  module Core
+    module Configuration
+      def tracer: () -> Datadog::Tracing::Tracer
+
+      def logger: () -> Datadog::Core::Logger
+    end
+  end
+end

--- a/sig/datadog/core/configuration/agent_settings_resolver.rbs
+++ b/sig/datadog/core/configuration/agent_settings_resolver.rbs
@@ -1,0 +1,47 @@
+module Datadog
+  module Core
+    module Configuration
+      class AgentSettingsResolver
+        AgentSettings: untyped
+
+        def self.call: (untyped settings, ?logger: untyped logger) -> untyped
+
+        private
+
+        attr_reader logger: untyped
+
+        attr_reader settings: untyped
+
+        def initialize: (untyped settings, ?logger: untyped logger) -> untyped
+
+        def call: () -> untyped
+
+        def hostname: () -> untyped
+
+        def port: () -> untyped
+
+        def ssl?: () -> untyped
+
+        def timeout_seconds: () -> untyped
+
+        def deprecated_for_removal_transport_configuration_proc: () -> untyped
+
+        def deprecated_for_removal_transport_configuration_options: () -> untyped
+
+        def parsed_url: () -> untyped
+
+        def unparsed_url_from_env: () -> untyped
+
+        def pick_from: (configurations_in_priority_order: untyped configurations_in_priority_order, or_use_default: untyped or_use_default) -> untyped
+
+        def warn_if_configuration_mismatch: (untyped detected_configurations_in_priority_order) -> (nil | untyped)
+
+        def log_warning: (untyped message) -> untyped
+
+        DetectedConfiguration: untyped
+
+        ENVIRONMENT_AGENT_SETTINGS: untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/configuration/base.rbs
+++ b/sig/datadog/core/configuration/base.rbs
@@ -1,0 +1,27 @@
+module Datadog
+  module Core
+    module Configuration
+      module Base
+        def self.included: (untyped base) -> untyped
+
+        module ClassMethods
+          def settings: (untyped name) { () -> untyped } -> untyped
+
+          private
+
+          def new_settings_class: () { () -> untyped } -> untyped
+        end
+
+        module InstanceMethods
+          def initialize: (?::Hash[untyped, untyped] options) -> untyped
+
+          def configure: (?::Hash[untyped, untyped] opts) { (untyped) -> untyped } -> untyped
+
+          def to_h: () -> untyped
+
+          def reset!: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/configuration/components.rbs
+++ b/sig/datadog/core/configuration/components.rbs
@@ -44,7 +44,6 @@ module Datadog
 
         def initialize: (untyped settings) -> untyped
 
-        # Starts up components
         def startup!: (untyped settings) -> untyped
 
         def shutdown!: (?untyped? replacement) -> untyped

--- a/sig/datadog/core/configuration/components.rbs
+++ b/sig/datadog/core/configuration/components.rbs
@@ -1,0 +1,54 @@
+module Datadog
+  module Core
+    module Configuration
+      class Components
+        def self.build_health_metrics: (untyped settings) -> untyped
+
+        def self.build_logger: (untyped settings) -> untyped
+
+        def self.build_runtime_metrics: (untyped settings) -> untyped
+
+        def self.build_runtime_metrics_worker: (untyped settings) -> untyped
+
+        def self.build_tracer: (untyped settings, untyped agent_settings) -> untyped
+
+        def self.build_profiler: (untyped settings, untyped agent_settings, untyped tracer) -> (nil | untyped)
+
+        private
+
+        def self.build_tracer_tags: (untyped settings) -> untyped
+
+        def self.build_tracer_options: (untyped settings, untyped agent_settings) -> untyped
+
+        def self.build_tracer_test_mode_options: (untyped tracer_options, untyped settings, untyped agent_settings) -> untyped
+
+        def self.build_profiler_recorder: (untyped settings) -> untyped
+
+        def self.build_profiler_collectors: (untyped settings, untyped recorder, untyped trace_identifiers_helper) -> ::Array[untyped]
+
+        def self.build_profiler_exporters: (untyped settings, untyped agent_settings) -> ::Array[untyped]
+
+        def self.build_profiler_scheduler: (untyped settings, untyped recorder, untyped exporters) -> untyped
+
+        public
+
+        attr_reader health_metrics: untyped
+
+        attr_reader logger: untyped
+
+        attr_reader profiler: untyped
+
+        attr_reader runtime_metrics: untyped
+
+        attr_reader tracer: untyped
+
+        def initialize: (untyped settings) -> untyped
+
+        # Starts up components
+        def startup!: (untyped settings) -> untyped
+
+        def shutdown!: (?untyped? replacement) -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/configuration/dependency_resolver.rbs
+++ b/sig/datadog/core/configuration/dependency_resolver.rbs
@@ -1,0 +1,11 @@
+module Datadog
+  module Core
+    module Configuration
+      class DependencyResolver[Node]
+        include TSort::_Sortable[Node]
+
+        def initialize: (?::Hash[Node, Node] dependency_graph) -> void
+      end
+    end
+  end
+end

--- a/sig/datadog/core/configuration/option.rbs
+++ b/sig/datadog/core/configuration/option.rbs
@@ -1,0 +1,25 @@
+module Datadog
+  module Core
+    module Configuration
+      class Option
+        attr_reader definition: untyped
+
+        def initialize: (untyped definition, untyped context) -> untyped
+
+        def set: (untyped value) -> untyped
+
+        def get: () -> untyped
+
+        def reset: () -> untyped
+
+        def default_value: () -> untyped
+
+        private
+
+        def context_exec: (*untyped args) { () -> untyped } -> untyped
+
+        def context_eval: () { () -> untyped } -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/configuration/option_definition.rbs
+++ b/sig/datadog/core/configuration/option_definition.rbs
@@ -1,0 +1,57 @@
+module Datadog
+  module Core
+    module Configuration
+      class OptionDefinition
+        IDENTITY: untyped
+
+        attr_reader default: untyped
+
+        attr_reader delegate_to: untyped
+
+        attr_reader depends_on: untyped
+
+        attr_reader lazy: untyped
+
+        attr_reader name: untyped
+
+        attr_reader on_set: untyped
+
+        attr_reader resetter: untyped
+
+        attr_reader setter: untyped
+
+        def initialize: (untyped name, ?::Hash[untyped, untyped] meta) { () -> untyped } -> untyped
+
+        def build: (untyped context) -> untyped
+
+        class Builder
+          attr_reader helpers: untyped
+
+          def initialize: (untyped name, ?::Hash[untyped, untyped] options) { (untyped) -> untyped } -> untyped
+
+          def depends_on: (*untyped values) -> untyped
+
+          def default: (?untyped? value) { () -> untyped } -> untyped
+
+          def delegate_to: () { () -> untyped } -> untyped
+
+          def helper: (untyped name, *untyped _args) { () -> untyped } -> untyped
+
+          def lazy: (?bool value) -> untyped
+
+          def on_set: () { () -> untyped } -> untyped
+
+          def resetter: () { () -> untyped } -> untyped
+
+          def setter: () { () -> untyped } -> untyped
+
+          def apply_options!: (?::Hash[untyped, untyped] options) -> (nil | untyped)
+
+          def to_definition: () -> untyped
+
+          def meta: () -> { default: untyped, delegate_to: untyped, depends_on: untyped, lazy: untyped, on_set: untyped, resetter: untyped, setter: untyped }
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/configuration/option_definition_set.rbs
+++ b/sig/datadog/core/configuration/option_definition_set.rbs
@@ -1,0 +1,11 @@
+module Datadog
+  module Core
+    module Configuration
+      class OptionDefinitionSet < Hash[untyped, untyped]
+        def dependency_order: () -> untyped
+
+        def dependency_graph: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/configuration/option_set.rbs
+++ b/sig/datadog/core/configuration/option_set.rbs
@@ -1,0 +1,8 @@
+module Datadog
+  module Core
+    module Configuration
+      class OptionSet < Hash[untyped, untyped]
+      end
+    end
+  end
+end

--- a/sig/datadog/core/configuration/options.rbs
+++ b/sig/datadog/core/configuration/options.rbs
@@ -1,0 +1,45 @@
+module Datadog
+  module Core
+    module Configuration
+      module Options
+        def self.included: (untyped base) -> untyped
+
+        module ClassMethods
+          def options: () -> untyped
+
+          def option: (untyped name, ?::Hash[untyped, untyped] meta) ?{ (OptionDefinition::Builder) -> untyped } -> untyped
+
+          private
+
+          def default_helpers: (untyped name) -> ::Hash[untyped, untyped]
+
+          def define_helpers: (untyped helpers) -> untyped
+        end
+
+        module InstanceMethods
+          def options: () -> untyped
+
+          def set_option: (untyped name, untyped value) -> untyped
+
+          def get_option: (untyped name) -> untyped
+
+          def reset_option: (untyped name) -> untyped
+
+          def option_defined?: (untyped name) -> untyped
+
+          def options_hash: () -> untyped
+
+          def reset_options!: () -> untyped
+
+          private
+
+          def add_option: (untyped name) -> untyped
+
+          def assert_valid_option!: (untyped name) -> untyped
+        end
+
+        InvalidOptionError: untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/configuration/settings.rbs
+++ b/sig/datadog/core/configuration/settings.rbs
@@ -1,0 +1,19 @@
+module Datadog
+  module Core
+    module Configuration
+      class Settings
+        include Base
+
+        def initialize: (*untyped _) -> untyped
+
+        def logger=: (untyped logger) -> untyped
+
+        def runtime_metrics: (?untyped? options) -> untyped
+
+        def tracer: (?untyped? options) -> untyped
+
+        def tracer=: (untyped tracer) -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/environment/cgroup.rbs
+++ b/sig/datadog/core/environment/cgroup.rbs
@@ -1,0 +1,19 @@
+module Datadog
+  module Core
+    module Environment
+      # Reads information from Linux cgroups.
+      # This information is used to extract information
+      # about the current Linux container identity.
+      # @see https://man7.org/linux/man-pages/man7/cgroups.7.html
+      module Cgroup
+        LINE_REGEX: untyped
+
+        Descriptor: untyped
+
+        def self?.descriptors: (?::String process) -> untyped
+
+        def self?.parse: (untyped line) -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/environment/cgroup.rbs
+++ b/sig/datadog/core/environment/cgroup.rbs
@@ -1,10 +1,6 @@
 module Datadog
   module Core
     module Environment
-      # Reads information from Linux cgroups.
-      # This information is used to extract information
-      # about the current Linux container identity.
-      # @see https://man7.org/linux/man-pages/man7/cgroups.7.html
       module Cgroup
         LINE_REGEX: untyped
 

--- a/sig/datadog/core/environment/class_count.rbs
+++ b/sig/datadog/core/environment/class_count.rbs
@@ -1,0 +1,12 @@
+module Datadog
+  module Core
+    module Environment
+      # Retrieves number of classes from runtime
+      module ClassCount
+        def self?.value: () -> untyped
+
+        def self?.available?: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/environment/class_count.rbs
+++ b/sig/datadog/core/environment/class_count.rbs
@@ -1,7 +1,6 @@
 module Datadog
   module Core
     module Environment
-      # Retrieves number of classes from runtime
       module ClassCount
         def self?.value: () -> untyped
 

--- a/sig/datadog/core/environment/container.rbs
+++ b/sig/datadog/core/environment/container.rbs
@@ -1,0 +1,30 @@
+module Datadog
+  module Core
+    module Environment
+      # For container environments
+      module Container
+        UUID_PATTERN: untyped
+
+        CONTAINER_PATTERN: untyped
+
+        PLATFORM_REGEX: untyped
+
+        POD_REGEX: untyped
+
+        CONTAINER_REGEX: untyped
+
+        FARGATE_14_CONTAINER_REGEX: untyped
+
+        Descriptor: untyped
+
+        def self?.platform: () -> untyped
+
+        def self?.container_id: () -> untyped
+
+        def self?.task_uid: () -> untyped
+
+        def self?.descriptor: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/environment/container.rbs
+++ b/sig/datadog/core/environment/container.rbs
@@ -1,7 +1,6 @@
 module Datadog
   module Core
     module Environment
-      # For container environments
       module Container
         UUID_PATTERN: untyped
 

--- a/sig/datadog/core/environment/ext.rbs
+++ b/sig/datadog/core/environment/ext.rbs
@@ -1,0 +1,26 @@
+module Datadog
+  module Core
+    module Environment
+      module Ext
+        # Identity
+        LANG: untyped
+
+        LANG_ENGINE: untyped
+
+        LANG_INTERPRETER: untyped
+
+        LANG_PLATFORM: untyped
+
+        LANG_VERSION: untyped
+
+        RUBY_ENGINE: untyped
+
+        # e.g. 'ruby', 'jruby', 'truffleruby'
+        TRACER_VERSION: untyped
+
+        # e.g for CRuby '3.0.1', for JRuby '9.2.19.0', for TruffleRuby '21.1.0'
+        ENGINE_VERSION: untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/environment/ext.rbs
+++ b/sig/datadog/core/environment/ext.rbs
@@ -2,7 +2,6 @@ module Datadog
   module Core
     module Environment
       module Ext
-        # Identity
         LANG: untyped
 
         LANG_ENGINE: untyped
@@ -15,10 +14,8 @@ module Datadog
 
         RUBY_ENGINE: untyped
 
-        # e.g. 'ruby', 'jruby', 'truffleruby'
         TRACER_VERSION: untyped
 
-        # e.g for CRuby '3.0.1', for JRuby '9.2.19.0', for TruffleRuby '21.1.0'
         ENGINE_VERSION: untyped
       end
     end

--- a/sig/datadog/core/environment/gc.rbs
+++ b/sig/datadog/core/environment/gc.rbs
@@ -1,0 +1,12 @@
+module Datadog
+  module Core
+    module Environment
+      # Retrieves garbage collection statistics
+      module GC
+        def self?.stat: () -> untyped
+
+        def self?.available?: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/environment/gc.rbs
+++ b/sig/datadog/core/environment/gc.rbs
@@ -1,7 +1,6 @@
 module Datadog
   module Core
     module Environment
-      # Retrieves garbage collection statistics
       module GC
         def self?.stat: () -> untyped
 

--- a/sig/datadog/core/environment/identity.rbs
+++ b/sig/datadog/core/environment/identity.rbs
@@ -1,0 +1,25 @@
+module Datadog
+  module Core
+    module Environment
+      # For runtime identity
+      module Identity
+        extend Datadog::Core::Utils::Forking
+
+        # Retrieves number of classes from runtime
+        def self?.id: () -> untyped
+
+        def self?.lang: () -> untyped
+
+        def self?.lang_engine: () -> untyped
+
+        def self?.lang_interpreter: () -> untyped
+
+        def self?.lang_platform: () -> untyped
+
+        def self?.lang_version: () -> untyped
+
+        def self?.tracer_version: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/environment/identity.rbs
+++ b/sig/datadog/core/environment/identity.rbs
@@ -1,11 +1,9 @@
 module Datadog
   module Core
     module Environment
-      # For runtime identity
       module Identity
         extend Datadog::Core::Utils::Forking
 
-        # Retrieves number of classes from runtime
         def self?.id: () -> untyped
 
         def self?.lang: () -> untyped

--- a/sig/datadog/core/environment/socket.rbs
+++ b/sig/datadog/core/environment/socket.rbs
@@ -1,0 +1,10 @@
+module Datadog
+  module Core
+    module Environment
+      # For runtime identity
+      module Socket
+        def self?.hostname: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/environment/socket.rbs
+++ b/sig/datadog/core/environment/socket.rbs
@@ -1,7 +1,6 @@
 module Datadog
   module Core
     module Environment
-      # For runtime identity
       module Socket
         def self?.hostname: () -> untyped
       end

--- a/sig/datadog/core/environment/thread_count.rbs
+++ b/sig/datadog/core/environment/thread_count.rbs
@@ -1,0 +1,12 @@
+module Datadog
+  module Core
+    module Environment
+      # Retrieves number of threads from runtime
+      module ThreadCount
+        def self?.value: () -> untyped
+
+        def self?.available?: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/environment/thread_count.rbs
+++ b/sig/datadog/core/environment/thread_count.rbs
@@ -1,7 +1,6 @@
 module Datadog
   module Core
     module Environment
-      # Retrieves number of threads from runtime
       module ThreadCount
         def self?.value: () -> untyped
 

--- a/sig/datadog/core/environment/variable_helpers.rbs
+++ b/sig/datadog/core/environment/variable_helpers.rbs
@@ -1,0 +1,23 @@
+module Datadog
+  module Core
+    # Namespace for handling application environment
+    module Environment
+      # Defines helper methods for environment
+      module VariableHelpers
+        extend ::Datadog::Core::Environment::VariableHelpers
+
+        def env_to_bool: (untyped var, ?untyped? default) -> untyped
+
+        def env_to_int: (untyped var, ?untyped? default) -> untyped
+
+        def env_to_float: (untyped var, ?untyped? default) -> untyped
+
+        def env_to_list: (untyped var, ?untyped default) -> untyped
+
+        private
+
+        def decode_array: (untyped var) -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/environment/variable_helpers.rbs
+++ b/sig/datadog/core/environment/variable_helpers.rbs
@@ -1,8 +1,6 @@
 module Datadog
   module Core
-    # Namespace for handling application environment
     module Environment
-      # Defines helper methods for environment
       module VariableHelpers
         extend ::Datadog::Core::Environment::VariableHelpers
 

--- a/sig/datadog/core/logger.rbs
+++ b/sig/datadog/core/logger.rbs
@@ -1,0 +1,13 @@
+module Datadog
+  module Core
+    class Logger < ::Logger
+      PREFIX: ::String
+
+      def initialize: (*untyped args) ?{ () -> untyped } -> void
+
+      def add: (untyped severity, ?untyped? message, ?untyped? progname) { () -> untyped } -> untyped
+
+      alias log add
+    end
+  end
+end

--- a/sig/datadog/core/utils/compression.rbs
+++ b/sig/datadog/core/utils/compression.rbs
@@ -1,7 +1,6 @@
 module Datadog
   module Core
     module Utils
-      # Common database-related utility functions.
       module Compression
         def self?.gzip: (untyped string, ?level: untyped? level, ?strategy: untyped? strategy) -> untyped
 

--- a/sig/datadog/core/utils/compression.rbs
+++ b/sig/datadog/core/utils/compression.rbs
@@ -1,0 +1,12 @@
+module Datadog
+  module Core
+    module Utils
+      # Common database-related utility functions.
+      module Compression
+        def self?.gzip: (untyped string, ?level: untyped? level, ?strategy: untyped? strategy) -> untyped
+
+        def self?.gunzip: (untyped string, ?untyped encoding) -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/utils/forking.rbs
+++ b/sig/datadog/core/utils/forking.rbs
@@ -1,7 +1,6 @@
 module Datadog
   module Core
     module Utils
-      # Helper methods for managing forking behavior
       module Forking
         def self.included: (untyped base) -> untyped
 
@@ -15,12 +14,7 @@ module Datadog
 
         def fork_pid: () -> untyped
 
-        # Adds additional functionality for Classes that implement Forking
         module ClassExtensions
-          # Addresses an edge case where forking before invoking #update_fork_pid! on the
-          # object will cause forking to not be detected in the fork when it should have.
-          #
-          # This wrapper prevents this by initializing the fork PID when the object is created.
           def initialize: (*untyped args) { () -> untyped } -> untyped
         end
       end

--- a/sig/datadog/core/utils/forking.rbs
+++ b/sig/datadog/core/utils/forking.rbs
@@ -1,0 +1,29 @@
+module Datadog
+  module Core
+    module Utils
+      # Helper methods for managing forking behavior
+      module Forking
+        def self.included: (untyped base) -> untyped
+
+        def self.extended: (untyped base) -> untyped
+
+        def after_fork!: () { () -> untyped } -> untyped
+
+        def forked?: () -> untyped
+
+        def update_fork_pid!: () -> untyped
+
+        def fork_pid: () -> untyped
+
+        # Adds additional functionality for Classes that implement Forking
+        module ClassExtensions
+          # Addresses an edge case where forking before invoking #update_fork_pid! on the
+          # object will cause forking to not be detected in the fork when it should have.
+          #
+          # This wrapper prevents this by initializing the fork PID when the object is created.
+          def initialize: (*untyped args) { () -> untyped } -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/utils/object_set.rbs
+++ b/sig/datadog/core/utils/object_set.rbs
@@ -1,16 +1,9 @@
 module Datadog
   module Core
     module Utils
-      # Acts as a unique dictionary of objects
       class ObjectSet
-        # You can provide a block that defines how the key
-        # for this message type is resolved.
         def initialize: (?::Integer seed) { () -> untyped } -> untyped
 
-        # Submit an array of arguments that define the message.
-        # If they match an existing message, it will return the
-        # matching object. If it doesn't match, it will yield to
-        # the block with the next ID & args given.
         def fetch: (*untyped args) { (untyped, untyped) -> untyped } -> untyped
 
         def length: () -> untyped

--- a/sig/datadog/core/utils/object_set.rbs
+++ b/sig/datadog/core/utils/object_set.rbs
@@ -1,0 +1,24 @@
+module Datadog
+  module Core
+    module Utils
+      # Acts as a unique dictionary of objects
+      class ObjectSet
+        # You can provide a block that defines how the key
+        # for this message type is resolved.
+        def initialize: (?::Integer seed) { () -> untyped } -> untyped
+
+        # Submit an array of arguments that define the message.
+        # If they match an existing message, it will return the
+        # matching object. If it doesn't match, it will yield to
+        # the block with the next ID & args given.
+        def fetch: (*untyped args) { (untyped, untyped) -> untyped } -> untyped
+
+        def length: () -> untyped
+
+        def objects: () -> untyped
+
+        def freeze: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/utils/only_once.rbs
+++ b/sig/datadog/core/utils/only_once.rbs
@@ -1,14 +1,6 @@
 module Datadog
   module Core
     module Utils
-      # Helper class to execute something only once such as not repeating warning logs, and instrumenting classes
-      # only once.
-      #
-      # Thread-safe when used correctly (e.g. be careful of races when lazily initializing instances of this class).
-      #
-      # Note: In its current state, this class is not Ractor-safe.
-      # In https://github.com/DataDog/dd-trace-rb/pull/1398#issuecomment-797378810 we have a discussion of alternatives,
-      # including an alternative implementation that is Ractor-safe once spent.
       class OnlyOnce
         def initialize: () -> untyped
 

--- a/sig/datadog/core/utils/only_once.rbs
+++ b/sig/datadog/core/utils/only_once.rbs
@@ -1,0 +1,25 @@
+module Datadog
+  module Core
+    module Utils
+      # Helper class to execute something only once such as not repeating warning logs, and instrumenting classes
+      # only once.
+      #
+      # Thread-safe when used correctly (e.g. be careful of races when lazily initializing instances of this class).
+      #
+      # Note: In its current state, this class is not Ractor-safe.
+      # In https://github.com/DataDog/dd-trace-rb/pull/1398#issuecomment-797378810 we have a discussion of alternatives,
+      # including an alternative implementation that is Ractor-safe once spent.
+      class OnlyOnce
+        def initialize: () -> untyped
+
+        def run: () { () -> untyped } -> untyped
+
+        def ran?: () -> untyped
+
+        private
+
+        def reset_ran_once_state_for_tests: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/utils/sequence.rbs
+++ b/sig/datadog/core/utils/sequence.rbs
@@ -1,7 +1,6 @@
 module Datadog
   module Core
     module Utils
-      # Generates values from a consistent sequence
       class Sequence
         def initialize: (?::Integer seed) { () -> untyped } -> untyped
 

--- a/sig/datadog/core/utils/sequence.rbs
+++ b/sig/datadog/core/utils/sequence.rbs
@@ -1,0 +1,12 @@
+module Datadog
+  module Core
+    module Utils
+      # Generates values from a consistent sequence
+      class Sequence
+        def initialize: (?::Integer seed) { () -> untyped } -> untyped
+
+        def next: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/utils/string_table.rbs
+++ b/sig/datadog/core/utils/string_table.rbs
@@ -1,0 +1,22 @@
+module Datadog
+  module Core
+    module Utils
+      # Tracks strings and returns IDs
+      class StringTable
+        def initialize: () -> untyped
+
+        # Returns an ID for the string
+        def fetch: (untyped string) -> untyped
+
+        # Returns the canonical copy of this string
+        # Typically used for psuedo interning; reduce
+        # identical copies of a string to one object.
+        def fetch_string: (untyped string) -> (nil | untyped)
+
+        def []: (untyped id) -> untyped
+
+        def strings: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/utils/string_table.rbs
+++ b/sig/datadog/core/utils/string_table.rbs
@@ -1,16 +1,11 @@
 module Datadog
   module Core
     module Utils
-      # Tracks strings and returns IDs
       class StringTable
         def initialize: () -> untyped
 
-        # Returns an ID for the string
         def fetch: (untyped string) -> untyped
 
-        # Returns the canonical copy of this string
-        # Typically used for psuedo interning; reduce
-        # identical copies of a string to one object.
         def fetch_string: (untyped string) -> (nil | untyped)
 
         def []: (untyped id) -> untyped

--- a/sig/datadog/core/utils/time.rbs
+++ b/sig/datadog/core/utils/time.rbs
@@ -1,31 +1,12 @@
 module Datadog
   module Core
     module Utils
-      # Common database-related utility functions.
       module Time
-        # Current monotonic time.
-        # Falls back to `now` if monotonic clock
-        # is not available.
-        #
-        # @return [Float] in seconds, since some unspecified starting point
-        def self?.get_time: () -> untyped
-
-        # Current wall time.
-        #
-        # @return [Time] current time object
-        def self?.now: () -> untyped
-
-        # Overrides the implementation of `#now
-        # with the provided callable.
-        #
-        # Overriding the method `#now` instead of
-        # indirectly calling `block` removes
-        # one level of method call overhead.
-        #
-        # @param block [Proc] block that returns a `Time` object representing the current wall time
-        def self?.now_provider=: (untyped block) -> untyped
-
-        def self?.measure: () { () -> untyped } -> untyped
+        def self?.get_time: (?::Symbol unit) -> ::Numeric
+        def self?.now: () -> ::Time
+        def self?.now_provider=: (^() -> ::Time block) -> void
+        def self?.measure: (?::Symbol unit) { () -> void } -> ::Numeric
+        def self?.as_utc_epoch_ns: (::Time time) -> ::Integer
       end
     end
   end

--- a/sig/datadog/core/utils/time.rbs
+++ b/sig/datadog/core/utils/time.rbs
@@ -1,0 +1,32 @@
+module Datadog
+  module Core
+    module Utils
+      # Common database-related utility functions.
+      module Time
+        # Current monotonic time.
+        # Falls back to `now` if monotonic clock
+        # is not available.
+        #
+        # @return [Float] in seconds, since some unspecified starting point
+        def self?.get_time: () -> untyped
+
+        # Current wall time.
+        #
+        # @return [Time] current time object
+        def self?.now: () -> untyped
+
+        # Overrides the implementation of `#now
+        # with the provided callable.
+        #
+        # Overriding the method `#now` instead of
+        # indirectly calling `block` removes
+        # one level of method call overhead.
+        #
+        # @param block [Proc] block that returns a `Time` object representing the current wall time
+        def self?.now_provider=: (untyped block) -> untyped
+
+        def self?.measure: () { () -> untyped } -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/tracing.rbs
+++ b/sig/datadog/tracing.rbs
@@ -1,0 +1,4 @@
+module Datadog
+  module Tracing
+  end
+end

--- a/sig/datadog/tracing/contrib/utils/database.rbs
+++ b/sig/datadog/tracing/contrib/utils/database.rbs
@@ -1,0 +1,18 @@
+module Datadog
+  module Tracing
+    module Contrib
+      module Utils
+        # Common database-related utility functions.
+        module Database
+          VENDOR_DEFAULT: untyped
+
+          VENDOR_POSTGRES: untyped
+
+          VENDOR_SQLITE: untyped
+
+          def self?.normalize_vendor: (untyped vendor) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/tracing/contrib/utils/database.rbs
+++ b/sig/datadog/tracing/contrib/utils/database.rbs
@@ -2,7 +2,6 @@ module Datadog
   module Tracing
     module Contrib
       module Utils
-        # Common database-related utility functions.
         module Database
           VENDOR_DEFAULT: untyped
 

--- a/sig/datadog/tracing/correlation.rbs
+++ b/sig/datadog/tracing/correlation.rbs
@@ -1,0 +1,10 @@
+module Datadog
+  module Tracing
+    module Correlation
+      Identifier: Struct[untyped]
+
+      def self?.identifier_from_context: (untyped context) -> Struct[untyped] # Identifier
+    end
+  end
+end
+

--- a/sig/datadog/tracing/metadata/ext.rbs
+++ b/sig/datadog/tracing/metadata/ext.rbs
@@ -1,0 +1,104 @@
+module Datadog
+  module Tracing
+    module Metadata
+      module Ext
+        TAG_COMPONENT: ::String
+        TAG_OPERATION: ::String
+        TAG_PEER_HOSTNAME: ::String
+        TAG_PEER_SERVICE: ::String
+        TAG_KIND: ::String
+        TAG_TOP_LEVEL: ::String
+
+        module Analytics
+          DEFAULT_SAMPLE_RATE: ::Float
+          TAG_ENABLED: ::String
+          TAG_MEASURED: ::String
+          TAG_SAMPLE_RATE: ::String
+        end
+
+        module AppTypes
+          TYPE_WEB: ::String
+          TYPE_DB: ::String
+          TYPE_CACHE: ::String
+          TYPE_WORKER: ::String
+          TYPE_CUSTOM: ::String
+        end
+
+        module Distributed
+          TAG_DECISION_MAKER: ::String
+          TAG_ORIGIN: ::String
+          TAG_SAMPLING_PRIORITY: ::String
+          TAGS_PREFIX: ::String
+        end
+
+        module Errors
+          STATUS: ::Integer
+          TAG_MSG: ::String
+          TAG_STACK: ::String
+          TAG_TYPE: ::String
+        end
+
+        module HTTP
+          ERROR_RANGE: ::Range[::Integer]
+          TAG_BASE_URL: ::String
+          TAG_METHOD: ::String
+          TAG_STATUS_CODE: ::String
+          TAG_USER_AGENT: ::String
+          TAG_URL: ::String
+          TYPE_INBOUND: untyped
+          TYPE_OUTBOUND: ::String
+          TYPE_PROXY: ::String
+          TYPE_TEMPLATE: ::String
+          TAG_CLIENT_IP: ::String
+          HEADER_USER_AGENT: ::String
+
+          module Headers
+            INVALID_TAG_CHARACTERS: ::Regexp
+
+            def self?.to_tag: (untyped name) -> untyped
+          end
+
+          module RequestHeaders
+            PREFIX: ::String
+
+            def self?.to_tag: (untyped name) -> ::String
+          end
+
+          module ResponseHeaders
+            PREFIX: ::String
+
+            def self?.to_tag: (untyped name) -> ::String
+          end
+        end
+
+        module NET
+          TAG_HOSTNAME: ::String
+          TAG_TARGET_HOST: ::String
+          TAG_TARGET_PORT: ::String
+          TAG_DESTINATION_NAME: ::String
+          TAG_DESTINATION_PORT: ::String
+        end
+
+        module Sampling
+          TAG_AGENT_RATE: ::String
+          TAG_RULE_SAMPLE_RATE: ::String
+          TAG_RATE_LIMITER_RATE: ::String
+          TAG_SAMPLE_RATE: ::String
+        end
+
+        module SQL
+          TYPE: ::String
+          TAG_QUERY: ::String
+        end
+
+        module SpanKind
+          TAG_SERVER: ::String
+          TAG_CLIENT: ::String
+          TAG_PRODUCER: ::String
+          TAG_CONSUMER: ::String
+          TAG_INTERNAL: ::String
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/tracing/sampling/ext.rbs
+++ b/sig/datadog/tracing/sampling/ext.rbs
@@ -1,0 +1,27 @@
+module Datadog
+  module Tracing
+    module Sampling
+      module Ext
+        module Priority
+          USER_REJECT: ::Integer
+          AUTO_REJECT: ::Integer
+          AUTO_KEEP: ::Integer
+          USER_KEEP: ::Integer
+        end
+
+        module Mechanism
+          SPAN_SAMPLING_RATE: ::Integer
+        end
+
+        module Decision
+          DEFAULT: ::String
+          AGENT_RATE: ::String
+          TRACE_SAMPLING_RULE: ::String
+          MANUAL: ::String
+          ASM: ::String
+          SPAN_SAMPLING_RATE: ::String
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/tracing/span.rbs
+++ b/sig/datadog/tracing/span.rbs
@@ -1,0 +1,10 @@
+module Datadog
+  module Tracing
+    class Span
+      attr_accessor span_id: Integer
+
+      def set_tag: (String key, ?untyped? value) -> void
+    end
+  end
+end
+

--- a/sig/datadog/tracing/tracer.rbs
+++ b/sig/datadog/tracing/tracer.rbs
@@ -1,0 +1,11 @@
+module Datadog
+  module Tracing
+    class Tracer
+      def active_root_span: (?untyped? key) -> Datadog::Tracing::Span
+
+      def active_span: (?untyped? key) -> Datadog::Tracing::Span
+
+      def active_correlation: (?untyped? key) -> Struct[untyped] # Datadog::Correlation::Identifier
+    end
+  end
+end

--- a/sorbet/config
+++ b/sorbet/config
@@ -4,3 +4,4 @@
 --ignore=/integration
 --ignore=/yard
 --ignore=/vendor/bundle
+--ignore=/lib/datadog/appsec

--- a/sorbet/rbi/gems/ddtrace.rbi
+++ b/sorbet/rbi/gems/ddtrace.rbi
@@ -19,16 +19,3 @@ module Datadog::Transport::IO
   def self.default(options = nil); end
   def self.new(out, encoder); end
 end
-module Datadog::AppSec
-  extend Datadog::AppSec::Configuration::ClassMethods
-  include Datadog::AppSec::Configuration
-end
-module Datadog::AppSec::Contrib
-end
-module Datadog::AppSec::Contrib::Rack
-end
-module Datadog::AppSec::Contrib::Rack::Request
-end
-class Datadog::Core::Configuration::Settings
-  include Datadog::AppSec::Extensions::Settings
-end

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require 'datadog/appsec/spec_helper'
 

--- a/spec/datadog/appsec/extensions_spec.rb
+++ b/spec/datadog/appsec/extensions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require 'datadog/appsec/spec_helper'
 

--- a/spec/datadog/appsec/processor_spec.rb
+++ b/spec/datadog/appsec/processor_spec.rb
@@ -74,6 +74,8 @@ RSpec.describe Datadog::AppSec::Processor do
       before do
         allow(Object).to receive(:require).with('libddwaf').and_return(true)
         stub_const('Datadog::AppSec::WAF', Module.new)
+        stub_const('Datadog::AppSec::WAF::LibDDWAF', Module.new)
+        stub_const('Datadog::AppSec::WAF::LibDDWAF::Error', Class.new(StandardError))
       end
 
       it { expect(described_class.new.send(:load_libddwaf)).to be true }

--- a/spec/datadog/appsec/spec_helper.rb
+++ b/spec/datadog/appsec/spec_helper.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 
 require 'ddtrace'
 require 'datadog/appsec'

--- a/spec/datadog/appsec/utils/http/media_range_spec.rb
+++ b/spec/datadog/appsec/utils/http/media_range_spec.rb
@@ -5,6 +5,7 @@ require 'datadog/appsec/utils/http/media_range'
 RSpec.describe Datadog::AppSec::Utils::HTTP::MediaRange do
   describe '.new' do
     context 'with valid input' do
+      # rubocop:disable Layout/LineLength
       expectations = {
         '*/*' => { type: '*', subtype: '*', quality: 1.0, parameters: {}, accept_ext: {} },
         'text/*' => { type: 'text', subtype: '*', parameters: {}, accept_ext: {} },
@@ -41,6 +42,7 @@ RSpec.describe Datadog::AppSec::Utils::HTTP::MediaRange do
         'text/html;foo=bar;q=0.5;baz=qux' => { type: 'text', subtype: 'html', quality: 0.5, parameters: { 'foo' => 'bar' }, accept_ext: { 'baz' => 'qux' } },
         'text/html;foo="bar";q=0.5;baz="qux"' => { type: 'text', subtype: 'html', quality: 0.5, parameters: { 'foo' => 'bar' }, accept_ext: { 'baz' => 'qux' } },
       }
+      # rubocop:enable Layout/LineLength
 
       expectations.each do |str, expected|
         it "parses #{str.inspect} to #{expected.inspect}" do

--- a/spec/datadog/appsec/utils/http/media_range_spec.rb
+++ b/spec/datadog/appsec/utils/http/media_range_spec.rb
@@ -1,0 +1,390 @@
+# typed: ignore
+
+require 'datadog/appsec/utils/http/media_range'
+
+RSpec.describe Datadog::AppSec::Utils::HTTP::MediaRange do
+  describe '.new' do
+    context 'with valid input' do
+      expectations = {
+        '*/*' => { type: '*', subtype: '*', quality: 1.0, parameters: {}, accept_ext: {} },
+        'text/*' => { type: 'text', subtype: '*', parameters: {}, accept_ext: {} },
+        'text/html' => { type: 'text', subtype: 'html', quality: 1.0, parameters: {}, accept_ext: {} },
+        'Text/HTML' => { type: 'text', subtype: 'html', quality: 1.0, parameters: {}, accept_ext: {} },
+        'application/json' => { type: 'application', subtype: 'json', parameters: {}, accept_ext: {} },
+        'text/html;Q=1' => { type: 'text', subtype: 'html', quality: 1.0, parameters: {}, accept_ext: {} },
+        'text/html;q=1' => { type: 'text', subtype: 'html', quality: 1.0, parameters: {}, accept_ext: {} },
+        'text/html;q=1.0' => { type: 'text', subtype: 'html', quality: 1.0, parameters: {}, accept_ext: {} },
+        'text/html;q=1.00' => { type: 'text', subtype: 'html', quality: 1.0, parameters: {}, accept_ext: {} },
+        'text/html;q=1.000' => { type: 'text', subtype: 'html', quality: 1.0, parameters: {}, accept_ext: {} },
+        'text/html;q=0.5' => { type: 'text', subtype: 'html', quality: 0.5, parameters: {}, accept_ext: {} },
+        'text/html;q=0.333' => { type: 'text', subtype: 'html', quality: 0.333, parameters: {}, accept_ext: {} },
+        'text/html;q=0' => { type: 'text', subtype: 'html', quality: 0.0, parameters: {}, accept_ext: {} },
+        'text/html;q=0.0' => { type: 'text', subtype: 'html', quality: 0.0, parameters: {}, accept_ext: {} },
+        'text/html;q=0.00' => { type: 'text', subtype: 'html', quality: 0.0, parameters: {}, accept_ext: {} },
+        'text/html;q=0.000' => { type: 'text', subtype: 'html', quality: 0.0, parameters: {}, accept_ext: {} },
+        'Text/HTML;FOO=BAR' => { type: 'text', subtype: 'html', quality: 1.0, parameters: { 'foo' => 'bar' }, accept_ext: {} },
+        'text/html;foo=bar' => { type: 'text', subtype: 'html', quality: 1.0, parameters: { 'foo' => 'bar' }, accept_ext: {} },
+        'text/html ; foo=bar' => { type: 'text', subtype: 'html', quality: 1.0, parameters: { 'foo' => 'bar' }, accept_ext: {} },
+        'text/html; foo=bar' => { type: 'text', subtype: 'html', quality: 1.0, parameters: { 'foo' => 'bar' }, accept_ext: {} },
+        'text/html ;foo=bar' => { type: 'text', subtype: 'html', quality: 1.0, parameters: { 'foo' => 'bar' }, accept_ext: {} },
+        'text/html;foo="bar"' => { type: 'text', subtype: 'html', quality: 1.0, parameters: { 'foo' => 'bar' }, accept_ext: {} },
+        'text/html;foo=bar;baz=qux' => { type: 'text', subtype: 'html', quality: 1.0, parameters: { 'foo' => 'bar', 'baz' => 'qux' }, accept_ext: {} },
+        'text/html;foo="bar";baz="qux"' => { type: 'text', subtype: 'html', quality: 1.0, parameters: { 'foo' => 'bar', 'baz' => 'qux' }, accept_ext: {} },
+        'text/html;q=0.5;foo=bar' => { type: 'text', subtype: 'html', quality: 0.5, parameters: {}, accept_ext: { 'foo' => 'bar' } },
+        'text/html;q=0.5;foo="bar"' => { type: 'text', subtype: 'html', quality: 0.5, parameters: {}, accept_ext: { 'foo' => 'bar' } },
+        'text/html;q=0.5;foo=bar;baz=qux' => { type: 'text', subtype: 'html', quality: 0.5, parameters: {}, accept_ext: { 'foo' => 'bar', 'baz' => 'qux' } },
+        'text/html;q=0.5;foo="bar";baz="qux"' => { type: 'text', subtype: 'html', quality: 0.5, parameters: {}, accept_ext: { 'foo' => 'bar', 'baz' => 'qux' } },
+        'text/html;foo=bar;q=0.5' => { type: 'text', subtype: 'html', quality: 0.5, parameters: { 'foo' => 'bar' }, accept_ext: {} },
+        'text/html;foo="bar";q=0.5' => { type: 'text', subtype: 'html', quality: 0.5, parameters: { 'foo' => 'bar' }, accept_ext: {} },
+        'text/html;foo=bar;baz=qux;q=0.5' => { type: 'text', subtype: 'html', quality: 0.5, parameters: { 'foo' => 'bar', 'baz' => 'qux' }, accept_ext: {} },
+        'text/html;foo="bar";baz="qux";q=0.5' => { type: 'text', subtype: 'html', quality: 0.5, parameters: { 'foo' => 'bar', 'baz' => 'qux' }, accept_ext: {} },
+        'text/html;foo=bar;q=0.5;baz=qux' => { type: 'text', subtype: 'html', quality: 0.5, parameters: { 'foo' => 'bar' }, accept_ext: { 'baz' => 'qux' } },
+        'text/html;foo="bar";q=0.5;baz="qux"' => { type: 'text', subtype: 'html', quality: 0.5, parameters: { 'foo' => 'bar' }, accept_ext: { 'baz' => 'qux' } },
+      }
+
+      expectations.each do |str, expected|
+        it "parses #{str.inspect} to #{expected.inspect}" do
+          expect(described_class.new(str)).to have_attributes expected
+        end
+      end
+    end
+
+    context 'with invalid input' do
+      parse_error = described_class::ParseError
+      expectations = {
+        'text/html ' => parse_error,
+        ' text/html' => parse_error,
+        'text /html' => parse_error,
+        'text/ html' => parse_error,
+        'text/html;q=' => parse_error,
+        'text/html;q=1;' => parse_error,
+        'text/html;q=1.0000' => parse_error,
+        'text/html;q=1.001' => parse_error,
+        'text/html;q=0.0000' => parse_error,
+        'text/html;q=0.0001' => parse_error,
+        'text/html;foo =bar' => parse_error,
+        'text/html;foo= bar' => parse_error,
+        'text/html;foo=bar;' => parse_error,
+        'text/html;foo=bar"' => parse_error,
+        'text/html;foo="bar' => parse_error,
+        'text/html;foo="bar""' => parse_error,
+      }
+
+      expectations.each do |str, expected|
+        it "raises #{expected} with #{str.inspect}" do
+          expect { described_class.new(str) }.to raise_error(expected)
+        end
+      end
+    end
+  end
+
+  describe '#to_s' do
+    expectations = {
+      '*/*' => '*/*',
+      'text/*' => 'text/*',
+      'text/html' => 'text/html',
+      'application/json' => 'application/json',
+      'text/html;q=1' => 'text/html',
+      'text/html;q=1.0' => 'text/html',
+      'text/html;q=1.00' => 'text/html',
+      'text/html;q=1.000' => 'text/html',
+      'text/html;q=0.5' => 'text/html;q=0.5',
+      'text/html;q=0.333' => 'text/html;q=0.333',
+      'text/html;q=0' => 'text/html;q=0.0',
+      'text/html;q=0.0' => 'text/html;q=0.0',
+      'text/html;q=0.00' => 'text/html;q=0.0',
+      'text/html;q=0.000' => 'text/html;q=0.0',
+      'text/html;foo=bar' => 'text/html;foo=bar',
+      'text/html;foo="bar"' => 'text/html;foo=bar',
+      'text/html;foo=bar;baz=qux' => 'text/html;foo=bar;baz=qux',
+      'text/html;foo="bar";baz="qux"' => 'text/html;foo=bar;baz=qux',
+      'text/html;q=0.5;foo=bar' => 'text/html;q=0.5;foo=bar',
+      'text/html;q=0.5;foo="bar"' => 'text/html;q=0.5;foo=bar',
+      'text/html;q=0.5;foo=bar;baz=qux' => 'text/html;q=0.5;foo=bar;baz=qux',
+      'text/html;q=0.5;foo="bar";baz="qux"' => 'text/html;q=0.5;foo=bar;baz=qux',
+      'text/html;foo=bar;q=0.5' => 'text/html;foo=bar;q=0.5',
+      'text/html;foo="bar";q=0.5' => 'text/html;foo=bar;q=0.5',
+      'text/html;foo=bar;baz=qux;q=0.5' => 'text/html;foo=bar;baz=qux;q=0.5',
+      'text/html;foo="bar";baz="qux";q=0.5' => 'text/html;foo=bar;baz=qux;q=0.5',
+      'text/html;foo=bar;q=0.5;baz=qux' => 'text/html;foo=bar;q=0.5;baz=qux',
+      'text/html;foo="bar";q=0.5;baz="qux"' => 'text/html;foo=bar;q=0.5;baz=qux',
+    }
+
+    expectations.each do |str, expected|
+      it "returns #{expected.inspect} for #{str.inspect}" do
+        expect(described_class.new(str).to_s).to eq expected
+      end
+    end
+  end
+
+  describe '#wildcard?' do
+    expectations = {
+      '*/*' => true,
+      'text/*' => true,
+      'text/html' => false,
+    }
+
+    expectations.each do |str, expected|
+      it "returns #{expected.inspect} for #{str.inspect}" do
+        expect(described_class.new(str).wildcard?).to eq expected
+      end
+    end
+
+    context 'for type' do
+      expectations = {
+        '*/*' => true,
+        'text/*' => false,
+        'text/html' => false,
+      }
+
+      expectations.each do |str, expected|
+        it "returns #{expected.inspect} for #{str.inspect}" do
+          expect(described_class.new(str).wildcard?(:type)).to eq expected
+        end
+      end
+    end
+
+    context 'for subtype' do
+      expectations = {
+        '*/*' => true,
+        'text/*' => true,
+        'text/html' => false,
+      }
+
+      expectations.each do |str, expected|
+        it "returns #{expected.inspect} for #{str.inspect}" do
+          expect(described_class.new(str).wildcard?(:subtype)).to eq expected
+        end
+      end
+    end
+  end
+
+  describe '#specificity' do
+    expectations = {
+      '*/*' => 0,
+      'text/*' => 0,
+      'text/html' => 0,
+      'text/html;foo=bar' => 1,
+      'text/html;foo=bar;baz=qux' => 2,
+      'text/html;q=0.5;foo=bar' => 0,
+      'text/html;foo=bar;q=0.5' => 1,
+      'text/html;q=0.5;foo=bar;baz=qux' => 0,
+      'text/html;foo=bar;q=0.5;baz=qux' => 1,
+      'text/html;foo=bar;baz=qux;q=0.5' => 2,
+    }
+
+    expectations.each do |str, expected|
+      it "returns #{expected.inspect} for #{str.inspect}" do
+        expect(described_class.new(str).specificity).to eq expected
+      end
+    end
+  end
+
+  describe '#<=>' do
+    expectations = {
+      # quality
+      [
+        'text/html',
+        'text/html',
+      ] => 0,
+      [
+        'text/html',
+        'application/json',
+      ] => 0,
+      [
+        'text/html',
+        'application/json;q=0.5',
+      ] => 1,
+      [
+        'text/html;q=0.5',
+        'application/json',
+      ] => -1,
+
+      # specificity
+      [
+        'text/plain;format=flowed',
+        'text/plain',
+      ] => 1,
+      [
+        'text/plain',
+        'text/plain;format=flowed',
+      ] => -1,
+
+      # quality/specificity mix
+      [
+        'text/plain;format=flowed;q=0.5',
+        'text/plain',
+      ] => -1,
+      [
+        'text/plain',
+        'text/plain;format=flowed;q=0.5',
+      ] => 1,
+
+      # quality/extension mix
+      [
+        'text/plain;q=0.5;foo=bar',
+        'text/plain',
+      ] => -1,
+      [
+        'text/plain',
+        'text/plain;q=0.5;foo=bar',
+      ] => 1,
+
+      # quality/specificity/extension mix
+      [
+        'text/plain;format=flowed;q=0.5;foo=bar',
+        'text/plain',
+      ] => -1,
+      [
+        'text/plain',
+        'text/plain;format=flowed;q=0.5;foo=bar',
+      ] => 1,
+
+      # wildcard
+      [
+        '*/*',
+        '*/*',
+      ] => 0,
+      [
+        '*/*',
+        'text/html',
+      ] => -1,
+      [
+        'text/html',
+        '*/*',
+      ] => 1,
+    }
+
+    expectations.each do |(str1, str2), expected|
+      it "returns #{expected.inspect} for #{str1.inspect} <=> #{str2.inspect}" do
+        expect(described_class.new(str1) <=> described_class.new(str2)).to eq expected
+      end
+    end
+
+    context 'using sort' do
+      expectations = {
+        [
+          'audio/*;q=0.2',
+          'audio/basic',
+        ] => [
+          'audio/*;q=0.2',
+          'audio/basic',
+        ],
+        [
+          'text/plain;q=0.5',
+          'text/html',
+          'text/x-dvi;q=0.8',
+          'text/x-c',
+        ] => [
+          'text/plain;q=0.5',
+          'text/x-dvi;q=0.8',
+          'text/html',
+          'text/x-c',
+        ],
+        [
+          'text/*',
+          'text/plain',
+          'text/plain;format=flowed',
+          '*/*',
+        ] => [
+          '*/*',
+          'text/*',
+          'text/plain',
+          'text/plain;format=flowed',
+        ],
+        [
+          'text/*;q=0.3',
+          'text/html;q=0.7',
+          'text/html;level=1',
+          'text/html;level=2;q=0.4',
+          '*/*;q=0.5',
+        ] => [
+          'text/*;q=0.3',
+          'text/html;level=2;q=0.4',
+          '*/*;q=0.5',
+          'text/html;q=0.7',
+          'text/html;level=1',
+        ],
+      }
+
+      expectations.each do |array, expected|
+        it "returns #{expected.inspect} for #{array.inspect}" do
+          expect(array.map { |str| described_class.new(str) }.sort.map(&:to_s)).to eq expected
+        end
+      end
+    end
+  end
+
+  describe '#===' do
+    expectations = {
+      [
+        'text/html',
+        'text/html',
+      ] => true,
+      [
+        'text/html',
+        'text/plain',
+      ] => false,
+      [
+        'text/*',
+        'text/plain',
+      ] => true,
+      [
+        '*/*',
+        'text/plain',
+      ] => true,
+      [
+        'text/html;level=1',
+        'text/html',
+      ] => true,
+      [
+        'text/html;level=1',
+        'text/plain',
+      ] => false,
+      [
+        'text/html;q=0.5',
+        'text/html',
+      ] => true,
+      [
+        'text/html;q=0.5',
+        'text/plain',
+      ] => false,
+      [
+        'text/*;q=0.5',
+        'text/plain',
+      ] => true,
+      [
+        '*/*;q=0.5',
+        'text/plain',
+      ] => true,
+      [
+        'text/html;level=1',
+        'text/html;level=1',
+      ] => true,
+      [
+        'text/html',
+        'text/html;level=1',
+      ] => false,
+      [
+        'text/html;level=1;foo=bar',
+        'text/html;level=1',
+      ] => true,
+      [
+        'text/html;foo=bar;level=1',
+        'text/html;level=1',
+      ] => true,
+      [
+        'text/html',
+        'text/html;level=1;foo=bar',
+      ] => false,
+    }
+
+    expectations.each do |(range, type), expected|
+      let(:type_class) { Datadog::AppSec::Utils::HTTP::MediaType }
+
+      it "returns #{expected.inspect} for #{range.inspect} <=> #{type.inspect}" do
+        expect(described_class.new(range) === type_class.new(type)).to eq expected
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/utils/http/media_type_spec.rb
+++ b/spec/datadog/appsec/utils/http/media_type_spec.rb
@@ -1,0 +1,61 @@
+# typed: ignore
+
+require 'datadog/appsec/utils/http/media_type'
+
+RSpec.describe Datadog::AppSec::Utils::HTTP::MediaType do
+  describe '.new' do
+    context 'with valid input' do
+      expectations = {
+        '*/*' => { type: '*', subtype: '*' },
+        'text/*' => { type: 'text', subtype: '*' },
+        'text/html' => { type: 'text', subtype: 'html' },
+        'Text/HTML' => { type: 'text', subtype: 'html' },
+        'text/plain;format=flowed' => { type: 'text', subtype: 'plain', parameters: { 'format' => 'flowed' } },
+        'Text/PLAIN;FORMAT=FLOWED' => { type: 'text', subtype: 'plain', parameters: { 'format' => 'flowed' } },
+        'text/plain ; format=flowed' => { type: 'text', subtype: 'plain', parameters: { 'format' => 'flowed' } },
+        'text/plain; format=flowed' => { type: 'text', subtype: 'plain', parameters: { 'format' => 'flowed' } },
+        'text/plain ;format=flowed' => { type: 'text', subtype: 'plain', parameters: { 'format' => 'flowed' } },
+        'application/json' => { type: 'application', subtype: 'json' },
+      }
+
+      expectations.each do |str, expected|
+        it "parses #{str.inspect} to #{expected.inspect}" do
+          expect(described_class.new(str)).to have_attributes expected
+        end
+      end
+    end
+
+    context 'with invalid input' do
+      parse_error = described_class::ParseError
+      expectations = {
+        'text/html ' => parse_error,
+        ' text/html' => parse_error,
+        'text /html' => parse_error,
+        'text/ html' => parse_error,
+        'text/plain;format = flowed' => parse_error,
+        'text/plain;format= flowed' => parse_error,
+        'text/plain;format =flowed' => parse_error,
+      }
+
+      expectations.each do |str, expected|
+        it "raises #{expected} with #{str.inspect}" do
+          expect { described_class.new(str) }.to raise_error(expected)
+        end
+      end
+    end
+  end
+
+  describe '#to_s' do
+    expectations = {
+      'text/html' => 'text/html',
+      'application/json' => 'application/json',
+      'text/plain;format=flowed' => 'text/plain;format=flowed',
+    }
+
+    expectations.each do |str, expected|
+      it "converts #{str.inspect} to #{expected.inspect}" do
+        expect(described_class.new(str).to_s).to eq expected
+      end
+    end
+  end
+end

--- a/spec/ddtrace/release_gem_spec.rb
+++ b/spec/ddtrace/release_gem_spec.rb
@@ -24,11 +24,12 @@ RSpec.describe 'gem release process' do
           CONTRIBUTING.md
           Gemfile
           Rakefile
+          Steepfile
           ddtrace.gemspec
           docker-compose.yml
         ]
 
-        directories_excluded = %r{^(spec|docs|\.circleci|\.github|benchmarks|gemfiles|integration|tasks|sorbet|yard)/}
+        directories_excluded = %r{^(sig|spec|docs|\.circleci|\.github|benchmarks|gemfiles|integration|tasks|sorbet|yard)/}
 
         expect(files)
           .to match_array(

--- a/spec/ddtrace/release_gem_spec.rb
+++ b/spec/ddtrace/release_gem_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe 'gem release process' do
           docker-compose.yml
         ]
 
-        directories_excluded = %r{^(sig|spec|docs|\.circleci|\.github|benchmarks|gemfiles|integration|tasks|sorbet|yard)/}
+        directories_excluded = %r{
+          ^(sig|spec|docs|\.circleci|\.github|benchmarks|gemfiles|integration|tasks|sorbet|yard|vendor/rbs)/
+        }x
 
         expect(files)
           .to match_array(

--- a/vendor/rbs/ffi/0/ffi.rbs
+++ b/vendor/rbs/ffi/0/ffi.rbs
@@ -1,0 +1,62 @@
+module FFI
+  module Type
+    class Builtin
+    end
+
+    class Mapped
+    end
+  end
+
+  class AbstractMemory
+    def get_array_of_string: (::Integer, ::Integer) -> Array[String]
+    def read_bytes: (::Integer) -> ::String
+  end
+
+  class Pointer < AbstractMemory
+    NULL: Pointer
+
+    def null?: () -> bool
+  end
+
+  class MemoryPointer < Pointer
+    def self.from_string: (::String) -> MemoryPointer
+  end
+
+  class Enum
+  end
+
+  class Union
+    def self.layout: (*(Symbol | Integer)) -> void
+  end
+
+  type union = top # TODO: handle user-defined unions
+
+  class Struct
+    # TODO: layout args are actually "Symbol | Union, Integer, *(Symbol | Union, Integer)"
+    def self.layout: (*(Symbol | Integer | union)) -> void
+    def self.by_ref: () -> Type::Mapped
+    def self.size: () -> Integer
+
+    def null?: () -> bool
+    def initialize: (?Pointer) -> void
+    def []: (Symbol) -> untyped
+    def []=: (Symbol, untyped) -> untyped
+    def pointer: () -> Pointer
+  end
+
+  class Function < Pointer
+  end
+
+  module Library
+    # these can be worked around by typedef'ing to a Symbol
+    type enum = top # TODO: handle user-defined enum constants
+    type ref = top # TODO: handle by_ref references
+    type typedef = top # TODO: handle non-builtin types
+
+    def ffi_lib: (Array[String]) -> void
+    def typedef: (ref | Symbol, Symbol) -> (Type::Builtin | Type::Mapped | typedef)
+    def attach_function: (Symbol, Array[Symbol | Struct | enum], Symbol | Enum, ?blocking: bool) -> Function
+    def callback: (Symbol, Array[Symbol | Enum | Struct], Symbol | Enum) -> Function
+    def enum: (*untyped) -> Enum
+  end
+end

--- a/vendor/rbs/gem/0/gem.rbs
+++ b/vendor/rbs/gem/0/gem.rbs
@@ -1,0 +1,14 @@
+class Gem::Platform
+  def self.local: () -> Gem::Platform
+
+  def os: () -> String
+  def cpu: () -> String
+  def version: () -> String
+end
+
+class Gem::Platform
+end
+
+class Gem::BasicSpecification
+  def platform: () -> Gem::Platform
+end

--- a/vendor/rbs/jruby/0/jruby.rbs
+++ b/vendor/rbs/jruby/0/jruby.rbs
@@ -1,0 +1,3 @@
+module Kernel
+  def java: () -> untyped
+end

--- a/vendor/rbs/rails/0/rails.rbs
+++ b/vendor/rbs/rails/0/rails.rbs
@@ -1,0 +1,5 @@
+module ActionDispatch
+  class Response
+    def initialize: (::Integer status, ::Hash[::String, ::String] headers, ::Array[::String] body) -> void
+  end
+end

--- a/vendor/rbs/sinatra/0/sinatra.rbs
+++ b/vendor/rbs/sinatra/0/sinatra.rbs
@@ -1,0 +1,5 @@
+module Sinatra
+  class Response
+    def initialize: (::Array[::String] body, ::Integer status, ::Hash[::String, ::String] headers) -> void
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Add static type checking via RBS + Steep.

**Motivation**

Adding typing to dd-trace-rb has been discussed within the Ruby Guild, and initially attempted with Sorbet.

Unfortunately due to its focus coming from its Stripe ownership, Sorbet's scope and design is to typecheck applications, which doesn't lend itself well to libraries, and has technical limitations such as requiring possibly insecure side-effectful source evaluation or not being compatible with aarch64.

Sorbet's value is also limited without manual type annotations.

Static typing libddwaf-rb with RBS and Steep has found a dozen of edge-case issues, two of which would have had dramatic impact, proving the usage is promising at a larger scale.

This is therefore attempted with RBS syntax and Steep type checker, both projects being backed by the Ruby core team.

**Additional Notes**

This was prototyped during initial AppSec development, then removed by 8d05385654daa6b572fa180bd9fb538f9382c614. Lots has changed since then though.

**How to test the change?**

```
bundle exec steep check
```
