### PR TITLE
flaky:Datadog::Core::Workers::Polling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
 gem 'redcarpet', '~> 3.4' if RUBY_PLATFORM != 'java'
 gem 'rspec', '~> 3.12'
 gem 'rspec-collection_matchers', '~> 1.1'
+gem 'rspec-wait', '~> 0'
 if RUBY_VERSION >= '2.3.0'
   gem 'rspec_junit_formatter', '>= 0.5.1'
 else

--- a/spec/datadog/core/workers/polling_spec.rb
+++ b/spec/datadog/core/workers/polling_spec.rb
@@ -22,25 +22,14 @@ RSpec.describe Datadog::Core::Workers::Polling do
       let(:task) { proc { |*args| worker_spy.perform(*args) } }
       let(:worker_spy) { double('worker spy') }
 
-      before { allow(worker_spy).to receive(:perform) { sleep 5 } }
-
-      context 'by default' do
-        before { skip('TODO: This test sometimes hangs forever and other times flakes. Requires further investigation.') }
-
-        it do
-          perform
-          try_wait_until { worker.running? && worker.run_loop? }
-          expect(worker_spy).to have_received(:perform).at_least(:once)
-        end
-      end
+      before { allow(worker_spy).to receive(:perform) }
 
       context 'when #enabled? is true' do
         before { allow(worker).to receive(:enabled?).and_return(true) }
 
         it do
           perform
-          try_wait_until { worker.running? && worker.run_loop? }
-          expect(worker_spy).to have_received(:perform).at_least(:once)
+          wait_for(worker_spy).to have_received(:perform)
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift File.expand_path('..', __dir__)
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'pry'
 require 'rspec/collection_matchers'
+require 'rspec/wait'
 require 'webmock/rspec'
 require 'climate_control'
 
@@ -90,6 +91,7 @@ RSpec.configure do |config|
   config.order = :random
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+  config.wait_timeout = 5 # default timeout for `wait_for(...)`, in seconds
 
   if config.files_to_run.one?
     # Use the documentation formatter for detailed output,


### PR DESCRIPTION
Fixes flaky test ["Datadog::Core::Workers::Polling when included into a worker #perform when #enabled? is true is expected to have received perform(*(any args)) 1 time"](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/8907/workflows/0f3a873c-3af7-427c-864e-c80b4add5adc/jobs/331375) with the use of a new gadget:

```
Failure/Error: expect(worker_spy).to have_received(:perform).at_least(:once)

  (Double "worker spy").perform(*(any args))
      expected: at least 1 time with any arguments
      received: 0 times with any arguments
./spec/datadog/core/workers/polling_spec.rb:43:in `block (5 levels) in <top (required)>'
./spec/spec_helper.rb:220:in `block (2 levels) in <top (required)>'
./spec/spec_helper.rb:112:in `block (2 levels) in <top (required)>'
/usr/local/bundle/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

## New gadget

The most straightforward wait to write the offending test is: "Wait until the `worker_spy` has received `#perform`. If it takes too long, fail the test.".

We were using a proxy for the wait condition before, `worker.running? && worker.run_loop?`, but that's not a perfect proxy.

The best thing would be to wait for the real assertion itself. The issue is that the assertion condition is private to the RSpec spy `worker_spy`. The only way to inspect it is to trigger the expectation `expect(worker_spy).to have_received(:perform)`, but this exits the test immediately.

It is possible to assert `expect(...)` in a loop, but you have to rescue RSpec exceptions and it gets messy.

Thankfully `@laserlemon` did the hard work here: https://github.com/laserlemon/rspec-wait

This allows us to wait for the assertion itself, regardless of the complexity of the wait condition: `wait_for(worker_spy).to have_received(:perform)`

This is a generic approach that works for any expectation and has a timeout (I configured the default to 5 seconds, see PR).