### PR TITLE
Test Propagation class instead of styles directly

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2349,26 +2349,21 @@ Service C:
 
 Tracing supports the following distributed trace formats:
 
- - `Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG` (Default)
- - `Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3`
- - `Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_SINGLE_HEADER`
+ - `Datadog`: **Default**
+ - `b3multi`: [B3 multiple-headers](https://github.com/openzipkin/b3-propagation#multiple-headers)
+ - `b3`: [B3 single-header](https://github.com/openzipkin/b3-propagation#single-header)
+ - `tracecontext`: [W3C Trace Context](https://www.w3.org/TR/trace-context/)
+ - `none`: No-op.
 
 You can enable/disable the use of these formats via `Datadog.configure`:
 
 ```ruby
 Datadog.configure do |c|
   # List of header formats that should be extracted
-  c.tracing.distributed_tracing.propagation_extract_style = [
-    Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG,
-    Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3,
-    Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_SINGLE_HEADER
-
-  ]
+  c.tracing.distributed_tracing.propagation_extract_style = [ 'tracecontext', 'Datadog', 'b3' ]
 
   # List of header formats that should be injected
-  c.tracing.distributed_tracing.propagation_inject_style = [
-    Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG
-  ]
+  c.tracing.distributed_tracing.propagation_inject_style = [ 'tracecontext', 'Datadog' ]
 end
 ```
 

--- a/lib/datadog/tracing/contrib/grpc/distributed/propagation.rb
+++ b/lib/datadog/tracing/contrib/grpc/distributed/propagation.rb
@@ -5,6 +5,7 @@ require_relative 'fetcher'
 require_relative '../../../distributed/b3_multi'
 require_relative '../../../distributed/b3_single'
 require_relative '../../../distributed/datadog'
+require_relative '../../../distributed/none'
 require_relative '../../../distributed/propagation'
 require_relative '../../../distributed/trace_context'
 
@@ -26,7 +27,8 @@ module Datadog
                   Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG =>
                     Tracing::Distributed::Datadog.new(fetcher: Fetcher),
                   Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_TRACE_CONTEXT =>
-                    Tracing::Distributed::TraceContext.new(fetcher: Fetcher)
+                    Tracing::Distributed::TraceContext.new(fetcher: Fetcher),
+                  Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_NONE => Tracing::Distributed::None.new
                 })
             end
 

--- a/lib/datadog/tracing/contrib/http/distributed/propagation.rb
+++ b/lib/datadog/tracing/contrib/http/distributed/propagation.rb
@@ -6,6 +6,7 @@ require_relative '../../../distributed/propagation'
 require_relative '../../../distributed/b3_multi'
 require_relative '../../../distributed/b3_single'
 require_relative '../../../distributed/datadog'
+require_relative '../../../distributed/none'
 require_relative '../../../distributed/trace_context'
 
 module Datadog
@@ -25,7 +26,8 @@ module Datadog
                   Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG =>
                     Tracing::Distributed::Datadog.new(fetcher: Fetcher),
                   Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_TRACE_CONTEXT =>
-                    Tracing::Distributed::TraceContext.new(fetcher: Fetcher)
+                    Tracing::Distributed::TraceContext.new(fetcher: Fetcher),
+                  Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_NONE => Tracing::Distributed::None.new
                 })
             end
           end

--- a/lib/datadog/tracing/distributed/none.rb
+++ b/lib/datadog/tracing/distributed/none.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# typed: false
+
+module Datadog
+  module Tracing
+    module Distributed
+      # Propagator that does not inject nor extract data. It performs no operation.
+      # Supported for feature parity with OpenTelemetry.
+      # @see https://github.com/open-telemetry/opentelemetry-specification/blob/255a6c52b8914a2ed7e26bb5585abecab276aafc/specification/sdk-environment-variables.md?plain=1#L88
+      class None
+        # No-op
+        def inject!(_digest, _data); end
+
+        # No-op
+        def extract(_data); end
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/contrib/grpc/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/distributed/propagation_spec.rb
@@ -6,6 +6,7 @@ require 'datadog/tracing/contrib/grpc/distributed/propagation'
 require_relative '../../../distributed/b3_single_spec'
 require_relative '../../../distributed/b3_multi_spec'
 require_relative '../../../distributed/datadog_spec'
+require_relative '../../../distributed/none_spec'
 require_relative '../../../distributed/propagation_spec'
 require_relative '../../../distributed/trace_context_spec'
 
@@ -63,6 +64,13 @@ RSpec.describe Datadog::Tracing::Contrib::GRPC::Distributed::Propagation do
   context 'for Trace Context' do
     it_behaves_like 'Trace Context distributed format' do
       before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['tracecontext'] } }
