### PR TITLE
Semicolons not allwed in 'origin'

### DIFF
--- a/lib/datadog/tracing/distributed/trace_context.rb
+++ b/lib/datadog/tracing/distributed/trace_context.rb
@@ -341,8 +341,8 @@ module Datadog
         private_constant :TRACESTATE_VALUE_SIZE_LIMIT
 
         # Replace all characters with `_`, except ASCII characters 0x20-0x7E.
-        # Additionally, `,` and `=` must also be replaced by `_`.
-        INVALID_ORIGIN_CHARS = /[\u0000-\u0019,=\u007F-\u{10FFFF}]/.freeze
+        # Additionally, `,`, ';', and `=` must also be replaced by `_`.
+        INVALID_ORIGIN_CHARS = /[\u0000-\u0019,;=\u007F-\u{10FFFF}]/.freeze
         private_constant :INVALID_ORIGIN_CHARS
 
         # Replace all characters with `_`, except ASCII characters 0x21-0x7E.

--- a/spec/datadog/tracing/distributed/trace_context_spec.rb
+++ b/spec/datadog/tracing/distributed/trace_context_spec.rb
@@ -121,6 +121,7 @@ RSpec.shared_examples 'Trace Context distributed format' do
             "\u0000", # First unicode character
             "\u0019", # Last lower invalid character
             ',',
+            ';',
             '=',
             "\u007F", # First upper invalid character
             "\u{10FFFF}" # Last unicode character


### PR DESCRIPTION
Recent spec change: `;` are not allowed characters in the `origin` propagation field. They are replaced with `_`, as are all other disallowed characters.