### PR TITLE
Add event kit API

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -2,6 +2,10 @@ target :appsec do
   signature "sig"
 
   check "lib/datadog/appsec"
+
+  # TODO: disabled because of https://github.com/soutaro/steep/issues/701
+  # check "lib/datadog/kit"
+
   ignore "lib/datadog/appsec/contrib"
 
   library "pathname", "set"

--- a/lib/datadog/kit/enable_core_dumps.rb
+++ b/lib/datadog/kit/enable_core_dumps.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 module Datadog
   module Kit

--- a/lib/datadog/kit/events.rb
+++ b/lib/datadog/kit/events.rb
@@ -38,11 +38,14 @@ module Datadog
       # @param event [String] Mandatory. Event code.
       # @param trace [TraceOperation] Trace to attach data to.
       # @param others [Hash<Symbol, String>] Additional free-form
-      #   event information to attach to the trace.
+      #   event information to attach to the trace. Key must not
+      #   be :track.
       def self.track(event, trace, **others)
         trace.set_tag("appsec.events.#{event}.track", 'true')
 
         others.each do |k, v|
+          raise ArgumentError, 'key cannot be :track' if k.to_sym == :track
+
           trace.set_tag("appsec.events.#{event}.#{k}", v) unless v.nil?
         end
 

--- a/lib/datadog/kit/events.rb
+++ b/lib/datadog/kit/events.rb
@@ -1,4 +1,5 @@
 # typed: false
+# frozen_string_literal: true
 
 module Datadog
   module Kit

--- a/lib/datadog/kit/events.rb
+++ b/lib/datadog/kit/events.rb
@@ -1,0 +1,31 @@
+# typed: false
+
+module Datadog
+  module Kit
+    # Tracking events
+    module Events
+      def self.track_login(trace, id:, success:, **others)
+        subtag = success ? 'success' : 'failure'
+        event = "users.login.#{subtag}"
+
+        track(event, trace, **others)
+
+        if success
+          trace.set_tag('usr.id', id)
+        else
+          trace.set_tag("appsec.events.users.login.#{subtag}.usr.id", id)
+        end
+      end
+
+      def self.track(event, trace, **others)
+        trace.set_tag("appsec.events.#{event}.track", true)
+
+        others.each do |k, v|
+          trace.set_tag("appsec.events.#{event}.#{k}", v) unless v.nil?
+        end
+
+        trace.keep!
+      end
+    end
+  end
+end

--- a/lib/datadog/kit/events.rb
+++ b/lib/datadog/kit/events.rb
@@ -1,23 +1,44 @@
 # typed: false
 # frozen_string_literal: true
 
+require_relative 'identity'
+
 module Datadog
   module Kit
     # Tracking events
     module Events
-      def self.track_login(trace, id:, success:, **others)
+      # Attach login event information to the trace
+      #
+      # @param trace [TraceOperation] Trace to attach data to.
+      # @param success [bool] Whether login operation was successful or not.
+      # @param user [Hash<Symbol, String>] User information to pass to
+      #   Datadog::Kit::Identity.set_user. Must contain at least :id as key.
+      # @param others [Hash<String || Symbol, String>] Additional free-form
+      #   event information to attach to the trace.
+      def self.track_login(trace, success:, user:, **others)
         subtag = success ? 'success' : 'failure'
         event = "users.login.#{subtag}"
 
         track(event, trace, **others)
 
+        user_options = user.dup
+        user_id = user.delete(:id)
+
+        raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?
+
         if success
-          trace.set_tag('usr.id', id)
+          Kit::Identity.set_user(trace, id: user_id, **user_options)
         else
-          trace.set_tag("appsec.events.users.login.#{subtag}.usr.id", id)
+          trace.set_tag("appsec.events.users.login.#{subtag}.usr.id", user_id)
         end
       end
 
+      # Attach custom event information to the trace
+      #
+      # @param event [String] Mandatory. Event code.
+      # @param trace [TraceOperation] Trace to attach data to.
+      # @param others [Hash<Symbol, String>] Additional free-form
+      #   event information to attach to the trace.
       def self.track(event, trace, **others)
         trace.set_tag("appsec.events.#{event}.track", 'true')
 

