### PR TITLE
Minor: Don't actually start profiling in core specs

### DIFF
--- a/spec/datadog/core/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/core/diagnostics/environment_logger_spec.rb
@@ -316,7 +316,10 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
       end
 
       context 'with profiling enabled' do
-        before { Datadog.configure { |c| c.profiling.enabled = true } }
+        before do
+          allow_any_instance_of(Datadog::Profiling::Profiler).to receive(:start)
+          Datadog.configure { |c| c.profiling.enabled = true }
+        end
 
         it { is_expected.to include profiling_enabled: true }
       end

--- a/spec/datadog/core/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/core/diagnostics/environment_logger_spec.rb
@@ -298,26 +298,26 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
       end
 
       context 'with MRI' do
-        before { skip unless PlatformHelpers.mri? }
+        before { skip('Spec only runs on MRI') unless PlatformHelpers.mri? }
 
         it { is_expected.to include vm: start_with('ruby') }
       end
 
       context 'with JRuby' do
-        before { skip unless PlatformHelpers.jruby? }
+        before { skip('Spec only runs on JRuby') unless PlatformHelpers.jruby? }
 
         it { is_expected.to include vm: start_with('jruby') }
       end
 
       context 'with TruffleRuby' do
-        before { skip unless PlatformHelpers.truffleruby? }
+        before { skip('Spec only runs on TruffleRuby') unless PlatformHelpers.truffleruby? }
 
         it { is_expected.to include vm: start_with('truffleruby') }
       end
 
       context 'with profiling enabled' do
         before do
-          allow_any_instance_of(Datadog::Profiling::Profiler).to receive(:start)
+          allow_any_instance_of(Datadog::Profiling::Profiler).to receive(:start) if PlatformHelpers.mri?
           Datadog.configure { |c| c.profiling.enabled = true }
         end
 

--- a/spec/datadog/core/telemetry/collector_spec.rb
+++ b/spec/datadog/core/telemetry/collector_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Datadog::Core::Telemetry::Collector do
         require 'datadog/appsec'
 
         before do
-          allow_any_instance_of(Datadog::Profiling::Profiler).to receive(:start)
+          allow_any_instance_of(Datadog::Profiling::Profiler).to receive(:start) if PlatformHelpers.mri?
           Datadog.configure do |c|
             c.profiling.enabled = true
             c.appsec.enabled = true

--- a/spec/datadog/core/telemetry/collector_spec.rb
+++ b/spec/datadog/core/telemetry/collector_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe Datadog::Core::Telemetry::Collector do
           Datadog.configuration.appsec.enabled = false
           stub_const('Datadog::Core::Environment::Ext::TRACER_VERSION', '4.2')
         end
+
         after do
           Datadog.configuration.profiling.send(:reset!)
           Datadog.configuration.appsec.send(:reset!)
@@ -99,11 +100,13 @@ RSpec.describe Datadog::Core::Telemetry::Collector do
         require 'datadog/appsec'
 
         before do
+          allow_any_instance_of(Datadog::Profiling::Profiler).to receive(:start)
           Datadog.configure do |c|
             c.profiling.enabled = true
             c.appsec.enabled = true
           end
         end
+
         after do
           Datadog.configuration.profiling.send(:reset!)
           Datadog.configuration.appsec.send(:reset!)
@@ -223,6 +226,7 @@ RSpec.describe Datadog::Core::Telemetry::Collector do
     context 'when profiling is enabled' do
       before do
         stub_const('Datadog::Core::Environment::Ext::TRACER_VERSION', '4.2')
+        allow_any_instance_of(Datadog::Profiling::Profiler).to receive(:start)
         Datadog.configure do |c|
           c.profiling.enabled = true
         end

--- a/spec/datadog/profiling/profiler_spec.rb
+++ b/spec/datadog/profiling/profiler_spec.rb
@@ -1,6 +1,7 @@
 # typed: false
 
 require 'spec_helper'
+require 'datadog/profiling/spec_helper'
 
 require 'datadog/profiling'
 require 'datadog/profiling/profiler'
@@ -8,6 +9,8 @@ require 'datadog/profiling/collectors/old_stack'
 require 'datadog/profiling/scheduler'
 
 RSpec.describe Datadog::Profiling::Profiler do
+  before { skip_if_profiling_not_supported(self) }
+
   subject(:profiler) { described_class.new(collectors, scheduler) }
 
   let(:collectors) { Array.new(2) { instance_double(Datadog::Profiling::Collectors::OldStack) } }


### PR DESCRIPTION
**What does this PR do?**:

This PR tweaks two specs in the `spec/datadog/core` folder (for the environment logger and the telemetry collector) so that they don't actually start a real profiler during the test.

**Motivation**:

The changed tests are validating that the environment logger and the telemetry collector report if profiling was enabled or not, which is why they enable profiling.

But we don't need to actually profile during these specs, and actually doing so slows them down and can generate logging noise (profiler starting, trying to report, etc.).

**Additional Notes**:

In the future, when we separate out the components, we'll probably have a better way of doing this than `allow_any_instance_of`, but for now I couldn't come up with a simpler solution.

**How to test the change?**:

Validate that specs still pass.