### PR TITLE
[APPSEC-8112] Appsec allow to set user id denylist

### DIFF
--- a/lib/datadog/appsec/configuration.rb
+++ b/lib/datadog/appsec/configuration.rb
@@ -40,6 +40,10 @@ module Datadog
           options[:ip_denylist] = value
         end
 
+        def user_id_denylist=(value)
+          options[:user_id_denylist] = value
+        end
+
         # in microseconds
         def waf_timeout=(value)
           options[:waf_timeout] = value

--- a/lib/datadog/appsec/configuration.rb
+++ b/lib/datadog/appsec/configuration.rb
@@ -37,11 +37,11 @@ module Datadog
         end
 
         def ip_denylist=(value)
-          options[:ip_denylist] = value
+          options[:ip_denylist] = value || []
         end
 
         def user_id_denylist=(value)
-          options[:user_id_denylist] = value
+          options[:user_id_denylist] = value || []
         end
 
         # in microseconds

--- a/lib/datadog/appsec/configuration.rb
+++ b/lib/datadog/appsec/configuration.rb
@@ -37,11 +37,11 @@ module Datadog
         end
 
         def ip_denylist=(value)
-          options[:ip_denylist] = value || []
+          options[:ip_denylist] = value
         end
 
         def user_id_denylist=(value)
-          options[:user_id_denylist] = value || []
+          options[:user_id_denylist] = value
         end
 
         # in microseconds

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -142,6 +142,13 @@ module Datadog
           _ = @options[:ip_denylist]
         end
 
+        # EXPERIMENTAL: This configurable is not meant to be publicly used, but
+        #               is very useful for testing. It may change at any point in time.
+        def user_id_denylist
+          # Cast for Steep
+          _ = @options[:user_id_denylist]
+        end
+
         def waf_timeout
           # Cast for Steep
           _ = @options[:waf_timeout]

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -139,14 +139,14 @@ module Datadog
         #               is very useful for testing. It may change at any point in time.
         def ip_denylist
           # Cast for Steep
-          _ = @options[:ip_denylist]
+          _ = @options[:ip_denylist] || []
         end
 
         # EXPERIMENTAL: This configurable is not meant to be publicly used, but
         #               is very useful for testing. It may change at any point in time.
         def user_id_denylist
           # Cast for Steep
-          _ = @options[:user_id_denylist]
+          _ = @options[:user_id_denylist] || []
         end
 
         def waf_timeout

--- a/lib/datadog/appsec/extensions.rb
+++ b/lib/datadog/appsec/extensions.rb
@@ -54,6 +54,12 @@ module Datadog
           @settings.merge(dsl)
         end
 
+        def user_id_denylist=(arg)
+          dsl = AppSec::Configuration::DSL.new
+          dsl.user_id_denylist = arg
+          @settings.merge(dsl)
+        end
+
         def waf_timeout=(arg)
           dsl = AppSec::Configuration::DSL.new
           dsl.waf_timeout = arg
@@ -100,6 +106,10 @@ module Datadog
 
         def ip_denylist
           @settings.ip_denylist
+        end
+
+        def user_id_denylist
+          @settings.user_id_denylist
         end
 
         def waf_timeout

--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -82,8 +82,8 @@ module Datadog
 
       def update_rules_data_with_static_configured_values
         ruledata_setting = []
-        ruledata_setting << ip_denylist_data(Datadog::AppSec.settings.ip_denylist || [])
-        ruledata_setting << user_id_denylist_data(Datadog::AppSec.settings.user_id_denylist || [])
+        ruledata_setting << ip_denylist_data(Datadog::AppSec.settings.ip_denylist)
+        ruledata_setting << user_id_denylist_data(Datadog::AppSec.settings.user_id_denylist)
 
         update_rule_data(ruledata_setting)
       end

--- a/sig/datadog/appsec/configuration.rbs
+++ b/sig/datadog/appsec/configuration.rbs
@@ -27,6 +27,7 @@ module Datadog
         def enabled=: (bool) -> void
         def ruleset=: (::Symbol | ::String | ::Hash[::String, untyped] | ::File | ::StringIO) -> void
         def ip_denylist=: (::Array[::String]) -> void
+        def user_id_denylist=: (::Array[::String]) -> void
         def waf_timeout=: (::Integer) -> void
         def waf_debug=: (bool) -> void
         def trace_rate_limit=: (::Integer) -> void

