### PR TITLE
Add mandatory tags for rabbitmq integrations

### DIFF
--- a/lib/datadog/tracing/contrib/ext.rb
+++ b/lib/datadog/tracing/contrib/ext.rb
@@ -22,6 +22,7 @@ module Datadog
 
         module Messaging
           TAG_SYSTEM = 'messaging.system'
+          TAG_RABBITMQ_ROUTING_KEY = 'messaging.rabbitmq.routing_key'
         end
       end
     end

--- a/lib/datadog/tracing/contrib/sneakers/tracer.rb
+++ b/lib/datadog/tracing/contrib/sneakers/tracer.rb
@@ -39,6 +39,7 @@ module Datadog
 
               request_span.resource = @app.to_proc.binding.eval('self.class').to_s
               request_span.set_tag(Ext::TAG_JOB_ROUTING_KEY, delivery_info.routing_key)
+              request_span.set_tag(Contrib::Ext::Messaging::TAG_RABBITMQ_ROUTING_KEY, delivery_info.routing_key)
               request_span.set_tag(Ext::TAG_JOB_QUEUE, delivery_info.consumer.queue.name)
 
               request_span.set_tag(Ext::TAG_JOB_BODY, deserialized_msg) if configuration[:tag_body]

--- a/spec/datadog/tracing/contrib/sneakers/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/sneakers/tracer_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe Datadog::Tracing::Contrib::Sneakers::Tracer do
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('job')
       expect(span.get_tag('span.kind')).to eq('consumer')
       expect(span.get_tag('messaging.system')).to eq('rabbitmq')
+      expect(span.get_tag('messaging.rabbitmq.routing_key')).to eq('something')
     end
 
     context 'when the tag_body is true' do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds the mandatory tag `messaging.rabbitmq.routing_key` for rabbitmq integrations (only `sneakers`).

**Motivation**
<!-- What inspired you to submit this pull request? -->
Unify span tags across tracers.

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Updated unit tests.