### PR TITLE
Spec for `sidekiq.stop`

### DIFF
--- a/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Server internal tracer heartbeat' do
   end
 
   it 'traces the looping heartbeat' do
-    expect_in_sidekiq_server(wait_until: -> { fetch_spans.any? { |s| s.name == 'sidekiq.job_fetch' } }) do
+    expect_in_sidekiq_server(wait_until: -> { fetch_spans.any? { |s| s.name == 'sidekiq.heartbeat' } }) do
       span = spans.find { |s| s.service == tracer.default_service && s.name == 'sidekiq.heartbeat' }
 
       expect(span.service).to eq(tracer.default_service)

--- a/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Server internal tracer heartbeat' do
 
   context 'traces the stop command' do
     it do
-      after_stopping_sidekiq_server do
+      expect_after_stopping_sidekiq_server do
         span = spans.find { |s| s.name == 'sidekiq.stop' }
 
         expect(span.service).to eq(tracer.default_service)

--- a/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat_spec.rb
@@ -29,22 +29,18 @@ RSpec.describe 'Server internal tracer heartbeat' do
   end
 
   context 'traces the stop command' do
-    before do
-      skip('`exit` from `run_sidekiq_server` would terminate the program prematurely')
-
-      run_sidekiq_server
-    end
-
     it do
-      span = spans.find { |s| s.name == 'sidekiq.stop' }
+      after_stopping_sidekiq_server do
+        span = spans.find { |s| s.name == 'sidekiq.stop' }
 
-      expect(span.service).to eq(tracer.default_service)
-      expect(span.name).to eq('sidekiq.stop')
-      expect(span.span_type).to eq('worker')
-      expect(span.resource).to eq('sidekiq.stop')
-      expect(span).to_not have_error
-      expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('sidekiq')
-      expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('stop')
+        expect(span.service).to eq(tracer.default_service)
+        expect(span.name).to eq('sidekiq.stop')
+        expect(span.span_type).to eq('worker')
+        expect(span.resource).to eq('sidekiq.stop')
+        expect(span).to_not have_error
+        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('sidekiq')
+        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('stop')
+      end
     end
   end
 end

--- a/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/support/helper.rb
@@ -81,8 +81,6 @@ module SidekiqServerExpectations
   end
 
   def expect_after_stopping_sidekiq_server
-    app_tempfile = Tempfile.new(['sidekiq-server-app', '.rb'])
-
     expect_in_fork do
       # NB: This is needed because we want to patch within a forked process.
       if Datadog::Tracing::Contrib::Sidekiq::Patcher.instance_variable_get(:@patch_only_once)
@@ -96,7 +94,6 @@ module SidekiqServerExpectations
       configure_sidekiq
 
       cli = Sidekiq::CLI.instance
-      cli.parse(['--require', app_tempfile.path]) # boot the "app"
 
       # `timeout` is the deadline that waits up for all jobs to complete.
       # Default is 25, the reason for `stop` command to take so long.
@@ -105,8 +102,5 @@ module SidekiqServerExpectations
 
       yield
     end
-  ensure
-    app_tempfile.close
-    app_tempfile.unlink
   end
 end


### PR DESCRIPTION
**What does this PR do?**

* Add spec  for `sidekiq.stop` , which was previously skipped, https://github.com/DataDog/dd-trace-rb/pull/2441
* Fix `sidekiq.heartbeat` wait until condition
* Tweak for speed and streamline some setup

