### PR TITLE
[PROF-7192] Minor: Extend stack collector to be able to record the alloc-samples metric

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -83,7 +83,7 @@ static VALUE _native_sample(
   ENFORCE_TYPE(labels_array, T_ARRAY);
   ENFORCE_TYPE(numeric_labels_array, T_ARRAY);
 
-  if (RHASH_SIZE(metric_values_hash) != ENABLED_VALUE_TYPES_COUNT) {
+  if (RHASH_SIZE(metric_values_hash) > ENABLED_VALUE_TYPES_COUNT || RHASH_SIZE(metric_values_hash) == 0) {
     rb_raise(
       rb_eArgError,
       "Mismatched values for metrics; expected %lu values and got %lu instead",
@@ -92,8 +92,8 @@ static VALUE _native_sample(
     );
   }
 
-  int64_t metric_values[ENABLED_VALUE_TYPES_COUNT];
-  for (unsigned int i = 0; i < ENABLED_VALUE_TYPES_COUNT; i++) {
+  int64_t metric_values[ENABLED_VALUE_TYPES_COUNT] = {0};
+  for (unsigned int i = 0; i < RHASH_SIZE(metric_values_hash); i++) {
     VALUE metric_value = rb_hash_fetch(metric_values_hash, rb_str_new_cstr(enabled_value_types[i].type_.ptr));
     metric_values[i] = NUM2LONG(metric_value);
   }

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.h
@@ -29,7 +29,9 @@ static const ddog_prof_ValueType enabled_value_types[] = {
   #define CPU_SAMPLES_VALUE_POS 1
   CPU_SAMPLES_VALUE,
   #define WALL_TIME_VALUE_POS 2
-  WALL_TIME_VALUE
+  WALL_TIME_VALUE,
+  #define ALLOC_SAMPLES_VALUE_POS 3
+  ALLOC_SAMPLES_VALUE
 };
 
 #define ENABLED_VALUE_TYPES_COUNT (sizeof(enabled_value_types) / sizeof(ddog_prof_ValueType))

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           'cpu-time' => 'nanoseconds',
           'cpu-samples' => 'count',
           'wall-time' => 'nanoseconds',
+          'alloc-samples' => 'count',
         )
       end
 
@@ -139,7 +140,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
     end
 
     context 'when profile has a sample' do
-      let(:metric_values) { { 'cpu-time' => 123, 'cpu-samples' => 456, 'wall-time' => 789 } }
+      let(:metric_values) { { 'cpu-time' => 123, 'cpu-samples' => 456, 'wall-time' => 789, 'alloc-samples' => 4242 } }
       let(:labels) { { 'label_a' => 'value_a', 'label_b' => 'value_b' }.to_a }
 
       let(:samples) { samples_from_pprof(encoded_pprof) }
@@ -151,7 +152,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       end
 
       it 'encodes the sample with the metrics provided' do
-        expect(samples.first.values).to eq(:'cpu-time' => 123, :'cpu-samples' => 456, :'wall-time' => 789)
+        expect(samples.first.values)
+          .to eq(:'cpu-time' => 123, :'cpu-samples' => 456, :'wall-time' => 789, :'alloc-samples' => 4242)
       end
 
       it 'encodes the sample with the labels provided' do


### PR DESCRIPTION
**What does this PR do?**:

This PR enables an additional "value type" attached to profiling samples -- the `alloc-samples` metric. This will be used to expose more profiling information in follow-up PRs.

**Motivation**:

I've extracted this from a bigger branch, but this is in good shape for merging already.

**Additional Notes**:

(N/A)

**How to test the change?**:

Change includes test coverage.
