### PR TITLE
Add appsec component

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -379,6 +379,7 @@ Naming/FileName:
   Exclude:
     - 'integration/**/Gemfile'
     - 'integration/**/Rakefile'
+    - 'Steepfile'
 
 # Enforces boolean parameters with default to be keyword arguments.
 Style/OptionalBooleanParameter:

--- a/Steepfile
+++ b/Steepfile
@@ -1,25 +1,25 @@
 target :appsec do
-  signature "sig"
+  signature 'sig'
 
-  check "lib/datadog/appsec"
+  check 'lib/datadog/appsec'
 
   # TODO: disabled because of https://github.com/soutaro/steep/issues/701
-  # check "lib/datadog/kit"
+  # check 'lib/datadog/kit'
 
-  ignore "lib/datadog/appsec/contrib"
+  ignore 'lib/datadog/appsec/contrib'
 
-  library "pathname", "set"
-  library "cgi"
-  library "logger", "monitor"
-  library "tsort"
-  library "json"
+  library 'pathname', 'set'
+  library 'cgi'
+  library 'logger', 'monitor'
+  library 'tsort'
+  library 'json'
 
   # TODO: gem 'libddwaf'
 
-  repo_path "vendor/rbs"
-  library "ffi"
-  library "jruby"
-  library "gem"
-  library "rails"
-  library "sinatra"
+  repo_path 'vendor/rbs'
+  library 'ffi'
+  library 'jruby'
+  library 'gem'
+  library 'rails'
+  library 'sinatra'
 end

--- a/lib/datadog/appsec.rb
+++ b/lib/datadog/appsec.rb
@@ -9,6 +9,10 @@ module Datadog
     include Configuration
 
     class << self
+      def enabled?
+        Datadog.configuration.appsec.enabled
+      end
+
       def processor
         appsec_component = components.appsec
 

--- a/lib/datadog/appsec.rb
+++ b/lib/datadog/appsec.rb
@@ -9,12 +9,16 @@ module Datadog
     include Configuration
 
     class << self
-      def components
-        Datadog.send(:components)
+      def processor
+        appsec_component = components.appsec
+
+        appsec_component.processor if appsec_component
       end
 
-      def processor
-        components.appsec.processor if components.appsec
+      private
+
+      def components
+        Datadog.send(:components)
       end
     end
 

--- a/lib/datadog/appsec.rb
+++ b/lib/datadog/appsec.rb
@@ -8,6 +8,16 @@ module Datadog
   module AppSec
     include Configuration
 
+    class << self
+      def components
+        Datadog.send(:components)
+      end
+
+      def processor
+        components.appsec.processor if components.appsec
+      end
+    end
+
     def self.writer
       @writer ||= Writer.new
     end
@@ -21,3 +31,5 @@ end
 require_relative 'appsec/contrib/rack/integration'
 require_relative 'appsec/contrib/sinatra/integration'
 require_relative 'appsec/contrib/rails/integration'
+
+require_relative 'appsec/autoload'

--- a/lib/datadog/appsec/assets.rb
+++ b/lib/datadog/appsec/assets.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: false
 
 require 'pathname'
 

--- a/lib/datadog/appsec/autoload.rb
+++ b/lib/datadog/appsec/autoload.rb
@@ -1,12 +1,13 @@
 # typed: ignore
 
 if %w[1 true].include?((ENV['DD_APPSEC_ENABLED'] || '').downcase)
-  require_relative '../../ddtrace'
-
   begin
     require_relative 'contrib/auto_instrument'
     Datadog::AppSec::Contrib::AutoInstrument.patch_all
   rescue StandardError => e
-    puts "AppSec failed to instrument. No security check will be performed. error: #{e.class.name} #{e.message}"
+    Kernel.warn(
+      '[DDTRACE] AppSec failed to instrument. No security check will be performed. error: ' \
+      " #{e.class.name} #{e.message}"
+    )
   end
 end

