### PR TITLE
RFC: Move `agent.port` back to core

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -55,6 +55,12 @@ module Datadog
           # @return [String,nil]
           option :host
 
+          # Agent APM TCP port.
+          # @see https://docs.datadoghq.com/getting_started/tracing/#datadog-apm
+          # @default `DD_TRACE_AGENT_PORT` environment variable, otherwise `8126`
+          # @return [String,nil]
+          option :port
+
           # TODO: add declarative statsd configuration. Currently only usable via an environment variable.
           # Statsd configuration for agent access.
           # @public_api

--- a/lib/datadog/tracing/configuration/settings.rb
+++ b/lib/datadog/tracing/configuration/settings.rb
@@ -420,15 +420,6 @@ module Datadog
                 o.lazy
               end
             end
-
-            agent_settings = options[:agent].type
-            agent_settings.class_eval do
-              # Agent APM TCP port.
-              # @see https://docs.datadoghq.com/getting_started/tracing/#datadog-apm
-              # @default `DD_TRACE_AGENT_PORT` environment variable, otherwise `8126`
-              # @return [String,nil]
-              option :port
-            end
           end
         end
       end

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -911,6 +911,8 @@ RSpec.describe Datadog::Core::Configuration::Settings do
     end
   end
 
+  # Important note: These settings are used as inputs of the AgentSettingsResolver and are used by all components
+  # that consume its result (e.g. tracing, profiling, and telemetry, as of January 2023).
   describe '#agent' do
     describe '#host' do
       subject(:host) { settings.agent.host }
@@ -926,6 +928,25 @@ RSpec.describe Datadog::Core::Configuration::Settings do
           .to change { settings.agent.host }
           .from(nil)
           .to(host)
+      end
+    end
+
+    describe '#tracer' do
+      describe '#port' do
+        subject(:port) { settings.agent.port }
+
+        it { is_expected.to be nil }
+      end
+
+      describe '#port=' do
+        let(:port) { 1234 }
+
+        it 'updates the #port setting' do
+          expect { settings.agent.port = port }
+            .to change { settings.agent.port }
+            .from(nil)
+            .to(port)
+        end
       end
     end
   end

--- a/spec/datadog/tracing/configuration/settings_spec.rb
+++ b/spec/datadog/tracing/configuration/settings_spec.rb
@@ -19,27 +19,6 @@ RSpec.describe Datadog::Tracing::Configuration::Settings do
 
   let(:options) { {} }
 
-  describe '#agent' do
-    describe '#tracer' do
-      describe '#port' do
-        subject(:port) { settings.agent.port }
-
-        it { is_expected.to be nil }
-      end
-
-      describe '#port=' do
-        let(:port) { 1234 }
-
-        it 'updates the #port setting' do
-          expect { settings.agent.port = port }
-            .to change { settings.agent.port }
-            .from(nil)
-            .to(port)
-        end
-      end
-    end
-  end
-
   describe '#tracing' do
     describe '#analytics' do
       describe '#enabled' do


### PR DESCRIPTION
**What does this PR do?**:

This PR is a follow-up to #2494 and undoes some of the changes done in that PR.

In particular, it moves the `option :port` definition back to the core settings.

**Motivation**:

The `port` gets used by components other than tracing (both profiling and telemetry), as an input to the `AgentSettingsResolver`.

We've discussed this internally and this RFC PR is a potential path forward for making sure all components can still use the `port` in the future.

**Additional Notes**:

This is not just a `git revert` -- I've tried to minimize the diff from #2494.

**How to test the change?**:

Change includes test coverage.