### PR TITLE
[PROF-6557] Implement dynamic sampling rate for new profiler

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_dynamic_sampling_rate.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_dynamic_sampling_rate.c
@@ -1,0 +1,142 @@
+#include <ruby.h>
+
+#include "collectors_dynamic_sampling_rate.h"
+#include "helpers.h"
+#include "ruby_helpers.h"
+#include "time_helpers.h"
+
+// Used to pace the rate of profiling samples based on the last observed time for a sample.
+//
+// This file implements the native bits of the Datadog::Profiling::Collectors::DynamicSamplingRate module, and is
+// only exposed to Ruby for testing (it's always and only invoked by other C code in production).
+
+// ---
+// ## Dynamic Sampling Rate
+//
+// Our profilers get deployed in quite unpredictable situations in terms of system resources. While they can provide key
+// information to help customers solve their performance problems, the profilers must always be careful not to make
+// performance problems worse. This is where the idea of a dynamic sampling rate comes in.
+//
+// Instead of sampling at a fixed sample rate, the actual sampling rate should be decided by also observing the impact
+// that running the profiler is having. This protects against issues such as the profiler being deployed in very busy
+//machines or containers with unrealistic CPU restrictions.
+//
+// ### Implementation
+//
+// The APIs exposed by this file are used by the `CpuAndWallTimeWorker`.
+//
+// The main idea of the implementation below is the following: whenever the profiler takes a sample, the time we spent
+// sampling and the current wall-time are recorded by calling `dynamic_sampling_rate_after_sample()`.
+//
+// Inside `dynamic_sampling_rate_after_sample()`, both values are combined to decide a future wall-time before which
+// we should not sample. That is, we may decide that the next sample should happen no less than 200ms from now.
+//
+// Before taking a sample, the profiler checks using `dynamic_sampling_rate_should_sample()`, if it's time or not to
+// sample. If it's not, it will skip sampling.
+//
+// Finally, as an additional optimization, there's a `dynamic_sampling_rate_get_sleep()` which, given the current
+// wall-time, will return the time remaining (*there's an exception, check below) until the next sample.
+//
+// ---
+
+// This is the wall-time overhead we're targeting. E.g. we target to spend no more than 2%, or 1.2 seconds per minute,
+// taking profiling samples.
+#define WALL_TIME_OVERHEAD_TARGET_PERCENTAGE 2.0 // %
+// See `dynamic_sampling_rate_get_sleep()` for details
+#define MAX_SLEEP_TIME_NS MILLIS_AS_NS(100)
+// See `dynamic_sampling_rate_after_sample()` for details
+#define MAX_TIME_UNTIL_NEXT_SAMPLE_NS SECONDS_AS_NS(10)
+
+void dynamic_sampling_rate_init(dynamic_sampling_rate_state *state) {
+  atomic_init(&state->next_sample_after_monotonic_wall_time_ns, 0);
+}
+
+void dynamic_sampling_rate_reset(dynamic_sampling_rate_state *state) {
+  atomic_store(&state->next_sample_after_monotonic_wall_time_ns, 0);
+}
+
+uint64_t dynamic_sampling_rate_get_sleep(dynamic_sampling_rate_state *state, long current_monotonic_wall_time_ns) {
+  long next_sample_after_ns = atomic_load(&state->next_sample_after_monotonic_wall_time_ns);
+  long delta_ns = next_sample_after_ns - current_monotonic_wall_time_ns;
+
+  if (delta_ns > 0 && next_sample_after_ns > 0) {
+    // We don't want to sleep for too long as the profiler may be trying to stop.
+    //
+    // Instead, here we sleep for at most this time. Worst case, the profiler will still try to sample before
+    // `next_sample_after_monotonic_wall_time_ns`, BUT `dynamic_sampling_rate_should_sample()` will still be false
+    // so we still get the intended behavior.
+    return uint64_min_of(delta_ns, MAX_SLEEP_TIME_NS);
+  } else {
+    return 0;
+  }
+}
+
+bool dynamic_sampling_rate_should_sample(dynamic_sampling_rate_state *state, long wall_time_ns_before_sample) {
+  return wall_time_ns_before_sample >= atomic_load(&state->next_sample_after_monotonic_wall_time_ns);
+}
+
+void dynamic_sampling_rate_after_sample(dynamic_sampling_rate_state *state, long wall_time_ns_after_sample, uint64_t sampling_time_ns) {
+  double overhead_target = (double) WALL_TIME_OVERHEAD_TARGET_PERCENTAGE;
+
+  // The idea here is that we're targeting a maximum % of wall-time spent sampling.
+  // So for instance, if sampling_time_ns is 2% of the time we spend working, how much is the 98% we should spend
+  // sleeping? As an example, if the last sample took 1ms and the target overhead is 2%, we should sleep for 49ms.
+  uint64_t time_to_sleep_ns = sampling_time_ns * ((100.0 - overhead_target)/overhead_target);
+
+  // In case a sample took an unexpected long time (e.g. maybe a VM was paused, or a laptop was suspended), we clamp the
+  // value so it doesn't get too crazy
+  time_to_sleep_ns = uint64_min_of(time_to_sleep_ns, MAX_TIME_UNTIL_NEXT_SAMPLE_NS);
+
+  atomic_store(&state->next_sample_after_monotonic_wall_time_ns, wall_time_ns_after_sample + time_to_sleep_ns);
+}
+
+// ---
+// Below here is boilerplate to expose the above code to Ruby so that we can test it with RSpec as usual.
+
+VALUE _native_get_sleep(DDTRACE_UNUSED VALUE self, VALUE simulated_next_sample_after_monotonic_wall_time_ns, VALUE current_monotonic_wall_time_ns);
+VALUE _native_should_sample(DDTRACE_UNUSED VALUE self, VALUE simulated_next_sample_after_monotonic_wall_time_ns, VALUE wall_time_ns_before_sample);
+VALUE _native_after_sample(DDTRACE_UNUSED VALUE self, VALUE wall_time_ns_after_sample, VALUE sampling_time_ns);
+
+void collectors_dynamic_sampling_rate_init(VALUE profiling_module) {
+  VALUE collectors_module = rb_define_module_under(profiling_module, "Collectors");
+  VALUE dynamic_sampling_rate_module = rb_define_module_under(collectors_module, "DynamicSamplingRate");
+  VALUE testing_module = rb_define_module_under(dynamic_sampling_rate_module, "Testing");
+
+  rb_define_singleton_method(testing_module, "_native_get_sleep", _native_get_sleep, 2);
+  rb_define_singleton_method(testing_module, "_native_should_sample", _native_should_sample, 2);
+  rb_define_singleton_method(testing_module, "_native_after_sample", _native_after_sample, 2);
+}
+
+VALUE _native_get_sleep(DDTRACE_UNUSED VALUE self, VALUE simulated_next_sample_after_monotonic_wall_time_ns, VALUE current_monotonic_wall_time_ns) {
+  ENFORCE_TYPE(simulated_next_sample_after_monotonic_wall_time_ns, T_FIXNUM);
+  ENFORCE_TYPE(current_monotonic_wall_time_ns, T_FIXNUM);
+
+  dynamic_sampling_rate_state state;
+  dynamic_sampling_rate_init(&state);
+  atomic_store(&state.next_sample_after_monotonic_wall_time_ns, NUM2LONG(simulated_next_sample_after_monotonic_wall_time_ns));
+
+  return ULL2NUM(dynamic_sampling_rate_get_sleep(&state, NUM2LONG(current_monotonic_wall_time_ns)));
+}
+
+VALUE _native_should_sample(DDTRACE_UNUSED VALUE self, VALUE simulated_next_sample_after_monotonic_wall_time_ns, VALUE wall_time_ns_before_sample) {
+  ENFORCE_TYPE(simulated_next_sample_after_monotonic_wall_time_ns, T_FIXNUM);
+  ENFORCE_TYPE(wall_time_ns_before_sample, T_FIXNUM);
+
+  dynamic_sampling_rate_state state;
+  dynamic_sampling_rate_init(&state);
+  atomic_store(&state.next_sample_after_monotonic_wall_time_ns, NUM2LONG(simulated_next_sample_after_monotonic_wall_time_ns));
+
+  return dynamic_sampling_rate_should_sample(&state, NUM2LONG(wall_time_ns_before_sample)) ? Qtrue : Qfalse;
+}
+
+VALUE _native_after_sample(DDTRACE_UNUSED VALUE self, VALUE wall_time_ns_after_sample, VALUE sampling_time_ns) {
+  ENFORCE_TYPE(wall_time_ns_after_sample, T_FIXNUM);
+  ENFORCE_TYPE(sampling_time_ns, T_FIXNUM);
+
+  dynamic_sampling_rate_state state;
+  dynamic_sampling_rate_init(&state);
+
+  dynamic_sampling_rate_after_sample(&state, NUM2LONG(wall_time_ns_after_sample), NUM2ULL(sampling_time_ns));
+
+  return ULL2NUM(atomic_load(&state.next_sample_after_monotonic_wall_time_ns));
+}

