### PR TITLE
Fix leftover profiling `Makefile` breaking run of `rake spec:main`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,7 @@ namespace :spec do
   end
   if RUBY_ENGINE == 'ruby' && OS.linux? && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.0')
     # "bundle exec rake compile" currently only works on MRI Ruby on Linux
+    Rake::Task[:main].enhance([:clean])
     Rake::Task[:main].enhance([:compile])
   end
 


### PR DESCRIPTION
**What does this PR do?**:

Because `rake spec:main` also runs profiling tests, we've added as a dependency of that test the `rake compile` task, which compiles the native extension before running the tests.

But @TonyCTHsu reported an issue where compilation was failing, and upon analysis the issue was the following:

1. At some point in the past, he ran `rake compile`, which generated a `Makefile` for profiling. This `Makefile` included hardcoded paths for `libdatadog` 0.9 version.

2. Then I merged the upgrade to `libdatadog` 1.0 to master, and he pulled this update.

3. When running `rake spec:main`, the compile task re-ran, but it reused the existing `Makefile`. This existing `Makefile` was using `libdatadog` 0.9 and not 1.0, and thus compilation broke, because `master` requires version 1.0, and cannot use the older version.

The fix here is simple: I've added the `clean` task as a dependency of `spec:main` as well, so that a new `Makefile` is generated every time `spec:main` runs.

**Motivation**:

Fix the issue reported.

**Additional Notes**:

This issue only affects development, since a new `Makefile` is generated every time `ddtrace` gets installed so I don't expect this issue to have affected customers.

**How to test the change?**:

Verify that `rake spec:main` still works correctly, and that the

> `** Preparing to build the ddtrace profiling native extension... **`

message always shows when running this command (previously it would only show the first time).
