### PR TITLE
SQL comment propagation full mode with traceparent

### DIFF
--- a/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
@@ -46,7 +46,7 @@ module Datadog
                 propagation_mode = Contrib::Propagation::SqlComment::Mode.new(comment_propagation)
 
                 Contrib::Propagation::SqlComment.annotate!(span, propagation_mode)
-                sql = Contrib::Propagation::SqlComment.prepend_comment(sql, trace_op.to_digest, propagation_mode)
+                sql = Contrib::Propagation::SqlComment.prepend_comment(sql, span, trace_op, propagation_mode)
 
                 super(sql, options)
               end

--- a/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
@@ -22,7 +22,7 @@ module Datadog
             def query(sql, options = {})
               service = Datadog.configuration_for(self, :service_name) || datadog_configuration[:service_name]
 
-              Tracing.trace(Ext::SPAN_QUERY, service: service) do |span|
+              Tracing.trace(Ext::SPAN_QUERY, service: service) do |span, trace_op|
                 span.resource = sql
                 span.span_type = Tracing::Metadata::Ext::SQL::TYPE
 
@@ -46,7 +46,7 @@ module Datadog
                 propagation_mode = Contrib::Propagation::SqlComment::Mode.new(comment_propagation)
 
                 Contrib::Propagation::SqlComment.annotate!(span, propagation_mode)
-                sql = Contrib::Propagation::SqlComment.prepend_comment(sql, span, propagation_mode)
+                sql = Contrib::Propagation::SqlComment.prepend_comment(sql, trace_op.to_digest, propagation_mode)
 
                 super(sql, options)
               end

--- a/lib/datadog/tracing/contrib/pg/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/pg/instrumentation.rb
@@ -95,7 +95,8 @@ module Datadog
                   Contrib::Propagation::SqlComment.annotate!(span, propagation_mode)
                   propagated_sql_statement = Contrib::Propagation::SqlComment.prepend_comment(
                     sql,
-                    trace_op.to_digest,
+                    span,
+                    trace_op,
                     propagation_mode
                   )
                 end

--- a/lib/datadog/tracing/contrib/propagation/sql_comment/ext.rb
+++ b/lib/datadog/tracing/contrib/propagation/sql_comment/ext.rb
@@ -24,6 +24,7 @@ module Datadog
             KEY_ENVIRONMENT = 'dde'.freeze
             KEY_PARENT_SERVICE = 'ddps'.freeze
             KEY_VERSION = 'ddpv'.freeze
+            KEY_TRACEPARENT = 'traceparent'.freeze
           end
         end
       end

--- a/spec/datadog/tracing/contrib/propagation/sql_comment_spec.rb
+++ b/spec/datadog/tracing/contrib/propagation/sql_comment_spec.rb
@@ -56,16 +56,19 @@ RSpec.describe Datadog::Tracing::Contrib::Propagation::SqlComment do
     end
 
     let(:sql_statement) { 'SELECT 1' }
-    let(:digest) do
-      Datadog::Tracing::TraceDigest.new(
-        span_service: 'database_service',
-        trace_id: 0xC0FFEE,
-        span_id: 0xBEE,
-        trace_flags: 0xFE
+
+    let(:span_op) { double(service: 'database_service') }
+    let(:trace_op) do
+      double(
+        to_digest: Datadog::Tracing::TraceDigest.new(
+          trace_id: 0xC0FFEE,
+          span_id: 0xBEE,
+          trace_flags: 0xFE
+        )
       )
     end
 
-    subject { described_class.prepend_comment(sql_statement, digest, propagation_mode) }
+    subject { described_class.prepend_comment(sql_statement, span_op, trace_op, propagation_mode) }
 
     context 'when `disabled` mode' do
       let(:mode) { 'disabled' }

--- a/spec/datadog/tracing/contrib/sql_comment_propagation_examples.rb
+++ b/spec/datadog/tracing/contrib/sql_comment_propagation_examples.rb
@@ -34,15 +34,6 @@ RSpec.shared_examples_for 'with sql comment propagation' do |span_op_name:, erro
 end
 
 RSpec.shared_examples_for 'propagates with sql comment' do |mode:, span_op_name:, error: nil|
-  RSpec::Matchers.define :a_trace_digest_with do |expected|
-    match do |actual|
-      actual.instance_of?(Datadog::Tracing::TraceDigest) &&
-        expected.all? do |key, value|
-          actual.__send__(key) == value
-        end
-    end
-  end
-
   it "propagates with mode: #{mode}" do
     expect(Datadog::Tracing::Contrib::Propagation::SqlComment::Mode)
       .to receive(:new).with(mode).and_return(propagation_mode)
@@ -77,12 +68,8 @@ RSpec.shared_examples_for 'propagates with sql comment' do |mode:, span_op_name:
 
     expect(Datadog::Tracing::Contrib::Propagation::SqlComment).to have_received(:prepend_comment).with(
       sql_statement,
-      a_trace_digest_with(
-        span_service: service_name,
-        trace_id: trace.id,
-        span_id: span.id,
-        trace_sampling_priority: 1
-      ),
+      a_span_operation_with(service: service_name),
+      duck_type(:to_digest),
       propagation_mode
     )
   end


### PR DESCRIPTION
**What does this PR do?**

Implement SQL comment propagation with `full` mode, which includes `traceparent`