### PR TITLE
Lint: Fix Lint/ConstantDefinitionInBlock occurrences

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,15 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 3
-# Configuration parameters: AllowedMethods.
-# AllowedMethods: enums
-Lint/ConstantDefinitionInBlock:
-  Exclude:
-    - 'spec/datadog/core/workers/async_spec.rb'
-    - 'spec/datadog/tracing/benchmark/support/benchmark_helper.rb'
-    - 'spec/datadog/tracing/contrib/rails/rack_spec.rb'
-
 # Offense count: 9
 # Configuration parameters: MaximumRangeSize.
 Lint/MissingCopEnableDirective:

--- a/spec/datadog/core/workers/async_spec.rb
+++ b/spec/datadog/core/workers/async_spec.rb
@@ -475,11 +475,14 @@ RSpec.describe Datadog::Core::Workers::Async::Thread do
           skip 'Not supported on old Rubies' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
         end
 
-        class AsyncSpecThreadNaming < Datadog::Core::Worker
-          include Datadog::Core::Workers::Async::Thread
+        let(:worker_class) do
+          stub_const(
+            'AsyncSpecThreadNaming',
+            Class.new(Datadog::Core::Worker) do
+              include Datadog::Core::Workers::Async::Thread
+            end
+          )
         end
-
-        let(:worker_class) { AsyncSpecThreadNaming }
 
         it 'sets the name of the created thread to match the worker class name' do
           worker.perform

--- a/spec/datadog/tracing/benchmark/support/benchmark_helper.rb
+++ b/spec/datadog/tracing/benchmark/support/benchmark_helper.rb
@@ -251,19 +251,18 @@ RSpec.shared_context 'minimal agent' do
   let(:agent_server) { TCPServer.new '127.0.0.1', agent_port }
   let(:agent_port) { ENV[Datadog::Tracing::Configuration::Ext::Transport::ENV_DEFAULT_PORT].to_i }
 
-  # Sample agent response, collected from a real agent exchange.
-  AGENT_HTTP_RESPONSE = "HTTP/1.1 200\r\n" \
-    "Content-Length: 40\r\n" \
-    "Content-Type: application/json\r\n" \
-    "Date: Thu, 03 Sep 2020 20:05:54 GMT\r\n" \
-    "\r\n" \
-    "{\"rate_by_service\":{\"service:,env:\":1}}\n".freeze
-
   def server_runner
     previous_conn = nil
     loop do
       conn = agent_server.accept
-      conn.print AGENT_HTTP_RESPONSE
+
+      # Sample agent response, collected from a real agent exchange.
+      conn.print "HTTP/1.1 200\r\n" \
+        "Content-Length: 40\r\n" \
+        "Content-Type: application/json\r\n" \
+        "Date: Thu, 03 Sep 2020 20:05:54 GMT\r\n" \
+        "\r\n" \
+        "{\"rate_by_service\":{\"service:,env:\":1}}\n".freeze
       conn.flush
 
       # Read HTTP request to allow other side to have enough

--- a/spec/datadog/tracing/contrib/rails/rack_spec.rb
+++ b/spec/datadog/tracing/contrib/rails/rack_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe 'Rails Rack' do
   let(:controllers) { [controller, errors_controller] }
   let(:controller) do
     layout_ = layout
+    stub_const('RescuableError', Class.new(StandardError))
     stub_const(
       'TestController',
       Class.new(ActionController::Base) do
@@ -80,8 +81,6 @@ RSpec.describe 'Rails Rack' do
             render nothing: true, status: 520
           end
         end
-
-        RescuableError = Class.new(StandardError)
 
         def error_handled_by_rescue_from
           raise RescuableError


### PR DESCRIPTION
Fixes old cop infraction from `.rubocop_todo.yml`.