### PR TITLE
Move to Ruby 3.2.0 final

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,8 +529,8 @@ job_configuration:
     resource_class_to_use: medium+
   - &config-3_2
     <<: *filters_all_branches_and_tags
-    ruby_version: 'ruby-3.2.0-preview3'
-    image: ghcr.io/datadog/dd-trace-rb/ruby:3.2.0-preview3-dd
+    ruby_version: 'ruby-3.2.0'
+    image: ghcr.io/datadog/dd-trace-rb/ruby:3.2.0-dd
     resource_class_to_use: medium+
     # ADD NEW RUBIES HERE
   - &config-jruby-9_2_8_0 # Test with older 9.2 release because 9.2.9.0 changed behavior, see https://github.com/DataDog/dd-trace-rb/pull/1409

--- a/.circleci/images/primary/Dockerfile-3.2.0
+++ b/.circleci/images/primary/Dockerfile-3.2.0
@@ -1,4 +1,4 @@
-FROM ruby:3.2.0-preview3-bullseye
+FROM ruby:3.2.0-bullseye
 
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \

--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -49,8 +49,8 @@ jobs:
             version: 3.1.2
             dockerfile: Dockerfile-3.1.2
           - engine: ruby
-            version: 3.2.0-preview3
-            dockerfile: Dockerfile-3.2.0-preview3
+            version: 3.2.0
+            dockerfile: Dockerfile-3.2.0
           - engine: jruby
             version: 9.2.21.0
             dockerfile: Dockerfile-jruby-9.2.21.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,7 +225,7 @@ services:
       - bundle-3.1:/usr/local/bundle
       - "ddagent_var_run:${TEST_DDAGENT_VAR_RUN}"
   tracer-3.2:
-    image: ghcr.io/datadog/dd-trace-rb/ruby:3.2.0-preview3-dd
+    image: ghcr.io/datadog/dd-trace-rb/ruby:3.2.0-dd
     command: /bin/bash
     depends_on:
       - ddagent


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Move from the preview ruby image to the final one.

**Motivation**

So we can base ourselves on the latest thing to make things pass.

**Additional Notes**

CircleCI test is still disabled as tests don't pass yet, so we can change that right away as well without caring about the image being published.

**How to test the change?**

This should build the image in CI. As always publishing is done later.

Image can also be built locally as always, and then tested using docker compose:

```
docker buildx build . --platform linux/$(uname -m | sed 's/arm64/aarch64/') -f Dockerfile-3.1.1 -t ghcr.io/datadog/dd-trace-rb/ruby:3.1.1-dd
docker-compose run --rm tracer-3.2 /bin/bash
```