### PR TITLE
Add 'none' distributed propagator

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2349,26 +2349,21 @@ Service C:
 
 Tracing supports the following distributed trace formats:
 
- - `Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG` (Default)
- - `Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3`
- - `Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_SINGLE_HEADER`
+ - `Datadog`: **Default**
+ - `b3multi`: [B3 multiple-headers](https://github.com/openzipkin/b3-propagation#multiple-headers)
+ - `b3`: [B3 single-header](https://github.com/openzipkin/b3-propagation#single-header)
+ - `tracecontext`: [W3C Trace Context](https://www.w3.org/TR/trace-context/)
+ - `none`: No-op.
 
 You can enable/disable the use of these formats via `Datadog.configure`:
 
 ```ruby
 Datadog.configure do |c|
   # List of header formats that should be extracted
-  c.tracing.distributed_tracing.propagation_extract_style = [
-    Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG,
-    Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3,
-    Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_B3_SINGLE_HEADER
-
-  ]
+  c.tracing.distributed_tracing.propagation_extract_style = [ 'tracecontext', 'Datadog', 'b3' ]
 
   # List of header formats that should be injected
-  c.tracing.distributed_tracing.propagation_inject_style = [
-    Datadog::Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG
-  ]
+  c.tracing.distributed_tracing.propagation_inject_style = [ 'tracecontext', 'Datadog' ]
 end
 ```
 

--- a/lib/datadog/tracing/contrib/grpc/distributed/propagation.rb
+++ b/lib/datadog/tracing/contrib/grpc/distributed/propagation.rb
@@ -5,6 +5,7 @@ require_relative 'fetcher'
 require_relative '../../../distributed/b3_multi'
 require_relative '../../../distributed/b3_single'
 require_relative '../../../distributed/datadog'
+require_relative '../../../distributed/none'
 require_relative '../../../distributed/propagation'
 require_relative '../../../distributed/trace_context'
 
@@ -26,7 +27,8 @@ module Datadog
                   Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG =>
                     Tracing::Distributed::Datadog.new(fetcher: Fetcher),
                   Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_TRACE_CONTEXT =>
-                    Tracing::Distributed::TraceContext.new(fetcher: Fetcher)
+                    Tracing::Distributed::TraceContext.new(fetcher: Fetcher),
+                  Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_NONE => Tracing::Distributed::None.new
                 })
             end
 

--- a/lib/datadog/tracing/contrib/http/distributed/propagation.rb
+++ b/lib/datadog/tracing/contrib/http/distributed/propagation.rb
@@ -6,6 +6,7 @@ require_relative '../../../distributed/propagation'
 require_relative '../../../distributed/b3_multi'
 require_relative '../../../distributed/b3_single'
 require_relative '../../../distributed/datadog'
+require_relative '../../../distributed/none'
 require_relative '../../../distributed/trace_context'
 
 module Datadog
@@ -25,7 +26,8 @@ module Datadog
                   Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_DATADOG =>
                     Tracing::Distributed::Datadog.new(fetcher: Fetcher),
                   Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_TRACE_CONTEXT =>
-                    Tracing::Distributed::TraceContext.new(fetcher: Fetcher)
+                    Tracing::Distributed::TraceContext.new(fetcher: Fetcher),
+                  Tracing::Configuration::Ext::Distributed::PROPAGATION_STYLE_NONE => Tracing::Distributed::None.new
                 })
             end
           end

--- a/lib/datadog/tracing/distributed/none.rb
+++ b/lib/datadog/tracing/distributed/none.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# typed: false
+
+module Datadog
+  module Tracing
+    module Distributed
+      # Propagator that does not inject nor extract data. It performs no operation.
+      # Supported for feature parity with OpenTelemetry.
+      # @see https://github.com/open-telemetry/opentelemetry-specification/blob/255a6c52b8914a2ed7e26bb5585abecab276aafc/specification/sdk-environment-variables.md?plain=1#L88
+      class None
+        # No-op
+        def inject!(_digest, _data); end
+
+        # No-op
+        def extract(_data); end
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/contrib/grpc/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/contrib/grpc/distributed/propagation_spec.rb
@@ -6,6 +6,7 @@ require 'datadog/tracing/contrib/grpc/distributed/propagation'
 require_relative '../../../distributed/b3_single_spec'
 require_relative '../../../distributed/b3_multi_spec'
 require_relative '../../../distributed/datadog_spec'
+require_relative '../../../distributed/none_spec'
 require_relative '../../../distributed/propagation_spec'
 require_relative '../../../distributed/trace_context_spec'
 
@@ -63,6 +64,13 @@ RSpec.describe Datadog::Tracing::Contrib::GRPC::Distributed::Propagation do
   context 'for Trace Context' do
     it_behaves_like 'Trace Context distributed format' do
       before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['tracecontext'] } }
+      let(:datadog) { propagation }
+    end
+  end
+
+  context 'for None' do
+    it_behaves_like 'None distributed format' do
+      before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['none'] } }
       let(:datadog) { propagation }
     end
   end

--- a/spec/datadog/tracing/contrib/http/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/contrib/http/distributed/propagation_spec.rb
@@ -7,6 +7,7 @@ require 'datadog/tracing/contrib/http/distributed/propagation'
 require_relative '../../../distributed/b3_single_spec'
 require_relative '../../../distributed/b3_multi_spec'
 require_relative '../../../distributed/datadog_spec'
+require_relative '../../../distributed/none_spec'
 require_relative '../../../distributed/propagation_spec'
 require_relative '../../../distributed/trace_context_spec'
 
@@ -43,6 +44,13 @@ RSpec.describe Datadog::Tracing::Contrib::HTTP::Distributed::Propagation do
   context 'for Trace Context' do
     it_behaves_like 'Trace Context distributed format' do
       before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['tracecontext'] } }
+      let(:datadog) { propagation }
+    end
+  end
+
+  context 'for None' do
+    it_behaves_like 'None distributed format' do
+      before { Datadog.configure { |c| c.tracing.distributed_tracing.propagation_style = ['none'] } }
       let(:datadog) { propagation }
     end
   end

--- a/spec/datadog/tracing/distributed/none_spec.rb
+++ b/spec/datadog/tracing/distributed/none_spec.rb
@@ -1,0 +1,33 @@
+# typed: false
+
+require 'spec_helper'
+
+require 'datadog/tracing/distributed/none'
+require 'datadog/tracing/trace_digest'
+
+RSpec.shared_examples 'None distributed format' do
+  subject(:none) { described_class.new }
+
+  describe '#inject!' do
+    subject!(:inject!) { none.inject!(digest, data) }
+    let(:digest) { Datadog::Tracing::TraceDigest.new }
+    let(:data) { {} }
+
+    it 'does not inject data' do
+      expect { inject! }.to_not(change { data })
+    end
+  end
+
+  describe '#extract' do
+    subject(:extract) { none.extract(data) }
+    let(:data) { {} }
+
+    it 'never returns a digest' do
+      is_expected.to be_nil
+    end
+  end
+end
+
+RSpec.describe Datadog::Tracing::Distributed::None do
+  it_behaves_like 'None distributed format'
+end


### PR DESCRIPTION
Add feature parity support with OpenTelemetry's [`none`](https://github.com/open-telemetry/opentelemetry-specification/blob/255a6c52b8914a2ed7e26bb5585abecab276aafc/specification/sdk-environment-variables.md?plain=1#L88) propagation format.

This format performs no operation.

This is used as a convenience option to disable propagation.