### PR TITLE
Add 'type' to OptionDefinition

### DIFF
--- a/lib/datadog/core/configuration/base.rb
+++ b/lib/datadog/core/configuration/base.rb
@@ -32,10 +32,13 @@ module Datadog
             option(name) do |o|
               o.default { settings_class.new }
               o.lazy
+
               o.resetter do |value|
                 value.reset! if value.respond_to?(:reset!)
                 value
               end
+
+              o.type settings_class
             end
           end
 

--- a/lib/datadog/core/configuration/option_definition.rb
+++ b/lib/datadog/core/configuration/option_definition.rb
@@ -17,7 +17,8 @@ module Datadog
           :name,
           :on_set,
           :resetter,
-          :setter
+          :setter,
+          :type
 
         def initialize(name, meta = {}, &block)
           @default = meta[:default]
@@ -28,6 +29,7 @@ module Datadog
           @on_set = meta[:on_set]
           @resetter = meta[:resetter]
           @setter = meta[:setter] || block || IDENTITY
+          @type = meta[:type]
         end
 
         # Creates a new Option, bound to the context provided.
@@ -51,6 +53,7 @@ module Datadog
             @on_set = nil
             @resetter = nil
             @setter = OptionDefinition::IDENTITY
+            @type = nil
 
             # If options were supplied, apply them.
             apply_options!(options)
@@ -91,6 +94,10 @@ module Datadog
             @setter = block
           end
 
+          def type(value = nil)
+            @type = value
+          end
+
           # For applying options for OptionDefinition
           def apply_options!(options = {})
             return if options.nil? || options.empty?
@@ -102,6 +109,7 @@ module Datadog
             on_set(&options[:on_set]) if options.key?(:on_set)
             resetter(&options[:resetter]) if options.key?(:resetter)
             setter(&options[:setter]) if options.key?(:setter)
+            type(&options[:type]) if options.key?(:type)
           end
 
           def to_definition
@@ -116,7 +124,8 @@ module Datadog
               lazy: @lazy,
               on_set: @on_set,
               resetter: @resetter,
-              setter: @setter
+              setter: @setter,
+              type: @type
             }
           end
         end

--- a/spec/datadog/core/configuration/base_spec.rb
+++ b/spec/datadog/core/configuration/base_spec.rb
@@ -27,11 +27,23 @@ RSpec.describe Datadog::Core::Configuration::Base do
 
             it { is_expected.to be_a_kind_of(Datadog::Core::Configuration::OptionDefinition) }
 
+            it 'sets default properties' do
+              expect(definition.type).to be_a_kind_of(Class)
+              expect(definition.type.ancestors).to include(described_class)
+
+              is_expected.to have_attributes(
+                default: kind_of(Proc),
+                lazy: true,
+                resetter: kind_of(Proc)
+              )
+            end
+
             describe 'when instantiated' do
               subject(:option) { Datadog::Core::Configuration::Option.new(definition, self) }
+              let(:settings_object) { option.default_value }
 
-              it { expect(option.default_value).to be_a_kind_of(described_class) }
-              it { expect(option.default_value.option_defined?(:enabled)).to be true }
+              it { expect(settings_object).to be_a_kind_of(described_class) }
+              it { expect(settings_object.option_defined?(:enabled)).to be true }
             end
           end
         end

--- a/spec/datadog/core/configuration/option_definition_spec.rb
+++ b/spec/datadog/core/configuration/option_definition_spec.rb
@@ -138,6 +138,21 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition do
     end
   end
 
+  describe '#type' do
+    subject(:type) { definition.type }
+
+    context 'when given a value' do
+      let(:meta) { { type: type_value } }
+      let(:type_value) { double('type') }
+
+      it { is_expected.to be type_value }
+    end
+
+    context 'when not initialized' do
+      it { is_expected.to be nil }
+    end
+  end
+
   describe '#build' do
     subject(:build) { definition.build(context) }
 
@@ -184,7 +199,8 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
               name: name,
               on_set: nil,
               resetter: nil,
-              setter: Datadog::Core::Configuration::OptionDefinition::IDENTITY
+              setter: Datadog::Core::Configuration::OptionDefinition::IDENTITY,
+              type: nil
             )
           end
         end
@@ -329,6 +345,19 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
     it { is_expected.to be block }
   end
 
+  describe '#type' do
+    subject(:type) { builder.type(value) }
+
+    let(:value) { nil }
+
+    context 'given a value' do
+      let(:value) { String }
+
+      it { is_expected.to be value }
+      it { expect { type }.to change { builder.meta[:type] }.from(nil).to(value) }
+    end
+  end
+
   describe '#apply_options!' do
     subject(:apply_options!) { builder.apply_options!(options) }
 
@@ -444,7 +473,8 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
         :lazy,
         :on_set,
         :resetter,
-        :setter
+        :setter,
+        :type
       )
     end
   end


### PR DESCRIPTION
**What does this PR do?**

Adds a `type` field to `OptionDefinition`, which can be used to identify what kind of value the option should hold.

It also adds `type` to `settings` via to its `OptionDefinition`. `type` contains the auto-generated class used to encapsulate the option definitions contained within `settings`. Exposing this class allows you to metaprogram against an existing `settings`, such as adding or modifying option definitions.

**Motivation**

`type` allow for more descriptive option definitions, possibly type checking/coercion features later.

When creating `settings` options using the configuration DSL, it auto-generates an appropriate class with configuration behavior loaded. This class was entirely inaccessible, unless you instantiate the `settings` and its default value. Exposing `type` makes this class accessible without hacks.

**Additional Notes**

Also did a minor expansion on tests to encompass a bit more of the pre-existing behavior (adding coverage).