--- a/lib/datadog/appsec/autoload.rb
+++ b/lib/datadog/appsec/autoload.rb
@@ -4,12 +4,6 @@ if %w[1 true].include?((ENV['DD_APPSEC_ENABLED'] || '').downcase)
   require_relative '../../ddtrace'
 
   begin
-    require_relative '../appsec'
-  rescue StandardError => e
-    puts "AppSec failed to load. No security check will be performed. error: #{e.class.name} #{e.message}"
-  end
-
-  begin
     require_relative 'contrib/auto_instrument'
     Datadog::AppSec::Contrib::AutoInstrument.patch_all
   rescue StandardError => e

--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -11,14 +11,14 @@ module Datadog
         def build_appsec_component(settings)
           return unless settings.appsec.enabled
 
-          new(settings)
+          new
         end
       end
 
       attr_reader :processor
 
-      def initialize(settings)
-        @processor = Processor.new
+      def initialize(processor: Processor.new)
+        @processor = processor
       end
 
       def shutdown!

--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -1,0 +1,30 @@
+# typed: false
+# frozen_string_literal: true
+
+require_relative 'processor'
+
+module Datadog
+  module AppSec
+    # Core-pluggable component for AppSec
+    class Component
+      class << self
+        def build_appsec_component(settings)
+          return unless settings.appsec.enabled
+
+          new(settings)
+        end
+      end
+
+      attr_reader :processor
+
+      def initialize(settings)
+        @processor = Processor.new
+      end
+
+      def shutdown!
+        processor.finalize if processor
+        @processor = nil
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -9,7 +9,7 @@ module Datadog
     class Component
       class << self
         def build_appsec_component(settings)
-          return unless settings.appsec.enabled
+          return unless settings.enabled
 
           new
         end

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -23,7 +23,7 @@ module Datadog
           end
 
           def call(env)
-            return @app.call(env) unless Datadog.configuration.appsec.enabled
+            return @app.call(env) unless Datadog::AppSec.enabled?
 
             processor = Datadog::AppSec.processor
 

--- a/lib/datadog/appsec/processor.rb
+++ b/lib/datadog/appsec/processor.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: false
 
 require_relative 'assets'
 

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -90,7 +90,7 @@ module Datadog
           @telemetry = self.class.build_telemetry(settings)
 
           # AppSec
-          @appsec = Datadog::AppSec::Component.build_appsec_component(settings)
+          @appsec = Datadog::AppSec::Component.build_appsec_component(settings.appsec)
         end
 
         # Starts up components

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -114,7 +114,7 @@ module Datadog
         # and avoid tearing down parts still in use.
         def shutdown!(replacement = nil)
           # Decommission AppSec
-          appsec.shutdown! if appsec && !(replacement && appsec == replacement.appsec)
+          appsec.shutdown! if appsec
 
           # Shutdown the old tracer, unless it's still being used.
           # (e.g. a custom tracer instance passed in.)

--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -4,10 +4,8 @@
 require_relative 'datadog/tracing'
 require_relative 'datadog/tracing/contrib'
 
-# Load appsec
-require_relative 'datadog/appsec/autoload' # TODO: datadog/appsec?
-
 # Load other products (must follow tracing)
 require_relative 'datadog/profiling'
+require_relative 'datadog/appsec'
 require_relative 'datadog/ci'
 require_relative 'datadog/kit'

--- a/sig/datadog/appsec.rbs
+++ b/sig/datadog/appsec.rbs
@@ -1,6 +1,14 @@
 module Datadog
   module AppSec
     extend Configuration::ClassMethods
+
+    def self.enabled?: () -> bool
+
+    def self.processor: () -> Datadog::AppSec::Processor?
+
+    private
+
+    def self.components: () -> Datadog::Core::Configuration::Components
   end
 end
 