--- a/ext/ddtrace_profiling_native_extension/collectors_dynamic_sampling_rate.h
+++ b/ext/ddtrace_profiling_native_extension/collectors_dynamic_sampling_rate.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <stdatomic.h>
+#include <stdbool.h>
+
+typedef struct {
+  atomic_long next_sample_after_monotonic_wall_time_ns;
+} dynamic_sampling_rate_state;
+
+void dynamic_sampling_rate_init(dynamic_sampling_rate_state *state);
+void dynamic_sampling_rate_reset(dynamic_sampling_rate_state *state);
+uint64_t dynamic_sampling_rate_get_sleep(dynamic_sampling_rate_state *state, long current_monotonic_wall_time_ns);
+bool dynamic_sampling_rate_should_sample(dynamic_sampling_rate_state *state, long wall_time_ns_before_sample);
+void dynamic_sampling_rate_after_sample(dynamic_sampling_rate_state *state, long wall_time_ns_after_sample, uint64_t sampling_time_ns);

--- a/ext/ddtrace_profiling_native_extension/profiling.c
+++ b/ext/ddtrace_profiling_native_extension/profiling.c
@@ -12,6 +12,7 @@
 // Each class/module here is implemented in their separate file
 void collectors_cpu_and_wall_time_init(VALUE profiling_module);
 void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module);
