### PR TITLE
Add better error information to flaky thread-leak detection test

### DIFF
--- a/spec/datadog/integration_spec.rb
+++ b/spec/datadog/integration_spec.rb
@@ -25,15 +25,12 @@ RSpec.describe 'Datadog integration' do
     end
 
     context 'for threads' do
-      let!(:original_thread_count) { thread_count }
-      let!(:original_inspect_threads) { inspect_threads }
+      let(:original_threads) { Thread.list }
+      let!(:original_threads_inspect) { inspect_threads(original_threads) } # Store result as stack trace will change
+      let(:threads) { Thread.list }
 
-      def thread_count
-        Thread.list.count
-      end
-
-      def inspect_threads
-        Thread.list.map.with_index { |t, idx| "#{idx}=#{t.backtrace}" }.join(';')
+      def inspect_threads(threads)
+        threads.map.with_index { |t, idx| "#{idx}=#{t.backtrace}" }.join(';')
       end
 
       it 'closes tracer threads' do
@@ -42,9 +39,9 @@ RSpec.describe 'Datadog integration' do
 
         shutdown
 
-        expect(thread_count).to eq(original_thread_count),
-          "Expected #{original_thread_count} threads (#{original_inspect_threads}), "\
-                  "got #{thread_count} threads (#{inspect_threads})"
+        expect(threads.size).to eq(original_threads.size),
+          "Expected #{original_threads.size} threads (#{original_threads_inspect}), "\
+                  "got #{threads.size} threads (#{inspect_threads(threads)})"
       end
     end
 

--- a/spec/datadog/integration_spec.rb
+++ b/spec/datadog/integration_spec.rb
@@ -26,9 +26,14 @@ RSpec.describe 'Datadog integration' do
 
     context 'for threads' do
       let!(:original_thread_count) { thread_count }
+      let!(:original_inspect_threads) { inspect_threads }
 
       def thread_count
         Thread.list.count
+      end
+
+      def inspect_threads
+        Thread.list.map.with_index { |t, idx| "#{idx}=#{t.backtrace}" }.join(';')
       end
 
       it 'closes tracer threads' do
@@ -37,7 +42,9 @@ RSpec.describe 'Datadog integration' do
 
         shutdown
 
-        expect(thread_count).to eq(original_thread_count)
+        expect(thread_count).to eq(original_thread_count),
+          "Expected #{original_thread_count} threads (#{original_inspect_threads}), "\
+                  "got #{thread_count} threads (#{inspect_threads})"
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -278,3 +278,11 @@ end
 
 # Helper matchers
 RSpec::Matchers.define_negated_matcher :not_be, :be
+
+# The Ruby Timeout class uses a long-lived class-level thread that is never terminated.
+# Creating it early here ensures tests that tests that check for leaking threads are not
+# triggered by the creation of this thread.
+#
+# This has to be one once for the lifetime of this process, and was introduced in Ruby 3.1.
+# Before 3.1, a thread was created and destroyed on every Timeout#timeout call.
+Timeout.ensure_timeout_thread_created if Timeout.respond_to?(:ensure_timeout_thread_created)


### PR DESCRIPTION
I can't reproduce the flaky test [Datadog integration graceful shutdown for threads closes tracer threads](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/8871/workflows/78282204-4709-4f46-8a2e-2a864c911a23/jobs/330031/tests).

For now, I'm adding additional debug information: the stack trace of all running threads before and after the test runs.