### PR TITLE
Update Event SDK with latest RFC changes

### DIFF
--- a/lib/datadog/kit/events.rb
+++ b/lib/datadog/kit/events.rb
@@ -7,41 +7,57 @@ module Datadog
   module Kit
     # Tracking events
     module Events
-      # Attach login event information to the trace
+      # Attach login success event information to the trace
       #
       # @param trace [TraceOperation] Trace to attach data to.
-      # @param success [bool] Whether login operation was successful or not.
       # @param user [Hash<Symbol, String>] User information to pass to
       #   Datadog::Kit::Identity.set_user. Must contain at least :id as key.
       # @param others [Hash<String || Symbol, String>] Additional free-form
       #   event information to attach to the trace.
-      def self.track_login(trace, success:, user:, **others)
-        subtag = success ? 'success' : 'failure'
-        event = "users.login.#{subtag}"
+      def self.track_login_success(trace, user:, **others)
+        event = 'users.login.success'
 
-        track(event, trace, **others)
+        track(:appsec, event, trace, **others)
 
         user_options = user.dup
         user_id = user.delete(:id)
 
         raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?
 
-        if success
-          Kit::Identity.set_user(trace, id: user_id, **user_options)
-        else
-          trace.set_tag("appsec.events.users.login.#{subtag}.usr.id", user_id)
-        end
+        Kit::Identity.set_user(trace, id: user_id, **user_options)
+      end
+
+      # Attach login failure event information to the trace
+      #
+      # @param trace [TraceOperation] Trace to attach data to.
+      # @param user_id [String] User id that attempted login
+      #   Datadog::Kit::Identity.set_user. Must contain at least :id as key.
+      # @param user_exists [bool] Whether the user id that did a login attempt exists.
+      # @param others [Hash<String || Symbol, String>] Additional free-form
+      #   event information to attach to the trace.
+      def self.track_login_failure(trace, user_id:, user_exists:, **others)
+        event = 'users.login.failure'
+
+        track(:appsec, event, trace, **others)
+
+        raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?
+
+        trace.set_tag('appsec.events.users.login.failure.usr.id', user_id)
+        trace.set_tag('appsec.events.users.login.failure.usr.exists', user_exists)
       end
 
       # Attach custom event information to the trace
       #
+      # @param namespace [Symbol] Mandatory. Event namespace. Only :appsec is supported.
       # @param event [String] Mandatory. Event code.
       # @param trace [TraceOperation] Trace to attach data to.
       # @param others [Hash<Symbol, String>] Additional free-form
       #   event information to attach to the trace. Key must not
       #   be :track.
-      def self.track(event, trace, **others)
-        trace.set_tag("appsec.events.#{event}.track", 'true')
+      def self.track(namespace, event, trace, **others)
+        raise ArgumentError, "namespace cannot be #{namespace.inspect}" if namespace.to_sym != :appsec
+
+        trace.set_tag("#{namespace}.events.#{event}.track", 'true')
 
         others.each do |k, v|
           raise ArgumentError, 'key cannot be :track' if k.to_sym == :track

--- a/sig/datadog/kit/events.rbs
+++ b/sig/datadog/kit/events.rbs
@@ -1,9 +1,11 @@
 module Datadog
   module Kit
     module Events
-      def self.track_login: (Datadog::Tracing::TraceOperation trace, success: bool, user: Hash[::Symbol, ::String | nil], **::Hash[::Symbol, ::String | nil] others) -> void
+      def self.track_login_success: (Datadog::Tracing::TraceOperation trace, user: Hash[::Symbol, ::String | nil], **::Hash[::Symbol, ::String | nil] others) -> void
 
-      def self.track: (::String | ::Symbol event, Datadog::Tracing::TraceOperation trace, **::Hash[::Symbol, ::String | nil] others) -> void
+      def self.track_login_failure: (Datadog::Tracing::TraceOperation trace, user_id: ::String, user_exists: bool, **::Hash[::Symbol, ::String | nil] others) -> void
+
+      def self.track: (::Symbol namespace, ::String | ::Symbol event, Datadog::Tracing::TraceOperation trace, **::Hash[::Symbol, ::String | nil] others) -> void
     end
   end
 end

--- a/spec/datadog/kit/events_spec.rb
+++ b/spec/datadog/kit/events_spec.rb
@@ -10,64 +10,87 @@ require 'datadog/kit/events'
 RSpec.describe Datadog::Kit::Events do
   subject(:trace_op) { Datadog::Tracing::TraceOperation.new }
 
-  describe '#track_login' do
-    context 'login success' do
-      it 'sets event tracking key on trace' do
-        trace_op.measure('root') do
-          described_class.track_login(trace_op, user: { id: '42' }, success: true)
-        end
-        trace = trace_op.flush!
-        expect(trace.send(:meta)).to include('appsec.events.users.login.success.track' => 'true')
+  describe '#track_login_success' do
+    it 'sets event tracking key on trace' do
+      trace_op.measure('root') do
+        described_class.track_login_success(trace_op, user: { id: '42' })
       end
