### PR TITLE
Add W3C Trace Context propagator

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -105,6 +105,11 @@ Style/GuardClause:
 Style/CaseEquality:
   Enabled: false
 
+# Tests don't need strict string concatenation rules.
+Style/StringConcatenation:
+  Exclude:
+    - spec/**/*
+
 # New cops since Rubocop 1.0.
 # We have to explicitly opt-in for new cops to apply
 # before the next major release.

--- a/lib/datadog/tracing/distributed/trace_context.rb
+++ b/lib/datadog/tracing/distributed/trace_context.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# typed: true
+# typed: false
 
 module Datadog
   module Tracing

--- a/lib/datadog/tracing/sampling/priority_sampler.rb
+++ b/lib/datadog/tracing/sampling/priority_sampler.rb
@@ -85,6 +85,17 @@ module Datadog
           @priority_sampler.update(rate_by_service, decision: decision)
         end
 
+        # Check if the Priority Sampling decision is to keep or drop the trace.
+        # Other factors can influence the sampling decision; this method is only
+        # responsible for interpreting the Sampling Priority decision.
+        #
+        # @param priority_sampling [Integer] priority sampling number
+        # @return [Boolean] true if trace is "kept" by priority sampling
+        # @return [Boolean] false if trace is "dropped" by priority sampling
+        def self.sampled?(priority_sampling)
+          priority_sampling >= Ext::Priority::AUTO_KEEP
+        end
+
         private
 
         def pre_sample?(trace)

--- a/lib/datadog/tracing/trace_digest.rb
+++ b/lib/datadog/tracing/trace_digest.rb
@@ -6,6 +6,70 @@ module Datadog
     # Used to propagate context and continue traces across execution boundaries.
     # @public_api
     class TraceDigest
+      # @!attribute [r] span_id
+      #   Datadog id for the currently active span.
+      #   @return [Integer]
+      # @!attribute [r] span_name
+      #   The operation name of the currently active span.
+      #   @return [String]
+      # @!attribute [r] span_resource
+      #   The resource name of the currently active span.
+      #   @return [String]
+      # @!attribute [r] span_service
+      #   The service of the currently active span.
+      #   @return [String]
+      # @!attribute [r] span_type
+      #   The type of the currently active span.
+      #   @return [String]
+      # @!attribute [r] trace_distributed_tags
+      #   Datadog-specific tags that support richer distributed tracing association.
+      #   @return [Hash<String,String>]
+      # @!attribute [r] trace_hostname
+      #   The hostname of the currently active trace. Use to attribute traces to hosts.
+      #   @return [String]
+      # @!attribute [r] trace_id
+      #   Datadog id for the currently active trace.
+      #   @return [Integer]
+      # @!attribute [r] trace_name
+      #   Operation name for the currently active trace.
+      #   @return [Integer]
+      # @!attribute [r] trace_origin
+      #   Datadog-specific attribution of this trace's creation.
+      #   @return [String]
+      # @!attribute [r] trace_process_id
+      #   The OS-specific process id.
+      #   @return [Integer]
+      # @!attribute [r] trace_resource
+      #   The resource name of the currently active trace.
+      #   @return [String]
+      # @!attribute [r] trace_runtime_id
+      #   Unique id to this Ruby process. Used to differentiate traces coming from
+      #   child processes forked from same parent process.
+      #   @return [String]
+      # @!attribute [r] trace_sampling_priority
+      #   Datadog-specific sampling decision for the currently active trace.
+      #   @return [Integer]
+      # @!attribute [r] trace_service
+      #   The service of the currently active trace.
+      #   @return [String]
+      # @!attribute [r] trace_distributed_id
+      #   The trace id extracted from a distributed context, if different from `trace_id`.
+      #
+      #   The current use case is when the distributed context has a trace id integer larger than 64-bit:
+      #   This attribute will preserve the original id, while `trace_id` will only contain the lower 64 bits.
+      #   @return [Integer]
+      #   @see https://www.w3.org/TR/trace-context/#trace-id
+      # @!attribute [r] trace_tracestate
+      #   The W3C "tracestate" extracted from a distributed context.
+      #   This field is a string representing vendor-specific distribution data.
+      #   @return [String]
+      #   @see https://www.w3.org/TR/trace-context/#tracestate-header
+      # @!attribute [r] trace_flags
+      #   The W3C "trace-flags" extracted from a distributed context. This field is an 8-bit unsigned integer.
+      #   @return [Integer]
+      #   @see https://www.w3.org/TR/trace-context/#trace-flags
+      # TODO: The documentation for the last attribute above won't be rendered.
+      # TODO: This might be a YARD bug as adding an attribute, making it now second-last attribute, renders correctly.
       attr_reader \
         :span_id,
         :span_name,
