### PR TITLE
[PROF-6559] Mark Ruby CPU Profiling 2.0 as being in beta

### DIFF
--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -351,8 +351,9 @@ module Datadog
           def print_new_profiler_warnings
             if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
               Datadog.logger.warn(
-                'New Ruby profiler has been force-enabled. This feature is in alpha state. Please report any issues ' \
-                'you run into via <https://github.com/datadog/dd-trace-rb/issues/new>!'
+                'New Ruby profiler has been force-enabled. This feature is in beta state. We do not yet recommend ' \
+                'running it in production environments. Please report any issues ' \
+                'you run into to Datadog support or via <https://github.com/datadog/dd-trace-rb/issues/new>!'
               )
             else
               # For more details on the issue, see the "BIG Issue" comment on `gvl_owner` function in
@@ -360,7 +361,8 @@ module Datadog
               Datadog.logger.warn(
                 'New Ruby profiler has been force-enabled on a legacy Ruby version (< 2.6). This is not recommended in ' \
                 'production environments, as due to limitations in Ruby APIs, we suspect it may lead to crashes in very ' \
-                'rare situations. Please report any issues you run into via <https://github.com/datadog/dd-trace-rb/issues/new>!'
+                'rare situations. Please report any issues you run into to Datadog support or ' \
+                'via <https://github.com/datadog/dd-trace-rb/issues/new>!'
               )
             end
           end

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -1043,7 +1043,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
           it 'logs a warning message mentioning that profiler has been force-enabled' do
             expect(Datadog.logger).to receive(:warn).with(
-              /New Ruby profiler has been force-enabled. This feature is in alpha state/
+              /New Ruby profiler has been force-enabled. This feature is in beta state/
             )
 
             build_profiler


### PR DESCRIPTION
**What does this PR do?**:

This PR collects a few small changes needed before releasing the new Ruby profiler bits ("CPU Profiling 2.0") as opt-in (that is, disabled by default) public beta.

I recommend reviewing commit-by-commit.

**Motivation**:

We're finally ready to start telling customers they can enable this new mode.

**Additional Notes**:

(N/A)

**How to test the change?**:

Change includes test coverage (the little code that is affected).
