### PR TITLE
[PROF-6838] Upgrade to libdatadog 1.0.1.1.0

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -67,7 +67,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'libddwaf', '~> 1.5.1.0.0'
 
   # Used by profiling (and possibly others in the future)
-  spec.add_dependency 'libdatadog', '~> 0.9.0.1.0'
+  spec.add_dependency 'libdatadog', '~> 1.0.1.1.0'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb', 'ext/ddtrace_profiling_loader/extconf.rb']
 end

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -147,7 +147,7 @@ static void trigger_sample_for_thread(
   struct cpu_and_wall_time_collector_state *state,
   VALUE thread,
   struct per_thread_context *thread_context,
-  ddog_Slice_i64 metric_values_slice,
+  ddog_Slice_I64 metric_values_slice,
   sample_type type
 );
 static VALUE _native_thread_list(VALUE self);
@@ -366,7 +366,7 @@ void cpu_and_wall_time_collector_sample(VALUE self_instance, long current_monoto
       state,
       thread,
       thread_context,
-      (ddog_Slice_i64) {.ptr = metric_values, .len = ENABLED_VALUE_TYPES_COUNT},
+      (ddog_Slice_I64) {.ptr = metric_values, .len = ENABLED_VALUE_TYPES_COUNT},
       SAMPLE_REGULAR
     );
   }
@@ -520,7 +520,7 @@ VALUE cpu_and_wall_time_collector_sample_after_gc(VALUE self_instance) {
       state,
       thread,
       thread_context,
-      (ddog_Slice_i64) {.ptr = metric_values, .len = ENABLED_VALUE_TYPES_COUNT},
+      (ddog_Slice_I64) {.ptr = metric_values, .len = ENABLED_VALUE_TYPES_COUNT},
       SAMPLE_IN_GC
     );
 