+      let(:datadog) { propagation }
+    end
+  end
+
+  context 'for None' do
+    it_behaves_like 'None distributed format' do
+      before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['none'] } }
       let(:datadog) { propagation }
     end
   end

--- a/spec/datadog/tracing/contrib/grpc/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/distributed/propagation_spec.rb
@@ -10,8 +10,10 @@ require_relative '../../../distributed/propagation_spec'
 require_relative '../../../distributed/trace_context_spec'
 
 RSpec.describe Datadog::Tracing::Contrib::GRPC::Distributed::Propagation do
+  subject(:propagation) { described_class.new }
+
   it_behaves_like 'Distributed tracing propagator' do
-    subject(:propagation) { described_class.new }
+    subject(:propagator) { propagation }
 
     describe '.extract' do
       subject(:extract) { propagation.extract(data) }
@@ -39,29 +41,29 @@ RSpec.describe Datadog::Tracing::Contrib::GRPC::Distributed::Propagation do
 
   context 'for B3 Multi' do
     it_behaves_like 'B3 Multi distributed format' do
-      let(:b3) { Datadog::Tracing::Distributed::B3Multi.new(fetcher: fetcher_class) }
-      let(:fetcher_class) { Datadog::Tracing::Contrib::GRPC::Distributed::Fetcher }
+      before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['b3multi'] } }
+      let(:b3) { propagation }
     end
   end
 
   context 'for B3 Single' do
     it_behaves_like 'B3 Single distributed format' do
-      let(:b3_single) { Datadog::Tracing::Distributed::B3Single.new(fetcher: fetcher_class) }
-      let(:fetcher_class) { Datadog::Tracing::Contrib::GRPC::Distributed::Fetcher }
+      before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['b3'] } }
+      let(:b3_single) { propagation }
     end
   end
 
   context 'for Datadog' do
     it_behaves_like 'Datadog distributed format' do
-      let(:datadog) { Datadog::Tracing::Distributed::Datadog.new(fetcher: fetcher_class) }
-      let(:fetcher_class) { Datadog::Tracing::Contrib::GRPC::Distributed::Fetcher }
+      before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['Datadog'] } }
+      let(:datadog) { propagation }
     end
   end
 
   context 'for Trace Context' do
     it_behaves_like 'Trace Context distributed format' do
-      let(:datadog) { Datadog::Tracing::Distributed::TraceContext.new(fetcher: fetcher_class) }
-      let(:fetcher_class) { Datadog::Tracing::Contrib::GRPC::Distributed::Fetcher }
+      before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['tracecontext'] } }
+      let(:datadog) { propagation }
     end
   end
 end

--- a/spec/datadog/tracing/contrib/http/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/contrib/http/distributed/propagation_spec.rb
@@ -11,37 +11,39 @@ require_relative '../../../distributed/propagation_spec'
 require_relative '../../../distributed/trace_context_spec'
 
 RSpec.describe Datadog::Tracing::Contrib::HTTP::Distributed::Propagation do
+  subject(:propagation) { described_class.new }
+
   let(:prepare_key) { RackSupport.method(:header_to_rack) }
 
   it_behaves_like 'Distributed tracing propagator' do
-    subject(:propagation) { described_class.new }
+    subject(:propagator) { propagation }
   end
 
   context 'for B3 Multi' do
     it_behaves_like 'B3 Multi distributed format' do
-      let(:b3) { Datadog::Tracing::Distributed::B3Multi.new(fetcher: fetcher_class) }
-      let(:fetcher_class) { Datadog::Tracing::Contrib::HTTP::Distributed::Fetcher }
+      before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['b3multi'] } }
+      let(:b3) { propagation }
     end
   end
 
   context 'for B3 Single' do
     it_behaves_like 'B3 Single distributed format' do
-      let(:b3_single) { Datadog::Tracing::Distributed::B3Single.new(fetcher: fetcher_class) }
-      let(:fetcher_class) { Datadog::Tracing::Contrib::HTTP::Distributed::Fetcher }
+      before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['b3'] } }
+      let(:b3_single) { propagation }
     end
   end
 
   context 'for Datadog' do
     it_behaves_like 'Datadog distributed format' do
-      let(:datadog) { Datadog::Tracing::Distributed::Datadog.new(fetcher: fetcher_class) }
-      let(:fetcher_class) { Datadog::Tracing::Contrib::HTTP::Distributed::Fetcher }
+      before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['Datadog'] } }
+      let(:datadog) { propagation }
     end
   end
 
   context 'for Trace Context' do
     it_behaves_like 'Trace Context distributed format' do
-      let(:datadog) { Datadog::Tracing::Distributed::TraceContext.new(fetcher: fetcher_class) }
-      let(:fetcher_class) { Datadog::Tracing::Contrib::HTTP::Distributed::Fetcher }
+      before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['tracecontext'] } }
+      let(:datadog) { propagation }
     end
   end
 end

