### PR TITLE
Update integrations documentation

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -31,9 +31,6 @@ See `README.md` in each directory for more information:
 - `apps/sinatra2-classic`: Sinatra classic application
 - `apps/sinatra2-modular`: Sinatra modular application
 
-From the application folder you can control the ruby version image using the RUBY_VERSION env variable in the application `.envrc` file.
-For example: Setting the `RUBY_VERSION` variable to 3.2 on your .envrc file would use the `datadog/dd-apm-demo:rb-3.2` image.
-
 ### Base images
 
 The `images/` folders hosts some images for Ruby applications.

--- a/integration/README.md
+++ b/integration/README.md
@@ -10,6 +10,8 @@ Integration tests for `ddtrace` that use a variety of real applications.
     ./script/build-images
     ```
 
+You can specify which ruby version to build using the `-v` option.
+
 2. Choose an application and follow instructions (in corresponding `README.md`.)
 
 ## Demo applications

--- a/integration/README.md
+++ b/integration/README.md
@@ -31,6 +31,9 @@ See `README.md` in each directory for more information:
 - `apps/sinatra2-classic`: Sinatra classic application
 - `apps/sinatra2-modular`: Sinatra modular application
 
+From the application folder you can control the ruby version image using the RUBY_VERSION env variable in the application `.envrc` file.
+For example: Setting the `RUBY_VERSION` variable to 3.2 on your .envrc file would use the `datadog/dd-apm-demo:rb-3.2` image.
+
 ### Base images
 
 The `images/` folders hosts some images for Ruby applications.

--- a/integration/apps/hanami/.envrc.sample
+++ b/integration/apps/hanami/.envrc.sample
@@ -1,2 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
+export RUBY_VERSION=<Ruby version you are testing>

--- a/integration/apps/hanami/.envrc.sample
+++ b/integration/apps/hanami/.envrc.sample
@@ -1,3 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
-export RUBY_VERSION=<Ruby version you are testing>
+export RUBY_VERSION=2.7

--- a/integration/apps/hanami/README.md
+++ b/integration/apps/hanami/README.md
@@ -38,23 +38,13 @@ The `<process>` argument is optional, and will default to `DD_DEMO_ENV_PROCESS` 
 
 #### Running a specific version of Ruby
 
-By default it runs Ruby 2.7. You must reconfigure the application to use a different Ruby base image.
+By default it runs Ruby 2.7. You must reconfigure the application env variable `RUBY_VERSION`to use a different Ruby base image.
 
-First, update the `docker-compose.yml` to have the target Ruby version:
-
-```
-services:
-  app:
-    build:
-      context: .
-      args:
-        BASE_IMAGE: datadog/dd-apm-demo:rb-<YOUR RUBY VERSION> # e.g. dd-apm-demo:rb-3.1
-```
+Setting the `RUBY_VERSION` variable to 3.2 on your .envrc file would use the `datadog/dd-apm-demo:rb-3.2` image.
 
 If you haven't yet built the base image for this version, then you must:
 
-1. Build an appropriate Ruby base image via `./integration/script/build-images`
-2. Build a Ruby + Rails 6 base image via `./integration/apps/rails-six/script/build-images`
+1. Build an appropriate Ruby base image via `./integration/script/build-images -v 3.2`
 
 Then rebuild the application environment with:
 

--- a/integration/apps/hanami/docker-compose.yml
+++ b/integration/apps/hanami/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        BASE_IMAGE: datadog/dd-apm-demo:rb-2.7
+        BASE_IMAGE: "datadog/dd-apm-demo:rb-${RUBY_VERSION}"
     depends_on:
       - ddagent
     environment:

--- a/integration/apps/rack/.envrc.sample
+++ b/integration/apps/rack/.envrc.sample
@@ -1,2 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
+export RUBY_VERSION=<Ruby version you are testing>

--- a/integration/apps/rack/.envrc.sample
+++ b/integration/apps/rack/.envrc.sample
@@ -1,3 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
-export RUBY_VERSION=<Ruby version you are testing>
+export RUBY_VERSION=2.7

--- a/integration/apps/rack/README.md
+++ b/integration/apps/rack/README.md
@@ -32,6 +32,28 @@ docker-compose run --rm -p 80:80 app "bin/run <process>"
 
 The `<process>` argument is optional, and will default to `DD_DEMO_ENV_PROCESS` if not provided. See [Processes](#processes) for more details.
 
+#### Running a specific version of Ruby
+
+By default it runs Ruby 2.7. You must reconfigure the application env variable `RUBY_VERSION`to use a different Ruby base image.
+
+Setting the `RUBY_VERSION` variable to 3.2 on your .envrc file would use the `datadog/dd-apm-demo:rb-3.2` image.
+
+If you haven't yet built the base image for this version, then you must:
+
+1. Build an appropriate Ruby base image via `./integration/script/build-images -v 3.2`
+
+Then rebuild the application environment with:
+
+    ```
+    # Delete old containers & volumes first
+    docker-compose down -v
+
+    # Rebuild `app` image
+    docker-compose build --no-cache app
+    ```
+
+Finally start the application.
+
 ##### Processes
 
 Within the container, run `bin/run <process>` where `<process>` is one of the following values:

--- a/integration/apps/rack/docker-compose.yml
+++ b/integration/apps/rack/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        BASE_IMAGE: datadog/dd-apm-demo:rb-2.7
+        BASE_IMAGE: "datadog/dd-apm-demo:rb-${RUBY_VERSION}"
     depends_on:
       - ddagent
       - redis

--- a/integration/apps/rails-five/.envrc.sample
+++ b/integration/apps/rails-five/.envrc.sample
@@ -1,2 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
+export RUBY_VERSION=<Ruby version you are testing>

--- a/integration/apps/rails-five/.envrc.sample
+++ b/integration/apps/rails-five/.envrc.sample
@@ -1,3 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
-export RUBY_VERSION=<Ruby version you are testing>
+export RUBY_VERSION=2.7

--- a/integration/apps/rails-five/README.md
+++ b/integration/apps/rails-five/README.md
@@ -38,23 +38,13 @@ The `<process>` argument is optional, and will default to `DD_DEMO_ENV_PROCESS` 
 
 #### Running a specific version of Ruby
 
-By default it runs Ruby 2.7. You must reconfigure the application to use a different Ruby base image.
+By default it runs Ruby 2.7. You must reconfigure the application env variable `RUBY_VERSION`to use a different Ruby base image.
 
-First, update the `docker-compose.yml` to have the target Ruby version:
-
-```
-services:
-  app:
-    build:
-      context: .
-      args:
-        BASE_IMAGE: datadog/dd-apm-demo:rb-<YOUR RUBY VERSION> # e.g. dd-apm-demo:rb-2.7
-```
+Setting the `RUBY_VERSION` variable to 3.2 on your .envrc file would use the `datadog/dd-apm-demo:rb-3.2` image.
 
 If you haven't yet built the base image for this version, then you must:
 
-1. Build an appropriate Ruby base image via `./integration/script/build-images`
-2. Build a Ruby + Rails 5 base image via `./integration/apps/rails-five/script/build-images`
+1. Build an appropriate Ruby base image via `./integration/script/build-images -v 3.2`
 
 Then rebuild the application environment with:
 

--- a/integration/apps/rails-five/docker-compose.yml
+++ b/integration/apps/rails-five/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        BASE_IMAGE: datadog/dd-apm-demo:rb-2.7
+        BASE_IMAGE: "datadog/dd-apm-demo:rb-${RUBY_VERSION}"
     depends_on:
       - ddagent
       - mysql

--- a/integration/apps/rails-seven/.envrc.sample
+++ b/integration/apps/rails-seven/.envrc.sample
@@ -1,2 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
+export RUBY_VERSION=<Ruby version you are testing>

--- a/integration/apps/rails-seven/.envrc.sample
+++ b/integration/apps/rails-seven/.envrc.sample
@@ -1,3 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
-export RUBY_VERSION=<Ruby version you are testing>
+export RUBY_VERSION=2.7

--- a/integration/apps/rails-seven/README.md
+++ b/integration/apps/rails-seven/README.md
@@ -38,23 +38,13 @@ The `<process>` argument is optional, and will default to `DD_DEMO_ENV_PROCESS` 
 
 #### Running a specific version of Ruby
 
-By default it runs Ruby 2.7. You must reconfigure the application to use a different Ruby base image.
+By default it runs Ruby 2.7. You must reconfigure the application env variable `RUBY_VERSION`to use a different Ruby base image.
 
-First, update the `docker-compose.yml` to have the target Ruby version:
-
-```
-services:
-  app:
-    build:
-      context: .
-      args:
-        BASE_IMAGE: datadog/dd-apm-demo:rb-<YOUR RUBY VERSION> # e.g. dd-apm-demo:rb-3.1
-```
+Setting the `RUBY_VERSION` variable to 3.2 on your .envrc file would use the `datadog/dd-apm-demo:rb-3.2` image.
 
 If you haven't yet built the base image for this version, then you must:
 
-1. Build an appropriate Ruby base image via `./integration/script/build-images`
-2. Build a Ruby + Rails 7 base image via `./integration/apps/rails-seven/script/build-images`
+1. Build an appropriate Ruby base image via `./integration/script/build-images -v 3.2`
 
 Then rebuild the application environment with:
 

--- a/integration/apps/rails-seven/docker-compose.yml
+++ b/integration/apps/rails-seven/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     build:
       context: .
       args:
-        BASE_IMAGE: datadog/dd-apm-demo:rb-2.7
+        BASE_IMAGE: "datadog/dd-apm-demo:rb-${RUBY_VERSION}"
     depends_on:
       - ddagent
       - mysql

--- a/integration/apps/rails-six/.envrc.sample
+++ b/integration/apps/rails-six/.envrc.sample
@@ -1,2 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
+export RUBY_VERSION=<Ruby version you are testing>

--- a/integration/apps/rails-six/.envrc.sample
+++ b/integration/apps/rails-six/.envrc.sample
@@ -1,3 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
-export RUBY_VERSION=<Ruby version you are testing>
+export RUBY_VERSION=2.7

--- a/integration/apps/rails-six/README.md
+++ b/integration/apps/rails-six/README.md
@@ -38,23 +38,13 @@ The `<process>` argument is optional, and will default to `DD_DEMO_ENV_PROCESS` 
 
 #### Running a specific version of Ruby
 
-By default it runs Ruby 2.7. You must reconfigure the application to use a different Ruby base image.
+By default it runs Ruby 2.7. You must reconfigure the application env variable `RUBY_VERSION`to use a different Ruby base image.
 
-First, update the `docker-compose.yml` to have the target Ruby version:
-
-```
-services:
-  app:
-    build:
-      context: .
-      args:
-        BASE_IMAGE: datadog/dd-apm-demo:rb-<YOUR RUBY VERSION> # e.g. dd-apm-demo:rb-3.1
-```
+Setting the `RUBY_VERSION` variable to 3.2 on your .envrc file would use the `datadog/dd-apm-demo:rb-3.2` image.
 
 If you haven't yet built the base image for this version, then you must:
 
-1. Build an appropriate Ruby base image via `./integration/script/build-images`
-2. Build a Ruby + Rails 6 base image via `./integration/apps/rails-six/script/build-images`
+1. Build an appropriate Ruby base image via `./integration/script/build-images -v 3.2`
 
 Then rebuild the application environment with:
 

--- a/integration/apps/rails-six/docker-compose.yml
+++ b/integration/apps/rails-six/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        BASE_IMAGE: datadog/dd-apm-demo:rb-2.7
+        BASE_IMAGE: "datadog/dd-apm-demo:rb-${RUBY_VERSION}"
     depends_on:
       - ddagent
       - mysql

--- a/integration/apps/rspec/.envrc.sample
+++ b/integration/apps/rspec/.envrc.sample
@@ -1,2 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
+export RUBY_VERSION=<Ruby version you are testing>

--- a/integration/apps/rspec/.envrc.sample
+++ b/integration/apps/rspec/.envrc.sample
@@ -1,3 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
-export RUBY_VERSION=<Ruby version you are testing>
+export RUBY_VERSION=2.7

--- a/integration/apps/rspec/README.md
+++ b/integration/apps/rspec/README.md
@@ -32,6 +32,28 @@ docker-compose run --rm app bin/run <process>
 
 The `<process>` argument is optional, and will default to `DD_DEMO_ENV_PROCESS` if not provided. See [Processes](#processes) for more details.
 
+#### Running a specific version of Ruby
+
+By default it runs Ruby 2.7. You must reconfigure the application env variable `RUBY_VERSION`to use a different Ruby base image.
+
+Setting the `RUBY_VERSION` variable to 3.2 on your .envrc file would use the `datadog/dd-apm-demo:rb-3.2` image.
+
+If you haven't yet built the base image for this version, then you must:
+
+1. Build an appropriate Ruby base image via `./integration/script/build-images -v 3.2`
+
+Then rebuild the application environment with:
+
+    ```
+    # Delete old containers & volumes first
+    docker-compose down -v
+
+    # Rebuild `app` image
+    docker-compose build --no-cache app
+    ```
+
+Finally start the application.
+
 ##### Processes
 
 Within the container, run `bin/run <process>` where `<process>` is one of the following values:

--- a/integration/apps/rspec/docker-compose.yml
+++ b/integration/apps/rspec/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        BASE_IMAGE: datadog/dd-apm-demo:rb-3.0
+        BASE_IMAGE: "datadog/dd-apm-demo:rb-${RUBY_VERSION}"
     depends_on:
       - ddagent
     environment:

--- a/integration/apps/ruby/.envrc.sample
+++ b/integration/apps/ruby/.envrc.sample
@@ -1,2 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
+export RUBY_VERSION=3.0

--- a/integration/apps/ruby/README.md
+++ b/integration/apps/ruby/README.md
@@ -32,6 +32,28 @@ docker-compose run --rm app bin/run <process>
 
 The `<process>` argument is optional, and will default to `DD_DEMO_ENV_PROCESS` if not provided. See [Processes](#processes) for more details.
 
+#### Running a specific version of Ruby
+
+By default it runs Ruby 2.7. You must reconfigure the application env variable `RUBY_VERSION`to use a different Ruby base image.
+
+Setting the `RUBY_VERSION` variable to 3.2 on your .envrc file would use the `datadog/dd-apm-demo:rb-3.2` image.
+
+If you haven't yet built the base image for this version, then you must:
+
+1. Build an appropriate Ruby base image via `./integration/script/build-images -v 3.2`
+
+Then rebuild the application environment with:
+
+    ```
+    # Delete old containers & volumes first
+    docker-compose down -v
+
+    # Rebuild `app` image
+    docker-compose build --no-cache app
+    ```
+
+Finally start the application.
+
 ##### Processes
 
 Within the container, run `bin/run <process>` where `<process>` is one of the following values:

--- a/integration/apps/ruby/docker-compose.yml
+++ b/integration/apps/ruby/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        BASE_IMAGE: datadog/dd-apm-demo:rb-3.0
+        BASE_IMAGE: "datadog/dd-apm-demo:rb-${RUBY_VERSION}"
     depends_on:
       - ddagent
     environment:

--- a/integration/apps/sinatra2-classic/.envrc.sample
+++ b/integration/apps/sinatra2-classic/.envrc.sample
@@ -1,2 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
+export RUBY_VERSION=<Ruby version you are testing>

--- a/integration/apps/sinatra2-classic/.envrc.sample
+++ b/integration/apps/sinatra2-classic/.envrc.sample
@@ -1,3 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
-export RUBY_VERSION=<Ruby version you are testing>
+export RUBY_VERSION=2.7

--- a/integration/apps/sinatra2-classic/README.md
+++ b/integration/apps/sinatra2-classic/README.md
@@ -30,6 +30,28 @@ Alternatively, you can run it manually with:
 docker-compose run --rm -p 80:80 app "bin/run <process>"
 ```
 
