### PR TITLE
Appsec extract array creation from critical path

### DIFF
--- a/lib/datadog/appsec/contrib/rack/reactive/request.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/request.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 require_relative '../request'
 

--- a/lib/datadog/appsec/contrib/rack/reactive/request.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/request.rb
@@ -9,6 +9,15 @@ module Datadog
         module Reactive
           # Dispatch data from a Rack request to the WAF context
           module Request
+            ADDRESSES = [
+              'request.headers',
+              'request.uri.raw',
+              'request.query',
+              'request.cookies',
+              'request.client_ip',
+            ].freeze
+            private_constant :ADDRESSES
+
             def self.publish(op, request)
               catch(:block) do
                 op.publish('request.query', Rack::Request.query(request))
@@ -21,18 +30,9 @@ module Datadog
               end
             end
 
-            # rubocop:disable Metrics/MethodLength
             def self.subscribe(op, waf_context)
-              addresses = [
-                'request.headers',
-                'request.uri.raw',
-                'request.query',
-                'request.cookies',
-                'request.client_ip',
-              ]
-
-              op.subscribe(*addresses) do |*values|
-                Datadog.logger.debug { "reacted to #{addresses.inspect}: #{values.inspect}" }
+              op.subscribe(*ADDRESSES) do |*values|
+                Datadog.logger.debug { "reacted to #{ADDRESSES.inspect}: #{values.inspect}" }
                 headers = values[0]
                 headers_no_cookies = headers.dup.tap { |h| h.delete('cookie') }
                 uri_raw = values[1]
@@ -74,7 +74,6 @@ module Datadog
                 end
               end
             end
-            # rubocop:enable Metrics/MethodLength
           end
         end
       end

--- a/lib/datadog/appsec/contrib/rack/reactive/request_body.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/request_body.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 require_relative '../request'
 

--- a/lib/datadog/appsec/contrib/rack/reactive/request_body.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/request_body.rb
@@ -9,6 +9,11 @@ module Datadog
         module Reactive
           # Dispatch data from a Rack request to the WAF context
           module RequestBody
+            ADDRESSES = [
+              'request.body',
+            ].freeze
+            private_constant :ADDRESSES
+
             def self.publish(op, request)
               catch(:block) do
                 # params have been parsed from the request body
@@ -19,12 +24,8 @@ module Datadog
             end
 
             def self.subscribe(op, waf_context)
