### PR TITLE
Use stable Ruby 3.2 when testing integration apps

### DIFF
--- a/integration/images/ruby/3.2/Dockerfile
+++ b/integration/images/ruby/3.2/Dockerfile
@@ -1,5 +1,4 @@
-# TODO: Replace this with 3.2 once the 3.2.0 stable release is out!
-FROM ruby:3.2-rc
+FROM ruby:3.2
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
**What does this PR do?**:

Update the integration apps `Dockerfile` for Ruby 3.2 to use the latest stable release (3.2.0 as of this writing, but newer releases will be automatically picked up).

**Motivation**:

Make sure integration apps are running fine on Ruby 3.2.

**Additional Notes**:

~The CI failure (https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/8490/workflows/96149110-10e1-4042-8bb2-07023fd1bb66/jobs/315673) may look related (because it's also for 3.2) but it actually is unrelated -- we use different images for the integration apps.~

~The CI failure instead is due to #2510 and is affecting every PR right now (for instance [this other PR](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/8482/workflows/f8cfb120-aef9-4eea-8817-99ced812dffe/jobs/315376)).~

Update: CI failure fixed.

**How to test the change?**:

Run tests and check that Ruby 3.2.0 (or a latter version) are used.