### PR TITLE
Pin Appraisal to a specific commit to support Ruby 3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,9 @@ gemspec
 
 # Development dependencies
 gem 'addressable', '~> 2.4.0' # locking transitive dependency of webmock
-gem 'appraisal', '~> 2.2'
+# A temporary fix until support for Ruby 3.2 is released.
+# TODO: Revert back to the official appraisal gem when https://github.com/thoughtbot/appraisal/issues/199 is fixed.
+gem 'appraisal', '~> 2.2', github: 'toy/appraisal', ref: '7000fb64bfcd872218c18d008ecadbea8055b062'
 gem 'benchmark-ips', '~> 2.8'
 gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
 gem 'builder'


### PR DESCRIPTION
Until a fix for https://github.com/thoughtbot/appraisal/issues/199 is released, we can't run appraisal with Ruby 3.2.

There are two proposed fixes upstream: https://github.com/thoughtbot/appraisal/pull/201 and https://github.com/thoughtbot/appraisal/pull/200.

This PR pins the appraisal gem version to the fix in https://github.com/thoughtbot/appraisal/pull/201. Both seems equally correct.