-              addresses = [
-                'request.body',
-              ]
-
-              op.subscribe(*addresses) do |*values|
-                Datadog.logger.debug { "reacted to #{addresses.inspect}: #{values.inspect}" }
+              op.subscribe(*ADDRESSES) do |*values|
+                Datadog.logger.debug { "reacted to #{ADDRESSES.inspect}: #{values.inspect}" }
                 body = values[0]
 
                 waf_args = {

--- a/lib/datadog/appsec/contrib/rack/reactive/response.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/response.rb
@@ -9,6 +9,11 @@ module Datadog
         module Reactive
           # Dispatch data from a Rack response to the WAF context
           module Response
+            ADDRESSES = [
+              'response.status',
+            ].freeze
+            private_constant :ADDRESSES
+
             def self.publish(op, response)
               catch(:block) do
                 op.publish('response.status', Rack::Response.status(response))
@@ -18,12 +23,8 @@ module Datadog
             end
 
             def self.subscribe(op, waf_context)
-              addresses = [
-                'response.status',
-              ]
-
-              op.subscribe(*addresses) do |*values|
-                Datadog.logger.debug { "reacted to #{addresses.inspect}: #{values.inspect}" }
+              op.subscribe(*ADDRESSES) do |*values|
+                Datadog.logger.debug { "reacted to #{ADDRESSES.inspect}: #{values.inspect}" }
 
                 response_status = values[0]
 

--- a/lib/datadog/appsec/contrib/rack/reactive/response.rb
+++ b/lib/datadog/appsec/contrib/rack/reactive/response.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 require_relative '../response'
 

--- a/lib/datadog/appsec/contrib/rails/reactive/action.rb
+++ b/lib/datadog/appsec/contrib/rails/reactive/action.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 require_relative '../request'
 

--- a/lib/datadog/appsec/contrib/rails/reactive/action.rb
+++ b/lib/datadog/appsec/contrib/rails/reactive/action.rb
@@ -9,6 +9,12 @@ module Datadog
         module Reactive
           # Dispatch data from a Rails request to the WAF context
           module Action
+            ADDRESSES = [
+              'rails.request.body',
+              'rails.request.route_params',
+            ].freeze
+            private_constant :ADDRESSES
+
             def self.publish(op, request)
               catch(:block) do
                 # params have been parsed from the request body
@@ -20,13 +26,8 @@ module Datadog
             end
 
             def self.subscribe(op, waf_context)
-              addresses = [
-                'rails.request.body',
-                'rails.request.route_params',
-              ]
-
-              op.subscribe(*addresses) do |*values|
-                Datadog.logger.debug { "reacted to #{addresses.inspect}: #{values.inspect}" }
+              op.subscribe(*ADDRESSES) do |*values|
+                Datadog.logger.debug { "reacted to #{ADDRESSES.inspect}: #{values.inspect}" }
                 body = values[0]
                 path_params = values[1]
 

--- a/lib/datadog/appsec/contrib/sinatra/reactive/routed.rb
+++ b/lib/datadog/appsec/contrib/sinatra/reactive/routed.rb
@@ -5,8 +5,13 @@ module Datadog
     module Contrib
       module Sinatra
         module Reactive
-          # Dispatch data from a Rack request to the WAF context
+          # Dispatch data from a Sinatra request to the WAF context
           module Routed
+            ADDRESSES = [
+              'sinatra.request.route_params',
+            ].freeze
+            private_constant :ADDRESSES
+
             def self.publish(op, data)
               _request, route_params = data
 
@@ -18,12 +23,8 @@ module Datadog
             end
 
             def self.subscribe(op, waf_context)
-              addresses = [
-                'sinatra.request.route_params',
-              ]
-
-              op.subscribe(*addresses) do |*values|
-                Datadog.logger.debug { "reacted to #{addresses.inspect}: #{values.inspect}" }
+              op.subscribe(*ADDRESSES) do |*values|
+                Datadog.logger.debug { "reacted to #{ADDRESSES.inspect}: #{values.inspect}" }
                 path_params = values[0]
 
                 waf_args = {

--- a/lib/datadog/appsec/contrib/sinatra/reactive/routed.rb
+++ b/lib/datadog/appsec/contrib/sinatra/reactive/routed.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+# frozen_string_literal: true
 
 module Datadog
   module AppSec

--- a/sig/datadog/appsec/contrib/rack/reactive/request.rbs
+++ b/sig/datadog/appsec/contrib/rack/reactive/request.rbs
@@ -4,6 +4,8 @@ module Datadog
       module Rack
         module Reactive
           module Request
+            ADDRESSES: ::Array[::String]
+
             def self.publish: (untyped op, untyped request) -> untyped
 
             def self.subscribe: (untyped op, untyped waf_context) { (untyped) -> untyped } -> untyped

--- a/sig/datadog/appsec/contrib/rack/reactive/request_body.rbs
+++ b/sig/datadog/appsec/contrib/rack/reactive/request_body.rbs
@@ -4,6 +4,8 @@ module Datadog
       module Rack
         module Reactive
           module RequestBody
+            ADDRESSES: ::Array[::String]
+
             def self.publish: (untyped op, untyped request) -> untyped
 
             def self.subscribe: (untyped op, untyped waf_context) { (untyped) -> untyped } -> untyped

--- a/sig/datadog/appsec/contrib/rack/reactive/response.rbs
+++ b/sig/datadog/appsec/contrib/rack/reactive/response.rbs
@@ -4,6 +4,8 @@ module Datadog
       module Rack
         module Reactive
           module Response
+            ADDRESSES: ::Array[::String]
+
             def self.publish: (untyped op, untyped response) -> untyped
 
             def self.subscribe: (untyped op, untyped waf_context) { (untyped) -> untyped } -> untyped

--- a/sig/datadog/appsec/contrib/rails/reactive/action.rbs
+++ b/sig/datadog/appsec/contrib/rails/reactive/action.rbs
@@ -4,6 +4,8 @@ module Datadog
       module Rails
         module Reactive
           module Action
+            ADDRESSES: ::Array[::String]
+
             def self.publish: (untyped op, untyped request) -> untyped
 
             def self.subscribe: (untyped op, untyped waf_context) { (untyped) -> untyped } -> untyped

--- a/sig/datadog/appsec/contrib/sinatra/reactive/routed.rbs
+++ b/sig/datadog/appsec/contrib/sinatra/reactive/routed.rbs
@@ -4,6 +4,8 @@ module Datadog
       module Sinatra
         module Reactive
           module Routed
+            ADDRESSES: ::Array[::String]
+
             def self.publish: (untyped op, untyped data) -> untyped
 
             def self.subscribe: (untyped op, untyped waf_context) { (untyped) -> untyped } -> untyped


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Extract the `addresses` array creation from the critical path of appsec subscription. 
We now store it in a private constant with each of the files.

Also: 

- Update rbs files
- Added frozen string literal comment 

**Motivation**
<!-- What inspired you to submit this pull request? -->

Reduce the number of allocations in the critical path 

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

Split from https://github.com/DataDog/dd-trace-rb/pull/2588

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI 
