### PR TITLE
Add debug information for flaky grape test

### DIFF
--- a/spec/datadog/tracing/contrib/grape/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/grape/tracer_spec.rb
@@ -266,7 +266,10 @@ RSpec.describe 'Grape instrumentation' do
           expect(spans[0].status).to eq(1)
           expect(spans[0].get_tag('error.stack')).to_not be_nil
           expect(spans[0].get_tag('error.type')).to_not be_nil
-          expect(spans[0].get_tag('error.message')).to_not be_nil
+          expect(spans[0].get_tag('error.message')).to_not be_nil,
+            "DEV: 🚧 Flaky test! Please send the maintainers a link for this CI failure. Thank you! 🚧\n" \
+            "response=#{response.inspect}\n" \
+            "spans=#{spans.inspect}\n"
           expect(spans[0].get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('grape')
           expect(spans[0].get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
             .to eq('endpoint_run')


### PR DESCRIPTION
This is an old flaky test that doesn't happen super often but does happen still: https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/8259/workflows/4ad2adbf-5954-471a-bf16-6584d79e913d/jobs/307083/parallel-runs/21?filterBy=FAILED

I tried my best to debug it, but couldn't find out why. And I couldn't reproduce it either.

I'm instead then adding additional debug information in the event of a CI failure.