--- a/lib/datadog/kit/events.rb
+++ b/lib/datadog/kit/events.rb
@@ -19,7 +19,7 @@ module Datadog
       end
 
       def self.track(event, trace, **others)
-        trace.set_tag("appsec.events.#{event}.track", true)
+        trace.set_tag("appsec.events.#{event}.track", 'true')
 
         others.each do |k, v|
           trace.set_tag("appsec.events.#{event}.#{k}", v) unless v.nil?

--- a/lib/datadog/kit/identity.rb
+++ b/lib/datadog/kit/identity.rb
@@ -1,4 +1,5 @@
 # typed: false
+# frozen_string_literal: true
 
 module Datadog
   module Kit

--- a/lib/datadog/kit/identity.rb
+++ b/lib/datadog/kit/identity.rb
@@ -23,7 +23,7 @@ module Datadog
       #   currently possesses extracted from token or application security
       #   context. The value would come from the scope associated with an OAuth
       #   2.0 Access Token or an attribute value in a SAML 2.0 Assertion.
-      # @param others [Hash<String || Symbol, String>] Additional free-form
+      # @param others [Hash<Symbol, String>] Additional free-form
       #   user information to attach to the trace.
       #
       # rubocop:disable Metrics/CyclomaticComplexity
@@ -33,12 +33,12 @@ module Datadog
 
         # enforce types
 
-        raise TypeError, 'id must be a String'         unless id.is_a?(String)
-        raise TypeError, 'email must be a String'      unless email.nil? || email.is_a?(String)
-        raise TypeError, 'name must be a String'       unless name.nil? || name.is_a?(String)
-        raise TypeError, 'session_id must be a String' unless session_id.nil? || session_id.is_a?(String)
-        raise TypeError, 'role must be a String'       unless role.nil? || role.is_a?(String)
-        raise TypeError, 'scope must be a String'      unless scope.nil? || scope.is_a?(String)
+        raise TypeError, ':id must be a String'         unless id.is_a?(String)
+        raise TypeError, ':email must be a String'      unless email.nil? || email.is_a?(String)
+        raise TypeError, ':name must be a String'       unless name.nil? || name.is_a?(String)
+        raise TypeError, ':session_id must be a String' unless session_id.nil? || session_id.is_a?(String)
+        raise TypeError, ':role must be a String'       unless role.nil? || role.is_a?(String)
+        raise TypeError, ':scope must be a String'      unless scope.nil? || scope.is_a?(String)
 
         others.each do |k, v|
           raise TypeError, "#{k.inspect} must be a String" unless v.nil? || v.is_a?(String)

--- a/sig/datadog/kit/enable_core_dumps.rbs
+++ b/sig/datadog/kit/enable_core_dumps.rbs
@@ -1,0 +1,11 @@
+module Datadog
+  module Kit
+    # This helper is used to enable core dumps for the current Ruby app. This is useful when debugging native-level
+    # crashes.
+    #
+    # It can be enabled simply by adding `require 'datadog/kit/enable_core_dumps'` to start of the app.
+    module EnableCoreDumps
+      def self.call: () -> (nil | untyped)
+    end
+  end
+end

--- a/sig/datadog/kit/events.rbs
+++ b/sig/datadog/kit/events.rbs
@@ -1,0 +1,10 @@
+module Datadog
+  module Kit
+    module Events
+      def self.track_login: (Datadog::Tracing::TraceOperation trace, id: ::String, success: bool, **::Hash[::String, ::Symbol | ::String] others) -> void
+
+      def self.track: (::String | ::Symbol event, Datadog::Tracing::TraceOperation trace, **::Hash[::String, ::Symbol | ::String] others) -> void
+    end
+  end
+end
+

--- a/sig/datadog/kit/events.rbs
+++ b/sig/datadog/kit/events.rbs
@@ -1,10 +1,9 @@
 module Datadog
   module Kit
     module Events
-      def self.track_login: (Datadog::Tracing::TraceOperation trace, id: ::String, success: bool, **::Hash[::String, ::Symbol | ::String] others) -> void
+      def self.track_login: (Datadog::Tracing::TraceOperation trace, success: bool, user: Hash[::Symbol, ::String | nil], **::Hash[::Symbol, ::String | nil] others) -> void
 
