### PR TITLE
flaky:Datadog::Core::Workers::RuntimeMetrics integration test

### DIFF
--- a/spec/datadog/core/workers/runtime_metrics_spec.rb
+++ b/spec/datadog/core/workers/runtime_metrics_spec.rb
@@ -282,11 +282,9 @@ RSpec.describe Datadog::Core::Workers::RuntimeMetrics do
       it 'produces metrics every interval' do
         worker.perform
 
-        sleep(default_flush_interval * 2)
-
         # Metrics are produced once right away
         # and again after an interval.
-        expect(metrics).to have_received(:flush).at_least(2).times
+        wait(default_flush_interval * 2).for(metrics).to have_received(:flush).at_least(2).times
       end
     end
 

--- a/spec/datadog/core/workers/runtime_metrics_spec.rb
+++ b/spec/datadog/core/workers/runtime_metrics_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe Datadog::Core::Workers::RuntimeMetrics do
 
   describe 'integration tests', :integration do
     describe 'interval' do
-      let(:default_flush_interval) { 0.1 }
+      let(:default_flush_interval) { 0.01 }
 
       before do
         stub_const(
@@ -284,7 +284,7 @@ RSpec.describe Datadog::Core::Workers::RuntimeMetrics do
 
         # Metrics are produced once right away
         # and again after an interval.
-        wait(default_flush_interval * 2).for(metrics).to have_received(:flush).at_least(2).times
+        wait_for(metrics).to have_received(:flush).at_least(2).times
       end
     end
 

--- a/spec/datadog/core/workers/runtime_metrics_spec.rb
+++ b/spec/datadog/core/workers/runtime_metrics_spec.rb
@@ -282,11 +282,11 @@ RSpec.describe Datadog::Core::Workers::RuntimeMetrics do
       it 'produces metrics every interval' do
         worker.perform
 
-        sleep(default_flush_interval * 1.1)
+        sleep(default_flush_interval * 2)
 
         # Metrics are produced once right away
         # and again after an interval.
-        expect(metrics).to have_received(:flush).twice
+        expect(metrics).to have_received(:flush).at_least(2).times
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,7 +91,10 @@ RSpec.configure do |config|
   config.order = :random
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+
+  # rspec-wait configuration
   config.wait_timeout = 5 # default timeout for `wait_for(...)`, in seconds
+  config.wait_delay = 0.01 # default retry delay for `wait_for(...)`, in seconds
 
   if config.files_to_run.one?
     # Use the documentation formatter for detailed output,


### PR DESCRIPTION
Fixes this flaky test (to the best of my abilities): https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/8829/workflows/d051131f-b5fe-4967-aa7d-e99b8773996b/jobs/328470/tests

```
Failure/Error: expect(metrics).to have_received(:flush).twice

  (InstanceDouble(Datadog::Core::Runtime::Metrics) (anonymous)).flush(*(any args))
      expected: 2 times with any arguments
      received: 1 time with any arguments
./spec/datadog/core/workers/runtime_metrics_spec.rb:289:in `block in <main>'
./spec/spec_helper.rb:220:in `block in <main>'
./spec/spec_helper.rb:112:in `block in <main>'
/usr/local/bundle/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block in <main>'
```