### PR TITLE
[PROF-7252] Add `Profiling.allocation_count` API for new profiler

### DIFF
--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -153,6 +153,7 @@ void *simulate_sampling_signal_delivery(DDTRACE_UNUSED void *_unused);
 static void grab_gvl_and_sample(void);
 static void reset_stats(struct cpu_and_wall_time_worker_state *state);
 static void sleep_for(uint64_t time_ns);
+static VALUE _native_allocation_count(DDTRACE_UNUSED VALUE self);
 
 // Note on sampler global state safety:
 //
@@ -188,6 +189,7 @@ void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module) {
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_stop", _native_stop, 2);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_reset_after_fork", _native_reset_after_fork, 1);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_stats", _native_stats, 1);
+  rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_allocation_count", _native_allocation_count, 0);
   rb_define_singleton_method(testing_module, "_native_current_sigprof_signal_handler", _native_current_sigprof_signal_handler, 0);
   rb_define_singleton_method(testing_module, "_native_is_running?", _native_is_running, 1);
   rb_define_singleton_method(testing_module, "_native_install_testing_signal_handler", _native_install_testing_signal_handler, 0);
@@ -774,4 +776,9 @@ static void sleep_for(uint64_t time_ns) {
       ENFORCE_SUCCESS_NO_GVL(errno);
     }
   }
+}
+
+static VALUE _native_allocation_count(DDTRACE_UNUSED VALUE self) {
+  // TODO
+  return Qnil;
 }

--- a/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/ddtrace_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -121,7 +121,8 @@ static VALUE _native_initialize(
   VALUE self_instance,
   VALUE cpu_and_wall_time_collector_instance,
   VALUE gc_profiling_enabled,
-  VALUE idle_sampling_helper_instance
+  VALUE idle_sampling_helper_instance,
+  VALUE allocation_counting_enabled
 );
 static void cpu_and_wall_time_worker_typed_data_mark(void *state_ptr);
 static VALUE _native_sampling_loop(VALUE self, VALUE instance);
@@ -184,7 +185,7 @@ void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module) {
   // https://bugs.ruby-lang.org/issues/18007 for a discussion around this.
   rb_define_alloc_func(collectors_cpu_and_wall_time_worker_class, _native_new);
 
-  rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_initialize", _native_initialize, 4);
+  rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_initialize", _native_initialize, 5);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_sampling_loop", _native_sampling_loop, 1);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_stop", _native_stop, 2);
   rb_define_singleton_method(collectors_cpu_and_wall_time_worker_class, "_native_reset_after_fork", _native_reset_after_fork, 1);