-      def self.track: (::String | ::Symbol event, Datadog::Tracing::TraceOperation trace, **::Hash[::String, ::Symbol | ::String] others) -> void
+      def self.track: (::String | ::Symbol event, Datadog::Tracing::TraceOperation trace, **::Hash[::Symbol, ::String | nil] others) -> void
     end
   end
 end
-

--- a/sig/datadog/kit/identity.rbs
+++ b/sig/datadog/kit/identity.rbs
@@ -1,0 +1,7 @@
+module Datadog
+  module Kit
+    module Identity
+      def self.set_user: (Datadog::Tracing::TraceOperation trace, id: ::String, ?email: ::String?, ?name: ::String?, ?session_id: ::String?, ?role: ::String?, ?scope: ::String?, **::Hash[::String, ::Symbol | ::String] others) -> void
+    end
+  end
+end

--- a/sig/datadog/kit/identity.rbs
+++ b/sig/datadog/kit/identity.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Kit
     module Identity
-      def self.set_user: (Datadog::Tracing::TraceOperation trace, id: ::String, ?email: ::String?, ?name: ::String?, ?session_id: ::String?, ?role: ::String?, ?scope: ::String?, **::Hash[::String, ::Symbol | ::String] others) -> void
+      def self.set_user: (Datadog::Tracing::TraceOperation trace, id: ::String, ?email: ::String?, ?name: ::String?, ?session_id: ::String?, ?role: ::String?, ?scope: ::String?, **::Hash[::Symbol, ::String | nil] others) -> void
     end
   end
 end

--- a/sig/datadog/tracing/event.rbs
+++ b/sig/datadog/tracing/event.rbs
@@ -1,0 +1,25 @@
+module Datadog
+  module Tracing
+    module Events
+      def self.included: (untyped base) -> untyped
+
+      module ClassMethods
+        def build: (**untyped event_handlers) -> untyped
+      end
+
+      module InstanceMethods
+        def subscribe: (**untyped event_handlers) -> (nil | untyped)
+      end
+    end
+
+    class Event
+      attr_reader name: untyped
+      attr_reader subscriptions: untyped
+
+      def initialize: (untyped name) -> void
+      def subscribe: () ?{ () -> untyped } -> untyped
+      def unsubscribe_all!: () -> true
+      def publish: (*untyped args) -> true
+    end
+  end
+end