--- a/sig/datadog/appsec/component.rbs
+++ b/sig/datadog/appsec/component.rbs
@@ -1,0 +1,13 @@
+module Datadog
+  module AppSec
+    class Component
+      def self.build_appsec_component: (Core::Configuration::Settings settings) -> Datadog::AppSec::Component?
+
+      attr_reader processor: Datadog::AppSec::Processor?
+
+      def initialize: (Core::Configuration::Settings settings) -> void
+
+      def shutdown!: () -> untyped
+    end
+  end
+end

--- a/sig/datadog/appsec/component.rbs
+++ b/sig/datadog/appsec/component.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module AppSec
     class Component
-      def self.build_appsec_component: (Core::Configuration::Settings settings) -> Datadog::AppSec::Component?
+      def self.build_appsec_component: (Datadog::AppSec::Configuration::Settings settings) -> Datadog::AppSec::Component?
 
       attr_reader processor: Datadog::AppSec::Processor?
 

--- a/sig/datadog/appsec/component.rbs
+++ b/sig/datadog/appsec/component.rbs
@@ -5,7 +5,7 @@ module Datadog
 
       attr_reader processor: Datadog::AppSec::Processor?
 
-      def initialize: (Core::Configuration::Settings settings) -> void
+      def initialize: (?processor: Datadog::AppSec::Processor?) -> void
 
       def shutdown!: () -> untyped
     end

--- a/sig/datadog/core/configuration/agent_settings_resolver.rbs
+++ b/sig/datadog/core/configuration/agent_settings_resolver.rbs
@@ -2,9 +2,12 @@ module Datadog
   module Core
     module Configuration
       class AgentSettingsResolver
-        AgentSettings: untyped
+        class AgentSettings < ::Struct[untyped]
+          def initialize: (adapter: untyped, ssl: untyped, hostname: untyped, port: untyped, uds_path: untyped, timeout_seconds: untyped, deprecated_for_removal_transport_configuration_proc: untyped) -> void
+          def merge: (**::Hash[untyped, untyped] member_values) -> AgentSettingsResolver
+        end
 
-        def self.call: (untyped settings, ?logger: untyped logger) -> untyped
+        def self.call: (untyped settings, ?logger: untyped) -> untyped
 
         private
 
@@ -12,35 +15,61 @@ module Datadog
 
         attr_reader settings: untyped
 
-        def initialize: (untyped settings, ?logger: untyped logger) -> untyped
+        def initialize: (untyped settings, ?logger: untyped) -> void
 
         def call: () -> untyped
+
+        def adapter: () -> untyped
+
+        def configured_hostname: () -> untyped
+
+        def configured_port: () -> untyped
+
+        def try_parsing_as_integer: (value: untyped, friendly_name: untyped) -> untyped
+
+        def ssl?: () -> untyped
 
         def hostname: () -> untyped
 
         def port: () -> untyped
 
-        def ssl?: () -> untyped
+        def uds_path: () -> untyped
 
         def timeout_seconds: () -> untyped
 
-        def deprecated_for_removal_transport_configuration_proc: () -> untyped
+        def deprecated_for_removal_transport_configuration_proc: () -> (untyped | nil)
 
-        def deprecated_for_removal_transport_configuration_options: () -> untyped
+        def uds_fallback: () -> untyped
+
+        def should_use_uds_fallback?: () -> untyped
 
         def parsed_url: () -> untyped
 
-        def unparsed_url_from_env: () -> untyped
-
-        def pick_from: (configurations_in_priority_order: untyped configurations_in_priority_order, or_use_default: untyped or_use_default) -> untyped
+        def pick_from: (*untyped configurations_in_priority_order) -> untyped
 
         def warn_if_configuration_mismatch: (untyped detected_configurations_in_priority_order) -> (nil | untyped)
 
-        def log_warning: (untyped message) -> untyped
+        def log_warning: (untyped message) -> (untyped | nil)
 
-        DetectedConfiguration: untyped
+        def transport_options: () -> untyped
 