@@ -549,24 +549,24 @@ static void trigger_sample_for_thread(
   struct cpu_and_wall_time_collector_state *state,
   VALUE thread,
   struct per_thread_context *thread_context,
-  ddog_Slice_i64 metric_values_slice,
+  ddog_Slice_I64 metric_values_slice,
   sample_type type
 ) {
   int max_label_count =
     1 + // thread id
     1 + // thread name
     2;  // local root span id and span id
-  ddog_Label labels[max_label_count];
+  ddog_prof_Label labels[max_label_count];
   int label_pos = 0;
 
-  labels[label_pos++] = (ddog_Label) {
+  labels[label_pos++] = (ddog_prof_Label) {
     .key = DDOG_CHARSLICE_C("thread id"),
     .str = thread_context->thread_id_char_slice
   };
 
   VALUE thread_name = thread_name_for(thread);
   if (thread_name != Qnil) {
-    labels[label_pos++] = (ddog_Label) {
+    labels[label_pos++] = (ddog_prof_Label) {
       .key = DDOG_CHARSLICE_C("thread name"),
       .str = char_slice_from_ruby_string(thread_name)
     };
@@ -576,8 +576,8 @@ static void trigger_sample_for_thread(
   trace_identifiers_for(state, thread, &trace_identifiers_result);
 
   if (trace_identifiers_result.valid) {
-    labels[label_pos++] = (ddog_Label) {.key = DDOG_CHARSLICE_C("local root span id"), .str = trace_identifiers_result.local_root_span_id};
-    labels[label_pos++] = (ddog_Label) {.key = DDOG_CHARSLICE_C("span id"), .num = trace_identifiers_result.span_id};
+    labels[label_pos++] = (ddog_prof_Label) {.key = DDOG_CHARSLICE_C("local root span id"), .str = trace_identifiers_result.local_root_span_id};
+    labels[label_pos++] = (ddog_prof_Label) {.key = DDOG_CHARSLICE_C("span id"), .num = trace_identifiers_result.span_id};
 
     if (trace_identifiers_result.trace_endpoint != Qnil) {
       // The endpoint gets recorded in a different way because it is mutable in the tracer and can change during a
@@ -610,7 +610,7 @@ static void trigger_sample_for_thread(
     state->sampling_buffer,
     state->recorder_instance,
     metric_values_slice,
-    (ddog_Slice_label) {.ptr = labels, .len = label_pos},
+    (ddog_prof_Slice_Label) {.ptr = labels, .len = label_pos},
     type
   );
 }

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.h
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.h
@@ -10,8 +10,8 @@ void sample_thread(
   VALUE thread,
   sampling_buffer* buffer,
   VALUE recorder_instance,
-  ddog_Slice_i64 metric_values,
-  ddog_Slice_label labels,
+  ddog_Slice_I64 metric_values,
+  ddog_prof_Slice_Label labels,
   sample_type type
 );
 sampling_buffer *sampling_buffer_new(unsigned int max_frames);

--- a/ext/ddtrace_profiling_native_extension/libdatadog_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/libdatadog_helpers.h
@@ -9,6 +9,10 @@ inline static ddog_CharSlice char_slice_from_ruby_string(VALUE string) {
   return char_slice;
 }
 
-inline static VALUE ruby_string_from_vec_u8(ddog_Vec_u8 string) {
+inline static VALUE ruby_string_from_vec_u8(ddog_Vec_U8 string) {
+  return rb_str_new((char *) string.ptr, string.len);
+}
+
+inline static VALUE ruby_string_from_prof_vec_u8(ddog_prof_Vec_U8 string) {
   return rb_str_new((char *) string.ptr, string.len);
 }

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.h
@@ -10,7 +10,7 @@
 // ```
 // compiling ../../../../ext/ddtrace_profiling_native_extension/stack_recorder.c
 // ../../../../ext/ddtrace_profiling_native_extension/stack_recorder.c:23:1: error: initializer element is not constant
-// static const ddog_ValueType enabled_value_types[] = {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE};
+// static const ddog_prof_ValueType enabled_value_types[] = {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE};
 // ^
 // ```
 #define VALUE_STRING(string) {.ptr = "" string, .len = sizeof(string) - 1}
@@ -23,7 +23,7 @@
 #define HEAP_LIVE_SIZE_VALUE    {.type_ = VALUE_STRING("heap-live-size"),    .unit = VALUE_STRING("bytes")}
 #define HEAP_LIVE_SAMPLES_VALUE {.type_ = VALUE_STRING("heap-live-samples"), .unit = VALUE_STRING("count")}
 
-static const ddog_ValueType enabled_value_types[] = {
+static const ddog_prof_ValueType enabled_value_types[] = {
   #define CPU_TIME_VALUE_POS 0
   CPU_TIME_VALUE,
   #define CPU_SAMPLES_VALUE_POS 1
@@ -32,8 +32,8 @@ static const ddog_ValueType enabled_value_types[] = {
   WALL_TIME_VALUE
 };
 
-#define ENABLED_VALUE_TYPES_COUNT (sizeof(enabled_value_types) / sizeof(ddog_ValueType))
+#define ENABLED_VALUE_TYPES_COUNT (sizeof(enabled_value_types) / sizeof(ddog_prof_ValueType))
 
-void record_sample(VALUE recorder_instance, ddog_Sample sample);
+void record_sample(VALUE recorder_instance, ddog_prof_Sample sample);
 void record_endpoint(VALUE recorder_instance, ddog_CharSlice local_root_span_id, ddog_CharSlice endpoint);
 VALUE enforce_recorder_instance(VALUE object);

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -308,6 +308,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
           'end' => end_timestamp,
           'family' => 'ruby',
           'version' => '4',
+          'endpoint_counts' => nil,
         )
       end
 
@@ -354,6 +355,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
           'end' => end_timestamp,
           'family' => 'ruby',
           'version' => '4',
+          'endpoint_counts' => nil,
         )
 
         expect(body[code_provenance_file_name]).to be nil


### PR DESCRIPTION
**What does this PR do?**:

Upgrade dd-trace-rb to use the latest libdatadog release (1.0.1.1.0).

This libdatadog release includes:

* A number of API renames (documented in <https://github.com/DataDog/libdatadog/pull/73>)
* The addition of `endpoint_counts`, which we don't use yet, but that needed a few additional changes to API calls and specs.

**Motivation**:

Keep up with latest improvements and features being added to libdatadog.

**Additional Notes**:

I've skipped packaging the libdatadog 1.0.0 release, and we're going straight to 1.0.1.

~~I'm opening this PR as a draft because libdatadog 1.0.1.1.0 has not yet been published to rubygems (hence our CI failing with this PR). Once I've published it, I'll re-trigger CI and remove the draft label with no further changes.~~ Update: Published, and dropped draft label.

**How to test the change?**:

The changes in this PR are already covered by the existing tests.