### PR TITLE
Lock gem upgrade version for integration tests

### DIFF
--- a/integration/images/ruby/2.3/Dockerfile
+++ b/integration/images/ruby/2.3/Dockerfile
@@ -40,11 +40,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 3.3.26
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 3.3.26
 RUN gem install bundler
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 

--- a/integration/images/ruby/2.4/Dockerfile
+++ b/integration/images/ruby/2.4/Dockerfile
@@ -40,11 +40,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 3.3.26
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 3.3.26
 RUN gem install bundler
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 

--- a/integration/images/ruby/2.5/Dockerfile
+++ b/integration/images/ruby/2.5/Dockerfile
@@ -40,11 +40,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 3.3.26
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 3.3.26
 RUN gem install bundler
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 

--- a/integration/images/ruby/2.6/Dockerfile
+++ b/integration/images/ruby/2.6/Dockerfile
@@ -40,11 +40,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 3.4.1
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 3.4.1
 RUN gem install bundler
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 

--- a/integration/images/ruby/2.7/Dockerfile
+++ b/integration/images/ruby/2.7/Dockerfile
@@ -40,11 +40,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 3.4.1
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 3.4.1
 RUN gem install bundler
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 

--- a/integration/images/ruby/3.0/Dockerfile
+++ b/integration/images/ruby/3.0/Dockerfile
@@ -40,11 +40,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 3.4.1
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Upgrade RubyGems and Bundler
-RUN gem update --system
+RUN gem update --system 3.4.1
 RUN gem install bundler
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 

--- a/integration/images/ruby/3.1/Dockerfile
+++ b/integration/images/ruby/3.1/Dockerfile
@@ -40,11 +40,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 3.4.1
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Upgrade RubyGems and Bundler
-RUN gem update --system
+RUN gem update --system 3.4.1
 RUN gem install bundler
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 

--- a/integration/images/ruby/3.2/Dockerfile
+++ b/integration/images/ruby/3.2/Dockerfile
@@ -41,11 +41,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 3.4.1
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Upgrade RubyGems and Bundler
-RUN gem update --system
+RUN gem update --system 3.4.1
 RUN gem install bundler
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 


### PR DESCRIPTION
With the release of RubyGems 3.4.0, `gem update --system` gets confused in older versions of Ruby and tries to install the latest version, which is [not compatible with older rubies](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/8440/workflows/f4589780-3c72-4dd4-810e-af908e9d6da3/jobs/313812):
```
Step 8/15 : RUN gem update --system
 ---> Running in f24e823e31e6
ERROR:  Error installing rubygems-update:
	There are no versions of rubygems-update (= 3.4.1) compatible with your Ruby & RubyGems
	rubygems-update requires Ruby version >= 2.6.0. The current ruby version is 2.5.9.229.
```

This PR locks the version of RubyGems we upgrade to in each integration test environment.