### PR TITLE
Flaky:Remove race condition from integration test

### DIFF
--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -548,11 +548,13 @@ RSpec.describe 'Tracer integration tests' do
             span.service = 'my.service'
           end
 
-          sleep(1)
+          write.write('!') # Signals that this fork is ready
+          sleep(5)
         end
 
-        # Give the fork a chance to setup and sleep
-        sleep(0.2)
+        # Wait for fork to get ready
+        IO.select([read], [], [], 5) # 5 second timeout
+        read.getc # Reads '!'
 
         # Kill the process
         write.close

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -549,12 +549,13 @@ RSpec.describe 'Tracer integration tests' do
           end
 
           write.write('!') # Signals that this fork is ready
-          sleep(5)
+          sleep(5) # Should be interrupted
+          exit! # Should not be reached, will skip shutdown hooks
         end
 
         # Wait for fork to get ready
         IO.select([read], [], [], 5) # 5 second timeout
-        read.getc # Reads '!'
+        expect(read.getc).to eq('!') # Child process is ready
 
         # Kill the process
         write.close


### PR DESCRIPTION
This [flaky test](https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/9045/workflows/6841a910-893c-4922-93af-6e4948a13d04/jobs/336502/tests) happens because the wait condition for a forked process is time-dependent, and short:
```
Failure/Error: it { expect(terminated_process).to eq(graceful_signal) }

  expected: "graceful"
       got: ""

  (compared using ==)
./spec/datadog/tracing/integration_spec.rb:572:in `block (4 levels) in <top (required)>'
./spec/spec_helper.rb:225:in `block (2 levels) in <top (required)>'
./spec/spec_helper.rb:117:in `block (2 levels) in <top (required)>'
/usr/local/bundle/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
/usr/local/bundle/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'
```

This PR waits for a message from the child process instead.