### PR TITLE
Update libdatadog in lockfiles

### DIFF
--- a/gemfiles/jruby_9.2.21.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -1437,7 +1437,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.21.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -59,7 +59,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -63,7 +63,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -119,7 +119,7 @@ GEM
     inflecto (0.0.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     mail (2.7.1)

--- a/gemfiles/jruby_9.2.21.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.21.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -100,7 +100,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.21.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.2.21.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.21.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.21.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.2.21.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.21.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.21.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.2.21.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2.21.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -1437,7 +1437,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -59,7 +59,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -63,7 +63,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_hanami_1.gemfile.lock
@@ -12,8 +12,8 @@ PATH
   remote: ..
   specs:
     ddtrace (1.8.0)
-      debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -119,7 +119,7 @@ GEM
     inflecto (0.0.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     mail (2.7.1)
@@ -190,6 +190,9 @@ GEM
       rubocop (~> 1.19)
     ruby-debug-base (0.11.0-java)
     ruby-progressbar (1.11.0)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     spoon (0.0.6)
@@ -243,6 +246,7 @@ DEPENDENCIES
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   simplecov!
+  simplecov-cobertura (~> 2.1.0)
   warning (~> 1)
   webmock (>= 3.10.0)
   yard (~> 0.9)

--- a/gemfiles/jruby_9.2.8.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_mysql2.gemfile.lock
@@ -12,8 +12,8 @@ PATH
   remote: ..
   specs:
     ddtrace (1.8.0)
-      debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)
@@ -210,6 +210,9 @@ GEM
       rubocop (~> 1.19)
     ruby-debug-base (0.11.0-java)
     ruby-progressbar (1.11.0)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     spoon (0.0.6)
@@ -274,6 +277,7 @@ DEPENDENCIES
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   simplecov!
+  simplecov-cobertura (~> 2.1.0)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres.gemfile.lock
@@ -12,8 +12,8 @@ PATH
   remote: ..
   specs:
     ddtrace (1.8.0)
-      debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)
@@ -210,6 +210,9 @@ GEM
       rubocop (~> 1.19)
     ruby-debug-base (0.11.0-java)
     ruby-progressbar (1.11.0)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     spoon (0.0.6)
@@ -274,6 +277,7 @@ DEPENDENCIES
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   simplecov!
+  simplecov-cobertura (~> 2.1.0)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_redis.gemfile.lock
@@ -12,8 +12,8 @@ PATH
   remote: ..
   specs:
     ddtrace (1.8.0)
-      debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)
@@ -211,6 +211,9 @@ GEM
       rubocop (~> 1.19)
     ruby-debug-base (0.11.0-java)
     ruby-progressbar (1.11.0)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     spoon (0.0.6)
@@ -276,6 +279,7 @@ DEPENDENCIES
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   simplecov!
+  simplecov-cobertura (~> 2.1.0)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -100,7 +100,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails5_semantic_logger.gemfile.lock
@@ -12,8 +12,8 @@ PATH
   remote: ..
   specs:
     ddtrace (1.8.0)
-      debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      debase-ruby_core_source (>= 0.10.16, <= 3.2.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     loofah (2.15.0)
@@ -209,6 +209,9 @@ GEM
     ruby-progressbar (1.11.0)
     semantic_logger (4.10.0)
       concurrent-ruby (~> 1.0)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     spoon (0.0.6)
@@ -273,6 +276,7 @@ DEPENDENCIES
   rubocop-performance (~> 1.9)
   rubocop-rspec (~> 2.2)
   simplecov!
+  simplecov-cobertura (~> 2.1.0)
   sprockets (< 4)
   warning (~> 1)
   webmock (>= 3.10.0)

--- a/gemfiles/jruby_9.2.8.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.2.8.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/jruby_9.2.8.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.2.8.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.2.8.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.2.8.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -1437,7 +1437,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -59,7 +59,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -63,7 +63,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_hanami_1.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -120,7 +120,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     mail (2.7.1)

--- a/gemfiles/jruby_9.3.9.0_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -100,7 +100,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -116,7 +116,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.3.9.0_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -112,7 +112,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/jruby_9.3.9.0_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_redis_5.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.3.9.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.3.9.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.6.1)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -1489,7 +1489,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.0)