-
-      it 'sets user id on trace' do
-        trace_op.measure('root') do
-          described_class.track_login(trace_op, user: { id: '42' }, success: true)
-        end
-        trace = trace_op.flush!
-        expect(trace.send(:meta)).to include('usr.id' => '42')
-      end
-
-      it 'sets other keys on trace' do
-        trace_op.measure('root') do
-          described_class.track_login(trace_op, user: { id: '42' }, success: true, foo: 'bar')
-        end
-        trace = trace_op.flush!
-        expect(trace.send(:meta)).to include('usr.id' => '42', 'appsec.events.users.login.success.foo' => 'bar')
-      end
+      trace = trace_op.flush!
+      expect(trace.send(:meta)).to include('appsec.events.users.login.success.track' => 'true')
     end
 
-    context 'login failure' do
-      it 'sets event tracking key on trace' do
-        trace_op.measure('root') do
-          described_class.track_login(trace_op, user: { id: '42' }, success: false)
-        end
-        trace = trace_op.flush!
-        expect(trace.send(:meta)).to include('appsec.events.users.login.failure.track' => 'true')
+    it 'sets user id on trace' do
+      trace_op.measure('root') do
+        described_class.track_login_success(trace_op, user: { id: '42' })
       end
+      trace = trace_op.flush!
+      expect(trace.send(:meta)).to include('usr.id' => '42')
+    end
 
-      it 'sets user id on trace' do
-        trace_op.measure('root') do
-          described_class.track_login(trace_op, user: { id: '42' }, success: false)
-        end
-        trace = trace_op.flush!
-        expect(trace.send(:meta)).to include('appsec.events.users.login.failure.usr.id' => '42')
+    it 'sets other keys on trace' do
+      trace_op.measure('root') do
+        described_class.track_login_success(trace_op, user: { id: '42' }, foo: 'bar')
       end
+      trace = trace_op.flush!
+      expect(trace.send(:meta)).to include('usr.id' => '42', 'appsec.events.users.login.success.foo' => 'bar')
+    end
+  end
 
-      it 'sets other keys on trace' do
-        trace_op.measure('root') do
-          described_class.track_login(trace_op, user: { id: '42' }, success: false, foo: 'bar')
-        end
-        trace = trace_op.flush!
-        expect(trace.send(:meta)).to include('appsec.events.users.login.failure.foo' => 'bar')
+  describe '#track_login_failure' do
+    it 'sets event tracking key on trace' do
+      trace_op.measure('root') do
+        described_class.track_login_failure(trace_op, user_id: '42', user_exists: true)
       end
+      trace = trace_op.flush!
+      expect(trace.send(:meta)).to include('appsec.events.users.login.failure.track' => 'true')
+    end
+
+    it 'sets user id on trace' do
+      trace_op.measure('root') do
+        described_class.track_login_failure(trace_op, user_id: '42', user_exists: true)
+      end
+      trace = trace_op.flush!
+      expect(trace.send(:meta)).to include('appsec.events.users.login.failure.usr.id' => '42')
+    end
+
+    it 'sets user existence on trace' do
+      trace_op.measure('root') do
+        described_class.track_login_failure(trace_op, user_id: '42', user_exists: true)
+      end
+      trace = trace_op.flush!
+      expect(trace.send(:meta)).to include('appsec.events.users.login.failure.usr.exists' => 'true')
+    end
+
+    it 'sets user non-existence  on trace' do
+      trace_op.measure('root') do
+        described_class.track_login_failure(trace_op, user_id: '42', user_exists: false)
+      end
+      trace = trace_op.flush!
+      expect(trace.send(:meta)).to include('appsec.events.users.login.failure.usr.exists' => 'false')
+    end
+
+    it 'sets other keys on trace' do
+      trace_op.measure('root') do
+        described_class.track_login_failure(trace_op, user_id: '42', user_exists: true, foo: 'bar')
+      end
+      trace = trace_op.flush!
+      expect(trace.send(:meta)).to include('appsec.events.users.login.failure.foo' => 'bar')
     end
   end
 
   describe '#track' do
+    it 'rejects unexpected namespaces' do
+      trace_op.measure('root') do
+        expect { described_class.track(:foo, 'bar', trace_op) }.to raise_error ArgumentError
+      end
+
+      trace = trace_op.flush!
+      expect(trace.send(:meta)).to_not include('foo.events.bar.track' => 'true')
+    end
+
     it 'sets event tracking key on trace' do
       trace_op.measure('root') do
-        described_class.track('foo', trace_op)
+        described_class.track(:appsec, 'foo', trace_op)
       end
       trace = trace_op.flush!
       expect(trace.send(:meta)).to include('appsec.events.foo.track' => 'true')
@@ -75,7 +98,7 @@ RSpec.describe Datadog::Kit::Events do
 
     it 'sets other keys on trace' do
       trace_op.measure('root') do
-        described_class.track('foo', trace_op, bar: 'baz')
+        described_class.track(:appsec, 'foo', trace_op, bar: 'baz')
       end
       trace = trace_op.flush!
       expect(trace.send(:meta)).to include('appsec.events.foo.bar' => 'baz')


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

- Separate login and failure events
- Add a namespace (pegged to `:appsec`) for the generic event generator

**Motivation**

RFC for event SDK was updated following some additional feedback.

**Additional Notes**

Nope

**How to test the change?**

```
bundle exec rspec spec/datadog/kit/events_spec.rb
```