### PR TITLE
[PROF-7251] Exclude disabled profiling sample value types from output

### DIFF
--- a/benchmarks/profiler_sample_loop_v2.rb
+++ b/benchmarks/profiler_sample_loop_v2.rb
@@ -18,7 +18,7 @@ class ProfilerSampleLoopBenchmark
   PROFILER_OVERHEAD_STACK_THREAD = Thread.new { sleep }
 
   def create_profiler
-    @recorder = Datadog::Profiling::StackRecorder.new
+    @recorder = Datadog::Profiling::StackRecorder.new(cpu_time_enabled: true, alloc_samples_enabled: true)
     @collector = Datadog::Profiling::Collectors::CpuAndWallTime.new(recorder: @recorder, max_frames: 400, tracer: nil)
   end
 

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time.c
@@ -153,7 +153,7 @@ static void trigger_sample_for_thread(
   VALUE thread,
   VALUE stack_from_thread,
   struct per_thread_context *thread_context,
-  ddog_Slice_I64 metric_values_slice,
+  sample_values values,
   sample_type type
 );
 static VALUE _native_thread_list(VALUE self);
@@ -407,18 +407,12 @@ void update_metrics_and_sample(
     IS_WALL_TIME
   );
 
-  int64_t metric_values[ENABLED_VALUE_TYPES_COUNT] = {0};
-
-  metric_values[CPU_TIME_VALUE_POS] = cpu_time_elapsed_ns;
-  metric_values[CPU_SAMPLES_VALUE_POS] = 1;
-  metric_values[WALL_TIME_VALUE_POS] = wall_time_elapsed_ns;
-
   trigger_sample_for_thread(
     state,
     thread_being_sampled,
     stack_from_thread,
     thread_context,
-    (ddog_Slice_I64) {.ptr = metric_values, .len = ENABLED_VALUE_TYPES_COUNT},
+    (sample_values) {.cpu_time_ns = cpu_time_elapsed_ns, .cpu_samples = 1, .wall_time_ns = wall_time_elapsed_ns},
     SAMPLE_REGULAR
   );
 }
@@ -555,18 +549,12 @@ VALUE cpu_and_wall_time_collector_sample_after_gc(VALUE self_instance) {
       rb_raise(rb_eRuntimeError, "BUG: Unexpected zero value for gc_tracking.wall_time_at_start_ns");
     }
 
-    int64_t metric_values[ENABLED_VALUE_TYPES_COUNT] = {0};
-
-    metric_values[CPU_TIME_VALUE_POS] = gc_cpu_time_elapsed_ns;
-    metric_values[CPU_SAMPLES_VALUE_POS] = 1;
-    metric_values[WALL_TIME_VALUE_POS] = gc_wall_time_elapsed_ns;
-
     trigger_sample_for_thread(
       state,
       /* thread: */  thread,
       /* stack_from_thread: */ thread,
       thread_context,
-      (ddog_Slice_I64) {.ptr = metric_values, .len = ENABLED_VALUE_TYPES_COUNT},
+      (sample_values) {.cpu_time_ns = gc_cpu_time_elapsed_ns, .cpu_samples = 1, .wall_time_ns = gc_wall_time_elapsed_ns},
       SAMPLE_IN_GC
     );
 
