### PR TITLE
Add benchmark to test new profiler

### DIFF
--- a/benchmarks/profiler_sample_loop_v2.rb
+++ b/benchmarks/profiler_sample_loop_v2.rb
@@ -1,0 +1,68 @@
+# typed: ignore
+
+# Used to quickly run benchmark under RSpec as part of the usual test suite, to validate it didn't bitrot
+VALIDATE_BENCHMARK_MODE = ENV['VALIDATE_BENCHMARK'] == 'true'
+
+return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
+
+require 'benchmark/ips'
+require 'ddtrace'
+require 'pry'
+require_relative 'dogstatsd_reporter'
+
+# This benchmark measures the performance of the main stack sampling loop of the profiler
+
+class ProfilerSampleLoopBenchmark
+  def create_profiler
+    @recorder = Datadog::Profiling::StackRecorder.new
+    @collector = Datadog::Profiling::Collectors::CpuAndWallTime.new(recorder: @recorder, max_frames: 400, tracer: nil)
+  end
+
+  def thread_with_very_deep_stack(depth: 500)
+    deep_stack = proc do |n|
+      if n > 0
+        deep_stack.call(n - 1)
+      else
+        sleep
+      end
+    end
+
+    Thread.new { deep_stack.call(depth) }.tap { |t| t.name = "Deep stack #{depth}" }
+  end
+
+  def run_benchmark
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
+      x.config(**benchmark_time, suite: report_to_dogstatsd_if_enabled_via_environment_variable(benchmark_name: 'profiler_sample_loop_v2'))
+
+      x.report("stack collector #{ENV['CONFIG']}") do
+        Datadog::Profiling::Collectors::CpuAndWallTime::Testing._native_sample(@collector)
+      end
+
+      x.save! 'profiler-sample-loop-v2-results.json' unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    @recorder.serialize
+  end
+
+  def run_forever
+    while true
+      1000.times { Datadog::Profiling::Collectors::CpuAndWallTime::Testing._native_sample(@collector) }
+      @recorder.serialize
+      print '.'
+    end
+  end
+end
+
+puts "Current pid is #{Process.pid}"
+
+ProfilerSampleLoopBenchmark.new.instance_exec do
+  create_profiler
+  4.times { thread_with_very_deep_stack }
+  if ARGV.include?('--forever')
+    run_forever
+  else
+    run_benchmark
+  end
+end

--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe 'Profiling benchmarks', if: (RUBY_VERSION >= '2.4.0') do
     it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_sample_loop.rb' } }
   end
 
+  describe 'profiler_sample_loop_v2' do
+    it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_sample_loop_v2.rb' } }
+  end
+
   describe 'profiler_http_transport' do
     it('runs without raising errors') { expect_in_fork { load './benchmarks/profiler_http_transport.rb' } }
   end


### PR DESCRIPTION
**What does this PR do?**:

This PR adds a new stand alone benchmark `benchmarks/profiler_sample_loop_v2.rb` to test the new profiler.

The benchmark itself is a copy-pasted version of the original `benchmarks/profiler_sample_loop.rb` but adjusted to use the new profiler.

**Motivation**:

This benchmark is useful to test performance improvements on the sampling part of the profiler (as well as libdatadog -- see for instance <https://github.com/DataDog/libdatadog/pull/72>).

**Additional Notes**:

(None)

**How to test the change?**:

Run the benchmark! Also, I've updated the rspec test that runs it once during the regular test suite to ensure that it doesn't bitrot.
