### PR TITLE
Support runtime metrics without tracing

### DIFF
--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -412,6 +412,8 @@ module Datadog
           else
             @logger.debug('Profiling is disabled')
           end
+
+          @runtime_metrics.perform # Starts worker. No-op if disabled.
         end
 
         # Shuts down all the components in use.

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -1283,6 +1283,13 @@ RSpec.describe Datadog::Core::Configuration::Components do
         end
       end
     end
+
+    context 'for runtime metrics' do
+      it 'initializes the worker' do
+        expect(components.runtime_metrics).to receive(:perform)
+        startup!
+      end
+    end
   end
 
   describe '#shutdown!' do

--- a/spec/datadog/core/configuration_spec.rb
+++ b/spec/datadog/core/configuration_spec.rb
@@ -362,7 +362,7 @@ RSpec.describe Datadog::Core::Configuration do
             expect(test_class.send(:components).runtime_metrics).to_not be @old_runtime_metrics
 
             expect(test_class.send(:components).runtime_metrics.enabled?).to be true
-            expect(test_class.send(:components).runtime_metrics.running?).to be false
+            expect(test_class.send(:components).runtime_metrics.running?).to be true
           end
         end
       end

--- a/spec/datadog/integration_spec.rb
+++ b/spec/datadog/integration_spec.rb
@@ -161,4 +161,30 @@ RSpec.describe 'Datadog integration' do
       end
     end
   end
+
+  context 'runtime metrics' do
+    context 'enabled' do
+      let(:configure) do
+        Datadog.configure do |c|
+          c.runtime_metrics.enabled = true
+        end
+      end
+
+      it 'starts the runtime metrics worker' do
+        expect { configure }.to change { Datadog.send(:components).runtime_metrics.running? }.from(false).to(true)
+      end
+    end
+
+    context 'disabled' do
+      let(:configure) do
+        Datadog.configure do |c|
+          c.runtime_metrics.enabled = false
+        end
+      end
+
+      it 'starts the runtime metrics worker' do
+        expect { configure }.to_not change { Datadog.send(:components).runtime_metrics.running? }.from(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR ensures the RuntimeMetrics worker, when `c.runtime_metrics.enabled = true`, starts its background worker thread on `ddtrace` startup.

Before this PR, the RuntimeMetrics worker only starts reporting metrics when the first trace is flushed by the `Datadog::Tracing::Writer`, and a service association is performed: https://github.com/DataDog/dd-trace-rb/blob/cf56509d29ef6f1163477242e30256e431f8222a/lib/datadog/tracing/writer.rb#L139-L142

This means no runtime metrics will be reported if tracing is disabled.

After this PR, the RuntimeMetrics worker will start immediately. It starts up being associated with `DD_SERVICE`, so metrics are reported to the correct service: https://github.com/DataDog/dd-trace-rb/blob/cf56509d29ef6f1163477242e30256e431f8222a/lib/datadog/core/configuration/components.rb#L41