### PR TITLE
Action:Upgrade setup-ruby to fix bundler version matching

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@6148f408d35df04b0189be5e64c1458377b8ae13 # v1.114.0
+      - uses: ruby/setup-ruby@03b78bdda287ae04217ee12e4b64996630a03542 # v1.131.0
         with:
           ruby-version: '3.1'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/test-head.yaml
+++ b/.github/workflows/test-head.yaml
@@ -17,7 +17,7 @@ jobs:
       # want the former only. relax the constraint to allow any version for
       # head rubies
       - run: sed -i~ -e '/spec\.required_ruby_version/d' ddtrace.gemspec
-      - uses: ruby/setup-ruby@6148f408d35df04b0189be5e64c1458377b8ae13 # v1.114.0
+      - uses: ruby/setup-ruby@03b78bdda287ae04217ee12e4b64996630a03542 # v1.131.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -31,7 +31,7 @@ jobs:
       # head rubies
       - if: ${{ matrix.ruby == 'head' }}
         run: sed -i~ -e '/spec\.required_ruby_version/d' ddtrace.gemspec
-      - uses: ruby/setup-ruby@6148f408d35df04b0189be5e64c1458377b8ae13 # v1.114.0
+      - uses: ruby/setup-ruby@03b78bdda287ae04217ee12e4b64996630a03542 # v1.131.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
Upgrade to release https://github.com/ruby/setup-ruby/releases/tag/v1.131.0, titled "Use the correct Bundler version depending on the target Ruby version".

This should fix our GitHub Action CI failures due to bundler version mismatches.