### PR TITLE
Disable Rubocop's `Style/WordArray` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -434,3 +434,6 @@ Naming/VariableNumber:
 # that have already dropped support for our minimum supported Ruby version.
 Gemspec/RequiredRubyVersion:
   Enabled: false
+
+Style/WordArray:
+  Enabled: false


### PR DESCRIPTION
**What does this PR do?**:

The `Style/WordArray` cop
(<https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/WordArray>) by default enforces this:

```ruby
 # good
%w[foo bar baz]

 # bad
['foo', 'bar', 'baz']
```

In #2572 both me, @lloeki and @tonycthsu agreed that we didn't particularly like the `%w[]` style, so I'm opening a PR to disable it.

**Motivation**:

Rubocop has a lot of extremely opinionated cops that even the Rubocop authors disable (which is why there are as many Rubocop config variants as there are Ruby projects...), so we shouldn't get too stuck on the defaults.

**Additional Notes**:

This cop could be configured in a flipped way (e.g. consider `%w[]` bad and `['foo']` good but I don't think it's worth enabling it.

I can live with either, and we can change our minds at any time.

**How to test the change?**:

Write the example above to a file and confirm that Rubocop does not complain about the use of either style.