### PR TITLE
Extract components out of Core

### DIFF
--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -8,11 +8,8 @@ require_relative '../runtime/metrics'
 require_relative '../telemetry/client'
 require_relative '../workers/runtime_metrics'
 
-require_relative '../../tracing/tracer'
-require_relative '../../tracing/flush'
-require_relative '../../tracing/sync_writer'
-require_relative '../../tracing/sampling/span/rule_parser'
-require_relative '../../tracing/sampling/span/sampler'
+require_relative '../../tracing/component'
+require_relative '../../profiling/component'
 
 module Datadog
   module Core
@@ -20,6 +17,9 @@ module Datadog
       # Global components for the trace library.
       class Components
         class << self
+          include Datadog::Tracing::Component
+          include Datadog::Profiling::Component
+
           def build_health_metrics(settings)
             settings = settings.diagnostics.health_metrics
             options = { enabled: settings.enabled }
@@ -57,223 +57,6 @@ module Datadog
             Telemetry::Client.new(enabled: settings.telemetry.enabled)
           end
 
-          def build_tracer(settings, agent_settings)
-            # If a custom tracer has been provided, use it instead.
-            # Ignore all other options (they should already be configured.)
-            tracer = settings.tracing.instance
-            return tracer unless tracer.nil?
-
-            # Apply test mode settings if test mode is activated
-            if settings.tracing.test_mode.enabled
-              trace_flush = build_test_mode_trace_flush(settings)
-              sampler = build_test_mode_sampler
-              writer = build_test_mode_writer(settings, agent_settings)
-            else
-              trace_flush = build_trace_flush(settings)
-              sampler = build_sampler(settings)
-              writer = build_writer(settings, agent_settings)
-            end
-
-            subscribe_to_writer_events!(writer, sampler, settings.tracing.test_mode.enabled)
-
-            Tracing::Tracer.new(
-              default_service: settings.service,
-              enabled: settings.tracing.enabled,
-              trace_flush: trace_flush,
-              sampler: sampler,
-              span_sampler: build_span_sampler(settings),
-              writer: writer,
-              tags: build_tracer_tags(settings),
-            )
-          end
-
-          def build_trace_flush(settings)
-            if settings.tracing.partial_flush.enabled
-              Tracing::Flush::Partial.new(
-                min_spans_before_partial_flush: settings.tracing.partial_flush.min_spans_threshold
-              )
-            else
-              Tracing::Flush::Finished.new
-            end
-          end
-
-          # TODO: Sampler should be a top-level component.
-          # It is currently part of the Tracer initialization
-          # process, but can take a variety of options (including
-          # a fully custom instance) that makes the Tracer
-          # initialization process complex.
-          def build_sampler(settings)
-            if (sampler = settings.tracing.sampler)
-              if settings.tracing.priority_sampling == false
-                sampler
-              else
-                ensure_priority_sampling(sampler, settings)
-              end
-            elsif settings.tracing.priority_sampling == false
-              Tracing::Sampling::RuleSampler.new(
-                rate_limit: settings.tracing.sampling.rate_limit,
-                default_sample_rate: settings.tracing.sampling.default_rate
-              )
-            else
-              Tracing::Sampling::PrioritySampler.new(
-                base_sampler: Tracing::Sampling::AllSampler.new,
-                post_sampler: Tracing::Sampling::RuleSampler.new(
-                  rate_limit: settings.tracing.sampling.rate_limit,
-                  default_sample_rate: settings.tracing.sampling.default_rate
-                )
-              )
-            end
-          end
-
-          def ensure_priority_sampling(sampler, settings)
-            if sampler.is_a?(Tracing::Sampling::PrioritySampler)
-              sampler
-            else
-              Tracing::Sampling::PrioritySampler.new(
-                base_sampler: sampler,
-                post_sampler: Tracing::Sampling::RuleSampler.new(
-                  rate_limit: settings.tracing.sampling.rate_limit,
-                  default_sample_rate: settings.tracing.sampling.default_rate
-                )
-              )
-            end
-          end
-
-          # TODO: Writer should be a top-level component.
-          # It is currently part of the Tracer initialization
-          # process, but can take a variety of options (including
-          # a fully custom instance) that makes the Tracer
-          # initialization process complex.
-          def build_writer(settings, agent_settings)
-            if (writer = settings.tracing.writer)
-              return writer
-            end
-
-            Tracing::Writer.new(agent_settings: agent_settings, **settings.tracing.writer_options)
-          end
-
-          def subscribe_to_writer_events!(writer, sampler, test_mode)
-            return unless writer.respond_to?(:events) # Check if it's a custom, external writer
-
-            writer.events.after_send.subscribe(&WRITER_RECORD_ENVIRONMENT_INFORMATION_CALLBACK)
-
-            return unless sampler.is_a?(Tracing::Sampling::PrioritySampler)
-
-            # DEV: We need to ignore priority sampling updates coming from the agent in test mode
-            # because test mode wants to *unconditionally* sample all traces.
-            #
-            # This can cause trace metrics to be overestimated, but that's a trade-off we take
-            # here to achieve 100% sampling rate.
-            return if test_mode
-
-            writer.events.after_send.subscribe(&writer_update_priority_sampler_rates_callback(sampler))
-          end
-
-          WRITER_RECORD_ENVIRONMENT_INFORMATION_CALLBACK = lambda do |_, responses|
-            Core::Diagnostics::EnvironmentLogger.log!(responses)
-          end
-
-          # Create new lambda for writer callback,
-          # capture the current sampler in the callback closure.
-          def writer_update_priority_sampler_rates_callback(sampler)
-            lambda do |_, responses|
-              response = responses.last
-
-              next unless response && !response.internal_error? && response.service_rates
-
-              sampler.update(response.service_rates, decision: Tracing::Sampling::Ext::Decision::AGENT_RATE)
-            end
-          end
-
-          def build_span_sampler(settings)
-            rules = Tracing::Sampling::Span::RuleParser.parse_json(settings.tracing.sampling.span_rules)
-            Tracing::Sampling::Span::Sampler.new(rules || [])
-          end
-
-          def build_profiler(settings, agent_settings, tracer)
-            return unless settings.profiling.enabled
-
-            # Workaround for weird dependency direction: the Core::Configuration::Components class currently has a
-            # dependency on individual products, in this case the Profiler.
-            # (Note "currently": in the future we want to change this so core classes don't depend on specific products)
-            #
-            # If the current file included a `require 'datadog/profiler'` at its beginning, we would generate circular
-            # requires when used from profiling:
-            #
-            # datadog/profiling
-            #     └─requires─> datadog/core
-            #                      └─requires─> datadog/core/configuration/components
-            #                                       └─requires─> datadog/profiling       # Loop!
-            #
-            # ...thus in #1998 we removed such a require.
-            #
-            # On the other hand, if datadog/core is loaded by a different product and no general `require 'ddtrace'` is
-            # done, then profiling may not be loaded, and thus to avoid this issue we do a require here (which is a
-            # no-op if profiling is already loaded).
-            require_relative '../../profiling'
-            return unless Profiling.supported?
-
-            unless defined?(Profiling::Tasks::Setup)
-              # In #1545 a user reported a NameError due to this constant being uninitialized
-              # I've documented my suspicion on why that happened in
-              # https://github.com/DataDog/dd-trace-rb/issues/1545#issuecomment-856049025
-              #
-              # > Thanks for the info! It seems to feed into my theory: there's two moments in the code where we check if
-              # > profiler is "supported": 1) when loading ddtrace (inside preload) and 2) when starting the profile
-              # > after Datadog.configure gets run.
-              # > The problem is that the code assumes that both checks 1) and 2) will always reach the same conclusion:
-              # > either profiler is supported, or profiler is not supported.
-              # > In the problematic case, it looks like in your case check 1 decides that profiler is not
-              # > supported => doesn't load it, and then check 2 decides that it is => assumes it is loaded and tries to
-              # > start it.
-              #
-              # I was never able to validate if this was the issue or why exactly .supported? would change its mind BUT
-              # just in case it happens again, I've left this check which avoids breaking the user's application AND
-              # would instead direct them to report it to us instead, so that we can investigate what's wrong.
-              #
-              # TODO: As of June 2021, most checks in .supported? are related to the google-protobuf gem; so it's
-              # very likely that it was the origin of the issue we saw. Thus, if, as planned we end up moving away from
-              # protobuf OR enough time has passed and no users saw the issue again, we can remove this check altogether.
-              Datadog.logger.error(
-                'Profiling was marked as supported and enabled, but setup task was not loaded properly. ' \
-                'Please report this at https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug'
-              )
-
-              return
-            end
-
-            # Load extensions needed to support some of the Profiling features
-            Profiling::Tasks::Setup.new.run
-
-            # NOTE: Please update the Initialization section of ProfilingDevelopment.md with any changes to this method
-
-            if settings.profiling.advanced.force_enable_new_profiler
-              print_new_profiler_warnings
-
-              recorder = Datadog::Profiling::StackRecorder.new
-              collector = Datadog::Profiling::Collectors::CpuAndWallTimeWorker.new(
-                recorder: recorder,
-                max_frames: settings.profiling.advanced.max_frames,
-                tracer: tracer,
-                gc_profiling_enabled: should_enable_gc_profiling?(settings)
-              )
-            else
-              trace_identifiers_helper = Profiling::TraceIdentifiers::Helper.new(
-                tracer: tracer,
-                endpoint_collection_enabled: settings.profiling.advanced.endpoint.collection.enabled
-              )
-
-              recorder = build_profiler_old_recorder(settings)
-              collector = build_profiler_oldstack_collector(settings, recorder, trace_identifiers_helper)
-            end
-
-            exporter = build_profiler_exporter(settings, recorder)
-            transport = build_profiler_transport(settings, agent_settings)
-            scheduler = Profiling::Scheduler.new(exporter: exporter, transport: transport)
-
-            Profiling::Profiler.new([collector], scheduler)
-          end
-
           private
 
           def build_tracer_tags(settings)