-        ENVIRONMENT_AGENT_SETTINGS: untyped
+        class DetectedConfiguration
+          attr_reader friendly_name: untyped
+
+          attr_reader value: untyped
+
+          def initialize: (friendly_name: untyped, value: untyped) -> void
+
+          def value?: () -> untyped
+        end
+
+        TransportOptions: untyped
+
+        class TransportOptionsResolver
+          def initialize: (untyped transport_options) -> void
+
+          def adapter: (untyped kind_or_custom_adapter, *untyped args, **untyped kwargs) -> nil
+        end
       end
     end
   end

--- a/sig/datadog/core/configuration/settings.rbs
+++ b/sig/datadog/core/configuration/settings.rbs
@@ -13,6 +13,8 @@ module Datadog
         def tracer: (?untyped? options) -> untyped
 
         def tracer=: (untyped tracer) -> untyped
+
+        def appsec: (?untyped? options) -> Datadog::AppSec::Configuration::Settings
       end
     end
   end

--- a/sig/datadog/core/configuration/settings.rbs
+++ b/sig/datadog/core/configuration/settings.rbs
@@ -10,10 +10,6 @@ module Datadog
 
         def runtime_metrics: (?untyped? options) -> untyped
 
-        def tracer: (?untyped? options) -> untyped
-
-        def tracer=: (untyped tracer) -> untyped
-
         def appsec: (?untyped? options) -> Datadog::AppSec::Configuration::Settings
       end
     end

--- a/sorbet/config
+++ b/sorbet/config
@@ -4,5 +4,4 @@
 --ignore=/integration
 --ignore=/yard
 --ignore=/vendor/bundle
---ignore=/lib/datadog/appsec
 --ignore=/tmp

--- a/spec/datadog/appsec/component_spec.rb
+++ b/spec/datadog/appsec/component_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe Datadog::AppSec::Component do
   describe '.build_appsec_component' do
     context 'when appsec is enabled' do
       it 'returns a Datadog::AppSec::Component instance' do
-        settings = double('AppSec::Settings', appsec: double('enabled', enabled: true))
-        component = described_class.build_appsec_component(settings)
+        Datadog.configuration.appsec.enabled = true
+        component = described_class.build_appsec_component(Datadog.configuration)
         expect(component).to be_a(described_class)
       end
     end
 
     context 'when appsec is not enabled' do
       it 'returns nil' do
-        settings = double('AppSec::Settings', appsec: double('enabled', enabled: false))
-        component = described_class.build_appsec_component(settings)
+        Datadog.configuration.appsec.enabled = false
+        component = described_class.build_appsec_component(Datadog.configuration)
         expect(component).to be_nil
       end
     end
@@ -24,23 +24,20 @@ RSpec.describe Datadog::AppSec::Component do
 
   describe '#shutdown!' do
     context 'when processor is not nil' do
-      it 'finalize processor' do
-        settings = double('AppSec::Settings')
-        processor = double('AppSec::Processor')
-        component = described_class.new(settings)
+      it 'finalizes the processor' do
+        processor = Datadog::AppSec::Processor.new
 
-        expect(component).to receive(:processor).twice.and_return(processor)
+        component = described_class.new(processor: processor)
+
         expect(processor).to receive(:finalize)
         component.shutdown!
       end
     end
 
     context 'when processor is nil' do
-      it 'do not finalize processor' do
-        settings = double('AppSec::Settings')
-        component = described_class.new(settings)
+      it 'do not finalizes the processor' do
+        component = described_class.new(processor: nil)
 
-        expect(component).to receive(:processor).and_return(nil)
         expect_any_instance_of(Datadog::AppSec::Processor).to_not receive(:finalize)
         component.shutdown!
       end

--- a/spec/datadog/appsec/component_spec.rb
+++ b/spec/datadog/appsec/component_spec.rb
@@ -7,16 +7,24 @@ RSpec.describe Datadog::AppSec::Component do
   describe '.build_appsec_component' do
     context 'when appsec is enabled' do
       it 'returns a Datadog::AppSec::Component instance' do
