### PR TITLE
Adds span.kind:client for dalli

### DIFF
--- a/lib/datadog/tracing/contrib/dalli/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/dalli/instrumentation.rb
@@ -24,6 +24,8 @@ module Datadog
                 span.service = datadog_configuration[:service_name]
                 span.span_type = Ext::SPAN_TYPE_COMMAND
 
+                span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
+
                 span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
                 span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_COMMAND)
 

--- a/spec/datadog/tracing/contrib/dalli/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/dalli/instrumentation_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe 'Dalli instrumentation' do
       expect(span.get_tag('out.host')).to eq(test_host)
       expect(span.get_tag('out.port')).to eq(test_port.to_f)
       expect(span.get_tag('db.system')).to eq('memcached')
+      expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('client')
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('dalli')
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('command')
     end
@@ -95,6 +96,7 @@ RSpec.describe 'Dalli instrumentation' do
         expect(span.get_tag('out.port')).to eq(test_port.to_f)
 
         expect(span.get_tag('db.system')).to eq('memcached')
+        expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_KIND)).to eq('client')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT)).to eq('dalli')
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION)).to eq('command')
       end


### PR DESCRIPTION
**What does this PR do?**
Adds `span.kind:client` for dalli

**Motivation**
Unify span tags across tracers