--- a/sig/datadog/tracing/metadata/tagging.rbs
+++ b/sig/datadog/tracing/metadata/tagging.rbs
@@ -1,0 +1,23 @@
+module Datadog
+  module Tracing
+    module Metadata
+      module Tagging
+        NUMERIC_TAG_SIZE_RANGE: ::Range[untyped]
+        ENSURE_AGENT_TAGS: ::Hash[untyped, true]
+
+        def get_tag: (untyped key) -> untyped
+        def set_tag: (untyped key, ?untyped? value) -> untyped
+        def set_tags: (untyped tags) -> untyped
+        def has_tag?: (untyped tag) -> untyped
+        def clear_tag: (untyped key) -> untyped
+        alias []= set_tag
+        alias [] get_tag
+        def get_metric: (untyped key) -> untyped
+        def set_metric: (untyped key, untyped value) -> untyped
+        def clear_metric: (untyped key) -> untyped
+        def meta: () -> untyped
+        def metrics: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/tracing/trace_operation.rbs
+++ b/sig/datadog/tracing/trace_operation.rbs
@@ -1,0 +1,84 @@
+module Datadog
+  module Tracing
+    class TraceOperation
+      include Metadata::Tagging
+
+      DEFAULT_MAX_LENGTH: ::Integer
+
+      attr_accessor agent_sample_rate: untyped
+      attr_accessor hostname: untyped
+      attr_accessor origin: untyped
+      attr_accessor rate_limiter_rate: untyped
+      attr_accessor rule_sample_rate: untyped
+      attr_accessor sample_rate: untyped
+      attr_accessor sampling_priority: untyped
+      attr_reader active_span_count: untyped
+      attr_reader active_span: untyped
+      attr_reader id: untyped
+      attr_reader max_length: untyped
+      attr_reader parent_span_id: untyped
+      attr_writer name: untyped
+      attr_writer resource: untyped
+      attr_writer sampled: untyped
+      attr_writer service: untyped
+
+      def initialize: (?agent_sample_rate: untyped?, ?events: untyped?, ?hostname: untyped?, ?id: untyped?, ?max_length: untyped, ?name: untyped?, ?origin: untyped?, ?parent_span_id: untyped?, ?rate_limiter_rate: untyped?, ?resource: untyped?, ?rule_sample_rate: untyped?, ?sample_rate: untyped?, ?sampled: untyped?, ?sampling_priority: untyped?, ?service: untyped?, ?tags: untyped?, ?metrics: untyped?) -> void
+      def full?: () -> untyped
+      def finished_span_count: () -> untyped
+      def finished?: () -> untyped
+      def sampled?: () -> bool
+      def priority_sampled?: () -> bool
+      def keep!: () -> untyped
+      def reject!: () -> untyped
+      def name: () -> untyped
+      def resource: () -> untyped
+      def resource_override?: () -> bool
+      def service: () -> untyped
+      def measure: (untyped op_name, ?events: untyped?, ?on_error: untyped?, ?resource: untyped?, ?service: untyped?, ?start_time: untyped?, ?tags: untyped?, ?type: untyped?) { (untyped, untyped) -> untyped } -> untyped
+      def build_span: (untyped op_name, ?events: untyped?, ?on_error: untyped?, ?resource: untyped?, ?service: untyped?, ?start_time: untyped?, ?tags: untyped?, ?type: untyped?) -> untyped
+      def flush!: () { (untyped) -> untyped } -> untyped
+      def to_digest: () -> untyped
+      def fork_clone: () -> untyped
+
+      class Events
+        include Tracing::Events
+
+        attr_reader span_before_start: untyped
+        attr_reader span_finished: untyped
+        attr_reader trace_finished: untyped
+
+        def initialize: () -> void
+
+        class SpanBeforeStart < Tracing::Event
+          def initialize: () -> void
+        end
+
+        class SpanFinished < Tracing::Event
+          def initialize: () -> void
+        end
+
+        class TraceFinished < Tracing::Event
+          def initialize: () -> void
+
+          def deactivate_trace_subscribed?: () -> untyped
+          def subscribe_deactivate_trace: () ?{ () -> untyped } -> untyped
+        end
+      end
+
+      private
+
+      attr_reader events: untyped
+      attr_reader root_span: untyped
+
+      def activate_span!: (untyped span_op) -> untyped
+      def deactivate_span!: (untyped span_op) -> untyped
+      def start_span: (untyped span_op) -> untyped
+      def finish_span: (untyped span, untyped span_op, untyped parent) -> untyped
+
+      def set_root_span!: (untyped span) -> (nil | untyped)
+
+      def build_trace: (untyped spans, ?bool partial) -> untyped
+      def distributed_tags: () -> untyped
+    end
+  end
+end

