### PR TITLE
Temporarily disable GC profiling by default in new Ruby profiler due to overhead

### DIFF
--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -333,14 +333,14 @@ module Datadog
           end
 
           def should_enable_gc_profiling?(settings)
-            return true if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3')
-
             # See comments on the setting definition for more context on why it exists.
             if settings.profiling.advanced.force_enable_gc_profiling
-              Datadog.logger.debug(
-                'Profiling time/resources spent in Garbage Collection force enabled. Do not use Ractors in combination ' \
-                'with this option as profiles will be incomplete.'
-              )
+              if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3')
+                Datadog.logger.debug(
+                  'Profiling time/resources spent in Garbage Collection force enabled. Do not use Ractors in combination ' \
+                  'with this option as profiles will be incomplete.'
+                )
+              end
 
               true
             else

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -273,7 +273,9 @@ module Datadog
             # If you use Ruby 3.x and your application does not use Ractors (or if your Ruby has been patched), the
             # feature is fully safe to enable and this toggle can be used to do so.
             #
-            # We expect that once the above issue is patched, we'll automatically re-enable the feature on fixed Ruby
+            # Furthermore, currently this feature can add a lot of overhead for GC-heavy workloads.
+            #
+            # We expect the once the above issues are overcome, we'll automatically enable the feature on fixed Ruby
             # versions.
             option :force_enable_gc_profiling do |o|
               o.default { env_to_bool('DD_PROFILING_FORCE_ENABLE_GC', false) }

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -1062,8 +1062,20 @@ RSpec.describe Datadog::Core::Configuration::Components do
           end
         end
 
-        context 'on Ruby 2.x' do
-          before { skip 'Behavior does not apply to current Ruby version' if RUBY_VERSION >= '3.0' }
+        it 'initializes a CpuAndWallTimeWorker collector with gc_profiling_enabled set to false' do
+          expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with hash_including(
+            gc_profiling_enabled: false,
+          )
+
+          build_profiler
+        end
+
+        context 'when force_enable_gc_profiling is enabled' do
+          before do
+            settings.profiling.advanced.force_enable_gc_profiling = true
+
+            allow(Datadog.logger).to receive(:debug)
+          end
 
           it 'initializes a CpuAndWallTimeWorker collector with gc_profiling_enabled set to true' do
             expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with hash_including(
@@ -1072,33 +1084,9 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
             build_profiler
           end
-        end
 
-        context 'on Ruby 3.x' do
-          before { skip 'Behavior does not apply to current Ruby version' if RUBY_VERSION < '3.0' }
-
-          it 'initializes a CpuAndWallTimeWorker collector with gc_profiling_enabled set to false' do
-            expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with hash_including(
-              gc_profiling_enabled: false,
-            )
-
-            build_profiler
-          end
-
-          context 'when force_enable_gc_profiling is enabled' do
-            before do
-              settings.profiling.advanced.force_enable_gc_profiling = true
-
-              allow(Datadog.logger).to receive(:debug)
-            end
-
-            it 'initializes a CpuAndWallTimeWorker collector with gc_profiling_enabled set to true' do
-              expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with hash_including(
-                gc_profiling_enabled: true,
-              )
-
-              build_profiler
-            end
+          context 'on Ruby 3.x' do
+            before { skip 'Behavior does not apply to current Ruby version' if RUBY_VERSION < '3.0' }
 
             it 'logs a debug message' do
               expect(Datadog.logger).to receive(:debug).with(/Garbage Collection force enabled/)


### PR DESCRIPTION
**What does this PR do?**:

We previously only enabled GC profiling by default on Ruby 2.x (we disabled it on 3.x due to a bug, see #2354).

This PR changes the profiling configuration to never enable GC profiling by default (thus bringing the Ruby 2.x and 3.x defaults into sync).

**Motivation**:

I've had one new Ruby profiler alpha user report that GC profiling had a quite big overhead, and I could replicate the issue on a GC-heavy benchmark.

Since we'd like to get the new Ruby profiler out into customer's hands in beta, I decided to disable this feature by default, and come back to it after beta is out.

**Additional Notes**:

GC profiling can still be enabled via configuration.

**How to test the change?**:

Change includes test coverage. Furthermore, profiling any application will no longer show the `Garbage Collection` frames in the flamegraph by default.