### PR TITLE
[PROF-6900] Fix wrong libdatadog version being picked during profiler build

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -67,6 +67,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'libddwaf', '~> 1.5.1.0.0'
 
   # Used by profiling (and possibly others in the future)
+  # When updating the version here, please also update the version in `native_extension_helpers.rb` (and yes we have a test for it)
   spec.add_dependency 'libdatadog', '~> 0.9.0.1.0'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb', 'ext/ddtrace_profiling_loader/extconf.rb']

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -2,7 +2,7 @@
 
 # typed: ignore
 
-require 'libdatadog'
+require 'rubygems'
 require 'pathname'
 
 module Datadog
@@ -16,6 +16,8 @@ module Datadog
 
       # Older Rubies don't have the MJIT header, used by the JIT compiler, so we need to use a different approach
       CAN_USE_MJIT_HEADER = RUBY_VERSION >= '2.6'
+
+      LIBDATADOG_VERSION = '~> 0.9.0.1.0'
 
       def self.fail_install_if_missing_extension?
         ENV[ENV_FAIL_INSTALL_IF_MISSING_EXTENSION].to_s.strip.downcase == 'true'
@@ -88,6 +90,7 @@ module Datadog
             not_on_amd64_or_arm64? ||
             on_ruby_2_1? ||
             expected_to_use_mjit_but_mjit_is_disabled? ||
+            libdatadog_not_available? ||
             libdatadog_not_usable?
         end
 
@@ -277,6 +280,25 @@ module Datadog
           )
 
           ruby_without_mjit if CAN_USE_MJIT_HEADER && RbConfig::CONFIG['MJIT_SUPPORT'] != 'yes'
+        end
+
+        private_class_method def self.libdatadog_not_available?
+          begin
+            gem 'libdatadog', LIBDATADOG_VERSION
+            require 'libdatadog'
+            nil
+          # rubocop:disable Lint/RescueException
+          rescue Exception => e
+            explain_issue(
+              'there was an exception during loading of the `libdatadog` gem:',
+              e.class.name,
+              *e.message.split("\n"),
+              *Array(e.backtrace),
+              '.',
+              suggested: CONTACT_SUPPORT,
+            )
+          end
+          # rubocop:enable Lint/RescueException
         end
 
         private_class_method def self.libdatadog_not_usable?

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -142,11 +142,6 @@ module Datadog
           '<https://dtdg.co/ruby-profiler-troubleshooting>.'
         ].freeze
 
-        REPORT_ISSUE = [
-          'If you needed to use this, please tell us why on',
-          '<https://github.com/DataDog/dd-trace-rb/issues/new> so we can fix it :)',
-        ].freeze
-
         GET_IN_TOUCH = [
           "Get in touch with us if you're interested in profiling your app!"
         ].freeze
@@ -188,10 +183,15 @@ module Datadog
         )
 
         private_class_method def self.disabled_via_env?
+          report_disabled = [
+            'If you needed to use this, please tell us why on',
+            '<https://github.com/DataDog/dd-trace-rb/issues/new> so we can fix it :)',
+          ].freeze
+
           disabled_via_env = explain_issue(
             'the `DD_PROFILING_NO_EXTENSION` environment variable is/was set to',
             '`true` during installation.',
-            suggested: REPORT_ISSUE,
+            suggested: report_disabled,
           )
 
           return unless ENV[ENV_NO_EXTENSION].to_s.strip.downcase == 'true'

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -1,7 +1,7 @@
 # typed: ignore
 
 require 'ext/ddtrace_profiling_native_extension/native_extension_helpers'
-
+require 'libdatadog'
 require 'datadog/profiling/spec_helper'
 
 RSpec.describe Datadog::Profiling::NativeExtensionHelpers do
@@ -37,6 +37,16 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers do
       it do
         expect(described_class.libdatadog_folder_relative_to_native_lib_folder(libdatadog_pkgconfig_folder: nil)).to be nil
       end