--- a/spec/datadog/tracing/contrib/http/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/contrib/http/distributed/propagation_spec.rb
@@ -7,6 +7,7 @@ require 'datadog/tracing/contrib/http/distributed/propagation'
 require_relative '../../../distributed/b3_single_spec'
 require_relative '../../../distributed/b3_multi_spec'
 require_relative '../../../distributed/datadog_spec'
+require_relative '../../../distributed/none_spec'
 require_relative '../../../distributed/propagation_spec'
 require_relative '../../../distributed/trace_context_spec'
 
@@ -43,6 +44,13 @@ RSpec.describe Datadog::Tracing::Contrib::HTTP::Distributed::Propagation do
   context 'for Trace Context' do
     it_behaves_like 'Trace Context distributed format' do
       before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['tracecontext'] } }
+      let(:datadog) { propagation }
+    end
+  end
+
+  context 'for None' do
+    it_behaves_like 'None distributed format' do
+      before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['none'] } }
       let(:datadog) { propagation }
     end
   end

--- a/spec/datadog/tracing/distributed/b3_single_spec.rb
+++ b/spec/datadog/tracing/distributed/b3_single_spec.rb
@@ -30,7 +30,7 @@ RSpec.shared_examples 'B3 Single distributed format' do
         )
       end
 
-      it { is_expected.to eq(b3_single_header => '2710-4e20') }
+      it { expect(data).to eq(b3_single_header => '2710-4e20') }
 
       [
         [-1, 0],
@@ -47,9 +47,7 @@ RSpec.shared_examples 'B3 Single distributed format' do
             )
           end
 
-          it {
-            is_expected.to eq(b3_single_header => "c350-ea60-#{expected}")
-          }
+          it { expect(data).to eq(b3_single_header => "c350-ea60-#{expected}") }
         end
       end
 
@@ -62,7 +60,7 @@ RSpec.shared_examples 'B3 Single distributed format' do
           )
         end
 
-        it { is_expected.to eq(b3_single_header => '15f90-186a0') }
+        it { expect(data).to eq(b3_single_header => '15f90-186a0') }
       end
     end
   end

--- a/spec/datadog/tracing/distributed/datadog_spec.rb
+++ b/spec/datadog/tracing/distributed/datadog_spec.rb
@@ -29,7 +29,8 @@ RSpec.shared_examples 'Datadog distributed format' do
       end
 
       it do
