### PR TITLE
Bump to version 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ You can enable it:
 
 ```ruby
 Datadog.configure do |c|
-  # … existing configuration …
+  # ... existing configuration ...
 
   c.profiling.advanced.force_enable_new_profiler = true
 end
@@ -28,14 +28,14 @@ end
 
 What to expect from Ruby CPU Profiling 2.0 beta?
 
-* **Finer-grained profiling data due to our sampling engine rewritten in C+Rust**. The profiler will be able to run more often and get more information while keeping the same 2% overhead target you’re used to, and with a lower impact on latency. Especially when looking at the “Code Hotspots” panel for a distributed trace, expect more and finer grained profiles.
-* Thread id information now includes the operating system thread id for Ruby 3.1+, so you’ll be able to correlate your thread information when looking at other system monitoring tools
-* Thread names are now collected and you’ll be able to filter your profiles by these names
-* Experimental support for capturing CPU and Wall-time spent doing Garbage Collection. This is disabled by default as we’re still improving the performance of this feature and fixing a few incompatibilities with Ruby Ractors. You can enable it by adding `DD_PROFILING_FORCE_ENABLE_GC=true` or `c.profiling.advancedforce_enable_gc_profiling = true` to the instructions seen above.
+* **Finer-grained profiling data due to our sampling engine rewritten in C+Rust**. The profiler will be able to run more often and get more information while keeping the same 2% overhead target you're used to, and with a lower impact on latency. Especially when looking at the "Code Hotspots" panel for a distributed trace, expect more and finer grained profiles.
+* Thread id information now includes the operating system thread id for Ruby 3.1+, so you'll be able to correlate your thread information when looking at other system monitoring tools
+* Thread names are now collected and you'll be able to filter your profiles by these names
+* Experimental support for capturing CPU and Wall-time spent doing Garbage Collection. This is disabled by default as we're still improving the performance of this feature and fixing a few incompatibilities with Ruby Ractors. You can enable it by adding `DD_PROFILING_FORCE_ENABLE_GC=true` or `c.profiling.advancedforce_enable_gc_profiling = true` to the instructions seen above.
 
-…with more and faster improvements to come in early 2023!
+...with more and faster improvements to come in early 2023!
 
-Give it a try, and we’d love to hear your feedback. Do note that while in beta, we don’t recommend using Ruby CPU Profiling 2.0 in production environments. Below, you’ll find a list of known issues that we’re still looking into.
+Give it a try, and we'd love to hear your feedback. Do note that while in beta, we don't recommend using Ruby CPU Profiling 2.0 in production environments. Below, you'll find a list of known issues that we're still looking into.
 
 Known issues:
 * Profiling CPU-time overhead is not shown in flamegraphs (unlike with the existing profiler). We will be fixing this soon!
@@ -52,7 +52,7 @@ Known issues:
 
 ### `redis` 5 instrumentation upgrade notes
 
-dd-trace-rb officially supports `redis` 5 instrumentation. When upgrading `redis` gem to 5.x and with configuration per instance, change your code by passing `{custom: datadog: { … }}` tags during redis instantiation.
+dd-trace-rb officially supports `redis` 5 instrumentation. When upgrading `redis` gem to 5.x and with configuration per instance, change your code by passing `{custom: datadog: { ... }}` tags during redis instantiation.
 
 Before redis 5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,78 +4,10 @@
 
 ## [1.8.0] - 2022-12-14
 
-Happy holidays! This release includes two big items we're pretty excited about and want to call out explicitly:
+Release notes: https://github.com/DataDog/dd-trace-rb/releases/tag/v1.8.0
 
-* CPU Profiling 2.0 is now in beta!
-* `redis` 5 instrumentation upgrade notes
-
-### CPU Profiling 2.0 is now in beta!
-
-As of ddtrace 1.8.0, CPU Profiling 2.0 is now in opt-in (that is, disabled by default) public beta.
-
-You can enable it:
-
-* Using an environment variable by setting `DD_PROFILING_FORCE_ENABLE_NEW=true`
-* Or via code by adding to your `Datadog.configure` block:
-
-```ruby
-Datadog.configure do |c|
-  # ... existing configuration ...
-
-  c.profiling.advanced.force_enable_new_profiler = true
-end
-```
-
-What to expect from Ruby CPU Profiling 2.0 beta?
-
-* **Finer-grained profiling data due to our sampling engine rewritten in C+Rust**. The profiler will be able to run more often and get more information while keeping the same 2% overhead target you're used to, and with a lower impact on latency. Especially when looking at the "Code Hotspots" panel for a distributed trace, expect more and finer grained profiles.
-* Thread id information now includes the operating system thread id for Ruby 3.1+, so you'll be able to correlate your thread information when looking at other system monitoring tools
-* Thread names are now collected and you'll be able to filter your profiles by these names
-* Experimental support for capturing CPU and Wall-time spent doing Garbage Collection. This is disabled by default as we're still improving the performance of this feature and fixing a few incompatibilities with Ruby Ractors. You can enable it by adding `DD_PROFILING_FORCE_ENABLE_GC=true` or `c.profiling.advancedforce_enable_gc_profiling = true` to the instructions seen above.
-
-...with more and faster improvements to come in early 2023!
-
-Give it a try, and we'd love to hear your feedback. Do note that while in beta, we don't recommend using Ruby CPU Profiling 2.0 in production environments. Below, you'll find a list of known issues that we're still looking into.
-
-Known issues:
-* Profiling CPU-time overhead is not shown in flamegraphs (unlike with the existing profiler). We will be fixing this soon!
-* Rare incompatibilities with native extensions/libraries.
-
-    Ruby CPU Profiling 2.0 gathers profiling data by sending SIGPROF unix signals to Ruby applications. This is a common approach used by many other profilers, and it may cause system calls performed by native extensions/libraries to be interrupted with an EINTR error code ([reference](https://man7.org/linux/man-pages/man7/signal.7.html#:~:text=Interruption%20of%20system%20calls%20and%20library%20functions%20by%20signal%20handlers)).
-
-    Most native extensions/libraries are unaffected by this issue, but we know of at least one case: when using the `mysql2` gem together with versions of libmysqlclient older than 8.0.0 this can lead to failed database requests ([reference](https://bugs.mysql.com/bug.php?id=83109)). The affected libmysqlclient version is known to be present on Ubuntu 18.04, but not 20.04 and later releases.
-
-    We expect these occurrences to be rare, and will be working to both improve the ecosystem as well as to deploy countermeasures in the profiler itself to avoid triggering these issues.
-* Ruby 2.5 and below are missing an API that allows the profiler to detect the currently-active Ruby thread. We have deployed a workaround, but suspect that it may lead to crashes in extremely rare situations. We are still researching a solution for this issue and do not plan on rolling out CPU Profiling 2.0 automatically to Ruby 2.5 and below applications until it is fixed.
-* The disabled-by-default experimental support for capturing CPU and Wall-time spent doing Garbage Collection is incompatible with Ractors due to Ruby upstream bugs (<https://bugs.ruby-lang.org/issues/18464> and <https://bugs.ruby-lang.org/issues/19112>). We plan to work with the Ruby developers to incorporate fixes for these issues.
-* The disabled-by-default experimental support for capturing CPU and Wall-time spent doing Garbage Collection can cause a lot of overhead in Ruby applications with high object allocation rates. We will be fixing this soon!
-
-### `redis` 5 instrumentation upgrade notes
-
-dd-trace-rb officially supports `redis` 5 instrumentation. When upgrading `redis` gem to 5.x and with configuration per instance, change your code by passing `{custom: datadog: { ... }}` tags during redis instantiation.
-
-Before redis 5
-
-```ruby
-customer_cache = Redis.new
-invoice_cache = Redis.new
-
-Datadog.configure_onto(customer_cache, service_name: 'customer-cache')
-Datadog.configure_onto(invoice_cache, service_name: 'invoice-cache')
-
-customer_cache.get(...)
-invoice_cache.get(...)
-```
-
-After upgrading to redis 5.x
-
-```ruby
-customer_cache = Redis.new(custom: { datadog: { service_name: 'custom-cache' } })
-invoice_cache = Redis.new(custom: { datadog: { service_name: 'invoice-cache' } })
-
-customer_cache.get(...)
-invoice_cache.get(...)
-```
+As of ddtrace 1.8.0, CPU Profiling 2.0 is now in opt-in (that is, disabled by default) public beta. For more details,
+check the release notes.
 
 ### Added
 

--- a/gemfiles/jruby_9.2.21.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -191,4 +191,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -161,4 +161,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -248,4 +248,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -280,4 +280,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -280,4 +280,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -282,4 +282,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -299,4 +299,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -288,4 +288,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -279,4 +279,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -299,4 +299,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -299,4 +299,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -301,4 +301,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -306,4 +306,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -298,4 +298,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -296,4 +296,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -296,4 +296,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -298,4 +298,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -315,4 +315,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -304,4 +304,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -295,4 +295,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.2.8.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -185,4 +185,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -185,4 +185,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.2.8.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -177,4 +177,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.6
+   2.3.26

--- a/gemfiles/jruby_9.3.9.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/jruby_9.3.9.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.1.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_sinatra.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.2.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_sinatra.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_hanami_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.3.8_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_sinatra.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)

--- a/gemfiles/ruby_2.4.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -1613,9 +1613,17 @@ GEM
       rake (~> 12.3)
       serverengine (~> 2.1.0)
       thor
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sqlite3 (1.3.13)
     sucker_punch (3.0.1)
       concurrent-ruby (~> 1.0)
@@ -1712,6 +1720,8 @@ DEPENDENCIES
   sidekiq
   simplecov (~> 0.17)
   sneakers (>= 2.12.0)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sqlite3 (~> 1.3.6)
   sucker_punch
   typhoeus

--- a/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -135,6 +135,14 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.1.0)
     webmock (3.13.0)
@@ -186,6 +194,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 

--- a/gemfiles/ruby_2.4.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -116,6 +116,14 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.1.0)
     webmock (3.13.0)
@@ -163,6 +171,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 

--- a/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -136,6 +136,14 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.1.0)
     webmock (3.13.0)
@@ -184,6 +192,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 

--- a/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -161,6 +161,14 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.2.1)
@@ -214,6 +222,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 

--- a/gemfiles/ruby_2.4.10_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_hanami_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -197,6 +197,14 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     transproc (1.1.1)
@@ -251,6 +259,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 

--- a/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -211,6 +211,14 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -274,6 +282,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -211,6 +211,14 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -274,6 +282,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -212,6 +212,14 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -276,6 +284,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -228,6 +228,14 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -293,6 +301,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -220,6 +220,14 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -285,6 +293,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   sidekiq
   simplecov (~> 0.17)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -210,6 +210,14 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -273,6 +281,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.4.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -37,11 +37,15 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -113,6 +117,14 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     webmock (3.13.0)
@@ -125,6 +137,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -160,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 

--- a/gemfiles/ruby_2.4.10_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_redis_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -37,11 +37,15 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -113,6 +117,14 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     webmock (3.13.0)
@@ -125,6 +137,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -160,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 

--- a/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -138,6 +138,14 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.1.0)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.10)
     unicode-display_width (2.1.0)
@@ -190,6 +198,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 

--- a/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -138,6 +138,14 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.1.0)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.10)
     unicode-display_width (2.1.0)
@@ -190,6 +198,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 

--- a/gemfiles/ruby_2.4.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_sinatra.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -129,6 +129,14 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.1.0)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     unicode-display_width (2.3.0)
@@ -179,6 +187,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   simplecov (~> 0.17)
   sinatra
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   webmock (>= 3.10.0)
   yard (~> 0.9)
 

--- a/gemfiles/ruby_2.5.9_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -1620,9 +1620,17 @@ GEM
       rake (~> 12.3)
       serverengine (~> 2.1.0)
       thor
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sqlite3 (1.4.2)
     sucker_punch (3.0.1)
       concurrent-ruby (~> 1.0)
@@ -1725,6 +1733,8 @@ DEPENDENCIES
   sidekiq
   simplecov!
   sneakers (>= 2.12.0)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sqlite3 (~> 1.4.1)
   sucker_punch
   typhoeus

--- a/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -178,6 +178,14 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     statsd-ruby (1.5.0)
     thin (1.8.1)
       daemons (~> 1.0, >= 1.0.9)
@@ -240,6 +248,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.5.9_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -123,6 +123,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.1.0)
     warning (1.2.1)
@@ -171,6 +179,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -143,6 +143,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.1.0)
     warning (1.2.1)
@@ -192,6 +200,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -169,6 +169,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.2.1)
@@ -224,6 +232,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -169,6 +169,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.2.1)
@@ -224,6 +232,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.5.9_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -203,6 +203,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     transproc (1.1.1)
@@ -258,6 +266,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -222,6 +222,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -288,6 +296,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -222,6 +222,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -288,6 +296,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -223,6 +223,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -290,6 +298,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -239,6 +239,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -307,6 +315,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -228,6 +228,14 @@ GEM
       redis (>= 4.2.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -296,6 +304,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   sidekiq
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -221,6 +221,14 @@ GEM
       concurrent-ruby (~> 1.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -287,6 +295,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -241,6 +241,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -307,6 +315,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -241,6 +241,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -307,6 +315,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -242,6 +242,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -309,6 +317,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -247,6 +247,14 @@ GEM
       redis (>= 4.2.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -314,6 +322,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   sidekiq (>= 6.1.2)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -240,6 +240,14 @@ GEM
       concurrent-ruby (~> 1.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -306,6 +314,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -237,6 +237,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -304,6 +312,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -237,6 +237,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -304,6 +312,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -238,6 +238,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -306,6 +314,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -254,6 +254,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -323,6 +331,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -243,6 +243,14 @@ GEM
       redis (>= 4.2.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -312,6 +320,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   sidekiq
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -236,6 +236,14 @@ GEM
       concurrent-ruby (~> 1.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -303,6 +311,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.5.9_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -47,11 +47,15 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.21.9)
+    google-protobuf (3.21.9-x86_64-linux)
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -120,6 +124,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -133,6 +145,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -168,6 +181,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.5.9_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -47,11 +47,15 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.21.9)
+    google-protobuf (3.21.9-x86_64-linux)
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -120,6 +124,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -133,6 +145,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -168,6 +181,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.5.9_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -48,11 +48,15 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.21.9)
+    google-protobuf (3.21.9-x86_64-linux)
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -124,6 +128,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -137,6 +149,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -172,6 +185,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -144,6 +144,14 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.2.0)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.10)
     unicode-display_width (2.1.0)
@@ -195,6 +203,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -144,6 +144,14 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.2.0)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.10)
     unicode-display_width (2.1.0)
@@ -195,6 +203,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.5.9_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -136,6 +136,14 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.2.2)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     unicode-display_width (2.3.0)
@@ -187,6 +195,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   simplecov!
   sinatra
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.6.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -1682,9 +1682,17 @@ GEM
       rake (~> 12.3)
       serverengine (~> 2.1.0)
       thor
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sqlite3 (1.4.4)
     sucker_punch (3.1.0)
       concurrent-ruby (~> 1.0)
@@ -1787,6 +1795,8 @@ DEPENDENCIES
   sidekiq (~> 6.4.1)
   simplecov!
   sneakers (>= 2.12.0)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sqlite3 (~> 1.4.1)
   sucker_punch
   typhoeus

--- a/gemfiles/ruby_2.6.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -182,6 +182,14 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     statsd-ruby (1.5.0)
     thin (1.8.1)
       daemons (~> 1.0, >= 1.0.9)
@@ -244,6 +252,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.6.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -127,6 +127,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -175,6 +183,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.6.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -147,6 +147,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -196,6 +204,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.6.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -173,6 +173,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.2.1)
@@ -228,6 +236,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.6.10_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -173,6 +173,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.2.1)
@@ -228,6 +236,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.6.10_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -207,6 +207,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     transproc (1.1.1)
@@ -262,6 +270,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.6.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -224,6 +224,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -289,6 +297,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -224,6 +224,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -289,6 +297,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -225,6 +225,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -291,6 +299,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -241,6 +241,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -309,6 +317,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -230,6 +230,14 @@ GEM
       redis (>= 4.5.0, < 5)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -297,6 +305,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   sidekiq
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -223,6 +223,14 @@ GEM
       concurrent-ruby (~> 1.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -288,6 +296,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -243,6 +243,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -308,6 +316,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -243,6 +243,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -308,6 +316,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -244,6 +244,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -310,6 +318,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -249,6 +249,14 @@ GEM
       redis (>= 4.5.0, < 5)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -315,6 +323,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   sidekiq (>= 6.1.2)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -242,6 +242,14 @@ GEM
       concurrent-ruby (~> 1.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -307,6 +315,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -239,6 +239,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -305,6 +313,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -239,6 +239,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -305,6 +313,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -240,6 +240,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -307,6 +315,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -256,6 +256,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -325,6 +333,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -245,6 +245,14 @@ GEM
       redis (>= 4.5.0, < 5)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -313,6 +321,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   sidekiq
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -238,6 +238,14 @@ GEM
       concurrent-ruby (~> 1.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -304,6 +312,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.6.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.21.9)
+    google-protobuf (3.21.9-x86_64-linux)
     hashdiff (1.0.1)
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -124,6 +128,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -137,6 +149,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -172,6 +185,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.6.10_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.21.9)
+    google-protobuf (3.21.9-x86_64-linux)
     hashdiff (1.0.1)
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -124,6 +128,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -137,6 +149,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -172,6 +185,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.6.10_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.21.9)
+    google-protobuf (3.21.9-x86_64-linux)
     hashdiff (1.0.1)
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -128,6 +132,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -141,6 +153,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -176,6 +189,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.6.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -148,6 +148,14 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.0.3)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     unicode-display_width (2.3.0)
@@ -199,6 +207,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.6.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -148,6 +148,14 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.0.3)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     unicode-display_width (2.3.0)
@@ -199,6 +207,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.6.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -140,6 +140,14 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.0.3)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10461)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     unicode-display_width (2.3.0)
@@ -191,6 +199,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   simplecov!
   sinatra (>= 3)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.7.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -1684,9 +1684,17 @@ GEM
       rake (~> 12.3)
       serverengine (~> 2.1.0)
       thor
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sqlite3 (1.4.4)
     sucker_punch (3.1.0)
       concurrent-ruby (~> 1.0)
@@ -1785,6 +1793,8 @@ DEPENDENCIES
   sidekiq (~> 6)
   simplecov!
   sneakers (>= 2.12.0)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sqlite3 (~> 1.4.1)
   sucker_punch
   typhoeus

--- a/gemfiles/ruby_2.7.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -182,6 +182,14 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     statsd-ruby (1.5.0)
     thin (1.8.1)
       daemons (~> 1.0, >= 1.0.9)
@@ -244,6 +252,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.7.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -127,6 +127,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -175,6 +183,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.7.6_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -147,6 +147,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -196,6 +204,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.7.6_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -172,6 +172,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.2.1)
@@ -226,6 +234,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.7.6_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -172,6 +172,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.2.1)
@@ -226,6 +234,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.7.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_hanami_1.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -211,6 +211,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     transproc (1.1.1)
@@ -268,6 +276,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.7.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -224,6 +224,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -288,6 +296,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -224,6 +224,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -288,6 +296,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -225,6 +225,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -290,6 +298,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -241,6 +241,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -308,6 +316,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -233,6 +233,14 @@ GEM
       redis (>= 4.2.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -299,6 +307,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   sidekiq (~> 6)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -223,6 +223,14 @@ GEM
       concurrent-ruby (~> 1.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -287,6 +295,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -243,6 +243,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -307,6 +315,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -243,6 +243,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -307,6 +315,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -244,6 +244,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -309,6 +317,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -251,6 +251,14 @@ GEM
       redis-client (>= 0.9.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -316,6 +324,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   sidekiq (>= 6.1.2)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -242,6 +242,14 @@ GEM
       concurrent-ruby (~> 1.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -306,6 +314,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -239,6 +239,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -304,6 +312,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -239,6 +239,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -304,6 +312,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -240,6 +240,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -306,6 +314,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -256,6 +256,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -324,6 +332,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -248,6 +248,14 @@ GEM
       redis (>= 4.2.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -315,6 +323,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   sidekiq (~> 6)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -238,6 +238,14 @@ GEM
       concurrent-ruby (~> 1.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -303,6 +311,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_2.7.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.21.9)
+    google-protobuf (3.21.9-x86_64-linux)
     hashdiff (1.0.1)
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -124,6 +128,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -137,6 +149,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -172,6 +185,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.7.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.21.9)
+    google-protobuf (3.21.9-x86_64-linux)
     hashdiff (1.0.1)
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -124,6 +128,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -137,6 +149,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -172,6 +185,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.7.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.21.9)
+    google-protobuf (3.21.9-x86_64-linux)
     hashdiff (1.0.1)
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -128,6 +132,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -141,6 +153,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -176,6 +189,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.7.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -148,6 +148,14 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.0.3)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     unicode-display_width (2.3.0)
@@ -199,6 +207,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.7.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -148,6 +148,14 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.0.3)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     unicode-display_width (2.3.0)
@@ -199,6 +207,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -143,6 +143,14 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.0.3)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     unicode-display_width (2.3.0)
@@ -195,6 +203,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   simplecov!
   sinatra (>= 3)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/ruby_3.0.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -1668,9 +1668,17 @@ GEM
       rake (~> 12.3)
       serverengine (~> 2.1.0)
       thor
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sqlite3 (1.5.4-aarch64-linux)
     sqlite3 (1.5.4-x86_64-linux)
     sucker_punch (3.1.0)
@@ -1773,6 +1781,8 @@ DEPENDENCIES
   sidekiq (~> 6)
   simplecov!
   sneakers (>= 2.12.0)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sqlite3 (>= 1.4.2)
   sucker_punch
   typhoeus

--- a/gemfiles/ruby_3.0.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -182,6 +182,14 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     statsd-ruby (1.5.0)
     thin (1.8.1)
       daemons (~> 1.0, >= 1.0.9)
@@ -243,6 +251,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.0.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -127,6 +127,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -175,6 +183,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.0.4_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -147,6 +147,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -196,6 +204,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.0.4_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -172,6 +172,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.2.1)
@@ -226,6 +234,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.0.4_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -172,6 +172,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.2.1)
@@ -226,6 +234,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.0.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -247,6 +247,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -314,6 +322,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_3.0.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -247,6 +247,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -314,6 +322,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_3.0.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -248,6 +248,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -316,6 +324,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_3.0.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -261,6 +261,14 @@ GEM
       redis-client (>= 0.9.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -330,6 +338,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   sidekiq (>= 6.1.2)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_3.0.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -246,6 +246,14 @@ GEM
       concurrent-ruby (~> 1.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -313,6 +321,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_3.0.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.21.9)
+    google-protobuf (3.21.9-x86_64-linux)
     hashdiff (1.0.1)
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -124,6 +128,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -137,6 +149,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -172,6 +185,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.0.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.21.9)
+    google-protobuf (3.21.9-x86_64-linux)
     hashdiff (1.0.1)
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -124,6 +128,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -137,6 +149,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -172,6 +185,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.0.4_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.21.9)
+    google-protobuf (3.21.9-x86_64-linux)
     hashdiff (1.0.1)
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -128,6 +132,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -141,6 +153,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -176,6 +189,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.0.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -148,6 +148,14 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.0.3)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     unicode-display_width (2.3.0)
@@ -199,6 +207,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.0.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -152,6 +152,14 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.0.3)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     unicode-display_width (2.3.0)
@@ -203,6 +211,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.0.4_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -140,6 +140,14 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.0.3)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     unicode-display_width (2.3.0)
@@ -191,6 +199,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   simplecov!
   sinatra (>= 3)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.1.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -1611,9 +1611,17 @@ GEM
       rake (~> 12.3)
       serverengine (~> 2.1.0)
       thor
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sqlite3 (1.4.2)
     sucker_punch (3.0.1)
       concurrent-ruby (~> 1.0)
@@ -1714,6 +1722,8 @@ DEPENDENCIES
   sidekiq (~> 6)
   simplecov!
   sneakers (>= 2.12.0)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sqlite3 (>= 1.4.2)
   sucker_punch
   typhoeus

--- a/gemfiles/ruby_3.1.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -179,6 +179,14 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     statsd-ruby (1.5.0)
     thin (1.8.1)
       daemons (~> 1.0, >= 1.0.9)
@@ -240,6 +248,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.1.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -124,6 +124,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.1.0)
     warning (1.2.1)
@@ -172,6 +180,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.1.2_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -144,6 +144,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.1.0)
     warning (1.2.1)
@@ -193,6 +201,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.1.2_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -170,6 +170,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.2.1)
@@ -224,6 +232,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.1.2_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -170,6 +170,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.2.1)
@@ -224,6 +232,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.1.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -249,6 +249,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -316,6 +324,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_3.1.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -249,6 +249,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -316,6 +324,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_3.1.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -250,6 +250,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -318,6 +326,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_3.1.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -261,6 +261,14 @@ GEM
       redis (>= 4.2.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -330,6 +338,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   sidekiq (>= 6.1.2)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_3.1.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -248,6 +248,14 @@ GEM
       concurrent-ruby (~> 1.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -315,6 +323,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/ruby_3.1.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.21.9)
+    google-protobuf (3.21.9-x86_64-linux)
     hashdiff (1.0.1)
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -124,6 +128,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -137,6 +149,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -172,6 +185,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.1.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -48,12 +48,16 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.21.9)
+    google-protobuf (3.21.9-x86_64-linux)
     hashdiff (1.0.1)
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -124,6 +128,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -137,6 +149,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -172,6 +185,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.1.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -49,12 +49,16 @@ GEM
     extlz4 (0.3.3)
     ffi (1.15.5)
     google-protobuf (3.21.9)
+    google-protobuf (3.21.9-x86_64-linux)
     hashdiff (1.0.1)
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
     libdatadog (0.9.0.1.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -128,6 +132,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -141,6 +153,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -176,6 +189,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.1.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -145,6 +145,14 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.2.0)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.10)
     unicode-display_width (2.1.0)
@@ -196,6 +204,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.1.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -145,6 +145,14 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.2.0)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.10)
     unicode-display_width (2.1.0)
@@ -196,6 +204,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.1.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -140,6 +140,14 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.0.2)
       tilt (~> 2.0)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     tilt (2.0.11)
     unicode-display_width (2.3.0)
@@ -191,6 +199,8 @@ DEPENDENCIES
   ruby-prof (~> 1.4)
   simplecov!
   sinatra (>= 3)
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_core_old.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_5.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/gemfiles/ruby_3.2.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_sinatra.gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ..
   specs:
-    ddtrace (1.7.0)
+    ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
       libdatadog (~> 0.9.0.1.0)
       libddwaf (~> 1.5.1.0.0)
@@ -46,13 +46,13 @@ GEM
     dogstatsd-ruby (5.5.0)
     extlz4 (0.3.3)
     ffi (1.15.5)
-    google-protobuf (3.21.10)
+    google-protobuf (3.21.12)
     hashdiff (1.0.1)
-    json (2.6.2)
+    json (2.6.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0-aarch64-linux)
-    libddwaf (1.5.1.0.0-aarch64-linux)
+    libdatadog (0.9.0.1.0-x86_64-linux)
+    libddwaf (1.5.1.0.0-x86_64-linux)
       ffi (~> 1.0)
     memory_profiler (0.9.14)
     method_source (1.0.0)
@@ -87,7 +87,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -119,6 +119,14 @@ GEM
     ruby-progressbar (1.11.0)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sorbet (0.5.9672)
+      sorbet-static (= 0.5.9672)
+    sorbet-runtime (0.5.10588)
+    sorbet-static (0.5.9672-x86_64-linux)
+    spoom (1.1.13)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     thor (1.2.1)
     unicode-display_width (2.3.0)
     warning (1.3.0)
@@ -131,7 +139,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
-  aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   addressable (~> 2.4.0)
@@ -165,6 +173,8 @@ DEPENDENCIES
   rubocop-rspec (~> 2.2)
   ruby-prof (~> 1.4)
   simplecov!
+  sorbet (= 0.5.9672)
+  spoom (~> 1.1)
   warning (~> 1)
   webmock (>= 3.10.0)
   webrick (>= 1.7.0)

--- a/lib/ddtrace/version.rb
+++ b/lib/ddtrace/version.rb
@@ -3,7 +3,7 @@
 module DDTrace
   module VERSION
     MAJOR = 1
-    MINOR = 7
+    MINOR = 8
     PATCH = 0
     PRE = nil
 


### PR DESCRIPTION
**What does this PR do?**:

This PR sets up the 1.8.0 release. It includes the version bump, the changelog update, and the usual gemfiles refresh.

**Motivation**:

Release 1.8.0 :)

**Additional Notes**:

(N/A)

**How to test the change?**:

No code changes in this PR! Check that CI is still green.
