### PR TITLE
Changes `error.msg` to `error.message` for UNC

### DIFF
--- a/lib/datadog/tracing/metadata/ext.rb
+++ b/lib/datadog/tracing/metadata/ext.rb
@@ -60,7 +60,7 @@ module Datadog
         # @public_api
         module Errors
           STATUS = 1
-          TAG_MSG = 'error.msg'
+          TAG_MSG = 'error.message'
           TAG_STACK = 'error.stack'
           TAG_TYPE = 'error.type'
         end

--- a/spec/datadog/tracing/contrib/grape/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/grape/tracer_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe 'Grape instrumentation' do
           expect(spans[0].status).to eq(1)
           expect(spans[0].get_tag('error.stack')).to_not be_nil
           expect(spans[0].get_tag('error.type')).to_not be_nil
-          expect(spans[0].get_tag('error.msg')).to_not be_nil
+          expect(spans[0].get_tag('error.message')).to_not be_nil
           expect(spans[0].get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('grape')
           expect(spans[0].get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
             .to eq('endpoint_run')
@@ -284,7 +284,7 @@ RSpec.describe 'Grape instrumentation' do
             expect(spans[0].status).to eq(1)
             expect(spans[0].get_tag('error.stack')).to_not be_nil
             expect(spans[0].get_tag('error.type')).to_not be_nil
-            expect(spans[0].get_tag('error.msg')).to_not be_nil
+            expect(spans[0].get_tag('error.message')).to_not be_nil
             expect(spans[0].get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('grape')
             expect(spans[0].get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
               .to eq('endpoint_run')
@@ -303,7 +303,7 @@ RSpec.describe 'Grape instrumentation' do
             expect(spans[0].status).to eq(1)
             expect(spans[0].get_tag('error.stack')).to_not be_nil
             expect(spans[0].get_tag('error.type')).to_not be_nil
-            expect(spans[0].get_tag('error.msg')).to_not be_nil
+            expect(spans[0].get_tag('error.message')).to_not be_nil
             expect(spans[0].get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('grape')
             expect(spans[0].get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
               .to eq('endpoint_run')
@@ -322,7 +322,7 @@ RSpec.describe 'Grape instrumentation' do
             expect(spans[0]).to_not have_error
             expect(spans[0].get_tag('error.stack')).to be_nil
             expect(spans[0].get_tag('error.type')).to be_nil
-            expect(spans[0].get_tag('error.msg')).to be_nil
+            expect(spans[0].get_tag('error.message')).to be_nil
             expect(spans[0].get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('grape')
             expect(spans[0].get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
               .to eq('endpoint_run')
@@ -341,7 +341,7 @@ RSpec.describe 'Grape instrumentation' do
             expect(spans[0].status).to eq(0)
             expect(spans[0].get_tag('error.stack')).to be_nil
             expect(spans[0].get_tag('error.type')).to be_nil
-            expect(spans[0].get_tag('error.msg')).to be_nil
+            expect(spans[0].get_tag('error.message')).to be_nil
             expect(spans[0].get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('grape')
             expect(spans[0].get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
               .to eq('endpoint_run')

--- a/spec/datadog/tracing/contrib/http/request_spec.rb
+++ b/spec/datadog/tracing/contrib/http/request_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe 'net/http requests' do
         expect(span.get_tag('span.kind')).to eq('client')
         expect(span.status).to eq(1)
         expect(span.get_tag('error.type')).to eq('Net::HTTPNotFound')
-        expect(span.get_tag('error.msg')).to be nil
+        expect(span.get_tag('error.message')).to be nil
       end
 
       it_behaves_like 'a peer service span' do
@@ -136,7 +136,7 @@ RSpec.describe 'net/http requests' do
             expect(response.code).to eq('404')
             expect(span.status).to eq(1)
             expect(span.get_tag('error.type')).to eq('Net::HTTPNotFound')
-            expect(span.get_tag('error.msg')).to eq(body)
+            expect(span.get_tag('error.message')).to eq(body)
           end
         end
       end

--- a/spec/datadog/tracing/contrib/mongodb/client_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/client_spec.rb
@@ -483,7 +483,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
         end
         expect(span.get_tag('mongodb.rows')).to be nil
         expect(span.status).to eq(1)
-        expect(span.get_tag('error.msg')).to eq('ns not found (26)')
+        expect(span.get_tag('error.message')).to eq('ns not found (26)')
       end
 
       context 'that triggers #failed before #started' do
@@ -536,7 +536,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
             expect(insert_span.resource).to match(/"operation"\s*=>\s*:insert/)
             expect(insert_span.status).to eq(1)
             expect(insert_span.get_tag('error.type')).to eq('Mongo::Monitoring::Event::CommandFailed')
-            expect(insert_span.get_tag('error.msg')).to match(/.*is not authorized to access.*/)
+            expect(insert_span.get_tag('error.message')).to match(/.*is not authorized to access.*/)
             expect(insert_span.get_tag('db.system')).to eq('mongodb')
           end
 
@@ -544,7 +544,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
           expect(auth_span.resource).to match(/"operation"\s*=>\s*[:"]saslStart/)
           expect(auth_span.status).to eq(1)
           expect(auth_span.get_tag('error.type')).to eq('Mongo::Monitoring::Event::CommandFailed')
-          expect(auth_span.get_tag('error.msg')).to eq('Unsupported mechanism PLAIN (2)')
+          expect(auth_span.get_tag('error.message')).to eq('Unsupported mechanism PLAIN (2)')
           expect(auth_span.get_tag('db.system')).to eq('mongodb')
         end
       end

--- a/spec/datadog/tracing/contrib/mysql2/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/mysql2/patcher_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe 'Mysql2::Client patcher' do
           expect(span.status).to eq(1)
           expect(span.get_tag('span.kind')).to eq('client')
           expect(span.get_tag('db.system')).to eq('mysql')
-          expect(span.get_tag('error.msg'))
+          expect(span.get_tag('error.message'))
             .to eq("Unknown column 'INVALID' in 'field list'")
         end
 

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -449,7 +449,7 @@ RSpec.describe 'Rack integration tests' do
             expect(span.get_tag('http.url')).to eq('/exception/')
             expect(span.get_tag('http.base_url')).to eq('http://example.org')
             expect(span.get_tag('error.type')).to eq('StandardError')
-            expect(span.get_tag('error.msg')).to eq('Unable to process the request')
+            expect(span.get_tag('error.message')).to eq('Unable to process the request')
             expect(span.get_tag('error.stack')).to_not be nil
             expect(span.status).to eq(1)
             expect(span).to be_root_span
@@ -490,7 +490,7 @@ RSpec.describe 'Rack integration tests' do
             expect(span.get_tag('http.url')).to eq('/exception/')
             expect(span.get_tag('http.base_url')).to eq('http://example.org')
             expect(span.get_tag('error.type')).to eq('NoMemoryError')
-            expect(span.get_tag('error.msg')).to eq('Non-standard error')
+            expect(span.get_tag('error.message')).to eq('Non-standard error')
             expect(span.get_tag('error.stack')).to_not be nil
             expect(span.status).to eq(1)
             expect(span).to be_root_span

--- a/spec/datadog/tracing/contrib/rails/cache_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/cache_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe 'Rails cache' do
         expect(span.get_tag('rails.cache.backend').to_s).to eq('file_store')
         expect(span.get_tag('rails.cache.key')).to eq('exception')
         expect(span.get_tag('error.type')).to eq('RuntimeError')
-        expect(span.get_tag('error.msg')).to eq('oops')
+        expect(span.get_tag('error.message')).to eq('oops')
 
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT))
           .to eq('active_support')
@@ -349,7 +349,7 @@ RSpec.describe 'Rails cache' do
           expect(span.get_tag('rails.cache.backend').to_s).to eq('file_store')
           expect(span.get_tag('rails.cache.keys')).to eq('["exception", "another", "one"]')
           expect(span.get_tag('error.type')).to eq('RuntimeError')
-          expect(span.get_tag('error.msg')).to eq('oops')
+          expect(span.get_tag('error.message')).to eq('oops')
 
           expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT))
             .to eq('active_support')

--- a/spec/datadog/tracing/contrib/rails/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/middleware_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe 'Rails middleware' do
           expect(span.get_tag('http.method')).to eq('GET')
           expect(span.get_tag('http.status_code')).to eq('500')
           expect(span.get_tag('error.type')).to eq('NotImplementedError')
-          expect(span.get_tag('error.msg')).to eq('NotImplementedError')
+          expect(span.get_tag('error.message')).to eq('NotImplementedError')
           expect(span).to have_error
           expect(span.get_tag('error.stack')).to_not be nil
         end
@@ -205,7 +205,7 @@ RSpec.describe 'Rails middleware' do
           expect(span.get_tag('http.status_code')).to eq('404')
 
           expect(span.get_tag('error.type')).to be nil
-          expect(span.get_tag('error.msg')).to be nil
+          expect(span.get_tag('error.message')).to be nil
           expect(span).to_not have_error
           expect(span.get_tag('error.stack')).to be nil
         end
@@ -266,7 +266,7 @@ RSpec.describe 'Rails middleware' do
           expect(span.get_tag('http.method')).to eq('GET')
           expect(span.get_tag('http.status_code')).to eq('500')
           expect(span.get_tag('error.type')).to eq('CustomError')
-          expect(span.get_tag('error.msg')).to eq('Custom error message!')
+          expect(span.get_tag('error.message')).to eq('Custom error message!')
           expect(span).to have_error
           expect(span.get_tag('error.stack')).to_not be nil
         end
@@ -312,7 +312,7 @@ RSpec.describe 'Rails middleware' do
             expect(span.get_tag('http.method')).to eq('GET')
             expect(span.get_tag('http.status_code')).to eq('404')
             expect(span.get_tag('error.type')).to be nil
-            expect(span.get_tag('error.msg')).to be nil
+            expect(span.get_tag('error.message')).to be nil
             expect(span).to_not have_error
             expect(span.get_tag('error.stack')).to be nil
           end

--- a/spec/datadog/tracing/contrib/redis/shared_examples.rb
+++ b/spec/datadog/tracing/contrib/redis/shared_examples.rb
@@ -237,7 +237,7 @@ RSpec.shared_examples_for 'redis instrumentation' do |options = {}|
 
         end
         expect(span.status).to eq(1)
-        expect(span.get_tag('error.msg')).to match(/ERR unknown command/)
+        expect(span.get_tag('error.message')).to match(/ERR unknown command/)
         expect(span.get_tag('error.type')).to match(/CommandError/)
         expect(span.get_tag('error.stack').length).to be >= 3
       end


### PR DESCRIPTION
What does this PR do?

Renames the `error.msg` tag to `error.message` tag in order to meet the requirements of naming across all tracers.