@@ -596,7 +584,7 @@ static void trigger_sample_for_thread(
   VALUE thread,
   VALUE stack_from_thread, // This can be different when attributing profiler overhead using a different stack
   struct per_thread_context *thread_context,
-  ddog_Slice_I64 metric_values_slice,
+  sample_values values,
   sample_type type
 ) {
   int max_label_count =
@@ -664,7 +652,7 @@ static void trigger_sample_for_thread(
     stack_from_thread,
     state->sampling_buffer,
     state->recorder_instance,
-    metric_values_slice,
+    values,
     (ddog_prof_Slice_Label) {.ptr = labels, .len = label_pos},
     type
   );

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.c
@@ -40,7 +40,7 @@ static void maybe_add_placeholder_frames_omitted(VALUE thread, sampling_buffer* 
 static void record_placeholder_stack_in_native_code(
   sampling_buffer* buffer,
   VALUE recorder_instance,
-  ddog_Slice_I64 metric_values,
+  sample_values values,
   ddog_prof_Slice_Label labels,
   sampling_buffer *record_buffer,
   int extra_frames_in_record_buffer
@@ -49,7 +49,7 @@ static void sample_thread_internal(
   VALUE thread,
   sampling_buffer* buffer,
   VALUE recorder_instance,
-  ddog_Slice_I64 metric_values,
+  sample_values values,
   ddog_prof_Slice_Label labels,
   sampling_buffer *record_buffer,
   int extra_frames_in_record_buffer
@@ -83,20 +83,13 @@ static VALUE _native_sample(
   ENFORCE_TYPE(labels_array, T_ARRAY);
   ENFORCE_TYPE(numeric_labels_array, T_ARRAY);
 
-  if (RHASH_SIZE(metric_values_hash) > ENABLED_VALUE_TYPES_COUNT || RHASH_SIZE(metric_values_hash) == 0) {
-    rb_raise(
-      rb_eArgError,
-      "Mismatched values for metrics; expected %lu values and got %lu instead",
-      ENABLED_VALUE_TYPES_COUNT,
-      RHASH_SIZE(metric_values_hash)
-    );
-  }
-
-  int64_t metric_values[ENABLED_VALUE_TYPES_COUNT] = {0};
-  for (unsigned int i = 0; i < RHASH_SIZE(metric_values_hash); i++) {
-    VALUE metric_value = rb_hash_fetch(metric_values_hash, rb_str_new_cstr(enabled_value_types[i].type_.ptr));
-    metric_values[i] = NUM2LONG(metric_value);
-  }
+  VALUE zero = INT2NUM(0);
+  sample_values values = {
+    .cpu_time_ns   = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("cpu-time"),      zero)),
+    .cpu_samples   = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("cpu-samples"),   zero)),
+    .wall_time_ns  = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("wall-time"),     zero)),
+    .alloc_samples = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("alloc-samples"), zero)),
+  };
 
   long labels_count = RARRAY_LEN(labels_array) + RARRAY_LEN(numeric_labels_array);
   ddog_prof_Label labels[labels_count];
@@ -127,7 +120,7 @@ static VALUE _native_sample(
     thread,
     buffer,
     recorder_instance,
-    (ddog_Slice_I64) {.ptr = metric_values, .len = ENABLED_VALUE_TYPES_COUNT},
+    values,
     (ddog_prof_Slice_Label) {.ptr = labels, .len = labels_count},
     RTEST(in_gc) ? SAMPLE_IN_GC : SAMPLE_REGULAR
   );
