### PR TITLE
Pin bundler and rubygems fro Rubies < 2.6

### DIFF
--- a/.circleci/images/primary/Dockerfile-2.1.10
+++ b/.circleci/images/primary/Dockerfile-2.1.10
@@ -131,7 +131,10 @@ RUN echo 'deb http://ftp.debian.org/debian stretch-backports main\ndeb-src http:
   && rm -rf /var/lib/apt/lists/*
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
+RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
+  && chmod +x /usr/local/bin/dockerize \
+  && dockerize --version
 
 RUN mkdir /app
 WORKDIR /app

--- a/.circleci/images/primary/Dockerfile-2.1.10
+++ b/.circleci/images/primary/Dockerfile-2.1.10
@@ -112,7 +112,7 @@ ENV LANGUAGE en_US:en
 RUN set -ex \
   && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/$(arch)/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/$(arch)/${DOCKER_VERSION}" \
-  && echo Docker URL: $DOCKER_URL \
+  && echo DOCKER_URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \
   && tar -xz -C /tmp -f /tmp/docker.tgz \
@@ -131,7 +131,8 @@ RUN echo 'deb http://ftp.debian.org/debian stretch-backports main\ndeb-src http:
   && rm -rf /var/lib/apt/lists/*
 
 # Install Dockerize
-RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(arch | sed 's/aarch64/arm64/')" \
+  && echo DOCKERIZE_URL: $DOCKERIZE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-2.1.10
+++ b/.circleci/images/primary/Dockerfile-2.1.10
@@ -131,7 +131,7 @@ RUN echo 'deb http://ftp.debian.org/debian stretch-backports main\ndeb-src http:
   && rm -rf /var/lib/apt/lists/*
 
 # Install Dockerize
-RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-2.1.10
+++ b/.circleci/images/primary/Dockerfile-2.1.10
@@ -131,7 +131,7 @@ RUN echo 'deb http://ftp.debian.org/debian stretch-backports main\ndeb-src http:
   && rm -rf /var/lib/apt/lists/*
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
+RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
 
 RUN mkdir /app
 WORKDIR /app

--- a/.circleci/images/primary/Dockerfile-2.2.10
+++ b/.circleci/images/primary/Dockerfile-2.2.10
@@ -113,7 +113,7 @@ ENV LANGUAGE en_US:en
 RUN set -ex \
   && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/$(arch)/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/$(arch)/${DOCKER_VERSION}" \
-  && echo Docker URL: $DOCKER_URL \
+  && echo DOCKER_URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \
   && tar -xz -C /tmp -f /tmp/docker.tgz \
@@ -132,7 +132,8 @@ RUN echo 'deb http://ftp.debian.org/debian stretch-backports main\ndeb-src http:
   && rm -rf /var/lib/apt/lists/*
 
 # Install Dockerize
-RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(arch | sed 's/aarch64/arm64/')" \
+  && echo DOCKERIZE_URL: $DOCKERIZE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-2.2.10
+++ b/.circleci/images/primary/Dockerfile-2.2.10
@@ -132,7 +132,7 @@ RUN echo 'deb http://ftp.debian.org/debian stretch-backports main\ndeb-src http:
   && rm -rf /var/lib/apt/lists/*
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
+RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
 
 RUN mkdir /app
 WORKDIR /app

--- a/.circleci/images/primary/Dockerfile-2.2.10
+++ b/.circleci/images/primary/Dockerfile-2.2.10
@@ -132,7 +132,7 @@ RUN echo 'deb http://ftp.debian.org/debian stretch-backports main\ndeb-src http:
   && rm -rf /var/lib/apt/lists/*
 
 # Install Dockerize
-RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-2.2.10
+++ b/.circleci/images/primary/Dockerfile-2.2.10
@@ -132,7 +132,10 @@ RUN echo 'deb http://ftp.debian.org/debian stretch-backports main\ndeb-src http:
   && rm -rf /var/lib/apt/lists/*
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
+RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
+  && chmod +x /usr/local/bin/dockerize \
+  && dockerize --version
 
 RUN mkdir /app
 WORKDIR /app

--- a/.circleci/images/primary/Dockerfile-2.3.8
+++ b/.circleci/images/primary/Dockerfile-2.3.8
@@ -49,7 +49,10 @@ RUN echo 'deb http://ftp.debian.org/debian stretch-backports main\ndeb-src http:
   && rm -rf /var/lib/apt/lists/*
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
+RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
+  && chmod +x /usr/local/bin/dockerize \
+  && dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-2.3.8
+++ b/.circleci/images/primary/Dockerfile-2.3.8
@@ -30,7 +30,7 @@ ENV LANGUAGE en_US:en
 RUN set -ex \
   && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/$(arch)/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/$(arch)/${DOCKER_VERSION}" \
-  && echo Docker URL: $DOCKER_URL \
+  && echo DOCKER_URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \
   && tar -xz -C /tmp -f /tmp/docker.tgz \
@@ -49,7 +49,8 @@ RUN echo 'deb http://ftp.debian.org/debian stretch-backports main\ndeb-src http:
   && rm -rf /var/lib/apt/lists/*
 
 # Install Dockerize
-RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(arch | sed 's/aarch64/arm64/')" \
+  && echo DOCKERIZE_URL: $DOCKERIZE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-2.3.8
+++ b/.circleci/images/primary/Dockerfile-2.3.8
@@ -49,7 +49,7 @@ RUN echo 'deb http://ftp.debian.org/debian stretch-backports main\ndeb-src http:
   && rm -rf /var/lib/apt/lists/*
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
+RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-2.3.8
+++ b/.circleci/images/primary/Dockerfile-2.3.8
@@ -49,7 +49,7 @@ RUN echo 'deb http://ftp.debian.org/debian stretch-backports main\ndeb-src http:
   && rm -rf /var/lib/apt/lists/*
 
 # Install Dockerize
-RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-2.4.10
+++ b/.circleci/images/primary/Dockerfile-2.4.10
@@ -29,7 +29,7 @@ ENV LANGUAGE en_US:en
 RUN set -ex \
   && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/$(arch)/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/$(arch)/${DOCKER_VERSION}" \
-  && echo Docker URL: $DOCKER_URL \
+  && echo DOCKER_URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \
   && tar -xz -C /tmp -f /tmp/docker.tgz \
@@ -40,12 +40,14 @@ RUN set -ex \
 
 # Install Docker Compose
 RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/download/1.29.2-ls51/docker-compose-$(dpkg --print-architecture)" \
+  && echo COMPOSE_URL: $COMPOSE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
   && chmod +x /usr/bin/docker-compose \
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(arch | sed 's/aarch64/arm64/')" \
+  && echo DOCKERIZE_URL: $DOCKERIZE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-2.4.10
+++ b/.circleci/images/primary/Dockerfile-2.4.10
@@ -45,7 +45,10 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
+RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
+  && chmod +x /usr/local/bin/dockerize \
+  && dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-2.4.10
+++ b/.circleci/images/primary/Dockerfile-2.4.10
@@ -45,7 +45,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-2.4.10
+++ b/.circleci/images/primary/Dockerfile-2.4.10
@@ -45,7 +45,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
+RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-2.4.10
+++ b/.circleci/images/primary/Dockerfile-2.4.10
@@ -51,8 +51,8 @@ RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Install RubyGems and Bundler
-RUN gem update --system
-RUN gem install bundler
+RUN gem update --system 3.3.26
+RUN gem install bundler -v '~> 2.3.26'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/.circleci/images/primary/Dockerfile-2.5.9
+++ b/.circleci/images/primary/Dockerfile-2.5.9
@@ -29,7 +29,7 @@ ENV LANGUAGE en_US:en
 RUN set -ex \
   && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/$(arch)/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/$(arch)/${DOCKER_VERSION}" \
-  && echo Docker URL: $DOCKER_URL \
+  && echo DOCKER_URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \
   && tar -xz -C /tmp -f /tmp/docker.tgz \
@@ -40,12 +40,14 @@ RUN set -ex \
 
 # Install Docker Compose
 RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/download/1.29.2-ls51/docker-compose-$(dpkg --print-architecture)" \
+  && echo COMPOSE_URL: $COMPOSE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
   && chmod +x /usr/bin/docker-compose \
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(arch | sed 's/aarch64/arm64/')" \
+  && echo DOCKERIZE_URL: $DOCKERIZE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-2.5.9
+++ b/.circleci/images/primary/Dockerfile-2.5.9
@@ -45,7 +45,10 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
+RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
+  && chmod +x /usr/local/bin/dockerize \
+  && dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-2.5.9
+++ b/.circleci/images/primary/Dockerfile-2.5.9
@@ -45,7 +45,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-2.5.9
+++ b/.circleci/images/primary/Dockerfile-2.5.9
@@ -45,7 +45,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
+RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-2.5.9
+++ b/.circleci/images/primary/Dockerfile-2.5.9
@@ -51,8 +51,8 @@ RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Install RubyGems and Bundler
-RUN gem update --system
-RUN gem install bundler
+RUN gem update --system 3.3.26
+RUN gem install bundler -v '~> 2.3.26'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/.circleci/images/primary/Dockerfile-2.6.10
+++ b/.circleci/images/primary/Dockerfile-2.6.10
@@ -29,7 +29,7 @@ ENV LANGUAGE en_US:en
 RUN set -ex \
   && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/$(arch)/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/$(arch)/${DOCKER_VERSION}" \
-  && echo Docker URL: $DOCKER_URL \
+  && echo DOCKER_URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \
   && tar -xz -C /tmp -f /tmp/docker.tgz \
@@ -40,12 +40,14 @@ RUN set -ex \
 
 # Install Docker Compose
 RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/download/1.29.2-ls51/docker-compose-$(dpkg --print-architecture)" \
+  && echo COMPOSE_URL: $COMPOSE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
   && chmod +x /usr/bin/docker-compose \
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(arch | sed 's/aarch64/arm64/')" \
+  && echo DOCKERIZE_URL: $DOCKERIZE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-2.6.10
+++ b/.circleci/images/primary/Dockerfile-2.6.10
@@ -45,7 +45,10 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
+RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
+  && chmod +x /usr/local/bin/dockerize \
+  && dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-2.6.10
+++ b/.circleci/images/primary/Dockerfile-2.6.10
@@ -45,7 +45,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-2.6.10
+++ b/.circleci/images/primary/Dockerfile-2.6.10
@@ -45,7 +45,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
+RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-2.7.6
+++ b/.circleci/images/primary/Dockerfile-2.7.6
@@ -29,7 +29,7 @@ ENV LANGUAGE en_US:en
 RUN set -ex \
   && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/$(arch)/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/$(arch)/${DOCKER_VERSION}" \
-  && echo Docker URL: $DOCKER_URL \
+  && echo DOCKER_URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \
   && tar -xz -C /tmp -f /tmp/docker.tgz \
@@ -40,12 +40,14 @@ RUN set -ex \
 
 # Install Docker Compose
 RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/download/1.29.2-ls51/docker-compose-$(dpkg --print-architecture)" \
+  && echo COMPOSE_URL: $COMPOSE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
   && chmod +x /usr/bin/docker-compose \
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(arch | sed 's/aarch64/arm64/')" \
+  && echo DOCKERIZE_URL: $DOCKERIZE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-2.7.6
+++ b/.circleci/images/primary/Dockerfile-2.7.6
@@ -45,7 +45,10 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
+RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
+  && chmod +x /usr/local/bin/dockerize \
+  && dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-2.7.6
+++ b/.circleci/images/primary/Dockerfile-2.7.6
@@ -45,7 +45,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-2.7.6
+++ b/.circleci/images/primary/Dockerfile-2.7.6
@@ -45,7 +45,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
+RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-3.0.4
+++ b/.circleci/images/primary/Dockerfile-3.0.4
@@ -29,7 +29,7 @@ ENV LANGUAGE en_US:en
 RUN set -ex \
   && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/$(arch)/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/$(arch)/${DOCKER_VERSION}" \
-  && echo Docker URL: $DOCKER_URL \
+  && echo DOCKER_URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \
   && tar -xz -C /tmp -f /tmp/docker.tgz \
@@ -40,12 +40,14 @@ RUN set -ex \
 
 # Install Docker Compose
 RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/download/1.29.2-ls51/docker-compose-$(dpkg --print-architecture)" \
+  && echo COMPOSE_URL: $COMPOSE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
   && chmod +x /usr/bin/docker-compose \
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(arch | sed 's/aarch64/arm64/')" \
+  && echo DOCKERIZE_URL: $DOCKERIZE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-3.0.4
+++ b/.circleci/images/primary/Dockerfile-3.0.4
@@ -45,7 +45,10 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
+RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
+  && chmod +x /usr/local/bin/dockerize \
+  && dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-3.0.4
+++ b/.circleci/images/primary/Dockerfile-3.0.4
@@ -45,7 +45,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-3.0.4
+++ b/.circleci/images/primary/Dockerfile-3.0.4
@@ -45,7 +45,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
+RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-3.1.2
+++ b/.circleci/images/primary/Dockerfile-3.1.2
@@ -29,7 +29,7 @@ ENV LANGUAGE en_US:en
 RUN set -ex \
   && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/$(arch)/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/$(arch)/${DOCKER_VERSION}" \
-  && echo Docker URL: $DOCKER_URL \
+  && echo DOCKER_URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \
   && tar -xz -C /tmp -f /tmp/docker.tgz \
@@ -40,12 +40,14 @@ RUN set -ex \
 
 # Install Docker Compose
 RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/download/1.29.2-ls51/docker-compose-$(dpkg --print-architecture)" \
+  && echo COMPOSE_URL: $COMPOSE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
   && chmod +x /usr/bin/docker-compose \
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(arch | sed 's/aarch64/arm64/')" \
+  && echo DOCKERIZE_URL: $DOCKERIZE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-3.1.2
+++ b/.circleci/images/primary/Dockerfile-3.1.2
@@ -45,7 +45,10 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
+RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
+  && chmod +x /usr/local/bin/dockerize \
+  && dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-3.1.2
+++ b/.circleci/images/primary/Dockerfile-3.1.2
@@ -45,7 +45,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-3.1.2
+++ b/.circleci/images/primary/Dockerfile-3.1.2
@@ -45,7 +45,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
+RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-3.2.0
+++ b/.circleci/images/primary/Dockerfile-3.2.0
@@ -29,7 +29,7 @@ ENV LANGUAGE en_US:en
 RUN set -ex \
   && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/$(arch)/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/$(arch)/${DOCKER_VERSION}" \
-  && echo Docker URL: $DOCKER_URL \
+  && echo DOCKER_URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \
   && tar -xz -C /tmp -f /tmp/docker.tgz \
@@ -40,12 +40,14 @@ RUN set -ex \
 
 # Install Docker Compose
 RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/download/1.29.2-ls51/docker-compose-$(dpkg --print-architecture)" \
+  && echo COMPOSE_URL: $COMPOSE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
   && chmod +x /usr/bin/docker-compose \
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(arch | sed 's/aarch64/arm64/')" \
+  && echo DOCKERIZE_URL: $DOCKERIZE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-3.2.0
+++ b/.circleci/images/primary/Dockerfile-3.2.0
@@ -45,7 +45,10 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
+RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
+  && chmod +x /usr/local/bin/dockerize \
+  && dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-3.2.0
+++ b/.circleci/images/primary/Dockerfile-3.2.0
@@ -45,7 +45,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-3.2.0
+++ b/.circleci/images/primary/Dockerfile-3.2.0
@@ -45,7 +45,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
+RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
@@ -94,7 +94,10 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
+RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
+  && chmod +x /usr/local/bin/dockerize \
+  && dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
@@ -94,7 +94,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
+RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
@@ -30,7 +30,7 @@ RUN mkdir -p /opt/jruby/etc \
     echo 'update: --no-document'; \
   } >> /opt/jruby/etc/gemrc
 
-RUN gem install bundler rake net-telnet xmlrpc
+RUN gem install rake net-telnet xmlrpc
 
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
@@ -100,8 +100,8 @@ RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Upgrade RubyGems and Bundler
-RUN gem update --system
-RUN gem install bundler
+RUN gem update --system 3.3.26
+RUN gem install bundler -v '~> 2.3.26'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 # Ensure JRuby is available when running "bash --login"

--- a/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
@@ -94,7 +94,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
@@ -78,7 +78,7 @@ ENV LANGUAGE en_US:en
 RUN set -ex \
   && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/$(arch)/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/$(arch)/${DOCKER_VERSION}" \
-  && echo Docker URL: $DOCKER_URL \
+  && echo DOCKER_URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \
   && tar -xz -C /tmp -f /tmp/docker.tgz \
@@ -89,12 +89,14 @@ RUN set -ex \
 
 # Install Docker Compose
 RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/download/1.29.2-ls51/docker-compose-$(dpkg --print-architecture)" \
+  && echo COMPOSE_URL: $COMPOSE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
   && chmod +x /usr/bin/docker-compose \
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(arch | sed 's/aarch64/arm64/')" \
+  && echo DOCKERIZE_URL: $DOCKERIZE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-jruby-9.2.8.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.8.0
@@ -95,7 +95,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-jruby-9.2.8.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.8.0
@@ -79,7 +79,7 @@ ENV LANGUAGE en_US:en
 RUN set -ex \
   && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/$(arch)/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/$(arch)/${DOCKER_VERSION}" \
-  && echo Docker URL: $DOCKER_URL \
+  && echo DOCKER_URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \
   && tar -xz -C /tmp -f /tmp/docker.tgz \
@@ -90,12 +90,14 @@ RUN set -ex \
 
 # Install Docker Compose
 RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/download/1.29.2-ls51/docker-compose-$(dpkg --print-architecture)" \
+  && echo COMPOSE_URL: $COMPOSE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
   && chmod +x /usr/bin/docker-compose \
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(arch | sed 's/aarch64/arm64/')" \
+  && echo DOCKERIZE_URL: $DOCKERIZE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-jruby-9.2.8.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.8.0
@@ -32,7 +32,7 @@ RUN mkdir -p /opt/jruby/etc \
     echo 'update: --no-document'; \
   } >> /opt/jruby/etc/gemrc
 
-RUN gem install bundler rake net-telnet xmlrpc
+RUN gem install rake net-telnet xmlrpc
 
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
@@ -101,8 +101,8 @@ RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Upgrade RubyGems and Bundler
-RUN gem update --system
-RUN gem install bundler
+RUN gem update --system 3.3.26
+RUN gem install bundler -v '~> 2.3.26'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 # Ensure JRuby is available when running "bash --login"

--- a/.circleci/images/primary/Dockerfile-jruby-9.2.8.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.8.0
@@ -95,7 +95,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
+RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-jruby-9.2.8.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.8.0
@@ -95,7 +95,10 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
+RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
+  && chmod +x /usr/local/bin/dockerize \
+  && dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
@@ -94,7 +94,10 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
+RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
+  && chmod +x /usr/local/bin/dockerize \
+  && dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
@@ -94,7 +94,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
+RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
@@ -94,7 +94,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
@@ -78,7 +78,7 @@ ENV LANGUAGE en_US:en
 RUN set -ex \
   && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/$(arch)/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/$(arch)/${DOCKER_VERSION}" \
-  && echo Docker URL: $DOCKER_URL \
+  && echo DOCKER_URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \
   && tar -xz -C /tmp -f /tmp/docker.tgz \
@@ -89,12 +89,14 @@ RUN set -ex \
 
 # Install Docker Compose
 RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/download/1.29.2-ls51/docker-compose-$(dpkg --print-architecture)" \
+  && echo COMPOSE_URL: $COMPOSE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
   && chmod +x /usr/bin/docker-compose \
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(arch | sed 's/aarch64/arm64/')" \
+  && echo DOCKERIZE_URL: $DOCKERIZE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-jruby-9.4.0.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.4.0.0
@@ -94,7 +94,10 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
+RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
+  && chmod +x /usr/local/bin/dockerize \
+  && dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-jruby-9.4.0.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.4.0.0
@@ -94,7 +94,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
+RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
 
 # Install RubyGems
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"

--- a/.circleci/images/primary/Dockerfile-jruby-9.4.0.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.4.0.0
@@ -94,7 +94,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-jruby-9.4.0.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.4.0.0
@@ -78,7 +78,7 @@ ENV LANGUAGE en_US:en
 RUN set -ex \
   && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/$(arch)/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/$(arch)/${DOCKER_VERSION}" \
-  && echo Docker URL: $DOCKER_URL \
+  && echo DOCKER_URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \
   && tar -xz -C /tmp -f /tmp/docker.tgz \
@@ -89,12 +89,14 @@ RUN set -ex \
 
 # Install Docker Compose
 RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/download/1.29.2-ls51/docker-compose-$(dpkg --print-architecture)" \
+  && echo COMPOSE_URL: $COMPOSE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
   && chmod +x /usr/bin/docker-compose \
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(arch | sed 's/aarch64/arm64/')" \
+  && echo DOCKERIZE_URL: $DOCKERIZE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-truffleruby-22.3.0
+++ b/.circleci/images/primary/Dockerfile-truffleruby-22.3.0
@@ -46,7 +46,10 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
+RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
+  && chmod +x /usr/local/bin/dockerize \
+  && dockerize --version
 
 # Set missing vars
 ENV GEM_HOME="/usr/local/bundle"

--- a/.circleci/images/primary/Dockerfile-truffleruby-22.3.0
+++ b/.circleci/images/primary/Dockerfile-truffleruby-22.3.0
@@ -46,7 +46,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize
+RUN curl -sfL $(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4) | install /dev/stdin /usr/local/bin/dockerize; dockerize --version
 
 # Set missing vars
 ENV GEM_HOME="/usr/local/bundle"

--- a/.circleci/images/primary/Dockerfile-truffleruby-22.3.0
+++ b/.circleci/images/primary/Dockerfile-truffleruby-22.3.0
@@ -30,7 +30,7 @@ ENV LANGUAGE en_US:en
 RUN set -ex \
   && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/$(arch)/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/$(arch)/${DOCKER_VERSION}" \
-  && echo Docker URL: $DOCKER_URL \
+  && echo DOCKER_URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \
   && tar -xz -C /tmp -f /tmp/docker.tgz \
@@ -41,12 +41,14 @@ RUN set -ex \
 
 # Install Docker Compose
 RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/download/1.29.2-ls51/docker-compose-$(dpkg --print-architecture)" \
+  && echo COMPOSE_URL: $COMPOSE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
   && chmod +x /usr/bin/docker-compose \
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(arch | sed 's/aarch64/arm64/')" \
+  && echo DOCKERIZE_URL: $DOCKERIZE_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version

--- a/.circleci/images/primary/Dockerfile-truffleruby-22.3.0
+++ b/.circleci/images/primary/Dockerfile-truffleruby-22.3.0
@@ -46,7 +46,7 @@ RUN COMPOSE_URL="https://github.com/linuxserver/docker-docker-compose/releases/d
   && docker-compose version
 
 # Install Dockerize
-RUN DOCKERIZE_URL="$(curl -s https://api.github.com/repos/powerman/dockerize/releases/latest | grep -i /dockerize-$(uname -s)-$(dpkg --print-architecture)\" | cut -d\" -f4)" \
+RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(dpkg --print-architecture)" \
   && curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL \
   && chmod +x /usr/local/bin/dockerize \
   && dockerize --version


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Pin rubygems and bundler to last known compatible versions for old rubies

**Motivation**

Newer rubygems and bundler versions require 2.6

**Additional Notes**

Removed a duplicate install of bundler from jruby.

**How to test the change?**

Images should build in CI.