@@ -21,7 +85,10 @@ module Datadog
         :trace_resource,
         :trace_runtime_id,
         :trace_sampling_priority,
-        :trace_service
+        :trace_service,
+        :trace_distributed_id,
+        :trace_flags,
+        :trace_state
 
       def initialize(
         span_id: nil,
@@ -38,7 +105,10 @@ module Datadog
         trace_resource: nil,
         trace_runtime_id: nil,
         trace_sampling_priority: nil,
-        trace_service: nil
+        trace_service: nil,
+        trace_distributed_id: nil,
+        trace_flags: nil,
+        trace_state: nil
       )
         @span_id = span_id
         @span_name = span_name && span_name.dup.freeze
@@ -55,6 +125,9 @@ module Datadog
         @trace_runtime_id = trace_runtime_id && trace_runtime_id.dup.freeze
         @trace_sampling_priority = trace_sampling_priority
         @trace_service = trace_service && trace_service.dup.freeze
+        @trace_distributed_id = trace_distributed_id
+        @trace_flags = trace_flags
+        @trace_state = trace_state && trace_state.dup.freeze
 
         freeze
       end

--- a/spec/datadog/tracing/distributed/trace_context_spec.rb
+++ b/spec/datadog/tracing/distributed/trace_context_spec.rb
@@ -1,0 +1,384 @@
+# typed: false
+
+require 'spec_helper'
+
+require 'datadog/tracing/distributed/trace_context'
+require 'datadog/tracing/trace_digest'
+
+RSpec.shared_examples 'Trace Context distributed format' do
+  subject(:datadog) { described_class.new(fetcher: fetcher_class) }
+  let(:fetcher_class) { Datadog::Tracing::Distributed::Fetcher }
+
+  let(:prepare_key) { defined?(super) ? super() : proc { |key| key } }
+
+  describe '#inject!' do
+    subject(:inject!) { datadog.inject!(digest, data) }
+    let(:data) { {} }
+
+    let(:traceparent) { inject!['traceparent'] }
+    let(:tracestate) { inject!['tracestate'] }
+    let(:trace_flags) { traceparent[53..54] }
+
+    context 'with a nil digest' do
+      let(:digest) { nil }
+      it { is_expected.to be nil }
+    end
+
+    context 'a digest' do
+      let(:digest) { Datadog::Tracing::TraceDigest.new(trace_id: 0xC0FFEE, span_id: 0xBEE, **options) }
+      let(:options) { {} }
+
+      it { expect(traceparent).to eq('00-00000000000000000000000000c0ffee-0000000000000bee-00') }
+
+      context 'with trace_distributed_id' do
+        let(:options) { { trace_distributed_id: 0xACE00000000000000000000000C0FFEE } }
+        it 'prioritizes the original trace_distributed_id' do
+          expect(traceparent).to eq('00-ace00000000000000000000000c0ffee-0000000000000bee-00')
+        end
+      end
+
+      context 'with trace_flags' do
+        context 'with a dropped trace' do
+          let(:options) { { trace_flags: 0xFF, trace_sampling_priority: -1 } }
+
+          it 'changes last bit to 0' do
+            expect(trace_flags).to eq('fe')
+          end
+        end
+
+        context 'with a kept trace' do
+          let(:options) { { trace_flags: 0xFE, trace_sampling_priority: 1 } }
+
+          it 'changes last bit to 1' do
+            expect(trace_flags).to eq('ff')
+          end
+        end
+
+        context 'with no priority sampling' do
+          let(:options) { { trace_flags: 0xFF, trace_sampling_priority: nil } }
+
+          it 'does not change the last bit' do
+            expect(trace_flags).to eq('ff')
+          end
+        end
+      end
+
+      context 'with sampling priority' do
+        {
+          -1 => '00',
+          0 => '00',
+          1 => '01',
+          2 => '01',
+        }.each do |sampling_priority, expected_trace_flags|
+          context "with sampling_priority #{sampling_priority}" do
+            let(:digest) do
+              Datadog::Tracing::TraceDigest.new(
+                trace_id: 0xC0FFEE,
+                span_id: 0xBEE,
+                trace_sampling_priority: sampling_priority
+              )
+            end
+
+            it "sets trace-flags to #{expected_trace_flags}" do
+              expect(trace_flags).to eq(expected_trace_flags)
+            end
+
+            it "sets tracestate to s:#{sampling_priority}" do
+              expect(tracestate).to eq("dd=s:#{sampling_priority}")
+            end
+          end
+        end
+
+        context 'with origin' do
+          let(:digest) do
+            Datadog::Tracing::TraceDigest.new(
+              trace_id: 0xC0FFEE,
+              span_id: 0xBEE,
+              trace_sampling_priority: 1,
+              trace_origin: 'synthetics'
+            )
+          end
+
+          it { expect(tracestate).to eq('dd=s:1;o:synthetics') }
+        end
+      end
+
+      context 'with origin' do
+        let(:digest) do
+          Datadog::Tracing::TraceDigest.new(
+            trace_id: 0xC0FFEE,
+            span_id: 0xBEE,
+            trace_origin: origin
+          )
+        end
+
+        let(:origin) { 'synthetics' }
+
+        it { expect(tracestate).to eq('dd=o:synthetics') }
+
+        context 'with invalid characters' do
+          [
+            "\u0000", # First unicode character
+            "\u0019", # Last lower invalid character
+            ',',
+            '=',
+            "\u007F", # First upper invalid character
+            "\u{10FFFF}" # Last unicode character
+          ].each do |character|
+            context character.inspect do
+              let(:origin) { character }
+
+              it { expect(tracestate).to eq('dd=o:_') }
+            end
+          end
+        end
+      end
+
+      context 'with trace_distributed_tags' do
+        let(:digest) do
+          Datadog::Tracing::TraceDigest.new(
+            trace_id: 0xC0FFEE,
+            span_id: 0xBEE,
+            trace_distributed_tags: tags
+          )
+        end
+
+        context 'nil' do
+          let(:tags) { nil }
+          it { expect(tracestate).to be_nil }
+        end
+
+        context '{}' do
+          let(:tags) { {} }
+          it { expect(tracestate).to be_nil }
+        end
+
+        context "{ 'key' => 'value' }" do
+          let(:tags) { { 'key' => 'value' } }
+          it { expect(tracestate).to eq('dd=t.key:value') }
+        end
+
+        context "{ '_dd.p.dm' => '-1' }" do
+          let(:tags) { { '_dd.p.dm' => '-1' } }
+          it { expect(tracestate).to eq('dd=t.dm:-1') }
+        end
+
+        context "{ 'key' => 'value=with=equals' }" do
+          let(:tags) { { 'key' => 'value=with=equals' } }
+          it { expect(tracestate).to eq('dd=t.key:value:with:equals') }
+        end
+
+        context 'too large' do
+          let(:tags) { { 'k' => 'v' * 250 } } # 257 chars after it's formatted as "dd=t.#{key}:#{value}"
+
+          it { expect(tracestate).to be_nil }
+        end
+
+        context 'with the maximum size' do
+          let(:tags) { { 'k' => 'v' * 249 } } # 256 chars after it's formatted as "dd=t.#{key}:#{value}"
+
+          it { expect(tracestate.size).to eq(256) }
+        end
+
+        context 'invalid key characters' do
+          [
+            "\u0000", # First unicode character
+            ' ', # Last lower invalid character
+            ',',
+            '=',
+            "\u007F", # First upper invalid character
+            "\u{10FFFF}" # Last unicode character
+          ].each do |character|
+            context character.inspect do
+              let(:tags) { { character => 'value' } }
+
+              it { expect(tracestate).to eq('dd=t._:value') }
+            end
+          end
+        end
+
+        context 'invalid value characters' do
+          [
+            "\u0000", # First unicode character
+            "\u001F", # Last lower invalid character
+            ',',
+            ':',
+            ';',
+            "\u007F", # First upper invalid character
+            "\u{10FFFF}" # Last unicode character
+          ].each do |character|
+            context character.inspect do
+              let(:tags) { { 'key' => character } }
+
+              it { expect(tracestate).to eq('dd=t.key:_') }
+            end
+          end
+        end
+      end
+
+      context 'with a upstream tracestate' do
+        let(:options) { { trace_state: upstream_tracestate } }
+        let(:upstream_tracestate) { 'other=vendor' }
+
+        context 'without local Datadog-specific values' do
+          it 'propagates unmodified tracestate' do
+            expect(tracestate).to eq(upstream_tracestate)
+          end
+
+          context 'with upstream `dd=` values' do
+            let(:upstream_tracestate) { 'dd=old_value,other=vendor,dd=oops_forgot_to_remove_this' }
+
+            it 'propagates unmodified tracestate' do
+              expect(tracestate).to eq(upstream_tracestate)
+            end
+          end
+        end
+
+        context 'with local Datadog-specific values' do
+          let(:options) { super().merge(trace_origin: 'origin') }
+
+          context 'and existing `dd=` tracestate values' do
+            let(:upstream_tracestate) { 'dd=old_value,other=vendor,dd=oops_forgot_to_remove_this' }
+
+            it 'removes existing `dd=` values, prepending new `dd=` value' do
+              expect(tracestate).to eq('dd=o:origin,other=vendor')
+            end
+          end
+
+          context 'and 32 upstream tracestate entries' do
+            let(:upstream_tracestate) { Array.new(32) { |i| "other=vendor#{i}" }.join(',') }
+
+            it 'removes 1 trailing value, prepending new `dd=` value' do
+              expect(tracestate).to eq('dd=o:origin,' + Array.new(31) { |i| "other=vendor#{i}" }.join(','))
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe '#extract' do
+    subject(:extract) { datadog.extract(data) }
+    let(:data) do
+      { prepare_key['traceparent'] => traceparent,
+        prepare_key['tracestate'] => tracestate }
+    end
+    let(:traceparent) { '00-00000000000000000000000000c0ffee-0000000000000bee-00' }
+    let(:tracestate) { '' }
+
+    let(:digest) { extract }
+
+    context 'without data' do
+      let(:data) { {} }
+      it { is_expected.to be nil }
+    end
+
+    context 'with valid trace_id and parent_id' do
+      let(:traceparent) { '00-00000000000000000000000000c0ffee-0000000000000bee-00' }
+
+      it { expect(digest.trace_id).to eq(0xC0FFEE) }
+      it { expect(digest.span_id).to eq(0xBEE) }
+      it { expect(digest.trace_origin).to be nil }
+      it { expect(digest.trace_sampling_priority).to eq(0) }
+
+      context 'and trace_id larger than 64 bits' do
+        let(:traceparent) { '00-ace00000000000000000000000c0ffee-0000000000000bee-00' }
+
+        it { expect(digest.trace_id).to eq(0xC0FFEE) }
+        it { expect(digest.trace_distributed_id).to eq(0xACE00000000000000000000000C0FFEE) }
+      end
+
+      context 'with sampling priority' do
+        [
+          { sampled_flag: 0, priority: -1, expected_priority: -1 },
+          { sampled_flag: 0, priority: 0, expected_priority: 0 },
+          { sampled_flag: 0, priority: 1, expected_priority: 0 },
+          { sampled_flag: 0, priority: 2, expected_priority: 0 },
+          { sampled_flag: 0, priority: nil, expected_priority: 0 },
+          { sampled_flag: 1, priority: nil, expected_priority: 1 },
+          { sampled_flag: 1, priority: -1, expected_priority: 1 },
+          { sampled_flag: 1, priority: 0, expected_priority: 1 },
+          { sampled_flag: 1, priority: 1, expected_priority: 1 },
+          { sampled_flag: 1, priority: 2, expected_priority: 2 },
+        ].each do |args|
+          sampled_flag = args[:sampled_flag]
+          priority = args[:priority]
+          expected_priority = args[:expected_priority]
+
+          context "with sampled flag #{sampled_flag} and incoming sampling priority #{priority.inspect}" do
+            let(:traceparent) { "00-00000000000000000000000000c0ffee-0000000000000bee-0#{sampled_flag}" }
+            let(:tracestate) { "dd=s:#{priority}" }
+
+            it "return sampling priority #{expected_priority}" do
+              expect(digest.trace_sampling_priority).to eq(expected_priority)
+            end
+          end
+        end
+      end
+
+      context 'with origin' do
+        let(:tracestate) { 'dd=o:synthetics' }
+
+        it { expect(digest.trace_origin).to eq('synthetics') }
+      end
+
+      context 'with trace_distributed_tags' do
+        subject(:trace_distributed_tags) { extract.trace_distributed_tags }
+        let(:tracestate) { "dd=#{tags}" }
+
+        context 'nil' do
+          let(:tags) { nil }
+          it { is_expected.to be_nil }
+        end
+
+        context 'an empty value' do
+          let(:tags) { '' }
+          it { is_expected.to be_nil }
+        end
+
+        context "{ '_dd.p.key' => 'value' }" do
+          let(:tags) { 't.key:value' }
+          it { is_expected.to eq('_dd.p.key' => 'value') }
+        end
+
+        context "{ '_dd.p.dm' => '-1' }" do
+          let(:tags) { 't.dm:-1' }
+          it { is_expected.to eq('_dd.p.dm' => '-1') }
+        end
+
+        context "{ 'key' => 'value=with=equals' }" do
+          let(:tags) { 't.key:value:with:equals' }
+          it { is_expected.to eq('_dd.p.key' => 'value=with=equals') }
+        end
+      end
+
+      context 'with unknown tracestate fields' do
+        let(:tracestate) { "dd=i_don't_know_this:field;o:origin;s:0" }
+
+        it { expect(digest.trace_id).to eq(0xC0FFEE) }
+        it { expect(digest.span_id).to eq(0xBEE) }
+        it { expect(digest.trace_origin).to eq('origin') }
+        it { expect(digest.trace_sampling_priority).to eq(0) }
+      end
+
+      context 'but version not 00' do
+        let(:traceparent) { '01-00000000000000000000000000c0ffee-0000000000000bee-00' }
+        it { is_expected.to be nil }
+      end
+    end
+
+    context 'with only trace_id' do
+      let(:traceparent) { '00-00000000000000000000000000c0ffee-0000000000000000-00' }
+      it { is_expected.to be nil }
+    end
+
+    context 'with only parent_id' do
+      let(:traceparent) { '00-00000000000000000000000000000000-0000000000000bee-00' }
+      it { is_expected.to be nil }
+    end
+  end
+end
+
+RSpec.describe Datadog::Tracing::Distributed::TraceContext do
+  it_behaves_like 'Trace Context distributed format'
+end

