### PR TITLE
Print threads on stuck on flaky test

### DIFF
--- a/spec/datadog/core/workers/interval_loop_spec.rb
+++ b/spec/datadog/core/workers/interval_loop_spec.rb
@@ -124,9 +124,9 @@ RSpec.describe Datadog::Core::Workers::IntervalLoop do
               backtrace = ['(Not available)'] if backtrace.nil? || backtrace.empty?
 
               msg = "#{idx}: #{t} (#{t.class.name})",
-                'Thread Backtrace:',
-                backtrace.map { |l| "\t#{l}" }.join("\n"),
-                "\n"
+                    'Thread Backtrace:',
+                    backtrace.map { |l| "\t#{l}" }.join("\n"),
+                    "\n"
 
               warn(msg)
             end
@@ -183,9 +183,9 @@ RSpec.describe Datadog::Core::Workers::IntervalLoop do
               backtrace = ['(Not available)'] if backtrace.nil? || backtrace.empty?
 
               msg = "#{idx}: #{t} (#{t.class.name})",
-                'Thread Backtrace:',
-                backtrace.map { |l| "\t#{l}" }.join("\n"),
-                "\n"
+                    'Thread Backtrace:',
+                    backtrace.map { |l| "\t#{l}" }.join("\n"),
+                    "\n"
 
               warn(msg)
             end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -114,7 +114,35 @@ RSpec.configure do |config|
   #
   # rubocop:disable Style/GlobalVars
   config.around do |example|
+    # Enforce timeout for tests that are stuck for any reason.
+    # Prints all active threads to allow for further investigation.
+    # CircleCI shuts down containers after no output for 10 minutes.
+    # The timeout is currently 5 minutes for a single test.
+    timeout_thread = Thread.new do
+      timeout = 5 * 60 # 5 minutes
+      sleep(timeout)
+
+      warn("Test timed out after #{timeout}s. List of active threads:")
+
+      Thread.list.select { |t| t.alive? && t != Thread.current }.each_with_index.map do |t, idx|
+        backtrace = t.backtrace
+        backtrace = ['(Not available)'] if backtrace.nil? || backtrace.empty?
+
+        msg = "#{idx}: #{t} (#{t.class.name})",
+              'Thread Backtrace:',
+              backtrace.map { |l| "\t#{l}" }.join("\n"),
+              "\n"
+
+        warn(msg)
+      end
+
+      Process.kill('INT', Process.pid)
+    end
+    timeout_thread.name = 'Test timeout enforcer' if timeout_thread.respond_to?(:name=) # Ruby 2.3+
+
     example.run.tap do
+      timeout_thread.kill
+
       # Stop reporting on background thread leaks after too many
       # successive failures. The output is very verbose and, at that point,
       # it's better to work on fixing the very first occurrences.
@@ -142,6 +170,8 @@ RSpec.configure do |config|
         t == Thread.current ||
           # Thread has shut down, but we caught it right as it was still alive
           !t.alive? ||
+          # Timeout enforcing thread
+          t == timeout_thread ||
           # Internal JRuby thread
           defined?(JRuby) && JRuby.reference(t).native_thread.name == 'Finalizer' ||
           # WEBrick singleton thread for handling timeouts
@@ -250,7 +280,8 @@ end
 
 Thread.prepend(DatadogThreadDebugger)
 
-# Enforce test time limit, to allow us to debug why some test runs get stuck in CI
+# Enforce test time limit for the whole process, to allow debugging test runs
+# that get stuck outside of a test run.
 if ENV.key?('CI')
   require 'spec/support/thread_helpers'
 


### PR DESCRIPTION
This PR is meant to help debug flaky test runs that get stuck inside the execution of the `#work_pending?` test.

[Here's an example where CircleCI shuts down a container with no output after 10 minutes of inactivity:](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/8983/workflows/9b48a273-844c-4b4b-8de3-758e088e3c8e/jobs/334181)
```
Datadog::Core::Workers::IntervalLoop
  when included into a worker
    #loop_wait_time=
      is expected to change `worker.loop_wait_time` from 1 to 0.6986260331927575
    #work_pending?
      when the worker is not running
        is expected to equal false
      when the worker is running
Killed
/usr/local/bin/ruby -I/usr/local/bundle/gems/rspec-core-3.12.0/lib:/usr/local/bundle/gems/rspec-support-3.12.0/lib /usr/local/bundle/gems/rspec-core-3.12.0/exe/rspec --pattern spec/\*\*/\*_spec.rb  --exclude-pattern spec/\*\*/\{contrib,benchmark,redis,opentracer,auto_instrument,opentelemetry\}/\*\*/\*_spec.rb,\ spec/\*\*/\{auto_instrument,opentelemetry\}_spec.rb failed
rake aborted!
Command failed with status (1): [bundle exec appraisal ruby-2.7.6-core-old ...]
```