### PR TITLE
Reduce the number of literal string and use constant in the appsec library

### DIFF
--- a/bin/ddtracerb
+++ b/bin/ddtracerb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+$LOAD_PATH.push File.expand_path('../lib', __dir__)
+
 require 'datadog/profiling/tasks/exec'
 require 'datadog/profiling/tasks/help'
 

--- a/bin/ddtracerb
+++ b/bin/ddtracerb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-$LOAD_PATH.push File.expand_path('../lib', __dir__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 require 'datadog/profiling/tasks/exec'
 require 'datadog/profiling/tasks/help'

--- a/lib/datadog/appsec/contrib/rack/configuration/settings.rb
+++ b/lib/datadog/appsec/contrib/rack/configuration/settings.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 require_relative '../../configuration/settings'
 require_relative '../ext'

--- a/lib/datadog/appsec/contrib/rack/ext.rb
+++ b/lib/datadog/appsec/contrib/rack/ext.rb
@@ -11,7 +11,7 @@ module Datadog
           ENV_ENABLED = 'DD_TRACE_RACK_ENABLED' # TODO: DD_APPSEC?
 
           RESPONSE_STATUS = 'response.status'
-          RESQUEST_BODY = 'request.body'
+          REQUEST_BODY = 'request.body'
           REQUEST_HEADERS = 'request.headers'
           REQUEST_URI_RAW = 'request.uri.raw'
           REQUEST_QUERY = 'request.query'

--- a/lib/datadog/appsec/contrib/rack/ext.rb
+++ b/lib/datadog/appsec/contrib/rack/ext.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 module Datadog
   module AppSec
@@ -6,8 +7,20 @@ module Datadog
       module Rack
         # Rack integration constants
         module Ext
-          APP = 'rack'.freeze
-          ENV_ENABLED = 'DD_TRACE_RACK_ENABLED'.freeze # TODO: DD_APPSEC?
+          APP = 'rack'
+          ENV_ENABLED = 'DD_TRACE_RACK_ENABLED' # TODO: DD_APPSEC?
+
+          RESPONSE_STATUS = 'response.status'
+          RESQUEST_BODY = 'request.body'
+          REQUEST_HEADERS = 'request.headers'
+          REQUEST_URI_RAW = 'request.uri.raw'
+          REQUEST_QUERY = 'request.query'
+          REQUEST_COOKIES = 'request.cookies'
+          REQUEST_CLIENT_IP = 'request.client_ip'
+
+          RACK_REQUEST = 'rack.request'
+          RACK_REQUEST_BODY = 'rack.request.body'
+          RACK_RESPONSE = 'rack.response'
         end
       end
     end

--- a/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 require_relative '../../../instrumentation/gateway'
 require_relative '../../../reactive/operation'
@@ -6,6 +7,7 @@ require_relative '../reactive/request'
 require_relative '../reactive/request_body'
 require_relative '../reactive/response'
 require_relative '../../../event'
+require_relative '../ext'
 
 module Datadog
   module AppSec
@@ -19,12 +21,12 @@ module Datadog
             # rubocop:disable Metrics/CyclomaticComplexity
             # rubocop:disable Metrics/PerceivedComplexity
             def self.watch
-              Instrumentation.gateway.watch('rack.request', :appsec) do |stack, request|
+              Instrumentation.gateway.watch(Ext::RACK_REQUEST, :appsec) do |stack, request|
                 block = false
                 event = nil
                 waf_context = request.env['datadog.waf.context']
 
-                AppSec::Reactive::Operation.new('rack.request') do |op|
+                AppSec::Reactive::Operation.new(Ext::RACK_REQUEST) do |op|
                   trace = active_trace
                   span = active_span
 
@@ -60,12 +62,12 @@ module Datadog
                 [ret, res]
               end
 
-              Instrumentation.gateway.watch('rack.response', :appsec) do |stack, response|
+              Instrumentation.gateway.watch(Ext::RACK_RESPONSE, :appsec) do |stack, response|
                 block = false
                 event = nil
                 waf_context = response.instance_eval { @waf_context }
 
-                AppSec::Reactive::Operation.new('rack.response') do |op|
+                AppSec::Reactive::Operation.new(Ext::RACK_RESPONSE) do |op|
                   trace = active_trace
                   span = active_span
 
@@ -101,12 +103,12 @@ module Datadog
                 [ret, res]
               end
 
-              Instrumentation.gateway.watch('rack.request.body', :appsec) do |stack, request|
+              Instrumentation.gateway.watch(Ext::RACK_REQUEST_BODY, :appsec) do |stack, request|
                 block = false
                 event = nil
                 waf_context = request.env['datadog.waf.context']
 
-                AppSec::Reactive::Operation.new('rack.request.body') do |op|
+                AppSec::Reactive::Operation.new(Ext::RACK_REQUEST_BODY) do |op|
                   trace = active_trace
                   span = active_span
 

--- a/lib/datadog/appsec/contrib/rack/integration.rb
+++ b/lib/datadog/appsec/contrib/rack/integration.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 require_relative '../integration'
 
@@ -6,6 +7,7 @@ require_relative 'configuration/settings'
 require_relative 'patcher'
 require_relative 'request_middleware'
 require_relative 'request_body_middleware'
+require_relative 'ext'
 
 module Datadog
   module AppSec
@@ -20,7 +22,7 @@ module Datadog
           register_as :rack, auto_patch: false
 
           def self.version
-            Gem.loaded_specs['rack'] && Gem.loaded_specs['rack'].version
+            Gem.loaded_specs[Ext::APP] && Gem.loaded_specs[Ext::APP].version
           end
 
           def self.loaded?

--- a/lib/datadog/appsec/contrib/rack/integration.rb
+++ b/lib/datadog/appsec/contrib/rack/integration.rb
@@ -22,7 +22,7 @@ module Datadog
           register_as :rack, auto_patch: false
 
           def self.version
-            Gem.loaded_specs[Ext::APP] && Gem.loaded_specs[Ext::APP].version
+            Gem.loaded_specs['rack'] && Gem.loaded_specs['rack'].version
           end
 
           def self.loaded?

--- a/lib/datadog/appsec/contrib/rack/patcher.rb
+++ b/lib/datadog/appsec/contrib/rack/patcher.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 require_relative '../patcher'
 require_relative 'gateway/watcher'

--- a/lib/datadog/appsec/contrib/rack/reactive/request.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/request.rb
@@ -11,14 +11,14 @@ module Datadog
         module Reactive
           # Dispatch data from a Rack request to the WAF context
           module Request
-            WAF_ADDRESSES = [
+            ADDRESSES = [
               Ext::REQUEST_HEADERS,
               Ext::REQUEST_URI_RAW,
               Ext::REQUEST_QUERY,
               Ext::REQUEST_COOKIES,
               Ext::REQUEST_CLIENT_IP,
             ].freeze
-            private_constant :WAF_ADDRESSES
+            private_constant :ADDRESSES
 
             def self.publish(op, request)
               catch(:block) do
@@ -33,8 +33,8 @@ module Datadog
             end
 
             def self.subscribe(op, waf_context)
-              op.subscribe(*WAF_ADDRESSES) do |*values|
-                Datadog.logger.debug { "reacted to #{WAF_ADDRESSES.inspect}: #{values.inspect}" }
+              op.subscribe(*ADDRESSES) do |*values|
+                Datadog.logger.debug { "reacted to #{ADDRESSES.inspect}: #{values.inspect}" }
                 headers = values[0]
                 headers_no_cookies = headers.dup.tap { |h| h.delete('cookie') }
                 uri_raw = values[1]

--- a/lib/datadog/appsec/contrib/rack/reactive/request_body.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/request_body.rb
@@ -11,10 +11,10 @@ module Datadog
         module Reactive
           # Dispatch data from a Rack request to the WAF context
           module RequestBody
-            WAF_ADDRESSES = [
+            ADDRESSES = [
               Ext::RESQUEST_BODY
             ].freeze
-            private_constant :WAF_ADDRESSES
+            private_constant :ADDRESSES
 
             def self.publish(op, request)
               catch(:block) do
@@ -26,8 +26,8 @@ module Datadog
             end
 
             def self.subscribe(op, waf_context)
-              op.subscribe(*WAF_ADDRESSES) do |*values|
-                Datadog.logger.debug { "reacted to #{WAF_ADDRESSES.inspect}: #{values.inspect}" }
+              op.subscribe(*ADDRESSES) do |*values|
+                Datadog.logger.debug { "reacted to #{ADDRESSES.inspect}: #{values.inspect}" }
                 body = values[0]
 
                 waf_args = {

--- a/lib/datadog/appsec/contrib/rack/reactive/request_body.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/request_body.rb
@@ -12,14 +12,14 @@ module Datadog
           # Dispatch data from a Rack request to the WAF context
           module RequestBody
             ADDRESSES = [
-              Ext::RESQUEST_BODY
+              Ext::REQUEST_BODY
             ].freeze
             private_constant :ADDRESSES
 
             def self.publish(op, request)
               catch(:block) do
                 # params have been parsed from the request body
-                op.publish(Ext::RESQUEST_BODY, Rack::Request.form_hash(request))
+                op.publish(Ext::REQUEST_BODY, Rack::Request.form_hash(request))
 
                 nil
               end

--- a/lib/datadog/appsec/contrib/rack/reactive/response.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/response.rb
@@ -1,6 +1,8 @@
 # typed: ignore
+# frozen_string_literal: true
 
 require_relative '../response'
+require_relative '../ext'
 
 module Datadog
   module AppSec
@@ -9,21 +11,22 @@ module Datadog
         module Reactive
           # Dispatch data from a Rack response to the WAF context
           module Response
+            WAF_ADDRESSES = [
+              Ext::RESPONSE_STATUS
+            ].freeze
+            private_constant :WAF_ADDRESSES
+
             def self.publish(op, response)
               catch(:block) do
-                op.publish('response.status', Rack::Response.status(response))
+                op.publish(Ext::RESPONSE_STATUS, Rack::Response.status(response))
 
                 nil
               end
             end
 
             def self.subscribe(op, waf_context)
-              addresses = [
-                'response.status',
-              ]
-
-              op.subscribe(*addresses) do |*values|
-                Datadog.logger.debug { "reacted to #{addresses.inspect}: #{values.inspect}" }
+              op.subscribe(*WAF_ADDRESSES) do |*values|
+                Datadog.logger.debug { "reacted to #{WAF_ADDRESSES.inspect}: #{values.inspect}" }
 
                 response_status = values[0]
 

--- a/lib/datadog/appsec/contrib/rack/reactive/response.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/response.rb
@@ -11,10 +11,10 @@ module Datadog
         module Reactive
           # Dispatch data from a Rack response to the WAF context
           module Response
-            WAF_ADDRESSES = [
+            ADDRESSES = [
               Ext::RESPONSE_STATUS
             ].freeze
-            private_constant :WAF_ADDRESSES
+            private_constant :ADDRESSES
 
             def self.publish(op, response)
               catch(:block) do
@@ -25,8 +25,8 @@ module Datadog
             end
 
             def self.subscribe(op, waf_context)
-              op.subscribe(*WAF_ADDRESSES) do |*values|
-                Datadog.logger.debug { "reacted to #{WAF_ADDRESSES.inspect}: #{values.inspect}" }
+              op.subscribe(*ADDRESSES) do |*values|
+                Datadog.logger.debug { "reacted to #{ADDRESSES.inspect}: #{values.inspect}" }
 
                 response_status = values[0]
 

--- a/lib/datadog/appsec/contrib/rack/request_body_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_body_middleware.rb
@@ -1,5 +1,7 @@
 # typed: ignore
+# frozen_string_literal: true
 
+require_relative 'ext'
 require_relative '../../instrumentation/gateway'
 require_relative '../../response'
 
@@ -24,7 +26,7 @@ module Datadog
 
             request = ::Rack::Request.new(env)
 
-            request_return, request_response = Instrumentation.gateway.push('rack.request.body', request) do
+            request_return, request_response = Instrumentation.gateway.push(Ext::RACK_REQUEST_BODY, request) do
               @app.call(env)
             end
 

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -1,7 +1,9 @@
 # typed: ignore
+# frozen_string_literal: true
 
 require 'json'
 
+require_relative 'ext'
 require_relative '../../instrumentation/gateway'
 require_relative '../../processor'
 require_relative '../../response'
@@ -35,7 +37,7 @@ module Datadog
 
             add_appsec_tags(active_trace, active_span, env)
 
-            request_return, request_response = Instrumentation.gateway.push('rack.request', request) do
+            request_return, request_response = Instrumentation.gateway.push(Ext::RACK_REQUEST, request) do
               @app.call(env)
             end
 
@@ -48,7 +50,7 @@ module Datadog
               @waf_context = context
             end
 
-            _response_return, _response_response = Instrumentation.gateway.push('rack.response', response)
+            _response_return, _response_response = Instrumentation.gateway.push(Ext::RACK_RESPONSE, response)
 
             context.events.each do |e|
               e[:response] ||= response

--- a/lib/datadog/appsec/contrib/rails/configuration/settings.rb
+++ b/lib/datadog/appsec/contrib/rails/configuration/settings.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 require_relative '../../configuration/settings'
 require_relative '../ext'

--- a/lib/datadog/appsec/contrib/rails/ext.rb
+++ b/lib/datadog/appsec/contrib/rails/ext.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 module Datadog
   module AppSec
@@ -6,8 +7,12 @@ module Datadog
       module Rails
         # Rack integration constants
         module Ext
-          APP = 'rails'.freeze
-          ENV_ENABLED = 'DD_TRACE_RAILS_ENABLED'.freeze
+          APP = 'rails'
+          ENV_ENABLED = 'DD_TRACE_RAILS_ENABLED'
+
+          RAILS_REQUEST_ACTION = 'rails.request.action'
+          RAILS_REQUEST_BODY = 'rails.request.body'
+          RAILS_REQUEST_ROUTE_PARMS = 'rails.request.route_params'
         end
       end
     end

--- a/lib/datadog/appsec/contrib/rails/ext.rb
+++ b/lib/datadog/appsec/contrib/rails/ext.rb
@@ -5,7 +5,7 @@ module Datadog
   module AppSec
     module Contrib
       module Rails
-        # Rack integration constants
+        # Rails integration constants
         module Ext
           APP = 'rails'
           ENV_ENABLED = 'DD_TRACE_RAILS_ENABLED'

--- a/lib/datadog/appsec/contrib/rails/framework.rb
+++ b/lib/datadog/appsec/contrib/rails/framework.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
@@ -1,5 +1,7 @@
 # typed: ignore
+# frozen_string_literal: true
 
+require_relative '../ext'
 require_relative '../../../instrumentation/gateway'
 require_relative '../../../reactive/operation'
 require_relative '../reactive/action'
@@ -13,12 +15,12 @@ module Datadog
           # Watcher for Rails gateway events
           module Watcher
             def self.watch
-              Instrumentation.gateway.watch('rails.request.action', :appsec) do |stack, request|
+              Instrumentation.gateway.watch(Ext::RAILS_REQUEST_ACTION, :appsec) do |stack, request|
                 block = false
                 event = nil
                 waf_context = request.env['datadog.waf.context']
 
-                AppSec::Reactive::Operation.new('rails.request.action') do |op|
+                AppSec::Reactive::Operation.new(Ext::RAILS_REQUEST_ACTION) do |op|
                   trace = active_trace
                   span = active_span
 

--- a/lib/datadog/appsec/contrib/rails/integration.rb
+++ b/lib/datadog/appsec/contrib/rails/integration.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 require_relative '../integration'
 

--- a/lib/datadog/appsec/contrib/rails/patcher.rb
+++ b/lib/datadog/appsec/contrib/rails/patcher.rb
@@ -1,4 +1,7 @@
 # typed: ignore
+# frozen_string_literal: true
+
+require_relative 'ext'
 
 require_relative '../../../core/utils/only_once'
 
@@ -79,7 +82,7 @@ module Datadog
 
               # TODO: handle exceptions, except for super
 
-              request_return, request_response = Instrumentation.gateway.push('rails.request.action', request) do
+              request_return, request_response = Instrumentation.gateway.push(Ext::RAILS_REQUEST_ACTION, request) do
                 super
               end
 
@@ -131,7 +134,7 @@ module Datadog
           end
 
           def inspect_middlewares(app)
-            Datadog.logger.debug { 'Rails middlewares: ' << app.middleware.map(&:inspect).inspect }
+            Datadog.logger.debug { "Rails middlewares: #{app.middleware.map(&:inspect).inspect}" }
           end
 
           def patch_after_intialize

--- a/lib/datadog/appsec/contrib/rails/reactive/action.rb
+++ b/lib/datadog/appsec/contrib/rails/reactive/action.rb
@@ -11,12 +11,12 @@ module Datadog
         module Reactive
           # Dispatch data from a Rails request to the WAF context
           module Action
-            WAF_ADDRESSES = [
+            ADDRESSES = [
               Ext::RAILS_REQUEST_BODY,
               Ext::RAILS_REQUEST_ROUTE_PARMS,
             ].freeze
 
-            private_constant :WAF_ADDRESSES
+            private_constant :ADDRESSES
 
             def self.publish(op, request)
               catch(:block) do
@@ -29,8 +29,8 @@ module Datadog
             end
 
             def self.subscribe(op, waf_context)
-              op.subscribe(*WAF_ADDRESSES) do |*values|
-                Datadog.logger.debug { "reacted to #{WAF_ADDRESSES.inspect}: #{values.inspect}" }
+              op.subscribe(*ADDRESSES) do |*values|
+                Datadog.logger.debug { "reacted to #{ADDRESSES.inspect}: #{values.inspect}" }
                 body = values[0]
                 path_params = values[1]
 

--- a/lib/datadog/appsec/contrib/rails/request.rb
+++ b/lib/datadog/appsec/contrib/rails/request.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/contrib/rails/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rails/request_middleware.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/contrib/sinatra/configuration/settings.rb
+++ b/lib/datadog/appsec/contrib/sinatra/configuration/settings.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 require_relative '../../configuration/settings'
 require_relative '../ext'

--- a/lib/datadog/appsec/contrib/sinatra/ext.rb
+++ b/lib/datadog/appsec/contrib/sinatra/ext.rb
@@ -11,7 +11,7 @@ module Datadog
           ENV_ENABLED = 'DD_TRACE_SINATRA_ENABLED'
           ROUTE_INTERRUPT = :datadog_appsec_contrib_sinatra_route_interrupt
 
-          REQUEST_DISPATH = 'sinatra.request.dispatch'
+          REQUEST_DISPATCH = 'sinatra.request.dispatch'
           REQUEST_ROUTE_PARAMS = 'sinatra.request.route_params'
           REQUEST_ROUTED = 'sinatra.request.routed'
         end

--- a/lib/datadog/appsec/contrib/sinatra/ext.rb
+++ b/lib/datadog/appsec/contrib/sinatra/ext.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 module Datadog
   module AppSec
@@ -6,9 +7,13 @@ module Datadog
       module Sinatra
         # Sinatra integration constants
         module Ext
-          APP = 'sinatra'.freeze
-          ENV_ENABLED = 'DD_TRACE_SINATRA_ENABLED'.freeze
+          APP = 'sinatra'
+          ENV_ENABLED = 'DD_TRACE_SINATRA_ENABLED'
           ROUTE_INTERRUPT = :datadog_appsec_contrib_sinatra_route_interrupt
+
+          REQUEST_DISPATH = 'sinatra.request.dispatch'
+          REQUEST_ROUTE_PARAMS = 'sinatra.request.route_params'
+          REQUEST_ROUTED = 'sinatra.request.routed'
         end
       end
     end

--- a/lib/datadog/appsec/contrib/sinatra/framework.rb
+++ b/lib/datadog/appsec/contrib/sinatra/framework.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
@@ -17,12 +17,12 @@ module Datadog
           module Watcher
             # rubocop:disable Metrics/MethodLength
             def self.watch
-              Instrumentation.gateway.watch(Ext::REQUEST_DISPATH, :appsec) do |stack, request|
+              Instrumentation.gateway.watch(Ext::REQUEST_DISPATCH, :appsec) do |stack, request|
                 block = false
                 event = nil
                 waf_context = request.env['datadog.waf.context']
 
-                AppSec::Reactive::Operation.new(Ext::REQUEST_DISPATH) do |op|
+                AppSec::Reactive::Operation.new(Ext::REQUEST_DISPATCH) do |op|
                   trace = active_trace
                   span = active_span
 

--- a/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
@@ -1,10 +1,12 @@
 # typed: ignore
+# frozen_string_literal: true
 
 require_relative '../../../instrumentation/gateway'
 require_relative '../../../reactive/operation'
 require_relative '../../rack/reactive/request_body'
 require_relative '../reactive/routed'
 require_relative '../../../event'
+require_relative '../ext'
 
 module Datadog
   module AppSec
@@ -15,12 +17,12 @@ module Datadog
           module Watcher
             # rubocop:disable Metrics/MethodLength
             def self.watch
-              Instrumentation.gateway.watch('sinatra.request.dispatch', :appsec) do |stack, request|
+              Instrumentation.gateway.watch(Ext::REQUEST_DISPATH, :appsec) do |stack, request|
                 block = false
                 event = nil
                 waf_context = request.env['datadog.waf.context']
 
-                AppSec::Reactive::Operation.new('sinatra.request.dispatch') do |op|
+                AppSec::Reactive::Operation.new(Ext::REQUEST_DISPATH) do |op|
                   trace = active_trace
                   span = active_span
 
@@ -56,12 +58,12 @@ module Datadog
                 [ret, res]
               end
 
-              Instrumentation.gateway.watch('sinatra.request.routed', :appsec) do |stack, (request, route_params)|
+              Instrumentation.gateway.watch(Ext::REQUEST_ROUTED, :appsec) do |stack, (request, route_params)|
                 block = false
                 event = nil
                 waf_context = request.env['datadog.waf.context']
 
-                AppSec::Reactive::Operation.new('sinatra.request.routed') do |op|
+                AppSec::Reactive::Operation.new(Ext::REQUEST_ROUTED) do |op|
                   trace = active_trace
                   span = active_span
 

--- a/lib/datadog/appsec/contrib/sinatra/integration.rb
+++ b/lib/datadog/appsec/contrib/sinatra/integration.rb
@@ -1,10 +1,12 @@
 # typed: ignore
+# frozen_string_literal: true
 
 require_relative '../integration'
 
 require_relative 'configuration/settings'
 require_relative 'patcher'
 require_relative 'request_middleware'
+require_relative 'ext'
 
 module Datadog
   module AppSec
@@ -19,7 +21,7 @@ module Datadog
           register_as :sinatra
 
           def self.version
-            Gem.loaded_specs['sinatra'] && Gem.loaded_specs['sinatra'].version
+            Gem.loaded_specs[Ext::APP] && Gem.loaded_specs[Ext::APP].version
           end
 
           def self.loaded?

--- a/lib/datadog/appsec/contrib/sinatra/integration.rb
+++ b/lib/datadog/appsec/contrib/sinatra/integration.rb
@@ -21,7 +21,7 @@ module Datadog
           register_as :sinatra
 
           def self.version
-            Gem.loaded_specs[Ext::APP] && Gem.loaded_specs[Ext::APP].version
+            Gem.loaded_specs['sinatra'] && Gem.loaded_specs['sinatra'].version
           end
 
           def self.loaded?

--- a/lib/datadog/appsec/contrib/sinatra/patcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/patcher.rb
@@ -60,7 +60,7 @@ module Datadog
 
             # TODO: handle exceptions, except for super
 
-            request_return, request_response = Instrumentation.gateway.push(Ext::REQUEST_DISPATH, request) do
+            request_return, request_response = Instrumentation.gateway.push(Ext::REQUEST_DISPATCH, request) do
               # handle process_route interruption
               catch(Ext::ROUTE_INTERRUPT) { super }
             end

--- a/lib/datadog/appsec/contrib/sinatra/patcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/patcher.rb
@@ -1,4 +1,7 @@
 # typed: ignore
+# frozen_string_literal: true
+
+require_relative 'ext'
 
 require_relative '../../../tracing/contrib/rack/middlewares'
 
@@ -57,7 +60,7 @@ module Datadog
 
             # TODO: handle exceptions, except for super
 
-            request_return, request_response = Instrumentation.gateway.push('sinatra.request.dispatch', request) do
+            request_return, request_response = Instrumentation.gateway.push(Ext::REQUEST_DISPATH, request) do
               # handle process_route interruption
               catch(Ext::ROUTE_INTERRUPT) { super }
             end
@@ -92,7 +95,7 @@ module Datadog
               # At this point params has both route params and normal params.
               route_params = params.each.with_object({}) { |(k, v), h| h[k] = v unless base_params.key?(k) }
 
-              _, request_response = Instrumentation.gateway.push('sinatra.request.routed', [request, route_params])
+              _, request_response = Instrumentation.gateway.push(Ext::REQUEST_ROUTED, [request, route_params])
 
               if request_response && request_response.any? { |action, _event| action == :block }
                 self.response = AppSec::Response.negotiate(env).to_sinatra_response

--- a/lib/datadog/appsec/contrib/sinatra/reactive/routed.rb
+++ b/lib/datadog/appsec/contrib/sinatra/reactive/routed.rb
@@ -8,10 +8,10 @@ module Datadog
         module Reactive
           # Dispatch data from a Rack request to the WAF context
           module Routed
-            WAF_ADDRESSES = [
+            ADDRESSES = [
               Ext::REQUEST_ROUTE_PARAMS
             ].freeze
-            private_constant :WAF_ADDRESSES
+            private_constant :ADDRESSES
 
             def self.publish(op, data)
               _request, route_params = data
@@ -24,8 +24,8 @@ module Datadog
             end
 
             def self.subscribe(op, waf_context)
-              op.subscribe(*WAF_ADDRESSES) do |*values|
-                Datadog.logger.debug { "reacted to #{WAF_ADDRESSES.inspect}: #{values.inspect}" }
+              op.subscribe(*ADDRESSES) do |*values|
+                Datadog.logger.debug { "reacted to #{ADDRESSES.inspect}: #{values.inspect}" }
                 path_params = values[0]
 
                 waf_args = {

--- a/lib/datadog/appsec/contrib/sinatra/reactive/routed.rb
+++ b/lib/datadog/appsec/contrib/sinatra/reactive/routed.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 module Datadog
   module AppSec
@@ -7,23 +8,24 @@ module Datadog
         module Reactive
           # Dispatch data from a Rack request to the WAF context
           module Routed
+            WAF_ADDRESSES = [
+              Ext::REQUEST_ROUTE_PARAMS
+            ].freeze
+            private_constant :WAF_ADDRESSES
+
             def self.publish(op, data)
               _request, route_params = data
 
               catch(:block) do
-                op.publish('sinatra.request.route_params', route_params)
+                op.publish(Ext::REQUEST_ROUTE_PARAMS, route_params)
 
                 nil
               end
             end
 
             def self.subscribe(op, waf_context)
-              addresses = [
-                'sinatra.request.route_params',
-              ]
-
-              op.subscribe(*addresses) do |*values|
-                Datadog.logger.debug { "reacted to #{addresses.inspect}: #{values.inspect}" }
+              op.subscribe(*WAF_ADDRESSES) do |*values|
+                Datadog.logger.debug { "reacted to #{WAF_ADDRESSES.inspect}: #{values.inspect}" }
                 path_params = values[0]
 
                 waf_args = {

--- a/lib/datadog/appsec/contrib/sinatra/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/sinatra/request_middleware.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 module Datadog
   module AppSec

--- a/sig/datadog/appsec/contrib/rack/ext.rbs
+++ b/sig/datadog/appsec/contrib/rack/ext.rbs
@@ -10,7 +10,7 @@ module Datadog
 
           RESPONSE_STATUS: "response.status"
 
-          RESQUEST_BODY: "request.body"
+          REQUEST_BODY: "request.body"
 
           REQUEST_HEADERS: "request.headers"
 

--- a/sig/datadog/appsec/contrib/rack/ext.rbs
+++ b/sig/datadog/appsec/contrib/rack/ext.rbs
@@ -2,10 +2,31 @@ module Datadog
   module AppSec
     module Contrib
       module Rack
+        # Rack integration constants
         module Ext
-          APP: untyped
+          APP: "rack"
 
-          ENV_ENABLED: untyped
+          ENV_ENABLED: "DD_TRACE_RACK_ENABLED"
+
+          RESPONSE_STATUS: "response.status"
+
+          RESQUEST_BODY: "request.body"
+
+          REQUEST_HEADERS: "request.headers"
+
+          REQUEST_URI_RAW: "request.uri.raw"
+
+          REQUEST_QUERY: "request.query"
+
+          REQUEST_COOKIES: "request.cookies"
+
+          REQUEST_CLIENT_IP: "request.client_ip"
+
+          RACK_REQUEST: "rack.request"
+
+          RACK_REQUEST_BODY: "rack.request.body"
+
+          RACK_RESPONSE: "rack.response"
         end
       end
     end

--- a/sig/datadog/appsec/contrib/rails/ext.rbs
+++ b/sig/datadog/appsec/contrib/rails/ext.rbs
@@ -2,10 +2,17 @@ module Datadog
   module AppSec
     module Contrib
       module Rails
+        # Rails integration constants
         module Ext
           APP: "rails"
 
           ENV_ENABLED: "DD_TRACE_RAILS_ENABLED"
+
+          RAILS_REQUEST_ACTION: "rails.request.action"
+
+          RAILS_REQUEST_BODY: "rails.request.body"
+
+          RAILS_REQUEST_ROUTE_PARMS: "rails.request.route_params"
         end
       end
     end

--- a/sig/datadog/appsec/contrib/sinatra/ext.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/ext.rbs
@@ -10,7 +10,7 @@ module Datadog
 
           ROUTE_INTERRUPT: :datadog_appsec_contrib_sinatra_route_interrupt
 
-          REQUEST_DISPATH: "sinatra.request.dispatch"
+          REQUEST_DISPATCH: "sinatra.request.dispatch"
 
           REQUEST_ROUTE_PARAMS: "sinatra.request.route_params"
 

--- a/sig/datadog/appsec/contrib/sinatra/ext.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/ext.rbs
@@ -2,12 +2,19 @@ module Datadog
   module AppSec
     module Contrib
       module Sinatra
+        # Sinatra integration constants
         module Ext
           APP: "sinatra"
 
           ENV_ENABLED: "DD_TRACE_SINATRA_ENABLED"
 
           ROUTE_INTERRUPT: :datadog_appsec_contrib_sinatra_route_interrupt
+
+          REQUEST_DISPATH: "sinatra.request.dispatch"
+
+          REQUEST_ROUTE_PARAMS: "sinatra.request.route_params"
+
+          REQUEST_ROUTED: "sinatra.request.routed"
         end
       end
     end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
While going over the `appsec` library code to familiarise myself  with it. I noticed we have a lot os string literals over the code base. I created a bunch of constant in the `Ext` namespace for each the integrations. I replace the string literals with the constants. 

Also, I added the `# frozen_string_literal: true` on the files I touched. 

Additional I fixed the `LOAD_PATH` for the binary that we ship with the gem `bin/ddtracerb`

**Motivation**
Code cleanup 

**Additional Notes**
Am I using the Ext namespace correctly? 

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI should be green.