--- a/spec/datadog/tracing/sampling/priority_sampler_spec.rb
+++ b/spec/datadog/tracing/sampling/priority_sampler_spec.rb
@@ -197,4 +197,20 @@ RSpec.describe Datadog::Tracing::Sampling::PrioritySampler do
       end
     end
   end
+
+  describe '.sampled?' do
+    subject(:sampled?) { described_class.sampled?(priority_sampling) }
+
+    {
+      -1 => false,
+      0 => false,
+      1 => true,
+      2 => true
+    }.each do |priority_sampling, sampled|
+      context "with priority_sampling #{priority_sampling}" do
+        let(:priority_sampling) { priority_sampling }
+        it { is_expected.to eq(sampled) }
+      end
+    end
+  end
 end

--- a/spec/datadog/tracing/trace_digest_spec.rb
+++ b/spec/datadog/tracing/trace_digest_spec.rb
@@ -29,7 +29,10 @@ RSpec.describe Datadog::Tracing::TraceDigest do
           trace_resource: nil,
           trace_runtime_id: nil,
           trace_sampling_priority: nil,
-          trace_service: nil
+          trace_service: nil,
+          trace_distributed_id: nil,
+          trace_flags: nil,
+          trace_state: nil
         )
       end
 
@@ -140,6 +143,27 @@ RSpec.describe Datadog::Tracing::TraceDigest do
         let(:trace_service) { 'job-worker' }
 
         it { is_expected.to have_attributes(trace_service: be_a_frozen_copy_of(trace_service)) }
+      end
+
+      context ':trace_distributed_id' do
+        let(:options) { { trace_distributed_id: trace_distributed_id } }
+        let(:trace_distributed_id) { 1 << 127 }
+
+        it { is_expected.to have_attributes(trace_distributed_id: 1 << 127) }
+      end
+
+      context ':trace_flags' do
+        let(:options) { { trace_flags: trace_flags } }
+        let(:trace_flags) { 0xFF }
+
+        it { is_expected.to have_attributes(trace_flags: 0xFF) }
+      end
+
+      context ':trace_state' do
+        let(:options) { { trace_state: trace_state } }
+        let(:trace_state) { 'dd=o:origin,vendor=value' }
+
+        it { is_expected.to have_attributes(trace_state: be_a_frozen_copy_of('dd=o:origin,vendor=value')) }
       end
     end
   end


### PR DESCRIPTION
This PR adds support trace propagation through the the "W3C Trace Context": https://www.w3.org/TR/trace-context/.

This standard is used by OpenTelemetry to propagate traces by default.

This PR adds the propagator class **but does not wire it yet**, as to make this PR smaller to review.