--- a/sig/datadog/appsec/configuration/settings.rbs
+++ b/sig/datadog/appsec/configuration/settings.rbs
@@ -29,6 +29,7 @@ module Datadog
         def enabled: () -> bool
         def ruleset: () -> (::Symbol | ::String | ::Hash[::String, untyped] | ::File | ::StringIO)
         def ip_denylist: () -> ::Array[::String]
+        def user_id_denylist: () -> ::Array[::String]
         def waf_timeout: () -> ::Integer
         def waf_debug: () -> bool
         def trace_rate_limit: () -> ::Integer

--- a/sig/datadog/appsec/extensions.rbs
+++ b/sig/datadog/appsec/extensions.rbs
@@ -19,6 +19,7 @@ module Datadog
         def enabled=: (bool arg) -> untyped
         def ruleset=: ((::Symbol | ::String | ::Hash[::String, untyped] | ::File | ::StringIO) arg) -> untyped
         def ip_denylist=: (::Array[::String] arg) -> untyped
+        def user_id_denylist=: (::Array[::String] arg) -> untyped
         def waf_timeout=: (::Integer arg) -> untyped
         def waf_debug=: (bool arg) -> untyped
         def trace_rate_limit=: (::Integer arg) -> untyped
@@ -30,6 +31,7 @@ module Datadog
         def enabled: () -> bool
         def ruleset: () -> (::Symbol | ::String | ::Hash[::String, untyped] | ::File | ::StringIO)
         def ip_denylist: () -> ::Array[::String]
+        def user_id_denylist: () -> ::Array[::String]
         def waf_timeout: () -> ::Integer
         def waf_debug: () -> bool
         def trace_rate_limit: () -> ::Integer

--- a/sig/datadog/appsec/processor.rbs
+++ b/sig/datadog/appsec/processor.rbs
@@ -29,18 +29,17 @@ module Datadog
       def new_context: () -> Context
       def update_rule_data: (untyped data) -> untyped
       def toggle_rules: (untyped map) -> untyped
-      def update_rules_data_with_static_configured_values: () -> untyped
-      def ip_denylist_data: (::Array[String?] denylist, ?id: ::String) -> ::Hash[::String, untyped]
-      def user_id_denylist_data: (::Array[String?] denylist, ?id: ::String) -> ::Hash[::String, untyped]
       def finalize: () -> void
 
       attr_reader handle: untyped
 
       private
 
+      def apply_denylist_data: (Configuration::Settings settings) -> untyped
+      def denylist_data: (String id, ::Array[untyped] denylist) -> ::Hash[::String, untyped | "data_with_expiration"]
       def load_libddwaf: () -> bool
-      def load_ruleset: () -> bool
-      def create_waf_handle: () -> bool
+      def load_ruleset: (Configuration::Settings settings) -> bool
+      def create_waf_handle: (Configuration::Settings settings) -> bool
 
       def self.libddwaf_provides_waf?: () -> bool
       def self.require_libddwaf: () -> bool

--- a/sig/datadog/appsec/processor.rbs
+++ b/sig/datadog/appsec/processor.rbs
@@ -29,7 +29,9 @@ module Datadog
       def new_context: () -> Context
       def update_rule_data: (untyped data) -> untyped
       def toggle_rules: (untyped map) -> untyped
-      def update_ip_denylist: (?untyped denylist, ?id: ::String) -> untyped
+      def update_rules_data_with_static_configured_values: () -> untyped
+      def ip_denylist_data: (::Array[String?] denylist, ?id: ::String) -> ::Hash[::String, untyped]
+      def user_id_denylist_data: (::Array[String?] denylist, ?id: ::String) -> ::Hash[::String, untyped]
       def finalize: () -> void
 
       attr_reader handle: untyped

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -82,6 +82,26 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
       it { expect { trace_rate_limit_ }.to change { settings.trace_rate_limit }.from(100).to(2) }
     end
 
+    describe '#ip_denylist' do
+      subject(:ip_denylist) { settings.ip_denylist }
+      it { is_expected.to eq(nil) }
+    end
+
+    describe '#ip_denylist=' do
+      subject(:ip_denylist_) { settings.merge(dsl.tap { |c| c.ip_denylist = ['192.192.1.1'] }) }
+      it { expect { ip_denylist_ }.to change { settings.ip_denylist }.from(nil).to(['192.192.1.1']) }
+    end
+
+    describe '#user_id_denylist' do
+      subject(:user_id_denylist) { settings.user_id_denylist }
+      it { is_expected.to eq(nil) }
+    end
+
+    describe '#user_id_denylist=' do
+      subject(:user_id_denylist_) { settings.merge(dsl.tap { |c| c.user_id_denylist = ['8764937902709'] }) }
+      it { expect { user_id_denylist_ }.to change { settings.user_id_denylist }.from(nil).to(['8764937902709']) }
+    end
+
     describe '#obfuscator_key_regex' do
       subject(:obfuscator_key_regex) { settings.obfuscator_key_regex }
       it { is_expected.to include('token') }

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -84,22 +84,22 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
 
     describe '#ip_denylist' do
       subject(:ip_denylist) { settings.ip_denylist }
