### PR TITLE
[APPSEC-7804] update libddwaf version to 1.6.2.0.0

### DIFF
--- a/ddtrace.gemspec
+++ b/ddtrace.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'debase-ruby_core_source', '>= 0.10.16', '<= 3.2.0'
 
   # Used by appsec
-  spec.add_dependency 'libddwaf', '~> 1.5.1.0.0'
+  spec.add_dependency 'libddwaf', '~> 1.6.2.0.0'
 
   # Used by profiling (and possibly others in the future)
   # When updating the version here, please also update the version in `native_extension_helpers.rb` (and yes we have a test for it)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Update libddwaf version to 1.6.2.0.0

Check the [CHANGELOG](https://github.com/DataDog/libddwaf-rb/blob/master/CHANGELOG.md#2023-02-03-v16200) for the updates related to libddwaf. 


