### PR TITLE
Fix unsafely raising exceptions without global VM lock in new profiler

### DIFF
--- a/ext/ddtrace_profiling_native_extension/NativeExtensionDesign.md
+++ b/ext/ddtrace_profiling_native_extension/NativeExtensionDesign.md
@@ -57,7 +57,7 @@ Non-exhaustive list of APIs that cause exceptions to be raised:
 
 * `Check_TypedStruct`, `Check_Type`, `ENFORCE_TYPE`
 * `rb_funcall`
-* `rb_thread_call_without_gvl`, `rb_thread_call_without_gvl2`
+* `rb_thread_call_without_gvl`
 * [Numeric conversion APIs, e.g. `NUM2LONG`, `NUM2INT`, etc.](https://silverhammermba.github.io/emberb/c/?#translation)
 * Our `char_slice_from_ruby_string` helper
 

--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -87,7 +87,7 @@ static VALUE _native_grab_gvl_and_raise(DDTRACE_UNUSED VALUE _self, VALUE except
     grab_gvl_and_raise(args.exception_class, "%s", args.test_message);
   }
 
-  rb_raise(rb_eRuntimeError, "This should never happen");
+  rb_raise(rb_eRuntimeError, "Failed to raise exception in _native_grab_gvl_and_raise; this should never happen");
 }
 
 static void *trigger_grab_gvl_and_raise(void *trigger_args) {
@@ -123,7 +123,7 @@ static VALUE _native_grab_gvl_and_raise_syserr(DDTRACE_UNUSED VALUE _self, VALUE
     grab_gvl_and_raise_syserr(args.syserr_errno, "%s", args.test_message);
   }
 
-  rb_raise(rb_eRuntimeError, "This should never happen");
+  rb_raise(rb_eRuntimeError, "Failed to raise exception in _native_grab_gvl_and_raise_syserr; this should never happen");
 }
 
 static void *trigger_grab_gvl_and_raise_syserr(void *trigger_args) {

--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -5,6 +5,7 @@
 #include "clock_id.h"
 #include "helpers.h"
 #include "private_vm_api_access.h"
+#include "ruby_helpers.h"
 #include "setup_signal_handler.h"
 
 // Each class/module here is implemented in their separate file
@@ -15,6 +16,10 @@ void http_transport_init(VALUE profiling_module);
 void stack_recorder_init(VALUE profiling_module);
 
 static VALUE native_working_p(VALUE self);
+static VALUE _native_grab_gvl_and_raise(DDTRACE_UNUSED VALUE _self, VALUE exception_class, VALUE test_message, VALUE test_message_arg);
+static void *trigger_grab_gvl_and_raise(void *trigger_args);
+static VALUE _native_grab_gvl_and_raise_syserr(DDTRACE_UNUSED VALUE _self, VALUE syserr_errno, VALUE test_message, VALUE test_message_arg);
+static void *trigger_grab_gvl_and_raise_syserr(void *trigger_args);
 static VALUE _native_ddtrace_rb_ractor_main_p(DDTRACE_UNUSED VALUE _self);
 static VALUE _native_is_current_thread_holding_the_gvl(DDTRACE_UNUSED VALUE _self);
 static VALUE _native_release_gvl_and_call_is_current_thread_holding_the_gvl(DDTRACE_UNUSED VALUE _self);
@@ -41,6 +46,8 @@ void DDTRACE_EXPORT Init_ddtrace_profiling_native_extension(void) {
 
   // Hosts methods used for testing the native code using RSpec
   VALUE testing_module = rb_define_module_under(native_extension_module, "Testing");
+  rb_define_singleton_method(testing_module, "_native_grab_gvl_and_raise", _native_grab_gvl_and_raise, 3);
+  rb_define_singleton_method(testing_module, "_native_grab_gvl_and_raise_syserr", _native_grab_gvl_and_raise_syserr, 3);
   rb_define_singleton_method(testing_module, "_native_ddtrace_rb_ractor_main_p", _native_ddtrace_rb_ractor_main_p, 0);
   rb_define_singleton_method(testing_module, "_native_is_current_thread_holding_the_gvl", _native_is_current_thread_holding_the_gvl, 0);
   rb_define_singleton_method(
@@ -57,6 +64,70 @@ static VALUE native_working_p(DDTRACE_UNUSED VALUE _self) {
   self_test_clock_id();
 
   return Qtrue;
+}
+
+struct trigger_grab_gvl_and_raise_arguments {
+  VALUE exception_class;
+  char *test_message;
+  int test_message_arg;
+};
+
+static VALUE _native_grab_gvl_and_raise(DDTRACE_UNUSED VALUE _self, VALUE exception_class, VALUE test_message, VALUE test_message_arg) {
+  ENFORCE_TYPE(test_message, T_STRING);
+
+  struct trigger_grab_gvl_and_raise_arguments args;
+
+  args.exception_class = exception_class;
+  args.test_message = StringValueCStr(test_message);
+  args.test_message_arg = test_message_arg != Qnil ? NUM2INT(test_message_arg) : -1;
+
+  rb_thread_call_without_gvl(trigger_grab_gvl_and_raise, &args, NULL, NULL);
+
+  rb_raise(rb_eRuntimeError, "This should never happen");
+}
+
+static void *trigger_grab_gvl_and_raise(void *trigger_args) {
+  struct trigger_grab_gvl_and_raise_arguments *args = (struct trigger_grab_gvl_and_raise_arguments *) trigger_args;
+
+  if (args->test_message_arg >= 0) {
+    grab_gvl_and_raise(args->exception_class, args->test_message, args->test_message_arg);
+  } else {
+    grab_gvl_and_raise(args->exception_class, args->test_message);
+  }
+
+  return NULL;
+}
+
+struct trigger_grab_gvl_and_raise_syserr_arguments {
+  int syserr_errno;
+  char *test_message;
+  int test_message_arg;
+};
+
+static VALUE _native_grab_gvl_and_raise_syserr(DDTRACE_UNUSED VALUE _self, VALUE syserr_errno, VALUE test_message, VALUE test_message_arg) {
+  ENFORCE_TYPE(test_message, T_STRING);
+
+  struct trigger_grab_gvl_and_raise_syserr_arguments args;
+
+  args.syserr_errno = NUM2INT(syserr_errno);
+  args.test_message = StringValueCStr(test_message);
+  args.test_message_arg = test_message_arg != Qnil ? NUM2INT(test_message_arg) : -1;
+
+  rb_thread_call_without_gvl(trigger_grab_gvl_and_raise_syserr, &args, NULL, NULL);
+
+  rb_raise(rb_eRuntimeError, "This should never happen");
+}
+
+static void *trigger_grab_gvl_and_raise_syserr(void *trigger_args) {
+  struct trigger_grab_gvl_and_raise_syserr_arguments *args = (struct trigger_grab_gvl_and_raise_syserr_arguments *) trigger_args;
+
+  if (args->test_message_arg >= 0) {
+    grab_gvl_and_raise_syserr(args->syserr_errno, args->test_message, args->test_message_arg);
+  } else {
+    grab_gvl_and_raise_syserr(args->syserr_errno, args->test_message);
+  }
+
+  return NULL;
 }
 
 static VALUE _native_ddtrace_rb_ractor_main_p(DDTRACE_UNUSED VALUE _self) {

--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -90,9 +90,9 @@ static void *trigger_grab_gvl_and_raise(void *trigger_args) {
   struct trigger_grab_gvl_and_raise_arguments *args = (struct trigger_grab_gvl_and_raise_arguments *) trigger_args;
 
   if (args->test_message_arg >= 0) {
-    grab_gvl_and_raise(args->exception_class, args->test_message, args->test_message_arg);
+    grab_gvl_and_raise(args->exception_class, "%s%d", args->test_message, args->test_message_arg);
   } else {
-    grab_gvl_and_raise(args->exception_class, args->test_message);
+    grab_gvl_and_raise(args->exception_class, "%s", args->test_message);
   }
 
   return NULL;
@@ -122,9 +122,9 @@ static void *trigger_grab_gvl_and_raise_syserr(void *trigger_args) {
   struct trigger_grab_gvl_and_raise_syserr_arguments *args = (struct trigger_grab_gvl_and_raise_syserr_arguments *) trigger_args;
 
   if (args->test_message_arg >= 0) {
-    grab_gvl_and_raise_syserr(args->syserr_errno, args->test_message, args->test_message_arg);
+    grab_gvl_and_raise_syserr(args->syserr_errno, "%s%d", args->test_message, args->test_message_arg);
   } else {
-    grab_gvl_and_raise_syserr(args->syserr_errno, args->test_message);
+    grab_gvl_and_raise_syserr(args->syserr_errno, "%s", args->test_message);
   }
 
   return NULL;

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.c
@@ -1,3 +1,6 @@
+#include <ruby.h>
+#include <ruby/thread.h>
+
 #include "ruby_helpers.h"
 
 void raise_unexpected_type(
@@ -21,4 +24,54 @@ void raise_unexpected_type(
       )
     )
   );
+}
+
+#define MAX_RAISE_MESSAGE_SIZE 256
+
+struct raise_arguments {
+  VALUE exception_class;
+  char exception_message[MAX_RAISE_MESSAGE_SIZE];
+};
+
+static void *trigger_raise(void *raise_arguments) {
+  struct raise_arguments *args = (struct raise_arguments *) raise_arguments;
+  rb_raise(args->exception_class, "%s", args->exception_message);
+}
+
+void grab_gvl_and_raise(VALUE exception_class, const char *format_string, ...) {
+  struct raise_arguments args;
+
+  args.exception_class = exception_class;
+
+  va_list format_string_arguments;
+  va_start(format_string_arguments, format_string);
+  vsnprintf(args.exception_message, MAX_RAISE_MESSAGE_SIZE, format_string, format_string_arguments);
+
+  rb_thread_call_with_gvl(trigger_raise, &args);
+
+  rb_bug("[DDTRACE] Unexpected: Reached the end of grab_gvl_and_raise while raising '%s'\n", args.exception_message);
+}
+
+struct syserr_raise_arguments {
+  int syserr_errno;
+  char exception_message[MAX_RAISE_MESSAGE_SIZE];
+};
+
+static void *trigger_syserr_raise(void *syserr_raise_arguments) {
+  struct syserr_raise_arguments *args = (struct syserr_raise_arguments *) syserr_raise_arguments;
+  rb_syserr_fail(args->syserr_errno, args->exception_message);
+}
+
+void grab_gvl_and_raise_syserr(int syserr_errno, const char *format_string, ...) {
+  struct syserr_raise_arguments args;
+
+  args.syserr_errno = syserr_errno;
+
+  va_list format_string_arguments;
+  va_start(format_string_arguments, format_string);
+  vsnprintf(args.exception_message, MAX_RAISE_MESSAGE_SIZE, format_string, format_string_arguments);
+
+  rb_thread_call_with_gvl(trigger_syserr_raise, &args);
+
+  rb_bug("[DDTRACE] Unexpected: Reached the end of grab_gvl_and_raise_syserr while raising '%s'\n", args.exception_message);
 }

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.h
@@ -62,5 +62,11 @@ NORETURN(void raise_unexpected_type(
 
 #define VALUE_COUNT(array) (sizeof(array) / sizeof(VALUE))
 
-NORETURN(void grab_gvl_and_raise(VALUE exception_class, const char *format_string, ...));
-NORETURN(void grab_gvl_and_raise_syserr(int syserr_errno, const char *format_string, ...));
+NORETURN(
+  void grab_gvl_and_raise(VALUE exception_class, const char *format_string, ...)
+  __attribute__ ((format (printf, 2, 3)));
+);
+NORETURN(
+  void grab_gvl_and_raise_syserr(int syserr_errno, const char *format_string, ...)
+  __attribute__ ((format (printf, 2, 3)));
+);

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.h
@@ -61,3 +61,6 @@ NORETURN(void raise_unexpected_type(
 ));
 
 #define VALUE_COUNT(array) (sizeof(array) / sizeof(VALUE))
+
+NORETURN(void grab_gvl_and_raise(VALUE exception_class, const char *format_string, ...));
+NORETURN(void grab_gvl_and_raise_syserr(int syserr_errno, const char *format_string, ...));

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Datadog::Profiling::NativeExtension do
     end
 
     it 'accepts printf-style string formatting' do
-      expect { described_class::Testing._native_grab_gvl_and_raise(ZeroDivisionError, 'divided zero by %d', 42) }
+      expect { described_class::Testing._native_grab_gvl_and_raise(ZeroDivisionError, 'divided zero by ', 42) }
         .to raise_exception(ZeroDivisionError, 'divided zero by 42')
     end
 
@@ -189,7 +189,7 @@ RSpec.describe Datadog::Profiling::NativeExtension do
 
     it 'accepts printf-style string formatting' do
       expect do
-        described_class::Testing._native_grab_gvl_and_raise_syserr(Errno::EINTR::Errno, 'divided zero by %d', 42)
+        described_class::Testing._native_grab_gvl_and_raise_syserr(Errno::EINTR::Errno, 'divided zero by ', 42)
       end.to raise_exception(Errno::EINTR, "#{Errno::EINTR.exception.message} - divided zero by 42")
     end
 

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -163,33 +163,40 @@ RSpec.describe Datadog::Profiling::NativeExtension do
 
   describe 'grab_gvl_and_raise' do
     it 'raises the requested exception with the passed in message' do
-      expect { described_class::Testing._native_grab_gvl_and_raise(ZeroDivisionError, 'this is a test', nil) }
+      expect { described_class::Testing._native_grab_gvl_and_raise(ZeroDivisionError, 'this is a test', nil, true) }
         .to raise_exception(ZeroDivisionError, 'this is a test')
     end
 
     it 'accepts printf-style string formatting' do
-      expect { described_class::Testing._native_grab_gvl_and_raise(ZeroDivisionError, 'divided zero by ', 42) }
+      expect { described_class::Testing._native_grab_gvl_and_raise(ZeroDivisionError, 'divided zero by ', 42, true) }
         .to raise_exception(ZeroDivisionError, 'divided zero by 42')
     end
 
     it 'limits the exception message to 255 characters' do
       big_message = 'a' * 500
 
-      expect { described_class::Testing._native_grab_gvl_and_raise(ZeroDivisionError, big_message, nil) }
+      expect { described_class::Testing._native_grab_gvl_and_raise(ZeroDivisionError, big_message, nil, true) }
         .to raise_exception(ZeroDivisionError, /a{255}\z/)
+    end
+
+    context 'when called without releasing the gvl' do
+      it 'raises a RuntimeError' do
+        expect { described_class::Testing._native_grab_gvl_and_raise(ZeroDivisionError, 'this is a test', nil, false) }
+          .to raise_exception(RuntimeError, /called by thread holding the global VM lock/)
+      end
     end
   end
 
   describe 'grab_gvl_and_raise_syserr' do
     it 'raises an exception with the passed in message and errno' do
       expect do
-        described_class::Testing._native_grab_gvl_and_raise_syserr(Errno::EINTR::Errno, 'this is a test', nil)
+        described_class::Testing._native_grab_gvl_and_raise_syserr(Errno::EINTR::Errno, 'this is a test', nil, true)
       end.to raise_exception(Errno::EINTR, "#{Errno::EINTR.exception.message} - this is a test")
     end
 
     it 'accepts printf-style string formatting' do
       expect do
-        described_class::Testing._native_grab_gvl_and_raise_syserr(Errno::EINTR::Errno, 'divided zero by ', 42)
+        described_class::Testing._native_grab_gvl_and_raise_syserr(Errno::EINTR::Errno, 'divided zero by ', 42, true)
       end.to raise_exception(Errno::EINTR, "#{Errno::EINTR.exception.message} - divided zero by 42")
     end
 
@@ -197,8 +204,16 @@ RSpec.describe Datadog::Profiling::NativeExtension do
       big_message = 'a' * 500
 
       expect do
-        described_class::Testing._native_grab_gvl_and_raise_syserr(Errno::EINTR::Errno, big_message, nil)
+        described_class::Testing._native_grab_gvl_and_raise_syserr(Errno::EINTR::Errno, big_message, nil, true)
       end.to raise_exception(Errno::EINTR, /.+a{255}\z/)
+    end
+
+    context 'when called without releasing the gvl' do
+      it 'raises a RuntimeError' do
+        expect do
+          described_class::Testing._native_grab_gvl_and_raise_syserr(Errno::EINTR::Errno, 'this is a test', nil, false)
+        end.to raise_exception(RuntimeError, /called by thread holding the global VM lock/)
+      end
     end
   end
 


### PR DESCRIPTION
**What does this PR do?**:

While working on other parts of the profiler, I observed that if the `serializer_flip_active_and_inactive_slots` function in `stack_recorder.c` tried to raise an exception, the Ruby VM could crash.

**Fortunately, the `StackRecorder` is only used on the new profiler codepath, which is still considered in alpha state and off by default**. Furthermore, the exceptions would only happen in cases that are not expected to ever happen in production.

The crash was caused by the fact that `serializer_flip_active_and_inactive_slots` is called without the Global VM Lock being held, and it's not valid to try to raise exceptions in this state.

To fix this, and because I still find raising exceptions to be useful in the native parts of the profiler, I've introduced two new helpers

* `grab_gvl_and_raise`
* `grab_gvl_and_raise_syserr`

that can be used to safely raise exceptions by making sure they grab the GVL before calling the Ruby exception-raising APIs.

**Motivation**:

The added helpers may seem slightly overkill as they're currently only used by the `StackRecorder`, but I plan to use them right away in the implementation of a new component that's living in a different branch.

**Additional Notes**:

(None)

**How to test the change?**:

Change includes test coverage.

Additionally, if you're curious to see the VM crashing, run the `stack_recorder_spec.rb` without this fix and add

```ruby
Thread.new do
  Object.new while true
end
```

to the very top of the spec file. This will usually trigger the crash because there will be two threads trying to allocate objects in the Ruby heap -- the added one, as well as the thread running `serializer_flip_active_and_inactive_slots`, which should set off the fireworks.