### PR TITLE
Add specs for appsec contrib reactive components

### DIFF
--- a/spec/datadog/appsec/contrib/rack/reactive/request_body_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/reactive/request_body_spec.rb
@@ -1,0 +1,157 @@
+# typed: ignore
+# frozen_string_literal: true
+
+require 'datadog/appsec/spec_helper'
+require 'datadog/appsec/reactive/operation'
+require 'datadog/appsec/contrib/rack/reactive/request_body'
+require 'rack'
+
+RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::RequestBody do
+  let(:operation) { Datadog::AppSec::Reactive::Operation.new('test') }
+  let(:request) do
+    Rack::Request.new(
+      Rack::MockRequest.env_for(
+        'http://example.com:8080/?a=foo',
+        { method: 'POST', params: { 'foo' => 'bar' } }
+      )
+    )
+  end
+
+  describe '.publish' do
+    it 'propagates request body attributes to the operation' do
+      expect(operation).to receive(:publish).with('request.body', { 'foo' => 'bar' })
+
+      described_class.publish(operation, request)
+    end
+  end
+
+  describe '.subscribe' do
+    let(:waf_context) { double(:waf_context) }
+
+    context 'not all addresses have been published' do
+      it 'does not call the waf context' do
+        expect(operation).to receive(:subscribe).with('request.body').and_call_original
+        expect(waf_context).to_not receive(:run)
+        described_class.subscribe(operation, waf_context)
+      end
+    end
+
+    context 'all addresses have been published' do
+      it 'does call the waf context with the right arguments' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        expected_waf_arguments = { 'server.request.body' => { 'foo' => 'bar' } }
+
+        waf_result = double(:waf_result, status: :ok, timeout: false)
+        expect(waf_context).to receive(:run).with(
+          expected_waf_arguments,
+          Datadog::AppSec.settings.waf_timeout
+        ).and_return(waf_result)
+        described_class.subscribe(operation, waf_context)
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is a match' do
+      it 'yields result and no blocking action' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :match, timeout: false, actions: [''])
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        described_class.subscribe(operation, waf_context) do |result, block|
+          expect(result).to eq(waf_result)
+          expect(block).to eq(false)
+        end
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+
+      it 'yields result and blocking action. The publish method catches the resul as well' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :match, timeout: false, actions: ['block'])
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        described_class.subscribe(operation, waf_context) do |result, block|
+          expect(result).to eq(waf_result)
+          expect(block).to eq(true)
+        end
+        publish_result, publish_block = described_class.publish(operation, request)
+        expect(publish_result).to eq(waf_result)
+        expect(publish_block).to eq(true)
+      end
+    end
+
+    context 'waf result is ok' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :ok, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is invalid_call' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :invalid_call, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is invalid_rule' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :invalid_rule, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is invalid_flow' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :invalid_flow, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is no_rule' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :no_rule, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is unknown' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :foo, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/contrib/rack/reactive/request_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/reactive/request_spec.rb
@@ -1,0 +1,173 @@
+# typed: ignore
+# frozen_string_literal: true
+
+require 'datadog/appsec/spec_helper'
+require 'datadog/appsec/reactive/operation'
+require 'datadog/appsec/contrib/rack/reactive/request'
+require 'rack'
+
+RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Request do
+  let(:operation) { Datadog::AppSec::Reactive::Operation.new('test') }
+  let(:request) do
+    Rack::Request.new(
+      Rack::MockRequest.env_for(
+        'http://example.com:8080/?a=foo',
+        { 'REMOTE_ADDR' => '10.10.10.10', 'HTTP_CONTENT_TYPE' => 'text/html' }
+      )
+    )
+  end
+
+  describe '.publish' do
+    it 'propagates request attributes to the operation' do
+      expect(operation).to receive(:publish).with('request.query', [{ 'a' => 'foo' }])
+      expect(operation).to receive(:publish).with('request.headers', { 'content-type' => 'text/html' })
+      expect(operation).to receive(:publish).with('request.uri.raw', 'http://example.com:8080/?a=foo')
+      expect(operation).to receive(:publish).with('request.cookies', {})
+      expect(operation).to receive(:publish).with('request.client_ip', '10.10.10.10')
+      described_class.publish(operation, request)
+    end
+  end
+
+  describe '.subscribe' do
+    let(:waf_context) { double(:waf_context) }
+
+    context 'not all addresses have been published' do
+      it 'does not call the waf context' do
+        expect(operation).to receive(:subscribe).with(
+          'request.headers',
+          'request.uri.raw',
+          'request.query',
+          'request.cookies',
+          'request.client_ip'
+        ).and_call_original
+        expect(waf_context).to_not receive(:run)
+        described_class.subscribe(operation, waf_context)
+      end
+    end
+
+    context 'all addresses have been published' do
+      it 'does call the waf context with the right arguments' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        expected_waf_arguments = {
+          'server.request.cookies' => {},
+          'server.request.query' => [{ 'a' => 'foo' }],
+          'server.request.uri.raw' => 'http://example.com:8080/?a=foo',
+          'server.request.headers' => { 'content-type' => 'text/html' },
+          'server.request.headers.no_cookies' => { 'content-type' => 'text/html' },
+          'http.client_ip' => '10.10.10.10'
+        }
+
+        waf_result = double(:waf_result, status: :ok, timeout: false)
+        expect(waf_context).to receive(:run).with(
+          expected_waf_arguments,
+          Datadog::AppSec.settings.waf_timeout
+        ).and_return(waf_result)
+        described_class.subscribe(operation, waf_context)
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is a match' do
+      it 'yields result and no blocking action' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :match, timeout: false, actions: [''])
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        described_class.subscribe(operation, waf_context) do |result, block|
+          expect(result).to eq(waf_result)
+          expect(block).to eq(false)
+        end
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+
+      it 'yields result and blocking action. The publish method catches the resul as well' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :match, timeout: false, actions: ['block'])
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        described_class.subscribe(operation, waf_context) do |result, block|
+          expect(result).to eq(waf_result)
+          expect(block).to eq(true)
+        end
+        publish_result, publish_block = described_class.publish(operation, request)
+        expect(publish_result).to eq(waf_result)
+        expect(publish_block).to eq(true)
+      end
+    end
+
+    context 'waf result is ok' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :ok, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is invalid_call' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :invalid_call, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is invalid_rule' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :invalid_rule, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is invalid_flow' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :invalid_flow, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is no_rule' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :no_rule, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is unknown' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :foo, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/contrib/rack/reactive/response_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/reactive/response_spec.rb
@@ -1,0 +1,152 @@
+# typed: ignore
+# frozen_string_literal: true
+
+require 'datadog/appsec/spec_helper'
+require 'datadog/appsec/reactive/operation'
+require 'datadog/appsec/contrib/rack/reactive/response'
+require 'rack'
+
+RSpec.describe Datadog::AppSec::Contrib::Rack::Reactive::Response do
+  let(:operation) { Datadog::AppSec::Reactive::Operation.new('test') }
+  let(:response) do
+    Rack::Response.new
+  end
+
+  describe '.publish' do
+    it 'propagates response attributes to the operation' do
+      expect(operation).to receive(:publish).with('response.status', 200)
+
+      described_class.publish(operation, response)
+    end
+  end
+
+  describe '.subscribe' do
+    let(:waf_context) { double(:waf_context) }
+
+    context 'not all addresses have been published' do
+      it 'does not call the waf context' do
+        expect(operation).to receive(:subscribe).with('response.status').and_call_original
+        expect(waf_context).to_not receive(:run)
+        described_class.subscribe(operation, waf_context)
+      end
+    end
+
+    context 'all addresses have been published' do
+      it 'does call the waf context with the right arguments' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        expected_waf_arguments = { 'server.response.status' => '200' }
+
+        waf_result = double(:waf_result, status: :ok, timeout: false)
+        expect(waf_context).to receive(:run).with(
+          expected_waf_arguments,
+          Datadog::AppSec.settings.waf_timeout
+        ).and_return(waf_result)
+        described_class.subscribe(operation, waf_context)
+        result = described_class.publish(operation, response)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is a match' do
+      it 'yields result and no blocking action' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :match, timeout: false, actions: [''])
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        described_class.subscribe(operation, waf_context) do |result, block|
+          expect(result).to eq(waf_result)
+          expect(block).to eq(false)
+        end
+        result = described_class.publish(operation, response)
+        expect(result).to be_nil
+      end
+
+      it 'yields result and blocking action. The publish method catches the resul as well' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :match, timeout: false, actions: ['block'])
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        described_class.subscribe(operation, waf_context) do |result, block|
+          expect(result).to eq(waf_result)
+          expect(block).to eq(true)
+        end
+        publish_result, publish_block = described_class.publish(operation, response)
+        expect(publish_result).to eq(waf_result)
+        expect(publish_block).to eq(true)
+      end
+    end
+
+    context 'waf result is ok' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :ok, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, response)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is invalid_call' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :invalid_call, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, response)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is invalid_rule' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :invalid_rule, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, response)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is invalid_flow' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :invalid_flow, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, response)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is no_rule' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :no_rule, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, response)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is unknown' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :foo, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, response)
+        expect(result).to be_nil
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/contrib/rails/reactive/action_spec.rb
+++ b/spec/datadog/appsec/contrib/rails/reactive/action_spec.rb
@@ -1,0 +1,164 @@
+# typed: ignore
+
+require 'datadog/appsec/spec_helper'
+require 'datadog/appsec/reactive/operation'
+require 'datadog/appsec/contrib/rails/reactive/action'
+require 'action_dispatch'
+
+RSpec.describe Datadog::AppSec::Contrib::Rails::Reactive::Action do
+  let(:operation) { Datadog::AppSec::Reactive::Operation.new('test') }
+  let(:request) do
+    request_env = Rack::MockRequest.env_for(
+      'http://example.com:8080/?a=foo',
+      { method: 'POST', params: { 'foo' => 'bar' }, 'action_dispatch.request.path_parameters' => { id: '1234' } }
+    )
+
+    if ActionDispatch::TestRequest.respond_to?(:create)
+      ActionDispatch::TestRequest.create(request_env)
+    else
+      ActionDispatch::TestRequest.new(request_env)
+    end
+  end
+
+  describe '.publish' do
+    it 'propagates request attributes to the operation' do
+      expect(operation).to receive(:publish).with('rails.request.body', { 'foo' => 'bar' })
+      expect(operation).to receive(:publish).with('rails.request.route_params', { id: '1234' })
+
+      described_class.publish(operation, request)
+    end
+  end
+
+  describe '.subscribe' do
+    let(:waf_context) { double(:waf_context) }
+
+    context 'not all addresses have been published' do
+      it 'does not call the waf context' do
+        expect(operation).to receive(:subscribe).with('rails.request.body', 'rails.request.route_params').and_call_original
+        expect(waf_context).to_not receive(:run)
+        described_class.subscribe(operation, waf_context)
+      end
+    end
+
+    context 'all addresses have been published' do
+      it 'does call the waf context with the right arguments' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        expected_waf_arguments = {
+          'server.request.body' => { 'foo' => 'bar' },
+          'server.request.path_params' => { id: '1234' }
+        }
+
+        waf_result = double(:waf_result, status: :ok, timeout: false)
+        expect(waf_context).to receive(:run).with(
+          expected_waf_arguments,
+          Datadog::AppSec.settings.waf_timeout
+        ).and_return(waf_result)
+        described_class.subscribe(operation, waf_context)
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is a match' do
+      it 'yields result and no blocking action' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :match, timeout: false, actions: [''])
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        described_class.subscribe(operation, waf_context) do |result, block|
+          expect(result).to eq(waf_result)
+          expect(block).to eq(false)
+        end
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+
+      it 'yields result and blocking action. The publish method catches the resul as well' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :match, timeout: false, actions: ['block'])
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        described_class.subscribe(operation, waf_context) do |result, block|
+          expect(result).to eq(waf_result)
+          expect(block).to eq(true)
+        end
+        publish_result, publish_block = described_class.publish(operation, request)
+        expect(publish_result).to eq(waf_result)
+        expect(publish_block).to eq(true)
+      end
+    end
+
+    context 'waf result is ok' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :ok, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is invalid_call' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :invalid_call, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is invalid_rule' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :invalid_rule, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is invalid_flow' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :invalid_flow, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is no_rule' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :no_rule, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is unknown' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :foo, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, request)
+        expect(result).to be_nil
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/contrib/sinatra/reactive/routed_spec.rb
+++ b/spec/datadog/appsec/contrib/sinatra/reactive/routed_spec.rb
@@ -1,0 +1,159 @@
+# typed: ignore
+# frozen_string_literal: true
+
+require 'datadog/appsec/spec_helper'
+require 'datadog/appsec/reactive/operation'
+require 'datadog/appsec/contrib/sinatra/reactive/routed'
+require 'rack'
+
+RSpec.describe Datadog::AppSec::Contrib::Sinatra::Reactive::Routed do
+  let(:operation) { Datadog::AppSec::Reactive::Operation.new('test') }
+  let(:request) do
+    Rack::Request.new(
+      Rack::MockRequest.env_for(
+        'http://example.com:8080/?a=foo',
+        { 'REMOTE_ADDR' => '10.10.10.10', 'HTTP_CONTENT_TYPE' => 'text/html' }
+      )
+    )
+  end
+
+  describe '.publish' do
+    it 'propagates routed params attributes to the operation' do
+      expect(operation).to receive(:publish).with('sinatra.request.route_params', { id: '1234' })
+
+      described_class.publish(operation, [request, { id: '1234' }])
+    end
+  end
+
+  describe '.subscribe' do
+    let(:waf_context) { double(:waf_context) }
+
+    context 'not all addresses have been published' do
+      it 'does not call the waf context' do
+        expect(operation).to receive(:subscribe).with('sinatra.request.route_params').and_call_original
+        expect(waf_context).to_not receive(:run)
+        described_class.subscribe(operation, waf_context)
+      end
+    end
+
+    context 'all addresses have been published' do
+      it 'does call the waf context with the right arguments' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        expected_waf_arguments = {
+          'server.request.path_params' => { id: '1234' }
+        }
+
+        waf_result = double(:waf_result, status: :ok, timeout: false)
+        expect(waf_context).to receive(:run).with(
+          expected_waf_arguments,
+          Datadog::AppSec.settings.waf_timeout
+        ).and_return(waf_result)
+        described_class.subscribe(operation, waf_context)
+        result = described_class.publish(operation, [request, { id: '1234' }])
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is a match' do
+      it 'yields result and no blocking action' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :match, timeout: false, actions: [''])
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        described_class.subscribe(operation, waf_context) do |result, block|
+          expect(result).to eq(waf_result)
+          expect(block).to eq(false)
+        end
+        result = described_class.publish(operation, [request, { id: '1234' }])
+        expect(result).to be_nil
+      end
+
+      it 'yields result and blocking action. The publish method catches the resul as well' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :match, timeout: false, actions: ['block'])
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        described_class.subscribe(operation, waf_context) do |result, block|
+          expect(result).to eq(waf_result)
+          expect(block).to eq(true)
+        end
+        publish_result, publish_block = described_class.publish(operation, [request, { id: '1234' }])
+        expect(publish_result).to eq(waf_result)
+        expect(publish_block).to eq(true)
+      end
+    end
+
+    context 'waf result is ok' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :ok, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, [request, { id: '1234' }])
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is invalid_call' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :invalid_call, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, [request, { id: '1234' }])
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is invalid_rule' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :invalid_rule, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, [request, { id: '1234' }])
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is invalid_flow' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :invalid_flow, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, [request, { id: '1234' }])
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is no_rule' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :no_rule, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, [request, { id: '1234' }])
+        expect(result).to be_nil
+      end
+    end
+
+    context 'waf result is unknown' do
+      it 'does not yield' do
+        expect(operation).to receive(:subscribe).and_call_original
+
+        waf_result = double(:waf_result, status: :foo, timeout: false)
+        expect(waf_context).to receive(:run).and_return(waf_result)
+        expect { |b| described_class.subscribe(operation, waf_context, &b) }.not_to yield_control
+        result = described_class.publish(operation, [request, { id: '1234' }])
+        expect(result).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Adds unit tests for the reactive components in the appsec folder: `appsec/contrib/*/reactive/*.rb`

**Motivation**
<!-- What inspired you to submit this pull request? -->

Having unit test would allow us to more easily refactor some pieces without fear of breaking the existing logic. 



**How to test the change?**
CI