@@ -301,70 +84,6 @@ module Datadog
             # Flush traces synchronously, to guarantee they are written.
             writer_options = settings.tracing.test_mode.writer_options || {}
             Tracing::SyncWriter.new(agent_settings: agent_settings, **writer_options)
-          end
-
-          def build_profiler_old_recorder(settings)
-            Profiling::OldRecorder.new([Profiling::Events::StackSample], settings.profiling.advanced.max_events)
-          end
-
-          def build_profiler_exporter(settings, recorder)
-            code_provenance_collector =
-              (Profiling::Collectors::CodeProvenance.new if settings.profiling.advanced.code_provenance_enabled)
-
-            Profiling::Exporter.new(pprof_recorder: recorder, code_provenance_collector: code_provenance_collector)
-          end
-
-          def build_profiler_oldstack_collector(settings, old_recorder, trace_identifiers_helper)
-            Profiling::Collectors::OldStack.new(
-              old_recorder,
-              trace_identifiers_helper: trace_identifiers_helper,
-              max_frames: settings.profiling.advanced.max_frames
-            )
-          end
-
-          def build_profiler_transport(settings, agent_settings)
-            settings.profiling.exporter.transport ||
-              Profiling::HttpTransport.new(
-                agent_settings: agent_settings,
-                site: settings.site,
-                api_key: settings.api_key,
-                upload_timeout_seconds: settings.profiling.upload.timeout_seconds,
-              )
-          end
-
-          def should_enable_gc_profiling?(settings)
-            # See comments on the setting definition for more context on why it exists.
-            if settings.profiling.advanced.force_enable_gc_profiling
-              if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3')
-                Datadog.logger.debug(
-                  'Profiling time/resources spent in Garbage Collection force enabled. Do not use Ractors in combination ' \
-                  'with this option as profiles will be incomplete.'
-                )
-              end
-
-              true
-            else
-              false
-            end
-          end
-
-          def print_new_profiler_warnings
-            if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
-              Datadog.logger.warn(
-                'New Ruby profiler has been force-enabled. This feature is in beta state. We do not yet recommend ' \
-                'running it in production environments. Please report any issues ' \
-                'you run into to Datadog support or via <https://github.com/datadog/dd-trace-rb/issues/new>!'
-              )
-            else
-              # For more details on the issue, see the "BIG Issue" comment on `gvl_owner` function in
-              # `private_vm_api_access.c`.
-              Datadog.logger.warn(
-                'New Ruby profiler has been force-enabled on a legacy Ruby version (< 2.6). This is not recommended in ' \
-                'production environments, as due to limitations in Ruby APIs, we suspect it may lead to crashes in very ' \
-                'rare situations. Please report any issues you run into to Datadog support or ' \
-                'via <https://github.com/datadog/dd-trace-rb/issues/new>!'
-              )
-            end
           end
         end
 

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -1,0 +1,157 @@
+# typed: ignore
+# frozen_string_literal: true
+
+module Datadog
+  module Profiling
+    # Profiling component
+    module Component
+      def build_profiler(settings, agent_settings, tracer)
+        return unless settings.profiling.enabled
+
+        # Workaround for weird dependency direction: the Core::Configuration::Components class currently has a
+        # dependency on individual products, in this case the Profiler.
+        # (Note "currently": in the future we want to change this so core classes don't depend on specific products)
+        #
+        # If the current file included a `require 'datadog/profiler'` at its beginning, we would generate circular
+        # requires when used from profiling:
+        #
+        # datadog/profiling
+        #     └─requires─> datadog/core
+        #                      └─requires─> datadog/core/configuration/components
+        #                                       └─requires─> datadog/profiling       # Loop!
+        #
+        # ...thus in #1998 we removed such a require.
+        #
+        # On the other hand, if datadog/core is loaded by a different product and no general `require 'ddtrace'` is
+        # done, then profiling may not be loaded, and thus to avoid this issue we do a require here (which is a
+        # no-op if profiling is already loaded).
+        require_relative '../profiling'
+        return unless Profiling.supported?
+
+        unless defined?(Profiling::Tasks::Setup)
+          # In #1545 a user reported a NameError due to this constant being uninitialized
+          # I've documented my suspicion on why that happened in
+          # https://github.com/DataDog/dd-trace-rb/issues/1545#issuecomment-856049025
+          #
+          # > Thanks for the info! It seems to feed into my theory: there's two moments in the code where we check if
+          # > profiler is "supported": 1) when loading ddtrace (inside preload) and 2) when starting the profile
+          # > after Datadog.configure gets run.
+          # > The problem is that the code assumes that both checks 1) and 2) will always reach the same conclusion:
+          # > either profiler is supported, or profiler is not supported.
+          # > In the problematic case, it looks like in your case check 1 decides that profiler is not
+          # > supported => doesn't load it, and then check 2 decides that it is => assumes it is loaded and tries to
+          # > start it.
+          #
+          # I was never able to validate if this was the issue or why exactly .supported? would change its mind BUT
+          # just in case it happens again, I've left this check which avoids breaking the user's application AND
+          # would instead direct them to report it to us instead, so that we can investigate what's wrong.
+          #
+          # TODO: As of June 2021, most checks in .supported? are related to the google-protobuf gem; so it's
+          # very likely that it was the origin of the issue we saw. Thus, if, as planned we end up moving away from
+          # protobuf OR enough time has passed and no users saw the issue again, we can remove this check altogether.
+          Datadog.logger.error(
+            'Profiling was marked as supported and enabled, but setup task was not loaded properly. ' \
+            'Please report this at https://github.com/DataDog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug'
+          )
+
+          return
+        end
+
+        # Load extensions needed to support some of the Profiling features
+        Profiling::Tasks::Setup.new.run
+
+        # NOTE: Please update the Initialization section of ProfilingDevelopment.md with any changes to this method
+
+        if settings.profiling.advanced.force_enable_new_profiler
+          print_new_profiler_warnings
+
+          recorder = Datadog::Profiling::StackRecorder.new
+          collector = Datadog::Profiling::Collectors::CpuAndWallTimeWorker.new(
+            recorder: recorder,
+            max_frames: settings.profiling.advanced.max_frames,
+            tracer: tracer,
+            gc_profiling_enabled: should_enable_gc_profiling?(settings)
+          )
+        else
+          trace_identifiers_helper = Profiling::TraceIdentifiers::Helper.new(
+            tracer: tracer,
+            endpoint_collection_enabled: settings.profiling.advanced.endpoint.collection.enabled
+          )
+
+          recorder = build_profiler_old_recorder(settings)
+          collector = build_profiler_oldstack_collector(settings, recorder, trace_identifiers_helper)
+        end
+
+        exporter = build_profiler_exporter(settings, recorder)
+        transport = build_profiler_transport(settings, agent_settings)
+        scheduler = Profiling::Scheduler.new(exporter: exporter, transport: transport)
+
+        Profiling::Profiler.new([collector], scheduler)
+      end
+
+      def build_profiler_old_recorder(settings)
+        Profiling::OldRecorder.new([Profiling::Events::StackSample], settings.profiling.advanced.max_events)
+      end
+
+      def build_profiler_exporter(settings, recorder)
+        code_provenance_collector =
+          (Profiling::Collectors::CodeProvenance.new if settings.profiling.advanced.code_provenance_enabled)
+
+        Profiling::Exporter.new(pprof_recorder: recorder, code_provenance_collector: code_provenance_collector)
+      end
+
+      def build_profiler_oldstack_collector(settings, old_recorder, trace_identifiers_helper)
+        Profiling::Collectors::OldStack.new(
+          old_recorder,
+          trace_identifiers_helper: trace_identifiers_helper,
+          max_frames: settings.profiling.advanced.max_frames
+        )
+      end
+
+      def build_profiler_transport(settings, agent_settings)
+        settings.profiling.exporter.transport ||
+          Profiling::HttpTransport.new(
+            agent_settings: agent_settings,
+            site: settings.site,
+            api_key: settings.api_key,
+            upload_timeout_seconds: settings.profiling.upload.timeout_seconds,
+          )
+      end
+
+      def should_enable_gc_profiling?(settings)
+        # See comments on the setting definition for more context on why it exists.
+        if settings.profiling.advanced.force_enable_gc_profiling
+          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3')
+            Datadog.logger.debug(
+              'Profiling time/resources spent in Garbage Collection force enabled. Do not use Ractors in combination ' \
+              'with this option as profiles will be incomplete.'
+            )
+          end
+
+          true
+        else
+          false
+        end
+      end
+
+      def print_new_profiler_warnings
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
+          Datadog.logger.warn(
+            'New Ruby profiler has been force-enabled. This feature is in beta state. We do not yet recommend ' \
+            'running it in production environments. Please report any issues ' \
+            'you run into to Datadog support or via <https://github.com/datadog/dd-trace-rb/issues/new>!'
+          )
+        else
+          # For more details on the issue, see the "BIG Issue" comment on `gvl_owner` function in
+          # `private_vm_api_access.c`.
+          Datadog.logger.warn(
+            'New Ruby profiler has been force-enabled on a legacy Ruby version (< 2.6). This is not recommended in ' \
+            'production environments, as due to limitations in Ruby APIs, we suspect it may lead to crashes in very ' \
+            'rare situations. Please report any issues you run into to Datadog support or ' \
+            'via <https://github.com/datadog/dd-trace-rb/issues/new>!'
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/tracing/component.rb
+++ b/lib/datadog/tracing/component.rb
@@ -1,0 +1,148 @@
+# typed: ignore
+# frozen_string_literal: true
+
+require_relative 'tracer'
+require_relative 'flush'
+require_relative 'sync_writer'
+require_relative 'sampling/span/rule_parser'
+require_relative 'sampling/span/sampler'
+
+module Datadog
+  module Tracing
+    # Tracing component
+    module Component
+      def build_tracer(settings, agent_settings)
+        # If a custom tracer has been provided, use it instead.
+        # Ignore all other options (they should already be configured.)
+        tracer = settings.tracing.instance
+        return tracer unless tracer.nil?
+
+        # Apply test mode settings if test mode is activated
+        if settings.tracing.test_mode.enabled
+          trace_flush = build_test_mode_trace_flush(settings)
+          sampler = build_test_mode_sampler
+          writer = build_test_mode_writer(settings, agent_settings)
+        else
+          trace_flush = build_trace_flush(settings)
+          sampler = build_sampler(settings)
+          writer = build_writer(settings, agent_settings)
+        end
+
+        subscribe_to_writer_events!(writer, sampler, settings.tracing.test_mode.enabled)
+
+        Tracing::Tracer.new(
+          default_service: settings.service,
+          enabled: settings.tracing.enabled,
+          trace_flush: trace_flush,
+          sampler: sampler,
+          span_sampler: build_span_sampler(settings),
+          writer: writer,
+          tags: build_tracer_tags(settings),
+        )
+      end
+
+      def build_trace_flush(settings)
+        if settings.tracing.partial_flush.enabled
+          Tracing::Flush::Partial.new(
+            min_spans_before_partial_flush: settings.tracing.partial_flush.min_spans_threshold
+          )
+        else
+          Tracing::Flush::Finished.new
+        end
+      end
+
+      # TODO: Sampler should be a top-level component.
+      # It is currently part of the Tracer initialization
+      # process, but can take a variety of options (including
+      # a fully custom instance) that makes the Tracer
+      # initialization process complex.
+      def build_sampler(settings)
+        if (sampler = settings.tracing.sampler)
+          if settings.tracing.priority_sampling == false
+            sampler
+          else
+            ensure_priority_sampling(sampler, settings)
+          end
+        elsif settings.tracing.priority_sampling == false
+          Tracing::Sampling::RuleSampler.new(
+            rate_limit: settings.tracing.sampling.rate_limit,
+            default_sample_rate: settings.tracing.sampling.default_rate
+          )
+        else
+          Tracing::Sampling::PrioritySampler.new(
+            base_sampler: Tracing::Sampling::AllSampler.new,
+            post_sampler: Tracing::Sampling::RuleSampler.new(
+              rate_limit: settings.tracing.sampling.rate_limit,
+              default_sample_rate: settings.tracing.sampling.default_rate
+            )
+          )
+        end
+      end
+
+      def ensure_priority_sampling(sampler, settings)
+        if sampler.is_a?(Tracing::Sampling::PrioritySampler)
+          sampler
+        else
+          Tracing::Sampling::PrioritySampler.new(
+            base_sampler: sampler,
+            post_sampler: Tracing::Sampling::RuleSampler.new(
+              rate_limit: settings.tracing.sampling.rate_limit,
+              default_sample_rate: settings.tracing.sampling.default_rate
+            )
+          )
+        end
+      end
+
+      # TODO: Writer should be a top-level component.
+      # It is currently part of the Tracer initialization
+      # process, but can take a variety of options (including
+      # a fully custom instance) that makes the Tracer
+      # initialization process complex.
+      def build_writer(settings, agent_settings)
+        if (writer = settings.tracing.writer)
+          return writer
+        end
+
+        Tracing::Writer.new(agent_settings: agent_settings, **settings.tracing.writer_options)
+      end
+
+      def subscribe_to_writer_events!(writer, sampler, test_mode)
+        return unless writer.respond_to?(:events) # Check if it's a custom, external writer
+
+        writer.events.after_send.subscribe(&WRITER_RECORD_ENVIRONMENT_INFORMATION_CALLBACK)
+
+        return unless sampler.is_a?(Tracing::Sampling::PrioritySampler)
+
+        # DEV: We need to ignore priority sampling updates coming from the agent in test mode
+        # because test mode wants to *unconditionally* sample all traces.
+        #
+        # This can cause trace metrics to be overestimated, but that's a trade-off we take
+        # here to achieve 100% sampling rate.
+        return if test_mode
+
+        writer.events.after_send.subscribe(&writer_update_priority_sampler_rates_callback(sampler))
+      end
+
+      WRITER_RECORD_ENVIRONMENT_INFORMATION_CALLBACK = lambda do |_, responses|
+        Core::Diagnostics::EnvironmentLogger.log!(responses)
+      end
+
+      # Create new lambda for writer callback,
+      # capture the current sampler in the callback closure.
+      def writer_update_priority_sampler_rates_callback(sampler)
+        lambda do |_, responses|
+          response = responses.last
+
+          next unless response && !response.internal_error? && response.service_rates
+
+          sampler.update(response.service_rates, decision: Tracing::Sampling::Ext::Decision::AGENT_RATE)
+        end
+      end
+
+      def build_span_sampler(settings)
+        rules = Tracing::Sampling::Span::RuleParser.parse_json(settings.tracing.sampling.span_rules)
+        Tracing::Sampling::Span::Sampler.new(rules || [])
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Move component-specific code out of `Core::Configuration::Components`

**Motivation**

Reduce coupling. Core should be unaware of component details.

**Additional Notes**

Using the [noop noop noop interface maneuver](https://www.dotconferences.com/2016/10/katrina-owen-the-scandalous-story-of-the-dreadful-code-written-by-the-best-of-us).

As a first step I simply moved the most obvious code out of `lib/datadog/core/configuration/components` into `lib/datadog/{tracing,profiling}`, inside their own module, and then `include`'d these modules right back where the methods used to be.

Second step should be:

- changing these modules to classes that create the tracer and profiler instances and their dependencies
- swapping the tracing and profile instances in `Core::Configuration::Components` with instances of the respective Component classes
- delegating relevant methods from each `<foo>::Component` to each respective `<foo>` instance
- `Core::Configuration::Components` would still reference

Third step should be:

- having each component call a register method on `Core::Configuration::Components` upon the `lib/datadog/<foo>/component.rb` file being required
- having `Core::Configuration::Components` use the registered list by removing direct references to `<foo>` from it
- any dependency between components would be handled by having a `require '../<bar>/component'` at the top of `<foo>/component`. This would make each component registered in order.

**How to test the change?**

Specs should still pass.