### PR TITLE
Increase timeout on flaky Ethon test

### DIFF
--- a/spec/datadog/tracing/contrib/ethon/integration_context.rb
+++ b/spec/datadog/tracing/contrib/ethon/integration_context.rb
@@ -53,7 +53,7 @@ RSpec.shared_context 'integration context' do
   let(:port) { @port }
   let(:method) { 'GET' }
   let(:simulate_timeout) { false }
-  let(:timeout) { 0.5 }
+  let(:timeout) { 5 }
   let(:return_headers) { false }
   let(:query) do
     query = { status: status }


### PR DESCRIPTION
This PR attempts to address flaky Ethon tests.
Some Ethon test have been flaking for quite some time, but not away on the same test.

I'm not able to 100% reproduce the issue without making code changes, but I was able to get the exact same error as the recent flaky Ethon test,
https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/8928/workflows/ea1be057-92b7-420c-af6a-3a60e087c8b7/jobs/332182/tests:
```
Failure/Error: expect(request.body).to eq('response')

  expected: "response"
       got: ""

  (compared using ==)
Shared Example Group: "instrumented request" called from ./spec/datadog/tracing/contrib/ethon/integration_test_spec.rb:81
./spec/datadog/tracing/contrib/ethon/shared_examples.rb:79:in `block in <main>'
./spec/datadog/tracing/contrib/ethon/integration_context.rb:82:in `block in <main>'
./spec/datadog/tracing/contrib/support/tracer_helpers.rb:96:in `block in TracerHelpers'
./spec/spec_helper.rb:220:in `block in <main>'
./spec/spec_helper.rb:112:in `block in <main>'
/usr/local/bundle/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block in <main>'
```

I was able to "reproduce" it by dropping the test timeout to zero. This meant a bunch of tests failed, but most importantly, they failed with exact same failure scenario as this recent flaky test above.

The time before was 500ms, which is relatively short given our varied test matrix: this PR changes it to 5 seconds now. This is the server timeout for the test execution, which is in line with our other timeouts: https://github.com/DataDog/dd-trace-rb/blob/81b338b003cbe928491529211ca5f78422802352/spec/support/synchronization_helpers.rb#L43-L55