### PR TITLE
Improve redis integration patching

### DIFF
--- a/lib/datadog/tracing/contrib/patcher.rb
+++ b/lib/datadog/tracing/contrib/patcher.rb
@@ -66,14 +66,14 @@ module Datadog
             Datadog.health_metrics.error_instrumentation_patch(1, tags: tags)
           end
 
-          private
-
           def default_tags
             ["patcher:#{patch_name}"].tap do |tags|
               tags << "target_version:#{target_version}" if respond_to?(:target_version) && !target_version.nil?
-              tags += super if defined?(super)
+              super.each { |t| tags << t } if defined?(super)
             end
           end
+
+          private
 
           def patch_only_once
             # NOTE: This is not thread-safe

--- a/lib/datadog/tracing/contrib/patcher.rb
+++ b/lib/datadog/tracing/contrib/patcher.rb
@@ -71,6 +71,7 @@ module Datadog
           def default_tags
             ["patcher:#{patch_name}"].tap do |tags|
               tags << "target_version:#{target_version}" if respond_to?(:target_version) && !target_version.nil?
+              tags += super if defined?(super)
             end
           end
 

--- a/lib/datadog/tracing/contrib/redis/integration.rb
+++ b/lib/datadog/tracing/contrib/redis/integration.rb
@@ -14,19 +14,52 @@ module Datadog
 
           MINIMUM_VERSION = Gem::Version.new('3.2')
 
+          # Support `Config#custom`
+          # https://github.com/redis-rb/redis-client/blob/master/CHANGELOG.md#0110
+          REDISCLIENT_MINIMUM_VERSION = Gem::Version.new('0.11.0')
+
           # @public_api Changing the integration name or integration options can cause breaking changes
           register_as :redis, auto_patch: true
 
+          # Until Redis 4, all instrumentation happened in one gem: redis.
+          # Since Redis 5, instrumentation happens in a separate gem: redis-client.
+          # Because Redis 4 does not depend on redis-client, it's possible for both gems to be installed at the same time.
+          # For example, if Sidekiq 7 and Redis 4 are installed: both redis and redis-client will be installed.
+          # If redis-client and redis > 5 are installed, than they will be in sync, and only redis-client will be installed.
           def self.version
+            redis_version || redis_client_version
+          end
+
+          def self.redis_version
             Gem.loaded_specs['redis'] && Gem.loaded_specs['redis'].version
           end
 
+          def self.redis_client_version
+            Gem.loaded_specs['redis-client'] && Gem.loaded_specs['redis-client'].version
+          end
+
           def self.loaded?
+            redis_loaded? || redis_client_loaded?
+          end
+
+          def self.redis_loaded?
             !defined?(::Redis).nil?
           end
 
+          def self.redis_client_loaded?
+            !defined?(::RedisClient).nil?
+          end
+
           def self.compatible?
-            super && version >= MINIMUM_VERSION
+            redis_compatible? || redis_client_compatible?
+          end
+
+          def self.redis_compatible?
+            !!(redis_version && redis_version >= MINIMUM_VERSION)
+          end
+
+          def self.redis_client_compatible?
+            !!(redis_client_version && redis_client_version >= REDISCLIENT_MINIMUM_VERSION)
           end
 
           def new_configuration

--- a/lib/datadog/tracing/contrib/redis/integration.rb
+++ b/lib/datadog/tracing/contrib/redis/integration.rb
@@ -51,7 +51,7 @@ module Datadog
           end
 
           def self.compatible?
-            redis_compatible? || redis_client_compatible?
+            super && (redis_compatible? || redis_client_compatible?)
           end
 
           def self.redis_compatible?

--- a/lib/datadog/tracing/contrib/redis/patcher.rb
+++ b/lib/datadog/tracing/contrib/redis/patcher.rb
@@ -49,17 +49,22 @@ module Datadog
 
           module_function
 
-          def target_version
-            Integration.version
+          def default_tags
+            [].tap do |tags|
+              tags << "target_redis_version:#{Integration.redis_version}"               if Integration.redis_version
+              tags << "target_redis_client_version:#{Integration.redis_client_version}" if Integration.redis_client_version
+            end
           end
 
           def patch
             # Redis 5+ extracts RedisClient to its own gem and provide instrumentation interface
-            if target_version >= Gem::Version.new('5.0.0')
+            if Integration.redis_client_compatible?
               require_relative 'trace_middleware'
 
               ::RedisClient.register(TraceMiddleware)
-            else
+            end
+
+            if Integration.redis_compatible? && Integration.redis_version < Gem::Version.new('5.0.0')
               require_relative 'instrumentation'
 
               ::Redis.include(InstancePatch)

--- a/spec/datadog/tracing/contrib/redis/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/patcher_spec.rb
@@ -1,0 +1,23 @@
+# typed: ignore
+
+require 'datadog/tracing/contrib/support/spec_helper'
+
+require 'datadog/tracing/contrib/redis/patcher'
+
+RSpec.describe Datadog::Tracing::Contrib::Redis::Patcher do
+  describe '.default_tags' do
+    it do
+      result = described_class.default_tags
+
+      expect(result).to include(start_with('patcher:'))
+
+      if Datadog::Tracing::Contrib::Redis::Integration.redis_version
+        expect(result).to include(start_with('target_redis_version:'))
+      end
+
+      if Datadog::Tracing::Contrib::Redis::Integration.redis_client_version
+        expect(result).to include(start_with('target_redis_client_version:'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

Until `redis` 4, all instrumentation happened in one gem: `redis`. Since `redis` 5, instrumentation happens in a separate gem: `redis-client`. Because `redis` 4 does not depend on `redis-client`, it's possible for both gems to be installed at the same time. 

For example, if `sidekiq` 7 and `redis` 4 are installed: both `redis` and `redis-client` will be installed.

This implementation improves the patching condition to apply to whenever it is possible.

PS. The minimun `redis-client` supported would be `0.11.0`, where `Config#custom` is implemented.