@@ -236,7 +237,8 @@ static VALUE _native_initialize(
   VALUE self_instance,
   VALUE cpu_and_wall_time_collector_instance,
   VALUE gc_profiling_enabled,
-  VALUE idle_sampling_helper_instance
+  VALUE idle_sampling_helper_instance,
+  DDTRACE_UNUSED VALUE allocation_counting_enabled
 ) {
   ENFORCE_BOOLEAN(gc_profiling_enabled);
 

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -249,7 +249,7 @@ module Datadog
               end
             end
 
-            # Forces enabling the new profiler. We do not yet recommend turning on this option.
+            # Forces enabling the new profiler.
             #
             # Note that setting this to "false" (or not setting it) will not prevent the new profiler from
             # being automatically used in the future.

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -281,8 +281,15 @@ module Datadog
               o.lazy
             end
 
-            # Can be used to disable the Datadog::Profiling.allocation_count feature.
-            option :allocation_counting_enabled, default: true
+            # Can be used to enable/disable the Datadog::Profiling.allocation_count feature.
+            #
+            # This feature is safe and enabled by default on Ruby 2.x, but
+            # on Ruby 3.x it can break in applications that make use of Ractors due to two Ruby VM bugs:
+            # https://bugs.ruby-lang.org/issues/19112 AND https://bugs.ruby-lang.org/issues/18464.
+            #
+            # If you use Ruby 3.x and your application does not use Ractors (or if your Ruby has been patched), the
+            # feature is fully safe to enable and this toggle can be used to do so.
+            option :allocation_counting_enabled, default: RUBY_VERSION.start_with?('2.')
           end
 
           # @public_api

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -206,6 +206,7 @@ module Datadog
             # This should never be reduced, as it can cause the resulting profiles to become biased.
             # The current default should be enough for most services, allowing 16 threads to be sampled around 30 times
             # per second for a 60 second period.
+            # This setting is ignored when CPU Profiling 2.0 is in use.
             option :max_events, default: 32768
 
             # Controls the maximum number of frames for each thread sampled. Can be tuned to avoid omitted frames in the
@@ -232,8 +233,8 @@ module Datadog
               end
             end
 
-            # Disable gathering of names and versions of gems in use by the service, used to power grouping and
-            # categorization of stack traces.
+            # Can be used to disable the gathering of names and versions of gems in use by the service, used to power
+            # grouping and categorization of stack traces.
             option :code_provenance_enabled, default: true
 
             # No longer does anything, and will be removed on dd-trace-rb 2.0.
@@ -249,7 +250,7 @@ module Datadog
               end
             end
 
-            # Forces enabling the new profiler.
+            # Forces enabling the new CPU Profiling 2.0 profiler (see ddtrace release notes for more details).
             #
             # Note that setting this to "false" (or not setting it) will not prevent the new profiler from
             # being automatically used in the future.

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -280,6 +280,9 @@ module Datadog
               o.default { env_to_bool('DD_PROFILING_FORCE_ENABLE_GC', false) }
               o.lazy
             end
+
+            # Can be used to disable the Datadog::Profiling.allocation_count feature.
+            option :allocation_counting_enabled, default: true
           end
 
           # @public_api

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -5,7 +5,7 @@ require_relative 'core/environment/variable_helpers'
 require_relative 'core/utils/only_once'
 
 module Datadog
-  # Contains profiler for generating stack profiles, etc.
+  # Datadog Continuous Profiler implementation: https://docs.datadoghq.com/profiler/
   module Profiling
     GOOGLE_PROTOBUF_MINIMUM_VERSION = Gem::Version.new('3.0')
     private_constant :GOOGLE_PROTOBUF_MINIMUM_VERSION

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -41,6 +41,38 @@ module Datadog
       !!profiler
     end
 
+    # Returns an ever-increasing counter of the number of allocations observed by the profiler in this thread.
+    #
+    # Note 1: This counter may not start from zero on new threads. It should only be used to measure how many
+    # allocations have happened between two calls to this API:
+    # ```
+    # allocations_before = Datadog::Profiling.allocation_count
+    # do_some_work()
+    # allocations_after = Datadog::Profiling.allocation_count
+    # puts "Allocations during do_some_work: #{allocations_after - allocations_before}"
+    # ```
+    #
+    # Note 2: All fibers in the same thread will share the same counter values.
+    #
+    # Only available when the profiler is running, the new CPU Profiling 2.0 profiler is in use, and allocation-related
+    # features are not disabled via configuration.
+    # For instructions on enabling CPU Profiling 2.0 see the ddtrace release notes.
+    #
+    # @return [Integer] number of allocations observed in the current thread.
+    # @return [nil] when not available.
+    # @public_api
+    def self.allocation_count
+      # This no-op implementation is used when profiling failed to load.
+      # It gets replaced inside #replace_noop_allocation_count.
+      nil
+    end
+
+    private_class_method def self.replace_noop_allocation_count
+      def self.allocation_count # rubocop:disable Lint/DuplicateMethods, Lint/NestedMethodDefinition (On purpose!)
+        Datadog::Profiling::Collectors::CpuAndWallTimeWorker._native_allocation_count
+      end
+    end
+
     private_class_method def self.native_library_compilation_skipped?
       skipped_reason = try_reading_skipped_reason_file
 
@@ -168,6 +200,8 @@ module Datadog
       require_relative 'profiling/pprof/pprof_pb'
       require_relative 'profiling/tag_builder'
       require_relative 'profiling/http_transport'
+
+      replace_noop_allocation_count
 
       true
     end

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: false
 
 require_relative 'core'
 require_relative 'core/environment/variable_helpers'

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -51,6 +51,7 @@ module Datadog
     # allocations_after = Datadog::Profiling.allocation_count
     # puts "Allocations during do_some_work: #{allocations_after - allocations_before}"
     # ```
+    # (This is similar to some OS-based time representations.)
     #
     # Note 2: All fibers in the same thread will share the same counter values.
     #

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -20,10 +20,17 @@ module Datadog
           max_frames:,
           tracer:,
           gc_profiling_enabled:,
+          allocation_counting_enabled:,
           cpu_and_wall_time_collector: CpuAndWallTime.new(recorder: recorder, max_frames: max_frames, tracer: tracer),
           idle_sampling_helper: IdleSamplingHelper.new
         )