-        Datadog.configuration.appsec.enabled = true
-        component = described_class.build_appsec_component(Datadog.configuration)
+        settings = Datadog::AppSec::Configuration::Settings.new.merge(
+          Datadog::AppSec::Configuration::DSL.new.tap do |it|
+            it.enabled = true
+          end
+        )
+        component = described_class.build_appsec_component(settings)
         expect(component).to be_a(described_class)
       end
     end
 
     context 'when appsec is not enabled' do
       it 'returns nil' do
-        Datadog.configuration.appsec.enabled = false
-        component = described_class.build_appsec_component(Datadog.configuration)
+        settings = Datadog::AppSec::Configuration::Settings.new.merge(
+          Datadog::AppSec::Configuration::DSL.new.tap do |it|
+            it.enabled = false
+          end
+        )
+        component = described_class.build_appsec_component(settings)
         expect(component).to be_nil
       end
     end
@@ -25,20 +33,11 @@ RSpec.describe Datadog::AppSec::Component do
   describe '#shutdown!' do
     context 'when processor is not nil' do
       it 'finalizes the processor' do
-        processor = Datadog::AppSec::Processor.new
+        processor = instance_double(Datadog::AppSec::Processor)
 
         component = described_class.new(processor: processor)
 
         expect(processor).to receive(:finalize)
-        component.shutdown!
-      end
-    end
-
-    context 'when processor is nil' do
-      it 'do not finalizes the processor' do
-        component = described_class.new(processor: nil)
-
-        expect_any_instance_of(Datadog::AppSec::Processor).to_not receive(:finalize)
         component.shutdown!
       end
     end

--- a/spec/datadog/appsec/component_spec.rb
+++ b/spec/datadog/appsec/component_spec.rb
@@ -1,0 +1,49 @@
+# typed: ignore
+
+require 'datadog/appsec/spec_helper'
+require 'datadog/appsec/component'
+
+RSpec.describe Datadog::AppSec::Component do
+  describe '.build_appsec_component' do
+    context 'when appsec is enabled' do
+      it 'returns a Datadog::AppSec::Component instance' do
+        settings = double('AppSec::Settings', appsec: double('enabled', enabled: true))
+        component = described_class.build_appsec_component(settings)
+        expect(component).to be_a(described_class)
+      end
+    end
+
+    context 'when appsec is not enabled' do
+      it 'returns nil' do
+        settings = double('AppSec::Settings', appsec: double('enabled', enabled: false))
+        component = described_class.build_appsec_component(settings)
+        expect(component).to be_nil
+      end
+    end
+  end
+
+  describe '#shutdown!' do
+    context 'when processor is not nil' do
+      it 'finalize processor' do
+        settings = double('AppSec::Settings')
+        processor = double('AppSec::Processor')
+        component = described_class.new(settings)
+
+        expect(component).to receive(:processor).twice.and_return(processor)
+        expect(processor).to receive(:finalize)
+        component.shutdown!
+      end
+    end
+
+    context 'when processor is nil' do
+      it 'do not finalize processor' do
+        settings = double('AppSec::Settings')
+        component = described_class.new(settings)
+
+        expect(component).to receive(:processor).and_return(nil)
+        expect_any_instance_of(Datadog::AppSec::Processor).to_not receive(:finalize)
+        component.shutdown!
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/extensions_spec.rb
+++ b/spec/datadog/appsec/extensions_spec.rb
@@ -37,9 +37,15 @@ RSpec.describe Datadog::AppSec::Extensions do
 
             it 'configures the integration' do
               # If integration_class.loaded? is invoked, it means the correct integration is being activated.
-              expect(integration_class).to receive(:loaded?).and_return(false)
+              begin
+                old_appsec_enabled = ENV['DD_APPSEC_ENABLED']
+                ENV['DD_APPSEC_ENABLED'] = 'true'
+                expect(integration_class).to receive(:loaded?).and_return(false)
 
