### PR TITLE
Lint: Rubocop running out of memory in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,11 @@ step_bundle_install: &step_bundle_install
 step_rubocop: &step_rubocop
   run:
     name: Delint with Rubocop
-    command: bundle exec rake rubocop
+    # There's no straightforward way to get the number of available processors & CPU threads in CircleCI.
+    # Currently it always return 18 physical processors and 36 threads, regardless of executor size.
+    # The workaround is to use `cpu.shares / 1024`:
+    # https://discuss.circleci.com/t/environment-variable-set-to-the-number-of-available-cpus/32670/4
+    command: PARALLEL_PROCESSOR_COUNT=$((`cat /sys/fs/cgroup/cpu/cpu.shares` / 1024)) bundle exec rake rubocop
 step_sorbet_type_checker: &step_sorbet_type_checker
   run:
     name: Run sorbet type checker
@@ -559,7 +563,7 @@ workflows:
   build-and-test:
     jobs:
       - orb/lint:
-          <<: *config-2_7
+          <<: *config-2_7-small
           name: lint
           requires:
             - build-2.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -559,7 +559,7 @@ workflows:
   build-and-test:
     jobs:
       - orb/lint:
-          <<: *config-2_7-small
+          <<: *config-2_7
           name: lint
           requires:
             - build-2.7


### PR DESCRIPTION
The CI Rubocop job (`lint`) has been running at [99% memory recently](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/8450/workflows/552247af-bfb0-4a9d-9a96-d2856fcb0ac8/jobs/314215/resources):
<img width="1233" alt="Screen Shot 2023-01-03 at 12 44 31 PM" src="https://user-images.githubusercontent.com/583503/210438503-1623a58c-eff1-43de-b993-49683c9d6435.png">

Sometimes, it fails with `Parallel::DeadWorker`, likely due to out of memory errors.

This PR bumps up the machine size from 2Gb, to 6Gb (our default). I skipped the 4Gb runner because it would add combination of runners to our `config.yml`, and the 6Gb runner is also faster (more CPU) so there are still benefits to it.