### PR TITLE
Fix hanami integration app dependencies

### DIFF
--- a/integration/apps/hanami/Gemfile
+++ b/integration/apps/hanami/Gemfile
@@ -6,6 +6,7 @@ gem 'rake'
 gem 'hanami',       '~> 1.3'
 gem 'hanami-model', '~> 1.3'
 gem 'dry-container', '~> 0.8.0'
+gem 'dry-configurable', '~> 0.12.0'
 
 gem 'sqlite3'
 gem 'puma'

--- a/integration/apps/hanami/config/puma.rb
+++ b/integration/apps/hanami/config/puma.rb
@@ -12,8 +12,6 @@ threads max_threads_count, min_threads_count
 
 preload_app!
 
-rackup DefaultRackup
-
 port ENV.fetch("PORT") { 80 }
 
 environment ENV.fetch("HANAMI_ENV") { "development" }


### PR DESCRIPTION
**What does this PR do?**

Since we do not check lock files into version control, the dependencies are stale without version constraint. Causing error

```
app_1          | /usr/local/bundle/gems/dry-configurable-0.16.1/lib/dry/configurable/dsl.rb:31:in `setting': wrong number of arguments (given 2, expected 1) (ArgumentError)
hanami_app_1 exited with code 1
```

1. Limit `dry-configurable`
2. Remove constant for Puma 6