### PR TITLE
[PROF-6557] Record stats for time spent sampling in new profiler

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -375,12 +375,13 @@ VALUE cpu_and_wall_time_collector_sample(VALUE self_instance) {
 
   state->sample_count++;
 
-  // TODO: This seems somewhat overkill and inefficient to do often; right now we just doing every few samples
+  // TODO: This seems somewhat overkill and inefficient to do often; right now we just do it every few samples
   // but there's probably a better way to do this if we actually track when threads finish
   if (state->sample_count % 100 == 0) remove_context_for_dead_threads(state);
 
-  // Return a VALUE to make it easier to call this function from Ruby APIs that expect a return value (such as rb_rescue2)
-  return Qnil;
+  long sampling_time_ns = wall_time_now_ns(RAISE_ON_FAILURE) - current_wall_time_ns;
+
+  return LONG2NUM(sampling_time_ns);
 }
 
 // This function gets called when Ruby is about to start running the Garbage Collector on the current thread.


### PR DESCRIPTION
**What does this PR do?**:

This PR adds tracking of the min, max and total wall-time that the profiler spent sampling.

For now this is exposed as `#stats` and not particularly recorded or sent anywhere.

**Motivation**:

I'm preparing to introduce dynamic sampling rate into the profiler, and as part of it, I'll need to use the time the profiler spent sampling to decide how often the profiler runs.

For a long time I've wanted to add these stats for debugging and analysis so I decided to do a small PR to add them first, and then later have the dynamic sampling rate PR rely on them as well.

**Additional Notes**:

(N/A)

**How to test the change?**:

Change includes code coverage.