+#### Running a specific version of Ruby
+
+By default it runs Ruby 2.7. You must reconfigure the application env variable `RUBY_VERSION`to use a different Ruby base image.
+
+Setting the `RUBY_VERSION` variable to 3.2 on your .envrc file would use the `datadog/dd-apm-demo:rb-3.2` image.
+
+If you haven't yet built the base image for this version, then you must:
+
+1. Build an appropriate Ruby base image via `./integration/script/build-images -v 3.2`
+
+Then rebuild the application environment with:
+
+    ```
+    # Delete old containers & volumes first
+    docker-compose down -v
+
+    # Rebuild `app` image
+    docker-compose build --no-cache app
+    ```
+
+Finally start the application.
+
 The `<process>` argument is optional, and will default to `DD_DEMO_ENV_PROCESS` if not provided. See [Processes](#processes) for more details.
 
 ##### Processes

--- a/integration/apps/sinatra2-classic/docker-compose.yml
+++ b/integration/apps/sinatra2-classic/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        BASE_IMAGE: datadog/dd-apm-demo:rb-2.7
+        BASE_IMAGE: "datadog/dd-apm-demo:rb-${RUBY_VERSION}"
     depends_on:
       - ddagent
     environment:

--- a/integration/apps/sinatra2-modular/.envrc.sample
+++ b/integration/apps/sinatra2-modular/.envrc.sample
@@ -1,2 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
+export RUBY_VERSION=<Ruby version you are testing>

--- a/integration/apps/sinatra2-modular/.envrc.sample
+++ b/integration/apps/sinatra2-modular/.envrc.sample
@@ -1,3 +1,3 @@
 export DD_API_KEY=<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
-export RUBY_VERSION=<Ruby version you are testing>
+export RUBY_VERSION=2.7

--- a/integration/apps/sinatra2-modular/README.md
+++ b/integration/apps/sinatra2-modular/README.md
@@ -43,6 +43,28 @@ Within the container, run `bin/run <process>` where `<process>` is one of the fo
 
  Alternatively, set `DD_DEMO_ENV_PROCESS` to run a particular process by default when `bin/run` is run.
 
+ #### Running a specific version of Ruby
+
+By default it runs Ruby 2.7. You must reconfigure the application env variable `RUBY_VERSION`to use a different Ruby base image.
+
+Setting the `RUBY_VERSION` variable to 3.2 on your .envrc file would use the `datadog/dd-apm-demo:rb-3.2` image.
+
+If you haven't yet built the base image for this version, then you must:
+
+1. Build an appropriate Ruby base image via `./integration/script/build-images -v 3.2`
+
+Then rebuild the application environment with:
+
+    ```
+    # Delete old containers & volumes first
+    docker-compose down -v
+
+    # Rebuild `app` image
+    docker-compose build --no-cache app
+    ```
+
+Finally start the application.
+
 ##### Features
 
 Set `DD_DEMO_ENV_FEATURES` to a comma-delimited list of any of the following values to activate the feature:

--- a/integration/apps/sinatra2-modular/docker-compose.yml
+++ b/integration/apps/sinatra2-modular/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        BASE_IMAGE: datadog/dd-apm-demo:rb-2.7
+        BASE_IMAGE: "datadog/dd-apm-demo:rb-${RUBY_VERSION}"
     depends_on:
       - ddagent
     environment:

--- a/integration/script/build-images
+++ b/integration/script/build-images
@@ -27,7 +27,7 @@ echo "== Building base images... =="
 # docker build -t datadog/dd-apm-demo:wrk -f $INTEGRATION_DIR/images/wrk/Dockerfile $INTEGRATION_DIR/images
 docker build -t datadog/dd-apm-demo:agent -f $INTEGRATION_DIR/images/agent/Dockerfile $INTEGRATION_DIR/images/agent
 
-if [ -v APP_RUBY_VERSION ]; then
+if [[ ! -z $APP_RUBY_VERSION ]]; then
   docker build -t datadog/dd-apm-demo:rb-$APP_RUBY_VERSION -f $INTEGRATION_DIR/images/ruby/$APP_RUBY_VERSION/Dockerfile $INTEGRATION_DIR/images
 else
   docker build -t datadog/dd-apm-demo:rb-2.1 -f $INTEGRATION_DIR/images/ruby/2.1/Dockerfile $INTEGRATION_DIR/images


### PR DESCRIPTION
**What does this PR do?**
While testing some of the [integration](https://github.com/DataDog/dd-trace-rb/tree/master/integration) apps I noticed a couple things:

- We do not respect the `-v` when building the ruby images. So we have to manually remove the ruby images from the list.
- When running `docker-compose up` from inside the different apps the ruby version is hardcoded. I made it so we can changed  the version using the `RUBY_VERSION` env var from each app folder.

