### PR TITLE
Move `agent.port` to `Tracing::Configuration::Settings`

### DIFF
--- a/lib/datadog/core/configuration/base.rb
+++ b/lib/datadog/core/configuration/base.rb
@@ -32,10 +32,13 @@ module Datadog
             option(name) do |o|
               o.default { settings_class.new }
               o.lazy
+
               o.resetter do |value|
                 value.reset! if value.respond_to?(:reset!)
                 value
               end
+
+              o.type settings_class
             end
           end
 

--- a/lib/datadog/core/configuration/option_definition.rb
+++ b/lib/datadog/core/configuration/option_definition.rb
@@ -17,7 +17,8 @@ module Datadog
           :name,
           :on_set,
           :resetter,
-          :setter
+          :setter,
+          :type
 
         def initialize(name, meta = {}, &block)
           @default = meta[:default]
@@ -28,6 +29,7 @@ module Datadog
           @on_set = meta[:on_set]
           @resetter = meta[:resetter]
           @setter = meta[:setter] || block || IDENTITY
+          @type = meta[:type]
         end
 
         # Creates a new Option, bound to the context provided.
@@ -51,6 +53,7 @@ module Datadog
             @on_set = nil
             @resetter = nil
             @setter = OptionDefinition::IDENTITY
+            @type = nil
 
             # If options were supplied, apply them.
             apply_options!(options)
@@ -91,6 +94,10 @@ module Datadog
             @setter = block
           end
 
+          def type(value = nil)
+            @type = value
+          end
+
           # For applying options for OptionDefinition
           def apply_options!(options = {})
             return if options.nil? || options.empty?
@@ -102,6 +109,7 @@ module Datadog
             on_set(&options[:on_set]) if options.key?(:on_set)
             resetter(&options[:resetter]) if options.key?(:resetter)
             setter(&options[:setter]) if options.key?(:setter)
+            type(&options[:type]) if options.key?(:type)
           end
 
           def to_definition
@@ -116,7 +124,8 @@ module Datadog
               lazy: @lazy,
               on_set: @on_set,
               resetter: @resetter,
-              setter: @setter
+              setter: @setter,
+              type: @type
             }
           end
         end

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -20,10 +20,6 @@ module Datadog
       class Settings
         include Base
 
-        # TODO: Tracing should manage its own settings.
-        #       Keep this extension here for now to keep things working.
-        extend Datadog::Tracing::Configuration::Settings
-
         # @!visibility private
         def initialize(*_)
           super
@@ -58,12 +54,6 @@ module Datadog
           # @default `DD_AGENT_HOST` environment variable, otherwise `127.0.0.1`
           # @return [String,nil]
           option :host
-
-          # Agent APM TCP port.
-          # @see https://docs.datadoghq.com/getting_started/tracing/#datadog-apm
-          # @default `DD_TRACE_AGENT_PORT` environment variable, otherwise `8126`
-          # @return [String,nil]
-          option :port
 
           # TODO: add declarative statsd configuration. Currently only usable via an environment variable.
           # Statsd configuration for agent access.
@@ -437,6 +427,10 @@ module Datadog
             o.lazy
           end
         end
+
+        # TODO: Tracing should manage its own settings.
+        #       Keep this extension here for now to keep things working.
+        extend Datadog::Tracing::Configuration::Settings
       end
       # rubocop:enable Metrics/BlockLength
     end

--- a/lib/datadog/tracing/configuration/settings.rb
+++ b/lib/datadog/tracing/configuration/settings.rb
@@ -420,6 +420,15 @@ module Datadog
                 o.lazy
               end
             end
+
+            agent_settings = options[:agent].type
+            agent_settings.class_eval do
+              # Agent APM TCP port.
+              # @see https://docs.datadoghq.com/getting_started/tracing/#datadog-apm
+              # @default `DD_TRACE_AGENT_PORT` environment variable, otherwise `8126`
+              # @return [String,nil]
+              option :port
+            end
           end
         end
       end

--- a/spec/datadog/core/configuration/base_spec.rb
+++ b/spec/datadog/core/configuration/base_spec.rb
@@ -27,11 +27,23 @@ RSpec.describe Datadog::Core::Configuration::Base do
 
             it { is_expected.to be_a_kind_of(Datadog::Core::Configuration::OptionDefinition) }
 
+            it 'sets default properties' do
+              expect(definition.type).to be_a_kind_of(Class)
+              expect(definition.type.ancestors).to include(described_class)
+
+              is_expected.to have_attributes(
+                default: kind_of(Proc),
+                lazy: true,
+                resetter: kind_of(Proc)
+              )
+            end
+
             describe 'when instantiated' do
               subject(:option) { Datadog::Core::Configuration::Option.new(definition, self) }
