### PR TITLE
Pin bundler to 2.3

### DIFF
--- a/.circleci/images/primary/Dockerfile-2.1.10
+++ b/.circleci/images/primary/Dockerfile-2.1.10
@@ -71,8 +71,7 @@ RUN set -ex \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
-    BUNDLE_BIN="$GEM_HOME/bin" \
+ENV BUNDLE_BIN="$GEM_HOME/bin" \
     BUNDLE_SILENCE_ROOT_WARNING=1 \
     BUNDLE_APP_CONFIG="$GEM_HOME"
 ENV PATH $BUNDLE_BIN:$PATH

--- a/.circleci/images/primary/Dockerfile-2.2.10
+++ b/.circleci/images/primary/Dockerfile-2.2.10
@@ -72,8 +72,7 @@ RUN set -ex \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
-    BUNDLE_BIN="$GEM_HOME/bin" \
+ENV BUNDLE_BIN="$GEM_HOME/bin" \
     BUNDLE_SILENCE_ROOT_WARNING=1 \
     BUNDLE_APP_CONFIG="$GEM_HOME"
 ENV PATH $BUNDLE_BIN:$PATH

--- a/.circleci/images/primary/Dockerfile-2.6.10
+++ b/.circleci/images/primary/Dockerfile-2.6.10
@@ -56,8 +56,8 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Install RubyGems
-RUN gem update --system
-RUN gem install bundler
+RUN gem update --system 3.3.26
+RUN gem install bundler -v '~> 2.3.26'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/.circleci/images/primary/Dockerfile-2.7.6
+++ b/.circleci/images/primary/Dockerfile-2.7.6
@@ -56,8 +56,8 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Upgrade RubyGems and Bundler # Upgrading disabled until https://github.com/thoughtbot/appraisal/issues/162 is fixed
-RUN gem update --system
-RUN gem install bundler
+RUN gem update --system 3.3.26
+RUN gem install bundler -v '~> 2.3.26'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/.circleci/images/primary/Dockerfile-3.1.2
+++ b/.circleci/images/primary/Dockerfile-3.1.2
@@ -56,8 +56,8 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Upgrade RubyGems and Bundler
-RUN gem update --system
-RUN gem install bundler
+RUN gem update --system 3.3.26
+RUN gem install bundler -v '~> 2.3.26'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/.circleci/images/primary/Dockerfile-3.2.0
+++ b/.circleci/images/primary/Dockerfile-3.2.0
@@ -56,8 +56,8 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Upgrade RubyGems and Bundler
-RUN gem update --system
-RUN gem install bundler
+RUN gem update --system 3.3.26
+RUN gem install bundler -v '~> 2.3.26'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.21.0
@@ -35,8 +35,7 @@ RUN gem install rake net-telnet xmlrpc
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
-    BUNDLE_BIN="$GEM_HOME/bin" \
+ENV BUNDLE_BIN="$GEM_HOME/bin" \
     BUNDLE_SILENCE_ROOT_WARNING=1 \
     BUNDLE_APP_CONFIG="$GEM_HOME"
 ENV PATH $BUNDLE_BIN:$PATH

--- a/.circleci/images/primary/Dockerfile-jruby-9.2.8.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.2.8.0
@@ -37,8 +37,7 @@ RUN gem install rake net-telnet xmlrpc
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
-    BUNDLE_BIN="$GEM_HOME/bin" \
+ENV BUNDLE_BIN="$GEM_HOME/bin" \
     BUNDLE_SILENCE_ROOT_WARNING=1 \
     BUNDLE_APP_CONFIG="$GEM_HOME"
 ENV PATH $BUNDLE_BIN:$PATH

--- a/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
@@ -30,7 +30,7 @@ RUN mkdir -p /opt/jruby/etc \
     echo 'update: --no-document'; \
   } >> /opt/jruby/etc/gemrc
 
-RUN gem install bundler rake net-telnet xmlrpc
+RUN gem install rake net-telnet xmlrpc
 
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
@@ -105,8 +105,8 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Upgrade RubyGems and Bundler
-RUN gem update --system
-RUN gem install bundler
+RUN gem update --system 3.3.26
+RUN gem install bundler -v '~> 2.3.26'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 # Ensure JRuby is available when running "bash --login"

--- a/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.3.9.0
@@ -35,8 +35,7 @@ RUN gem install rake net-telnet xmlrpc
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
-    BUNDLE_BIN="$GEM_HOME/bin" \
+ENV BUNDLE_BIN="$GEM_HOME/bin" \
     BUNDLE_SILENCE_ROOT_WARNING=1 \
     BUNDLE_APP_CONFIG="$GEM_HOME"
 ENV PATH $BUNDLE_BIN:$PATH

--- a/.circleci/images/primary/Dockerfile-jruby-9.4.0.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.4.0.0
@@ -30,7 +30,7 @@ RUN mkdir -p /opt/jruby/etc \
     echo 'update: --no-document'; \
   } >> /opt/jruby/etc/gemrc
 
-RUN gem install bundler rake net-telnet xmlrpc
+RUN gem install rake net-telnet xmlrpc
 
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
@@ -105,8 +105,8 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Upgrade RubyGems and Bundler
-RUN gem update --system
-RUN gem install bundler
+RUN gem update --system 3.3.26
+RUN gem install bundler -v '~> 2.3.26'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 # Ensure JRuby is available when running "bash --login"

--- a/.circleci/images/primary/Dockerfile-jruby-9.4.0.0
+++ b/.circleci/images/primary/Dockerfile-jruby-9.4.0.0
@@ -35,8 +35,7 @@ RUN gem install rake net-telnet xmlrpc
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
-    BUNDLE_BIN="$GEM_HOME/bin" \
+ENV BUNDLE_BIN="$GEM_HOME/bin" \
     BUNDLE_SILENCE_ROOT_WARNING=1 \
     BUNDLE_APP_CONFIG="$GEM_HOME"
 ENV PATH $BUNDLE_BIN:$PATH

--- a/.circleci/images/primary/Dockerfile-truffleruby-22.3.0
+++ b/.circleci/images/primary/Dockerfile-truffleruby-22.3.0
@@ -57,12 +57,11 @@ RUN DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17
 ENV GEM_HOME="/usr/local/bundle"
 
 # Install RubyGems
-RUN gem update --system
 RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Upgrade RubyGems and Bundler
-RUN gem update --system
-RUN gem install bundler
+RUN gem update --system 3.3.26
+RUN gem install bundler -v '~> 2.3.26'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir -p /app


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

- pin bundler
- remove an env var that causes confusion

**Motivation**

Things (including appraisal command) are broken with 2.4!

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**

- Images should generate properly
- Images should not have bundler 2.4
- Images should install gems in /usr/local/bundle whether via `gem install` or `bundle install`.