-          self.class._native_initialize(self, cpu_and_wall_time_collector, gc_profiling_enabled, idle_sampling_helper)
+          self.class._native_initialize(
+            self,
+            cpu_and_wall_time_collector,
+            gc_profiling_enabled,
+            idle_sampling_helper,
+            allocation_counting_enabled
+          )
           @worker_thread = nil
           @failure_exception = nil
           @start_stop_mutex = Mutex.new

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -73,7 +73,8 @@ module Datadog
             recorder: recorder,
             max_frames: settings.profiling.advanced.max_frames,
             tracer: tracer,
-            gc_profiling_enabled: should_enable_gc_profiling?(settings)
+            gc_profiling_enabled: should_enable_gc_profiling?(settings),
+            allocation_counting_enabled: settings.profiling.advanced.allocation_counting_enabled,
           )
         else
           trace_identifiers_helper = Profiling::TraceIdentifiers::Helper.new(

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -1033,6 +1033,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
             max_frames: settings.profiling.advanced.max_frames,
             tracer: tracer,
             gc_profiling_enabled: anything,
+            allocation_counting_enabled: anything,
           )
 
           build_profiler
@@ -1093,6 +1094,28 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
               build_profiler
             end
+          end
+        end
+
+        it 'initializes a CpuAndWallTimeWorker collector with allocation_counting_enabled set to true' do
+          expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with hash_including(
+            allocation_counting_enabled: true,
+          )
+
+          build_profiler
+        end
+
+        context 'when allocation_counting_enabled is disabled' do
+          before do
+            settings.profiling.advanced.allocation_counting_enabled = false
+          end
+
+          it 'initializes a CpuAndWallTimeWorker collector with allocation_counting_enabled set to false' do
+            expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with hash_including(
+              allocation_counting_enabled: false,
+            )
+
+            build_profiler
           end
         end
 

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -1097,12 +1097,18 @@ RSpec.describe Datadog::Core::Configuration::Components do
           end
         end
 
-        it 'initializes a CpuAndWallTimeWorker collector with allocation_counting_enabled set to true' do
-          expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with hash_including(
-            allocation_counting_enabled: true,
-          )
+        context 'when allocation_counting_enabled is enabled' do
+          before do
+            settings.profiling.advanced.allocation_counting_enabled = true
+          end
 
-          build_profiler
+          it 'initializes a CpuAndWallTimeWorker collector with allocation_counting_enabled set to true' do
+            expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with hash_including(
+              allocation_counting_enabled: true,
+            )
+
+            build_profiler
+          end
         end
 
         context 'when allocation_counting_enabled is disabled' do

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -496,6 +496,33 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             .to(true)
         end
       end
+
+      describe '#allocation_counting_enabled' do
+        subject(:allocation_counting_enabled) { settings.profiling.advanced.allocation_counting_enabled }
+
+        context 'on Ruby 2.x' do
+          before { skip("Spec doesn't run on Ruby 3.x") unless RUBY_VERSION.start_with?('2.') }
+
+          it { is_expected.to be true }
+        end
+
+        context 'on Ruby 3.x' do
+          before { skip("Spec doesn't run on Ruby 2.x") if RUBY_VERSION.start_with?('2.') }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      describe '#allocation_counting_enabled=' do
+        it 'updates the #allocation_counting_enabled setting' do
+          settings.profiling.advanced.allocation_counting_enabled = true
+
+          expect { settings.profiling.advanced.allocation_counting_enabled = false }
+            .to change { settings.profiling.advanced.allocation_counting_enabled }
+            .from(true)
+            .to(false)
+        end
+      end
     end
 
     describe '#upload' do

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -364,6 +364,8 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       # specs. Unfortunately, there's a VM crash in that case as well -- https://bugs.ruby-lang.org/issues/18464 --
       # so this must be disabled when interacting with Ractors.
       let(:gc_profiling_enabled) { false }
+      # ...same thing for the tracepoint for allocation counting/profiling :(
+      let(:allocation_counting_enabled) { false }
 
       describe 'handle_sampling_signal' do
         include_examples 'does not trigger a sample',

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -535,6 +535,13 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
     end
   end
 