+    end
+  end
+
+  describe '::LIBDATADOG_VERSION' do
+    it 'must match the version restriction set on the gemspec' do
+      # This test is expected to break when the libdatadog version on the .gemspec is updated but we forget to update
+      # the version on the `native_extension_helpers.rb` file. Kindly keep them in sync! :)
+      expect(described_class::LIBDATADOG_VERSION).to eq(
+        Gem.loaded_specs['ddtrace'].dependencies.find { |dependency| dependency.name == 'libdatadog' }.requirement.to_s
+      )
     end
   end
 end
@@ -122,6 +132,22 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
           context 'when not on Ruby 2.1' do
             before { stub_const('RUBY_VERSION', '2.2.0') }
 
+            shared_examples 'libdatadog available' do
+              context 'when libdatadog fails to activate' do
+                before do
+                  expect(described_class)
+                    .to receive(:gem).with('libdatadog', Datadog::Profiling::NativeExtensionHelpers::LIBDATADOG_VERSION)
+                    .and_raise(LoadError.new('Simulated error activating gem'))
+                end
+
+                it { is_expected.to include 'exception during loading' }
+              end
+
+              context 'when libdatadog successfully activates' do
+                include_examples 'libdatadog usable'
+              end
+            end
+
             shared_examples 'libdatadog usable' do
               context 'when libdatadog DOES NOT HAVE binaries for the current platform' do
                 before do
@@ -142,7 +168,7 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
             context 'on a Ruby version where we CAN NOT use the MJIT header' do
               before { stub_const('Datadog::Profiling::NativeExtensionHelpers::CAN_USE_MJIT_HEADER', false) }
 
-              include_examples 'libdatadog usable'
+              include_examples 'libdatadog available'
             end
 
             context 'on a Ruby version where we CAN use the MJIT header' do
@@ -157,7 +183,7 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
               context 'and DOES have MJIT support' do
                 before { expect(RbConfig::CONFIG).to receive(:[]).with('MJIT_SUPPORT').and_return('yes') }
 
-                include_examples 'libdatadog usable'
+                include_examples 'libdatadog available'
               end
             end
           end


### PR DESCRIPTION
**What does this PR do?**:

This PR fixes an issue I spotted recently relating to the libdatadog version that gets picked during profiler build.

Specifically, I had the following setup:

* Two versions of the libdatadog gem locally installed (1.0.1.1.0, 0.9.0.1.0)
* I tried to install ddtrace 1.8.0 from rubygems

The ddtrace 1.8.0 release has a dependency on libdatadog 0.9.x.

But, what I observed is that building the profiler (and thus installing ddtrace) failed because the profiling native extension was trying to compile and link to libdatadog 1.0.x instead of 0.9.x.

Upon investigation, I've discovered that the issue is that the `extconf.rb` script (which gets called by rubygems during installation) is not run with the equivalent of `bundle exec`, e.g. it can access all gems (and versions) that are installed locally, not just the ones that are defined in the dependencies of our gem in the `gemspec`.

Thus, at least on my machine, when we did `require 'libdatadog'` to access the `libdatadog` gem, rubygems picked a version which did not match the one that was stated in the `gemspec`.

To fix this, I've modified the `native_extension_helpers.rb` (which gets called by the `extconf.rb`) to tell RubyGems to activate the exact version of `libdatadog` that we need.

Additionally, I've added error handling so we gracefully recover from any errors that can happen on this step.

**Motivation**:

Avoid impacting customers that are installing ddtrace (and avoid having them endup having to disable profiling to install ddtrace).

**Additional Notes**:

Hopefully no customers ever got bitten by this (we had no reports thus far). To reproduce this, they'd need to have a weird combination of having a more modern version of libdatadog than they needed, and then install an older version of ddtrace.

**How to test the change?**:

See instructions above for the setup I had that triggered this issue. You'll have to check out the exact commit where the fix happened, because then I had to merge master into this branch, and master brought in support for the latest libdatadog, which will make the issue not trigger again until there's a newer version of libdatadog out there.
