### PR TITLE
Allow try_wait_until to be configured with seconds

### DIFF
--- a/spec/datadog/core/workers/runtime_metrics_spec.rb
+++ b/spec/datadog/core/workers/runtime_metrics_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe Datadog::Core::Workers::RuntimeMetrics do
 
               # Restart worker & wait
               worker.perform
-              try_wait_until(attempts: 30) { @flushed }
+              try_wait_until(seconds: 3) { @flushed }
 
               # Verify state of the worker
               expect(worker.error?).to be false

--- a/spec/datadog/tracing/contrib/presto/client_spec.rb
+++ b/spec/datadog/tracing/contrib/presto/client_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Presto::Client instrumentation' do
   # rubocop:disable Style/GlobalVars
   before do
     unless $presto_is_online
-      try_wait_until(attempts: 100, backoff: 0.1) { presto_online? }
+      try_wait_until(seconds: 10) { presto_online? }
       $presto_is_online = true
     end
   end

--- a/spec/datadog/tracing/contrib/redis/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/redis/integration_test_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Redis integration test' do
   it do
     expect(redis.set('FOO', 'bar')).to eq('OK')
     expect(redis.get('FOO')).to eq('bar')
-    try_wait_until(attempts: 30) { tracer.writer.stats[:traces_flushed] >= 2 }
+    try_wait_until(seconds: 3) { tracer.writer.stats[:traces_flushed] >= 2 }
     expect(tracer.writer.stats[:traces_flushed]).to be >= 2
   end
 end

--- a/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
@@ -69,8 +69,7 @@ module SidekiqServerExpectations
         cli.run
       end
 
-      # 10 second wait time
-      try_wait_until(attempts: 100) { wait_until.call } if wait_until
+      try_wait_until(seconds: 10) { wait_until.call } if wait_until
 
       Thread.kill(t)
 

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -617,7 +617,7 @@ RSpec.describe 'Tracer integration tests' do
           end
         end
 
-        try_wait_until(attempts: 20) { tracer.writer.stats[:traces_flushed] >= 1 }
+        try_wait_until(seconds: 2) { tracer.writer.stats[:traces_flushed] >= 1 }
         stats = tracer.writer.stats
 
         expect(stats[:traces_flushed]).to eq(1)
@@ -640,7 +640,7 @@ RSpec.describe 'Tracer integration tests' do
       let(:set_agent_rates!) do
         # Send span to receive response from "agent" with mocked service rates above.
         tracer.trace('send_trace_to_fetch_service_rates') {}
-        try_wait_until(attempts: 20) { tracer.writer.stats[:traces_flushed] >= 1 }
+        try_wait_until(seconds: 2) { tracer.writer.stats[:traces_flushed] >= 1 }
 
         # Reset stats and collected segments before test starts
         tracer.writer.send(:reset_stats!)
@@ -870,7 +870,7 @@ RSpec.describe 'Tracer integration tests' do
           end
         end
 
-        try_wait_until(attempts: 20) { tracer.writer.stats[:traces_flushed] >= 1 }
+        try_wait_until(seconds: 2) { tracer.writer.stats[:traces_flushed] >= 1 }
         stats = tracer.writer.stats
 
         expect(stats[:traces_flushed]).to eq(1)
@@ -1046,7 +1046,7 @@ RSpec.describe 'Tracer integration tests' do
 
           tracer.trace('name') {}
 
-          try_wait_until(attempts: 20) { tracer.writer.stats[:traces_flushed] >= 1 }
+          try_wait_until(seconds: 2) { tracer.writer.stats[:traces_flushed] >= 1 }
 
           stats = tracer.writer.stats
           expect(stats[:traces_flushed]).to eq(1)

--- a/spec/datadog/tracing/workers/trace_writer_spec.rb
+++ b/spec/datadog/tracing/workers/trace_writer_spec.rb
@@ -596,7 +596,7 @@ RSpec.describe Datadog::Tracing::Workers::AsyncTraceWriter do
             expect_in_fork do
               # Queue up traces, wait for worker to process them.
               traces.each { |trace| writer.write(trace) }
-              try_wait_until(attempts: 30) { !writer.work_pending? }
+              try_wait_until(seconds: 3) { !writer.work_pending? }
               writer.stop
 
               # Verify state of the writer

--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -40,8 +40,30 @@ module SynchronizationHelpers
     end
   end
 
-  # Defaults to 5 second timeout
-  def try_wait_until(attempts: 50, backoff: 0.1)
+  # Waits for the condition provided by the block argument to return truthy.
+  #
+  # Waits for 5 seconds by default.
+  #
+  # Can be configured by setting either:
+  #   * `seconds`, or
+  #   * `attempts` and `backoff`
+  #
+  # @yieldreturn [Boolean] block executed until it returns truthy
+  # @param [Numeric] seconds number of seconds to wait
+  # @param [Integer] attempts number of attempts at checking the condition
+  # @param [Numeric] backoff wait time between condition checking attempts
+  def try_wait_until(seconds: nil, attempts: nil, backoff: nil)
+    raise 'Provider either `seconds` or `attempts` & `backoff`, not both' if seconds && (attempts || backoff)
+
+    if seconds
+      attempts = seconds * 10
+      backoff = 0.1
+    else
+      # 5 seconds by default, but respect the provide values if any.
+      attempts ||= 50
+      backoff ||= 0.1
+    end
+
     # It's common for tests to want to run simple tasks in a background thread
     # but call this method without the thread having even time to start.
     #


### PR DESCRIPTION
While adding a `try_wait_until` of 10 seconds to https://github.com/DataDog/dd-trace-rb/pull/2477 I noticed how opaque the configuration options are for `try_wait_until`.

This PR adds a hopefully simpler to reason about `seconds` configuration option.

Instead of configuring `try_wait_until(attempts: 100, backoff: 0.1)` we can now do `try_wait_until(seconds: 10)`: these two scenarios yield the same configuration to `try_wait_until`.