### PR TITLE
Minor: Tweak profiling error message when pkg-config is missing

### DIFF
--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -170,10 +170,10 @@ module Datadog
         PKG_CONFIG_IS_MISSING = explain_issue(
           #+-----------------------------------------------------------------------------+
           'the `pkg-config` system tool is missing.',
-          'This issue can usually be fixed by installing:',
-          '1. the `pkg-config` package on Homebrew and Debian/Ubuntu-based Linux;',
-          '2. the `pkgconf` package on Arch and Alpine-based Linux;',
-          '3. the `pkgconf-pkg-config` package on Fedora/Red Hat-based Linux.',
+          'This issue can usually be fixed by installing one of the following:',
+          'the `pkg-config` package on Homebrew and Debian/Ubuntu-based Linux;',
+          'the `pkgconf` package on Arch and Alpine-based Linux;',
+          'the `pkgconf-pkg-config` package on Fedora/Red Hat-based Linux.',
           suggested: CONTACT_SUPPORT,
         )
 


### PR DESCRIPTION
**What does this PR do?**:

This PR slightly tweaks the error message that users get presented with when the `pkg-config` tool is missing from:

```
Profiling was requested but is not supported, profiling disabled: Your
ddtrace installation is missing support for the Continuous Profiler
because the `pkg-config` system tool is missing. This issue can usually
be fixed by installing: 1. the `pkg-config` package on Homebrew and
Debian/Ubuntu-based Linux; 2. the `pkgconf` package on Arch and
Alpine-based Linux; 3. the `pkgconf-pkg-config` package on
Fedora/Red Hat-based Linux.
```

to:

```
Profiling was requested but is not supported, profiling disabled: Your
dtrace installation is missing support for the Continuous Profiler
because the `pkg-config` system tool is missing. This issue can usually
be fixed by installing one of the following: the `pkg-config` package
on Homebrew and Debian/Ubuntu-based Linux; the `pkgconf` package on
Arch and Alpine-based Linux; the `pkgconf-pkg-config` package on
Fedora/Red Hat-based Linux.
```

**Motivation**:

When a customer reported that they saw this issue, I thought that the enumeration seemed confusing -- the 1./2./3. seemed to suggest that you needed all three, which is not true.

So I've removed the enumeration and added "one of the following" to hopefully clarify this.

**Additional Notes**:

I've been considering reimplementing the `pkg-config` logic so that customers don't need to have it installed. I welcome feedback on the idea :)

**How to test the change?**:

The easiest way of triggering this error is to use the docker development images, and cripple `pkg-config` on them:

```
$ docker-compose run --no-deps --rm tracer-2.7 /bin/bash
$ rm `which pkg-config`
$ bundle exec rake clean compile
$ DD_PROFILING_ENABLED=true bundle exec ddtracerb exec ruby -e sleep
```