### PR TITLE
[PROF-6557] Groundwork for using C atomic primitives

### DIFF
--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -187,7 +187,7 @@ unless pkg_config('datadog_profiling_with_rpath')
   )
 end
 
-unless have_type("atomic_int", ['stdatomic.h'])
+unless have_type('atomic_int', ['stdatomic.h'])
   skip_building_extension!(Datadog::Profiling::NativeExtensionHelpers::Supported::COMPILER_ATOMIC_MISSING)
 end
 

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -67,6 +67,10 @@ $stderr.puts(
 # that may fail on an environment not properly setup for building Ruby extensions.
 require 'mkmf'
 
+Logging.message(" [ddtrace] Using compiler:\n")
+xsystem("#{CONFIG['CC']} -v")
+Logging.message(" [ddtrace] End of compiler information\n")
+
 # mkmf on modern Rubies actually has an append_cflags that does something similar
 # (see https://github.com/ruby/ruby/pull/5760), but as usual we need a bit more boilerplate to deal with legacy Rubies
 def add_compiler_flag(flag)
@@ -190,10 +194,6 @@ $LDFLAGS += \
   ' -Wl,-rpath,$$$\\\\{ORIGIN\\}/' \
   "#{Datadog::Profiling::NativeExtensionHelpers.libdatadog_folder_relative_to_native_lib_folder}"
 Logging.message(" [ddtrace] After pkg-config $LDFLAGS were set to: #{$LDFLAGS.inspect}\n")
-
-Logging.message(" [ddtrace] Using compiler:\n")
-xsystem("#{CONFIG['CC']} --version")
-Logging.message(" [ddtrace] End of compiler information\n")
 
 # Tag the native extension library with the Ruby version and Ruby platform.
 # This makes it easier for development (avoids "oops I forgot to rebuild when I switched my Ruby") and ensures that

--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -187,6 +187,10 @@ unless pkg_config('datadog_profiling_with_rpath')
   )
 end
 
+unless have_type("atomic_int", ['stdatomic.h'])
+  skip_building_extension!(Datadog::Profiling::NativeExtensionHelpers::Supported::COMPILER_ATOMIC_MISSING)
+end
+
 # See comments on the helper method being used for why we need to additionally set this.
 # The extremely excessive escaping around ORIGIN below seems to be correct and was determined after a lot of
 # experimentation. We need to get these special characters across a lot of tools untouched...

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -179,6 +179,14 @@ module Datadog
           suggested: CONTACT_SUPPORT,
         )
 
+        # Validation for this check is done in extconf.rb because it relies on mkmf
+        COMPILER_ATOMIC_MISSING = explain_issue(
+          'your C compiler is missing support for the <stdatomic.h> header.',
+          'This issue can usually be fixed by upgrading to a later version of your',
+          'operating system image or compiler.',
+          suggested: CONTACT_SUPPORT,
+        )
+
         private_class_method def self.disabled_via_env?
           disabled_via_env = explain_issue(
             'the `DD_PROFILING_NO_EXTENSION` environment variable is/was set to',


### PR DESCRIPTION
**What does this PR do?**:

This PR introduces the use of C atomic primitives to the profiling native extension.

In particular, it:
* Adds checking at gem installation time that the C atomic primitives are available (and a suitable user-friendly error message when they aren't)
* Converts the `volatile bool should_run` into an atomic type. I've wanted to do this for some time (even left a comment about it) but didn't want to venture into atomic types until now.

**Motivation**:

I'm preparing to introduce dynamic sampling rate into the profiler, and my plans will require atomic types, so I decided to start with a small PR to ensure we could use them without issues.

**Additional Notes**:

(N/A)

**How to test the change?**:

There were no behavior changes, so the existing test coverage should be enough.