-      it { is_expected.to eq(nil) }
+      it { is_expected.to eq([]) }
     end
 
     describe '#ip_denylist=' do
       subject(:ip_denylist_) { settings.merge(dsl.tap { |c| c.ip_denylist = ['192.192.1.1'] }) }
-      it { expect { ip_denylist_ }.to change { settings.ip_denylist }.from(nil).to(['192.192.1.1']) }
+      it { expect { ip_denylist_ }.to change { settings.ip_denylist }.from([]).to(['192.192.1.1']) }
     end
 
     describe '#user_id_denylist' do
       subject(:user_id_denylist) { settings.user_id_denylist }
-      it { is_expected.to eq(nil) }
+      it { is_expected.to eq([]) }
     end
 
     describe '#user_id_denylist=' do
       subject(:user_id_denylist_) { settings.merge(dsl.tap { |c| c.user_id_denylist = ['8764937902709'] }) }
-      it { expect { user_id_denylist_ }.to change { settings.user_id_denylist }.from(nil).to(['8764937902709']) }
+      it { expect { user_id_denylist_ }.to change { settings.user_id_denylist }.from([]).to(['8764937902709']) }
     end
 
     describe '#obfuscator_key_regex' do

--- a/spec/datadog/appsec/extensions_spec.rb
+++ b/spec/datadog/appsec/extensions_spec.rb
@@ -105,36 +105,22 @@ RSpec.describe Datadog::AppSec::Extensions do
 
       describe '#ip_denylist' do
         subject(:ip_denylist) { settings.ip_denylist }
-        it { is_expected.to eq(nil) }
+        it { is_expected.to eq([]) }
       end
 
       describe '#ip_denylist=' do
-        context 'with non nil value' do
-          subject(:ip_denylist_) { settings.ip_denylist = ['192.192.1.1'] }
-          it { expect { ip_denylist_ }.to change { settings.ip_denylist }.from(nil).to(['192.192.1.1']) }
-        end
-
-        context 'with nil value' do
-          subject(:ip_denylist_) { settings.ip_denylist = nil }
-          it { expect { ip_denylist_ }.to change { settings.ip_denylist }.from(nil).to([]) }
-        end
+        subject(:ip_denylist_) { settings.ip_denylist = ['192.192.1.1'] }
+        it { expect { ip_denylist_ }.to change { settings.ip_denylist }.from([]).to(['192.192.1.1']) }
       end
 
       describe '#user_id_denylist' do
         subject(:user_id_denylist) { settings.user_id_denylist }
-        it { is_expected.to eq(nil) }
+        it { is_expected.to eq([]) }
       end
 
       describe '#user_id_denylist=' do
-        context 'with non nil value' do
-          subject(:user_id_denylist_) { settings.user_id_denylist = ['24528736564812'] }
-          it { expect { user_id_denylist_ }.to change { settings.user_id_denylist }.from(nil).to(['24528736564812']) }
-        end
-
-        context 'with nil value' do
-          subject(:user_id_denylist_) { settings.user_id_denylist = nil }
-          it { expect { user_id_denylist_ }.to change { settings.user_id_denylist }.from(nil).to([]) }
-        end
+        subject(:user_id_denylist_) { settings.user_id_denylist = ['24528736564812'] }
+        it { expect { user_id_denylist_ }.to change { settings.user_id_denylist }.from([]).to(['24528736564812']) }
       end
 
       describe '#[]' do

--- a/spec/datadog/appsec/extensions_spec.rb
+++ b/spec/datadog/appsec/extensions_spec.rb
@@ -109,8 +109,15 @@ RSpec.describe Datadog::AppSec::Extensions do
       end
 
       describe '#ip_denylist=' do