-              configure
+                configure
+              ensure
+                ENV['DD_APPSEC_ENABLED'] = old_appsec_enabled
+              end
             end
           end
         end

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -1384,24 +1384,6 @@ RSpec.describe Datadog::Core::Configuration::Components do
         end
       end
 
-      context 'when the appsec is re-used' do
-        include_context 'replacement' do
-          let(:appsec) { components.appsec }
-        end
-
-        it 'shuts down all components but the tracer' do
-          expect(components.tracer).to receive(:shutdown!)
-          expect(components.appsec).to_not receive(:shutdown!) unless components.appsec.nil?
-          expect(components.profiler).to receive(:shutdown!) unless components.profiler.nil?
-          expect(components.runtime_metrics).to receive(:stop)
-            .with(true, close_metrics: false)
-          expect(components.runtime_metrics.metrics.statsd).to receive(:close)
-          expect(components.health_metrics.statsd).to receive(:close)
-
-          shutdown!
-        end
-      end
-
       context 'when one of Statsd instances are reused' do
         include_context 'replacement' do
           let(:runtime_metrics_worker) { components.runtime_metrics }

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -1299,6 +1299,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
       it 'shuts down all components' do
         expect(components.tracer).to receive(:shutdown!)
         expect(components.profiler).to receive(:shutdown!) unless components.profiler.nil?
+        expect(components.appsec).to receive(:shutdown!) unless components.appsec.nil?
         expect(components.runtime_metrics).to receive(:stop)
           .with(true, close_metrics: false)
         expect(components.runtime_metrics.metrics.statsd).to receive(:close)
@@ -1315,6 +1316,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
         let(:replacement) { instance_double(described_class) }
         let(:tracer) { instance_double(Datadog::Tracing::Tracer) }
         let(:profiler) { Datadog::Profiling.supported? ? instance_double(Datadog::Profiling::Profiler) : nil }
+        let(:appsec) { instance_double(Datadog::AppSec::Component) }
         let(:runtime_metrics_worker) { instance_double(Datadog::Core::Workers::RuntimeMetrics, metrics: runtime_metrics) }
         let(:runtime_metrics) { instance_double(Datadog::Core::Runtime::Metrics, statsd: statsd) }
         let(:health_metrics) { instance_double(Datadog::Core::Diagnostics::Health::Metrics, statsd: statsd) }
@@ -1324,6 +1326,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
         before do
           allow(replacement).to receive(:tracer).and_return(tracer)
           allow(replacement).to receive(:profiler).and_return(profiler)
+          allow(replacement).to receive(:appsec).and_return(appsec)
           allow(replacement).to receive(:runtime_metrics).and_return(runtime_metrics_worker)
           allow(replacement).to receive(:health_metrics).and_return(health_metrics)
           allow(replacement).to receive(:telemetry).and_return(telemetry)
@@ -1336,6 +1339,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
         it 'shuts down all components' do
           expect(components.tracer).to receive(:shutdown!)
           expect(components.profiler).to receive(:shutdown!) unless components.profiler.nil?
+          expect(components.appsec).to receive(:shutdown!) unless components.appsec.nil?
           expect(components.runtime_metrics).to receive(:stop)
             .with(true, close_metrics: false)
           expect(components.runtime_metrics.metrics.statsd).to receive(:close)
@@ -1370,6 +1374,24 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
         it 'shuts down all components but the tracer' do
           expect(components.tracer).to_not receive(:shutdown!)