@@ -141,7 +134,7 @@ void sample_thread(
   VALUE thread,
   sampling_buffer* buffer,
   VALUE recorder_instance,
-  ddog_Slice_I64 metric_values,
+  sample_values values,
   ddog_prof_Slice_Label labels,
   sample_type type
 ) {
@@ -149,7 +142,7 @@ void sample_thread(
   if (type == SAMPLE_REGULAR) {
     sampling_buffer *record_buffer = buffer;
     int extra_frames_in_record_buffer = 0;
-    sample_thread_internal(thread, buffer, recorder_instance, metric_values, labels, record_buffer, extra_frames_in_record_buffer);
+    sample_thread_internal(thread, buffer, recorder_instance, values, labels, record_buffer, extra_frames_in_record_buffer);
     return;
   }
 
@@ -173,7 +166,7 @@ void sample_thread(
     };
     sampling_buffer *record_buffer = buffer; // We pass in the original buffer as the record_buffer, but not as the regular buffer
     int extra_frames_in_record_buffer = 1;
-    sample_thread_internal(thread, &thread_in_gc_buffer, recorder_instance, metric_values, labels, record_buffer, extra_frames_in_record_buffer);
+    sample_thread_internal(thread, &thread_in_gc_buffer, recorder_instance, values, labels, record_buffer, extra_frames_in_record_buffer);
     return;
   }
 
@@ -203,7 +196,7 @@ static void sample_thread_internal(
   VALUE thread,
   sampling_buffer* buffer,
   VALUE recorder_instance,
-  ddog_Slice_I64 metric_values,
+  sample_values values,
   ddog_prof_Slice_Label labels,
   sampling_buffer *record_buffer,
   int extra_frames_in_record_buffer
@@ -221,7 +214,7 @@ static void sample_thread_internal(
     record_placeholder_stack_in_native_code(
       buffer,
       recorder_instance,
-      metric_values,
+      values,
       labels,
       record_buffer,
       extra_frames_in_record_buffer
@@ -278,11 +271,9 @@ static void sample_thread_internal(
 
   record_sample(
     recorder_instance,
-    (ddog_prof_Sample) {
-      .locations = (ddog_prof_Slice_Location) {.ptr = record_buffer->locations, .len = captured_frames + extra_frames_in_record_buffer},
-      .values = metric_values,
-      .labels = labels,
-    }
+    (ddog_prof_Slice_Location) {.ptr = record_buffer->locations, .len = captured_frames + extra_frames_in_record_buffer},
+    values,
+    labels
   );
 }
 
@@ -330,7 +321,7 @@ static void maybe_add_placeholder_frames_omitted(VALUE thread, sampling_buffer* 
 static void record_placeholder_stack_in_native_code(
   sampling_buffer* buffer,
   VALUE recorder_instance,
-  ddog_Slice_I64 metric_values,
+  sample_values values,
   ddog_prof_Slice_Label labels,
   sampling_buffer *record_buffer,
   int extra_frames_in_record_buffer
@@ -344,11 +335,9 @@ static void record_placeholder_stack_in_native_code(
 
   record_sample(
     recorder_instance,
-    (ddog_prof_Sample) {
-      .locations = (ddog_prof_Slice_Location) {.ptr = record_buffer->locations, .len = 1 + extra_frames_in_record_buffer},
-      .values = metric_values,
-      .labels = labels,
-    }
+    (ddog_prof_Slice_Location) {.ptr = record_buffer->locations, .len = 1 + extra_frames_in_record_buffer},
+    values,
+    labels
   );
 }
 

--- a/ext/ddtrace_profiling_native_extension/collectors_stack.h
+++ b/ext/ddtrace_profiling_native_extension/collectors_stack.h
@@ -2,6 +2,8 @@
 
 #include <datadog/profiling.h>
 
+#include "stack_recorder.h"
+
 typedef struct sampling_buffer sampling_buffer;
 
 typedef enum { SAMPLE_REGULAR, SAMPLE_IN_GC } sample_type;
@@ -10,7 +12,7 @@ void sample_thread(
   VALUE thread,
   sampling_buffer* buffer,
   VALUE recorder_instance,
-  ddog_Slice_I64 metric_values,
+  sample_values values,
   ddog_prof_Slice_Label labels,
   sample_type type
 );

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -325,7 +325,7 @@ static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_insta
     state->position_for[CPU_TIME_VALUE_ID] = next_disabled_pos++;
   }
 
-  if (alloc_samples_enabled) {
+  if (alloc_samples_enabled == Qtrue) {
     enabled_value_types[next_enabled_pos] = (ddog_prof_ValueType) ALLOC_SAMPLES_VALUE;
     state->position_for[ALLOC_SAMPLES_VALUE_ID] = next_enabled_pos++;
   } else {

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.c
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.c
@@ -144,25 +144,22 @@ static VALUE stack_recorder_class = Qnil;
 #define VALUE_STRING(string) {.ptr = "" string, .len = sizeof(string) - 1}
 
 #define CPU_TIME_VALUE          {.type_ = VALUE_STRING("cpu-time"),          .unit = VALUE_STRING("nanoseconds")}
+#define CPU_TIME_VALUE_ID 0
 #define CPU_SAMPLES_VALUE       {.type_ = VALUE_STRING("cpu-samples"),       .unit = VALUE_STRING("count")}
+#define CPU_SAMPLES_VALUE_ID 1
 #define WALL_TIME_VALUE         {.type_ = VALUE_STRING("wall-time"),         .unit = VALUE_STRING("nanoseconds")}
-#define ALLOC_SIZE_VALUE        {.type_ = VALUE_STRING("alloc-size"),        .unit = VALUE_STRING("bytes")}
+#define WALL_TIME_VALUE_ID 2
 #define ALLOC_SAMPLES_VALUE     {.type_ = VALUE_STRING("alloc-samples"),     .unit = VALUE_STRING("count")}
-#define HEAP_LIVE_SIZE_VALUE    {.type_ = VALUE_STRING("heap-live-size"),    .unit = VALUE_STRING("bytes")}
-#define HEAP_LIVE_SAMPLES_VALUE {.type_ = VALUE_STRING("heap-live-samples"), .unit = VALUE_STRING("count")}
+#define ALLOC_SAMPLES_VALUE_ID 3
 
-static const ddog_prof_ValueType enabled_value_types[] = {
-  #define CPU_TIME_VALUE_POS 0
-  CPU_TIME_VALUE,
-  #define CPU_SAMPLES_VALUE_POS 1
-  CPU_SAMPLES_VALUE,
-  #define WALL_TIME_VALUE_POS 2
-  WALL_TIME_VALUE,
-  #define ALLOC_SAMPLES_VALUE_POS 3
-  ALLOC_SAMPLES_VALUE
-};
+static const ddog_prof_ValueType all_value_types[] = {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE, ALLOC_SAMPLES_VALUE};
 
-#define ENABLED_VALUE_TYPES_COUNT (sizeof(enabled_value_types) / sizeof(ddog_prof_ValueType))
+// This array MUST be kept in sync with all_value_types above and is intended to act as a "hashmap" between VALUE_ID and the position it
+// occupies on the all_value_types array.
+// E.g. all_value_types_positions[CPU_TIME_VALUE_ID] => 0, means that CPU_TIME_VALUE was declared at position 0 of all_value_types.
+static const uint8_t all_value_types_positions[] = {CPU_TIME_VALUE_ID, CPU_SAMPLES_VALUE_ID, WALL_TIME_VALUE_ID, ALLOC_SAMPLES_VALUE_ID};
+
+#define ALL_VALUE_TYPES_COUNT (sizeof(all_value_types) / sizeof(ddog_prof_ValueType))
 
 // Contains native state for each instance
 struct stack_recorder_state {
@@ -173,6 +170,9 @@ struct stack_recorder_state {
   ddog_prof_Profile *slot_two_profile;
 
   short active_slot; // MUST NEVER BE ACCESSED FROM record_sample; this is NOT for the sampler thread to use.
+
+  uint8_t position_for[ALL_VALUE_TYPES_COUNT];
+  uint8_t enabled_values_count;
 };
 
 // Used to return a pair of values from sampler_lock_active_profile()
@@ -197,6 +197,7 @@ struct call_serialize_without_gvl_arguments {
 static VALUE _native_new(VALUE klass);
 static void initialize_slot_concurrency_control(struct stack_recorder_state *state);
 static void stack_recorder_typed_data_free(void *data);
+static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE cpu_time_enabled, VALUE alloc_samples_enabled);
 static VALUE _native_serialize(VALUE self, VALUE recorder_instance);
 static VALUE ruby_time_from(ddog_Timespec ddprof_time);
 static void *call_serialize_without_gvl(void *call_args);
@@ -227,6 +228,7 @@ void stack_recorder_init(VALUE profiling_module) {
   // https://bugs.ruby-lang.org/issues/18007 for a discussion around this.
   rb_define_alloc_func(stack_recorder_class, _native_new);
 
+  rb_define_singleton_method(stack_recorder_class, "_native_initialize", _native_initialize, 3);
   rb_define_singleton_method(stack_recorder_class, "_native_serialize",  _native_serialize, 1);
   rb_define_singleton_method(stack_recorder_class, "_native_reset_after_fork", _native_reset_after_fork, 1);
   rb_define_singleton_method(testing_module, "_native_active_slot", _native_active_slot, 1);
@@ -253,9 +255,11 @@ static const rb_data_type_t stack_recorder_typed_data = {
 static VALUE _native_new(VALUE klass) {
   struct stack_recorder_state *state = ruby_xcalloc(1, sizeof(struct stack_recorder_state));
 
-  ddog_prof_Slice_ValueType sample_types = {.ptr = enabled_value_types, .len = ENABLED_VALUE_TYPES_COUNT};
+  ddog_prof_Slice_ValueType sample_types = {.ptr = all_value_types, .len = ALL_VALUE_TYPES_COUNT};
 
   initialize_slot_concurrency_control(state);
+  for (uint8_t i = 0; i < ALL_VALUE_TYPES_COUNT; i++) { state->position_for[i] = all_value_types_positions[i]; }
+  state->enabled_values_count = ALL_VALUE_TYPES_COUNT;
 
   // Note: Don't raise exceptions after this point, since it'll lead to libdatadog memory leaking!
 
@@ -285,6 +289,58 @@ static void stack_recorder_typed_data_free(void *state_ptr) {
   ddog_prof_Profile_drop(state->slot_two_profile);
 
   ruby_xfree(state);
+}
+
+static VALUE _native_initialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE cpu_time_enabled, VALUE alloc_samples_enabled) {
+  ENFORCE_BOOLEAN(cpu_time_enabled);
+  ENFORCE_BOOLEAN(alloc_samples_enabled);
+
+  struct stack_recorder_state *state;
+  TypedData_Get_Struct(recorder_instance, struct stack_recorder_state, &stack_recorder_typed_data, state);
+
+  if (cpu_time_enabled == Qtrue && alloc_samples_enabled == Qtrue) return Qtrue; // Nothing to do, this is the default
+
+  // When some sample types are disabled, we need to reconfigure libdatadog to record less types,
+  // as well as reconfigure the position_for array to push the disabled types to the end so they don't get recorded.
+  // See record_sample for details on the use of position_for.
+
+  state->enabled_values_count = ALL_VALUE_TYPES_COUNT - (cpu_time_enabled == Qtrue ? 0 : 1) - (alloc_samples_enabled == Qtrue? 0 : 1);
+
+  ddog_prof_ValueType enabled_value_types[ALL_VALUE_TYPES_COUNT];
+  uint8_t next_enabled_pos = 0;
+  uint8_t next_disabled_pos = state->enabled_values_count;
+
+  // CPU_SAMPLES_VALUE is always enabled
+  enabled_value_types[next_enabled_pos] = (ddog_prof_ValueType) CPU_SAMPLES_VALUE;
+  state->position_for[CPU_SAMPLES_VALUE_ID] = next_enabled_pos++;
+
+  // WALL_TIME_VALUE is always enabled
+  enabled_value_types[next_enabled_pos] = (ddog_prof_ValueType) WALL_TIME_VALUE;
+  state->position_for[WALL_TIME_VALUE_ID] = next_enabled_pos++;
+
+  if (cpu_time_enabled == Qtrue) {
+    enabled_value_types[next_enabled_pos] = (ddog_prof_ValueType) CPU_TIME_VALUE;
+    state->position_for[CPU_TIME_VALUE_ID] = next_enabled_pos++;
+  } else {
+    state->position_for[CPU_TIME_VALUE_ID] = next_disabled_pos++;
+  }
+
+  if (alloc_samples_enabled) {
+    enabled_value_types[next_enabled_pos] = (ddog_prof_ValueType) ALLOC_SAMPLES_VALUE;
+    state->position_for[ALLOC_SAMPLES_VALUE_ID] = next_enabled_pos++;
+  } else {
+    state->position_for[ALLOC_SAMPLES_VALUE_ID] = next_disabled_pos++;
+  }
+
+  ddog_prof_Slice_ValueType sample_types = {.ptr = enabled_value_types, .len = state->enabled_values_count};
+
+  ddog_prof_Profile_drop(state->slot_one_profile);
+  ddog_prof_Profile_drop(state->slot_two_profile);
+
+  state->slot_one_profile = ddog_prof_Profile_new(sample_types, NULL /* period is optional */, NULL /* start_time is optional */);
+  state->slot_two_profile = ddog_prof_Profile_new(sample_types, NULL /* period is optional */, NULL /* start_time is optional */);
+
+  return Qtrue;
 }
 
 static VALUE _native_serialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) {
@@ -348,17 +404,23 @@ void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, 
 
   struct active_slot_pair active_slot = sampler_lock_active_profile(state);
 
-  int64_t metric_values[ENABLED_VALUE_TYPES_COUNT] = {0};
-  metric_values[CPU_TIME_VALUE_POS] = values.cpu_time_ns;
-  metric_values[CPU_SAMPLES_VALUE_POS] = values.cpu_samples;
-  metric_values[WALL_TIME_VALUE_POS] = values.wall_time_ns;
-  metric_values[ALLOC_SAMPLES_VALUE_POS] = values.alloc_samples;
+  // Note: We initialize this array to have ALL_VALUE_TYPES_COUNT but only tell libdatadog to use the first
+  // state->enabled_values_count values. This simplifies handling disabled value types -- we still put them on the
+  // array, but in _native_initialize we arrange so their position starts from state->enabled_values_count and thus
+  // libdatadog doesn't touch them.
+  int64_t metric_values[ALL_VALUE_TYPES_COUNT] = {0};
+  uint8_t *position_for = state->position_for;
+
+  metric_values[position_for[CPU_TIME_VALUE_ID]]      = values.cpu_time_ns;
+  metric_values[position_for[CPU_SAMPLES_VALUE_ID]]   = values.cpu_samples;
+  metric_values[position_for[WALL_TIME_VALUE_ID]]     = values.wall_time_ns;
+  metric_values[position_for[ALLOC_SAMPLES_VALUE_ID]] = values.alloc_samples;
 
   ddog_prof_Profile_AddResult result = ddog_prof_Profile_add(
     active_slot.profile,
     (ddog_prof_Sample) {
       .locations = locations,
-      .values = (ddog_Slice_I64) {.ptr = metric_values, .len = ENABLED_VALUE_TYPES_COUNT},
+      .values = (ddog_Slice_I64) {.ptr = metric_values, .len = state->enabled_values_count},
       .labels = labels
     }
   );

--- a/ext/ddtrace_profiling_native_extension/stack_recorder.h
+++ b/ext/ddtrace_profiling_native_extension/stack_recorder.h
@@ -2,40 +2,13 @@
 
 #include <datadog/profiling.h>
 
-// Note: Please DO NOT use `VALUE_STRING` anywhere else, instead use `DDOG_CHARSLICE_C`.
-// `VALUE_STRING` is only needed because older versions of gcc (4.9.2, used in our Ruby 2.2 CI test images)
-// tripped when compiling `enabled_value_types` using `-std=gnu99` due to the extra cast that is included in
-// `DDOG_CHARSLICE_C` with the following error:
-//
-// ```
-// compiling ../../../../ext/ddtrace_profiling_native_extension/stack_recorder.c
-// ../../../../ext/ddtrace_profiling_native_extension/stack_recorder.c:23:1: error: initializer element is not constant
-// static const ddog_prof_ValueType enabled_value_types[] = {CPU_TIME_VALUE, CPU_SAMPLES_VALUE, WALL_TIME_VALUE};
-// ^
-// ```
-#define VALUE_STRING(string) {.ptr = "" string, .len = sizeof(string) - 1}
+typedef struct sample_values {
+  int64_t cpu_time_ns;
+  int64_t wall_time_ns;
+  uint32_t cpu_samples;
+  uint32_t alloc_samples;
+} sample_values;
 
-#define CPU_TIME_VALUE          {.type_ = VALUE_STRING("cpu-time"),          .unit = VALUE_STRING("nanoseconds")}
-#define CPU_SAMPLES_VALUE       {.type_ = VALUE_STRING("cpu-samples"),       .unit = VALUE_STRING("count")}
-#define WALL_TIME_VALUE         {.type_ = VALUE_STRING("wall-time"),         .unit = VALUE_STRING("nanoseconds")}
-#define ALLOC_SIZE_VALUE        {.type_ = VALUE_STRING("alloc-size"),        .unit = VALUE_STRING("bytes")}
-#define ALLOC_SAMPLES_VALUE     {.type_ = VALUE_STRING("alloc-samples"),     .unit = VALUE_STRING("count")}
-#define HEAP_LIVE_SIZE_VALUE    {.type_ = VALUE_STRING("heap-live-size"),    .unit = VALUE_STRING("bytes")}
-#define HEAP_LIVE_SAMPLES_VALUE {.type_ = VALUE_STRING("heap-live-samples"), .unit = VALUE_STRING("count")}
-
-static const ddog_prof_ValueType enabled_value_types[] = {
-  #define CPU_TIME_VALUE_POS 0
-  CPU_TIME_VALUE,
-  #define CPU_SAMPLES_VALUE_POS 1
-  CPU_SAMPLES_VALUE,
-  #define WALL_TIME_VALUE_POS 2
-  WALL_TIME_VALUE,
-  #define ALLOC_SAMPLES_VALUE_POS 3
-  ALLOC_SAMPLES_VALUE
-};
-
-#define ENABLED_VALUE_TYPES_COUNT (sizeof(enabled_value_types) / sizeof(ddog_prof_ValueType))
-
-void record_sample(VALUE recorder_instance, ddog_prof_Sample sample);
+void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, sample_values values, ddog_prof_Slice_Label labels);
 void record_endpoint(VALUE recorder_instance, uint64_t local_root_span_id, ddog_CharSlice endpoint);
 VALUE enforce_recorder_instance(VALUE object);

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -65,7 +65,10 @@ module Datadog
         if settings.profiling.advanced.force_enable_new_profiler
           print_new_profiler_warnings
 
-          recorder = Datadog::Profiling::StackRecorder.new
+          recorder = Datadog::Profiling::StackRecorder.new(
+            cpu_time_enabled: RUBY_PLATFORM.include?('linux'), # Only supported on Linux currently
+            alloc_samples_enabled: false, # Always disabled for now -- work in progress
+          )
           collector = Datadog::Profiling::Collectors::CpuAndWallTimeWorker.new(
             recorder: recorder,
             max_frames: settings.profiling.advanced.max_frames,

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -6,8 +6,7 @@ module Datadog
     # Note that `record_sample` is only accessible from native code.
     # Methods prefixed with _native_ are implemented in `stack_recorder.c`
     class StackRecorder
-      # TODO: Remove after wiring up component creation
-      def initialize(cpu_time_enabled: true, alloc_samples_enabled: true)
+      def initialize(cpu_time_enabled:, alloc_samples_enabled:)
         # This mutex works in addition to the fancy C-level mutexes we have in the native side (see the docs there).
         # It prevents multiple Ruby threads calling serialize at the same time -- something like
         # `10.times { Thread.new { stack_recorder.serialize } }`.

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -6,7 +6,8 @@ module Datadog
     # Note that `record_sample` is only accessible from native code.
     # Methods prefixed with _native_ are implemented in `stack_recorder.c`
     class StackRecorder
-      def initialize
+      # TODO: Remove after wiring up component creation
+      def initialize(cpu_time_enabled: true, alloc_samples_enabled: true)
         # This mutex works in addition to the fancy C-level mutexes we have in the native side (see the docs there).
         # It prevents multiple Ruby threads calling serialize at the same time -- something like
         # `10.times { Thread.new { stack_recorder.serialize } }`.
@@ -14,6 +15,8 @@ module Datadog
         # C-level mutexes (that there is a single serializer thread), we add it here as an extra safeguard against it
         # accidentally happening.
         @no_concurrent_synchronize_mutex = Mutex.new
+
+        self.class._native_initialize(self, cpu_time_enabled, alloc_samples_enabled)
       end
 
       def serialize

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -1111,6 +1111,35 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
           build_profiler
         end
+
+        it 'sets up the StackRecorder with alloc_samples_enabled: false' do
+          expect(Datadog::Profiling::StackRecorder)
+            .to receive(:new).with(hash_including(alloc_samples_enabled: false)).and_call_original
+
+          build_profiler
+        end
+
+        context 'when on Linux' do
+          before { stub_const('RUBY_PLATFORM', 'some-linux-based-platform') }
+
+          it 'sets up the StackRecorder with cpu_time_enabled: true' do
+            expect(Datadog::Profiling::StackRecorder)
+              .to receive(:new).with(hash_including(cpu_time_enabled: true)).and_call_original
+
+            build_profiler
+          end
+        end
+
+        context 'when not on Linux' do
+          before { stub_const('RUBY_PLATFORM', 'some-other-os') }
+
+          it 'sets up the StackRecorder with cpu_time_enabled: false' do
+            expect(Datadog::Profiling::StackRecorder)
+              .to receive(:new).with(hash_including(cpu_time_enabled: false)).and_call_original
+
+            build_profiler
+          end
+        end
       end
 
       it 'runs the setup task to set up any needed extensions for profiling' do

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTime do
     expect(Thread.list).to include(Thread.main, t1, t2, t3)
   end
 
-  let(:recorder) { Datadog::Profiling::StackRecorder.new }
+  let(:recorder) { build_stack_recorder }
   let(:ready_queue) { Queue.new }
   let(:t1) do
     Thread.new(ready_queue) do |ready_queue|

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -6,7 +6,7 @@ require 'datadog/profiling/collectors/cpu_and_wall_time_worker'
 RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   before { skip_if_profiling_not_supported(self) }
 
-  let(:recorder) { Datadog::Profiling::StackRecorder.new }
+  let(:recorder) { build_stack_recorder }
   let(:gc_profiling_enabled) { true }
   let(:options) { {} }
 
@@ -56,7 +56,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       allow(Datadog.logger).to receive(:warn)
 
       another_instance = described_class.new(
-        recorder: Datadog::Profiling::StackRecorder.new,
+        recorder: build_stack_recorder,
         max_frames: 400,
         tracer: nil,
         gc_profiling_enabled: gc_profiling_enabled,
@@ -238,7 +238,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         expect_in_fork do
           another_instance = described_class.new(
-            recorder: Datadog::Profiling::StackRecorder.new,
+            recorder: build_stack_recorder,
             max_frames: 400,
             tracer: nil,
             gc_profiling_enabled: gc_profiling_enabled,
@@ -254,7 +254,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         expect_in_fork do
           another_instance = described_class.new(
-            recorder: Datadog::Profiling::StackRecorder.new,
+            recorder: build_stack_recorder,
             max_frames: 400,
             tracer: nil,
             gc_profiling_enabled: gc_profiling_enabled,

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -386,7 +386,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   context 'when trying to sample something which is not a thread' do
     it 'raises a TypeError' do
       expect do
-        sample(:not_a_thread, Datadog::Profiling::StackRecorder.new, metric_values, labels)
+        sample(:not_a_thread, build_stack_recorder, metric_values, labels)
       end.to raise_error(TypeError)
     end
   end
@@ -394,7 +394,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   context 'when max_frames is too small' do
     it 'raises an ArgumentError' do
       expect do
-        sample(Thread.current, Datadog::Profiling::StackRecorder.new, metric_values, labels, max_frames: 4)
+        sample(Thread.current, build_stack_recorder, metric_values, labels, max_frames: 4)
       end.to raise_error(ArgumentError)
     end
   end
@@ -402,7 +402,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
   context 'when max_frames is too large' do
     it 'raises an ArgumentError' do
       expect do
-        sample(Thread.current, Datadog::Profiling::StackRecorder.new, metric_values, labels, max_frames: 10_001)
+        sample(Thread.current, build_stack_recorder, metric_values, labels, max_frames: 10_001)
       end.to raise_error(ArgumentError)
     end
   end
@@ -413,7 +413,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     end
   end
 
-  def sample_and_decode(thread, max_frames: 400, recorder: Datadog::Profiling::StackRecorder.new, in_gc: false)
+  def sample_and_decode(thread, max_frames: 400, recorder: build_stack_recorder, in_gc: false)
     sample(thread, recorder, metric_values, labels, max_frames: max_frames, in_gc: in_gc)
 
     samples = samples_from_pprof(recorder.serialize!)

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -93,6 +93,10 @@ module ProfileHelpers
   def samples_for_thread(samples, thread)
     samples.select { |sample| object_id_from(sample.labels.fetch(:'thread id')) == thread.object_id }
   end
+
+  def build_stack_recorder
+    Datadog::Profiling::StackRecorder.new(cpu_time_enabled: true, alloc_samples_enabled: true)
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -7,8 +7,12 @@ RSpec.describe Datadog::Profiling::StackRecorder do
   before { skip_if_profiling_not_supported(self) }
 
   let(:numeric_labels) { [] }
+  let(:cpu_time_enabled) { true }
+  let(:alloc_samples_enabled) { true }
 
-  subject(:stack_recorder) { described_class.new }
+  subject(:stack_recorder) do
+    described_class.new(cpu_time_enabled: cpu_time_enabled, alloc_samples_enabled: alloc_samples_enabled)
+  end
 
   # NOTE: A lot of libdatadog integration behaviors are tested in the Collectors::Stack specs, since we need actual
   # samples in order to observe what comes out of libdatadog
@@ -109,13 +113,56 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         expect(start).to be <= finish
       end
 
-      it 'returns a pprof with the configured sample types' do
-        expect(sample_types_from(decoded_profile)).to eq(
-          'cpu-time' => 'nanoseconds',
-          'cpu-samples' => 'count',
-          'wall-time' => 'nanoseconds',
-          'alloc-samples' => 'count',
-        )
+      context 'when all profile types are enabled' do
+        let(:cpu_time_enabled) { true }
+        let(:alloc_samples_enabled) { true }
+
+        it 'returns a pprof with the configured sample types' do
+          expect(sample_types_from(decoded_profile)).to eq(
+            'cpu-time' => 'nanoseconds',
+            'cpu-samples' => 'count',
+            'wall-time' => 'nanoseconds',
+            'alloc-samples' => 'count',
+          )
+        end
+      end
+
+      context 'when cpu-time is disabled' do
+        let(:cpu_time_enabled) { false }
+        let(:alloc_samples_enabled) { true }
+
+        it 'returns a pprof without the cpu-type type' do
+          expect(sample_types_from(decoded_profile)).to eq(
+            'cpu-samples' => 'count',
+            'wall-time' => 'nanoseconds',
+            'alloc-samples' => 'count',
+          )
+        end
+      end
+
+      context 'when alloc-samples is disabled' do
+        let(:cpu_time_enabled) { true }
+        let(:alloc_samples_enabled) { false }
+
+        it 'returns a pprof without the alloc-samples type' do
+          expect(sample_types_from(decoded_profile)).to eq(
+            'cpu-time' => 'nanoseconds',
+            'cpu-samples' => 'count',
+            'wall-time' => 'nanoseconds',
+          )
+        end
+      end
+
+      context 'when all optional types are disabled' do
+        let(:cpu_time_enabled) { false }
+        let(:alloc_samples_enabled) { false }
+
+        it 'returns a pprof with without the optional types' do
+          expect(sample_types_from(decoded_profile)).to eq(
+            'cpu-samples' => 'count',
+            'wall-time' => 'nanoseconds',
+          )
+        end
       end
 
       it 'returns an empty pprof' do
@@ -154,6 +201,15 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       it 'encodes the sample with the metrics provided' do
         expect(samples.first.values)
           .to eq(:'cpu-time' => 123, :'cpu-samples' => 456, :'wall-time' => 789, :'alloc-samples' => 4242)
+      end
+
+      context 'when disabling an optional profile sample type' do
+        let(:cpu_time_enabled) { false }
+
+        it 'encodes the sample with the metrics provided, ignoring the disabled ones' do
+          expect(samples.first.values)
+            .to eq(:'cpu-samples' => 456, :'wall-time' => 789, :'alloc-samples' => 4242)
+        end
       end
 
       it 'encodes the sample with the labels provided' do


### PR DESCRIPTION
**What does this PR do?**:

Up until now, the profiler always included all sample value types in the resulting profile, even if some value is was expected to always be zero.

(Why would a value always be zero? The `cpu-time` value is only available on Linux, and would always be zero on macOS; and we plan to have a way to disable allocation profiling, and thus `alloc-samples` will also be zero.)

This PR:

* Abstracts away from all components other than the `StackRecorder` which sample value types are enabled, by introducing a new `sample_values` struct that every other component can use instead of having to deal with the old array and other implementation details.

* Extends the `StackRecorder` to allow `cpu-time` and `alloc-samples` to be disabled

* Updates the profiler component creation to configure `StackRecorder` correctly.

**Motivation**:

Having the extra sample value types always being included as we did so far is mostly harmless.

But, it does make one thing difficult -- detection of which profile types are actually enabled in an application, in general.

Thus, the main reason for doing this change is so that the Datadog profiling backend can easily detect which profile types are enabled, and which aren't, so it can display better guidance and error messages to customers.

**Additional Notes**:

N/A

**How to test the change?**:

The change includes test coverage.

To manually validate this, you can download a pprof profile via the Datadog UX and confirm that only the enabled sample value types are available in it, for instance by running `go tool pprof -raw rubyprofile.pprof` and observing the columns shown after the `Samples:` header -- disabled value types will not show up there.
 