-        subject(:ip_denylist_) { settings.ip_denylist = ['192.192.1.1'] }
-        it { expect { ip_denylist_ }.to change { settings.ip_denylist }.from(nil).to(['192.192.1.1']) }
+        context 'with non nil value' do
+          subject(:ip_denylist_) { settings.ip_denylist = ['192.192.1.1'] }
+          it { expect { ip_denylist_ }.to change { settings.ip_denylist }.from(nil).to(['192.192.1.1']) }
+        end
+
+        context 'with nil value' do
+          subject(:ip_denylist_) { settings.ip_denylist = nil }
+          it { expect { ip_denylist_ }.to change { settings.ip_denylist }.from(nil).to([]) }
+        end
       end
 
       describe '#user_id_denylist' do
@@ -119,8 +126,15 @@ RSpec.describe Datadog::AppSec::Extensions do
       end
 
       describe '#user_id_denylist=' do
-        subject(:user_id_denylist_) { settings.user_id_denylist = ['24528736564812'] }
-        it { expect { user_id_denylist_ }.to change { settings.user_id_denylist }.from(nil).to(['24528736564812']) }
+        context 'with non nil value' do
+          subject(:user_id_denylist_) { settings.user_id_denylist = ['24528736564812'] }
+          it { expect { user_id_denylist_ }.to change { settings.user_id_denylist }.from(nil).to(['24528736564812']) }
+        end
+
+        context 'with nil value' do
+          subject(:user_id_denylist_) { settings.user_id_denylist = nil }
+          it { expect { user_id_denylist_ }.to change { settings.user_id_denylist }.from(nil).to([]) }
+        end
       end
 
       describe '#[]' do

--- a/spec/datadog/appsec/extensions_spec.rb
+++ b/spec/datadog/appsec/extensions_spec.rb
@@ -103,6 +103,26 @@ RSpec.describe Datadog::AppSec::Extensions do
         it { expect { trace_rate_limit_ }.to change { settings.trace_rate_limit }.from(100).to(2) }
       end
 
+      describe '#ip_denylist' do
+        subject(:ip_denylist) { settings.ip_denylist }
+        it { is_expected.to eq(nil) }
+      end
+
+      describe '#ip_denylist=' do
+        subject(:ip_denylist_) { settings.ip_denylist = ['192.192.1.1'] }
+        it { expect { ip_denylist_ }.to change { settings.ip_denylist }.from(nil).to(['192.192.1.1']) }
+      end
+
+      describe '#user_id_denylist' do
+        subject(:user_id_denylist) { settings.user_id_denylist }
+        it { is_expected.to eq(nil) }
+      end
+
+      describe '#user_id_denylist=' do
+        subject(:user_id_denylist_) { settings.user_id_denylist = ['24528736564812'] }
+        it { expect { user_id_denylist_ }.to change { settings.user_id_denylist }.from(nil).to(['24528736564812']) }
+      end
+
       describe '#[]' do
         describe 'when the integration exists' do
           subject(:get) { settings[integration_name] }

--- a/spec/datadog/appsec/processor_spec.rb
+++ b/spec/datadog/appsec/processor_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Datadog::AppSec::Processor do
     allow(logger).to receive(:error)
 
     allow(Datadog).to receive(:logger).and_return(logger)
+    allow(Datadog::AppSec.settings).to receive(:ip_denylist).and_return([])
+    allow(Datadog::AppSec.settings).to receive(:user_id_denylist).and_return([])
   end
 
   context 'self' do

--- a/spec/datadog/appsec/processor_spec.rb
+++ b/spec/datadog/appsec/processor_spec.rb
@@ -85,10 +85,7 @@ RSpec.describe Datadog::AppSec::Processor do
   end
 
   describe '#load_ruleset' do
-    before do
-      allow(Datadog::AppSec.settings).to receive(:ruleset).and_return(ruleset)
-    end
-
+    let(:settings) { Datadog::AppSec.settings }
     let(:basic_ruleset) do
       {
         'version' => '1.0',
@@ -106,6 +103,10 @@ RSpec.describe Datadog::AppSec::Processor do
       }
     end
 
+    before do
+      allow(settings).to receive(:ruleset).and_return(ruleset)
+    end
+
     context 'when ruleset is :recommended' do
       let(:ruleset) { :recommended }
 
@@ -113,7 +114,7 @@ RSpec.describe Datadog::AppSec::Processor do
         expect(Datadog::AppSec::Assets).to receive(:waf_rules).with(:recommended).and_call_original.twice
       end
 
-      it { expect(described_class.new.send(:load_ruleset)).to be true }
+      it { expect(described_class.new.send(:load_ruleset, settings)).to be true }
     end
 
     context 'when ruleset is :strict' do
@@ -123,7 +124,7 @@ RSpec.describe Datadog::AppSec::Processor do
         expect(Datadog::AppSec::Assets).to receive(:waf_rules).with(:strict).and_call_original.twice
       end
 
