### PR TITLE
Fix leftover profiling `Makefile` breaking integration app run

### DIFF
--- a/integration/images/include/build_ddtrace_profiling_native_extension.rb
+++ b/integration/images/include/build_ddtrace_profiling_native_extension.rb
@@ -6,7 +6,7 @@ if local_gem_path = ENV['DD_DEMO_ENV_GEM_LOCAL_DDTRACE']
   else
     puts "\n== Building profiler native extension =="
     success =
-      system("export BUNDLE_GEMFILE=#{local_gem_path}/Gemfile && cd #{local_gem_path} && bundle install && bundle exec rake compile")
+      system("export BUNDLE_GEMFILE=#{local_gem_path}/Gemfile && cd #{local_gem_path} && bundle install && bundle exec rake clean compile")
     raise 'Failure to compile profiler native extension' unless success
   end
 else


### PR DESCRIPTION
**What does this PR do?**:

This PR is a follow-up of #2535 and fixes the same issue, but this time in the integration apps (I missed fixing them on that other PR...).

@TonyCTHsu reported an issue where compilation was failing in the integration apps, and upon analysis the issue was the following:

1. When the `build_ddtrace_profiling_native_extension.rb` step runs to setup the integration apps, it ran `rake compile`, which generated a `Makefile` for profiling. This `Makefile` included hardcoded paths for `libdatadog` version 0.9.

2. Then I merged the upgrade to `libdatadog` 1.0 to master, and he pulled this update.

3. When running the integration apps, the `build_ddtrace_profiling_native_extension.rb` step re-ran, but it reused the existing `Makefile`. This existing `Makefile` was using `libdatadog` 0.9 and not 1.0, and thus compilation broke, because `master` requires version 1.0, and cannot use the older version.

The fix here is simple: I've added the `clean` task as a required step on `build_ddtrace_profiling_native_extension.rb`, so that a new `Makefile` is generated every time this step runs.

**Motivation**:

Fix the issue reported.

**Additional Notes**:

This issue only affects development, since a new `Makefile` is generated every time `ddtrace` gets installed so I don't expect this issue to have affected customers.

**How to test the change?**:

Verify that the integration apps still work correctly, and that the

> `** Preparing to build the ddtrace profiling native extension... **`

message always shows when building the test app container (before the `bundle install` step).