### PR TITLE
Minor: Log libdatadog version while building profiler + Tweak banner when new profiler is enabled 

### DIFF
--- a/ext/ddtrace_profiling_native_extension/extconf.rb
+++ b/ext/ddtrace_profiling_native_extension/extconf.rb
@@ -165,6 +165,7 @@ end
 # If we got here, libdatadog is available and loaded
 ENV['PKG_CONFIG_PATH'] = "#{ENV['PKG_CONFIG_PATH']}:#{Libdatadog.pkgconfig_folder}"
 Logging.message(" [ddtrace] PKG_CONFIG_PATH set to #{ENV['PKG_CONFIG_PATH'].inspect}\n")
+$stderr.puts("Using libdatadog #{Libdatadog::VERSION} from #{Libdatadog.pkgconfig_folder}")
 
 unless pkg_config('datadog_profiling_with_rpath')
   skip_building_extension!(

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -351,8 +351,7 @@ module Datadog
           def print_new_profiler_warnings
             if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
               Datadog.logger.warn(
-                'New Ruby profiler has been force-enabled. This feature is in beta state. We do not yet recommend ' \
-                'running it in production environments. Please report any issues ' \
+                'New Ruby profiler has been force-enabled. This is a beta feature. Please report any issues ' \
                 'you run into to Datadog support or via <https://github.com/datadog/dd-trace-rb/issues/new>!'
               )
             else

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -1043,7 +1043,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
           it 'logs a warning message mentioning that profiler has been force-enabled' do
             expect(Datadog.logger).to receive(:warn).with(
-              /New Ruby profiler has been force-enabled. This feature is in beta state/
+              /New Ruby profiler has been force-enabled. This is a beta feature/
             )
 
             build_profiler


### PR DESCRIPTION
**What does this PR do?**

This PR includes two small changes:

* Log libdatadog version when buidling the profiling native extension

    This is not visible by default when installing the gem, it only shows up in logs or when installation breaks.

* Tweak banner when new Ruby profiler is enabled 

    We are still in beta, but we have had enough feedback from internal and external testing that we are now recommending trying the new profiler out in production.

**Motivation**

Clarify and improve our logging.

**Additional Notes**

(N/A)

**How to test the change?**

Change includes test coverage.