+          expect(components.profiler).to receive(:shutdown!) unless components.profiler.nil?
+          expect(components.runtime_metrics).to receive(:stop)
+            .with(true, close_metrics: false)
+          expect(components.runtime_metrics.metrics.statsd).to receive(:close)
+          expect(components.health_metrics.statsd).to receive(:close)
+
+          shutdown!
+        end
+      end
+
+      context 'when the appsec is re-used' do
+        include_context 'replacement' do
+          let(:appsec) { components.appsec }
+        end
+
+        it 'shuts down all components but the tracer' do
+          expect(components.tracer).to receive(:shutdown!)
+          expect(components.appsec).to_not receive(:shutdown!) unless components.appsec.nil?
           expect(components.profiler).to receive(:shutdown!) unless components.profiler.nil?
           expect(components.runtime_metrics).to receive(:stop)
             .with(true, close_metrics: false)

--- a/spec/datadog/core/diagnostics/environment_logger_spec.rb
+++ b/spec/datadog/core/diagnostics/environment_logger_spec.rb
@@ -33,7 +33,11 @@ RSpec.describe Datadog::Core::Diagnostics::EnvironmentLogger do
 
     before do
       allow(Datadog).to receive(:logger).and_return(tracer_logger)
+      allow(tracer_logger).to receive(:debug?).and_return true
+      allow(tracer_logger).to receive(:debug)
       allow(tracer_logger).to receive(:info)
+      allow(tracer_logger).to receive(:warn)
+      allow(tracer_logger).to receive(:error)
     end
 
     it 'with a default tracer settings' do

--- a/spec/datadog/tracing/buffer_spec.rb
+++ b/spec/datadog/tracing/buffer_spec.rb
@@ -81,10 +81,6 @@ RSpec.shared_examples 'thread-safe buffer' do
       context 'with #pop operations' do
         let(:barrier) { Concurrent::CyclicBarrier.new(thread_count + 1) }
 
-        before do
-          allow(Datadog).to receive(:logger).and_return(double)
-        end
-
         it 'executes without error' do
           threads
 
@@ -154,10 +150,6 @@ RSpec.shared_examples 'thread-safe buffer' do
 
       context 'with #pop operations' do
         let(:barrier) { Concurrent::CyclicBarrier.new(thread_count + 1) }
-
-        before do
-          allow(Datadog).to receive(:logger).and_return(double)
-        end
 
         it 'executes without error' do
           threads
@@ -446,13 +438,35 @@ end
 RSpec.describe Datadog::Tracing::ThreadSafeTraceBuffer do
   let(:items) { get_test_traces(items_count) }
 
+  before do
+    logger = double(Datadog::Core::Logger)
+    allow(logger).to receive(:debug?).and_return true
+    allow(logger).to receive(:debug)
+    allow(logger).to receive(:info)
+    allow(logger).to receive(:warn)
+    allow(logger).to receive(:error)
+
+    allow(Datadog).to receive(:logger).and_return(logger)
+  end
+
   it_behaves_like 'trace buffer'
   it_behaves_like 'thread-safe buffer'
   it_behaves_like 'performance'
 end
 
 RSpec.describe Datadog::Tracing::CRubyTraceBuffer do
-  before { skip unless PlatformHelpers.mri? }
+  before do
+    skip unless PlatformHelpers.mri?
+
+    logger = double(Datadog::Core::Logger)
+    allow(logger).to receive(:debug?).and_return true
+    allow(logger).to receive(:debug)
+    allow(logger).to receive(:info)
+    allow(logger).to receive(:warn)
+    allow(logger).to receive(:error)
+
+    allow(Datadog).to receive(:logger).and_return(logger)
+  end
 
   let(:items) { get_test_traces(items_count) }
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Add an AppSec component, encapsulating the processor independently of the Rack integration.

Another significant change we introduce is that customers no longer need to `require ddtrace/appsec` to enable appsec specific settings.  The autoloading feature of appsec still works as expected. 

When booting ddtrace and when creating the appsec component, if appsec is not enabled, the component will not be instantiated. 

**Motivation**

Enabling AppSec lifecycle management outside of the Rack integration

**Additional Notes**

The value of this component will increase as reconfiguration, notably through remote configuration, becomes a requirement.

**How to test the change?**

Unit tests have been added for the new appsec components and modified existing tests in the core.
