### PR TITLE
Minor: Remove unused AgentSettings#merge method

### DIFF
--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: false
 
 require 'uri'
 

--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -49,21 +49,6 @@ module Datadog
               )
               freeze
             end
-
-            # Returns a frozen copy of this struct
-            # with the provided +member_values+ modified.
-            #
-            # TODO: This is only used when configuring profiling, and can be removed once
-            # https://github.com/DataDog/dd-trace-rb/pull/1924 is merged
-            def merge(**member_values)
-              new_struct = dup
-
-              member_values.each do |member, value|
-                new_struct[member] = value
-              end
-
-              new_struct.freeze
-            end
           end
 
         def self.call(settings, logger: Datadog.logger)


### PR DESCRIPTION
**What does this PR do?**:

This PR removes a `merge` method that is no longer in use. This is safe to remove because it is not part of ddtrace's public API.

This was only used by the legacy profiling transport (as hinted in the comment attached to the code), and the legacy profiling transport was removed in https://github.com/DataDog/dd-trace-rb/pull/2062 (search for `configure_for_agent` inside `lib/datadog/profiling/transport/http.rb`).

**Motivation**:

Remove unused code :)

**Additional Notes**:

N/A

**How to test the change?**:

Check that CI is still green.