### PR TITLE
Flexible header matching for HTTP propagator

### DIFF
--- a/lib/datadog/tracing/contrib/http/distributed/fetcher.rb
+++ b/lib/datadog/tracing/contrib/http/distributed/fetcher.rb
@@ -8,13 +8,20 @@ module Datadog
     module Contrib
       module HTTP
         module Distributed
-          # Retrieves Rack formatted headers from HTTP headers.
+          # Retrieves HTTP headers from carrier.
+          # Headers will also match if Rack-formatted:
+          # 'my-header' will match 'my-header' and 'HTTP_MY_HEADER'.
+          #
+          # In case both variants are present, the verbatim match will be used.
           class Fetcher < Tracing::Distributed::Fetcher
-            # TODO: Don't assume Rack format.
-            #       Make distributed tracing headers apathetic.
             # DEV: Should we try to parse both verbatim an Rack-formatted headers,
             # DEV: given Rack-formatted is the most common format in Ruby?
             def [](name)
+              # Try to fetch with the plain key
+              value = super(name)
+              return value if value && !value.empty?
+
+              # If not found, try the Rack-formatted key
               rack_header = "HTTP-#{name}"
               rack_header.upcase!
               rack_header.tr!('-'.freeze, '_'.freeze)

--- a/spec/datadog/tracing/contrib/http/distributed/fetcher_spec.rb
+++ b/spec/datadog/tracing/contrib/http/distributed/fetcher_spec.rb
@@ -29,14 +29,29 @@ RSpec.describe Datadog::Tracing::Contrib::HTTP::Distributed::Fetcher do
       context 'that is not empty' do
         let(:env) { { 'HTTP_MY_KEY' => 'value' } }
         it { is_expected.to eq('value') }
+
+        context 'and a plain header' do
+          let(:env) { super().merge('my-key' => 'plain-match') }
+
+          it 'prefers the plain header match' do
+            is_expected.to eq('plain-match')
+          end
+        end
       end
     end
 
-    context 'with a header not Rack formatted' do
-      let(:key) { 'my-key' }
-      let(:env) { { key => 'value' } }
+    context 'with a plain header associated' do
+      let(:key) { 'rack.session' }
 
-      it { is_expected.to be_nil }
+      context 'that is empty' do
+        let(:env) { { key => '' } }
+        it { is_expected.to be_nil }
+      end
+
+      context 'that is not empty' do
+        let(:env) { { key => 'value' } }
+        it { is_expected.to eq('value') }
+      end
     end
   end
 end


### PR DESCRIPTION
While working with OpenTelemetry, I noticed their propagator is flexible when working with [Rack HTTP headers](https://github.com/rack/rack/blob/a7d56490fd2fb41de8c94ead2f63fbad71c5c489/SPEC.rdoc?plain=1#L63-L73).

Our HTTP propagator has always only matched headers that are formatted as `HTTP_MY_HEADER_NAME`. This means it was not possible to perform simple matches, like `my-header-name`.

Because it's possible to do both at the same time with almost guarantee safety, this PR does that.

The only conflicting case is if both `my-header-name` and `HTTP_MY_HEADER_NAME` are present in the environment. In such case, we prefer to perform the exact match: `my-header-name`.

I believe this will have no effect on current users.