### PR TITLE
Minor: Remove leftover `OnlyOnce` instance

### DIFF
--- a/lib/datadog/tracing/contrib/configuration/settings.rb
+++ b/lib/datadog/tracing/contrib/configuration/settings.rb
@@ -12,8 +12,6 @@ module Datadog
         class Settings
           include Core::Configuration::Base
 
-          DEPRECATION_WARN_ONLY_ONCE = Core::Utils::OnlyOnce.new
-
           option :analytics_enabled, default: false
           option :analytics_sample_rate, default: 1.0
           option :enabled, default: true


### PR DESCRIPTION
**What does this PR do?**:

Remove a stray `OnlyOnce` instance that is no longer in use. There are no references to it anymore in the entire codebase.

**Motivation**:

Remove something not in use.

**Additional Notes**:

(N/A)

**How to test the change?**:

CI stays green!