### PR TITLE
Update banner on 1.0 upgrade guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-**We've recently released the 1.x version series. If you're upgrading from a 0.x version, check out our [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md#from-0x-to-10).**
-
 # Datadog Trace Client
 
 [![Gem](https://img.shields.io/gem/v/ddtrace)](https://rubygems.org/gems/ddtrace/)
@@ -11,6 +9,8 @@
 databases and microservices so that developers have great visiblity into bottlenecks and troublesome requests.
 
 ## Getting started
+
+**If you're upgrading from a 0.x version, check out our [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md#from-0x-to-10).**
 
 For a basic product overview, check out our [setup documentation][setup docs].
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,11 +1,11 @@
-**We've recently released the 1.x version series. If you're upgrading from a 0.x version, check out our [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md#from-0x-to-10).**
-
 # Datadog Ruby Trace Client
 
 `ddtrace` is Datadog’s tracing client for Ruby. It is used to trace requests as they flow across web servers,
 databases and microservices so that developers have high visibility into bottlenecks and troublesome requests.
 
 ## Getting started
+
+**If you're upgrading from a 0.x version, check out our [upgrade guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md#from-0x-to-10).**
 
 For the general APM documentation, see our [setup documentation][setup docs].
 


### PR DESCRIPTION
As the 1.x ddtrace series has been released for quite some time, thus the phrasing `We've recently released the 1.x version series` is no longer accurate.

Also the banner was placed at the very top of our documentation pages, which I believe is not longer needed.

This PR moves the banner to the first actual documentation section and rephrases the "recently released" language.