### PR TITLE
Fix flaky spec on Ruby 3.2

### DIFF
--- a/spec/datadog/core/environment/cgroup_spec.rb
+++ b/spec/datadog/core/environment/cgroup_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe Datadog::Core::Environment::Cgroup do
 
     context 'when the \'/proc/self/cgroup\' file is not present' do
       before do
+        expect(Datadog.logger).to_not receive(:error)
+
         expect(File).to receive(:exist?)
           .with('/proc/self/cgroup')
           .and_return(false)
-
-        expect(Datadog.logger).to_not receive(:error)
       end
 
       it do


### PR DESCRIPTION
**What does this PR do?**:

This PR fixes a flaky spec for Ruby 3.2 I observed in CI in <https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/8878/workflows/f72fda28-a30a-4349-b567-def2b0c94679/jobs/330338>

This issue can also be reproduced locally (again on 3.2) by running `bundle exec rspec ./spec/datadog/core/environment/cgroup_spec.rb:17`.

```
Datadog::Core::Environment::Cgroup
  ::descriptors
    when the '/proc/self/cgroup' file is not present
      is expected to receive exist?("/proc/self/cgroup") 1 time (FAILED - 1)

Failures:

  1) Datadog::Core::Environment::Cgroup::descriptors when the '/proc/self/cgroup' file is not present is expected to receive exist?("/proc/self/cgroup") 1 time
     Failure/Error: super

       #<File (class)> received :exist? with unexpected arguments
         expected: ("/proc/self/cgroup")
              got: ("<STDOUT>")
     # ./lib/datadog/core/logger.rb:16:in `initialize'
     # ./lib/datadog/core/configuration.rb:265:in `new'
     # ./lib/datadog/core/configuration.rb:265:in `logger_without_components'
     # ./lib/datadog/core/configuration.rb:174:in `logger'
     # ./spec/datadog/core/environment/cgroup_spec.rb:17:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:220:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:112:in `block (2 levels) in <top (required)>'
     # /home/ivo.anjo/.rvm/gems/ruby-3.2.0/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

This issue is caused by the built-in `Logger` in Ruby 3.2 (which we subclass in our `Datadog::Core::Logger`) also using `File.exist?`.

Thus, because in this test we setup a very restrictive expectation on this method, this was causing the `Logger` class to fail.

This test was flaky because this initialization relied on no logger existing before -- if any other test had triggered the logger initialization, then this spec would pass.

I've fixed this by making sure the logger is initialized before we setup any expectations on `File`.

**Motivation**:

Let's get to ZERO flaky specs!

**Additional Notes**:

(N/A)

**How to test the change?**:

See instructions above -- the spec fails when executed individually before this change, and is fixed by this PR.

