### PR TITLE
Change base to keyword argument

### DIFF
--- a/lib/datadog/tracing/distributed/b3_single.rb
+++ b/lib/datadog/tracing/distributed/b3_single.rb
@@ -47,8 +47,8 @@ module Datadog
           return unless value
 
           parts = value.split('-')
-          trace_id = Helpers.value_to_id(parts[0], 16) unless parts.empty?
-          span_id = Helpers.value_to_id(parts[1], 16) if parts.length > 1
+          trace_id = Helpers.value_to_id(parts[0], base: 16) unless parts.empty?
+          span_id = Helpers.value_to_id(parts[1], base: 16) if parts.length > 1
           sampling_priority = Helpers.value_to_number(parts[2]) if parts.length > 2
 
           # Return if this propagation is not valid

--- a/lib/datadog/tracing/distributed/fetcher.rb
+++ b/lib/datadog/tracing/distributed/fetcher.rb
@@ -18,11 +18,11 @@ module Datadog
         end
 
         def id(key, base: 10)
-          Helpers.value_to_id(self[key], base)
+          Helpers.value_to_id(self[key], base: base)
         end
 
         def number(key, base: 10)
-          Helpers.value_to_number(self[key], base)
+          Helpers.value_to_number(self[key], base: base)
         end
       end
     end

--- a/lib/datadog/tracing/distributed/helpers.rb
+++ b/lib/datadog/tracing/distributed/helpers.rb
@@ -40,9 +40,8 @@ module Datadog
           value.sub(/^0*(?=(0$)|[^0])/, '')
         end
 
-        # DEV: move `base` to a keyword argument
-        def self.value_to_id(value, base = 10)
-          id = value_to_number(value, base)
+        def self.value_to_id(value, base: 10)
+          id = value_to_number(value, base: base)
 
           # Return early if we could not parse a number
           return if id.nil?
@@ -53,8 +52,7 @@ module Datadog
           id < 0 ? id + (2**64) : id
         end
 
-        # DEV: move `base` to a keyword argument
-        def self.value_to_number(value, base = 10)
+        def self.value_to_number(value, base: 10)
           # It's important to make a difference between no data and zero.
           return if value.nil?
 

--- a/spec/datadog/tracing/distributed/fetcher_spec.rb
+++ b/spec/datadog/tracing/distributed/fetcher_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Datadog::Tracing::Distributed::Fetcher do
 
     it 'delegates to Datadog::Tracing::Distributed::Helpers.value_to_id' do
       ret = double('return')
-      expect(Datadog::Tracing::Distributed::Helpers).to receive(:value_to_id).with(value, base).and_return(ret)
+      expect(Datadog::Tracing::Distributed::Helpers).to receive(:value_to_id).with(value, base: base).and_return(ret)
       is_expected.to eq(ret)
     end
   end
@@ -48,7 +48,7 @@ RSpec.describe Datadog::Tracing::Distributed::Fetcher do
 
     it 'delegates to Datadog::Tracing::Distributed::Helpers.value_to_number' do
       ret = double('return')
-      expect(Datadog::Tracing::Distributed::Helpers).to receive(:value_to_number).with(value, base).and_return(ret)
+      expect(Datadog::Tracing::Distributed::Helpers).to receive(:value_to_number).with(value, base: base).and_return(ret)
       is_expected.to eq(ret)
     end
   end

--- a/spec/datadog/tracing/distributed/helpers_spec.rb
+++ b/spec/datadog/tracing/distributed/helpers_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Datadog::Tracing::Distributed::Helpers do
         ['deadbeef', 3735928559],
       ].each do |value, expected|
         context value.inspect do
-          it { expect(described_class.value_to_id(value, 16)).to eq(expected) }
+          it { expect(described_class.value_to_id(value, base: 16)).to eq(expected) }
         end
       end
     end
@@ -170,7 +170,7 @@ RSpec.describe Datadog::Tracing::Distributed::Helpers do
         ['invalid-base16', nil]
       ].each do |value, expected|
         context value.inspect do
-          subject(:subject) { described_class.value_to_number(value, 16) }
+          subject(:subject) { described_class.value_to_number(value, base: 16) }
 
           it { is_expected.to be == expected }
         end


### PR DESCRIPTION
**What does this PR do?**

Change method signature to keyword arguments with default, a bit more explicit during invokation and easier to be extended with more arguments