### PR TITLE
Upgrade profiler to use libdatadog v2.0.0

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -69,7 +69,7 @@ Gem::Specification.new do |spec|
 
   # Used by profiling (and possibly others in the future)
   # When updating the version here, please also update the version in `native_extension_helpers.rb` (and yes we have a test for it)
-  spec.add_dependency 'libdatadog', '~> 1.0.1.1.0'
+  spec.add_dependency 'libdatadog', '~> 2.0.0.1.0'
 
   spec.extensions = ['ext/ddtrace_profiling_native_extension/extconf.rb', 'ext/ddtrace_profiling_loader/extconf.rb']
 end

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -124,12 +124,9 @@ struct per_thread_context {
 
 // Used to correlate profiles with traces
 struct trace_identifiers {
-  #define MAXIMUM_LENGTH_64_BIT_IDENTIFIER 21 // Why 21? 2^64 => 20 digits + 1 for \0
-
   bool valid;
-  ddog_CharSlice local_root_span_id;
+  uint64_t local_root_span_id;
   uint64_t span_id;
-  char local_root_span_id_buffer[MAXIMUM_LENGTH_64_BIT_IDENTIFIER];
   VALUE trace_endpoint;
 };
 
@@ -576,7 +573,7 @@ static void trigger_sample_for_thread(
   trace_identifiers_for(state, thread, &trace_identifiers_result);
 
   if (trace_identifiers_result.valid) {
-    labels[label_pos++] = (ddog_prof_Label) {.key = DDOG_CHARSLICE_C("local root span id"), .str = trace_identifiers_result.local_root_span_id};
+    labels[label_pos++] = (ddog_prof_Label) {.key = DDOG_CHARSLICE_C("local root span id"), .num = trace_identifiers_result.local_root_span_id};
     labels[label_pos++] = (ddog_prof_Label) {.key = DDOG_CHARSLICE_C("span id"), .num = trace_identifiers_result.span_id};
 
     if (trace_identifiers_result.trace_endpoint != Qnil) {
@@ -851,13 +848,7 @@ static void trace_identifiers_for(struct cpu_and_wall_time_collector_state *stat
   VALUE numeric_span_id = rb_ivar_get(active_span, at_id_id /* @id */);
   if (numeric_local_root_span_id == Qnil || numeric_span_id == Qnil) return;
 
-  unsigned long long local_root_span_id = NUM2ULL(numeric_local_root_span_id);
-  snprintf(trace_identifiers_result->local_root_span_id_buffer, MAXIMUM_LENGTH_64_BIT_IDENTIFIER, "%llu", local_root_span_id);
-
-  trace_identifiers_result->local_root_span_id = (ddog_CharSlice) {
-    .ptr = trace_identifiers_result->local_root_span_id_buffer,
-    .len = strlen(trace_identifiers_result->local_root_span_id_buffer)
-  };
+  trace_identifiers_result->local_root_span_id = NUM2ULL(numeric_local_root_span_id);
   trace_identifiers_result->span_id = NUM2ULL(numeric_span_id);
 
   trace_identifiers_result->valid = true;

--- a/ext/ddtrace_profiling_native_extension/libdatadog_helpers.h
+++ b/ext/ddtrace_profiling_native_extension/libdatadog_helpers.h
@@ -13,6 +13,13 @@ inline static VALUE ruby_string_from_vec_u8(ddog_Vec_U8 string) {
   return rb_str_new((char *) string.ptr, string.len);
 }
 
-inline static VALUE ruby_string_from_prof_vec_u8(ddog_prof_Vec_U8 string) {
-  return rb_str_new((char *) string.ptr, string.len);
+inline static VALUE ruby_string_from_error(const ddog_Error *error) {
+  ddog_CharSlice char_slice = ddog_Error_message(error);
+  return rb_str_new(char_slice.ptr, char_slice.len);
+}
+
+inline static VALUE get_error_details_and_drop(ddog_Error *error) {
+  VALUE result = ruby_string_from_error(error);
+  ddog_Error_drop(error);
+  return result;
 }

--- a/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/ddtrace_profiling_native_extension/native_extension_helpers.rb
@@ -17,7 +17,7 @@ module Datadog
       # Older Rubies don't have the MJIT header, used by the JIT compiler, so we need to use a different approach
       CAN_USE_MJIT_HEADER = RUBY_VERSION >= '2.6'
 
-      LIBDATADOG_VERSION = '~> 1.0.1.1.0'
+      LIBDATADOG_VERSION = '~> 2.0.0.1.0'
 
       def self.fail_install_if_missing_extension?
         ENV[ENV_FAIL_INSTALL_IF_MISSING_EXTENSION].to_s.strip.downcase == 'true'

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -290,8 +290,7 @@ static VALUE _native_serialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instan
   ddog_Timespec ddprof_start = serialized_profile.ok.start;
   ddog_Timespec ddprof_finish = serialized_profile.ok.end;
 
-  // FIXME: Temporarily disabled until a libdatadog crash gets fixed
-  // ddog_prof_EncodedProfile_drop(&serialized_profile.ok);
+  ddog_prof_EncodedProfile_drop(&serialized_profile.ok);
 
   VALUE start = ruby_time_from(ddprof_start);
   VALUE finish = ruby_time_from(ddprof_finish);

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -317,9 +317,11 @@ void record_sample(VALUE recorder_instance, ddog_prof_Sample sample) {
 
   struct active_slot_pair active_slot = sampler_lock_active_profile(state);
 
-  ddog_prof_Profile_add(active_slot.profile, sample);
+  uint64_t success = ddog_prof_Profile_add(active_slot.profile, sample);
 
   sampler_unlock_active_profile(active_slot);
+
+  if (!success) rb_raise(rb_eArgError, "Failed to record sample: ddog_prof_Profile_add returned failure status code");
 }
 
 void record_endpoint(VALUE recorder_instance, uint64_t local_root_span_id, ddog_CharSlice endpoint) {

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -322,7 +322,7 @@ void record_sample(VALUE recorder_instance, ddog_prof_Sample sample) {
   sampler_unlock_active_profile(active_slot);
 }
 
-void record_endpoint(VALUE recorder_instance, ddog_CharSlice local_root_span_id, ddog_CharSlice endpoint) {
+void record_endpoint(VALUE recorder_instance, uint64_t local_root_span_id, ddog_CharSlice endpoint) {
   struct stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, struct stack_recorder_state, &stack_recorder_typed_data, state);
 
@@ -475,6 +475,7 @@ static void serializer_set_start_timestamp_for_next_profile(struct stack_recorde
 }
 
 static VALUE _native_record_endpoint(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE local_root_span_id, VALUE endpoint) {
-  record_endpoint(recorder_instance, char_slice_from_ruby_string(local_root_span_id), char_slice_from_ruby_string(endpoint));
+  ENFORCE_TYPE(local_root_span_id, T_FIXNUM);
+  record_endpoint(recorder_instance, NUM2ULL(local_root_span_id), char_slice_from_ruby_string(endpoint));
   return Qtrue;
 }

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.h
@@ -35,5 +35,5 @@ static const ddog_prof_ValueType enabled_value_types[] = {
 #define ENABLED_VALUE_TYPES_COUNT (sizeof(enabled_value_types) / sizeof(ddog_prof_ValueType))
 
 void record_sample(VALUE recorder_instance, ddog_prof_Sample sample);
-void record_endpoint(VALUE recorder_instance, ddog_CharSlice local_root_span_id, ddog_CharSlice endpoint);
+void record_endpoint(VALUE recorder_instance, uint64_t local_root_span_id, ddog_CharSlice endpoint);
 VALUE enforce_recorder_instance(VALUE object);

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
@@ -348,7 +348,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
             sample
 
             expect(t1_sample.fetch(:labels)).to include(
-              :'local root span id' => @t1_local_root_span_id.to_s,
+              :'local root span id' => @t1_local_root_span_id.to_i,
               :'span id' => @t1_span_id.to_i,
             )
           end

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   let(:gathered_stack) { stacks.fetch(:gathered) }
 
   def sample(thread, recorder_instance, metric_values_hash, labels_array, max_frames: 400, in_gc: false)
-    described_class::Testing._native_sample(thread, recorder_instance, metric_values_hash, labels_array, max_frames, in_gc)
+    numeric_labels_array = []
+    described_class::Testing._native_sample(thread, recorder_instance, metric_values_hash, labels_array, numeric_labels_array, max_frames, in_gc)
   end
 
   # This spec explicitly tests the main thread because an unpatched rb_profile_frames returns one more frame in the

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -176,6 +176,21 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       end
     end
 
+    context 'when sample is invalid' do
+      context 'because the local root span id is being defined using a string instead of as a number' do
+        let(:metric_values) { { 'cpu-time' => 123, 'cpu-samples' => 456, 'wall-time' => 789 } }
+
+        it do
+          # We're using `_native_sample` here to test the behavior of `record_sample` in `stack_recorder.c`
+          expect do
+            Datadog::Profiling::Collectors::Stack::Testing._native_sample(
+              Thread.current, stack_recorder, metric_values, { 'local root span id' => 'incorrect' }.to_a, [], 400, false
+            )
+          end.to raise_error(ArgumentError)
+        end
+      end
+    end
+
     describe 'trace endpoint behavior' do
       let(:metric_values) { { 'cpu-time' => 101, 'cpu-samples' => 1, 'wall-time' => 789 } }
       let(:samples) { samples_from_pprof(encoded_pprof) }

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -6,6 +6,8 @@ require 'datadog/profiling/stack_recorder'
 RSpec.describe Datadog::Profiling::StackRecorder do
   before { skip_if_profiling_not_supported(self) }
 
+  let(:numeric_labels) { [] }
+
   subject(:stack_recorder) { described_class.new }
 
   # NOTE: A lot of libdatadog integration behaviors are tested in the Collectors::Stack specs, since we need actual
@@ -144,7 +146,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
       before do
         Datadog::Profiling::Collectors::Stack::Testing
-          ._native_sample(Thread.current, stack_recorder, metric_values, labels, 400, false)
+          ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels, 400, false)
         expect(samples.size).to be 1
       end
 
@@ -175,23 +177,23 @@ RSpec.describe Datadog::Profiling::StackRecorder do
     end
 
     describe 'trace endpoint behavior' do
-      let(:metric_values) { { 'cpu-time' => 123, 'cpu-samples' => 1, 'wall-time' => 789 } }
+      let(:metric_values) { { 'cpu-time' => 101, 'cpu-samples' => 1, 'wall-time' => 789 } }
       let(:samples) { samples_from_pprof(encoded_pprof) }
 
       it 'includes the endpoint for all matching samples taken before and after recording the endpoint' do
-        local_root_span_id_with_endpoint = { 'local root span id' => '123' }
-        local_root_span_id_without_endpoint = { 'local root span id' => '456' }
+        local_root_span_id_with_endpoint = { 'local root span id' => 123 }
+        local_root_span_id_without_endpoint = { 'local root span id' => 456 }
 
-        sample = proc do |labels = {}|
+        sample = proc do |numeric_labels = {}|
           Datadog::Profiling::Collectors::Stack::Testing
-            ._native_sample(Thread.current, stack_recorder, metric_values, labels.to_a, 400, false)
+            ._native_sample(Thread.current, stack_recorder, metric_values, [], numeric_labels.to_a, 400, false)
         end
 
         sample.call
         sample.call(local_root_span_id_without_endpoint)
         sample.call(local_root_span_id_with_endpoint)
 
-        described_class::Testing._native_record_endpoint(stack_recorder, '123', 'recorded-endpoint')
+        described_class::Testing._native_record_endpoint(stack_recorder, 123, 'recorded-endpoint')
 
         sample.call
         sample.call(local_root_span_id_without_endpoint)
@@ -201,12 +203,12 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
         # Other samples have not been changed
         expect(samples.select { |it| it[:labels].empty? }).to have(2).items
-        expect(samples.select { |it| it[:labels] == { :'local root span id' => '456' } }).to have(2).items
+        expect(samples.select { |it| it[:labels] == { :'local root span id' => 456 } }).to have(2).items
 
         # Matching samples taken before and after recording the endpoint have been changed
         expect(
           samples.select do |it|
-            it[:labels] == { :'local root span id' => '123', :'trace endpoint' => 'recorded-endpoint' }
+            it[:labels] == { :'local root span id' => 123, :'trace endpoint' => 'recorded-endpoint' }
           end
         ).to have(2).items
       end
@@ -314,7 +316,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       it 'makes the next calls to serialize return no data' do
         # Add some data
         Datadog::Profiling::Collectors::Stack::Testing
-          ._native_sample(Thread.current, stack_recorder, metric_values, labels, 400, false)
+          ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels, 400, false)
 
         # Sanity check: validate that data is there, to avoid the test passing because of other issues
         sanity_check_samples = samples_from_pprof(stack_recorder.serialize.last)
@@ -322,7 +324,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
         # Add some data, again
         Datadog::Profiling::Collectors::Stack::Testing
-          ._native_sample(Thread.current, stack_recorder, metric_values, labels, 400, false)
+          ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels, 400, false)
 
         reset_after_fork
 


### PR DESCRIPTION
**What does this PR do?**:

This PR updates the profiler to use the new libdatadog v2.0.0 APIs.

In particular:
* The "local root span id" is now attached to samples as a number
* The error reporting API changed, and I tweaked how we got error messages from libdatadog
* Some of the libdatadog memory release methods ("drop" methods") were replaced, and I've adopted the new ones where needed.

**Motivation**:

Enable the Ruby profiler to use the latest libdatadog release.

**Additional Notes**:

A few of the changes were committed incrementally, so it may be easier to review commit-by-commit.

**How to test the change?**:

The changes are covered by our existing test suite. In fact, this branch helped pinpoint a libdatadog bug that was fixed before release.