### PR TITLE
Minor: Document that `DD_PROFILING_MAX_FRAMES` can be used to configure profiling `max_frames`

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -204,6 +204,8 @@ module Datadog
 
             # Controls the maximum number of frames for each thread sampled. Can be tuned to avoid omitted frames in the
             # produced profiles. Increasing this may increase the overhead of profiling.
+            #
+            # @default `DD_PROFILING_MAX_FRAMES` environment variable, otherwise 400
             option :max_frames do |o|
               o.default { env_to_int(Profiling::Ext::ENV_MAX_FRAMES, 400) }
               o.lazy


### PR DESCRIPTION
**What does this PR do?**:

Add missing documentation to settings.rb.

**Motivation**:

This is a setting that most customers should never need to touch, but if they need to, it's helpful to document that they can also use an environment variable.

**Additional Notes**:

(N/A)

**How to test the change?**:

Check that API documentation includes the newly-added information :)