### PR TITLE
Test: Migrate to Codecov Uploader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,8 @@ filters_only_release_tags: &filters_only_release_tags
 
 orbs:
   orb:
+    orbs:
+      codecov: codecov/codecov@3.2.3
     jobs:
       build:
         <<: *test_job_default
@@ -368,13 +370,12 @@ orbs:
           - attach_workspace:
               at: /tmp/workspace
           - run:
-              name: Install codecov
-              command: bundle add codecov
-          - run:
-              name: Generate coverage report artifact "coverage/index.html"
+              name: Generate combined coverage report for all tests
               command: COVERAGE_DIR=/tmp/workspace/coverage bundle exec rake coverage:report
+          - codecov/upload:
+              file: /tmp/workspace/coverage/report/coverage.xml
           - run:
-              name: Generate coverage report artifact "coverage/versions/*/index.html"
+              name: Generate individual coverage report for each Ruby version
               command: COVERAGE_DIR=/tmp/workspace/coverage bundle exec rake coverage:report_per_ruby_version
           - store_artifacts:
               path: /tmp/workspace/coverage/report/

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ if RUBY_VERSION >= '2.5.0'
   # We have a fix up for review, https://github.com/simplecov-ruby/simplecov/pull/972,
   # but given it only affects unsupported version of Ruby, it might not get merged.
   gem 'simplecov', git: 'https://github.com/DataDog/simplecov', ref: '3bb6b7ee58bf4b1954ca205f50dd44d6f41c57db'
+  gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 else
   # Compatible with older rubies. This version still produces compatible output
   # with a newer version when the reports are merged.

--- a/Rakefile
+++ b/Rakefile
@@ -414,10 +414,10 @@ namespace :coverage do
     SimpleCov.collate resultset_files do
       coverage_dir "#{ENV.fetch('COVERAGE_DIR', 'coverage')}/report"
       if ENV['CI'] == 'true'
-        require 'codecov'
+        require 'simplecov-cobertura'
         formatter SimpleCov::Formatter::MultiFormatter.new(
           [SimpleCov::Formatter::HTMLFormatter,
-           SimpleCov::Formatter::Codecov]
+           SimpleCov::Formatter::CoberturaFormatter] # Used by codecov
         )
       else
         formatter SimpleCov::Formatter::HTMLFormatter


### PR DESCRIPTION
Codecov has deprecated language-specific uploaders, include the [Ruby gem](https://github.com/codecov/codecov-ruby) we use: https://about.codecov.io/blog/codecov-uploader-deprecation-plan/

This PR follows the [Deprecated Uploader Migration Guide](https://docs.codecov.com/docs/deprecated-uploader-migration-guide#ruby-uploader) steps, now uploading an `xml` format coverage report using [Codecov's CircleCI Orb](https://circleci.com/developer/orbs/orb/codecov/codecov).

There are no behaviour changes in this PR.