### PR TITLE
Ignore `vendor/bundle` for rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,7 @@ AllCops:
     - 'integration/apps/hanami/Rakefile'
     - 'lib/datadog/profiling/pprof/pprof_pb.rb'
     - 'spec/**/**/interesting_backtrace_helper.rb' # This file needs quite a few bizarre code patterns by design
+    - 'vendor/bundle/**/*'
   NewCops: disable # Don't allow new cops to be enabled implicitly.
 
 Layout/LineLength:


### PR DESCRIPTION




<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Have Rubocop ignore `vendor/bundle`

**Motivation**

Depending on one's setup, `vendor/bundle` may be used to install gems per project. Rubocop looks recursively into subfolders for additional `.rubocop.yml`, which is not going to work.

See https://github.com/rubocop/rubocop/issues/9832

**Additional Notes**

The error I encountered (spurious cop notices + missing `panolint` gem):

```
bundle exec rake rubocop
Running RuboCop...
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.

Please also note that you can opt-in to new cops by default by adding this to your config:
  AllCops:
    NewCops: enable

Gemspec/DeprecatedAttributeAssignment: # new in 1.30
  Enabled: true
Gemspec/RequireMFA: # new in 1.23
  Enabled: true
Layout/LineContinuationLeadingSpace: # new in 1.31
  Enabled: true
Layout/LineContinuationSpacing: # new in 1.31
  Enabled: true
Layout/LineEndStringConcatenationIndentation: # new in 1.18
  Enabled: true
Layout/SpaceBeforeBrackets: # new in 1.7
  Enabled: true
Lint/AmbiguousAssignment: # new in 1.7
  Enabled: true
Lint/AmbiguousOperatorPrecedence: # new in 1.21
  Enabled: true
Lint/AmbiguousRange: # new in 1.19
  Enabled: true
Lint/ConstantOverwrittenInRescue: # new in 1.31
  Enabled: true
Lint/DeprecatedConstants: # new in 1.8
  Enabled: true
Lint/DuplicateBranch: # new in 1.3
  Enabled: true
Lint/DuplicateRegexpCharacterClassElement: # new in 1.1
  Enabled: true
Lint/EmptyBlock: # new in 1.1
  Enabled: true
Lint/EmptyClass: # new in 1.3
  Enabled: true
Lint/EmptyInPattern: # new in 1.16
  Enabled: true
Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
  Enabled: true
Lint/LambdaWithoutLiteralBlock: # new in 1.8
  Enabled: true
Lint/NoReturnInBeginEndBlocks: # new in 1.2
  Enabled: true
Lint/NonAtomicFileOperation: # new in 1.31
  Enabled: true
Lint/NumberedParameterAssignment: # new in 1.9
  Enabled: true
Lint/OrAssignmentToConstant: # new in 1.9
  Enabled: true
Lint/RedundantDirGlobSort: # new in 1.8
  Enabled: true
Lint/RefinementImportMethods: # new in 1.27
  Enabled: true
Lint/RequireRangeParentheses: # new in 1.32
  Enabled: true
Lint/RequireRelativeSelfPath: # new in 1.22
  Enabled: true
Lint/SymbolConversion: # new in 1.9
  Enabled: true
Lint/ToEnumArguments: # new in 1.1
  Enabled: true
Lint/TripleQuotes: # new in 1.9
  Enabled: true
Lint/UnexpectedBlockArity: # new in 1.5
  Enabled: true
Lint/UnmodifiedReduceAccumulator: # new in 1.1
  Enabled: true
Lint/UselessRuby2Keywords: # new in 1.23
  Enabled: true
Naming/BlockForwarding: # new in 1.24
  Enabled: true
Security/CompoundHash: # new in 1.28
  Enabled: true
Security/IoMethods: # new in 1.22
  Enabled: true
Style/ArgumentsForwarding: # new in 1.1
  Enabled: true
Style/CollectionCompact: # new in 1.2
  Enabled: true
Style/DocumentDynamicEvalDefinition: # new in 1.1
  Enabled: true
Style/EmptyHeredoc: # new in 1.32
  Enabled: true
Style/EndlessMethod: # new in 1.8
  Enabled: true
Style/EnvHome: # new in 1.29
  Enabled: true
Style/FetchEnvVar: # new in 1.28
  Enabled: true
Style/FileRead: # new in 1.24
  Enabled: true
Style/FileWrite: # new in 1.24
  Enabled: true
Style/HashConversion: # new in 1.10
  Enabled: true
Style/HashExcept: # new in 1.7
  Enabled: true
Style/IfWithBooleanLiteralBranches: # new in 1.9
  Enabled: true
Style/InPatternThen: # new in 1.16
  Enabled: true
Style/MapCompactWithConditionalBlock: # new in 1.30
  Enabled: true
Style/MapToHash: # new in 1.24
  Enabled: true
Style/MultilineInPatternThen: # new in 1.16
  Enabled: true
Style/NegatedIfElseCondition: # new in 1.2
  Enabled: true
Style/NestedFileDirname: # new in 1.26
  Enabled: true
Style/NilLambda: # new in 1.3
  Enabled: true
Style/NumberedParameters: # new in 1.22
  Enabled: true
Style/NumberedParametersLimit: # new in 1.22
  Enabled: true
Style/ObjectThen: # new in 1.28
  Enabled: true
Style/OpenStructUse: # new in 1.23
  Enabled: true
Style/QuotedSymbols: # new in 1.16
  Enabled: true
Style/RedundantArgument: # new in 1.4
  Enabled: true
Style/RedundantInitialize: # new in 1.27
  Enabled: true
Style/RedundantSelfAssignmentBranch: # new in 1.19
  Enabled: true
Style/SelectByRegexp: # new in 1.22
  Enabled: true
Style/StringChars: # new in 1.12
  Enabled: true
Style/SwapValues: # new in 1.1
  Enabled: true
Performance/AncestorsInclude: # new in 1.7
  Enabled: true
Performance/BigDecimalWithNumericArgument: # new in 1.7
  Enabled: true
Performance/BlockGivenWithExplicitBlock: # new in 1.9
  Enabled: true
Performance/CollectionLiteralInLoop: # new in 1.8
  Enabled: true
Performance/ConcurrentMonotonicTime: # new in 1.12
  Enabled: true
Performance/ConstantRegexp: # new in 1.9
  Enabled: true
Performance/MapCompact: # new in 1.11
  Enabled: true
Performance/MethodObjectAsBlock: # new in 1.9
  Enabled: true
Performance/RedundantEqualityComparisonBlock: # new in 1.10
  Enabled: true
Performance/RedundantSortBlock: # new in 1.7
  Enabled: true
Performance/RedundantSplitRegexpArgument: # new in 1.10
  Enabled: true
Performance/RedundantStringChars: # new in 1.7
  Enabled: true
Performance/ReverseFirst: # new in 1.7
  Enabled: true
Performance/SortReverse: # new in 1.7
  Enabled: true
Performance/Squeeze: # new in 1.7
  Enabled: true
Performance/StringIdentifierArgument: # new in 1.13
  Enabled: true
Performance/StringInclude: # new in 1.7
  Enabled: true
Performance/Sum: # new in 1.8
  Enabled: true
RSpec/BeEq: # new in 2.9.0
  Enabled: true
RSpec/BeNil: # new in 2.9.0
  Enabled: true
RSpec/ChangeByZero: # new in 2.11.0
  Enabled: true
RSpec/ExcessiveDocstringSpacing: # new in 2.5
  Enabled: true
RSpec/IdenticalEqualityAssertion: # new in 2.4
  Enabled: true
RSpec/SubjectDeclaration: # new in 2.5
  Enabled: true
RSpec/VerifiedDoubleReference: # new in 2.10.0
  Enabled: true
RSpec/Capybara/SpecificMatcher: # new in 2.12
  Enabled: true
RSpec/FactoryBot/SyntaxMethods: # new in 2.7
  Enabled: true
RSpec/Rails/AvoidSetupHook: # new in 2.4
  Enabled: true
RSpec/Rails/HaveHttpStatus: # new in 2.12
  Enabled: true
For more information: https://docs.rubocop.org/rubocop/versioning.html
Unable to find gem panolint; is the gem installed? Gem::MissingSpecError
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/config_loader_resolver.rb:278:in `rescue in gem_config_path'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/config_loader_resolver.rb:268:in `gem_config_path'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/config_loader_resolver.rb:69:in `block (2 levels) in resolve_inheritance_from_gems'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/config_loader_resolver.rb:67:in `reverse_each'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/config_loader_resolver.rb:67:in `block in resolve_inheritance_from_gems'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/config_loader_resolver.rb:61:in `each_pair'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/config_loader_resolver.rb:61:in `resolve_inheritance_from_gems'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/config_loader.rb:52:in `load_file'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/config_loader.rb:105:in `configuration_from_file'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/config_store.rb:68:in `for_dir'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/config_store.rb:58:in `for'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/target_finder.rb:161:in `ruby_interpreters'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/target_finder.rb:153:in `ruby_executable?'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/target_finder.rb:169:in `ruby_file?'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/target_finder.rb:73:in `to_inspect?'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/target_finder.rb:64:in `block in target_files_in_dir'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/target_finder.rb:64:in `select'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/target_finder.rb:64:in `target_files_in_dir'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/target_finder.rb:32:in `find'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/runner.rb:81:in `find_target_files'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/runner.rb:42:in `run'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/cli/command/execute_runner.rb:26:in `block in execute_runner'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/cli/command/execute_runner.rb:52:in `with_redirect'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/cli/command/execute_runner.rb:25:in `execute_runner'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/cli/command/execute_runner.rb:17:in `run'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/cli/command.rb:11:in `run'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/cli/environment.rb:18:in `run'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/cli.rb:72:in `run_command'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/cli.rb:79:in `execute_runners'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/cli.rb:48:in `run'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/rake_task.rb:51:in `run_cli'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/rake_task.rb:26:in `block (2 levels) in initialize'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/file_utils_ext.rb:58:in `verbose'
/usr/local/bundle/gems/rubocop-1.32.0/lib/rubocop/rake_task.rb:24:in `block in initialize'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/task.rb:281:in `block in execute'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/task.rb:281:in `each'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/task.rb:281:in `execute'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/task.rb:199:in `synchronize'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/task.rb:199:in `invoke_with_call_chain'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/task.rb:188:in `invoke'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/application.rb:160:in `invoke_task'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/application.rb:116:in `block (2 levels) in top_level'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/application.rb:116:in `each'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/application.rb:116:in `block in top_level'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/application.rb:125:in `run_with_threads'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/application.rb:110:in `top_level'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/application.rb:83:in `block in run'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/application.rb:186:in `standard_exception_handling'
/usr/local/bundle/gems/rake-13.0.6/lib/rake/application.rb:80:in `run'
/usr/local/bundle/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/usr/local/bundle/bin/rake:25:in `load'
/usr/local/bundle/bin/rake:25:in `<top (required)>'
/usr/local/bundle/gems/bundler-2.4.3/lib/bundler/cli/exec.rb:58:in `load'
/usr/local/bundle/gems/bundler-2.4.3/lib/bundler/cli/exec.rb:58:in `kernel_load'
/usr/local/bundle/gems/bundler-2.4.3/lib/bundler/cli/exec.rb:23:in `run'
/usr/local/bundle/gems/bundler-2.4.3/lib/bundler/cli.rb:491:in `exec'
/usr/local/bundle/gems/bundler-2.4.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/bundle/gems/bundler-2.4.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/usr/local/bundle/gems/bundler-2.4.3/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/usr/local/bundle/gems/bundler-2.4.3/lib/bundler/cli.rb:34:in `dispatch'
/usr/local/bundle/gems/bundler-2.4.3/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/usr/local/bundle/gems/bundler-2.4.3/lib/bundler/cli.rb:28:in `start'
/usr/local/bundle/gems/bundler-2.4.3/exe/bundle:45:in `block in <top (required)>'
/usr/local/bundle/gems/bundler-2.4.3/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
/usr/local/bundle/gems/bundler-2.4.3/exe/bundle:33:in `<top (required)>'
/usr/local/bundle/bin/bundle:25:in `load'
/usr/local/bundle/bin/bundle:25:in `<main>'
RuboCop failed!
```

**How to test the change?**

- `export BUNDLE_PATH="$PWD/vendor/bundle"`
- `bundle install`
- `bundle exec rake rubocop`