+  describe '._native_allocation_count' do
+    subject(:_native_allocation_count) { described_class._native_allocation_count }
+
+    # TODO
+    it { is_expected.to be nil }
+  end
+
   def wait_until_running
     try_wait_until(backoff: 0.01) { described_class::Testing._native_is_running?(cpu_and_wall_time_worker) }
   end

--- a/spec/datadog/profiling_spec.rb
+++ b/spec/datadog/profiling_spec.rb
@@ -49,7 +49,11 @@ RSpec.describe Datadog::Profiling do
       end
 
       it 'does not reference the CpuAndWallTimeWorker' do
-        expect(defined?(Datadog::Profiling::Collectors::CpuAndWallTimeWorker)).to be_falsey
+        if defined?(Datadog::Profiling::Collectors::CpuAndWallTimeWorker)
+          without_partial_double_verification do
+            expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to_not receive(:_native_allocation_count)
+          end
+        end
 
         allocation_count
       end

--- a/spec/datadog/profiling_spec.rb
+++ b/spec/datadog/profiling_spec.rb
@@ -27,6 +27,37 @@ RSpec.describe Datadog::Profiling do
     end
   end
 
+  describe '.allocation_count' do
+    subject(:allocation_count) { described_class.allocation_count }
+
+    context 'when profiling is supported' do
+      before do
+        skip('Test only runs on setups where profiling is supported') unless described_class.supported?
+      end
+
+      it 'delegates to the CpuAndWallTimeWorker' do
+        expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker)
+          .to receive(:_native_allocation_count).and_return(:allocation_count_result)
+
+        expect(allocation_count).to be :allocation_count_result
+      end
+    end
+
+    context 'when profiling is not supported' do
+      before do
+        skip('Test only runs on setups where profiling is not supported') if described_class.supported?
+      end
+
+      it 'does not reference the CpuAndWallTimeWorker' do
+        expect(defined?(Datadog::Profiling::Collectors::CpuAndWallTimeWorker)).to be_falsey
+
+        allocation_count
+      end
+
+      it { is_expected.to be nil }
+    end
+  end
+
   describe '::supported?' do
     subject(:supported?) { described_class.supported? }
 


### PR DESCRIPTION
**What does this PR do?**:

This PR adds a new profiler public API: `Datadog::Profiling.allocation_count`.

The public documentation for this API is as follows:

> Returns an ever-increasing counter of the number of allocations observed by the profiler in this thread.
>
> Note 1: This counter may not start from zero on new threads. It should only be used to measure how many allocations have happened between two calls to this API:
> ```ruby
> allocations_before = Datadog::Profiling.allocation_count
> do_some_work()
> allocations_after = Datadog::Profiling.allocation_count
> puts "Allocations during do_some_work: #{allocations_after - allocations_before}"
> ```
> (This is similar to some OS-based time representations.)
>
> Note 2: All fibers in the same thread will share the same counter values.
>
> Only available when the profiler is running, the new CPU Profiling 2.0 profiler is in use, and allocation-related features are not disabled via configuration.
> For instructions on enabling CPU Profiling 2.0 see the ddtrace release notes.

On Ruby 2.x, as long as CPU Profiling 2.0 is in use, this API is enabled by default.

On Ruby 3.x, this API is disabled by default [because of a Ractor bug](https://bugs.ruby-lang.org/issues/18464). On Ruby 3 apps that don't use Ractors, this is still safe to enable (via configuration).

To manually enable or disable this feature, this PR adds a new setting:

```ruby
Datadog.configure do |c|
  c.profiling.advanced.allocation_counting_enabled = # ...
end
```

**Motivation**:

This feature has long been something we want to provide with ddtrace, see issues #2164 and #468, as well as PRs #1891, #1805, #597.

As part of the ongoing work of enabling allocation profiling, counting the number of allocations comes at a very cheap cost since the profiler needs to have a `RUBY_INTERNAL_EVENT_NEWOBJ` tracepoint anyway -- it's just a matter of also incrementing a counter inside it.

**Additional Notes**:

Note that this does not yet change any user-visible feature for ddtrace. I'm counting on @marcotc to pick up the task of using this API to make some tracing magic :)

**This PR is on top of #2634 just for my convenience, but both changes are independent.**

**How to test the change?**:

This change includes code coverage.

---

Fixes #2164
