### PR TITLE
Fix profiler race between starting CpuAndWallTimeWorker background thread and stopping it

### DIFF
--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -62,7 +62,7 @@ module Datadog
 
             return unless @worker_thread
 
-            self.class._native_stop(self)
+            self.class._native_stop(self, @worker_thread)
 
             @worker_thread.join
             @worker_thread = nil

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -381,6 +381,16 @@ RSpec.xdescribe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   describe '#stop' do
     subject(:stop) { cpu_and_wall_time_worker.stop }
 
+    context 'when called immediately after start' do
+      it 'stops the CpuAndWallTimeWorker' do
+        cpu_and_wall_time_worker.start
+
+        stop
+
+        expect(described_class::Testing._native_is_running?(cpu_and_wall_time_worker)).to be false
+      end
+    end
+
     context 'after starting' do
       before do
         cpu_and_wall_time_worker.start


### PR DESCRIPTION
**What does this PR do?**:

This PR fixes a race that happens between `CpuAndWallTimeWorker#start` and `CpuAndWallTimeWorker#stop`. If `#stop` was called immediately after `#start`, the following sequence of operations could happen:

1. `#start` creates a new background thread, but the thread does not start running imediately (needs to wait for its turn)
2. `#stop` calls `_native_stop` which sets `state->should_run = false`
3. `#stop` blocks on `@worker_thread.join`
4. The background thread starts running, calls `_native_sampling_loop` which sets `state->should_run = true`
5. The `CpuAndWallTimeWorker` does not actually stop, and thus `@worker_thread.join` is stuck

Effectively, the `state->should_run` set in step 2 gets clobbered by step 4.

To solve this, I've introduced a new field `stop_thread`, which is used in step 4 to identify exactly which thread should be stopped.

This is needed because `state->should_run` could be set to `false` for multiple reasons, and this allows us to detect that it was set by a `_native_stop` for a specific worker thread.

**Motivation**:

This situation should be rare but I'm thinking it could happen for a Ruby app that starts and stops really fast (e.g. because of an error).

**Additional Notes**:

This only affects the new Ruby profiler, which is still considered alpha and off by default so no customers should've been affected by this.

**Extra note**: The `cpu_and_wall_time_worker_spec.rb` is temporarily disabled because one fix I did recently uncovered a few other issues which cause flaky tests. The spec can still be ran locally, and I plan to re-enable all of it later this week.

**How to test the change?**:

Change includes code coverage.