### PR TITLE
Allow profiler development on arm64 macOS

### DIFF
--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -257,7 +257,7 @@ module Datadog
             suggested: GET_IN_TOUCH,
           )
 
-          architecture_not_supported unless RUBY_PLATFORM.start_with?('x86_64', 'aarch64')
+          architecture_not_supported unless RUBY_PLATFORM.start_with?('x86_64', 'aarch64', 'arm64')
         end
 
         private_class_method def self.on_ruby_2_1?

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -210,9 +210,17 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
         context 'when macOS testing override is enabled' do
           around { |example| ClimateControl.modify('DD_PROFILING_MACOS_TESTING' => 'true') { example.run } }
 
-          before { stub_const('RUBY_PLATFORM', 'x86_64-darwin19') }
+          context 'when on amd64 (x86-64) macOS' do
+            before { stub_const('RUBY_PLATFORM', 'x86_64-darwin19') }
 
-          include_examples 'supported ruby validation'
+            include_examples 'supported ruby validation'
+          end
+
+          context 'when on arm64 macOS' do
+            before { stub_const('RUBY_PLATFORM', 'arm64-darwin21') }
+
+            include_examples 'supported ruby validation'
+          end
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?**:

This PR tweaks the ruby platform check prior to compiling the profiling native extension to allow compilation on arm64 macOS.

We already allowed for arm64 on Linux, but the architecture is reported differently on macOS than on Linux (aarch64 vs arm64). (Because of course it would be reported differently!)

**Motivation**:

We don't officially support the Continuous Profiler on macOS BUT it actually mostly works, and so we have a toggle to enable it for development and testing purposes.

But up until now all macOS development had been on x86-64, and thus I had not noticed that our checks were too restrictive to allow development on arm64 macOS.

**Additional Notes**:

If there's enough customer interest, we may explore officially supporting profiling on macOS at some point.

**How to test the change?**:

Change includes test coverage. You can also test it if you have an arm64 macOS machine, by checking that

```bash
DD_PROFILING_MACOS_TESTING=true bundle exec rake clean compile
```

does not complain about the architecture not being supported.

(It will probably complain about a missing libdatadog, which is another thing you'll need to compile manually on macOS).