### PR TITLE
Allow `debase-ruby_core_source` 3.2.0 to be used

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |spec|
   # forward.
   #
   # We're pinning it at the latest available version and will manually bump the dependency as needed.
-  spec.add_dependency 'debase-ruby_core_source', '>= 0.10.16', '<= 0.10.18'
+  spec.add_dependency 'debase-ruby_core_source', '>= 0.10.16', '<= 3.2.0'
 
   # Used by appsec
   spec.add_dependency 'libddwaf', '~> 1.5.1.0.0'


### PR DESCRIPTION
**What does this PR do?**:

Allow using the latest `debase-ruby_core_source` together with dd-trace-rb.

**Motivation**:

As discussed in #1740, we decided to pin the range of versions of `debase-ruby_core_source` we use, so that we can validate each version as it comes out.

The changes on 3.2.0
(<https://my.diffend.io/gems/debase-ruby_core_source/0.10.18/3.2.0>) don't impact dd-trace-rb, because they only affect Ruby 3.2.0 and 2.0.0 and we don't use `debase-ruby_core_source` on Ruby >= 2.6 (nor support Ruby 2.0).

Nevertheless, it's important we keep our version up-to-date as customers may need the latest version of `debase-ruby_core_source` for other gems they use.

**Additional Notes**:

~CI is breaking for Ruby 3.2 for an unrelated reason.~ Update: fixed.

**How to test the change?**:

CI should still be green for all supported Ruby versions.