### PR TITLE
Flaky:Increase worker shutdown timing tolerance

### DIFF
--- a/spec/datadog/tracing/workers_integration_spec.rb
+++ b/spec/datadog/tracing/workers_integration_spec.rb
@@ -243,13 +243,13 @@ RSpec.describe 'Datadog::Workers::AsyncTransport integration tests' do
     end
 
     context 'which overruns the timeout' do
-      let(:task) { proc { sleep(interval) } }
+      let(:task) { proc { sleep(10) } }
       let(:trace_task) { task }
       let(:service_task) { task }
 
-      it do
+      it 'interrupts the worker to speed up shutdown' do
         expect(@shutdown_end - @shutdown_beg)
-          .to be_within(0.5).of(
+          .to be_within(5).of(
             Datadog::Tracing::Workers::AsyncTransport::SHUTDOWN_TIMEOUT
           )
       end


### PR DESCRIPTION
This PR changes the timing constraints for the test for the timely shutdown of `Datadog::Tracing::Workers::AsyncTransport`. 
This is the worker used by the tracer's transport.

[This test has flaked recently in CI](https://github.com/DataDog/dd-trace-rb/actions/runs/4245838791/jobs/7381877786):
```
  1) Datadog::Workers::AsyncTransport integration tests when terminating the worker which overruns the timeout is expected to be within 0.5 of 1
     Failure/Error:
       expect(@shutdown_end - @shutdown_beg)
         .to be_within(0.5).of(
           Datadog::Tracing::Workers::AsyncTransport::SHUTDOWN_TIMEOUT
         )

       expected 1.762315 to be within 0.5 of 1
     # ./spec/datadog/tracing/workers_integration_spec.rb:251:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:225:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:117:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.2.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'
```

This PR uses our test default timeout of 5 seconds for this.