### PR TITLE
[PROF-6691] Send span id in profiles as number and not string

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -128,9 +128,8 @@ struct trace_identifiers {
 
   bool valid;
   ddog_CharSlice local_root_span_id;
-  ddog_CharSlice span_id;
+  uint64_t span_id;
   char local_root_span_id_buffer[MAXIMUM_LENGTH_64_BIT_IDENTIFIER];
-  char span_id_buffer[MAXIMUM_LENGTH_64_BIT_IDENTIFIER];
   VALUE trace_endpoint;
 };
 
@@ -583,7 +582,7 @@ static void trigger_sample_for_thread(
 
   if (trace_identifiers_result.valid) {
     labels[label_pos++] = (ddog_Label) {.key = DDOG_CHARSLICE_C("local root span id"), .str = trace_identifiers_result.local_root_span_id};
-    labels[label_pos++] = (ddog_Label) {.key = DDOG_CHARSLICE_C("span id"), .str = trace_identifiers_result.span_id};
+    labels[label_pos++] = (ddog_Label) {.key = DDOG_CHARSLICE_C("span id"), .num = trace_identifiers_result.span_id};
 
     if (trace_identifiers_result.trace_endpoint != Qnil) {
       // The endpoint gets recorded in a different way because it is mutable in the tracer and can change during a
@@ -870,19 +869,13 @@ static void trace_identifiers_for(struct cpu_and_wall_time_collector_state *stat
   if (numeric_local_root_span_id == Qnil || numeric_span_id == Qnil) return;
 
   unsigned long long local_root_span_id = NUM2ULL(numeric_local_root_span_id);
-  unsigned long long span_id = NUM2ULL(numeric_span_id);
-
   snprintf(trace_identifiers_result->local_root_span_id_buffer, MAXIMUM_LENGTH_64_BIT_IDENTIFIER, "%llu", local_root_span_id);
-  snprintf(trace_identifiers_result->span_id_buffer, MAXIMUM_LENGTH_64_BIT_IDENTIFIER, "%llu", span_id);
 
   trace_identifiers_result->local_root_span_id = (ddog_CharSlice) {
     .ptr = trace_identifiers_result->local_root_span_id_buffer,
     .len = strlen(trace_identifiers_result->local_root_span_id_buffer)
   };
-  trace_identifiers_result->span_id = (ddog_CharSlice) {
-    .ptr = trace_identifiers_result->span_id_buffer,
-    .len = strlen(trace_identifiers_result->span_id_buffer)
-  };
+  trace_identifiers_result->span_id = NUM2ULL(numeric_span_id);
 
   trace_identifiers_result->valid = true;
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
 
             expect(t1_sample.fetch(:labels)).to include(
               :'local root span id' => @t1_local_root_span_id.to_s,
-              :'span id' => @t1_span_id.to_s,
+              :'span id' => @t1_span_id.to_i,
             )
           end
 

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -65,7 +65,7 @@ module ProfileHelpers
         labels: sample.label.map do |it|
           [
             string_table[it.key].to_sym,
-            it.num == 0 ? string_table[it.str] : raise('Unexpected: label encoded as number instead of string'),
+            it.num == 0 ? string_table[it.str] : it.num,
           ]
         end.to_h,
       }


### PR DESCRIPTION
**What does this PR do?**:

This PR changes the `span id` sent in profiling data (and used to power the "Code Hotspots" tab when viewing a trace) as a number in the underlying pprof, instead of as a string.

**Motivation**:

The numeric representation is smaller and also avoids needing to use the string table to represent this information.

We've wanted to do this change for a while, but only now was the profiling backend extended to support this.

**Additional Notes**:

The `local root span id` is still recorded as a string because there's a feature in libdatadog that relies/assumes this string representation.

I plan to later change libdatadog at a later time to allow us to send both values as a number.

This change affects only the new (still in alpha) Ruby profiler codepath, and thus is not expected to affect existing customers.

**How to test the change?**:

Change includes code coverage. Furthermore, you can validate this is working correctly by profiling an application that is generating traces, and checking that the "Code Hotspots" for spans show up correctly.