--- a/gemfiles/jruby_9.4.0.0_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.6.1)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -60,7 +60,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.6.1)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_cucumber3.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.6.1)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -64,7 +64,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_cucumber4.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.6.1)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_cucumber5.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.6.1)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -84,7 +84,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.6.1)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.6.1)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.6.1)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.6.1)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -118,7 +118,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     lograge (0.12.0)

--- a/gemfiles/jruby_9.4.0.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.6.1)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -117,7 +117,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     loofah (2.19.0)

--- a/gemfiles/jruby_9.4.0.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.6.1)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.6.1)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -47,7 +47,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/jruby_9.4.0.0_sinatra.gemfile.lock
+++ b/gemfiles/jruby_9.4.0.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.6.1)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.17)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -46,7 +46,7 @@ GEM
     json (2.6.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0-java)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.1.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -126,7 +126,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     makara (0.4.1)

--- a/gemfiles/ruby_2.1.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -75,7 +75,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -72,7 +72,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.1.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.1.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.1.10_sinatra.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -1262,7 +1262,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -75,7 +75,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -72,7 +72,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.2.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.2.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.2.10_sinatra.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.12)

--- a/gemfiles/ruby_2.3.8_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -1358,7 +1358,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.0)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -50,7 +50,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -56,7 +56,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_cucumber4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -76,7 +76,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_hanami_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -113,7 +113,7 @@ GEM
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     mail (2.7.1)

--- a/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -75,7 +75,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -71,7 +71,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails32_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -72,7 +72,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     mail (2.5.5)

--- a/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -80,7 +80,7 @@ GEM
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails4_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -79,7 +79,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -87,7 +87,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     lograge (0.11.2)

--- a/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -86,7 +86,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     loofah (2.15.0)

--- a/gemfiles/ruby_2.3.8_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.3.8_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.3.8_sinatra.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -38,7 +38,7 @@ GEM
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.0)
       ffi (~> 1.0)
     memory_profiler (0.9.14)

--- a/gemfiles/ruby_2.4.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.4.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_cucumber4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.4.10_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_hanami_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.4.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.4.10_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_redis_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.4.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.4.10_sinatra.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.5.9_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.5.9_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.6.10_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.6.10_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -1498,7 +1498,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0)

--- a/gemfiles/ruby_2.7.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_hanami_1.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -128,7 +128,7 @@ GEM
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0)

--- a/gemfiles/ruby_2.7.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails5_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_rails6_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_redis_5.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
+++ b/gemfiles/ruby_2.7.6_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 
@@ -53,7 +53,7 @@ GEM
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (0.9.0.1.0)
+    libdatadog (1.0.1.1.0)
     libdatadog (0.9.0.1.0-aarch64-linux)
     libdatadog (0.9.0.1.0-x86_64-linux)
     libddwaf (1.5.1.0.0)

--- a/gemfiles/ruby_3.0.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.0.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.0.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.0.4_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.0.4_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.0.4_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.0.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.0.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.0.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.0.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.0.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.0.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.0.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.0.4_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.0.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.0.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.0.4_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.0.4_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.1.2_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.1.2_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_contrib_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_core_old.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_cucumber5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_mysql2.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_redis.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_postgres_sidekiq.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_rails61_semantic_logger.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_redis_5.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_redis_5.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis3.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_resque2_redis4.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 

--- a/gemfiles/ruby_3.2.0_sinatra.gemfile.lock
+++ b/gemfiles/ruby_3.2.0_sinatra.gemfile.lock
@@ -13,7 +13,7 @@ PATH
   specs:
     ddtrace (1.8.0)
       debase-ruby_core_source (>= 0.10.16, <= 0.10.18)
-      libdatadog (~> 0.9.0.1.0)
+      libdatadog (~> 1.0.1.1.0)
       libddwaf (~> 1.5.1.0.0)
       msgpack
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Propagate `libdatadog` version change

**Motivation**

`libdatadog` is out of sync in appraisal lockfiles, preventing `appraisal install` to run, which breaks local dev and broke CI here: https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/8664/workflows/cd49e56f-4ea4-4266-952d-a8082a62aac4/jobs/322629

**Additional Notes**

Nope

**How to test the change?**

`appraisal install` should work, notably from a clean state.