### PR TITLE
[PROF-6556] Fix new alpha profiler not being able to sample in periods of idleness

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -4,6 +4,7 @@
 #include <ruby/debug.h>
 #include <stdbool.h>
 #include <signal.h>
+
 #include "helpers.h"
 #include "ruby_helpers.h"
 #include "collectors_cpu_and_wall_time.h"
@@ -190,7 +191,7 @@ static const rb_data_type_t cpu_and_wall_time_worker_typed_data = {
   .function = {
     .dmark = cpu_and_wall_time_worker_typed_data_mark,
     .dfree = RUBY_DEFAULT_FREE,
-    .dsize = NULL, // We don't track profile memory usage (although it'd be cool if we did!)
+    .dsize = NULL, // We don't track memory usage (although it'd be cool if we did!)
     //.dcompact = NULL, // FIXME: Add support for compaction
   },
   .flags = RUBY_TYPED_FREE_IMMEDIATELY

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -8,6 +8,7 @@
 #include "helpers.h"
 #include "ruby_helpers.h"
 #include "collectors_cpu_and_wall_time.h"
+#include "collectors_idle_sampling_helper.h"
 #include "private_vm_api_access.h"
 #include "setup_signal_handler.h"
 
@@ -80,6 +81,7 @@ struct cpu_and_wall_time_worker_state {
   bool gc_profiling_enabled;
   VALUE self_instance;
   VALUE cpu_and_wall_time_collector_instance;
+  VALUE idle_sampling_helper_instance;
   VALUE owner_thread;
 
   // When something goes wrong during sampling, we record the Ruby exception here, so that it can be "re-raised" on
@@ -94,7 +96,9 @@ struct cpu_and_wall_time_worker_state {
   struct stats {
     // How many times we tried to trigger a sample
     unsigned int trigger_sample_attempts;
-    // How many times we chose to simulate signal delivery
+    // How many times we tried to simulate signal delivery
+    unsigned int trigger_simulated_signal_delivery_attempts;
+    // How many times we actually simulated signal delivery
     unsigned int simulated_signal_delivery;
     // How many times we actually called rb_postponed_job_register_one from a signal handler
     unsigned int signal_handler_enqueued_sample;
@@ -110,7 +114,8 @@ static VALUE _native_initialize(
   DDTRACE_UNUSED VALUE _self,
   VALUE self_instance,
   VALUE cpu_and_wall_time_collector_instance,
-  VALUE gc_profiling_enabled
+  VALUE gc_profiling_enabled,
+  VALUE idle_sampling_helper_instance
 );
 static void cpu_and_wall_time_worker_typed_data_mark(void *state_ptr);
 static VALUE _native_sampling_loop(VALUE self, VALUE instance);
@@ -138,6 +143,7 @@ static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE instance)
 static VALUE _native_is_sigprof_blocked_in_current_thread(DDTRACE_UNUSED VALUE self);
 static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance);
 void *simulate_sampling_signal_delivery(DDTRACE_UNUSED void *_unused);
+static void grab_gvl_and_sample(void);
 
 // Note on sampler global state safety:
 //
@@ -168,7 +174,7 @@ void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module) {
   // https://bugs.ruby-lang.org/issues/18007 for a discussion around this.
   rb_define_alloc_func(collectors_cpu_and_wall_time_worker_class, _native_new);
 
-  rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_initialize", _native_initialize, 3);
+  rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_initialize", _native_initialize, 4);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_sampling_loop", _native_sampling_loop, 1);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_stop", _native_stop, 2);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_reset_after_fork", _native_reset_after_fork, 1);
@@ -203,6 +209,7 @@ static VALUE _native_new(VALUE klass) {
   state->should_run = false;
   state->gc_profiling_enabled = false;
   state->cpu_and_wall_time_collector_instance = Qnil;
+  state->idle_sampling_helper_instance = Qnil;
   state->owner_thread = Qnil;
   state->failure_exception = Qnil;
   state->stop_thread = Qnil;
@@ -215,7 +222,8 @@ static VALUE _native_initialize(
   DDTRACE_UNUSED VALUE _self,
   VALUE self_instance,
   VALUE cpu_and_wall_time_collector_instance,
-  VALUE gc_profiling_enabled
+  VALUE gc_profiling_enabled,
+  VALUE idle_sampling_helper_instance
 ) {
   ENFORCE_BOOLEAN(gc_profiling_enabled);
 
@@ -224,6 +232,7 @@ static VALUE _native_initialize(
 
   state->gc_profiling_enabled = (gc_profiling_enabled == Qtrue);
   state->cpu_and_wall_time_collector_instance = enforce_cpu_and_wall_time_collector_instance(cpu_and_wall_time_collector_instance);
+  state->idle_sampling_helper_instance = idle_sampling_helper_instance;
   state->gc_tracepoint = rb_tracepoint_new(Qnil, RUBY_INTERNAL_EVENT_GC_ENTER | RUBY_INTERNAL_EVENT_GC_EXIT, on_gc_event, NULL /* unused */);
 
   return Qtrue;
@@ -234,6 +243,7 @@ static void cpu_and_wall_time_worker_typed_data_mark(void *state_ptr) {
   struct cpu_and_wall_time_worker_state *state = (struct cpu_and_wall_time_worker_state *) state_ptr;
 
   rb_gc_mark(state->cpu_and_wall_time_collector_instance);
+  rb_gc_mark(state->idle_sampling_helper_instance);
   rb_gc_mark(state->owner_thread);
   rb_gc_mark(state->failure_exception);
   rb_gc_mark(state->stop_thread);
@@ -395,9 +405,14 @@ static void *run_sampling_trigger_loop(void *state_ptr) {
       pthread_kill(owner.owner, SIGPROF);
     } else {
       // If no thread owns the Global VM Lock, the application is probably idle at the moment. We still want to sample
-      // so let's take matters into our own hands -- let's temporarily grab the GVL and simulate getting a SIGPROF.
-      state->stats.simulated_signal_delivery++;
-      rb_thread_call_with_gvl(simulate_sampling_signal_delivery, NULL);
+      // so we "ask a friend" (the IdleSamplingHelper component) to grab the GVL and simulate getting a SIGPROF.
+      //
+      // In a previous version of the code, we called `grab_gvl_and_sample` directly BUT this was problematic because
+      // Ruby may concurrently get busy and so the CpuAndWallTimeWorker would be blocked in line to acquire the GVL
+      // for an uncontrolled amount of time. (This can still happen to the IdleSamplingHelper, but the
+      // CpuAndWallTimeWorker will still be free to interrupt the Ruby VM and keep sampling for the entire blocking period).
+      state->stats.trigger_simulated_signal_delivery_attempts++;
+      idle_sampling_helper_request_action(state->idle_sampling_helper_instance, grab_gvl_and_sample);
     }
 
     nanosleep(&time_between_signals, NULL);
@@ -640,20 +655,30 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance) {
 
   VALUE stats_as_hash = rb_hash_new();
   VALUE arguments[] = {
-    ID2SYM(rb_intern("trigger_sample_attempts")),        /* => */ UINT2NUM(state->stats.trigger_sample_attempts),
-    ID2SYM(rb_intern("simulated_signal_delivery")),      /* => */ UINT2NUM(state->stats.simulated_signal_delivery),
-    ID2SYM(rb_intern("signal_handler_enqueued_sample")), /* => */ UINT2NUM(state->stats.signal_handler_enqueued_sample),
-    ID2SYM(rb_intern("signal_handler_wrong_thread")),    /* => */ UINT2NUM(state->stats.signal_handler_wrong_thread),
-    ID2SYM(rb_intern("sampled")),                        /* => */ UINT2NUM(state->stats.sampled),
+    ID2SYM(rb_intern("trigger_sample_attempts")),                    /* => */ UINT2NUM(state->stats.trigger_sample_attempts),
+    ID2SYM(rb_intern("trigger_simulated_signal_delivery_attempts")), /* => */ UINT2NUM(state->stats.trigger_simulated_signal_delivery_attempts),
+    ID2SYM(rb_intern("simulated_signal_delivery")),                  /* => */ UINT2NUM(state->stats.simulated_signal_delivery),
+    ID2SYM(rb_intern("signal_handler_enqueued_sample")),             /* => */ UINT2NUM(state->stats.signal_handler_enqueued_sample),
+    ID2SYM(rb_intern("signal_handler_wrong_thread")),                /* => */ UINT2NUM(state->stats.signal_handler_wrong_thread),
+    ID2SYM(rb_intern("sampled")),                                    /* => */ UINT2NUM(state->stats.sampled),
   };
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
   return stats_as_hash;
 }
 
 void *simulate_sampling_signal_delivery(DDTRACE_UNUSED void *_unused) {
+  struct cpu_and_wall_time_worker_state *state = active_sampler_instance_state; // Read from global variable, see "sampler global state safety" note above
+
+  // This can potentially happen if the CpuAndWallTimeWorker was stopped while the IdleSamplingHelper was trying to execute this action
+  if (state == NULL) return NULL;
+
+  state->stats.simulated_signal_delivery++;
+
   // @ivoanjo: We could instead directly call sample_from_postponed_job, but I chose to go through the signal handler
   // so that the simulated case is as close to the original one as well (including any metrics increases, etc).
   handle_sampling_signal(0, NULL, NULL);
 
   return NULL; // Unused
 }
+
+static void grab_gvl_and_sample(void) { rb_thread_call_with_gvl(simulate_sampling_signal_delivery, NULL); }

--- a/ext/ddtrace_profiling_native_extension/collectors_idle_sampling_helper.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_idle_sampling_helper.c
@@ -1,0 +1,241 @@
+#include <ruby.h>
+#include <ruby/thread.h>
+#include <pthread.h>
+#include <stdbool.h>
+
+#include "helpers.h"
+#include "ruby_helpers.h"
+
+// Used by the Collectors::CpuAndWallTimeWorker to gather samples when the Ruby process is idle.
+//
+// Specifically, the IdleSamplingHelper is expected to be triggered by the CpuAndWallTimeWorker whenever it needs to
+// trigger a sample, but the VM is otherwise idle. See implementation of CpuAndWallTimeWorker for details.
+//
+// The IdleSamplingHelper keeps a background thread that waits for functions to run on a single-element "queue".
+// Other threads communicate with it by asking it to ACTION_RUN a `requested_action` or ACTION_STOP to terminate.
+//
+// The state is protected by the `wakeup_mutex`, and the background thread is woken up after changes using the
+// `wakeup` condition variable.
+
+typedef enum { ACTION_WAIT, ACTION_RUN, ACTION_STOP } action;
+
+// Contains state for a single CpuAndWallTimeWorker instance
+struct idle_sampling_loop_state {
+  pthread_mutex_t wakeup_mutex;
+  pthread_cond_t wakeup;
+  action requested_action;
+  void (*run_action_function)(void);
+};
+
+static VALUE _native_new(VALUE klass);
+static void reset_state(struct idle_sampling_loop_state *state);
+static VALUE _native_idle_sampling_loop(DDTRACE_UNUSED VALUE self, VALUE self_instance);
+static VALUE _native_stop(DDTRACE_UNUSED VALUE self, VALUE self_instance);
+static void *run_idle_sampling_loop(void *state_ptr);
+static void interrupt_idle_sampling_loop(void *state_ptr);
+static VALUE _native_reset(DDTRACE_UNUSED VALUE self, VALUE self_instance);
+void idle_sampling_helper_request_action(VALUE self_instance, void (*run_action_function)(void));
+static VALUE _native_idle_sampling_helper_request_action(DDTRACE_UNUSED VALUE self, VALUE self_instance);
+static void *request_testing_action(void *self_instance_ptr);
+void grab_gvl_and_run_testing_action(void);
+static void *run_testing_action(DDTRACE_UNUSED void *unused);
+
+void collectors_idle_sampling_helper_init(VALUE profiling_module) {
+  VALUE collectors_module = rb_define_module_under(profiling_module, "Collectors");
+  VALUE collectors_idle_sampling_helper_class = rb_define_class_under(collectors_module, "IdleSamplingHelper", rb_cObject);
+  // Hosts methods used for testing the native code using RSpec
+  VALUE testing_module = rb_define_module_under(collectors_idle_sampling_helper_class, "Testing");
+
+  // Instances of the IdleSamplingHelper class are "TypedData" objects.
+  // "TypedData" objects are special objects in the Ruby VM that can wrap C structs.
+  // In this case, it wraps the idle_sampling_loop_state.
+  //
+  // Because Ruby doesn't know how to initialize native-level structs, we MUST override the allocation function for objects
+  // of this class so that we can manage this part. Not overriding or disabling the allocation function is a common
+  // gotcha for "TypedData" objects that can very easily lead to VM crashes, see for instance
+  // https://bugs.ruby-lang.org/issues/18007 for a discussion around this.
+  rb_define_alloc_func(collectors_idle_sampling_helper_class, _native_new);
+
+  rb_define_singleton_method(collectors_idle_sampling_helper_class, "_native_idle_sampling_loop", _native_idle_sampling_loop, 1);
+  rb_define_singleton_method(collectors_idle_sampling_helper_class, "_native_stop", _native_stop, 1);
+  rb_define_singleton_method(collectors_idle_sampling_helper_class, "_native_reset", _native_reset, 1);
+  rb_define_singleton_method(testing_module, "_native_idle_sampling_helper_request_action", _native_idle_sampling_helper_request_action, 1);
+}
+
+// This structure is used to define a Ruby object that stores a pointer to a struct idle_sampling_loop_state
+// See also https://github.com/ruby/ruby/blob/master/doc/extension.rdoc for how this works
+static const rb_data_type_t idle_sampling_helper_typed_data = {
+  .wrap_struct_name = "Datadog::Profiling::Collectors::IdleSamplingHelper",
+  .function = {
+    .dmark = NULL, // We don't store references to Ruby objects so we don't need to mark any of them
+    .dfree = RUBY_DEFAULT_FREE,
+    .dsize = NULL, // We don't track memory usage (although it'd be cool if we did!)
+    //.dcompact = NULL, // Not needed -- we don't store references to Ruby objects
+  },
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+static VALUE _native_new(VALUE klass) {
+  struct idle_sampling_loop_state *state = ruby_xcalloc(1, sizeof(struct idle_sampling_loop_state));
+
+  reset_state(state);
+
+  return TypedData_Wrap_Struct(klass, &idle_sampling_helper_typed_data, state);
+}
+
+static void reset_state(struct idle_sampling_loop_state *state) {
+  state->wakeup_mutex = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
+  state->wakeup = (pthread_cond_t) PTHREAD_COND_INITIALIZER;
+  state->requested_action = ACTION_WAIT;
+  state->run_action_function = NULL;
+}
+
+// The same instance of the IdleSamplingHelper can be reused multiple times, and this resets it back to
+// a pristine state before recreating the worker thread (this includes resetting the mutex in case it was left
+// locked halfway through the VM forking)
+static VALUE _native_reset(DDTRACE_UNUSED VALUE self, VALUE self_instance) {
+  struct idle_sampling_loop_state *state;
+  TypedData_Get_Struct(self_instance, struct idle_sampling_loop_state, &idle_sampling_helper_typed_data, state);
+
+  reset_state(state);
+
+  return Qtrue;
+}
+
+static VALUE _native_idle_sampling_loop(DDTRACE_UNUSED VALUE self, VALUE self_instance) {
+  struct idle_sampling_loop_state *state;
+  TypedData_Get_Struct(self_instance, struct idle_sampling_loop_state, &idle_sampling_helper_typed_data, state);
+
+  // Release GVL and run the loop waiting for requests
+  rb_thread_call_without_gvl(run_idle_sampling_loop, state, interrupt_idle_sampling_loop, state);
+
+  return Qtrue;
+}
+
+static void *run_idle_sampling_loop(void *state_ptr) {
+  struct idle_sampling_loop_state *state = (struct idle_sampling_loop_state *) state_ptr;
+  int error = 0;
+
+  while (true) {
+    ENFORCE_SUCCESS_NO_GVL(pthread_mutex_lock(&state->wakeup_mutex));
+
+    action next_action;
+    void (*run_action_function)(void);
+
+    // Await for an action
+    while ((next_action = state->requested_action) == ACTION_WAIT) {
+      error = pthread_cond_wait(&state->wakeup, &state->wakeup_mutex);
+      if (error) {
+        // If something went wrong, try to leave the mutex unlocked at least
+        pthread_mutex_unlock(&state->wakeup_mutex);
+        ENFORCE_SUCCESS_NO_GVL(error);
+      }
+    }
+
+    // There's an action to be taken!
+
+    // Record function, if any
+    run_action_function = state->run_action_function;
+
+    // Reset buffer for next request
+    state->requested_action = ACTION_WAIT;
+
+    // Unlock the mutex immediately so other threads can continue to request actions without blocking
+    ENFORCE_SUCCESS_NO_GVL(pthread_mutex_unlock(&state->wakeup_mutex));
+
+    // Process pending action
+    if (next_action == ACTION_RUN) {
+      if (run_action_function == NULL) {
+        grab_gvl_and_raise(rb_eRuntimeError, "Unexpected NULL run_action_function in run_idle_sampling_loop");
+      }
+
+      run_action_function();
+    } else { // ACTION_STOP
+      return NULL;
+    }
+  }
+}
+
+static void interrupt_idle_sampling_loop(void *state_ptr) {
+  struct idle_sampling_loop_state *state = (struct idle_sampling_loop_state *) state_ptr;
+  int error = 0;
+
+  // Note about the error handling in this situation: Something bad happening at this stage is really really awkward to
+  // handle because we get called by the VM in a situation where we can't really raise exceptions, and the VM really really
+  // just wants us to stop what we're doing and return control of the thread to it.
+  //
+  // So if we return immediately on error, we may leave the VM hanging because we didn't actually interrupt the thread.
+  // We're also not at a great location to flag errors.
+  // That's why: a) I chose to log to stderr, as a last-ditch effort; b) even if something goes wrong we still try to
+  // ask the thread to stop, instead of exiting early.
+
+  error = pthread_mutex_lock(&state->wakeup_mutex);
+  if (error) { fprintf(stderr, "[DDTRACE] Error during pthread_mutex_lock in interrupt_idle_sampling_loop (%s)\n", strerror(error)); }
+
+  state->requested_action = ACTION_STOP;
+
+  error = pthread_mutex_unlock(&state->wakeup_mutex);
+  if (error) { fprintf(stderr, "[DDTRACE] Error during pthread_mutex_unlock in interrupt_idle_sampling_loop (%s)\n", strerror(error)); }
+
+  error = pthread_cond_broadcast(&state->wakeup);
+  if (error) { fprintf(stderr, "[DDTRACE] Error during pthread_cond_broadcast in interrupt_idle_sampling_loop (%s)\n", strerror(error)); }
+}
+
+static VALUE _native_stop(DDTRACE_UNUSED VALUE self, VALUE self_instance) {
+  struct idle_sampling_loop_state *state;
+  TypedData_Get_Struct(self_instance, struct idle_sampling_loop_state, &idle_sampling_helper_typed_data, state);
+
+  ENFORCE_SUCCESS_GVL(pthread_mutex_lock(&state->wakeup_mutex));
+  state->requested_action = ACTION_STOP;
+  ENFORCE_SUCCESS_GVL(pthread_mutex_unlock(&state->wakeup_mutex));
+
+  // Wake up worker thread, if needed; It's OK to call broadcast after releasing the mutex
+  ENFORCE_SUCCESS_GVL(pthread_cond_broadcast(&state->wakeup));
+
+  return Qtrue;
+}
+
+// Assumption: Function gets called without the global VM lock
+void idle_sampling_helper_request_action(VALUE self_instance, void (*run_action_function)(void)) {
+  struct idle_sampling_loop_state *state;
+  if (!rb_typeddata_is_kind_of(self_instance, &idle_sampling_helper_typed_data)) {
+    grab_gvl_and_raise(rb_eTypeError, "Wrong argument for idle_sampling_helper_request_action");
+  }
+  // This should never fail the the above check passes
+  TypedData_Get_Struct(self_instance, struct idle_sampling_loop_state, &idle_sampling_helper_typed_data, state);
+
+  ENFORCE_SUCCESS_NO_GVL(pthread_mutex_lock(&state->wakeup_mutex));
+  if (state->requested_action == ACTION_WAIT) {
+    state->requested_action = ACTION_RUN;
+    state->run_action_function = run_action_function;
+  }
+  ENFORCE_SUCCESS_NO_GVL(pthread_mutex_unlock(&state->wakeup_mutex));
+
+  // Wake up worker thread, if needed; It's OK to call broadcast after releasing the mutex
+  ENFORCE_SUCCESS_NO_GVL(pthread_cond_broadcast(&state->wakeup));
+}
+
+// Because the idle_sampling_helper_request_action is built to be called without the global VM lock, here we release it
+// to be able to call that API.
+static VALUE _native_idle_sampling_helper_request_action(DDTRACE_UNUSED VALUE self, VALUE self_instance) {
+  rb_thread_call_without_gvl(request_testing_action, (void *) self_instance, NULL, NULL);
+  return Qtrue;
+}
+
+static void *request_testing_action(void *self_instance_ptr) {
+  VALUE self_instance = (VALUE) self_instance_ptr;
+  idle_sampling_helper_request_action(self_instance, grab_gvl_and_run_testing_action);
+  return NULL;
+}
+
+// This gets called by the worker thread, which is not holding the global VM lock. To be able to actually run the action,
+// we need to acquire it
+void grab_gvl_and_run_testing_action(void) {
+  rb_thread_call_with_gvl(run_testing_action, NULL);
+}
+
+static void *run_testing_action(DDTRACE_UNUSED void *unused) {
+  VALUE idle_sampling_helper_testing_action = rb_gv_get("$idle_sampling_helper_testing_action");
+  rb_funcall(idle_sampling_helper_testing_action, rb_intern("call"), 0);
+  return NULL;
+}

--- a/ext/ddtrace_profiling_native_extension/collectors_idle_sampling_helper.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_idle_sampling_helper.c
@@ -5,6 +5,7 @@
 
 #include "helpers.h"
 #include "ruby_helpers.h"
+#include "collectors_idle_sampling_helper.h"
 
 // Used by the Collectors::CpuAndWallTimeWorker to gather samples when the Ruby process is idle.
 //
@@ -34,10 +35,9 @@ static VALUE _native_stop(DDTRACE_UNUSED VALUE self, VALUE self_instance);
 static void *run_idle_sampling_loop(void *state_ptr);
 static void interrupt_idle_sampling_loop(void *state_ptr);
 static VALUE _native_reset(DDTRACE_UNUSED VALUE self, VALUE self_instance);
-void idle_sampling_helper_request_action(VALUE self_instance, void (*run_action_function)(void));
 static VALUE _native_idle_sampling_helper_request_action(DDTRACE_UNUSED VALUE self, VALUE self_instance);
 static void *request_testing_action(void *self_instance_ptr);
-void grab_gvl_and_run_testing_action(void);
+static void grab_gvl_and_run_testing_action(void);
 static void *run_testing_action(DDTRACE_UNUSED void *unused);
 
 void collectors_idle_sampling_helper_init(VALUE profiling_module) {
@@ -230,7 +230,7 @@ static void *request_testing_action(void *self_instance_ptr) {
 
 // This gets called by the worker thread, which is not holding the global VM lock. To be able to actually run the action,
 // we need to acquire it
-void grab_gvl_and_run_testing_action(void) {
+static void grab_gvl_and_run_testing_action(void) {
   rb_thread_call_with_gvl(run_testing_action, NULL);
 }
 

--- a/ext/ddtrace_profiling_native_extension/collectors_idle_sampling_helper.h
+++ b/ext/ddtrace_profiling_native_extension/collectors_idle_sampling_helper.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void idle_sampling_helper_request_action(VALUE self_instance, void (*run_action_function)(void));

--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -11,6 +11,7 @@
 // Each class/module here is implemented in their separate file
 void collectors_cpu_and_wall_time_init(VALUE profiling_module);
 void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module);
+void collectors_idle_sampling_helper_init(VALUE profiling_module);
 void collectors_stack_init(VALUE profiling_module);
 void http_transport_init(VALUE profiling_module);
 void stack_recorder_init(VALUE profiling_module);
@@ -42,6 +43,7 @@ void DDTRACE_EXPORT Init_ddtrace_profiling_native_extension(void) {
 
   collectors_cpu_and_wall_time_init(profiling_module);
   collectors_cpu_and_wall_time_worker_init(profiling_module);
+  collectors_idle_sampling_helper_init(profiling_module);
   collectors_stack_init(profiling_module);
   http_transport_init(profiling_module);
   stack_recorder_init(profiling_module);

--- a/ext/ddtrace_profiling_native_extension/ruby_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/ruby_helpers.h
@@ -58,7 +58,7 @@ NORETURN(void raise_unexpected_type(
   const char *type_name,
   const char *file,
   int line,
-  const char* function_name
+  const char *function_name
 ));
 
 #define VALUE_COUNT(array) (sizeof(array) / sizeof(VALUE))

--- a/ext/ddtrace_profiling_native_extension/setup_signal_handler.c
+++ b/ext/ddtrace_profiling_native_extension/setup_signal_handler.c
@@ -7,6 +7,8 @@
 #include "setup_signal_handler.h"
 #include "ruby_helpers.h"
 
+// Used by Collectors::CpuAndWallTimeWorker to setup SIGPROF signal handlers used for cpu/wall-time profiling.
+
 static void install_sigprof_signal_handler_internal(
   void (*signal_handler_function)(int, siginfo_t *, void *),
   const char *handler_pretty_name,

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -149,6 +149,7 @@ module Datadog
       require_relative 'profiling/collectors/code_provenance'
       require_relative 'profiling/collectors/cpu_and_wall_time'
       require_relative 'profiling/collectors/cpu_and_wall_time_worker'
+      require_relative 'profiling/collectors/idle_sampling_helper'
       require_relative 'profiling/collectors/old_stack'
       require_relative 'profiling/collectors/stack'
       require_relative 'profiling/stack_recorder'

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -20,12 +20,14 @@ module Datadog
           max_frames:,
           tracer:,
           gc_profiling_enabled:,
-          cpu_and_wall_time_collector: CpuAndWallTime.new(recorder: recorder, max_frames: max_frames, tracer: tracer)
+          cpu_and_wall_time_collector: CpuAndWallTime.new(recorder: recorder, max_frames: max_frames, tracer: tracer),
+          idle_sampling_helper: IdleSamplingHelper.new
         )
-          self.class._native_initialize(self, cpu_and_wall_time_collector, gc_profiling_enabled)
+          self.class._native_initialize(self, cpu_and_wall_time_collector, gc_profiling_enabled, idle_sampling_helper)
           @worker_thread = nil
           @failure_exception = nil
           @start_stop_mutex = Mutex.new
+          @idle_sampling_helper = idle_sampling_helper
         end
 
         def start
@@ -33,6 +35,9 @@ module Datadog
             return if @worker_thread && @worker_thread.alive?
 
             Datadog.logger.debug { "Starting thread for: #{self}" }
+
+            @idle_sampling_helper.start
+
             @worker_thread = Thread.new do
               begin
                 Thread.current.name = self.class.name unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
@@ -43,7 +48,8 @@ module Datadog
               rescue Exception => e # rubocop:disable Lint/RescueException
                 @failure_exception = e
                 Datadog.logger.warn(
-                  "Worker thread error. Cause: #{e.class.name} #{e.message} Location: #{Array(e.backtrace).first}"
+                  'CpuAndWallTimeWorker thread error. ' \
+                  "Cause: #{e.class.name} #{e.message} Location: #{Array(e.backtrace).first}"
                 )
               end
             end
@@ -59,6 +65,8 @@ module Datadog
         def stop(*_)
           @start_stop_mutex.synchronize do
             Datadog.logger.debug('Requesting CpuAndWallTimeWorker thread shut down')
+
+            @idle_sampling_helper.stop
 
             return unless @worker_thread
 

--- a/lib/datadog/profiling/collectors/idle_sampling_helper.rb
+++ b/lib/datadog/profiling/collectors/idle_sampling_helper.rb
@@ -1,0 +1,68 @@
+# typed: false
+
+module Datadog
+  module Profiling
+    module Collectors
+      # Used by the Collectors::CpuAndWallTimeWorker to gather samples when the Ruby process is idle.
+      # Almost all of this class is implemented as native code.
+      #
+      # Methods prefixed with _native_ are implemented in `collecetors_idle_sampling_helper.c`
+      class IdleSamplingHelper
+        private
+
+        attr_accessor :failure_exception
+
+        public
+
+        def initialize
+          @worker_thread = nil
+          @start_stop_mutex = Mutex.new
+        end
+
+        def start
+          @start_stop_mutex.synchronize do
+            return if @worker_thread && @worker_thread.alive?
+
+            Datadog.logger.debug { "Starting thread for: #{self}" }
+
+            # The same instance of the IdleSamplingHelper can be reused multiple times, and this resets it back to
+            # a pristine state before recreating the worker thread
+            self.class._native_reset(self)
+
+            @worker_thread = Thread.new do
+              begin
+                Thread.current.name = self.class.name unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+
+                self.class._native_idle_sampling_loop(self)
+
+                Datadog.logger.debug('IdleSamplingHelper thread stopping cleanly')
+              rescue Exception => e # rubocop:disable Lint/RescueException
+                @failure_exception = e
+                Datadog.logger.warn(
+                  'IdleSamplingHelper thread error. ' \
+                  "Cause: #{e.class.name} #{e.message} Location: #{Array(e.backtrace).first}"
+                )
+              end
+            end
+          end
+
+          true
+        end
+
+        def stop(*_)
+          @start_stop_mutex.synchronize do
+            Datadog.logger.debug('Requesting IdleSamplingHelper thread shut down')
+
+            return unless @worker_thread
+
+            self.class._native_stop(self)
+
+            @worker_thread.join
+            @worker_thread = nil
+            @failure_exception = nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -34,6 +34,20 @@ module Datadog
         end
       end
 
+      def serialize!
+        status, result = @no_concurrent_synchronize_mutex.synchronize { self.class._native_serialize(self) }
+
+        if status == :ok
+          _start, _finish, encoded_pprof = result
+
+          encoded_pprof
+        else
+          error_message = result
+
+          raise("Failed to serialize profiling data: #{error_message}")
+        end
+      end
+
       def clear
         status, result = @no_concurrent_synchronize_mutex.synchronize { self.class._native_clear(self) }
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
@@ -33,12 +33,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
   end
   let(:max_frames) { 123 }
 
-  let(:pprof_result) do
-    serialization_result = recorder.serialize
-    raise 'Unexpected: Serialization failed' unless serialization_result
-
-    serialization_result.last
-  end
+  let(:pprof_result) { recorder.serialize! }
   let(:samples) { samples_from_pprof(pprof_result) }
   let(:invalid_time) { -1 }
   let(:tracer) { nil }

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -262,7 +262,7 @@ RSpec.xdescribe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       end
     end
 
-    context 'when main thread is sleeping but background thread is working' do
+    context 'when main thread is sleeping but a background thread is working' do
       let(:ready_queue) { Queue.new }
       let(:background_thread) do
         Thread.new do
@@ -297,18 +297,18 @@ RSpec.xdescribe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         stats = cpu_and_wall_time_worker.stats
 
-        trigger_sample_attempts = stats.fetch(:trigger_sample_attempts).to_f
-        signal_handler_enqueued_sample = stats.fetch(:signal_handler_enqueued_sample).to_f
-        signal_handler_wrong_thread = stats.fetch(:signal_handler_wrong_thread).to_f
+        trigger_sample_attempts = stats.fetch(:trigger_sample_attempts)
+        signal_handler_enqueued_sample = stats.fetch(:signal_handler_enqueued_sample)
+        signal_handler_wrong_thread = stats.fetch(:signal_handler_wrong_thread)
 
-        expect(signal_handler_enqueued_sample / trigger_sample_attempts).to (be >= 0.8), \
+        expect(signal_handler_enqueued_sample.to_f / trigger_sample_attempts).to (be >= 0.8), \
           "Expected at least 80% of signals to be delivered to correct thread (#{stats})"
 
         # Sanity checking
 
         # We're currently targeting 100 samples per second, so 5 in 100ms is a conservative approximation that hopefully
         # will not cause flakyness
-        expect(sample_count).to be >= 5, "Stats: #{stats}"
+        expect(sample_count).to be >= 5, "sample_count: #{sample_count}, stats: #{stats}"
         expect(trigger_sample_attempts).to be >= sample_count
         expect(trigger_sample_attempts).to be signal_handler_enqueued_sample + signal_handler_wrong_thread
       end
@@ -331,20 +331,20 @@ RSpec.xdescribe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         stats = cpu_and_wall_time_worker.stats
 
-        trigger_sample_attempts = stats.fetch(:trigger_sample_attempts).to_f
-        signal_handler_enqueued_sample = stats.fetch(:signal_handler_enqueued_sample).to_f
-        signal_handler_wrong_thread = stats.fetch(:signal_handler_wrong_thread).to_f
+        trigger_sample_attempts = stats.fetch(:trigger_sample_attempts)
+        signal_handler_enqueued_sample = stats.fetch(:signal_handler_enqueued_sample)
+        signal_handler_wrong_thread = stats.fetch(:signal_handler_wrong_thread)
 
-        simulated_signal_delivery = stats.fetch(:simulated_signal_delivery).to_f
+        simulated_signal_delivery = stats.fetch(:simulated_signal_delivery)
 
-        expect(simulated_signal_delivery / trigger_sample_attempts).to (be >= 0.8), \
+        expect(simulated_signal_delivery.to_f / trigger_sample_attempts).to (be >= 0.8), \
           "Expected at least 80% of signals to be simulated (#{stats})"
 
         # Sanity checking
 
         # We're currently targeting 100 samples per second, so 5 in 100ms is a conservative approximation that hopefully
         # will not cause flakyness
-        expect(sample_count).to be >= 5
+        expect(sample_count).to be >= 5, "sample_count: #{sample_count}, stats: #{stats}"
         expect(trigger_sample_attempts).to be >= sample_count
         expect(trigger_sample_attempts).to be signal_handler_enqueued_sample + signal_handler_wrong_thread
       end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -274,7 +274,7 @@ RSpec.xdescribe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         cpu_and_wall_time_worker.stop
         background_thread.kill
 
-        result = samples_for_thread(samples_from_pprof(recorder.serialize!), Thread.current)
+        result = samples_for_thread(samples_from_pprof_without_gc(recorder.serialize!), Thread.current)
         sample_count = result.map { |it| it.fetch(:values).fetch(:'cpu-samples') }.reduce(:+)
 
         stats = cpu_and_wall_time_worker.stats
@@ -309,7 +309,7 @@ RSpec.xdescribe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         cpu_and_wall_time_worker.stop
 
-        result = samples_for_thread(samples_from_pprof(recorder.serialize!), Thread.current)
+        result = samples_for_thread(samples_from_pprof_without_gc(recorder.serialize!), Thread.current)
         sample_count = result.map { |it| it.fetch(:values).fetch(:'cpu-samples') }.reduce(:+)
 
         stats = cpu_and_wall_time_worker.stats

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -133,11 +133,8 @@ RSpec.xdescribe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       start
 
       all_samples = try_wait_until do
-        serialization_result = recorder.serialize
-        raise 'Unexpected: Serialization failed' unless serialization_result
-
         samples =
-          samples_from_pprof(serialization_result.last)
+          samples_from_pprof(recorder.serialize!)
             .reject { |it| it.fetch(:locations).first.fetch(:path) == 'Garbage Collection' } # Separate test for GC below
 
         samples if samples.any?
@@ -153,11 +150,8 @@ RSpec.xdescribe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       start
 
       all_samples = try_wait_until do
-        serialization_result = recorder.serialize
-        raise 'Unexpected: Serialization failed' unless serialization_result
-
         samples =
-          samples_from_pprof(serialization_result.last)
+          samples_from_pprof(recorder.serialize!)
             .reject { |it| it.fetch(:locations).first.fetch(:path) == 'Garbage Collection' } # Separate test for GC below
 
         samples if samples.any?
@@ -198,10 +192,7 @@ RSpec.xdescribe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
       cpu_and_wall_time_worker.stop
 
-      serialization_result = recorder.serialize
-      raise 'Unexpected: Serialization failed' unless serialization_result
-
-      all_samples = samples_from_pprof(serialization_result.last)
+      all_samples = samples_from_pprof(recorder.serialize!)
 
       current_thread_gc_samples =
         samples_for_thread(all_samples, Thread.current)
@@ -289,10 +280,7 @@ RSpec.xdescribe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         cpu_and_wall_time_worker.stop
         background_thread.kill
 
-        serialization_result = recorder.serialize
-        raise 'Unexpected: Serialization failed' unless serialization_result
-
-        result = samples_for_thread(samples_from_pprof(serialization_result.last), Thread.current)
+        result = samples_for_thread(samples_from_pprof(recorder.serialize!), Thread.current)
         sample_count = result.map { |it| it.fetch(:values).fetch(:'cpu-samples') }.reduce(:+)
 
         stats = cpu_and_wall_time_worker.stats
@@ -327,10 +315,7 @@ RSpec.xdescribe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         cpu_and_wall_time_worker.stop
 
-        serialization_result = recorder.serialize
-        raise 'Unexpected: Serialization failed' unless serialization_result
-
-        result = samples_for_thread(samples_from_pprof(serialization_result.last), Thread.current)
+        result = samples_for_thread(samples_from_pprof(recorder.serialize!), Thread.current)
         sample_count = result.map { |it| it.fetch(:values).fetch(:'cpu-samples') }.reduce(:+)
 
         stats = cpu_and_wall_time_worker.stats
@@ -376,11 +361,8 @@ RSpec.xdescribe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         cpu_and_wall_time_worker.stop
 
-        serialization_result = recorder.serialize
-        raise 'Unexpected: Serialization failed' unless serialization_result
-
         samples_from_ractor =
-          samples_from_pprof(serialization_result.last)
+          samples_from_pprof(recorder.serialize!)
             .select { |it| it.fetch(:labels)[:'thread name'] == 'background ractor' }
 
         expect(samples_from_ractor).to be_empty

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -280,8 +280,8 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         trigger_sample_attempts = stats.fetch(:trigger_sample_attempts)
         signal_handler_enqueued_sample = stats.fetch(:signal_handler_enqueued_sample)
 
-        expect(signal_handler_enqueued_sample.to_f / trigger_sample_attempts).to (be >= 0.8), \
-          "Expected at least 80% of signals to be delivered to correct thread (#{stats})"
+        expect(signal_handler_enqueued_sample.to_f / trigger_sample_attempts).to (be >= 0.6), \
+          "Expected at least 60% of signals to be delivered to correct thread (#{stats})"
 
         # Sanity checking
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -310,7 +310,11 @@ RSpec.xdescribe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         # will not cause flakyness
         expect(sample_count).to be >= 5, "sample_count: #{sample_count}, stats: #{stats}"
         expect(trigger_sample_attempts).to be >= sample_count
-        expect(trigger_sample_attempts).to be signal_handler_enqueued_sample + signal_handler_wrong_thread
+        # It's possible that we stop in between trigger_sample_attempts being incrementing and the other values
+        # actually being updated, so this is why we allow both values
+        expect(
+          [trigger_sample_attempts, trigger_sample_attempts - 1]
+        ).to include(signal_handler_enqueued_sample + signal_handler_wrong_thread)
       end
     end
 
@@ -346,7 +350,11 @@ RSpec.xdescribe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         # will not cause flakyness
         expect(sample_count).to be >= 5, "sample_count: #{sample_count}, stats: #{stats}"
         expect(trigger_sample_attempts).to be >= sample_count
-        expect(trigger_sample_attempts).to be signal_handler_enqueued_sample + signal_handler_wrong_thread
+        # It's possible that we stop in between trigger_sample_attempts being incrementing and the other values
+        # actually being updated, so this is why we allow both values
+        expect(
+          [trigger_sample_attempts, trigger_sample_attempts - 1]
+        ).to include(signal_handler_enqueued_sample + signal_handler_wrong_thread)
       end
     end
   end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -68,6 +68,8 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       exception = try_wait_until(backoff: 0.01) { another_instance.send(:failure_exception) }
 
       expect(exception.message).to include 'another instance'
+
+      another_instance.stop
     end
 
     it 'installs the profiling SIGPROF signal handler' do
@@ -285,10 +287,10 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         # Sanity checking
 
         # We're currently targeting 100 samples per second, so 5 in 100ms is a conservative approximation that hopefully
-        # will not cause flakyness
+        # will not cause flakiness
         expect(sample_count).to be >= 5, "sample_count: #{sample_count}, stats: #{stats}"
         expect(trigger_sample_attempts).to be >= sample_count
-        # It's possible that we stop in between trigger_sample_attempts being incrementing and the other values
+        # It's possible that we stop in between trigger_sample_attempts being incremented and the other values
         # actually being updated, so this is why we allow both values
         expect(
           [trigger_sample_attempts, trigger_sample_attempts - 1]
@@ -322,10 +324,10 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         # Sanity checking
 
         # We're currently targeting 100 samples per second, so 5 in 100ms is a conservative approximation that hopefully
-        # will not cause flakyness
+        # will not cause flakiness
         expect(sample_count).to be >= 5, "sample_count: #{sample_count}, stats: #{stats}"
         expect(trigger_sample_attempts).to be >= sample_count
-        # It's possible that we stop in between trigger_sample_attempts being incrementing and the other values
+        # It's possible that we stop in between trigger_sample_attempts being incremented and the other values
         # actually being updated, so this is why we allow both values
         expect(
           [trigger_sample_attempts, trigger_sample_attempts - 1]

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -3,11 +3,7 @@
 require 'datadog/profiling/spec_helper'
 require 'datadog/profiling/collectors/cpu_and_wall_time_worker'
 
-# The changes in #2415 exposed a few bugs that cause this spec to be flaky. I've temporarily disabled it until I finish
-# the full patch series so that I can keep merging to master but not affecting other developers.
-# (Reminder: This component is part of the new profiler, which is not on by default and is considered to be in alpha
-# state)
-RSpec.xdescribe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
+RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   before { skip_if_profiling_not_supported(self) }
 
   let(:recorder) { Datadog::Profiling::StackRecorder.new }

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -279,7 +279,6 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         trigger_sample_attempts = stats.fetch(:trigger_sample_attempts)
         signal_handler_enqueued_sample = stats.fetch(:signal_handler_enqueued_sample)
-        signal_handler_wrong_thread = stats.fetch(:signal_handler_wrong_thread)
 
         expect(signal_handler_enqueued_sample.to_f / trigger_sample_attempts).to (be >= 0.8), \
           "Expected at least 80% of signals to be delivered to correct thread (#{stats})"
@@ -290,11 +289,6 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         # will not cause flakiness
         expect(sample_count).to be >= 5, "sample_count: #{sample_count}, stats: #{stats}"
         expect(trigger_sample_attempts).to be >= sample_count
-        # It's possible that we stop in between trigger_sample_attempts being incremented and the other values
-        # actually being updated, so this is why we allow both values
-        expect(
-          [trigger_sample_attempts, trigger_sample_attempts - 1]
-        ).to include(signal_handler_enqueued_sample + signal_handler_wrong_thread)
       end
     end
 
@@ -313,8 +307,6 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         stats = cpu_and_wall_time_worker.stats
 
         trigger_sample_attempts = stats.fetch(:trigger_sample_attempts)
-        signal_handler_enqueued_sample = stats.fetch(:signal_handler_enqueued_sample)
-        signal_handler_wrong_thread = stats.fetch(:signal_handler_wrong_thread)
 
         simulated_signal_delivery = stats.fetch(:simulated_signal_delivery)
 
@@ -327,11 +319,6 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         # will not cause flakiness
         expect(sample_count).to be >= 5, "sample_count: #{sample_count}, stats: #{stats}"
         expect(trigger_sample_attempts).to be >= sample_count
-        # It's possible that we stop in between trigger_sample_attempts being incremented and the other values
-        # actually being updated, so this is why we allow both values
-        expect(
-          [trigger_sample_attempts, trigger_sample_attempts - 1]
-        ).to include(signal_handler_enqueued_sample + signal_handler_wrong_thread)
       end
     end
   end

--- a/spec/datadog/profiling/collectors/idle_sampling_helper_spec.rb
+++ b/spec/datadog/profiling/collectors/idle_sampling_helper_spec.rb
@@ -1,0 +1,75 @@
+# typed: false
+
+require 'datadog/profiling/spec_helper'
+require 'datadog/profiling/collectors/idle_sampling_helper'
+
+RSpec.describe Datadog::Profiling::Collectors::IdleSamplingHelper do
+  before { skip_if_profiling_not_supported(self) }
+
+  subject(:idle_sampling_helper) { described_class.new }
+
+  describe '#start' do
+    subject(:start) { idle_sampling_helper.start }
+
+    after do
+      idle_sampling_helper.stop
+    end
+
+    it 'resets the IdleSamplingHelper before creating a new thread' do
+      expect(described_class).to receive(:_native_reset).with(idle_sampling_helper).ordered
+      expect(Thread).to receive(:new).ordered
+
+      start
+    end
+
+    it 'creates a new thread' do
+      expect(Thread).to receive(:new)
+
+      start
+    end
+
+    it 'does not create a second thread if start is called again' do
+      start
+
+      expect(Thread).to_not receive(:new)
+
+      idle_sampling_helper.start
+    end
+  end
+
+  describe '#stop' do
+    subject(:stop) { idle_sampling_helper.stop }
+
+    it 'shuts down the background thread' do
+      worker_thread = idle_sampling_helper.instance_variable_get(:@worker_thread)
+
+      stop
+
+      expect(Thread.list).to_not include(worker_thread)
+    end
+  end
+
+  describe 'idle_sampling_helper_request_action' do
+    before { idle_sampling_helper.start }
+    after { idle_sampling_helper.stop }
+
+    # rubocop:disable Style/GlobalVars
+    it 'runs the requested function in a background thread' do
+      action_ran = Queue.new
+
+      # idle_sampling_helper_request_action is built to be called from C code, not Ruby code, so the testing interface
+      # is somewhat awkward and relies on a global variable
+      $idle_sampling_helper_testing_action = proc do
+        expect(Thread.current).to eq idle_sampling_helper.instance_variable_get(:@worker_thread)
+        action_ran << true
+      end
+
+      described_class::Testing._native_idle_sampling_helper_request_action(idle_sampling_helper)
+
+      action_ran.pop
+
+      $idle_sampling_helper_testing_action = nil
+    end
+    # rubocop:enable Style/GlobalVars
+  end
+end

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -418,12 +418,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   def sample_and_decode(thread, max_frames: 400, recorder: Datadog::Profiling::StackRecorder.new, in_gc: false)
     sample(thread, recorder, metric_values, labels, max_frames: max_frames, in_gc: in_gc)
 
-    serialization_result = recorder.serialize
-    raise 'Unexpected: Serialization failed' unless serialization_result
-
-    pprof_data = serialization_result.last
-
-    samples = samples_from_pprof(pprof_data)
+    samples = samples_from_pprof(recorder.serialize!)
 
     expect(samples.size).to be 1
     samples.first.fetch(:locations)

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -256,6 +256,24 @@ RSpec.describe Datadog::Profiling::StackRecorder do
     end
   end
 
+  describe '#serialize!' do
+    subject(:serialize!) { stack_recorder.serialize! }
+
+    context 'when serialization succeeds' do
+      before do
+        expect(described_class).to receive(:_native_serialize).and_return([:ok, %w[start finish serialized-data]])
+      end
+
+      it { is_expected.to eq('serialized-data') }
+    end
+
+    context 'when serialization fails' do
+      before { expect(described_class).to receive(:_native_serialize).and_return([:error, 'test error message']) }
+
+      it { expect { serialize! }.to raise_error(RuntimeError, /test error message/) }
+    end
+  end
+
   describe '#reset_after_fork' do
     subject(:reset_after_fork) { stack_recorder.reset_after_fork }
 


### PR DESCRIPTION
**What does this PR do?**:

This PR finishes the work started in #2415 and #2438.

In particular, #2415 ("[PROF-6556] Fix profiler incorrectly detecting if a thread is holding the Global VM Lock") opened a bit of a can of worms, because we learned (and fixed) that we were asking the VM to sample in situations where we don't think it's safe.

Furthermore, we also learned that we could not sample when the application was idle. This caused, among other things, several `CpuAndWallTimeWorker` specs to be flaky, because sometimes we got unlucky and could not sample/sample enough during the spec.

This PR actually makes us able to take samples in periods of idleness in the Ruby VM, and also solves a bunch of flakiness in specs that missing this feature introduced.

In a first approach, I thought having the `CpuAndWallTimeWorker` grab the global VM lock when it was free would be enough, but actually it wasn't. In some corner cases, because there is no "trylock" GVL, we could observe the GVL to be free, then decide to grab it, then once we go to grab it other thread already grabbed it and the `CpuAndWallTimeWorker` would then be at the mercy of the Ruby scheduler.

Instead, this PR introduces a new component -- the `IdleSamplingHelper` which keeps a background thread that fulfills requests to grab the GVL and sample coming from the `CpuAndWallTimeWorker`. This way, the `CpuAndWallTimeWorker` never blocks and is always free to set the pace for samples.

**Motivation**:

This PR makes sure that the new profiler is able to sample correctly applications that are fully or partially idle.

**Additional Notes**:

This PR is atop #2467 as makes use of the new helpers introduced in that PR.

Furthermore, this PR includes a few more small changes for issues that I ran into while developing it. **I recommend reviewing commit-by-commit**, and as always let me know if this PR is getting a bit too hard to follow and I can try breaking it down further.

**How to test the change?**:

This PR includes test coverage. Furthermore, applications that have idle periods (or are entirely idle) are now correctly and accurately profiled by the new profiler.

[PROF-6556]: https://datadoghq.atlassian.net/browse/PROF-6556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