### PR TITLE
Wire W3C propagator to HTTP & gRPC propagation

### DIFF
--- a/lib/datadog/tracing/contrib/grpc/distributed/propagation.rb
+++ b/lib/datadog/tracing/contrib/grpc/distributed/propagation.rb
@@ -24,7 +24,9 @@ module Datadog
                   Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_SINGLE_HEADER =>
                     Tracing::Distributed::B3Single.new(fetcher: Fetcher),
                   Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG =>
-                    Tracing::Distributed::Datadog.new(fetcher: Fetcher)
+                    Tracing::Distributed::Datadog.new(fetcher: Fetcher),
+                  Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_TRACE_CONTEXT =>
+                    Tracing::Distributed::TraceContext.new(fetcher: Fetcher)
                 })
             end
 

--- a/lib/datadog/tracing/contrib/http/distributed/propagation.rb
+++ b/lib/datadog/tracing/contrib/http/distributed/propagation.rb
@@ -23,7 +23,9 @@ module Datadog
                   Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_SINGLE_HEADER =>
                     Tracing::Distributed::B3Single.new(fetcher: Fetcher),
                   Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG =>
-                    Tracing::Distributed::Datadog.new(fetcher: Fetcher)
+                    Tracing::Distributed::Datadog.new(fetcher: Fetcher),
+                  Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_TRACE_CONTEXT =>
+                    Tracing::Distributed::TraceContext.new(fetcher: Fetcher)
                 })
             end
           end

--- a/spec/datadog/tracing/contrib/grpc/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/distributed/propagation_spec.rb
@@ -7,6 +7,7 @@ require_relative '../../../distributed/b3_single_spec'
 require_relative '../../../distributed/b3_multi_spec'
 require_relative '../../../distributed/datadog_spec'
 require_relative '../../../distributed/propagation_spec'
+require_relative '../../../distributed/trace_context_spec'
 
 RSpec.describe Datadog::Tracing::Contrib::GRPC::Distributed::Propagation do
   it_behaves_like 'Distributed tracing propagator' do
@@ -53,6 +54,13 @@ RSpec.describe Datadog::Tracing::Contrib::GRPC::Distributed::Propagation do
   context 'for Datadog' do
     it_behaves_like 'Datadog distributed format' do
       let(:datadog) { Datadog::Tracing::Distributed::Datadog.new(fetcher: fetcher_class) }
+      let(:fetcher_class) { Datadog::Tracing::Contrib::GRPC::Distributed::Fetcher }
+    end
+  end
+
+  context 'for Trace Context' do
+    it_behaves_like 'Trace Context distributed format' do
+      let(:datadog) { Datadog::Tracing::Distributed::TraceContext.new(fetcher: fetcher_class) }
       let(:fetcher_class) { Datadog::Tracing::Contrib::GRPC::Distributed::Fetcher }
     end
   end

--- a/spec/datadog/tracing/contrib/http/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/contrib/http/distributed/propagation_spec.rb
@@ -7,6 +7,7 @@ require_relative '../../../distributed/b3_single_spec'
 require_relative '../../../distributed/b3_multi_spec'
 require_relative '../../../distributed/datadog_spec'
 require_relative '../../../distributed/propagation_spec'
+require_relative '../../../distributed/trace_context_spec'
 
 RSpec.describe Datadog::Tracing::Contrib::HTTP::Distributed::Propagation do
   let(:prepare_key) { proc { |key| "http-#{key}".upcase!.tr('-', '_') } }
@@ -32,6 +33,13 @@ RSpec.describe Datadog::Tracing::Contrib::HTTP::Distributed::Propagation do
   context 'for Datadog' do
     it_behaves_like 'Datadog distributed format' do
       let(:datadog) { Datadog::Tracing::Distributed::Datadog.new(fetcher: fetcher_class) }
+      let(:fetcher_class) { Datadog::Tracing::Contrib::HTTP::Distributed::Fetcher }
+    end
+  end
+
+  context 'for Trace Context' do
+    it_behaves_like 'Trace Context distributed format' do
+      let(:datadog) { Datadog::Tracing::Distributed::TraceContext.new(fetcher: fetcher_class) }
       let(:fetcher_class) { Datadog::Tracing::Contrib::HTTP::Distributed::Fetcher }
     end
   end


### PR DESCRIPTION
This PR adds support for the newly introduced [W3C Trace Context propagator](https://github.com/DataDog/dd-trace-rb/pull/2451).

This means that it is now possible to use the propagation style `tracecontext`, introduced in #2454, as a valid propagation style.