### PR TITLE
W3C: Propagate unknown values as-is

### DIFF
--- a/lib/datadog/tracing/trace_digest.rb
+++ b/lib/datadog/tracing/trace_digest.rb
@@ -59,15 +59,22 @@ module Datadog
       #   This attribute will preserve the original id, while `trace_id` will only contain the lower 64 bits.
       #   @return [Integer]
       #   @see https://www.w3.org/TR/trace-context/#trace-id
-      # @!attribute [r] trace_tracestate
-      #   The W3C "tracestate" extracted from a distributed context.
-      #   This field is a string representing vendor-specific distribution data.
-      #   @return [String]
-      #   @see https://www.w3.org/TR/trace-context/#tracestate-header
       # @!attribute [r] trace_flags
       #   The W3C "trace-flags" extracted from a distributed context. This field is an 8-bit unsigned integer.
       #   @return [Integer]
       #   @see https://www.w3.org/TR/trace-context/#trace-flags
+      # @!attribute [r] trace_state
+      #   The W3C "tracestate" extracted from a distributed context.
+      #   This field is a string representing vendor-specific distribution data.
+      #   The `dd=` entry is removed from `trace_state` as its value is dynamically calculated
+      #   on every propagation injection.
+      #   @return [String]
+      #   @see https://www.w3.org/TR/trace-context/#tracestate-header
+      # @!attribute [r] trace_state_unknown_fields
+      #   From W3C "tracestate"'s `dd=` entry, when keys are not recognized they are stored here long with their values.
+      #   This allows later propagation to include those unknown fields, as they can represent future versions of the spec
+      #   sending data through this service. This value ends in a trailing `;` to facilitate serialization.
+      #   @return [String]
       # TODO: The documentation for the last attribute above won't be rendered.
       # TODO: This might be a YARD bug as adding an attribute, making it now second-last attribute, renders correctly.
       attr_reader \
@@ -88,7 +95,8 @@ module Datadog
         :trace_service,
         :trace_distributed_id,
         :trace_flags,
-        :trace_state
+        :trace_state,
+        :trace_state_unknown_fields
 
       def initialize(
         span_id: nil,
@@ -108,7 +116,8 @@ module Datadog
         trace_service: nil,
         trace_distributed_id: nil,
         trace_flags: nil,
-        trace_state: nil
+        trace_state: nil,
+        trace_state_unknown_fields: nil
       )
         @span_id = span_id
         @span_name = span_name && span_name.dup.freeze
@@ -128,6 +137,7 @@ module Datadog
         @trace_distributed_id = trace_distributed_id
         @trace_flags = trace_flags
         @trace_state = trace_state && trace_state.dup.freeze
+        @trace_state_unknown_fields = trace_state_unknown_fields && trace_state_unknown_fields.dup.freeze
 
         freeze
       end

--- a/spec/datadog/tracing/distributed/trace_context_spec.rb
+++ b/spec/datadog/tracing/distributed/trace_context_spec.rb
@@ -242,7 +242,7 @@ RSpec.shared_examples 'Trace Context distributed format' do
             let(:upstream_tracestate) { 'dd=old_value,other=vendor,dd=oops_forgot_to_remove_this' }
 
             it 'removes existing `dd=` values, prepending new `dd=` value' do
-              expect(tracestate).to eq('dd=o:origin;future=field,other=vendor')
+              expect(tracestate).to eq('dd=o:origin,other=vendor')
             end
           end
 

--- a/spec/datadog/tracing/trace_digest_spec.rb
+++ b/spec/datadog/tracing/trace_digest_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe Datadog::Tracing::TraceDigest do
           trace_service: nil,
           trace_distributed_id: nil,
           trace_flags: nil,
-          trace_state: nil
+          trace_state: nil,
+          trace_state_unknown_fields: nil
         )
       end
 
@@ -162,9 +163,16 @@ RSpec.describe Datadog::Tracing::TraceDigest do
 
       context ':trace_state' do
         let(:options) { { trace_state: trace_state } }
-        let(:trace_state) { 'dd=o:origin,vendor=value' }
+        let(:trace_state) { 'vendor1=value,v2=v' }
 
-        it { is_expected.to have_attributes(trace_state: be_a_frozen_copy_of('dd=o:origin,vendor=value')) }
+        it { is_expected.to have_attributes(trace_state: be_a_frozen_copy_of('vendor=value,v2=v')) }
+      end
+
+      context 'trace_state_unknown_fields' do
+        let(:options) { { trace_state_unknown_fields: trace_state_unknown_fields } }
+        let(:trace_state_unknown_fields) { 'unknown1:field1;unknown2:field2;' }
+
+        it { is_expected.to have_attributes(trace_state_unknown_fields: be_a_frozen_copy_of(trace_state_unknown_fields)) }
       end
     end
   end

--- a/spec/datadog/tracing/trace_digest_spec.rb
+++ b/spec/datadog/tracing/trace_digest_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Datadog::Tracing::TraceDigest do
         let(:options) { { trace_state: trace_state } }
         let(:trace_state) { 'vendor1=value,v2=v' }
 
-        it { is_expected.to have_attributes(trace_state: be_a_frozen_copy_of('vendor=value,v2=v')) }
+        it { is_expected.to have_attributes(trace_state: be_a_frozen_copy_of('vendor1=value,v2=v')) }
       end
 
       context 'trace_state_unknown_fields' do


### PR DESCRIPTION
Unknown Datadog-specific fields should be propagated as-is, as they might belong to future versions Datadog Tracers.

`ddtrace`'s job is to simply pass the them downstream with the same incoming values.