### PR TITLE
[PROF-6660] Add `profiling_enabled` state to environment logger output

### DIFF
--- a/lib/datadog/core/diagnostics/environment_logger.rb
+++ b/lib/datadog/core/diagnostics/environment_logger.rb
@@ -221,9 +221,9 @@ module Datadog
           !!Datadog.configuration.diagnostics.health_metrics.enabled
         end
 
-        # TODO: Populate when profiling is implemented
-        # def profiling_enabled
-        # end
+        def profiling_enabled
+          !!Datadog.configuration.profiling.enabled
+        end
 
         # TODO: Populate when automatic log correlation is implemented
         # def logs_correlation_enabled
@@ -254,6 +254,7 @@ module Datadog
             partial_flushing_enabled: partial_flushing_enabled,
             priority_sampling_enabled: priority_sampling_enabled,
             health_metrics_enabled: health_metrics_enabled,
+            profiling_enabled: profiling_enabled,
             **instrumented_integrations_settings
           }
         end

--- a/spec/datadog/core/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/core/diagnostics/environment_logger_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
           'runtime_metrics_enabled' => false,
           'version' => DDTrace::VERSION::STRING,
           'vm' => be_a(String),
-          'service' => be_a(String)
+          'service' => be_a(String),
+          'profiling_enabled' => false,
         )
       end
     end
@@ -151,7 +152,8 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
           service: be_a(String),
           tags: nil,
           version: DDTrace::VERSION::STRING,
-          vm: be_a(String)
+          vm: be_a(String),
+          profiling_enabled: false,
         )
       end
 
@@ -311,6 +313,12 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
         before { skip unless PlatformHelpers.truffleruby? }
 
         it { is_expected.to include vm: start_with('truffleruby') }
+      end
+
+      context 'with profiling enabled' do
+        before { Datadog.configure { |c| c.profiling.enabled = true } }
+
+        it { is_expected.to include profiling_enabled: true }
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**:

This PR adds a `profiling_enabled` entry in the environment logger output, which reflects the current configuration for profiling.

**Motivation**:

This was requested internally as being useful to support, and at least Node and Java already provide this key.

We also had a TODO for it, so one less TODO.

**Additional Notes**:

I hesitated between adding the configuration of the profiler being on, or the profiler actually being on (e.g. it's possible that the profiler has been requested on, but can't be enabled because for instance google-protobuf is missing).

My thinking is that the information about if the profiler really is on could be instead relayed via telemetry, so it may not be worth duplicating it here.

**How to test the change?**:

Change includes test coverage.