### PR TITLE
Simplify system API error handling in profiler

### DIFF
--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -27,6 +27,8 @@ static void *testing_is_current_thread_holding_the_gvl(DDTRACE_UNUSED void *_unu
 static VALUE _native_install_holding_the_gvl_signal_handler(DDTRACE_UNUSED VALUE _self);
 static void holding_the_gvl_signal_handler(DDTRACE_UNUSED int _signal, DDTRACE_UNUSED siginfo_t *_info, DDTRACE_UNUSED void *_ucontext);
 static VALUE _native_trigger_holding_the_gvl_signal_handler_on(DDTRACE_UNUSED VALUE _self, VALUE background_thread);
+static VALUE _native_enforce_success(DDTRACE_UNUSED VALUE _self, VALUE syserr_errno, VALUE with_gvl);
+static void *trigger_enforce_success(void *trigger_args);
 
 void DDTRACE_EXPORT Init_ddtrace_profiling_native_extension(void) {
   VALUE datadog_module = rb_define_module("Datadog");
@@ -58,6 +60,7 @@ void DDTRACE_EXPORT Init_ddtrace_profiling_native_extension(void) {
   );
   rb_define_singleton_method(testing_module, "_native_install_holding_the_gvl_signal_handler", _native_install_holding_the_gvl_signal_handler, 0);
   rb_define_singleton_method(testing_module, "_native_trigger_holding_the_gvl_signal_handler_on", _native_trigger_holding_the_gvl_signal_handler_on, 1);
+  rb_define_singleton_method(testing_module, "_native_enforce_success", _native_enforce_success, 2);
 }
 
 static VALUE native_working_p(DDTRACE_UNUSED VALUE _self) {
@@ -226,4 +229,20 @@ static VALUE _native_trigger_holding_the_gvl_signal_handler_on(DDTRACE_UNUSED VA
   rb_hash_aset(result, ID2SYM(rb_intern("ruby_thread_has_gvl_p")), holding_the_gvl_signal_handler_result[1]);
   rb_hash_aset(result, ID2SYM(rb_intern("is_current_thread_holding_the_gvl")), holding_the_gvl_signal_handler_result[2]);
   return result;
+}
+
+static VALUE _native_enforce_success(DDTRACE_UNUSED VALUE _self, VALUE syserr_errno, VALUE with_gvl) {
+  if (RTEST(with_gvl)) {
+    ENFORCE_SUCCESS_GVL(NUM2INT(syserr_errno));
+  } else {
+    rb_thread_call_without_gvl(trigger_enforce_success, (void *) (intptr_t) NUM2INT(syserr_errno), NULL, NULL);
+  }
+
+  return Qtrue;
+}
+
+static void *trigger_enforce_success(void *trigger_args) {
+  intptr_t syserr_errno = (intptr_t) trigger_args;
+  ENFORCE_SUCCESS_NO_GVL(syserr_errno);
+  return NULL;
 }

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.c
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.c
@@ -93,3 +93,18 @@ void grab_gvl_and_raise_syserr(int syserr_errno, const char *format_string, ...)
 
   rb_bug("[DDTRACE] Unexpected: Reached the end of grab_gvl_and_raise_syserr while raising '%s'\n", args.exception_message);
 }
+
+void raise_syserr(
+  int syserr_errno,
+  bool have_gvl,
+  const char *expression,
+  const char *file,
+  int line,
+  const char *function_name
+) {
+  if (have_gvl) {
+    rb_exc_raise(rb_syserr_new_str(syserr_errno, rb_sprintf("Failure returned by '%s' at %s:%d:in `%s'", expression, file, line, function_name)));
+  } else {
+    grab_gvl_and_raise_syserr(syserr_errno, "Failure returned by '%s' at %s:%d:in `%s'", expression, file, line, function_name);
+  }
+}

--- a/ext/ddtrace_profiling_native_extension/setup_signal_handler.c
+++ b/ext/ddtrace_profiling_native_extension/setup_signal_handler.c
@@ -5,6 +5,7 @@
 
 #include "helpers.h"
 #include "setup_signal_handler.h"
+#include "ruby_helpers.h"
 
 static void install_sigprof_signal_handler_internal(
   void (*signal_handler_function)(int, siginfo_t *, void *),
@@ -107,7 +108,6 @@ void unblock_sigprof_signal_handler_from_running_in_current_thread(void) {
 VALUE is_sigprof_blocked_in_current_thread(void) {
   sigset_t current_signals;
   sigemptyset(&current_signals);
-  int error = pthread_sigmask(0, NULL, &current_signals);
-  if (error) rb_exc_raise(rb_syserr_new_str(error, rb_sprintf("Unexpected failure in is_sigprof_blocked_in_current_thread")));
+  ENFORCE_SUCCESS_GVL(pthread_sigmask(0, NULL, &current_signals));
   return sigismember(&current_signals, SIGPROF) ? Qtrue : Qfalse;
 }

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -239,8 +239,7 @@ static void initialize_slot_concurrency_control(struct stack_recorder_state *sta
   state->slot_two_mutex = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
 
   // A newly-created StackRecorder starts with slot one being active for samples, so let's lock slot two
-  int error = pthread_mutex_lock(&state->slot_two_mutex);
-  if (error) rb_syserr_fail(error, "Unexpected failure during pthread_mutex_lock");
+  ENFORCE_SUCCESS_GVL(pthread_mutex_lock(&state->slot_two_mutex));
 
   state->active_slot = 1;
 }
@@ -361,7 +360,7 @@ static struct active_slot_pair sampler_lock_active_profile(struct stack_recorder
 
   for (int attempts = 0; attempts < 2; attempts++) {
     error = pthread_mutex_trylock(&state->slot_one_mutex);
-    if (error && error != EBUSY) rb_syserr_fail(error, "Unexpected failure during sampler_lock_active_profile for slot_one_mutex");
+    if (error && error != EBUSY) ENFORCE_SUCCESS_GVL(error);
 
     // Slot one is active
     if (!error) return (struct active_slot_pair) {.mutex = &state->slot_one_mutex, .profile = state->slot_one_profile};
@@ -369,7 +368,7 @@ static struct active_slot_pair sampler_lock_active_profile(struct stack_recorder
     // If we got here, slot one was not active, let's try slot two
 
     error = pthread_mutex_trylock(&state->slot_two_mutex);
-    if (error && error != EBUSY) rb_syserr_fail(error, "Unexpected failure during sampler_lock_active_profile for slot_two_mutex");
+    if (error && error != EBUSY) ENFORCE_SUCCESS_GVL(error);
 
     // Slot two is active
     if (!error) return (struct active_slot_pair) {.mutex = &state->slot_two_mutex, .profile = state->slot_two_profile};
@@ -380,12 +379,10 @@ static struct active_slot_pair sampler_lock_active_profile(struct stack_recorder
 }
 
 static void sampler_unlock_active_profile(struct active_slot_pair active_slot) {
-  int error = pthread_mutex_unlock(active_slot.mutex);
-  if (error != 0) rb_syserr_fail(error, "Unexpected failure in sampler_unlock_active_profile");
+  ENFORCE_SUCCESS_GVL(pthread_mutex_unlock(active_slot.mutex));
 }
 
 static ddog_Profile *serializer_flip_active_and_inactive_slots(struct stack_recorder_state *state) {
-  int error;
   int previously_active_slot = state->active_slot;
 
   if (previously_active_slot != 1 && previously_active_slot != 2) {
@@ -396,12 +393,10 @@ static ddog_Profile *serializer_flip_active_and_inactive_slots(struct stack_reco
   pthread_mutex_t *previously_inactive = (previously_active_slot == 1) ? &state->slot_two_mutex : &state->slot_one_mutex;
 
   // Release the lock, thus making this slot active
-  error = pthread_mutex_unlock(previously_inactive);
-  if (error) grab_gvl_and_raise_syserr(error, "Unexpected failure during serializer_flip_active_and_inactive_slots for previously_inactive");
+  ENFORCE_SUCCESS_NO_GVL(pthread_mutex_unlock(previously_inactive));
 
   // Grab the lock, thus making this slot inactive
-  error = pthread_mutex_lock(previously_active);
-  if (error) grab_gvl_and_raise_syserr(error, "Unexpected failure during serializer_flip_active_and_inactive_slots for previously_active");
+  ENFORCE_SUCCESS_NO_GVL(pthread_mutex_lock(previously_active));
 
   // Update active_slot
   state->active_slot = (previously_active_slot == 1) ? 2 : 1;
@@ -438,13 +433,14 @@ static VALUE test_slot_mutex_state(VALUE recorder_instance, int slot) {
 
   if (error == 0) {
     // Mutex was unlocked
-    pthread_mutex_unlock(slot_mutex);
+    ENFORCE_SUCCESS_GVL(pthread_mutex_unlock(slot_mutex));
     return Qfalse;
   } else if (error == EBUSY) {
     // Mutex was locked
     return Qtrue;
   } else {
-    rb_syserr_fail(error, "Unexpected failure when checking mutex state");
+    ENFORCE_SUCCESS_GVL(error);
+    rb_raise(rb_eRuntimeError, "Failed to raise exception in test_slot_mutex_state; this should never happen");
   }
 }
 

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -317,8 +317,7 @@ RSpec.describe Datadog::Profiling::NativeExtension do
   describe 'enforce_success' do
     context 'when there is no error' do
       it 'does nothing' do
-        described_class::Testing._native_enforce_success(0, true)
-        # Nothing is raised
+        expect { described_class::Testing._native_enforce_success(0, true) }.to_not raise_error
       end
     end
 

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -313,4 +313,30 @@ RSpec.describe Datadog::Profiling::NativeExtension do
       end
     end
   end
+
+  describe 'enforce_success' do
+    context 'when there is no error' do
+      it 'does nothing' do
+        described_class::Testing._native_enforce_success(0, true)
+        # Nothing is raised
+      end
+    end
+
+    context 'when there is an error' do
+      let(:have_gvl) { true }
+
+      it 'raises an exception with the passed in errno' do
+        expect { described_class::Testing._native_enforce_success(Errno::EINTR::Errno, have_gvl) }
+          .to raise_exception(Errno::EINTR, /#{Errno::EINTR.exception.message}.+profiling\.c/)
+      end
+
+      context 'when called without the gvl' do
+        let(:have_gvl) { false }
+        it 'raises an exception with the passed in errno' do
+          expect { described_class::Testing._native_enforce_success(Errno::EINTR::Errno, have_gvl) }
+            .to raise_exception(Errno::EINTR, /#{Errno::EINTR.exception.message}.+profiling\.c/)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
**What does this PR do?**:

This PR introduces two new helpers in the profiler native code -- `ENFORCE_SUCCESS_GVL` and `ENFORCE_SUCCESS_NO_GVL` and updates existing code to use it.

**Motivation**:

Constantly checking for errors on system APIs such as `pthread_mutex_lock` is a lot of boiler plate that constantly breaks the flow of the code.

I decided to take a stab at improving this by introducing the new helpers.

**Additional Notes**:

The new helpers usually contain all of the information needed to tie the error back to where it came from in the native code. Here is one such example:

```
Errno::EINTR: Interrupted system call - Failure returned by 'syserr_errno' at
../../../../ext/ddtrace_profiling_native_extension/profiling.c:246:in `trigger_enforce_success'
```

Note that it includes:
* The errno string and description (these come from Ruby)
* The expression that caused the error (or variable containing it)
* The exact file, line, and function where it came from.

**How to test the change?**:

Change includes test coverage.