+void collectors_dynamic_sampling_rate_init(VALUE profiling_module);
 void collectors_idle_sampling_helper_init(VALUE profiling_module);
 void collectors_stack_init(VALUE profiling_module);
 void http_transport_init(VALUE profiling_module);
@@ -44,6 +45,7 @@ void DDTRACE_EXPORT Init_ddtrace_profiling_native_extension(void) {
 
   collectors_cpu_and_wall_time_init(profiling_module);
   collectors_cpu_and_wall_time_worker_init(profiling_module);
+  collectors_dynamic_sampling_rate_init(profiling_module);
   collectors_idle_sampling_helper_init(profiling_module);
   collectors_stack_init(profiling_module);
   http_transport_init(profiling_module);

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -149,6 +149,7 @@ module Datadog
       require_relative 'profiling/collectors/code_provenance'
       require_relative 'profiling/collectors/cpu_and_wall_time'
       require_relative 'profiling/collectors/cpu_and_wall_time_worker'
+      require_relative 'profiling/collectors/dynamic_sampling_rate'
       require_relative 'profiling/collectors/idle_sampling_helper'
       require_relative 'profiling/collectors/old_stack'
       require_relative 'profiling/collectors/stack'

--- a/lib/datadog/profiling/collectors/dynamic_sampling_rate.rb
+++ b/lib/datadog/profiling/collectors/dynamic_sampling_rate.rb
@@ -1,0 +1,14 @@
+# typed: false
+
+module Datadog
+  module Profiling
+    module Collectors
+      # Used to pace the rate of profiling samples based on the last observed time for a sample.
+      # All of this module is implemented as native code.
+      #
+      # Methods prefixed with _native_ are implemented in `collectors_dynamic_sampling_rate.c`
+      module DynamicSamplingRate
+      end
+    end
+  end
+end

--- a/lib/datadog/profiling/collectors/idle_sampling_helper.rb
+++ b/lib/datadog/profiling/collectors/idle_sampling_helper.rb
@@ -6,7 +6,7 @@ module Datadog
       # Used by the Collectors::CpuAndWallTimeWorker to gather samples when the Ruby process is idle.
       # Almost all of this class is implemented as native code.
       #
-      # Methods prefixed with _native_ are implemented in `collecetors_idle_sampling_helper.c`
+      # Methods prefixed with _native_ are implemented in `collectors_idle_sampling_helper.c`
       class IdleSamplingHelper
         private
 

--- a/spec/datadog/profiling/collectors/dynamic_sampling_rate_spec.rb
+++ b/spec/datadog/profiling/collectors/dynamic_sampling_rate_spec.rb
@@ -1,0 +1,89 @@
+# typed: false
+
+require 'datadog/profiling/spec_helper'
+require 'datadog/profiling/collectors/dynamic_sampling_rate'
+
+RSpec.describe Datadog::Profiling::Collectors::DynamicSamplingRate do
+  before { skip_if_profiling_not_supported(self) }
+
+  describe 'dynamic_sampling_rate_after_sample' do
+    let(:current_monotonic_wall_time_ns) { 123 }
+
+    it 'sets the next_sample_after_monotonic_wall_time_ns based on the current timestamp and max overhead target' do
+      max_overhead_target = 2.0 # WALL_TIME_OVERHEAD_TARGET_PERCENTAGE
+      sampling_time_ns = 456
+
+      # The idea here is -- if sampling_time_ns is 2% of the time we spend working, how much is the 98% we should spend
+      # sleeping?
+      expected_time_to_sleep = sampling_time_ns * ((100 - max_overhead_target) / max_overhead_target)
+
+      expect(described_class::Testing._native_after_sample(current_monotonic_wall_time_ns, sampling_time_ns))
+        .to be(current_monotonic_wall_time_ns + expected_time_to_sleep.to_i)
+    end
+
+    context 'when next_sample_after_monotonic_wall_time_ns would be too far in the future' do
+      it 'sets the next_sample_after_monotonic_wall_time_ns to be current timestamp + MAX_TIME_UNTIL_NEXT_SAMPLE_NS' do
+        max_time_until_next_sample_ns = 10_000_000_000 # MAX_TIME_UNTIL_NEXT_SAMPLE_NS
+        sampling_time_ns = 60_000_000_000
+
+        expect(described_class::Testing._native_after_sample(current_monotonic_wall_time_ns, sampling_time_ns))
+          .to be(current_monotonic_wall_time_ns + max_time_until_next_sample_ns)
+      end
+    end
+  end
+
+  describe 'dynamic_sampling_rate_should_sample' do
+    let(:next_sample_after_monotonic_wall_time_ns) { 10 }
+
+    subject(:dynamic_sampling_rate_should_sample) do
+      described_class::Testing._native_should_sample(next_sample_after_monotonic_wall_time_ns, wall_time_ns_before_sample)
+    end
+
+    context 'when wall_time_ns_before_sample is before next_sample_after_monotonic_wall_time_ns' do
+      let(:wall_time_ns_before_sample) { next_sample_after_monotonic_wall_time_ns - 1 }
+      it { is_expected.to be false }
+    end
+
+    context 'when wall_time_ns_before_sample is after next_sample_after_monotonic_wall_time_ns' do
+      let(:wall_time_ns_before_sample) { next_sample_after_monotonic_wall_time_ns + 1 }
+      it { is_expected.to be true }
+    end
+  end
+
+  describe 'dynamic_sampling_rate_get_sleep' do
+    let(:next_sample_after_monotonic_wall_time_ns) { 1_000_000_000 }
+
+    subject(:dynamic_sampling_rate_get_sleep) do
+      described_class::Testing._native_get_sleep(next_sample_after_monotonic_wall_time_ns, current_monotonic_wall_time_ns)
+    end
+
+    context 'when current_monotonic_wall_time_ns is before next_sample_after_monotonic_wall_time_ns' do
+      context(
+        'when current_monotonic_wall_time_ns is less than MAX_SLEEP_TIME_NS ' \
+        'from next_sample_after_monotonic_wall_time_ns'
+      ) do
+        let(:current_monotonic_wall_time_ns) { next_sample_after_monotonic_wall_time_ns - 1234 }
+
+        it 'returns the time between current_monotonic_wall_time_ns and next_sample_after_monotonic_wall_time_ns' do
+          expect(dynamic_sampling_rate_get_sleep).to be 1234
+        end
+      end
+
+      context(
+        'when current_monotonic_wall_time_ns is more than MAX_SLEEP_TIME_NS ' \
+        'from next_sample_after_monotonic_wall_time_ns'
+      ) do
+        let(:current_monotonic_wall_time_ns) { next_sample_after_monotonic_wall_time_ns - 123_456_789 }
+
+        it 'returns MAX_SLEEP_TIME_NS' do
+          expect(dynamic_sampling_rate_get_sleep).to be 100_000_000
+        end
+      end
+    end
+
+    context 'when current_monotonic_wall_time_ns is after next_sample_after_monotonic_wall_time_ns' do
+      let(:current_monotonic_wall_time_ns) { next_sample_after_monotonic_wall_time_ns + 1 }
+      it { is_expected.to be 0 }
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**:

This PR adds a dynamic sampling rate implementation for the new profiler. The old profiler implementation already included a similar strategy, and it has been serving us quite well.

To more easily test and document the new feature, even though in the end it's not that much code, I chose to implement it in a separate module -- `Collectors::DynamicSamplingRate`.

This module gets called by the `CpuAndWallTimeWorker` at key times during sampling and in the loop that triggers sampling, so that its internal tracking gets taken into account.

**Motivation**:

Our profilers get deployed in quite unpredictable situations in terms of system resources. While they can provide key information to help customers solve their performance problems, the profilers must always be careful not to make performance problems worse. This is where the idea of a dynamic sampling rate comes in.

Instead of sampling at a fixed sample rate, the actual sampling rate should be decided by also observing the impact that running the profiler is having. This protects against issues such as the profiler being deployed in very busy machines or containers with unrealistic CPU restrictions.

**Additional Notes**:

See the comments on `collectors_dynamic_sampling_rate.c` for a deeper explanation of how this works

**How to test the change?**:

This change includes code coverage. Furthermore, profiles should still continue to be correctly taken for applications.