### PR TITLE
Presto/Elasticsearch/qLess updates

### DIFF
--- a/lib/datadog/tracing/contrib/elasticsearch/patcher.rb
+++ b/lib/datadog/tracing/contrib/elasticsearch/patcher.rb
@@ -81,10 +81,11 @@ module Datadog
 
                     span.span_type = Datadog::Tracing::Contrib::Elasticsearch::Ext::SPAN_TYPE_QUERY
 
-                    span.set_tag(Contrib::Ext::DB::TAG_SYSTEM, Ext::TAG_SYSTEM)
-
                     span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
                     span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_QUERY)
+                    span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
+
+                    span.set_tag(Contrib::Ext::DB::TAG_SYSTEM, Ext::TAG_SYSTEM)
 
                     # load JSON for the following fields unless they're already strings
                     params = JSON.generate(params) if params && !params.is_a?(String)

--- a/lib/datadog/tracing/contrib/presto/ext.rb
+++ b/lib/datadog/tracing/contrib/presto/ext.rb
@@ -26,6 +26,7 @@ module Datadog
           TAG_COMPONENT = 'presto'.freeze
           TAG_OPERATION_QUERY = 'query'.freeze
           TAG_OPERATION_KILL = 'kill'.freeze
+          TAG_SYSTEM = 'presto'.freeze
         end
       end
     end

--- a/lib/datadog/tracing/contrib/presto/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/presto/instrumentation.rb
@@ -81,6 +81,9 @@ module Datadog
               def decorate!(span, operation)
                 span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
                 span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, operation)
+                span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
+
+                span.set_tag(Contrib::Ext::DB::TAG_SYSTEM, Ext::TAG_SYSTEM)
 
                 if (host_port = @options[:server])
                   host, port = Core::Utils.extract_host_port(host_port)

--- a/lib/datadog/tracing/contrib/qless/qless_job.rb
+++ b/lib/datadog/tracing/contrib/qless/qless_job.rb
@@ -15,8 +15,6 @@ module Datadog
             return super unless datadog_configuration && Tracing.enabled?
 
             Tracing.trace(Ext::SPAN_JOB, **span_options) do |span|
-              span.set_tag(Contrib::Ext::Messaging::TAG_SYSTEM, Ext::TAG_COMPONENT)
-
               span.resource = job.klass_name
               span.span_type = Tracing::Metadata::Ext::AppTypes::TYPE_WORKER
               span.set_tag(Ext::TAG_JOB_ID, job.jid)
@@ -37,6 +35,9 @@ module Datadog
 
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_JOB)
+              span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CONSUMER)
+
+              span.set_tag(Contrib::Ext::Messaging::TAG_SYSTEM, Ext::TAG_COMPONENT)
 
               # Set analytics sample rate
               if Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])

--- a/spec/datadog/tracing/contrib/elasticsearch/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/elasticsearch/patcher_spec.rb
@@ -81,6 +81,10 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Patcher do
       }
 
       it {
+        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('client')
+      }
+
+      it {
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION))
           .to eq('query')
       }
@@ -140,6 +144,10 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Patcher do
 
       it {
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('elasticsearch')
+      }
+
+      it {
+        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('client')
       }
 
       it {

--- a/spec/datadog/tracing/contrib/elasticsearch/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/elasticsearch/patcher_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Patcher do
       }
 
       it {
-        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('elasticsearch')
+        expect(span.get_tag('component')).to eq('elasticsearch')
       }
 
       it {
@@ -143,7 +143,7 @@ RSpec.describe Datadog::Tracing::Contrib::Elasticsearch::Patcher do
       }
 
       it {
-        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('elasticsearch')
+        expect(span.get_tag('component')).to eq('elasticsearch')
       }
 
       it {

--- a/spec/datadog/tracing/contrib/presto/client_spec.rb
+++ b/spec/datadog/tracing/contrib/presto/client_spec.rb
@@ -103,6 +103,8 @@ RSpec.describe 'Presto::Client instrumentation' do
         expect(span.get_tag('out.port')).to eq(port)
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('presto')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq(operation)
+        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('client')
+        expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_SYSTEM)).to eq('presto')
       end
     end
 

--- a/spec/datadog/tracing/contrib/presto/client_spec.rb
+++ b/spec/datadog/tracing/contrib/presto/client_spec.rb
@@ -103,8 +103,8 @@ RSpec.describe 'Presto::Client instrumentation' do
         expect(span.get_tag('out.port')).to eq(port)
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('presto')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq(operation)
-        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('client')
-        expect(span.get_tag(Datadog::Tracing::Contrib::Ext::DB::TAG_SYSTEM)).to eq('presto')
+        expect(span.get_tag('span.kind')).to eq('client')
+        expect(span.get_tag('db.system')).to eq('presto')
       end
     end
 

--- a/spec/datadog/tracing/contrib/qless/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/qless/instrumentation_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe 'Qless instrumentation' do
         expect(span).to_not have_error
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('qless')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('job')
+        expect(span.get_tag('span.kind')).to eq('consumer')
         expect(span.get_tag('messaging.system')).to eq('qless')
       end
 
@@ -83,6 +84,7 @@ RSpec.describe 'Qless instrumentation' do
         expect(span).to have_error_type(error_class_name)
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('qless')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('job')
+        expect(span.get_tag('span.kind')).to eq('consumer')
         expect(span.get_tag('messaging.system')).to eq('qless')
       end
     end


### PR DESCRIPTION
**What does this PR do?**
Updates various integrations based on unified naming convetion:

presto - adds spankind: client and db.system: presto
elasticsearch - adds spankind: client
qLess - adds spankind: consumer