-        is_expected.to eq(
+        inject!
+        expect(data).to eq(
           'x-datadog-trace-id' => '10000',
           'x-datadog-parent-id' => '20000'
         )
@@ -45,7 +46,8 @@ RSpec.shared_examples 'Datadog distributed format' do
         end
 
         it do
-          is_expected.to eq(
+          inject!
+          expect(data).to eq(
             'x-datadog-trace-id' => '50000',
             'x-datadog-parent-id' => '60000',
             'x-datadog-sampling-priority' => '1'
@@ -63,7 +65,8 @@ RSpec.shared_examples 'Datadog distributed format' do
           end
 
           it do
-            is_expected.to eq(
+            inject!
+            expect(data).to eq(
               'x-datadog-trace-id' => '70000',
               'x-datadog-parent-id' => '80000',
               'x-datadog-sampling-priority' => '1',
@@ -83,7 +86,8 @@ RSpec.shared_examples 'Datadog distributed format' do
         end
 
         it do
-          is_expected.to eq(
+          inject!
+          expect(data).to eq(
             'x-datadog-trace-id' => '90000',
             'x-datadog-parent-id' => '100000',
             'x-datadog-origin' => 'synthetics'
@@ -96,22 +100,34 @@ RSpec.shared_examples 'Datadog distributed format' do
 
         context 'nil' do
           let(:tags) { nil }
-          it { is_expected.to_not include('x-datadog-tags') }
+          it do
+            inject!
+            expect(data).to_not include('x-datadog-tags')
+          end
         end
 
         context '{}' do
           let(:tags) { {} }
-          it { is_expected.to_not include('x-datadog-tags') }
+          it do
+            inject!
+            expect(data).to_not include('x-datadog-tags')
+          end
         end
 
         context "{ key: 'value' }" do
           let(:tags) { { key: 'value' } }
-          it { is_expected.to include('x-datadog-tags' => 'key=value') }
+          it do
+            inject!
+            expect(data).to include('x-datadog-tags' => 'key=value')
+          end
         end
 
         context '{ _dd.p.dm: "-1" }' do
           let(:tags) { { '_dd.p.dm' => '-1' } }
-          it { is_expected.to include('x-datadog-tags' => '_dd.p.dm=-1') }
+          it do
+            inject!
+            expect(data).to include('x-datadog-tags' => '_dd.p.dm=-1')
+          end
         end
 
         context 'within an active trace' do
@@ -125,7 +141,10 @@ RSpec.shared_examples 'Datadog distributed format' do
           context 'with tags too large' do
             let(:tags) { { key: 'very large value' * 32 } }
 
-            it { is_expected.to_not include('x-datadog-tags') }
+            it do
+              inject!
+              expect(data).to_not include('x-datadog-tags')
+            end
 
             it 'sets error tag' do
               expect(active_trace).to receive(:set_tag).with('_dd.propagation_error', 'inject_max_size')
@@ -141,7 +160,10 @@ RSpec.shared_examples 'Datadog distributed format' do
 
             let(:tags) { { key: 'value' } }
 
-            it { is_expected.to_not include('x-datadog-tags') }
+            it do
+              inject!
+              expect(data).to_not include('x-datadog-tags')
+            end
 
             it 'sets error tag' do
               expect(active_trace).to receive(:set_tag).with('_dd.propagation_error', 'disabled')

--- a/spec/datadog/tracing/distributed/none_spec.rb
+++ b/spec/datadog/tracing/distributed/none_spec.rb
@@ -1,0 +1,33 @@
+# typed: false
+
+require 'spec_helper'
+
+require 'datadog/tracing/distributed/none'
+require 'datadog/tracing/trace_digest'
+
+RSpec.shared_examples 'None distributed format' do
+  subject(:none) { described_class.new }
+
+  describe '#inject!' do
+    subject!(:inject!) { none.inject!(digest, data) }
+    let(:digest) { Datadog::Tracing::TraceDigest.new }
+    let(:data) { {} }
+
+    it 'does not inject data' do
+      expect { inject! }.to_not(change { data })
+    end
+  end
+
+  describe '#extract' do
+    subject(:extract) { none.extract(data) }
+    let(:data) { {} }
+
+    it 'never returns a digest' do
+      is_expected.to be_nil
+    end
+  end
+end
+
+RSpec.describe Datadog::Tracing::Distributed::None do
+  it_behaves_like 'None distributed format'
+end

--- a/spec/datadog/tracing/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/distributed/propagation_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 require 'datadog/tracing/distributed/propagation'
 
 RSpec.shared_examples 'Distributed tracing propagator' do
-  subject(:propagation) { described_class.new(propagation_styles: propagation_styles) }
+  subject(:propagator) { described_class.new(propagation_styles: propagation_styles) }
 
   let(:propagation_styles) do
     {
@@ -19,7 +19,7 @@ RSpec.shared_examples 'Distributed tracing propagator' do
   let(:prepare_key) { defined?(super) ? super() : proc { |key| key } }
 
   describe '::inject!' do
-    subject(:inject!) { propagation.inject!(trace, data) }
+    subject(:inject!) { propagator.inject!(trace, data) }
     let(:data) { {} }
 
     shared_examples_for 'trace injection' do
@@ -124,7 +124,7 @@ RSpec.shared_examples 'Distributed tracing propagator' do
   end
 
   describe '.extract' do
-    subject(:extract) { propagation.extract(data) }
+    subject(:extract) { propagator.extract(data) }
     let(:trace_digest) { extract }
 
     context 'given empty data' do

--- a/spec/datadog/tracing/distributed/trace_context_spec.rb
+++ b/spec/datadog/tracing/distributed/trace_context_spec.rb
@@ -12,11 +12,11 @@ RSpec.shared_examples 'Trace Context distributed format' do
   let(:prepare_key) { defined?(super) ? super() : proc { |key| key } }
 
   describe '#inject!' do
-    subject(:inject!) { datadog.inject!(digest, data) }
+    subject!(:inject!) { datadog.inject!(digest, data) }
     let(:data) { {} }
 
-    let(:traceparent) { inject!['traceparent'] }
-    let(:tracestate) { inject!['tracestate'] }
+    let(:traceparent) { data['traceparent'] }
+    let(:tracestate) { data['tracestate'] }
     let(:trace_flags) { traceparent[53..54] }
 
     context 'with a nil digest' do


### PR DESCRIPTION
I noticed, while adding a new propagator style, that `spec/datadog/tracing/contrib/grpc/distributed/propagation_spec.rb` & `spec/datadog/tracing/contrib/http/distributed/propagation_spec.rb` were not failing tests when I accidentally removed existing propagator styles from their configuration.

This happened because those tests were testing the style classes directly, `Distributed::B3Multi.new(fetcher: Contrib::GRPC::Distributed::Fetcher)`, instead of through the Propagation class, `Contrib::GRPC::Distributed::Propagation.new`.

This PR makes those test cover the same test surface, but by using the respective `Propagation` class instead.

Now, there should be no coverage lacking in distributed tracing propagation.