--- a/sig/datadog/tracing/trace_segment.rbs
+++ b/sig/datadog/tracing/trace_segment.rbs
@@ -1,0 +1,72 @@
+module Datadog
+  module Tracing
+    class TraceSegment
+      TAG_NAME: ::String
+      TAG_RESOURCE: ::String
+      TAG_SERVICE: ::String
+
+      attr_reader id: untyped
+      attr_reader spans: untyped
+      attr_reader agent_sample_rate: untyped
+      attr_reader hostname: untyped
+      attr_reader lang: untyped
+      attr_reader name: untyped
+      attr_reader origin: untyped
+      attr_reader process_id: untyped
+      attr_reader rate_limiter_rate: untyped
+      attr_reader resource: untyped
+      attr_reader rule_sample_rate: untyped
+      attr_reader runtime_id: untyped
+      attr_reader sample_rate: untyped
+      attr_reader sampling_decision_maker: untyped
+      attr_reader sampling_priority: untyped
+      attr_reader service: untyped
+
+      def initialize: (untyped spans, ?agent_sample_rate: untyped?, ?hostname: untyped?, ?id: untyped?, ?lang: untyped?, ?name: untyped?, ?origin: untyped?, ?process_id: untyped?, ?rate_limiter_rate: untyped?, ?resource: untyped?, ?root_span_id: untyped?, ?rule_sample_rate: untyped?, ?runtime_id: untyped?, ?sample_rate: untyped?, ?sampling_priority: untyped?, ?service: untyped?, ?tags: untyped?, ?metrics: untyped?) -> void
+      def any?: () -> untyped
+      def count: () -> untyped
+      def empty?: () -> untyped
+      def length: () -> untyped
+      def size: () -> untyped
+
+      def keep!: () -> void
+      def reject!: () -> void
+      def sampled?: () -> untyped
+
+      attr_reader root_span_id: untyped
+      attr_reader meta: untyped
+      attr_reader metrics: untyped
+
+      private
+
+      attr_writer agent_sample_rate: untyped
+      attr_writer hostname: untyped
+      attr_writer lang: untyped
+      attr_writer name: untyped
+      attr_writer origin: untyped
+      attr_writer process_id: untyped
+      attr_writer rate_limiter_rate: untyped
+      attr_writer resource: untyped
+      attr_writer rule_sample_rate: untyped
+      attr_writer runtime_id: untyped
+      attr_writer sample_rate: untyped
+      attr_writer sampling_priority: untyped
+      attr_writer service: untyped
+
+      def agent_sample_rate_tag: () -> untyped
+      def hostname_tag: () -> untyped
+      def lang_tag: () -> untyped
+      def name_tag: () -> untyped
+      def origin_tag: () -> untyped
+      def process_id_tag: () -> untyped
+      def rate_limiter_rate_tag: () -> untyped
+      def resource_tag: () -> untyped
+      def rule_sample_rate_tag: () -> untyped
+      def runtime_id_tag: () -> untyped
+      def sample_rate_tag: () -> untyped
+      def sampling_decision_maker_tag: () -> untyped
+      def sampling_priority_tag: () -> untyped
+      def service_tag: () -> untyped
+    end
+  end
+end

--- a/spec/datadog/kit/events_spec.rb
+++ b/spec/datadog/kit/events_spec.rb
@@ -1,0 +1,84 @@
+# typed: ignore
+
+require 'spec_helper'
+
+require 'time'
+
+require 'datadog/tracing/trace_operation'
+require 'datadog/kit/events'
+
+RSpec.describe Datadog::Kit::Events do
+  subject(:trace_op) { Datadog::Tracing::TraceOperation.new }
+
+  describe '#track_login' do
+    context 'login success' do
+      it 'sets event tracking key on trace' do
+        trace_op.measure('root') do
+          described_class.track_login(trace_op, id: '42', success: true)
+        end
+        trace = trace_op.flush!
+        expect(trace.send(:meta)).to include('appsec.events.users.login.success.track' => 'true')
+      end
+
+      it 'sets user id on trace' do
+        trace_op.measure('root') do
+          described_class.track_login(trace_op, id: '42', success: true)
+        end
+        trace = trace_op.flush!
+        expect(trace.send(:meta)).to include('usr.id' => '42')
+      end
+
+      it 'sets other keys on trace' do
+        trace_op.measure('root') do
+          described_class.track_login(trace_op, id: '42', success: true, foo: 'bar')
+        end
+        trace = trace_op.flush!
+        expect(trace.send(:meta)).to include('usr.id' => '42', 'appsec.events.users.login.success.foo' => 'bar')
+      end
+    end
+
+    context 'login failure' do
+      it 'sets event tracking key on trace' do
+        trace_op.measure('root') do
+          described_class.track_login(trace_op, id: '42', success: false)
+        end
+        trace = trace_op.flush!
+        expect(trace.send(:meta)).to include('appsec.events.users.login.failure.track' => 'true')
+      end
+
+      it 'sets user id on trace' do
+        trace_op.measure('root') do
+          described_class.track_login(trace_op, id: '42', success: false)
+        end
+        trace = trace_op.flush!
+        expect(trace.send(:meta)).to include('appsec.events.users.login.failure.usr.id' => '42')
+      end
+
+      it 'sets other keys on trace' do
+        trace_op.measure('root') do
+          described_class.track_login(trace_op, id: '42', success: false, foo: 'bar')
+        end
+        trace = trace_op.flush!
+        expect(trace.send(:meta)).to include('appsec.events.users.login.failure.foo' => 'bar')
+      end
+    end
+  end
+
+  describe '#track' do
+    it 'sets event tracking key on trace' do
+      trace_op.measure('root') do
+        described_class.track('foo', trace_op)
+      end
+      trace = trace_op.flush!
+      expect(trace.send(:meta)).to include('appsec.events.foo.track' => 'true')
+    end
+
+    it 'sets other keys on trace' do
+      trace_op.measure('root') do
+        described_class.track('foo', trace_op, bar: 'baz')
+      end
+      trace = trace_op.flush!
+      expect(trace.send(:meta)).to include('appsec.events.foo.bar' => 'baz')
+    end
+  end
+end

