### PR TITLE
make sure to assign a valid processor to the appsec component

### DIFF
--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -32,7 +32,7 @@ module Datadog
       end
 
       def shutdown!
-        if processor
+        if processor && processor.ready?
           processor.finalize
           @processor = nil
         end

--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -11,19 +11,31 @@ module Datadog
         def build_appsec_component(settings)
           return unless settings.enabled
 
-          new
+          processor = create_processor
+          new(processor: processor)
+        end
+
+        private
+
+        def create_processor
+          processor = Processor.new
+          return nil unless processor.ready?
+
+          processor
         end
       end
 
       attr_reader :processor
 
-      def initialize(processor: Processor.new)
+      def initialize(processor:)
         @processor = processor
       end
 
       def shutdown!
-        processor.finalize if processor
-        @processor = nil
+        if processor
+          processor.finalize
+          @processor = nil
+        end
       end
     end
   end

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -27,7 +27,7 @@ module Datadog
 
             processor = Datadog::AppSec.processor
 
-            return @app.call(env) unless processor.ready?
+            return @app.call(env) unless processor
 
             # TODO: handle exceptions, except for @app.call
 

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -27,7 +27,7 @@ module Datadog
 
             processor = Datadog::AppSec.processor
 
-            return @app.call(env) unless processor
+            return @app.call(env) if processor.nil? || !processor.ready?
 
             # TODO: handle exceptions, except for @app.call
 

--- a/sig/datadog/appsec/component.rbs
+++ b/sig/datadog/appsec/component.rbs
@@ -3,9 +3,13 @@ module Datadog
     class Component
       def self.build_appsec_component: (Datadog::AppSec::Configuration::Settings settings) -> Datadog::AppSec::Component?
 
+      private
+
+      def self.create_processor: () -> Datadog::AppSec::Processor?
+
       attr_reader processor: Datadog::AppSec::Processor?
 
-      def initialize: (?processor: Datadog::AppSec::Processor?) -> void
+      def initialize: (processor: Datadog::AppSec::Processor?) -> void
 
       def shutdown!: () -> untyped
     end

--- a/spec/datadog/appsec/component_spec.rb
+++ b/spec/datadog/appsec/component_spec.rb
@@ -49,13 +49,34 @@ RSpec.describe Datadog::AppSec::Component do
   end
 
   describe '#shutdown!' do
-    context 'when processor is not nil' do
+    context 'when processor is not nil and ready' do
       it 'finalizes the processor' do
         processor = instance_double(Datadog::AppSec::Processor)
 
         component = described_class.new(processor: processor)
-
+        expect(processor).to receive(:ready?).and_return(true)
         expect(processor).to receive(:finalize)
+        component.shutdown!
+      end
+    end
+
+    context 'when processor is not ready' do
+      it 'does not finalize the processor' do
+        processor = instance_double(Datadog::AppSec::Processor)
+        expect(processor).to receive(:ready?).and_return(false)
+
+        component = described_class.new(processor: processor)
+
+        expect(processor).to_not receive(:finalize)
+        component.shutdown!
+      end
+    end
+
+    context 'when processor is nil' do
+      it 'does not finalize the processor' do
+        component = described_class.new(processor: nil)
+
+        expect_any_instance_of(Datadog::AppSec::Processor).to_not receive(:finalize)
         component.shutdown!
       end
     end

--- a/spec/datadog/appsec/component_spec.rb
+++ b/spec/datadog/appsec/component_spec.rb
@@ -5,25 +5,43 @@ require 'datadog/appsec/component'
 
 RSpec.describe Datadog::AppSec::Component do
   describe '.build_appsec_component' do
+    let(:settings) do
+      Datadog::AppSec::Configuration::Settings.new.merge(
+        Datadog::AppSec::Configuration::DSL.new.tap do |appsec|
+          appsec.enabled = appsec_enabled
+        end
+      )
+    end
     context 'when appsec is enabled' do
+      let(:appsec_enabled) { true }
       it 'returns a Datadog::AppSec::Component instance' do
-        settings = Datadog::AppSec::Configuration::Settings.new.merge(
-          Datadog::AppSec::Configuration::DSL.new.tap do |it|
-            it.enabled = true
-          end
-        )
         component = described_class.build_appsec_component(settings)
         expect(component).to be_a(described_class)
+      end
+
+      context 'when processor is ready' do
+        it 'returns a Datadog::AppSec::Component with a processor instance' do
+          expect_any_instance_of(Datadog::AppSec::Processor).to receive(:ready?).and_return(true)
+          component = described_class.build_appsec_component(settings)
+
+          expect(component.processor).to be_a(Datadog::AppSec::Processor)
+        end
+      end
+
+      context 'when processor fail to instanciate' do
+        it 'returns a Datadog::AppSec::Component with a nil processor' do
+          expect_any_instance_of(Datadog::AppSec::Processor).to receive(:ready?).and_return(false)
+          component = described_class.build_appsec_component(settings)
+
+          expect(component.processor).to be_nil
+        end
       end
     end
 
     context 'when appsec is not enabled' do
+      let(:appsec_enabled) { false }
+
       it 'returns nil' do
-        settings = Datadog::AppSec::Configuration::Settings.new.merge(
-          Datadog::AppSec::Configuration::DSL.new.tap do |it|
-            it.enabled = false
-          end
-        )
         component = described_class.build_appsec_component(settings)
         expect(component).to be_nil
       end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

After merging https://github.com/DataDog/dd-trace-rb/pull/2632, we got alerted that our system tests were failing. 
The scenario that is failing is when the appsec processor fails to parse the WAF rules. 
The test fails when the app wants tries to shout down and we try to finalize the appsec component. The problem is that the processor was never ready, so finalizing a non-ready processor caused an error. 

This PR fix that case by making sure to check if the processor is ready to assign to the appsec component. 


**Additional Notes**

Should we make the `AppSec::Component.new` method private and only allow to use `build_appsec_component`? 

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
