### PR TITLE
Tweak flaky profiling spec

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -321,7 +321,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         start
         wait_until_running
 
-        sleep 0.1
+        sleep 0.2
 
         cpu_and_wall_time_worker.stop
 
@@ -329,18 +329,19 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         sample_count = result.map { |it| it.fetch(:values).fetch(:'cpu-samples') }.reduce(:+)
 
         stats = cpu_and_wall_time_worker.stats
+        debug_failures = { thread_list: Thread.list, result: result }
 
         trigger_sample_attempts = stats.fetch(:trigger_sample_attempts)
         simulated_signal_delivery = stats.fetch(:simulated_signal_delivery)
 
         expect(simulated_signal_delivery.to_f / trigger_sample_attempts).to (be >= 0.8), \
-          "Expected at least 80% of signals to be simulated (#{stats})"
+          "Expected at least 80% of signals to be simulated, stats: #{stats}, debug_failures: #{debug_failures}"
 
         # Sanity checking
 
-        # We're currently targeting 100 samples per second, so 5 in 100ms is a conservative approximation that hopefully
+        # We're currently targeting 100 samples per second, so this is a conservative approximation that hopefully
         # will not cause flakiness
-        expect(sample_count).to be >= 5, "sample_count: #{sample_count}, stats: #{stats}"
+        expect(sample_count).to be >= 8, "sample_count: #{sample_count}, stats: #{stats}, debug_failures: #{debug_failures}"
         expect(trigger_sample_attempts).to be >= sample_count
       end
     end


### PR DESCRIPTION
**What does this PR do?**:

This PR tweaks a profiling spec that caused flakiness in CI:

* Ruby 2.4: <https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/8534/workflows/68f4694f-e9d1-4106-9662-a9f0a747eec7/jobs/317412/tests#failed-test-0>
* Ruby 2.3: <https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/8545/workflows/8eda1b26-3959-4c89-94e6-b2a94f0bbd78/jobs/317806>
* Ruby 2.6: <https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/8534/workflows/68f4694f-e9d1-4106-9662-a9f0a747eec7/jobs/317421/tests#failed-test-0>

This spec by design cannot escape some potential for flakiness, since it starts the profiler and then is checking some stats on how it did, and asserting on them.

In the failed cases, it looks like in the given time period the profiler did not manage to take the number of expected samples, and furthermore even though the test thread was supposed to be sleeping (which is what this spec checks -- sampling during sleeping), the VM seemed to be a bit busy and not idle as expected.

To improve this, I've extended the spec from running for 0.1 to 0.2 seconds, as well as tweaking the expected sample_count.

I've also gathered a bit more information to be printed when the test fails. Hopefully it won't again, but if it does, we'll have more information to debug the failure.

**Motivation**:

Fix any flakiness in CI.

**Additional Notes**:

(N/A)

**How to test the change?**:

Validate that specs are still green and that flakiness doesn't show up again.