--- a/spec/datadog/kit/events_spec.rb
+++ b/spec/datadog/kit/events_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Datadog::Kit::Events do
     context 'login success' do
       it 'sets event tracking key on trace' do
         trace_op.measure('root') do
-          described_class.track_login(trace_op, id: '42', success: true)
+          described_class.track_login(trace_op, user: { id: '42' }, success: true)
         end
         trace = trace_op.flush!
         expect(trace.send(:meta)).to include('appsec.events.users.login.success.track' => 'true')
@@ -22,7 +22,7 @@ RSpec.describe Datadog::Kit::Events do
 
       it 'sets user id on trace' do
         trace_op.measure('root') do
-          described_class.track_login(trace_op, id: '42', success: true)
+          described_class.track_login(trace_op, user: { id: '42' }, success: true)
         end
         trace = trace_op.flush!
         expect(trace.send(:meta)).to include('usr.id' => '42')
@@ -30,7 +30,7 @@ RSpec.describe Datadog::Kit::Events do
 
       it 'sets other keys on trace' do
         trace_op.measure('root') do
-          described_class.track_login(trace_op, id: '42', success: true, foo: 'bar')
+          described_class.track_login(trace_op, user: { id: '42' }, success: true, foo: 'bar')
         end
         trace = trace_op.flush!
         expect(trace.send(:meta)).to include('usr.id' => '42', 'appsec.events.users.login.success.foo' => 'bar')
@@ -40,7 +40,7 @@ RSpec.describe Datadog::Kit::Events do
     context 'login failure' do
       it 'sets event tracking key on trace' do
         trace_op.measure('root') do
-          described_class.track_login(trace_op, id: '42', success: false)
+          described_class.track_login(trace_op, user: { id: '42' }, success: false)
         end
         trace = trace_op.flush!
         expect(trace.send(:meta)).to include('appsec.events.users.login.failure.track' => 'true')
@@ -48,7 +48,7 @@ RSpec.describe Datadog::Kit::Events do
 
       it 'sets user id on trace' do
         trace_op.measure('root') do
-          described_class.track_login(trace_op, id: '42', success: false)
+          described_class.track_login(trace_op, user: { id: '42' }, success: false)
         end
         trace = trace_op.flush!
         expect(trace.send(:meta)).to include('appsec.events.users.login.failure.usr.id' => '42')
@@ -56,7 +56,7 @@ RSpec.describe Datadog::Kit::Events do
 
       it 'sets other keys on trace' do
         trace_op.measure('root') do
-          described_class.track_login(trace_op, id: '42', success: false, foo: 'bar')
+          described_class.track_login(trace_op, user: { id: '42' }, success: false, foo: 'bar')
         end
         trace = trace_op.flush!
         expect(trace.send(:meta)).to include('appsec.events.users.login.failure.foo' => 'bar')


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Implement event sugar API for users to emit either login events or custom business events to be tracked.

**Motivation**

These events are a key feature that Sqreen had and enabled higher level analysis and partially to fully automated security response.

**Additional Notes**

Just as with `Datadog::Kit::Identity#set_user` this looks like convenience syntactic sugar. Nonetheless, just as with `set_user`, wrapping the tag keys allows for these keys to evolve, or even the transport mechanism to change.

In addition, blocking may be handled and triggered, which is probably a feature we don't want in `set_tag`!

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

There are a bunch of specs added.