+              let(:settings_object) { option.default_value }
 
-              it { expect(option.default_value).to be_a_kind_of(described_class) }
-              it { expect(option.default_value.option_defined?(:enabled)).to be true }
+              it { expect(settings_object).to be_a_kind_of(described_class) }
+              it { expect(settings_object.option_defined?(:enabled)).to be true }
             end
           end
         end

--- a/spec/datadog/core/configuration/option_definition_spec.rb
+++ b/spec/datadog/core/configuration/option_definition_spec.rb
@@ -138,6 +138,21 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition do
     end
   end
 
+  describe '#type' do
+    subject(:type) { definition.type }
+
+    context 'when given a value' do
+      let(:meta) { { type: type_value } }
+      let(:type_value) { double('type') }
+
+      it { is_expected.to be type_value }
+    end
+
+    context 'when not initialized' do
+      it { is_expected.to be nil }
+    end
+  end
+
   describe '#build' do
     subject(:build) { definition.build(context) }
 
@@ -184,7 +199,8 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
               name: name,
               on_set: nil,
               resetter: nil,
-              setter: Datadog::Core::Configuration::OptionDefinition::IDENTITY
+              setter: Datadog::Core::Configuration::OptionDefinition::IDENTITY,
+              type: nil
             )
           end
         end
@@ -329,6 +345,19 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
     it { is_expected.to be block }
   end
 
+  describe '#type' do
+    subject(:type) { builder.type(value) }
+
+    let(:value) { nil }
+
+    context 'given a value' do
+      let(:value) { String }
+
+      it { is_expected.to be value }
+      it { expect { type }.to change { builder.meta[:type] }.from(nil).to(value) }
+    end
+  end
+
   describe '#apply_options!' do
     subject(:apply_options!) { builder.apply_options!(options) }
 
@@ -444,7 +473,8 @@ RSpec.describe Datadog::Core::Configuration::OptionDefinition::Builder do
         :lazy,
         :on_set,
         :resetter,
-        :setter
+        :setter,
+        :type
       )
     end
   end

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -928,26 +928,6 @@ RSpec.describe Datadog::Core::Configuration::Settings do
           .to(host)
       end
     end
-
-    # TODO: Migrate this to Tracing
-    describe '#tracer' do
-      describe '#port' do
-        subject(:port) { settings.agent.port }
-
-        it { is_expected.to be nil }
-      end
-
-      describe '#port=' do
-        let(:port) { 1234 }
-
-        it 'updates the #port setting' do
-          expect { settings.agent.port = port }
-            .to change { settings.agent.port }
-            .from(nil)
-            .to(port)
-        end
-      end
-    end
   end
 
   describe '#version' do

--- a/spec/datadog/tracing/configuration/settings_spec.rb
+++ b/spec/datadog/tracing/configuration/settings_spec.rb
@@ -14,10 +14,31 @@ require 'datadog/tracing/writer'
 RSpec.describe Datadog::Tracing::Configuration::Settings do
   # TODO: Core::Configuration::Settings directly extends Tracing::Configuration::Settings
   #       In the future, have tracing add this behavior itself. For now,
-  #       just use the core metrics class to drive the tests.
+  #       just use the core settings class to drive the tests.
   subject(:settings) { Datadog::Core::Configuration::Settings.new(options) }
 
   let(:options) { {} }
+
+  describe '#agent' do
+    describe '#tracer' do
+      describe '#port' do
+        subject(:port) { settings.agent.port }
+
+        it { is_expected.to be nil }
+      end
+
+      describe '#port=' do
+        let(:port) { 1234 }
+
+        it 'updates the #port setting' do
+          expect { settings.agent.port = port }
+            .to change { settings.agent.port }
+            .from(nil)
+            .to(port)
+        end
+      end
+    end
+  end
 
   describe '#tracing' do
     describe '#analytics' do


### PR DESCRIPTION
**What does this PR do?**

Moves `agent.port` setting to `Tracing::Configuration::Settings`.

To do this, it decorates the `agent` settings defined in `Core::Settings` with `port`, thus preserving existing functionality.

**Motivation**

I want to isolate tracing-specific features and supporting code within the `datadog/tracing` directory. This will reduce `Core`'s knowledge of `Tracing`, thereby reducing complexity.

**Additional Notes**

This should not contain any breaking changes, despite moving code from `Core` to `Tracing`.

Depends on #2493. Merge that first.
