### PR TITLE
Extra testing from W3C spec

### DIFF
--- a/lib/datadog/tracing/distributed/trace_context.rb
+++ b/lib/datadog/tracing/distributed/trace_context.rb
@@ -236,8 +236,11 @@ module Datadog
         def parse_traceparent_string(traceparent)
           return unless traceparent
 
-          version, trace_id, parent_id, trace_flags = traceparent.split('-')
-          return unless version == SPEC_VERSION
+          version, trace_id, parent_id, trace_flags, extra = traceparent.strip.split('-')
+
+          return if extra # Extra fields are not valid
+          return unless version == SPEC_VERSION # Different version
+          return if trace_id.size != 32 || parent_id.size != 16 || trace_flags.size != 2 # Invalid field sizes
 
           [Integer(trace_id, 16), Integer(parent_id, 16), Integer(trace_flags, 16)]
         rescue ArgumentError # Conversion to integer failed

--- a/spec/datadog/tracing/distributed/trace_context_spec.rb
+++ b/spec/datadog/tracing/distributed/trace_context_spec.rb
@@ -268,6 +268,33 @@ RSpec.shared_examples 'Trace Context distributed format' do
 
     let(:digest) { extract }
 
+    context 'with traceparent fields with incorrect sizes' do
+      context 'version with incorrect size' do
+        let(:traceparent) { '0-00000000000000000000000000c0ffee-0000000000000bee-01' }
+        it { is_expected.to be_nil }
+      end
+
+      context 'trace_id with incorrect size' do
+        let(:traceparent) { '00-fee-0000000000000bee-01' }
+        it { is_expected.to be_nil }
+      end
+
+      context 'parent_id with incorrect size' do
+        let(:traceparent) { '00-00000000000000000000000000c0ffee-bee-01' }
+        it { is_expected.to be_nil }
+      end
+
+      context 'trace flags with incorrect size' do
+        let(:traceparent) { '00-00000000000000000000000000c0ffee-0000000000000bee-0' }
+        it { is_expected.to be_nil }
+      end
+
+      context 'more fields than expected' do
+        let(:traceparent) { '00-00000000000000000000000000c0ffee-0000000000000bee-01-FFFFF' }
+        it { is_expected.to be_nil }
+      end
+    end
+
     context 'without data' do
       let(:data) { {} }
       it { is_expected.to be nil }
@@ -364,6 +391,14 @@ RSpec.shared_examples 'Trace Context distributed format' do
       context 'but version not 00' do
         let(:traceparent) { '01-00000000000000000000000000c0ffee-0000000000000bee-00' }
         it { is_expected.to be nil }
+      end
+
+      context 'trailing whitespace' do
+        let(:traceparent) { '00-00000000000000000000000000c0ffee-0000000000000bee-00 ' }
+
+        it { expect(digest.trace_id).to eq(0xC0FFEE) }
+        it { expect(digest.span_id).to eq(0xBEE) }
+        it { expect(digest.trace_sampling_priority).to eq(0) }
       end
     end
 


### PR DESCRIPTION
I looked at our internal RFC and found a few cases where we could process invalid `traceparent` headers:
1. Hex integers that are too large or too small are not allowed.
2. Trailing whitespace is allowed.