### PR TITLE
Fix profiling integration spec not shutting down tracer correctly

### DIFF
--- a/spec/datadog/profiling/integration_spec.rb
+++ b/spec/datadog/profiling/integration_spec.rb
@@ -114,15 +114,19 @@ RSpec.describe 'profiling integration test' do
 
     context 'with tracing' do
       around do |example|
-        Datadog.configuration.diagnostics.startup_logs.enabled = false
+        Datadog.configure do |c|
+          c.diagnostics.startup_logs.enabled = false
+          c.tracing.transport_options = proc { |t| t.adapter :test }
+        end
 
         Datadog::Tracing.trace('profiler.test') do |span, trace|
           @current_span = span
           @current_root_span = trace.send(:root_span)
           example.run
-
-          Datadog::Tracing.shutdown!
         end
+
+        Datadog::Tracing.shutdown!
+        Datadog.configuration.reset!
       end
 
       let(:tracer) { Datadog::Tracing.send(:tracer) }


### PR DESCRIPTION
**What does this PR do?**:

In 7930f62bef08f1f5c7a76742bee51b74655391cd I changed the profiling integration spec to avoid warnings coming from the tracer trying to report data and failing.

This PR reverts that change, and instead configures the tracer with a test adapter, so it accomplishes the same objective without the weird approach of calling `shutdown!` in the middle of a trace.

**Motivation**:

This makes the `profiling/integration_spec.rb` work correctly and not emit any log messages during execution.

**Additional Notes**:

(N/A)

**How to test the change?**:

Validate that CI is still green and that the
`profiling/integration_spec.rb` runs without outputting any extra messages to stdout/stderr.