-      it { expect(described_class.new.send(:load_ruleset)).to be true }
+      it { expect(described_class.new.send(:load_ruleset, settings)).to be true }
     end
 
     context 'when ruleset is :risky' do
@@ -133,45 +134,46 @@ RSpec.describe Datadog::AppSec::Processor do
         expect(Datadog::AppSec::Assets).to receive(:waf_rules).with(:recommended).and_call_original.twice
       end
 
-      it { expect(described_class.new.send(:load_ruleset)).to be true }
+      it { expect(described_class.new.send(:load_ruleset, settings)).to be true }
     end
 
     context 'when ruleset is an existing path' do
       let(:ruleset) { "#{__dir__}/../../../lib/datadog/appsec/assets/waf_rules/recommended.json" }
 
-      it { expect(described_class.new.send(:load_ruleset)).to be true }
+      it { expect(described_class.new.send(:load_ruleset, settings)).to be true }
     end
 
     context 'when ruleset is a non existing path' do
       let(:ruleset) { '/does/not/exist' }
 
-      it { expect(described_class.new.send(:load_ruleset)).to be false }
+      it { expect(described_class.new.send(:load_ruleset, settings)).to be false }
     end
 
     context 'when ruleset is IO-like' do
       let(:ruleset) { StringIO.new(JSON.dump(basic_ruleset)) }
 
-      it { expect(described_class.new.send(:load_ruleset)).to be true }
+      it { expect(described_class.new.send(:load_ruleset, settings)).to be true }
     end
 
     context 'when ruleset is Ruby' do
       let(:ruleset) { basic_ruleset }
 
-      it { expect(described_class.new.send(:load_ruleset)).to be true }
+      it { expect(described_class.new.send(:load_ruleset, settings)).to be true }
     end
 
     context 'when ruleset is not parseable' do
       let(:ruleset) { StringIO.new('this is not json') }
 
-      it { expect(described_class.new.send(:load_ruleset)).to be false }
+      it { expect(described_class.new.send(:load_ruleset, settings)).to be false }
     end
   end
 
   describe '#create_waf_handle' do
     let(:ruleset) { :recommended }
+    let(:settings) { Datadog::AppSec.settings }
 
     before do
-      allow(Datadog::AppSec.settings).to receive(:ruleset).and_return(ruleset)
+      allow(settings).to receive(:ruleset).and_return(ruleset)
     end
 
     context 'when ruleset is default' do
@@ -181,13 +183,13 @@ RSpec.describe Datadog::AppSec::Processor do
         expect(Datadog::AppSec::Assets).to receive(:waf_rules).with(:recommended).and_call_original
       end
 
-      it { expect(described_class.new.send(:create_waf_handle)).to be true }
+      it { expect(described_class.new.send(:create_waf_handle, settings)).to be true }
     end
 
     context 'when ruleset is invalid' do
       let(:ruleset) { { 'not' => 'valid' } }
 
-      it { expect(described_class.new.send(:create_waf_handle)).to be false }
+      it { expect(described_class.new.send(:create_waf_handle, settings)).to be false }
     end
   end
 

--- a/spec/datadog/appsec/processor_spec.rb
+++ b/spec/datadog/appsec/processor_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe Datadog::AppSec::Processor do
     allow(logger).to receive(:error)
 
     allow(Datadog).to receive(:logger).and_return(logger)
-    allow(Datadog::AppSec.settings).to receive(:ip_denylist).and_return([])
-    allow(Datadog::AppSec.settings).to receive(:user_id_denylist).and_return([])
   end
 
   context 'self' do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Introduce a new appsec configuration option `user_id_denylist`

That list would be use to populate the waf rules data at the initialization of a the `AppSec::Processor`. 

Changes in `AppSec::Processor`:
Previously we had a public method called `update_ip_denylist` which populated the waf rule data just for the IP denylist. Now that we have multiple configuration points for deny lists we have to change the code to account for that. 

I created a new private method `update_rules_data_with_static_configured_values` that creates all the necessary waf rule data for the different deny list configurations and call the waf handle `update_rule_data` function once with all the data. I made that change to reduce the number of calls to the handle. 

Also, I remove the public function `update_ip_denylist` from the processor interface. I thought about leaving it public and adding an extra public function `update_user_id_denylist`, but it seems that those are not needed. Ultimately in the future once Remote Configure is implemented we would have to compute the rules data separate and simply call `processor.update_rule_data(data)`
