### PR TITLE
Lint: Fix Lint/Void occurrences

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -46,12 +46,6 @@ Lint/StructNewOverride:
   Exclude:
     - 'lib/datadog/profiling/pprof/converter.rb'
 
-# Offense count: 2
-# Configuration parameters: CheckForMethodsWithNoSideEffects.
-Lint/Void:
-  Exclude:
-    - 'spec/datadog/tracing/contrib/grpc/support/grpc_helper.rb'
-
 # Offense count: 10
 Performance/MethodObjectAsBlock:
   Exclude:

--- a/spec/datadog/tracing/contrib/grpc/support/grpc_helper.rb
+++ b/spec/datadog/tracing/contrib/grpc/support/grpc_helper.rb
@@ -82,7 +82,7 @@ module GRPCHelper
 
     def stream_from_client(call)
       call.output_metadata.update(@trailing_metadata)
-      call.each_remote_read.each { |r| r }
+      call.each_remote_read.each {} # Consume data
       TestMessage.new
     end
 
@@ -93,7 +93,7 @@ module GRPCHelper
 
     def stream_both_ways(_requests, call)
       call.output_metadata.update(@trailing_metadata)
-      call.each_remote_read.each { |r| r }
+      call.each_remote_read.each {} # Consume data
       [TestMessage.new, TestMessage.new]
     end
   end


### PR DESCRIPTION
Fixes old cop infraction from `.rubocop_todo.yml`.